### PR TITLE
Add ami id nodepool

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -62,6 +62,10 @@ type NodePoolPlatform struct {
 // AWSNodePoolPlatform stores the configuration for a node pool
 // installed on AWS.
 type AWSNodePoolPlatform struct {
+	// AMI defines the AMI ID to use for the instances.
+	// This is region dependent.
+	// If not provided, the AMI ID of the host cluster machines will be used.
+	AMI string `json:"ami,omitempty"`
 	// InstanceType defines the ec2 instance type.
 	// eg. m4-large
 	InstanceType    string                `json:"instanceType"`

--- a/config/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/config/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -61,6 +61,9 @@ spec:
                   aws:
                     description: AWS is the configuration used when installing on AWS.
                     properties:
+                      ami:
+                        description: AMI defines the AMI ID to use for the instances. This is region dependent. If not provided, the AMI ID of the host cluster machines will be used.
+                        type: string
                       instanceProfile:
                         type: string
                       instanceType:


### PR DESCRIPTION
@csrwng @derekwaynecarr @ironcladlou @enxebre 

Reviewer question: Underlying AMI in the `AWSMachine` is type `AWSResourceReference`.  Should we expose the ability to specify by ARN and tags as well? Or just force it to be the AMI ID?