### PR TITLE
Rename target cluster kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ bin/hypershift create cluster \
 When the cluster is available, get the guest kubeconfig using:
 
 ```bash
-$ oc get secret --namespace example example-kubeconfig --template={{.data.value}} | base64 -D
+$ oc get secret --namespace example admin-kubeconfig --template={{.data.value}} | base64 -D
 ```
 
 To create additional node pools, create a resource like:

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -434,7 +434,7 @@ func (r *HostedControlPlaneReconciler) ensureControlPlane(ctx context.Context, h
 		return fmt.Errorf("couldn't determine cluster base domain  name: %w", err)
 	}
 	r.Log.Info(fmt.Sprintf("Cluster API URL: %s", fmt.Sprintf("https://%s:%d", infraStatus.APIAddress, APIServerPort)))
-	r.Log.Info(fmt.Sprintf("Kubeconfig is available in secret %q in the %s namespace", fmt.Sprintf("%s-kubeconfig", targetNamespace), hcp.GetNamespace()))
+	r.Log.Info(fmt.Sprintf("Kubeconfig is available in secret admin-kubeconfig in the %s namespace", hcp.GetNamespace()))
 	r.Log.Info(fmt.Sprintf("Console URL:  %s", fmt.Sprintf("https://console-openshift-console.%s", fmt.Sprintf("apps.%s", baseDomain))))
 	r.Log.Info(fmt.Sprintf("kubeadmin password is available in secret %q in the %s namespace", "kubeadmin-password", targetNamespace))
 
@@ -969,7 +969,7 @@ func generateKubeadminPasswordSecret(namespace, password string) *corev1.Secret 
 func generateKubeconfigSecret(name, namespace string, kubeconfigBytes []byte) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	secret.Namespace = namespace
-	secret.Name = fmt.Sprintf("%s-kubeconfig", name)
+	secret.Name = "admin-kubeconfig"
 	secret.Data = map[string][]byte{"value": kubeconfigBytes}
 	return secret, nil
 }

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -131,7 +131,7 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 			key := ctrl.ObjectKey{
 				// TODO: This resource needs extracted into a library function
 				Namespace: example.Cluster.GetName(),
-				Name:      example.Cluster.Name + "-kubeconfig",
+				Name:      "admin-kubeconfig",
 			}
 			if err := input.Client.Get(ctx, key, guestKubeConfigSecret); err != nil {
 				return false


### PR DESCRIPTION
Rename to a known predictable name so it can be tooling like autoscaling can be coonfigured to consume it ahead of time