### PR TITLE
Make the optional NodePool.AutoScaling field a pointer

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -35,9 +35,10 @@ type NodePoolSpec struct {
 	// ClusterName is the name of the Cluster this object belongs to.
 	ClusterName string `json:"clusterName"`
 	// +optional
-	NodeCount   *int32              `json:"nodeCount"`
-	AutoScaling NodePoolAutoScaling `json:"autoScaling,omitempty"`
-	Platform    NodePoolPlatform    `json:"platform"`
+	NodeCount *int32 `json:"nodeCount"`
+	// +optional
+	AutoScaling *NodePoolAutoScaling `json:"autoScaling,omitempty"`
+	Platform    NodePoolPlatform     `json:"platform"`
 }
 
 // NodePoolStatus defines the observed state of NodePool

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -552,7 +552,11 @@ func (in *NodePoolSpec) DeepCopyInto(out *NodePoolSpec) {
 		*out = new(int32)
 		**out = **in
 	}
-	in.AutoScaling.DeepCopyInto(&out.AutoScaling)
+	if in.AutoScaling != nil {
+		in, out := &in.AutoScaling, &out.AutoScaling
+		*out = new(NodePoolAutoScaling)
+		(*in).DeepCopyInto(*out)
+	}
 	in.Platform.DeepCopyInto(&out.Platform)
 }
 


### PR DESCRIPTION
This fixes patch operations against the type where .autoScaling=null.

Depends on https://github.com/openshift/hypershift/pull/28