### PR TITLE
Rename kubeconfig for target cluster

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1027,7 +1027,7 @@ func generateKubeadminPasswordSecret(namespace, password string) *corev1.Secret 
 func generateKubeconfigSecret(name, namespace string, kubeconfigBytes []byte) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	secret.Namespace = namespace
-	secret.Name = "admin-kubeconfig"
+	secret.Name = fmt.Sprintf("%v-kubeconfig", name)
 	secret.Data = map[string][]byte{"value": kubeconfigBytes}
 	return secret, nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -362,6 +362,9 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		Namespace:      targetNamespace,
 		ServiceAccount: autoScalerServiceAccount,
 		Image:          "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0",
+		//The client used by CAPI machine controller expects the kubeconfig to follow this naming convention
+		//https://github.com/kubernetes-sigs/cluster-api/blob/5c85a0a01ee44ecf7c8a3c3fdc867a88af87d73c/util/secret/secret.go#L29-L33
+		TargetClusterKubeconfigSecretName: fmt.Sprintf("%s-kubeconfig", capiCluster.GetName()),
 	}.Build()
 	autoScalerObjects := []ctrlclient.Object{
 		autoScalerRole,

--- a/hypershift-operator/controllers/hostedcluster/manifests/autoscaler/manifests.go
+++ b/hypershift-operator/controllers/hostedcluster/manifests/autoscaler/manifests.go
@@ -9,9 +9,10 @@ import (
 )
 
 type Deployment struct {
-	Namespace      *corev1.Namespace
-	ServiceAccount *corev1.ServiceAccount
-	Image          string
+	Namespace                         *corev1.Namespace
+	ServiceAccount                    *corev1.ServiceAccount
+	Image                             string
+	TargetClusterKubeconfigSecretName string
 }
 
 func (o Deployment) Build() *appsv1.Deployment {
@@ -52,7 +53,7 @@ func (o Deployment) Build() *appsv1.Deployment {
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									// TODO: this should come from HCP status
-									SecretName: "admin-kubeconfig",
+									SecretName: o.TargetClusterKubeconfigSecretName,
 									Items: []corev1.KeyToPath{
 										{
 											// TODO: this should come from HCP status

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"time"
 
@@ -132,7 +133,7 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 			key := ctrl.ObjectKey{
 				// TODO: This resource needs extracted into a library function
 				Namespace: example.Cluster.GetName(),
-				Name:      "admin-kubeconfig",
+				Name:      fmt.Sprintf("%s-kubeconfig", example.Cluster.GetName()),
 			}
 			if err := input.Client.Get(ctx, key, guestKubeConfigSecret); err != nil {
 				return false


### PR DESCRIPTION
The client used by CAPI machine controller expects the kubeconfig to follow this naming convention
https://github.com/kubernetes-sigs/cluster-api/blob/5c85a0a01ee44ecf7c8a3c3fdc867a88af87d73c/util/secret/secret.go#L29-L33