### PR TITLE
Set back right target kubeconfig key for autoscaling

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/manifests/autoscaler/manifests.go
+++ b/hypershift-operator/controllers/hostedcluster/manifests/autoscaler/manifests.go
@@ -56,7 +56,7 @@ func (o Deployment) Build() *appsv1.Deployment {
 									Items: []corev1.KeyToPath{
 										{
 											// TODO: should the key be published on status?
-											Key:  "kubeconfig",
+											Key:  "value",
 											Path: "target-kubeconfig",
 										},
 									},


### PR DESCRIPTION
This was mistakenly changed here https://github.com/openshift/hypershift/pull/40/files#diff-53eadb56aff39c25c42ea90aef35d6ff05c80c37aab763211f8d9c1306553177R59