### PR TITLE
workflow: ignore kubeconfig file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tools/bin
 .envrc
 
 .kube
+kubeconfig


### PR DESCRIPTION
I extract the kubeconfig for my guest cluster into my hypershift directory often and have added it to a commit a few times.

Not sure if this would help anyone else, but it would help me :)