### PR TITLE
Introduce machineDeployments

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -31,6 +30,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	hyperapi "openshift.io/hypershift/api"
+	hyperv1 "openshift.io/hypershift/api/v1alpha1"
+	"openshift.io/hypershift/hypershift-operator/controllers/hostedcluster/manifests"
+	"openshift.io/hypershift/hypershift-operator/controllers/hostedcluster/manifests/autoscaler"
+	"openshift.io/hypershift/hypershift-operator/controllers/hostedcluster/manifests/clusterapi"
+	"openshift.io/hypershift/hypershift-operator/controllers/hostedcluster/manifests/controlplaneoperator"
+	hyperutil "openshift.io/hypershift/hypershift-operator/controllers/util"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,14 +47,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	hyperapi "openshift.io/hypershift/api"
-	hyperv1 "openshift.io/hypershift/api/v1alpha1"
-
-	"openshift.io/hypershift/hypershift-operator/controllers/hostedcluster/manifests"
-	"openshift.io/hypershift/hypershift-operator/controllers/hostedcluster/manifests/autoscaler"
-	"openshift.io/hypershift/hypershift-operator/controllers/hostedcluster/manifests/clusterapi"
-	"openshift.io/hypershift/hypershift-operator/controllers/hostedcluster/manifests/controlplaneoperator"
 )
 
 const (
@@ -548,14 +546,6 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, req ctrl.Request) 
 	return true, nil
 }
 
-func parseNamespacedName(name string) types.NamespacedName {
-	parts := strings.SplitN(name, string(types.Separator), 2)
-	if len(parts) > 1 {
-		return types.NamespacedName{Namespace: parts[0], Name: parts[1]}
-	}
-	return types.NamespacedName{Name: parts[0]}
-}
-
 func enqueueParentHostedCluster(obj ctrlclient.Object) []reconcile.Request {
 	var hostedClusterName string
 	if obj.GetAnnotations() != nil {
@@ -565,6 +555,6 @@ func enqueueParentHostedCluster(obj ctrlclient.Object) []reconcile.Request {
 		return []reconcile.Request{}
 	}
 	return []reconcile.Request{
-		{NamespacedName: parseNamespacedName(hostedClusterName)},
+		{NamespacedName: hyperutil.ParseNamespacedName(hostedClusterName)},
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/hostedcluster/manifests/controlplaneoperator/manifests.go
@@ -6,10 +6,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	k8sutilspointer "k8s.io/utils/pointer"
 	hyperv1 "openshift.io/hypershift/api/v1alpha1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -282,7 +282,7 @@ func (o CAPICluster) Build() *capiv1.Cluster {
 			Namespace: o.Namespace.Name,
 			Name:      o.HostedCluster.GetName(),
 			Annotations: map[string]string{
-				hostedClusterAnnotation: namespacedName(o.HostedCluster).String(),
+				hostedClusterAnnotation: ctrlclient.ObjectKeyFromObject(o.HostedCluster).String(),
 			},
 		},
 		Spec: capiv1.ClusterSpec{
@@ -322,7 +322,7 @@ func (o HostedControlPlane) Build() *hyperv1.HostedControlPlane {
 			Namespace: o.Namespace.Name,
 			Name:      o.HostedCluster.GetName(),
 			Annotations: map[string]string{
-				hostedClusterAnnotation: namespacedName(o.HostedCluster).String(),
+				hostedClusterAnnotation: ctrlclient.ObjectKeyFromObject(o.HostedCluster).String(),
 			},
 		},
 		Spec: hyperv1.HostedControlPlaneSpec{
@@ -359,7 +359,7 @@ func (o ExternalInfraCluster) Build() *hyperv1.ExternalInfraCluster {
 			Namespace: o.Namespace.Name,
 			Name:      o.HostedCluster.GetName(),
 			Annotations: map[string]string{
-				hostedClusterAnnotation: namespacedName(o.HostedCluster).String(),
+				hostedClusterAnnotation: ctrlclient.ObjectKeyFromObject(o.HostedCluster).String(),
 			},
 		},
 		Spec: hyperv1.ExternalInfraClusterSpec{
@@ -368,11 +368,4 @@ func (o ExternalInfraCluster) Build() *hyperv1.ExternalInfraCluster {
 		},
 	}
 	return eic
-}
-
-func namespacedName(obj metav1.Object) types.NamespacedName {
-	return types.NamespacedName{
-		Namespace: obj.GetNamespace(),
-		Name:      obj.GetName(),
-	}
 }

--- a/hypershift-operator/controllers/util/util.go
+++ b/hypershift-operator/controllers/util/util.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ParseNamespacedName expects a string with the format "namespace/name"
+// and returns the proper types.NamespacedName.
+// This is useful when watching a CR annotated with the format above to requeue the CR
+// described in the annotation.
+func ParseNamespacedName(name string) types.NamespacedName {
+	parts := strings.SplitN(name, string(types.Separator), 2)
+	if len(parts) > 1 {
+		return types.NamespacedName{Namespace: parts[0], Name: parts[1]}
+	}
+	return types.NamespacedName{Name: parts[0]}
+}


### PR DESCRIPTION
This drops machineSets in favour of machineDeployments as the scalable resources for nodePools.
It also polish the nodePool controller and add a watcher on the underlying scalable resource.
This is a first step towards enabling rolling upgrades for compute nodes.