### PR TITLE
build: optimize code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,31 +28,30 @@ build: hypershift-operator control-plane-operator hosted-cluster-config-operator
 
 verify: build fmt vet
 
-# Generate Kube manifests (e.g. CRDs)
-.PHONY: hypershift-operator-manifests
-hypershift-operator-manifests:
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=cmd/install/assets/hypershift-operator
-
 # Build hypershift-operator binary
 .PHONY: hypershift-operator
 hypershift-operator:
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	$(GO_BUILD_RECIPE) -o bin/hypershift-operator ./hypershift-operator
 
 .PHONY: control-plane-operator
 control-plane-operator:
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	$(GO_BUILD_RECIPE) -o bin/control-plane-operator ./control-plane-operator
 
 # Build hosted-cluster-config-operator binary
 .PHONY: hosted-cluster-config-operator
 hosted-cluster-config-operator:
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	$(GO_BUILD_RECIPE) -o bin/hosted-cluster-config-operator ./hosted-cluster-config-operator
 
 .PHONY: hypershift
 hypershift:
 	$(GO_BUILD_RECIPE) -o bin/hypershift .
+
+# Run this when updating any of the types in the api package to regenerate the
+# deepcopy code and CRD manifest files.
+.PHONY: api
+api:
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=cmd/install/assets/hypershift-operator
 
 # Run tests
 .PHONY: test

--- a/cmd/install/assets/assets.go
+++ b/cmd/install/assets/assets.go
@@ -30,11 +30,15 @@ func getContents(file string) []byte {
 	return b
 }
 
+// getCustomResourceDefinition unmarshals a CRD from file. Note there's a hack
+// here to strip leading YAML document separator which controller-gen creates
+// even though there's only one object in the document.
 func getCustomResourceDefinition(file string) *apiextensionsv1.CustomResourceDefinition {
 	b := getContents(file)
-	o := apiextensionsv1.CustomResourceDefinition{}
-	if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(b), 100).Decode(&o); err != nil {
+	repaired := bytes.Replace(b, []byte("\n---\n"), []byte(""), 1)
+	crd := apiextensionsv1.CustomResourceDefinition{}
+	if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(repaired), 100).Decode(&crd); err != nil {
 		panic(err)
 	}
-	return &o
+	return &crd
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_externalinfraclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_externalinfraclusters.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
This patch introduces a new `api` make target which should be run whenever code
in the `openshift.io/hypershift/api` package changes. It regenerates things like
deepcopy boilerplate and CRD manifest files. Overall this means binary builds
are faster as we don't run controller-gen unnecessarily.

There's also a hack to work around controller-gen's behavior that prepends the
CRD YAML with document separators which break deserialization. The hack makes it
so we can live with the raw output of controller-gen without post-processing it
without dealing with additional shell work.

In a followup we should introduce a step to the `verify` target which detects
missed `api` executions for PRs.