### PR TITLE
Makefile: improve the verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,12 @@ all: build
 
 build: hypershift-operator control-plane-operator hosted-cluster-config-operator hypershift
 
-verify: build fmt vet
+.PHONY: verify
+verify: deps api fmt vet
+	git diff-index --cached --quiet --ignore-submodules HEAD --
+	git diff-files --quiet --ignore-submodules
+	$(eval STATUS = $(shell git status -s))
+	$(if $(strip $(STATUS)),$(error untracked files detected))
 
 # Build hypershift-operator binary
 .PHONY: hypershift-operator
@@ -71,6 +76,13 @@ fmt:
 .PHONY: vet
 vet:
 	$(GO) vet ./...
+
+# Updates Go modules
+.PHONY: deps
+deps:
+	$(GO) mod tidy
+	$(GO) mod vendor
+	$(GO) mod verify
 
 # Build the docker image
 .PHONY: docker-build

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,5 @@
 # cloud.google.com/go v0.54.0
 cloud.google.com/go/compute/metadata
-# github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
-## explicit
 # github.com/aws/aws-sdk-go v1.35.0
 ## explicit
 github.com/aws/aws-sdk-go/aws
@@ -114,8 +112,6 @@ github.com/mattn/go-colorable
 github.com/mattn/go-isatty
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/moby/spdystream v0.2.0
-## explicit
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
@@ -220,13 +216,9 @@ github.com/spf13/pflag
 # github.com/stretchr/testify v1.6.1
 ## explicit
 github.com/stretchr/testify/assert
-# github.com/ugorji/go v1.1.4
-## explicit
 # github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 ## explicit
 github.com/vincent-petithory/dataurl
-# github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
-## explicit
 # go.uber.org/atomic v1.6.0
 go.uber.org/atomic
 # go.uber.org/multierr v1.5.0


### PR DESCRIPTION
Update the verify target to ensure that the usual fmt/vet/codegen
operations don't result in any git diffs. This is intended to help
catch missed updates in pull requests.

Fixes #68
Fixes #69