### PR TITLE
Extract kube-apiserver manifests

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -617,6 +617,36 @@ func (r *HostedControlPlaneReconciler) generateControlPlaneManifests(ctx context
 	if err != nil {
 		return nil, fmt.Errorf("failed to render hypershift manifests for cluster: %w", err)
 	}
+
+	kubeAPIServerContext := render.NewKubeAPIServerManifestContext(&render.KubeAPIServerParams{
+		PodCIDR:               params.PodCIDR,
+		ServiceCIDR:           params.ServiceCIDR,
+		ExternalAPIAddress:    params.ExternalAPIAddress,
+		APIServerAuditEnabled: params.APIServerAuditEnabled,
+		CloudProvider:         params.CloudProvider,
+		EtcdClientName:        params.EtcdClientName,
+		DefaultFeatureGates:   params.DefaultFeatureGates,
+		ExtraFeatureGates:     params.ExtraFeatureGates,
+		IngressSubdomain:      params.IngressSubdomain,
+		InternalAPIPort:       params.InternalAPIPort,
+		NamedCerts:            params.NamedCerts,
+		PKI:                   pkiSecret.Data,
+		APIAvailabilityPolicy: render.KubeAPIServerParamsAvailabilityPolicy(params.APIAvailabilityPolicy),
+		ClusterID:             params.ClusterID,
+		Images:                releaseImage.ComponentImages(),
+		ApiserverLivenessPath: params.ApiserverLivenessPath,
+		APINodePort:           params.APINodePort,
+		ExternalOauthPort:     params.ExternalOauthPort,
+		ExternalOauthDNSName:  params.ExternalOauthDNSName,
+	})
+	kubeAPIServerManifests, err := kubeAPIServerContext.Render()
+	if err != nil {
+		return nil, fmt.Errorf("failed to render kube apiserver manifests: %w", err)
+	}
+	for k := range kubeAPIServerManifests {
+		manifests[k] = kubeAPIServerManifests[k]
+	}
+
 	return manifests, nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/render/kube_apiserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/kube_apiserver.go
@@ -1,0 +1,68 @@
+package render
+
+import "text/template"
+
+type KubeAPIServerParams struct {
+	PodCIDR               string
+	ServiceCIDR           string
+	ExternalAPIAddress    string
+	APIServerAuditEnabled bool
+	CloudProvider         string
+	EtcdClientName        string
+	DefaultFeatureGates   []string
+	ExtraFeatureGates     []string
+	IngressSubdomain      string
+	InternalAPIPort       uint
+	NamedCerts            []NamedCert
+	PKI                   map[string][]byte
+	APIAvailabilityPolicy KubeAPIServerParamsAvailabilityPolicy
+	ClusterID             string
+	Images                map[string]string
+	ApiserverLivenessPath string
+	APINodePort           uint
+	ExternalOauthPort     uint
+	ExternalOauthDNSName  string
+}
+
+type KubeAPIServerParamsAvailabilityPolicy string
+
+const (
+	KubeAPIServerParamsHighlyAvailable KubeAPIServerParamsAvailabilityPolicy = "HighlyAvailable"
+	KubeAPIServerParamsSingleReplica   KubeAPIServerParamsAvailabilityPolicy = "SingleReplica"
+)
+
+type kubeAPIServerManifestContext struct {
+	*renderContext
+	userManifestFiles []string
+	userManifests     map[string]string
+}
+
+func NewKubeAPIServerManifestContext(params *KubeAPIServerParams) *kubeAPIServerManifestContext {
+	ctx := &kubeAPIServerManifestContext{
+		renderContext: newRenderContext(params),
+		userManifests: make(map[string]string),
+	}
+	ctx.setFuncs(template.FuncMap{
+		"pki":         pkiFunc(params.PKI),
+		"include_pki": includePKIFunc(params.PKI),
+		"imageFor":    imageFunc(params.Images),
+		"include":     includeFileFunc(params, ctx.renderContext),
+	})
+	ctx.addManifestFiles(
+		"kube-apiserver/kube-apiserver-deployment.yaml",
+		"kube-apiserver/kube-apiserver-service.yaml",
+		"kube-apiserver/kube-apiserver-config-configmap.yaml",
+		"kube-apiserver/kube-apiserver-oauth-metadata-configmap.yaml",
+		"kube-apiserver/kube-apiserver-vpnclient-config.yaml",
+		"kube-apiserver/kube-apiserver-secret.yaml",
+		"kube-apiserver/kube-apiserver-configmap.yaml",
+		"kube-apiserver/kube-apiserver-vpnclient-secret.yaml",
+		"kube-apiserver/kube-apiserver-default-audit-policy.yaml",
+		"kube-apiserver/kube-apiserver-localhost-kubeconfig-secret.yaml",
+	)
+	return ctx
+}
+
+func (c *kubeAPIServerManifestContext) Render() (map[string][]byte, error) {
+	return c.renderManifests()
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
@@ -58,7 +58,6 @@ func (c *clusterManifestContext) setupManifests() {
 	c.hostedClusterConfigOperator()
 	c.serviceAdminKubeconfig()
 	c.etcd()
-	c.kubeAPIServer()
 	c.kubeControllerManager()
 	c.kubeScheduler()
 	c.clusterVersionOperator()
@@ -132,21 +131,6 @@ func (c *clusterManifestContext) oauthOpenshiftServer() {
 	)
 	c.addUserManifestFiles(
 		"oauth-openshift/ingress-certs-secret.yaml",
-	)
-}
-
-func (c *clusterManifestContext) kubeAPIServer() {
-	c.addManifestFiles(
-		"kube-apiserver/kube-apiserver-deployment.yaml",
-		"kube-apiserver/kube-apiserver-service.yaml",
-		"kube-apiserver/kube-apiserver-config-configmap.yaml",
-		"kube-apiserver/kube-apiserver-oauth-metadata-configmap.yaml",
-		"kube-apiserver/kube-apiserver-vpnclient-config.yaml",
-		"kube-apiserver/kube-apiserver-secret.yaml",
-		"kube-apiserver/kube-apiserver-configmap.yaml",
-		"kube-apiserver/kube-apiserver-vpnclient-secret.yaml",
-		"kube-apiserver/kube-apiserver-default-audit-policy.yaml",
-		"kube-apiserver/kube-apiserver-localhost-kubeconfig-secret.yaml",
 	)
 }
 


### PR DESCRIPTION
Start to untangle the components from one another by extracting the
kube-apiserver manifests into its own template rendering context
and input parameter structure. This is one small step towards managing
the component discretely as its own operand.