### PR TITLE
HCP: remove IngressController OwnerRef

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -805,7 +805,6 @@ func createIngressController(c client.Client, hcp *hyperv1.HostedControlPlane, n
 			},
 		},
 	}
-	ic.OwnerReferences = ensureHCPOwnerRef(hcp, ic.OwnerReferences)
 	if err := c.Create(context.TODO(), ic); err != nil && !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create ingress controller for %s: %w", name, err)
 	}


### PR DESCRIPTION
Fixes the guest cluster ingress proxy.  The HCP does not exist in the same namespace as the IngressController and, if the Owner does not exist in the same namespace as the resource, garbage collection immediately removes the resource.