### PR TITLE
Additional print columns for CLI

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -107,6 +107,9 @@ type ClusterVersionStatus struct {
 // +kubebuilder:resource:path=hostedclusters,shortName=hc;hcs,scope=Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version.history[?(@.state==\"Completed\")].version",description="Version"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Ready"
+// +kubebuilder:printcolumn:name="KubeConfig",type="string",JSONPath=".status.kubeconfig.name",description="KubeConfig Secret"
 // HostedCluster is the Schema for the hostedclusters API
 type HostedCluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -21,7 +21,9 @@ func init() {
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:scale:specpath=.spec.nodeCount,statuspath=.status.nodeCount
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".spec.clusterName",description="Cluster"
 // +kubebuilder:printcolumn:name="NodeCount",type="integer",JSONPath=".status.nodeCount",description="Available Nodes"
+// +kubebuilder:printcolumn:name="Autoscaling",type="string",JSONPath=".status.conditions[?(@.type==\"AutoscalingEnabled\")].status",description="Autoscaling Enabled"
 type NodePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -19,7 +19,20 @@ spec:
     singular: hostedcluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Version
+      jsonPath: .status.version.history[?(@.state=="Completed")].version
+      name: Version
+      type: string
+    - description: Ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: KubeConfig Secret
+      jsonPath: .status.kubeconfig.name
+      name: KubeConfig
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: HostedCluster is the Schema for the hostedclusters API

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -20,10 +20,18 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
     - description: Available Nodes
       jsonPath: .status.nodeCount
       name: NodeCount
       type: integer
+    - description: Autoscaling Enabled
+      jsonPath: .status.conditions[?(@.type=="AutoscalingEnabled")].status
+      name: Autoscaling
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Improves readability on CLI for `HostedCluster` and `NodePool`

```
$ oc get hostedclusters -A
NAMESPACE   NAME        VERSION   READY   KUBECONFIG
clusters    tugboat-1   4.7.0     true    tugboat-1-admin-kubeconfig

$ oc get nodepools -A
NAMESPACE   NAME        CLUSTER     NODECOUNT   AUTOSCALING
clusters    tugboat-1   tugboat-1   2           False
```

