### PR TITLE
Use InfraID as CAPI cluster name

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/render/types.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/types.go
@@ -9,6 +9,7 @@ func NewClusterParams() *ClusterParams {
 		"SupportPodPidsLimit=true",
 		"LocalStorageCapacityIsolation=false",
 		"RotateKubeletServerCertificate=true",
+		"LegacyNodeRoleBehavior=false",
 	}
 	p.ImageRegistryHTTPSecret = uuid.New().String()
 	return p

--- a/hypershift-operator/controllers/hostedcluster/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/hostedcluster/manifests/controlplaneoperator/manifests.go
@@ -281,7 +281,7 @@ func (o CAPICluster) Build() *capiv1.Cluster {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: o.Namespace.Name,
-			Name:      o.HostedCluster.GetName(),
+			Name:      o.HostedCluster.Spec.InfraID,
 			Annotations: map[string]string{
 				hostedClusterAnnotation: ctrlclient.ObjectKeyFromObject(o.HostedCluster).String(),
 			},

--- a/hypershift-operator/controllers/hostedcluster/manifests/manifests.go
+++ b/hypershift-operator/controllers/hostedcluster/manifests/manifests.go
@@ -1,6 +1,8 @@
 package manifests
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -137,7 +139,6 @@ func KubeConfigSecretName(hostedClusterNamespace string, hostedClusterName strin
 
 type KubeConfigSecret struct {
 	HostedCluster *hyperv1.HostedCluster
-	Data          []byte
 }
 
 func (o KubeConfigSecret) Build() *corev1.Secret {
@@ -152,7 +153,35 @@ func (o KubeConfigSecret) Build() *corev1.Secret {
 			Name:      name.Name,
 		},
 		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{"kubeconfig": o.Data},
+		Data: map[string][]byte{},
+	}
+	return secret
+}
+
+func CAPIKubeConfigSecretName(hc *hyperv1.HostedCluster) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: hc.Name,
+		Name:      fmt.Sprintf("%s-kubeconfig", hc.Spec.InfraID),
+	}
+}
+
+type CAPIKubeConfigSecret struct {
+	HostedCluster *hyperv1.HostedCluster
+}
+
+func (o CAPIKubeConfigSecret) Build() *corev1.Secret {
+	name := CAPIKubeConfigSecretName(o.HostedCluster)
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{},
 	}
 	return secret
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -355,7 +355,7 @@ func generateScalableResources(client ctrlclient.Client, ctx context.Context,
 			Namespace:   targetNamespace,
 			Annotations: annotations,
 			Labels: map[string]string{
-				capiv1.ClusterLabelName: nodePool.Spec.ClusterName,
+				capiv1.ClusterLabelName: infraName,
 			},
 		},
 		TypeMeta: metav1.TypeMeta{},
@@ -367,7 +367,7 @@ func generateScalableResources(client ctrlclient.Client, ctx context.Context,
 					MaxSurge:       &maxSurge,
 				},
 			},
-			ClusterName: nodePool.Spec.ClusterName,
+			ClusterName: infraName,
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					resourcesName: resourcesName,
@@ -377,7 +377,7 @@ func generateScalableResources(client ctrlclient.Client, ctx context.Context,
 				ObjectMeta: capiv1.ObjectMeta{
 					Labels: map[string]string{
 						resourcesName:           resourcesName,
-						capiv1.ClusterLabelName: nodePool.Spec.ClusterName,
+						capiv1.ClusterLabelName: infraName,
 					},
 					// TODO (alberto): drop/expose this annotation at the nodePool API
 					Annotations: map[string]string{


### PR DESCRIPTION
This makes it possible for machines to get a kubernetes cluster tag that
matches the rest of the infra for the cluster:
kubernetes.io/cluster/[infra-name]=owned

Renaming the CAPI cluster also required renaming the kubeconfig secret to access the cluster. Instead of having the control plane operator know about the CAPI requirements, it now creates a secret named `admin-kubeconfig` with a key of `kubeconfig`. The hosted cluster controller copies this secret to the appropriate name/key required by CAPI.