### PR TITLE
Hack logging to work where create infra is composed

### DIFF
--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -104,6 +104,10 @@ func (o *CreateInfraOptions) CreateInfra() (*CreateInfraOutput, error) {
 	if err = o.parseAdditionalTags(); err != nil {
 		return nil, err
 	}
+	// hack for where we compose command
+	if o.log == nil {
+		o.log = setupLogger()
+	}
 	result := &CreateInfraOutput{
 		InfraID:     o.InfraID,
 		ComputeCIDR: DefaultCIDRBlock,


### PR DESCRIPTION
Fixes nil pointer when calling `hypershift create cluster` where that command invokes create infra but is unable to pass a log.

We can find a cleaner solution for log passing later.