### PR TITLE
Remove HostedCluster SSH public key requirement

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -46,6 +46,5 @@
         $ bin/test-e2e -test.v -test.timeout 0 \
           --e2e.quick-start.aws-credentials-file /my/aws-credentials \
           --e2e.quick-start.pull-secret-file /my/pull-secret \
-          --e2e.quick-start.ssh-key-file /my/public-ssh-key \
           --e2e.quick-start.infra-json /tmp/infra.json
    ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The `hypershift` CLI tool comes with commands to help create an example hosted c
 - The `hypershift` CLI tool
 - The OpenShift `oc` CLI tool.
 - A valid pull secret file for the `quay.io/openshift-release-dev` repository
-- An SSH public key file for guest node access
 - An [AWS credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) with permissions to create infrastructure for the cluster
 
 Run the `hypershift` command to create an IAM instance profile for your workers:
@@ -76,7 +75,6 @@ Run the `hypershift` command to generate and install the example cluster:
 hypershift create cluster \
   --pull-secret /my/pull-secret \
   --aws-creds /my/aws-credentials \
-  --ssh-key /my/ssh-public-key \
   --infra-json /tmp/infra.json
 ```
 NOTE: The file specified in the `--infra-json` flag should be the same file you created with the `create infra aws` command above.

--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -18,13 +18,16 @@ type ExampleResources struct {
 }
 
 func (o *ExampleResources) AsObjects() []crclient.Object {
-	return []crclient.Object{
+	objects := []crclient.Object{
 		o.Namespace,
-		o.SSHKey,
 		o.PullSecret,
 		o.AWSCredentials,
 		o.Cluster,
 	}
+	if o.SSHKey != nil {
+		objects = append(objects, o.SSHKey)
+	}
+	return objects
 }
 
 type ExampleOptions struct {
@@ -90,18 +93,23 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		},
 	}
 
-	sshKeySecret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace.Name,
-			Name:      o.Name + "-ssh-key",
-		},
-		Data: map[string][]byte{
-			"id_rsa.pub": o.SSHKey,
-		},
+	var sshKeySecret *corev1.Secret
+	var sshKeyReference corev1.LocalObjectReference
+	if len(o.SSHKey) > 0 {
+		sshKeySecret = &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace.Name,
+				Name:      o.Name + "-ssh-key",
+			},
+			Data: map[string][]byte{
+				"id_rsa.pub": o.SSHKey,
+			},
+		}
+		sshKeyReference = corev1.LocalObjectReference{Name: sshKeySecret.Name}
 	}
 
 	cluster := &hyperv1.HostedCluster{
@@ -126,7 +134,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			InfraID:       o.InfraID,
 			PullSecret:    corev1.LocalObjectReference{Name: pullSecret.Name},
 			ProviderCreds: corev1.LocalObjectReference{Name: awsCredsSecret.Name},
-			SSHKey:        corev1.LocalObjectReference{Name: sshKeySecret.Name},
+			SSHKey:        sshKeyReference,
 			Platform: hyperv1.PlatformSpec{
 				AWS: &hyperv1.AWSPlatformSpec{
 					Region: o.AWS.Region,

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,7 +59,7 @@ func NewCreateCommand() *cobra.Command {
 		ReleaseImage:          releaseImage,
 		PullSecretFile:        "",
 		AWSCredentialsFile:    "",
-		SSHKeyFile:            filepath.Join(os.Getenv("HOME"), ".ssh", "id_rsa.pub"),
+		SSHKeyFile:            "",
 		NodePoolReplicas:      2,
 		Render:                false,
 		InfrastructureJSON:    "",
@@ -96,9 +95,13 @@ func NewCreateCommand() *cobra.Command {
 		if err != nil {
 			panic(err)
 		}
-		sshKey, err := ioutil.ReadFile(opts.SSHKeyFile)
-		if err != nil {
-			panic(err)
+		var sshKey []byte
+		if len(opts.SSHKeyFile) > 0 {
+			key, err := ioutil.ReadFile(opts.SSHKeyFile)
+			if err != nil {
+				panic(err)
+			}
+			sshKey = key
 		}
 		if len(opts.ReleaseImage) == 0 {
 			return fmt.Errorf("release-image flag is required if default can not be fetched")

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/99-worker-ssh.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/99-worker-ssh.yaml
@@ -11,6 +11,8 @@ spec:
     passwd:
       users:
       - name: core
+        {{ if .SSHKey }}
         sshAuthorizedKeys:
         - |-
           {{ .SSHKey }}
+        {{ end }}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -533,15 +533,20 @@ func (r *HostedControlPlaneReconciler) ensureControlPlane(ctx context.Context, h
 func (r *HostedControlPlaneReconciler) generateControlPlaneManifests(ctx context.Context, hcp *hyperv1.HostedControlPlane, infraStatus InfrastructureStatus, releaseImage *releaseinfo.ReleaseImage) (map[string][]byte, error) {
 	targetNamespace := hcp.GetName()
 
-	var sshKeySecret corev1.Secret
-	err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcp.Namespace, Name: hcp.Spec.SSHKey.Name}, &sshKeySecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get SSH key secret %s: %w", hcp.Spec.SSHKey.Name, err)
+	var sshKeyData []byte
+	if len(hcp.Spec.SSHKey.Name) > 0 {
+		var sshKeySecret corev1.Secret
+		err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcp.Namespace, Name: hcp.Spec.SSHKey.Name}, &sshKeySecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get SSH key secret %s: %w", hcp.Spec.SSHKey.Name, err)
+		}
+		data, hasSSHKeyData := sshKeySecret.Data["id_rsa.pub"]
+		if !hasSSHKeyData {
+			return nil, fmt.Errorf("SSH key secret secret %s is missing the id_rsa.pub key", hcp.Spec.SSHKey.Name)
+		}
+		sshKeyData = data
 	}
-	sshKeyData, hasSSHKeyData := sshKeySecret.Data["id_rsa.pub"]
-	if !hasSSHKeyData {
-		return nil, fmt.Errorf("SSH key secret secret %s is missing the id_rsa.pub key", hcp.Spec.SSHKey.Name)
-	}
+
 	baseDomain, err := clusterBaseDomain(r.Client, ctx, hcp.Name)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't determine cluster base domain  name: %w", err)

--- a/hypershift-operator/controllers/hostedcluster/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/hostedcluster/manifests/controlplaneoperator/manifests.go
@@ -338,9 +338,6 @@ func (o HostedControlPlane) Build() *hyperv1.HostedControlPlane {
 			PullSecret: corev1.LocalObjectReference{
 				Name: o.PullSecret.Name,
 			},
-			SSHKey: corev1.LocalObjectReference{
-				Name: o.SSHKey.Name,
-			},
 			ServiceCIDR:  o.HostedCluster.Spec.Networking.ServiceCIDR,
 			PodCIDR:      o.HostedCluster.Spec.Networking.PodCIDR,
 			MachineCIDR:  o.HostedCluster.Spec.Networking.MachineCIDR,
@@ -348,6 +345,11 @@ func (o HostedControlPlane) Build() *hyperv1.HostedControlPlane {
 			InfraID:      o.HostedCluster.Spec.InfraID,
 			Platform:     o.HostedCluster.Spec.Platform,
 		},
+	}
+	if o.SSHKey != nil {
+		hcp.Spec.SSHKey = corev1.LocalObjectReference{
+			Name: o.SSHKey.Name,
+		}
 	}
 	return hcp
 }


### PR DESCRIPTION
SSH public key isn't actually a requirement for creating a control plane or node
pools. Make the field optional to reduce the prerequisite list for users. In the
future we should consider removing SSH key from HostedControlPlane entirely as
this is probably a property of NodePool.