### PR TITLE
Add a `destroy cluster` command which can delete infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,56 +56,41 @@ The `hypershift` CLI tool comes with commands to help create an example hosted c
 
 Run the `hypershift` command to create an IAM instance profile for your workers:
 ```shell
-hypershift create iam aws --aws-creds /my/aws-credentials
+hypershift create iam aws --aws-creds ~/.aws/credentials
 ```
-NOTE: The default profile name is `hypershift-worker-profile`. To use a different name (for example, in a shared account), use the `--profile-name` flag. The worker instance profile only needs to be created once per account and you can reuse it as needed for your clusters.
+NOTE: The default profile name is `hypershift-worker-profile`. To use a different name 
+(for example, in a shared account), use the `--profile-name` flag. The worker instance
+profile only needs to be created once per account and you can reuse it as needed
+for your clusters.
 
-Run the `hypershift` command to create cloud infrastructure for your cluster:
-NOTE: Infrastructure for a cluster can be created once and reused. However it should only correspond to one cluster at a time.
-```shell
-hypershift create infra aws --aws-creds /my/aws-credentials --infra-id INFRA-ID --region us-east-2 --output-file /tmp/infra.json
-```
-For `INFRA-ID` use a short identifier for your cluster such as `mycluster-1234`. It should be unique in your AWS account.
-For region, the default region is `us-east-1`, specify a different region if desired.
-The output file will contain JSON with the details of your provisioned infrastructure.
-
-Run the `hypershift` command to generate and install the example cluster:
+Run the `hypershift` command to create a cluster named `example` in the `clusters`
+namespace, including the cloud infrastructure to support it.
 
 ```shell
 hypershift create cluster \
   --pull-secret /my/pull-secret \
-  --aws-creds /my/aws-credentials \
-  --infra-json /tmp/infra.json
+  --aws-creds ~/.aws/credentials
 ```
-NOTE: The file specified in the `--infra-json` flag should be the same file you created with the `create infra aws` command above.
-If you created an instance profile named something other than `hypershift-worker-profile`, you need to pass the profile name with the `--instance-profile` flag.
 
-Eventually the cluster's kubeconfig will become available and can be fetched and decoded locally:
+Eventually the cluster's kubeconfig will become available and can be printed to
+standard out using the `hypershift` CLI:
 
 ```shell
-oc get secret \
-  --template={{.data.kubeconfig}} \
+hypershift create kubeconfig
+```
+
+To delete the cluster and the infrastructure created earlier, run:
+
+```shell
+hypershift destroy cluster \
+  --aws-creds ~/.aws/credentials \
   --namespace clusters \
-  example-admin-kubeconfig | base64 --decode
+  --name example
 ```
 
-To delete the cluster, run:
-
+To destroy the IAM instance profile, run:
 ```shell
-oc delete --namespace clusters
-```
-
-NOTE: After deleting the cluster, you can use an existing `infra.json` to create a new cluster.
-
-To destroy your AWS infrastructure:
-```shell
-hypershift destroy infra aws --aws-creds /my/aws/credentials --infra-id INFRA-ID --region us-east-2
-```
-Specify the same INFRA-ID and region as your original `create infra` command.
-
-To destroy the IAM instance profile:
-```shell
-hypershift destroy iam aws --aws-creds /my/aws-credentials
+hypershift destroy iam aws --aws-creds ~/.aws/credentials
 ```
 
 ## How to add node pools to the example cluster

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,8 +8,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	hyperapi "github.com/openshift/hypershift/api"
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
@@ -20,6 +19,9 @@ import (
 	cr "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// NoopReconcile is just a default mutation function that does nothing.
+var NoopReconcile controllerutil.MutateFn = func() error { return nil }
 
 type Options struct {
 	Namespace             string
@@ -119,7 +121,7 @@ func NewCreateCommand() *cobra.Command {
 		}
 		if infra == nil {
 			infraID := opts.InfraID
-			if len(infraID) == 0 && infra == nil {
+			if len(infraID) == 0 {
 				infraID = generateID(opts.Name)
 			}
 			opt := awsinfra.CreateInfraOptions{
@@ -186,16 +188,12 @@ func apply(ctx context.Context, objects []crclient.Object) error {
 		return fmt.Errorf("failed to create kube client: %w", err)
 	}
 	for _, object := range objects {
-		var objectBytes bytes.Buffer
-		err := hyperapi.YamlSerializer.Encode(object, &objectBytes)
+		key := crclient.ObjectKeyFromObject(object)
+		_, err = controllerutil.CreateOrUpdate(ctx, client, object, NoopReconcile)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create object %q: %w", key, err)
 		}
-		err = client.Patch(ctx, object, crclient.RawPatch(types.ApplyPatchType, objectBytes.Bytes()), crclient.ForceOwnership, crclient.FieldOwner("hypershift"))
-		if err != nil {
-			return err
-		}
-		fmt.Printf("applied %s %s/%s\n", object.GetObjectKind().GroupVersionKind().Kind, object.GetNamespace(), object.GetName())
+		log.Info("applied resource", "key", key)
 	}
 	return nil
 }

--- a/cmd/cluster/destroy.go
+++ b/cmd/cluster/destroy.go
@@ -1,0 +1,122 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	hyperapi "github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	destroyFinalizer = "openshift.io/destroy-cluster"
+)
+
+type DestroyOptions struct {
+	Namespace          string
+	Name               string
+	AWSCredentialsFile string
+}
+
+func NewDestroyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster",
+		Short: "Destroys a HostedCluster and its associated infrastructure.",
+	}
+
+	opts := DestroyOptions{
+		Namespace:          "clusters",
+		Name:               "",
+		AWSCredentialsFile: "",
+	}
+
+	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A cluster namespace")
+	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A cluster name")
+	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
+
+	cmd.MarkFlagRequired("name")
+	cmd.MarkFlagRequired("aws-creds")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		return opts.destroy(ctx)
+	}
+
+	return cmd
+}
+
+func (o DestroyOptions) destroy(ctx context.Context) error {
+	c, err := crclient.New(ctrl.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	var hostedCluster hyperv1.HostedCluster
+	if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {
+		log.Info("hostedcluster not found")
+		return nil
+	}
+
+	controllerutil.AddFinalizer(&hostedCluster, destroyFinalizer)
+	if err := c.Update(ctx, &hostedCluster); err != nil {
+		return fmt.Errorf("failed to add finalizer, won't destroy: %w", err)
+	}
+
+	log.Info("deleting hostedcluster")
+	if err := c.Delete(ctx, &hostedCluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("WARNING: hostedcluster was finalized before infrastructure was deleted; resources may have been leaked")
+			return nil
+		} else {
+			return fmt.Errorf("failed to delete hostedcluster: %w", err)
+		}
+	}
+	err = wait.PollUntil(1*time.Second, func() (bool, error) {
+		if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {
+			log.Error(err, "failed to get hostedcluster")
+			return false, nil
+		}
+		done := len(hostedCluster.Finalizers) == 1 && hostedCluster.Finalizers[0] == destroyFinalizer
+		return done, nil
+	}, ctx.Done())
+	if err != nil {
+		return fmt.Errorf("error while waiting for hostedcluster to be deleted")
+	}
+
+	log.Info("destroying infrastructure", "infraID", hostedCluster.Spec.InfraID)
+	destroyInfraOpts := awsinfra.DestroyInfraOptions{
+		Region:             hostedCluster.Spec.Platform.AWS.Region,
+		InfraID:            hostedCluster.Spec.InfraID,
+		AWSCredentialsFile: o.AWSCredentialsFile,
+	}
+	destroyInfraOpts.Run(ctx)
+
+	controllerutil.RemoveFinalizer(&hostedCluster, destroyFinalizer)
+	if err := c.Update(ctx, &hostedCluster); err != nil {
+		return fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
+	log.Info("successfully destroyed cluster and infrastructure")
+	return nil
+}

--- a/cmd/cluster/log.go
+++ b/cmd/cluster/log.go
@@ -1,4 +1,4 @@
-package aws
+package cluster
 
 import (
 	"github.com/bombsimon/logrusr"

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -3,6 +3,7 @@ package create
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hypershift/cmd/cluster"
 	"github.com/openshift/hypershift/cmd/infra"
 )
 
@@ -14,6 +15,7 @@ func NewCommand() *cobra.Command {
 
 	cmd.AddCommand(infra.NewDestroyCommand())
 	cmd.AddCommand(infra.NewDestroyIAMCommand())
+	cmd.AddCommand(cluster.NewDestroyCommand())
 
 	return cmd
 }

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +21,6 @@ type CreateInfraOptions struct {
 	AdditionalTags     []string
 
 	additionalEC2Tags []*ec2.Tag
-	log               logr.Logger
 }
 
 type CreateInfraOutput struct {
@@ -52,7 +50,6 @@ func NewCreateCommand() *cobra.Command {
 
 	opts := CreateInfraOptions{
 		Region: "us-east-1",
-		log:    setupLogger(),
 	}
 
 	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Cluster ID with which to tag AWS resources (required)")
@@ -66,7 +63,7 @@ func NewCreateCommand() *cobra.Command {
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if err := opts.Run(); err != nil {
-			opts.log.Error(err, "Error")
+			log.Error(err, "Error")
 			os.Exit(1)
 		}
 	}
@@ -103,10 +100,6 @@ func (o *CreateInfraOptions) CreateInfra() (*CreateInfraOutput, error) {
 	var err error
 	if err = o.parseAdditionalTags(); err != nil {
 		return nil, err
-	}
-	// hack for where we compose command
-	if o.log == nil {
-		o.log = setupLogger()
 	}
 	result := &CreateInfraOutput{
 		InfraID:     o.InfraID,

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +16,6 @@ type CreateIAMOptions struct {
 	Region             string
 	AWSCredentialsFile string
 	ProfileName        string
-	log                logr.Logger
 }
 
 func NewCreateIAMCommand() *cobra.Command {
@@ -29,7 +27,6 @@ func NewCreateIAMCommand() *cobra.Command {
 	opts := CreateIAMOptions{
 		Region:      "us-east-1",
 		ProfileName: "hypershift-worker-profile",
-		log:         setupLogger(),
 	}
 
 	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
@@ -40,7 +37,7 @@ func NewCreateIAMCommand() *cobra.Command {
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if err := opts.CreateIAM(); err != nil {
-			opts.log.Error(err, "Error")
+			log.Error(err, "Error")
 			os.Exit(1)
 		}
 	}

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +14,6 @@ type DestroyIAMOptions struct {
 	Region             string
 	AWSCredentialsFile string
 	ProfileName        string
-	log                logr.Logger
 }
 
 func NewDestroyIAMCommand() *cobra.Command {
@@ -27,7 +25,6 @@ func NewDestroyIAMCommand() *cobra.Command {
 	opts := DestroyIAMOptions{
 		Region:      "us-east-1",
 		ProfileName: "hypershift-worker-profile",
-		log:         setupLogger(),
 	}
 
 	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
@@ -38,7 +35,7 @@ func NewDestroyIAMCommand() *cobra.Command {
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if err := opts.DestroyIAM(); err != nil {
-			opts.log.Error(err, "Error")
+			log.Error(err, "Error")
 			os.Exit(1)
 		}
 	}
@@ -69,7 +66,7 @@ func (o *DestroyIAMOptions) DestroyWorkerInstanceProfile(client iamiface.IAMAPI)
 			if err != nil {
 				return fmt.Errorf("cannot remove role %s from instance profile %s: %w", aws.StringValue(role.RoleName), o.ProfileName, err)
 			}
-			o.log.Info("Removed role from instance profile", "profile", o.ProfileName, "role", aws.StringValue(role.RoleName))
+			log.Info("Removed role from instance profile", "profile", o.ProfileName, "role", aws.StringValue(role.RoleName))
 		}
 		_, err := client.DeleteInstanceProfile(&iam.DeleteInstanceProfileInput{
 			InstanceProfileName: aws.String(o.ProfileName),
@@ -77,7 +74,7 @@ func (o *DestroyIAMOptions) DestroyWorkerInstanceProfile(client iamiface.IAMAPI)
 		if err != nil {
 			return fmt.Errorf("cannot delete instance profile %s: %w", o.ProfileName, err)
 		}
-		o.log.Info("Deleted instance profile", "profile", o.ProfileName)
+		log.Info("Deleted instance profile", "profile", o.ProfileName)
 	}
 	roleName := fmt.Sprintf("%s-role", o.ProfileName)
 	policyName := fmt.Sprintf("%s-policy", o.ProfileName)
@@ -98,7 +95,7 @@ func (o *DestroyIAMOptions) DestroyWorkerInstanceProfile(client iamiface.IAMAPI)
 			if err != nil {
 				return fmt.Errorf("cannot delete role policy %s from role %s: %w", policyName, roleName, err)
 			}
-			o.log.Info("Deleted role policy", "role", roleName, "policy", policyName)
+			log.Info("Deleted role policy", "role", roleName, "policy", policyName)
 		}
 		_, err = client.DeleteRole(&iam.DeleteRoleInput{
 			RoleName: aws.String(roleName),
@@ -106,7 +103,7 @@ func (o *DestroyIAMOptions) DestroyWorkerInstanceProfile(client iamiface.IAMAPI)
 		if err != nil {
 			return fmt.Errorf("cannot delete role %s: %w", roleName, err)
 		}
-		o.log.Info("Deleted role", "role", roleName)
+		log.Info("Deleted role", "role", roleName)
 	}
 	return nil
 }

--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -28,7 +28,7 @@ func (o *CreateInfraOptions) firstZone(client ec2iface.EC2API) (string, error) {
 
 	}
 	zone := aws.StringValue(result.AvailabilityZones[0].ZoneName)
-	o.log.Info("Using zone", "zone", zone)
+	log.Info("Using zone", "zone", zone)
 	return zone, nil
 }
 
@@ -47,9 +47,9 @@ func (o *CreateInfraOptions) createVPC(client ec2iface.EC2API) (string, error) {
 			return "", fmt.Errorf("failed to create VPC: %w", err)
 		}
 		vpcID = aws.StringValue(createResult.Vpc.VpcId)
-		o.log.Info("Created VPC", "id", vpcID)
+		log.Info("Created VPC", "id", vpcID)
 	} else {
-		o.log.Info("Found existing VPC", "id", vpcID)
+		log.Info("Found existing VPC", "id", vpcID)
 	}
 	_, err = client.ModifyVpcAttribute(&ec2.ModifyVpcAttributeInput{
 		VpcId:            aws.String(vpcID),
@@ -58,7 +58,7 @@ func (o *CreateInfraOptions) createVPC(client ec2iface.EC2API) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to modify VPC attributes: %w", err)
 	}
-	o.log.Info("Enabled DNS support on VPC", "id", vpcID)
+	log.Info("Enabled DNS support on VPC", "id", vpcID)
 	_, err = client.ModifyVpcAttribute(&ec2.ModifyVpcAttributeInput{
 		VpcId:              aws.String(vpcID),
 		EnableDnsHostnames: &ec2.AttributeBooleanValue{Value: aws.Bool(true)},
@@ -66,7 +66,7 @@ func (o *CreateInfraOptions) createVPC(client ec2iface.EC2API) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to modify VPC attributes: %w", err)
 	}
-	o.log.Info("Enabled DNS hostnames on VPC", "id", vpcID)
+	log.Info("Enabled DNS hostnames on VPC", "id", vpcID)
 	return vpcID, nil
 }
 
@@ -89,7 +89,7 @@ func (o *CreateInfraOptions) CreateVPCS3Endpoint(client ec2iface.EC2API, vpcID, 
 		return err
 	}
 	if len(existingEndpoint) > 0 {
-		o.log.Info("Found existing s3 VPC endpoint", "id", existingEndpoint)
+		log.Info("Found existing s3 VPC endpoint", "id", existingEndpoint)
 		return nil
 	}
 	result, err := client.CreateVpcEndpoint(&ec2.CreateVpcEndpointInput{
@@ -104,7 +104,7 @@ func (o *CreateInfraOptions) CreateVPCS3Endpoint(client ec2iface.EC2API, vpcID, 
 	if err != nil {
 		return fmt.Errorf("cannot create VPC S3 endpoint: %w", err)
 	}
-	o.log.Info("Created s3 VPC endpoint", "id", aws.StringValue(result.VpcEndpoint.VpcEndpointId))
+	log.Info("Created s3 VPC endpoint", "id", aws.StringValue(result.VpcEndpoint.VpcEndpointId))
 	return nil
 }
 
@@ -147,9 +147,9 @@ func (o *CreateInfraOptions) CreateDHCPOptions(client ec2iface.EC2API, vpcID str
 			return fmt.Errorf("cannot create dhcp-options: %w", err)
 		}
 		optID = aws.StringValue(result.DhcpOptions.DhcpOptionsId)
-		o.log.Info("Created DHCP options", "id", optID)
+		log.Info("Created DHCP options", "id", optID)
 	} else {
-		o.log.Info("Found existing DHCP options", "id", optID)
+		log.Info("Found existing DHCP options", "id", optID)
 	}
 	_, err = client.AssociateDhcpOptions(&ec2.AssociateDhcpOptionsInput{
 		DhcpOptionsId: aws.String(optID),
@@ -158,7 +158,7 @@ func (o *CreateInfraOptions) CreateDHCPOptions(client ec2iface.EC2API, vpcID str
 	if err != nil {
 		return fmt.Errorf("cannot associate dhcp-options to VPC: %w", err)
 	}
-	o.log.Info("Associated DHCP options with VPC", "vpc", vpcID, "dhcp options", optID)
+	log.Info("Associated DHCP options with VPC", "vpc", vpcID, "dhcp options", optID)
 	return nil
 }
 
@@ -189,7 +189,7 @@ func (o *CreateInfraOptions) CreateSubnet(client ec2iface.EC2API, vpcID, zone, c
 		return "", err
 	}
 	if len(subnetID) > 0 {
-		o.log.Info("Found existing subnet", "name", name, "id", subnetID)
+		log.Info("Found existing subnet", "name", name, "id", subnetID)
 		return subnetID, nil
 	}
 	result, err := client.CreateSubnet(&ec2.CreateSubnetInput{
@@ -202,7 +202,7 @@ func (o *CreateInfraOptions) CreateSubnet(client ec2iface.EC2API, vpcID, zone, c
 		return "", fmt.Errorf("cannot create public subnet: %w", err)
 	}
 	subnetID = aws.StringValue(result.Subnet.SubnetId)
-	o.log.Info("Created subnet", "name", name, "id", subnetID)
+	log.Info("Created subnet", "name", name, "id", subnetID)
 	return subnetID, nil
 }
 
@@ -233,9 +233,9 @@ func (o *CreateInfraOptions) CreateInternetGateway(client ec2iface.EC2API, vpcID
 			return "", fmt.Errorf("cannot create internet gateway: %w", err)
 		}
 		igw = result.InternetGateway
-		o.log.Info("Created internet gateway", "id", aws.StringValue(igw.InternetGatewayId))
+		log.Info("Created internet gateway", "id", aws.StringValue(igw.InternetGatewayId))
 	} else {
-		o.log.Info("Found existing internet gateway", "id", aws.StringValue(igw.InternetGatewayId))
+		log.Info("Found existing internet gateway", "id", aws.StringValue(igw.InternetGatewayId))
 	}
 	attached := false
 	for _, attachment := range igw.Attachments {
@@ -252,7 +252,7 @@ func (o *CreateInfraOptions) CreateInternetGateway(client ec2iface.EC2API, vpcID
 		if err != nil {
 			return "", fmt.Errorf("cannot attach internet gateway to vpc: %w", err)
 		}
-		o.log.Info("Attached internet gateway to VPC", "internet gateway", aws.StringValue(igw.InternetGatewayId), "vpc", vpcID)
+		log.Info("Attached internet gateway to VPC", "internet gateway", aws.StringValue(igw.InternetGatewayId), "vpc", vpcID)
 	}
 	return aws.StringValue(igw.InternetGatewayId), nil
 }
@@ -290,9 +290,9 @@ func (o *CreateInfraOptions) CreateNATGateway(client ec2iface.EC2API, publicSubn
 		if err != nil {
 			return "", fmt.Errorf("cannot tag NAT gateway EIP: %w", err)
 		}
-		o.log.Info("Created elastic IP for NAT gateway", "id", allocationID)
+		log.Info("Created elastic IP for NAT gateway", "id", allocationID)
 	} else {
-		o.log.Info("Found existing elastic IP for NAT gateway", "id", allocationID)
+		log.Info("Found existing elastic IP for NAT gateway", "id", allocationID)
 	}
 	natGatewayName := fmt.Sprintf("%s-nat-%s", o.InfraID, availabilityZone)
 	natGateway, err := o.existingNATGateway(client, natGatewayName)
@@ -306,9 +306,9 @@ func (o *CreateInfraOptions) CreateNATGateway(client ec2iface.EC2API, publicSubn
 			return "", fmt.Errorf("cannot create NAT gateway: %w", err)
 		}
 		natGateway = gatewayResult.NatGateway
-		o.log.Info("Created NAT gateway", "id", aws.StringValue(natGateway.NatGatewayId))
+		log.Info("Created NAT gateway", "id", aws.StringValue(natGateway.NatGatewayId))
 	} else {
-		o.log.Info("Found existing NAT gateway", "id", aws.StringValue(natGateway.NatGatewayId))
+		log.Info("Found existing NAT gateway", "id", aws.StringValue(natGateway.NatGatewayId))
 	}
 	natGatewayID := aws.StringValue(natGateway.NatGatewayId)
 	return natGatewayID, nil
@@ -378,9 +378,9 @@ func (o *CreateInfraOptions) CreatePrivateRouteTable(client ec2iface.EC2API, vpc
 		if err != nil {
 			return "", fmt.Errorf("cannot create nat gateway route in private route table: %w", err)
 		}
-		o.log.Info("Created route to NAT gateway", "route table", aws.StringValue(routeTable.RouteTableId), "nat gateway", natGatewayID)
+		log.Info("Created route to NAT gateway", "route table", aws.StringValue(routeTable.RouteTableId), "nat gateway", natGatewayID)
 	} else {
-		o.log.Info("Found existing route to NAT gateway", "route table", aws.StringValue(routeTable.RouteTableId), "nat gateway", natGatewayID)
+		log.Info("Found existing route to NAT gateway", "route table", aws.StringValue(routeTable.RouteTableId), "nat gateway", natGatewayID)
 	}
 	if !o.hasAssociatedSubnet(routeTable, subnetID) {
 		_, err = client.AssociateRouteTable(&ec2.AssociateRouteTableInput{
@@ -390,9 +390,9 @@ func (o *CreateInfraOptions) CreatePrivateRouteTable(client ec2iface.EC2API, vpc
 		if err != nil {
 			return "", fmt.Errorf("cannot associate private route table with subnet: %w", err)
 		}
-		o.log.Info("Associated subnet with route table", "route table", aws.StringValue(routeTable.RouteTableId), "subnet", subnetID)
+		log.Info("Associated subnet with route table", "route table", aws.StringValue(routeTable.RouteTableId), "subnet", subnetID)
 	} else {
-		o.log.Info("Subnet already associated with route table", "route table", aws.StringValue(routeTable.RouteTableId), "subnet", subnetID)
+		log.Info("Subnet already associated with route table", "route table", aws.StringValue(routeTable.RouteTableId), "subnet", subnetID)
 	}
 	return aws.StringValue(routeTable.RouteTableId), nil
 }
@@ -442,7 +442,7 @@ func (o *CreateInfraOptions) CreatePublicRouteTable(client ec2iface.EC2API, vpcI
 		if err != nil {
 			return "", fmt.Errorf("cannot set vpc main route table: %w", err)
 		}
-		o.log.Info("Set main VPC route table", "route table", tableID, "vpc", vpcID)
+		log.Info("Set main VPC route table", "route table", tableID, "vpc", vpcID)
 	}
 
 	// Create route to internet gateway
@@ -455,9 +455,9 @@ func (o *CreateInfraOptions) CreatePublicRouteTable(client ec2iface.EC2API, vpcI
 		if err != nil {
 			return "", fmt.Errorf("cannot create route to internet gateway: %w", err)
 		}
-		o.log.Info("Created route to internet gateway", "route table", tableID, "internet gateway", igwID)
+		log.Info("Created route to internet gateway", "route table", tableID, "internet gateway", igwID)
 	} else {
-		o.log.Info("Found existing route to internet gateway", "route table", tableID, "internet gateway", igwID)
+		log.Info("Found existing route to internet gateway", "route table", tableID, "internet gateway", igwID)
 	}
 
 	// Associate the route table with the public subnet ID
@@ -469,9 +469,9 @@ func (o *CreateInfraOptions) CreatePublicRouteTable(client ec2iface.EC2API, vpcI
 		if err != nil {
 			return "", fmt.Errorf("cannot associate private route table with subnet: %w", err)
 		}
-		o.log.Info("Associated route table with subnet", "route table", tableID, "subnet", subnetID)
+		log.Info("Associated route table with subnet", "route table", tableID, "subnet", subnetID)
 	} else {
-		o.log.Info("Found existing association between route table and subnet", "route table", tableID, "subnet", subnetID)
+		log.Info("Found existing association between route table and subnet", "route table", tableID, "subnet", subnetID)
 	}
 	return tableID, nil
 }
@@ -484,7 +484,7 @@ func (o *CreateInfraOptions) createRouteTable(client ec2iface.EC2API, vpcID, nam
 	if err != nil {
 		return nil, fmt.Errorf("cannot create route table: %w", err)
 	}
-	o.log.Info("Created route table", "name", name, "id", aws.StringValue(result.RouteTable.RouteTableId))
+	log.Info("Created route table", "name", name, "id", aws.StringValue(result.RouteTable.RouteTableId))
 	return result.RouteTable, nil
 }
 
@@ -494,7 +494,7 @@ func (o *CreateInfraOptions) existingRouteTable(client ec2iface.EC2API, name str
 		return nil, fmt.Errorf("cannot list route tables: %w", err)
 	}
 	if len(result.RouteTables) > 0 {
-		o.log.Info("Found existing route table", "name", name, "id", aws.StringValue(result.RouteTables[0].RouteTableId))
+		log.Info("Found existing route table", "name", name, "id", aws.StringValue(result.RouteTables[0].RouteTableId))
 		return result.RouteTables[0], nil
 	}
 	return nil, nil

--- a/cmd/infra/aws/ec2_sg.go
+++ b/cmd/infra/aws/ec2_sg.go
@@ -31,9 +31,9 @@ func (o *CreateInfraOptions) CreateWorkerSecurityGroup(client ec2iface.EC2API, v
 			return "", fmt.Errorf("cannot find security group after creation")
 		}
 		securityGroup = sgResult.SecurityGroups[0]
-		o.log.Info("Created security group", "name", groupName, "id", aws.StringValue(securityGroup.GroupId))
+		log.Info("Created security group", "name", groupName, "id", aws.StringValue(securityGroup.GroupId))
 	} else {
-		o.log.Info("Found existing security group", "name", groupName, "id", aws.StringValue(securityGroup.GroupId))
+		log.Info("Found existing security group", "name", groupName, "id", aws.StringValue(securityGroup.GroupId))
 	}
 	securityGroupID := aws.StringValue(securityGroup.GroupId)
 	sgUserID := aws.StringValue(securityGroup.OwnerId)
@@ -201,7 +201,7 @@ func (o *CreateInfraOptions) CreateWorkerSecurityGroup(client ec2iface.EC2API, v
 		if err != nil {
 			return "", fmt.Errorf("cannot apply security group egress permissions: %w", err)
 		}
-		o.log.Info("Authorized egress rules on security group", "id", securityGroupID)
+		log.Info("Authorized egress rules on security group", "id", securityGroupID)
 	}
 	if len(ingressToAuthorize) > 0 {
 		_, err = client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
@@ -211,7 +211,7 @@ func (o *CreateInfraOptions) CreateWorkerSecurityGroup(client ec2iface.EC2API, v
 		if err != nil {
 			return "", fmt.Errorf("cannot apply security group ingress permissions: %w", err)
 		}
-		o.log.Info("Authorized ingress rules on security group", "id", securityGroupID)
+		log.Info("Authorized ingress rules on security group", "id", securityGroupID)
 	}
 	return securityGroupID, nil
 }

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -52,9 +52,9 @@ func (o *CreateIAMOptions) CreateWorkerInstanceProfile(client iamiface.IAMAPI, p
 		if err != nil {
 			return fmt.Errorf("cannot create worker role: %w", err)
 		}
-		o.log.Info("Created role", "name", roleName)
+		log.Info("Created role", "name", roleName)
 	} else {
-		o.log.Info("Found existing role", "name", roleName)
+		log.Info("Found existing role", "name", roleName)
 	}
 	instanceProfile, err := existingInstanceProfile(client, profileName)
 	if err != nil {
@@ -69,9 +69,9 @@ func (o *CreateIAMOptions) CreateWorkerInstanceProfile(client iamiface.IAMAPI, p
 			return fmt.Errorf("cannot create instance profile: %w", err)
 		}
 		instanceProfile = result.InstanceProfile
-		o.log.Info("Created instance profile", "name", profileName)
+		log.Info("Created instance profile", "name", profileName)
 	} else {
-		o.log.Info("Found existing instance profile", "name", profileName)
+		log.Info("Found existing instance profile", "name", profileName)
 	}
 	hasRole := false
 	for _, role := range instanceProfile.Roles {
@@ -87,7 +87,7 @@ func (o *CreateIAMOptions) CreateWorkerInstanceProfile(client iamiface.IAMAPI, p
 		if err != nil {
 			return fmt.Errorf("cannot add role to instance profile: %w", err)
 		}
-		o.log.Info("Added role to instance profile", "role", roleName, "profile", profileName)
+		log.Info("Added role to instance profile", "role", roleName, "profile", profileName)
 	}
 	rolePolicyName := fmt.Sprintf("%s-policy", profileName)
 	hasPolicy, err := existingRolePolicy(client, roleName, rolePolicyName)
@@ -103,7 +103,7 @@ func (o *CreateIAMOptions) CreateWorkerInstanceProfile(client iamiface.IAMAPI, p
 		if err != nil {
 			return fmt.Errorf("cannot create profile policy: %w", err)
 		}
-		o.log.Info("Created role policy", "name", rolePolicyName)
+		log.Info("Created role policy", "name", rolePolicyName)
 	}
 	return nil
 }


### PR DESCRIPTION
The `create cluster` command can automatically create infrastructure. This commit adds
a `destroy cluster` command that knows how to delete the hostedcluster, wait for that
to finish, and then destroy the infrastructure.