### PR TITLE
Mirror control plane status onto HostedCluster version history

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -678,6 +678,7 @@ func computeClusterVersionStatus(clock Clock, hcluster *hyperv1.HostedCluster, h
 
 	// The rollout is complete, so update the current history entry
 	version.History[0].State = configv1.CompletedUpdate
+	version.History[0].Version = hcp.Status.Version
 
 	// If a new rollout is needed, update the desired version and prepend a new
 	// partial history entry to unblock rollouts.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -140,12 +140,12 @@ func TestComputeClusterVersionStatus(t *testing.T) {
 			},
 			ControlPlane: hyperv1.HostedControlPlane{
 				Spec:   hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
-				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a"},
+				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0"},
 			},
 			ExpectedStatus: hyperv1.ClusterVersionStatus{
 				Desired: hyperv1.Release{Image: "a"},
 				History: []configv1.UpdateHistory{
-					{Image: "a", State: configv1.CompletedUpdate, StartedTime: Now},
+					{Image: "a", Version: "1.0.0", State: configv1.CompletedUpdate, StartedTime: Now},
 				},
 			},
 		},
@@ -163,13 +163,13 @@ func TestComputeClusterVersionStatus(t *testing.T) {
 			},
 			ControlPlane: hyperv1.HostedControlPlane{
 				Spec:   hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
-				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a"},
+				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0"},
 			},
 			ExpectedStatus: hyperv1.ClusterVersionStatus{
 				Desired: hyperv1.Release{Image: "b"},
 				History: []configv1.UpdateHistory{
 					{Image: "b", State: configv1.PartialUpdate, StartedTime: Now},
-					{Image: "a", State: configv1.CompletedUpdate, StartedTime: Now},
+					{Image: "a", Version: "1.0.0", State: configv1.CompletedUpdate, StartedTime: Now},
 				},
 			},
 		},


### PR DESCRIPTION
Keep the HostedCluster's  version history's semantic version field
in sync with the HostedControlPlane.