### PR TITLE
Remove unused hostedcluster ready field

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -95,9 +95,6 @@ type HostedClusterStatus struct {
 	// +optional
 	Version *ClusterVersionStatus `json:"version,omitempty"`
 
-	// +optional
-	Ready bool `json:"ready,omitempty"`
-
 	// KubeConfig is a reference to the secret containing the default kubeconfig
 	// for the cluster.
 	// +optional
@@ -143,8 +140,8 @@ type ClusterVersionStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version.history[?(@.state==\"Completed\")].version",description="Version"
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Ready"
 // +kubebuilder:printcolumn:name="KubeConfig",type="string",JSONPath=".status.kubeconfig.name",description="KubeConfig Secret"
+// +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].status",description="Available"
 // HostedCluster is the Schema for the hostedclusters API
 type HostedCluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -24,13 +24,13 @@ spec:
       jsonPath: .status.version.history[?(@.state=="Completed")].version
       name: Version
       type: string
-    - description: Ready
-      jsonPath: .status.ready
-      name: Ready
-      type: string
     - description: KubeConfig Secret
       jsonPath: .status.kubeconfig.name
       name: KubeConfig
+      type: string
+    - description: Available
+      jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
       type: string
     name: v1alpha1
     schema:
@@ -268,8 +268,6 @@ spec:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-              ready:
-                type: boolean
               version:
                 description: Version is the status of the release version applied to the HostedCluster.
                 properties:


### PR DESCRIPTION
Remove the unused hostedcluster.status.ready field and clean up
printer column metadata.