### PR TITLE
Implement version history completion time

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -111,6 +111,10 @@ type HostedControlPlaneStatus struct {
 	// ReleaseImage is the release image applied to the hosted control plane.
 	ReleaseImage string `json:"releaseImage,omitempty"`
 
+	// lastReleaseImageTransitionTime is the time of the last update to the current
+	// releaseImage property.
+	LastReleaseImageTransitionTime metav1.Time `json:"lastReleaseImageTransitionTime"`
+
 	// KubeConfig is a reference to the secret containing the default kubeconfig
 	// for this control plane.
 	KubeConfig *KubeconfigSecretRef `json:"kubeConfig,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -509,6 +509,7 @@ func (in *HostedControlPlaneStatus) DeepCopyInto(out *HostedControlPlaneStatus) 
 		**out = **in
 	}
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
+	in.LastReleaseImageTransitionTime.DeepCopyInto(&out.LastReleaseImageTransitionTime)
 	if in.KubeConfig != nil {
 		in, out := &in.KubeConfig, &out.KubeConfig
 		*out = new(KubeconfigSecretRef)

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -257,6 +257,10 @@ spec:
                 - key
                 - name
                 type: object
+              lastReleaseImageTransitionTime:
+                description: lastReleaseImageTransitionTime is the time of the last update to the current releaseImage property.
+                format: date-time
+                type: string
               ready:
                 default: false
                 description: Ready denotes that the HostedControlPlane API Server is ready to receive requests
@@ -269,6 +273,7 @@ spec:
                 type: string
             required:
             - conditions
+            - lastReleaseImageTransitionTime
             - ready
             type: object
         type: object

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -679,6 +679,9 @@ func computeClusterVersionStatus(clock Clock, hcluster *hyperv1.HostedCluster, h
 	// The rollout is complete, so update the current history entry
 	version.History[0].State = configv1.CompletedUpdate
 	version.History[0].Version = hcp.Status.Version
+	if !hcp.Status.LastReleaseImageTransitionTime.IsZero() {
+		version.History[0].CompletionTime = hcp.Status.LastReleaseImageTransitionTime.DeepCopy()
+	}
 
 	// If a new rollout is needed, update the desired version and prepend a new
 	// partial history entry to unblock rollouts.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 var Now = metav1.NewTime(time.Now())
+var Later = metav1.NewTime(Now.Add(5 * time.Minute))
 
 type fixedClock struct{}
 
@@ -140,12 +141,12 @@ func TestComputeClusterVersionStatus(t *testing.T) {
 			},
 			ControlPlane: hyperv1.HostedControlPlane{
 				Spec:   hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
-				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0"},
+				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0", LastReleaseImageTransitionTime: Later},
 			},
 			ExpectedStatus: hyperv1.ClusterVersionStatus{
 				Desired: hyperv1.Release{Image: "a"},
 				History: []configv1.UpdateHistory{
-					{Image: "a", Version: "1.0.0", State: configv1.CompletedUpdate, StartedTime: Now},
+					{Image: "a", Version: "1.0.0", State: configv1.CompletedUpdate, StartedTime: Now, CompletionTime: &Later},
 				},
 			},
 		},
@@ -156,20 +157,20 @@ func TestComputeClusterVersionStatus(t *testing.T) {
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: hyperv1.Release{Image: "a"},
 						History: []configv1.UpdateHistory{
-							{Image: "a", State: configv1.CompletedUpdate, StartedTime: Now},
+							{Image: "a", State: configv1.CompletedUpdate, StartedTime: Now, CompletionTime: &Later},
 						},
 					},
 				},
 			},
 			ControlPlane: hyperv1.HostedControlPlane{
 				Spec:   hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
-				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0"},
+				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0", LastReleaseImageTransitionTime: Later},
 			},
 			ExpectedStatus: hyperv1.ClusterVersionStatus{
 				Desired: hyperv1.Release{Image: "b"},
 				History: []configv1.UpdateHistory{
 					{Image: "b", State: configv1.PartialUpdate, StartedTime: Now},
-					{Image: "a", Version: "1.0.0", State: configv1.CompletedUpdate, StartedTime: Now},
+					{Image: "a", Version: "1.0.0", State: configv1.CompletedUpdate, StartedTime: Now, CompletionTime: &Later},
 				},
 			},
 		},


### PR DESCRIPTION
This commit implements another missing piece of the HostedCluster version API to
track the completion time of rollouts. The HostedControlPlane is responsible for
tracking the transition time of its image rollouts and now reflects that on its
status using a new LastReleaseImageTransitionTime field. That transition time is
then mirrored to the HostedCluster during version the status calculation when
updating history entries.