### PR TITLE
Expand e2e to exercise CLI infrastructure workflow

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -34,17 +34,11 @@
 ### How to run the e2e tests
 
 1. Install HyperShift.
-2. Create IAM and Infra
-   ```shell
-   bin/hypershift create iam aws --aws-creds /my/aws-credentials
-   bin/hyperhisft create infra aws --aws-creds /my/aws-credentials --infra-id my-infra-id --output-file /tmp/infra.json
-   ```
 2. Run the tests.
 
    ```shell
         $ make e2e
         $ bin/test-e2e -test.v -test.timeout 0 \
-          --e2e.quick-start.aws-credentials-file /my/aws-credentials \
-          --e2e.quick-start.pull-secret-file /my/pull-secret \
-          --e2e.quick-start.infra-json /tmp/infra.json
+          --e2e.aws-credentials-file /my/aws-credentials \
+          --e2e.pull-secret-file /my/pull-secret
    ```

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
@@ -89,115 +91,111 @@ func NewCreateCommand() *cobra.Command {
 	cmd.MarkFlagRequired("aws-creds")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		pullSecret, err := ioutil.ReadFile(opts.PullSecretFile)
-		if err != nil {
-			panic(err)
-		}
-		awsCredentials, err := ioutil.ReadFile(opts.AWSCredentialsFile)
-		if err != nil {
-			panic(err)
-		}
-		var sshKey []byte
-		if len(opts.SSHKeyFile) > 0 {
-			key, err := ioutil.ReadFile(opts.SSHKeyFile)
-			if err != nil {
-				panic(err)
-			}
-			sshKey = key
-		}
-		if len(opts.ReleaseImage) == 0 {
-			return fmt.Errorf("release-image flag is required if default can not be fetched")
-		}
-		var infra *awsinfra.CreateInfraOutput
-		if len(opts.InfrastructureJSON) > 0 {
-			rawInfra, err := ioutil.ReadFile(opts.InfrastructureJSON)
-			if err != nil {
-				panic(err)
-			}
-			infra = &awsinfra.CreateInfraOutput{}
-			if err = json.Unmarshal(rawInfra, infra); err != nil {
-				panic(err)
-			}
-		}
-		if infra == nil {
-			infraID := opts.InfraID
-			if len(infraID) == 0 {
-				infraID = generateID(opts.Name)
-			}
-			opt := awsinfra.CreateInfraOptions{
-				Region:             opts.Region,
-				InfraID:            infraID,
-				AWSCredentialsFile: opts.AWSCredentialsFile,
-			}
-			infra, err = opt.CreateInfra()
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		exampleObjects := apifixtures.ExampleOptions{
-			Namespace:        opts.Namespace,
-			Name:             opts.Name,
-			ReleaseImage:     opts.ReleaseImage,
-			PullSecret:       pullSecret,
-			AWSCredentials:   awsCredentials,
-			SSHKey:           sshKey,
-			NodePoolReplicas: opts.NodePoolReplicas,
-			InfraID:          infra.InfraID,
-			ComputeCIDR:      infra.ComputeCIDR,
-			AWS: apifixtures.ExampleAWSOptions{
-				Region:          infra.Region,
-				Zone:            infra.Zone,
-				VPCID:           infra.VPCID,
-				SubnetID:        infra.PrivateSubnetID,
-				SecurityGroupID: infra.SecurityGroupID,
-				InstanceProfile: opts.WorkerInstanceProfile,
-				InstanceType:    opts.InstanceType,
-			},
-		}.Resources().AsObjects()
-
-		switch {
-		case opts.Render:
-			render(exampleObjects)
-		default:
-			err := apply(context.TODO(), exampleObjects)
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		return nil
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+		return CreateCluster(ctx, opts)
 	}
 
 	return cmd
 }
 
-func render(objects []crclient.Object) {
-	for _, object := range objects {
-		err := hyperapi.YamlSerializer.Encode(object, os.Stdout)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Println("---")
-	}
-}
-
-func apply(ctx context.Context, objects []crclient.Object) error {
-	client, err := crclient.New(cr.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
+func CreateCluster(ctx context.Context, opts Options) error {
+	pullSecret, err := ioutil.ReadFile(opts.PullSecretFile)
 	if err != nil {
-		return fmt.Errorf("failed to create kube client: %w", err)
+		return fmt.Errorf("failed to read pull secret file: %w", err)
 	}
-	for _, object := range objects {
-		key := crclient.ObjectKeyFromObject(object)
-		_, err = controllerutil.CreateOrUpdate(ctx, client, object, NoopReconcile)
+	awsCredentials, err := ioutil.ReadFile(opts.AWSCredentialsFile)
+	if err != nil {
+		return fmt.Errorf("failed to read aws credentials: %w", err)
+	}
+	var sshKey []byte
+	if len(opts.SSHKeyFile) > 0 {
+		key, err := ioutil.ReadFile(opts.SSHKeyFile)
 		if err != nil {
-			return fmt.Errorf("failed to create object %q: %w", key, err)
+			return fmt.Errorf("failed to read ssh key file: %w", err)
 		}
-		log.Info("applied resource", "key", key)
+		sshKey = key
 	}
-	return nil
-}
+	if len(opts.ReleaseImage) == 0 {
+		return fmt.Errorf("release-image flag is required if default can not be fetched")
+	}
+	var infra *awsinfra.CreateInfraOutput
+	if len(opts.InfrastructureJSON) > 0 {
+		rawInfra, err := ioutil.ReadFile(opts.InfrastructureJSON)
+		if err != nil {
+			return fmt.Errorf("failed to read infra json file: %w", err)
+		}
+		infra = &awsinfra.CreateInfraOutput{}
+		if err = json.Unmarshal(rawInfra, infra); err != nil {
+			return fmt.Errorf("failed to load infra json: %w", err)
+		}
+	}
+	if infra == nil {
+		infraID := opts.InfraID
+		if len(infraID) == 0 {
+			infraID = fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
+		}
+		opt := awsinfra.CreateInfraOptions{
+			Region:             opts.Region,
+			InfraID:            infraID,
+			AWSCredentialsFile: opts.AWSCredentialsFile,
+		}
+		infra, err = opt.CreateInfra()
+		if err != nil {
+			return fmt.Errorf("failed to create infra: %w", err)
+		}
+	}
 
-func generateID(name string) string {
-	return fmt.Sprintf("%s-%s", name, utilrand.String(5))
+	exampleObjects := apifixtures.ExampleOptions{
+		Namespace:        opts.Namespace,
+		Name:             opts.Name,
+		ReleaseImage:     opts.ReleaseImage,
+		PullSecret:       pullSecret,
+		AWSCredentials:   awsCredentials,
+		SSHKey:           sshKey,
+		NodePoolReplicas: opts.NodePoolReplicas,
+		InfraID:          infra.InfraID,
+		ComputeCIDR:      infra.ComputeCIDR,
+		AWS: apifixtures.ExampleAWSOptions{
+			Region:          infra.Region,
+			Zone:            infra.Zone,
+			VPCID:           infra.VPCID,
+			SubnetID:        infra.PrivateSubnetID,
+			SecurityGroupID: infra.SecurityGroupID,
+			InstanceProfile: opts.WorkerInstanceProfile,
+			InstanceType:    opts.InstanceType,
+		},
+	}.Resources().AsObjects()
+
+	switch {
+	case opts.Render:
+		for _, object := range exampleObjects {
+			err := hyperapi.YamlSerializer.Encode(object, os.Stdout)
+			if err != nil {
+				return fmt.Errorf("failed to encode objects: %w", err)
+			}
+			fmt.Println("---")
+		}
+	default:
+		client, err := crclient.New(cr.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
+		if err != nil {
+			return fmt.Errorf("failed to create kube client: %w", err)
+		}
+		for _, object := range exampleObjects {
+			key := crclient.ObjectKeyFromObject(object)
+			_, err = controllerutil.CreateOrUpdate(ctx, client, object, NoopReconcile)
+			if err != nil {
+				return fmt.Errorf("failed to create object %q: %w", key, err)
+			}
+			log.Info("applied resource", "key", key)
+		}
+		return nil
+	}
+
+	return nil
 }

--- a/cmd/cluster/destroy.go
+++ b/cmd/cluster/destroy.go
@@ -60,13 +60,13 @@ func NewDestroyCommand() *cobra.Command {
 			cancel()
 		}()
 
-		return opts.destroy(ctx)
+		return DestroyCluster(ctx, &opts)
 	}
 
 	return cmd
 }
 
-func (o DestroyOptions) destroy(ctx context.Context) error {
+func DestroyCluster(ctx context.Context, o *DestroyOptions) error {
 	c, err := crclient.New(ctrl.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
 	if err != nil {
 		return fmt.Errorf("failed to create kube client: %w", err)
@@ -74,7 +74,7 @@ func (o DestroyOptions) destroy(ctx context.Context) error {
 
 	var hostedCluster hyperv1.HostedCluster
 	if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {
-		log.Info("hostedcluster not found")
+		log.Info("hostedcluster not found, nothing to do", "namespace", o.Namespace, "name", o.Name)
 		return nil
 	}
 

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -97,6 +97,8 @@ func (o *CreateInfraOptions) Run() error {
 }
 
 func (o *CreateInfraOptions) CreateInfra() (*CreateInfraOutput, error) {
+	log.Info("Creating infrastructure", "id", o.InfraID)
+
 	var err error
 	if err = o.parseAdditionalTags(); err != nil {
 		return nil, err

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -4,326 +4,121 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
-	"flag"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/types"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/clientcmd"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperapi "github.com/openshift/hypershift/api"
-	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
+	cmdcluster "github.com/openshift/hypershift/cmd/cluster"
 )
 
 // ControlPlaneUpgradeOptions are the raw user input used to construct the test input.
 type ControlPlaneUpgradeOptions struct {
 	AWSCredentialsFile string
 	PullSecretFile     string
-	SSHKeyFile         string
-	InfraFile          string
-	InstanceProfile    string
 	FromReleaseImage   string
 	ToReleaseImage     string
 }
 
-var controlPlaneUpgradeOptions ControlPlaneUpgradeOptions
-
-func init() {
-	flag.StringVar(&controlPlaneUpgradeOptions.AWSCredentialsFile, "e2e.cp-upgrade.aws-credentials-file", "", "path to AWS credentials")
-	flag.StringVar(&controlPlaneUpgradeOptions.PullSecretFile, "e2e.cp-upgrade.pull-secret-file", "", "path to pull secret")
-	flag.StringVar(&controlPlaneUpgradeOptions.SSHKeyFile, "e2e.cp-upgrade.ssh-key-file", filepath.Join(os.Getenv("HOME"), ".ssh", "id_rsa.pub"), "path to SSH public key")
-	flag.StringVar(&controlPlaneUpgradeOptions.InfraFile, "e2e.cp-upgrade.infra-json", "", "File containing infra description")
-	flag.StringVar(&controlPlaneUpgradeOptions.InstanceProfile, "e2e.cp-upgrade.instance-profile", "hypershift-worker-profile", "Name of instance profile to use")
-	flag.StringVar(&controlPlaneUpgradeOptions.FromReleaseImage, "e2e.cp-upgrade.from-release-image", "", "OCP release image to test")
-	flag.StringVar(&controlPlaneUpgradeOptions.ToReleaseImage, "e2e.cp-upgrade.to-release-image", "", "OCP release image to upgrade to")
-}
-
-// ControlPlaneUpgradeInput are the validated options for running the test.
-type ControlPlaneUpgradeInput struct {
-	Client           crclient.Client
-	FromReleaseImage string
-	ToReleaseImage   string
-	AWSCredentials   []byte
-	PullSecret       []byte
-	SSHKey           []byte
-	Infra            awsinfra.CreateInfraOutput
-	InstanceProfile  string
-	InstanceType     string
-}
-
-// GetContext builds a QuickStartInput from the options.
-func (o ControlPlaneUpgradeOptions) GetInput() (*ControlPlaneUpgradeInput, error) {
-	pullSecret, err := ioutil.ReadFile(o.PullSecretFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read pull secret file %q: %w", o.PullSecretFile, err)
+func NewControlPlaneUpgradeOptions(globalOptions *GlobalTestOptions) ControlPlaneUpgradeOptions {
+	return ControlPlaneUpgradeOptions{
+		AWSCredentialsFile: globalOptions.AWSCredentialsFile,
+		PullSecretFile:     globalOptions.PullSecretFile,
+		FromReleaseImage:   globalOptions.PreviousReleaseImage,
+		ToReleaseImage:     globalOptions.LatestReleaseImage,
 	}
-	if len(pullSecret) == 0 {
-		return nil, fmt.Errorf("pull secret is required")
-	}
-
-	awsCredentials, err := ioutil.ReadFile(o.AWSCredentialsFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read aws credentials file %q: %w", o.AWSCredentialsFile, err)
-	}
-	if len(awsCredentials) == 0 {
-		return nil, fmt.Errorf("AWS credentials are required")
-	}
-
-	sshKey, err := ioutil.ReadFile(o.SSHKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read SSH key file %q: %w", o.SSHKeyFile, err)
-	}
-	if len(sshKey) == 0 {
-		return nil, fmt.Errorf("SSH key is required")
-	}
-
-	if len(o.FromReleaseImage) == 0 {
-		return nil, fmt.Errorf("release image is required")
-	}
-	if len(o.ToReleaseImage) == 0 {
-		return nil, fmt.Errorf("release image to upgrade to is required")
-	}
-
-	infraBytes, err := ioutil.ReadFile(o.InfraFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read infra file %q: %w", o.InfraFile, err)
-	}
-	infra := awsinfra.CreateInfraOutput{}
-	if err = json.Unmarshal(infraBytes, &infra); err != nil {
-		return nil, fmt.Errorf("could parse infra file %q: %w", o.InfraFile, err)
-	}
-
-	client, err := crclient.New(ctrl.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kube client: %w", err)
-	}
-
-	return &ControlPlaneUpgradeInput{
-		PullSecret:       pullSecret,
-		AWSCredentials:   awsCredentials,
-		SSHKey:           sshKey,
-		Infra:            infra,
-		InstanceProfile:  o.InstanceProfile,
-		FromReleaseImage: o.FromReleaseImage,
-		ToReleaseImage:   o.ToReleaseImage,
-		Client:           client,
-	}, nil
 }
 
 func TestControlPlaneUpgrade(t *testing.T) {
-	if os.Getenv("OPENSHIFT_CI") == "true" {
+	if GlobalOptions.IsRunningInCI {
 		t.Skipf("upgrade test is not yet enabled in CI")
 	}
-	if len(os.Getenv("UPGRADE_TEST")) == 0 {
-		t.Skipf("upgrade test is currently disabled by default, set UPGRADE_TEST=true to execute")
+	if !GlobalOptions.UpgradeTestsEnabled {
+		t.Skipf("upgrade tests aren't enabled")
 	}
 
 	ctx, cancel := context.WithCancel(GlobalTestContext)
 	defer cancel()
 
+	opts := NewControlPlaneUpgradeOptions(GlobalOptions)
+	t.Logf("Testing upgrade from %s to %s", opts.FromReleaseImage, opts.ToReleaseImage)
+
 	g := NewWithT(t)
 
-	input, err := controlPlaneUpgradeOptions.GetInput()
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create test context")
+	client, err := crclient.New(ctrl.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create kube client")
 
-	t.Logf("Testing upgrade from %s to %s", input.FromReleaseImage, input.ToReleaseImage)
+	// Create a namespace in which to place hostedclusters
+	namespace := GenerateNamespace(t, ctx, client, "e2e-clusters-")
 
-	client := input.Client
-
-	namespace := &corev1.Namespace{
+	// Define the cluster we'll be testing
+	hostedCluster := &hyperv1.HostedCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "e2e-",
-			Labels: map[string]string{
-				"hypershift-e2e-component": "hostedclusters-namespace",
-			},
+			Namespace: namespace.Name,
+			Name:      "example",
 		},
 	}
-	err = client.Create(ctx, namespace)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
-	g.Expect(namespace.Name).ToNot(BeEmpty(), "generated namespace has no name")
-
-	t.Logf("Created test namespace %s", namespace.Name)
 
 	// Clean up the namespace after the test
 	defer func() {
-		cleanupCtx := context.Background()
-		err := client.Delete(cleanupCtx, namespace, &crclient.DeleteOptions{})
-		g.Expect(err).NotTo(HaveOccurred(), "failed to delete test namespace")
-
-		t.Logf("Waiting for the test namespace %q to be deleted", namespace.Name)
-		err = wait.PollInfinite(1*time.Second, func() (done bool, err error) {
-			latestNamespace := &corev1.Namespace{}
-			key := crclient.ObjectKey{
-				Name: namespace.Name,
-			}
-			if err := client.Get(cleanupCtx, key, latestNamespace); err != nil {
-				if errors.IsNotFound(err) {
-					return true, nil
-				}
-				t.Logf("failed to get namespace %q: %s", latestNamespace.Name, err)
-				return false, nil
-			}
-			return false, nil
+		DestroyCluster(t, context.Background(), &cmdcluster.DestroyOptions{
+			Namespace:          hostedCluster.Namespace,
+			Name:               hostedCluster.Name,
+			AWSCredentialsFile: opts.AWSCredentialsFile,
 		})
-		g.Expect(err).NotTo(HaveOccurred(), "failed to clean up test namespace")
+		DeleteNamespace(t, context.Background(), client, namespace.Name)
 	}()
 
-	example := apifixtures.ExampleOptions{
-		Namespace:        namespace.Name,
-		Name:             "example-" + namespace.Name,
-		ReleaseImage:     input.FromReleaseImage,
-		PullSecret:       input.PullSecret,
-		AWSCredentials:   input.AWSCredentials,
-		SSHKey:           input.SSHKey,
-		InfraID:          input.Infra.InfraID,
-		ComputeCIDR:      input.Infra.ComputeCIDR,
-		NodePoolReplicas: 0,
-		AWS: apifixtures.ExampleAWSOptions{
-			Region:          input.Infra.Region,
-			Zone:            input.Infra.Zone,
-			VPCID:           input.Infra.VPCID,
-			SubnetID:        input.Infra.PrivateSubnetID,
-			SecurityGroupID: input.Infra.SecurityGroupID,
-			InstanceProfile: input.InstanceProfile,
-			InstanceType:    input.InstanceType,
-		},
-	}.Resources()
-
-	err = client.Create(ctx, example.PullSecret)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create pull secret")
-
-	t.Logf("Created test pull secret %s", example.PullSecret.Name)
-
-	err = client.Create(ctx, example.AWSCredentials)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create aws credentials secret")
-
-	t.Logf("Created test aws credentials secret %s", example.AWSCredentials.Name)
-
-	err = client.Create(ctx, example.SSHKey)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create ssh key secret")
-
-	t.Logf("Created test ssh key secret %s", example.SSHKey.Name)
-
-	err = client.Create(ctx, example.Cluster)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster resource")
-
-	t.Logf("Created test hostedcluster %s", example.Cluster.Name)
-
-	t.Logf("Waiting for guest kubeconfig to become available")
-	var guestKubeConfigSecret corev1.Secret
-	{
-		timeoutCtx, _ := context.WithTimeout(ctx, 5*time.Minute)
-		err := wait.PollUntil(1*time.Second, func() (done bool, err error) {
-			var currentCluster hyperv1.HostedCluster
-			err = client.Get(timeoutCtx, crclient.ObjectKeyFromObject(example.Cluster), &currentCluster)
-			if err != nil {
-				return false, nil
-			}
-			if currentCluster.Status.KubeConfig == nil {
-				return false, nil
-			}
-			key := crclient.ObjectKey{
-				Namespace: currentCluster.Namespace,
-				Name:      currentCluster.Status.KubeConfig.Name,
-			}
-			if err := client.Get(timeoutCtx, key, &guestKubeConfigSecret); err != nil {
-				return false, nil
-			}
-			return true, nil
-		}, timeoutCtx.Done())
-		g.Expect(err).NotTo(HaveOccurred(), "guest kubeconfig didn't become available")
+	// Create the cluster
+	createClusterOpts := cmdcluster.Options{
+		Namespace:          hostedCluster.Namespace,
+		Name:               hostedCluster.Name,
+		ReleaseImage:       opts.FromReleaseImage,
+		PullSecretFile:     opts.PullSecretFile,
+		AWSCredentialsFile: opts.AWSCredentialsFile,
+		// TODO: generate a key on the fly
+		SSHKeyFile:            "",
+		NodePoolReplicas:      0,
+		WorkerInstanceProfile: "hypershift-worker-profile",
+		Region:                "us-east-1",
+		InstanceType:          "m4.large",
 	}
+	err = cmdcluster.CreateCluster(ctx, createClusterOpts)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")
 
-	g.Expect(guestKubeConfigSecret.Data).To(HaveKey("kubeconfig"), "guest kubeconfig secret is missing kubeconfig key")
-	guestKubeConfigSecretData, _ := guestKubeConfigSecret.Data["kubeconfig"]
+	// Get the newly created cluster
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+	t.Logf("Created hostedcluster %s/%s", hostedCluster.Namespace, hostedCluster.Name)
 
-	guestRESTConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to build kube client from guest kubeconfig")
-
-	t.Logf("Establishing a connection to the guest apiserver")
-	var guestClient crclient.Client
-	{
-		timeoutCtx, _ := context.WithTimeout(ctx, 5*time.Minute)
-		err = wait.PollUntil(5*time.Second, func() (done bool, err error) {
-			kubeClient, err := crclient.New(guestRESTConfig, crclient.Options{Scheme: hyperapi.Scheme})
-			if err != nil {
-				return false, nil
-			}
-			guestClient = kubeClient
-			return true, nil
-		}, timeoutCtx.Done())
-		g.Expect(err).NotTo(HaveOccurred(), "failed to establish a connection to the guest apiserver")
-	}
-	g.Expect(guestClient).NotTo(BeNil(), "failed to create a guest client")
-
-	waitForImageRollout := func(ctx context.Context, clusterName types.NamespacedName, image string) (bool, error) {
-		var cluster hyperv1.HostedCluster
-		err = client.Get(ctx, clusterName, &cluster)
-		if err != nil {
-			t.Logf("error getting cluster: %s", err)
-			return false, nil
-		}
-
-		isAvailable := meta.IsStatusConditionPresentAndEqual(cluster.Status.Conditions, string(hyperv1.Available), metav1.ConditionTrue)
-
-		rolloutComplete := cluster.Status.Version != nil &&
-			cluster.Status.Version.Desired.Image == image &&
-			len(cluster.Status.Version.History) > 0 &&
-			cluster.Status.Version.History[0].Image == cluster.Status.Version.Desired.Image &&
-			cluster.Status.Version.History[0].State == configv1.CompletedUpdate
-
-		if isAvailable && rolloutComplete {
-			return true, nil
-		}
-		t.Logf("Waiting for cluster rollout (image=%s, isAvailable=%v, rolloutComplete=%v)", image, isAvailable, rolloutComplete)
-		return false, nil
-	}
+	// Wait for the cluster to be accessible
+	WaitForGuestClient(t, ctx, client, hostedCluster)
 
 	// Wait for the first rollout to be complete
-	t.Logf("Waiting for cluster rollout")
+	t.Logf("Waiting for initial cluster rollout")
 	{
 		timeoutCtx, _ := context.WithTimeout(ctx, 4*time.Minute)
-		err := wait.PollUntil(1*time.Second, func() (done bool, err error) {
-			return waitForImageRollout(timeoutCtx, crclient.ObjectKeyFromObject(example.Cluster), example.Cluster.Spec.Release.Image)
-		}, timeoutCtx.Done())
-		g.Expect(err).NotTo(HaveOccurred(), "timed out waiting for hostedcluster rollout")
+		WaitForImageRollout(t, timeoutCtx, client, hostedCluster, opts.FromReleaseImage)
 	}
 
 	// Update the cluster image
 	t.Logf("Updating cluster image")
-	var cluster hyperv1.HostedCluster
-	err = client.Get(ctx, crclient.ObjectKeyFromObject(example.Cluster), &cluster)
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
-	cluster.Spec.Release.Image = input.ToReleaseImage
-	err = client.Update(ctx, &cluster)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get update hostedcluster image")
+	hostedCluster.Spec.Release.Image = opts.ToReleaseImage
+	err = client.Update(ctx, hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
 
 	// Wait for the new rollout to be complete
-	t.Logf("Waiting for cluster rollout")
+	t.Logf("Waiting for updated cluster rollout")
 	{
 		timeoutCtx, _ := context.WithTimeout(ctx, 4*time.Minute)
-		err := wait.PollUntil(1*time.Second, func() (done bool, err error) {
-			return waitForImageRollout(timeoutCtx, crclient.ObjectKeyFromObject(&cluster), cluster.Spec.Release.Image)
-		}, timeoutCtx.Done())
-		g.Expect(err).NotTo(HaveOccurred(), "timed out waiting for updated hostedcluster rollout")
+		WaitForImageRollout(t, timeoutCtx, client, hostedCluster, opts.ToReleaseImage)
 	}
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -5,16 +5,71 @@ package e2e
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/hypershift/version"
 )
 
 // GlobalTestContext should be used as the parent context for any test code, and will
 // be cancelled if a SIGINT or SIGTERM is received.
 var GlobalTestContext context.Context
+
+type GlobalTestOptions struct {
+	AWSCredentialsFile   string
+	PullSecretFile       string
+	LatestReleaseImage   string
+	PreviousReleaseImage string
+	IsRunningInCI        bool
+	UpgradeTestsEnabled  bool
+}
+
+var GlobalOptions = &GlobalTestOptions{}
+
+func init() {
+	flag.StringVar(&GlobalOptions.AWSCredentialsFile, "e2e.aws-credentials-file", "", "path to AWS credentials")
+	flag.StringVar(&GlobalOptions.PullSecretFile, "e2e.pull-secret-file", "", "path to pull secret")
+	flag.StringVar(&GlobalOptions.LatestReleaseImage, "e2e.latest-release-image", "", "The latest OCP release image for use by tests")
+	flag.StringVar(&GlobalOptions.PreviousReleaseImage, "e2e.previous-release-image", "", "The previous OCP release image relative to the latest")
+}
+
+func (o *GlobalTestOptions) SetDefaults() error {
+	if len(o.LatestReleaseImage) == 0 {
+		defaultVersion, err := version.LookupDefaultOCPVersion()
+		if err != nil {
+			return fmt.Errorf("couldn't look up default OCP version: %w", err)
+		}
+		o.LatestReleaseImage = defaultVersion.PullSpec
+	}
+	// TODO: This is actually basically a required field right now. Maybe the input
+	// to tests should be a small API spec that describes the tests and their
+	// inputs to avoid having to make every test input required. Or extract
+	// e2e test suites into subcommands with their own distinct flags to make
+	// selectively running them easier?
+	if len(o.PreviousReleaseImage) == 0 {
+		o.PreviousReleaseImage = o.LatestReleaseImage
+	}
+
+	o.IsRunningInCI = os.Getenv("OPENSHIFT_CI") == "true"
+
+	return nil
+}
+
+func (o *GlobalTestOptions) Validate() error {
+	var errs []error
+
+	if len(o.LatestReleaseImage) == 0 {
+		errs = append(errs, fmt.Errorf("latest release image is required"))
+	}
+
+	return errors.NewAggregate(errs)
+}
 
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -27,6 +82,18 @@ func TestMain(m *testing.M) {
 		log.Printf("tests received shutdown signal and will be cancelled")
 		cancel()
 	}()
+
 	flag.Parse()
+
+	if err := GlobalOptions.SetDefaults(); err != nil {
+		log.Fatalf("failed to set up global test options: %s", err)
+	}
+
+	if err := GlobalOptions.Validate(); err != nil {
+		log.Fatalf("invalid global test options: %s", err)
+	}
+
+	log.Printf("Running e2e tests with global options: %#v", GlobalOptions)
+
 	os.Exit(m.Run())
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,0 +1,255 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperapi "github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	cmdcluster "github.com/openshift/hypershift/cmd/cluster"
+)
+
+func GenerateNamespace(t *testing.T, ctx context.Context, client crclient.Client, prefix string) *corev1.Namespace {
+	g := NewWithT(t)
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: prefix,
+			Labels: map[string]string{
+				"hypershift-e2e-component": "hostedclusters-namespace",
+			},
+		},
+	}
+	err := client.Create(ctx, namespace)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
+	g.Expect(namespace.Name).ToNot(BeEmpty(), "generated namespace has no name")
+	t.Logf("Created test namespace %s", namespace.Name)
+	return namespace
+}
+
+func DestroyCluster(t *testing.T, ctx context.Context, opts *cmdcluster.DestroyOptions) {
+	g := NewWithT(t)
+
+	t.Logf("Waiting for hostedcluster %s/%s to be destroyed", opts.Namespace, opts.Name)
+	err := wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+		err := cmdcluster.DestroyCluster(ctx, &cmdcluster.DestroyOptions{
+			Namespace:          opts.Namespace,
+			Name:               opts.Name,
+			AWSCredentialsFile: opts.AWSCredentialsFile,
+		})
+		if err != nil {
+			t.Logf("error destroying cluster, will retry: %s", err)
+			return false, nil
+		}
+		return true, nil
+	}, ctx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), "failed to destroy cluster")
+
+	t.Logf("Finished destroying hostedcluster %s/%s", opts.Namespace, opts.Name)
+}
+
+func DeleteNamespace(t *testing.T, ctx context.Context, client crclient.Client, namespace string) {
+	g := NewWithT(t)
+
+	t.Logf("Deleting namespace %s", namespace)
+	err := wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		err := client.Delete(ctx, ns, &crclient.DeleteOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			t.Logf("error deleting namespace %q, will retry: %s", namespace, err)
+			return false, nil
+		}
+		return true, nil
+	}, ctx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), "failed to delete namespace")
+
+	t.Logf("Waiting for namespace %q to be finalized", namespace)
+	err = wait.PollInfinite(1*time.Second, func() (done bool, err error) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		if err := client.Get(ctx, crclient.ObjectKeyFromObject(ns), ns); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			t.Logf("error getting namespace %q: %s", namespace, err)
+			return false, nil
+		}
+		return false, nil
+	})
+	g.Expect(err).NotTo(HaveOccurred(), "namespace was not finalized")
+
+	t.Logf("Finished deleting namespace %s", namespace)
+}
+
+func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) crclient.Client {
+	g := NewWithT(t)
+
+	t.Logf("Waiting for hostedcluster %s/%s kubeconfig to be published", hostedCluster.Namespace, hostedCluster.Name)
+	var guestKubeConfigSecret corev1.Secret
+	waitForKubeConfigCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	err := wait.PollUntil(1*time.Second, func() (done bool, err error) {
+		err = client.Get(waitForKubeConfigCtx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+		if err != nil {
+			return false, nil
+		}
+		if hostedCluster.Status.KubeConfig == nil {
+			return false, nil
+		}
+		key := crclient.ObjectKey{
+			Namespace: hostedCluster.Namespace,
+			Name:      hostedCluster.Status.KubeConfig.Name,
+		}
+		if err := client.Get(waitForKubeConfigCtx, key, &guestKubeConfigSecret); err != nil {
+			return false, nil
+		}
+		return true, nil
+	}, waitForKubeConfigCtx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), "guest kubeconfig didn't become available")
+
+	// TODO: this key should probably be published or an API constant
+	g.Expect(guestKubeConfigSecret.Data).To(HaveKey("kubeconfig"), "guest kubeconfig secret is missing kubeconfig key")
+	guestKubeConfigSecretData := guestKubeConfigSecret.Data["kubeconfig"]
+
+	guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
+	g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
+
+	t.Logf("Waiting for a successful connection to the guest apiserver")
+	var guestClient crclient.Client
+	waitForGuestClientCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	err = wait.PollUntil(5*time.Second, func() (done bool, err error) {
+		kubeClient, err := crclient.New(guestConfig, crclient.Options{Scheme: hyperapi.Scheme})
+		if err != nil {
+			return false, nil
+		}
+		guestClient = kubeClient
+		return true, nil
+	}, waitForGuestClientCtx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), "failed to establish a connection to the guest apiserver")
+
+	t.Logf("Successfully connected to the guest apiserver")
+	return guestClient
+}
+
+func WaitForReadyNodes(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+
+	t.Logf("Waiting for hostedcluster %s/%s nodes to become ready", hostedCluster.Namespace, hostedCluster.Name)
+	nodes := &corev1.NodeList{}
+	waitForNodesCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	err := wait.PollUntil(5*time.Second, func() (done bool, err error) {
+		err = client.List(waitForNodesCtx, nodes)
+		if err != nil {
+			return false, nil
+		}
+		if len(nodes.Items) == 0 {
+			return false, nil
+		}
+		var readyNodes []string
+		for _, node := range nodes.Items {
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+					readyNodes = append(readyNodes, node.Name)
+				}
+			}
+		}
+		if len(readyNodes) != hostedCluster.Spec.InitialComputeReplicas {
+			return false, nil
+		}
+		t.Logf("found %d ready nodes", len(nodes.Items))
+		return true, nil
+	}, waitForNodesCtx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), "failed to ensure guest nodes became ready")
+
+	t.Logf("All %d nodes for hostedcluster %s/%s appear to be ready", hostedCluster.Spec.InitialComputeReplicas, hostedCluster.Namespace, hostedCluster.Name)
+}
+
+func WaitForReadyClusterOperators(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+
+	t.Logf("Waiting for hostedcluster %s/%s operators to become ready", hostedCluster.Namespace, hostedCluster.Name)
+	clusterOperators := &configv1.ClusterOperatorList{}
+	waitForClusterOperatorsReadyCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	err := wait.PollUntil(10*time.Second, func() (done bool, err error) {
+		err = client.List(waitForClusterOperatorsReadyCtx, clusterOperators)
+		if err != nil {
+			t.Logf("failed to list cluster operators: %v", err)
+			return false, nil
+		}
+		if len(clusterOperators.Items) == 0 {
+			return false, nil
+		}
+		ready := true
+		for _, clusterOperator := range clusterOperators.Items {
+			available := false
+			degraded := true
+			for _, cond := range clusterOperator.Status.Conditions {
+				if cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionTrue {
+					available = true
+				}
+				if cond.Type == configv1.OperatorDegraded && cond.Status == configv1.ConditionFalse {
+					degraded = false
+				}
+			}
+			if !available || degraded {
+				ready = false
+				break
+			}
+		}
+		if !ready {
+			return false, nil
+		}
+		t.Logf("guest cluster operators are ready")
+		return true, nil
+	}, waitForClusterOperatorsReadyCtx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), "failed to ensure guest cluster operators became ready")
+
+	t.Logf("All cluster operators for hostedcluster %s/%s appear to be ready", hostedCluster.Namespace, hostedCluster.Name)
+}
+
+func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, image string) {
+	g := NewWithT(t)
+
+	t.Logf("Waiting for hostedcluster %s/%s to rollout image %s", hostedCluster.Namespace, hostedCluster.Name, image)
+	err := wait.PollUntil(1*time.Second, func() (done bool, err error) {
+		latest := hostedCluster.DeepCopy()
+		err = client.Get(ctx, crclient.ObjectKeyFromObject(latest), latest)
+		if err != nil {
+			t.Logf("error getting cluster: %s", err)
+			return false, nil
+		}
+
+		isAvailable := meta.IsStatusConditionPresentAndEqual(latest.Status.Conditions, string(hyperv1.Available), metav1.ConditionTrue)
+
+		rolloutComplete := latest.Status.Version != nil &&
+			latest.Status.Version.Desired.Image == image &&
+			len(latest.Status.Version.History) > 0 &&
+			latest.Status.Version.History[0].Image == latest.Status.Version.Desired.Image &&
+			latest.Status.Version.History[0].State == configv1.CompletedUpdate
+
+		if isAvailable && rolloutComplete {
+			return true, nil
+		}
+		t.Logf("Still waiting for hostedcluster rollout (image=%s, isAvailable=%v, rolloutComplete=%v)", image, isAvailable, rolloutComplete)
+		return false, nil
+	}, ctx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), "failed waiting for image rollout")
+
+	t.Logf("Observed hostedcluster %s/%s successfully rollout image %s", hostedCluster.Namespace, hostedCluster.Name, image)
+}

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -4,125 +4,30 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
-	"flag"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/clientcmd"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperapi "github.com/openshift/hypershift/api"
-	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
-	"github.com/openshift/hypershift/version"
-
-	configv1 "github.com/openshift/api/config/v1"
+	cmdcluster "github.com/openshift/hypershift/cmd/cluster"
 )
 
-// QuickStartOptions are the raw user input used to construct the test input.
 type QuickStartOptions struct {
 	AWSCredentialsFile string
 	PullSecretFile     string
-	SSHKeyFile         string
 	ReleaseImage       string
-	InfraFile          string
-	InstanceProfile    string
-	InstanceType       string
 }
 
-var quickStartOptions QuickStartOptions
-
-func init() {
-	flag.StringVar(&quickStartOptions.AWSCredentialsFile, "e2e.quick-start.aws-credentials-file", "", "path to AWS credentials")
-	flag.StringVar(&quickStartOptions.PullSecretFile, "e2e.quick-start.pull-secret-file", "", "path to pull secret")
-	flag.StringVar(&quickStartOptions.SSHKeyFile, "e2e.quick-start.ssh-key-file", filepath.Join(os.Getenv("HOME"), ".ssh", "id_rsa.pub"), "path to SSH public key")
-	flag.StringVar(&quickStartOptions.ReleaseImage, "e2e.quick-start.release-image", "", "OCP release image to test")
-	flag.StringVar(&quickStartOptions.InfraFile, "e2e.quick-start.infra-json", "", "File containing infra description")
-	flag.StringVar(&quickStartOptions.InstanceProfile, "e2e.quick-start.instance-profile", "hypershift-worker-profile", "Name of instance profile to use")
-	flag.StringVar(&quickStartOptions.InstanceType, "e2e.quick-start.instance-type", "m4.large", "Instance type to use in tests")
-}
-
-// QuickStartInput are the validated options for running the test.
-type QuickStartInput struct {
-	Client          crclient.Client
-	ReleaseImage    string
-	AWSCredentials  []byte
-	PullSecret      []byte
-	SSHKey          []byte
-	Infra           awsinfra.CreateInfraOutput
-	InstanceProfile string
-	InstanceType    string
-}
-
-// GetContext builds a QuickStartInput from the options.
-func (o QuickStartOptions) GetInput() (*QuickStartInput, error) {
-	input := &QuickStartInput{}
-
-	var err error
-	input.PullSecret, err = ioutil.ReadFile(o.PullSecretFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read pull secret file %q: %w", o.PullSecretFile, err)
+func NewQuickStartOptions(globalOptions *GlobalTestOptions) QuickStartOptions {
+	return QuickStartOptions{
+		AWSCredentialsFile: globalOptions.AWSCredentialsFile,
+		PullSecretFile:     globalOptions.PullSecretFile,
+		ReleaseImage:       globalOptions.LatestReleaseImage,
 	}
-	if len(input.PullSecret) == 0 {
-		return nil, fmt.Errorf("pull secret is required")
-	}
-
-	input.AWSCredentials, err = ioutil.ReadFile(o.AWSCredentialsFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read aws credentials file %q: %w", o.AWSCredentialsFile, err)
-	}
-	if len(input.AWSCredentials) == 0 {
-		return nil, fmt.Errorf("AWS credentials are required")
-	}
-
-	input.SSHKey, err = ioutil.ReadFile(o.SSHKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read SSH key file %q: %w", o.SSHKeyFile, err)
-	}
-	if len(input.SSHKey) == 0 {
-		return nil, fmt.Errorf("SSH key is required")
-	}
-
-	infraBytes, err := ioutil.ReadFile(o.InfraFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read infra file %q: %w", o.InfraFile, err)
-	}
-	if err = json.Unmarshal(infraBytes, &input.Infra); err != nil {
-		return nil, fmt.Errorf("could parse infra file %q: %w", o.InfraFile, err)
-	}
-
-	if len(o.ReleaseImage) == 0 {
-		defaultVersion, err := version.LookupDefaultOCPVersion()
-		if err != nil {
-			return nil, fmt.Errorf("couldn't look up default OCP version: %w", err)
-		}
-		input.ReleaseImage = defaultVersion.PullSpec
-	}
-	if len(input.ReleaseImage) == 0 {
-		return nil, fmt.Errorf("release image is required")
-	}
-
-	input.Client, err = crclient.New(ctrl.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kube client: %w", err)
-	}
-
-	input.InstanceProfile = o.InstanceProfile
-	input.InstanceType = o.InstanceType
-
-	return input, nil
 }
 
 // TestQuickStart implements a test that mimics the operation described in the
@@ -134,218 +39,61 @@ func TestQuickStart(t *testing.T) {
 	ctx, cancel := context.WithCancel(GlobalTestContext)
 	defer cancel()
 
-	input, err := quickStartOptions.GetInput()
-	if err != nil {
-		t.Fatalf("failed to create test context: %s", err)
-	}
+	opts := NewQuickStartOptions(GlobalOptions)
+	t.Logf("Testing OCP release image %s", opts.ReleaseImage)
 
-	t.Logf("Testing OCP release image %s", input.ReleaseImage)
+	g := NewWithT(t)
 
-	namespace := &corev1.Namespace{
+	client, err := crclient.New(ctrl.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create kube client")
+
+	// Create a namespace in which to place hostedclusters
+	namespace := GenerateNamespace(t, ctx, client, "e2e-clusters-")
+
+	// Define the cluster we'll be testing
+	hostedCluster := &hyperv1.HostedCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "e2e-",
+			Namespace: namespace.Name,
+			Name:      "example",
 		},
 	}
-	err = input.Client.Create(ctx, namespace)
-	if err != nil {
-		t.Fatalf("failed to create namespace: %s", err)
-	}
-	if len(namespace.Name) == 0 {
-		t.Fatalf("generated namespace has no name")
-	}
-	t.Logf("Created test namespace %s", namespace.Name)
 
-	// Clean up the namespace after the test
+	// Ensure we clean up after the test
 	defer func() {
-		cleanupCtx := context.Background()
-		err := input.Client.Delete(cleanupCtx, namespace, &crclient.DeleteOptions{})
-		if err != nil {
-			t.Fatalf("failed to delete namespace %q: %s", namespace.Name, err)
-		}
-		t.Logf("Waiting for the test namespace %q to be deleted", namespace.Name)
-		err = wait.PollInfinite(1*time.Second, func() (done bool, err error) {
-			latestNamespace := &corev1.Namespace{}
-			key := crclient.ObjectKey{
-				Name: namespace.Name,
-			}
-			if err := input.Client.Get(cleanupCtx, key, latestNamespace); err != nil {
-				if errors.IsNotFound(err) {
-					return true, nil
-				}
-				t.Logf("failed to get namespace %q: %s", latestNamespace.Name, err)
-				return false, nil
-			}
-			return false, nil
+		DestroyCluster(t, context.Background(), &cmdcluster.DestroyOptions{
+			Namespace:          hostedCluster.Namespace,
+			Name:               hostedCluster.Name,
+			AWSCredentialsFile: opts.AWSCredentialsFile,
 		})
-		if err != nil {
-			t.Fatalf("failed to clean up namespace %q: %s", namespace.Name, err)
-		}
+		DeleteNamespace(t, context.Background(), client, namespace.Name)
 	}()
 
-	example := apifixtures.ExampleOptions{
-		Namespace:        namespace.Name,
-		Name:             "example-" + namespace.Name,
-		ReleaseImage:     input.ReleaseImage,
-		PullSecret:       input.PullSecret,
-		AWSCredentials:   input.AWSCredentials,
-		SSHKey:           input.SSHKey,
-		NodePoolReplicas: 2,
-		InfraID:          input.Infra.InfraID,
-		ComputeCIDR:      input.Infra.ComputeCIDR,
-		AWS: apifixtures.ExampleAWSOptions{
-			Region:          input.Infra.Region,
-			Zone:            input.Infra.Zone,
-			VPCID:           input.Infra.VPCID,
-			SubnetID:        input.Infra.PrivateSubnetID,
-			SecurityGroupID: input.Infra.SecurityGroupID,
-			InstanceProfile: input.InstanceProfile,
-			InstanceType:    input.InstanceType,
-		},
-	}.Resources()
-
-	err = input.Client.Create(ctx, example.PullSecret)
-	if err != nil {
-		t.Fatalf("couldn't create pull secret: %s", err)
+	// Create the cluster
+	createClusterOpts := cmdcluster.Options{
+		Namespace:          hostedCluster.Namespace,
+		Name:               hostedCluster.Name,
+		ReleaseImage:       opts.ReleaseImage,
+		PullSecretFile:     opts.PullSecretFile,
+		AWSCredentialsFile: opts.AWSCredentialsFile,
+		// TODO: generate a key on the fly
+		SSHKeyFile:            "",
+		NodePoolReplicas:      2,
+		WorkerInstanceProfile: "hypershift-worker-profile",
+		Region:                "us-east-1",
+		InstanceType:          "m4.large",
 	}
-	t.Logf("Created test pull secret %s", example.PullSecret.Name)
+	err = cmdcluster.CreateCluster(ctx, createClusterOpts)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")
 
-	err = input.Client.Create(ctx, example.AWSCredentials)
-	if err != nil {
-		t.Fatalf("couldn't create aws credentials secret: %s", err)
-	}
-	t.Logf("Created test aws credentials secret %s", example.AWSCredentials.Name)
-
-	err = input.Client.Create(ctx, example.SSHKey)
-	if err != nil {
-		t.Fatalf("couldn't create ssh key secret: %s", err)
-	}
-	t.Logf("Created test ssh key secret %s", example.SSHKey.Name)
-
-	err = input.Client.Create(ctx, example.Cluster)
-	if err != nil {
-		t.Fatalf("couldn't create cluster: %s", err)
-	}
-	t.Logf("Created test hostedcluster %s", example.Cluster.Name)
+	// Get the newly created cluster
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+	t.Logf("Created hostedcluster %s/%s", hostedCluster.Namespace, hostedCluster.Name)
 
 	// Perform some very basic assertions about the guest cluster
-	t.Logf("Ensuring the guest cluster exposes a valid kubeconfig")
+	guestClient := WaitForGuestClient(t, ctx, client, hostedCluster)
 
-	t.Logf("Waiting for guest kubeconfig to become available")
+	WaitForReadyNodes(t, ctx, guestClient, hostedCluster)
 
-	var guestKubeConfigSecret corev1.Secret
-	waitForKubeConfigCtx, _ := context.WithTimeout(ctx, 5*time.Minute)
-	err = wait.PollUntil(1*time.Second, func() (done bool, err error) {
-		var currentCluster hyperv1.HostedCluster
-		err = input.Client.Get(waitForKubeConfigCtx, crclient.ObjectKeyFromObject(example.Cluster), &currentCluster)
-		if err != nil {
-			return false, nil
-		}
-		if currentCluster.Status.KubeConfig == nil {
-			return false, nil
-		}
-		key := crclient.ObjectKey{
-			Namespace: currentCluster.Namespace,
-			Name:      currentCluster.Status.KubeConfig.Name,
-		}
-		if err := input.Client.Get(waitForKubeConfigCtx, key, &guestKubeConfigSecret); err != nil {
-			return false, nil
-		}
-		return true, nil
-	}, waitForKubeConfigCtx.Done())
-	if err != nil {
-		t.Fatalf("guest kubeconfig didn't become available")
-	}
-
-	// TODO: this key should probably be published or an API constant
-	guestKubeConfigSecretData, hasData := guestKubeConfigSecret.Data["kubeconfig"]
-	if !hasData {
-		t.Fatalf("guest kubeconfig secret is missing kubeconfig key")
-	}
-
-	guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
-	if err != nil {
-		t.Fatalf("couldn't load guest kubeconfig: %s", err)
-	}
-
-	t.Logf("Establishing a connection to the guest apiserver")
-	var guestClient crclient.Client
-	waitForGuestClientCtx, _ := context.WithTimeout(ctx, 5*time.Minute)
-	err = wait.PollUntil(5*time.Second, func() (done bool, err error) {
-		kubeClient, err := crclient.New(guestConfig, crclient.Options{Scheme: hyperapi.Scheme})
-		if err != nil {
-			return false, nil
-		}
-		guestClient = kubeClient
-		return true, nil
-	}, waitForGuestClientCtx.Done())
-	if err != nil {
-		t.Fatalf("failed to establish a connection to the guest apiserver: %s", err)
-	}
-
-	t.Logf("Ensuring guest nodes become ready")
-	nodes := &corev1.NodeList{}
-	waitForNodesCtx, _ := context.WithTimeout(ctx, 10*time.Minute)
-	err = wait.PollUntil(5*time.Second, func() (done bool, err error) {
-		err = guestClient.List(waitForNodesCtx, nodes)
-		if err != nil {
-			return false, nil
-		}
-		if len(nodes.Items) == 0 {
-			return false, nil
-		}
-		var readyNodes []string
-		for _, node := range nodes.Items {
-			for _, cond := range node.Status.Conditions {
-				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-					readyNodes = append(readyNodes, node.Name)
-				}
-			}
-		}
-		if len(readyNodes) != example.Cluster.Spec.InitialComputeReplicas {
-			return false, nil
-		}
-		t.Logf("found %d ready nodes", len(nodes.Items))
-		return true, nil
-	}, waitForNodesCtx.Done())
-	if err != nil {
-		t.Fatalf("failed to ensure guest nodes became ready: %s", err)
-	}
-
-	clusterOperators := &configv1.ClusterOperatorList{}
-	waitForClusterOperatorsReadyCtx, _ := context.WithTimeout(ctx, 10*time.Minute)
-	err = wait.PollUntil(10*time.Second, func() (done bool, err error) {
-		err = guestClient.List(waitForClusterOperatorsReadyCtx, clusterOperators)
-		if err != nil {
-			t.Logf("failed to list cluster operators: %v", err)
-			return false, nil
-		}
-		if len(clusterOperators.Items) == 0 {
-			return false, nil
-		}
-		ready := true
-		for _, clusterOperator := range clusterOperators.Items {
-			available := false
-			degraded := true
-			for _, cond := range clusterOperator.Status.Conditions {
-				if cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionTrue {
-					available = true
-				}
-				if cond.Type == configv1.OperatorDegraded && cond.Status == configv1.ConditionFalse {
-					degraded = false
-				}
-			}
-			if !available || degraded {
-				ready = false
-				break
-			}
-		}
-		if !ready {
-			return false, nil
-		}
-		t.Logf("guest cluster operators are ready")
-		return true, nil
-	}, waitForClusterOperatorsReadyCtx.Done())
-	if err != nil {
-		t.Fatalf("failed to ensure guest cluster operators became ready: %v", err)
-	}
+	WaitForReadyClusterOperators(t, ctx, guestClient, hostedCluster)
 }


### PR DESCRIPTION
This commit expands the e2e coverage by incorporating the CLI workflows for
creating and destroying infrastructure for a cluster. This will provide
meaningful coverage for the documented workflows as well as make the tests
function totally independently, allowing for test clusters that don't share
infrastructure.
