### PR TITLE
Make create cluster generate IAM by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,25 +36,10 @@ Install HyperShift into the management cluster:
 hypershift install
 ```
 
-Create an IAM instance profile for your workers:
-```shell
-hypershift create iam aws --aws-creds ~/.aws/credentials
-```
-NOTE: The default profile name is `hypershift-worker-profile`. To use a different name 
-(for example, in a shared account), use the `--profile-name` flag and then refer
-to that profile using the `--instance-profile` argument to the the `create cluster`
-command when creating clusters. The worker instance profile only needs to be created
-once per account and you can reuse it as needed for your clusters.
-
 To uninstall HyperShift, run:
 
 ```shell
 hypershift install --render | oc delete -f -
-```
-
-To destroy the IAM instance profile, run:
-```shell
-hypershift destroy iam aws --aws-creds ~/.aws/credentials
 ```
 
 ## How to create a hosted cluster

--- a/cmd/cluster/destroy.go
+++ b/cmd/cluster/destroy.go
@@ -30,6 +30,7 @@ type DestroyOptions struct {
 	Namespace          string
 	Name               string
 	AWSCredentialsFile string
+	PreserveIAM        bool
 }
 
 func NewDestroyCommand() *cobra.Command {
@@ -42,11 +43,13 @@ func NewDestroyCommand() *cobra.Command {
 		Namespace:          "clusters",
 		Name:               "",
 		AWSCredentialsFile: "",
+		PreserveIAM:        false,
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A cluster namespace")
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A cluster name")
 	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
+	cmd.Flags().BoolVar(&opts.PreserveIAM, "preserve-iam", opts.PreserveIAM, "If true, skip deleting IAM. Otherwise destroy any default generated IAM along with other infra.")
 
 	cmd.MarkFlagRequired("name")
 	cmd.MarkFlagRequired("aws-creds")
@@ -111,6 +114,19 @@ func DestroyCluster(ctx context.Context, o *DestroyOptions) error {
 		AWSCredentialsFile: o.AWSCredentialsFile,
 	}
 	destroyInfraOpts.Run(ctx)
+
+	if !o.PreserveIAM {
+		log.Info("destroying IAM")
+		destroyOpts := awsinfra.DestroyIAMOptions{
+			Region:             hostedCluster.Spec.Platform.AWS.Region,
+			AWSCredentialsFile: o.AWSCredentialsFile,
+			ProfileName:        awsinfra.DefaultIAMName(hostedCluster.Spec.InfraID),
+		}
+		err := destroyOpts.DestroyIAM()
+		if err != nil {
+			return fmt.Errorf("failed to destroy IAM: %w", err)
+		}
+	}
 
 	controllerutil.RemoveFinalizer(&hostedCluster, destroyFinalizer)
 	if err := c.Update(ctx, &hostedCluster); err != nil {

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -25,8 +25,9 @@ func NewCreateIAMCommand() *cobra.Command {
 	}
 
 	opts := CreateIAMOptions{
-		Region:      "us-east-1",
-		ProfileName: "hypershift-worker-profile",
+		Region:             "us-east-1",
+		AWSCredentialsFile: "",
+		ProfileName:        "",
 	}
 
 	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
@@ -34,6 +35,7 @@ func NewCreateIAMCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "Region where cluster infra should be created")
 
 	cmd.MarkFlagRequired("aws-creds")
+	cmd.MarkFlagRequired("profile-name")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if err := opts.CreateIAM(); err != nil {
@@ -51,7 +53,12 @@ func (o *CreateIAMOptions) CreateIAM() error {
 	if err != nil {
 		return err
 	}
-	return o.CreateWorkerInstanceProfile(client, o.ProfileName)
+	err = o.CreateWorkerInstanceProfile(client, o.ProfileName)
+	if err != nil {
+		return err
+	}
+	log.Info("Created IAM profile", "name", o.ProfileName, "region", o.Region)
+	return nil
 }
 
 func IAMClient(creds, region string) (iamiface.IAMAPI, error) {

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -23,8 +23,9 @@ func NewDestroyIAMCommand() *cobra.Command {
 	}
 
 	opts := DestroyIAMOptions{
-		Region:      "us-east-1",
-		ProfileName: "hypershift-worker-profile",
+		Region:             "us-east-1",
+		AWSCredentialsFile: "",
+		ProfileName:        "",
 	}
 
 	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
@@ -32,6 +33,7 @@ func NewDestroyIAMCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "Region where cluster infra lives")
 
 	cmd.MarkFlagRequired("aws-creds")
+	cmd.MarkFlagRequired("profile-name")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if err := opts.DestroyIAM(); err != nil {

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -9,6 +9,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 )
 
+func DefaultIAMName(infraID string) string {
+	return infraID + "-default-iam"
+}
+
 func (o *CreateIAMOptions) CreateWorkerInstanceProfile(client iamiface.IAMAPI, profileName string) error {
 	const (
 		assumeRolePolicy = `{

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -82,11 +82,10 @@ func TestControlPlaneUpgrade(t *testing.T) {
 		PullSecretFile:     opts.PullSecretFile,
 		AWSCredentialsFile: opts.AWSCredentialsFile,
 		// TODO: generate a key on the fly
-		SSHKeyFile:            "",
-		NodePoolReplicas:      0,
-		WorkerInstanceProfile: "hypershift-worker-profile",
-		Region:                "us-east-1",
-		InstanceType:          "m4.large",
+		SSHKeyFile:       "",
+		NodePoolReplicas: 0,
+		Region:           "us-east-1",
+		InstanceType:     "m4.large",
 	}
 	err = cmdcluster.CreateCluster(ctx, createClusterOpts)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -76,11 +76,10 @@ func TestQuickStart(t *testing.T) {
 		PullSecretFile:     opts.PullSecretFile,
 		AWSCredentialsFile: opts.AWSCredentialsFile,
 		// TODO: generate a key on the fly
-		SSHKeyFile:            "",
-		NodePoolReplicas:      2,
-		WorkerInstanceProfile: "hypershift-worker-profile",
-		Region:                "us-east-1",
-		InstanceType:          "m4.large",
+		SSHKeyFile:       "",
+		NodePoolReplicas: 2,
+		Region:           "us-east-1",
+		InstanceType:     "m4.large",
 	}
 	err = cmdcluster.CreateCluster(ctx, createClusterOpts)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")


### PR DESCRIPTION
This commit makes the `create cluster` command generate IAM unique to the
cluster by default. The defaulting before this commit led to situations where
clusters in the same account (local development, CI, etc.) could be broken by CI
or developer activities inadvertantly deleting the shared profile.

A safer default is to share no infra per cluster, including IAM. The option to
provide a profile for sharing is still supported, just no longer the default.