### PR TITLE
Place control planes in unique namespaces

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -345,7 +345,7 @@ func (r *HostedControlPlaneReconciler) delete(ctx context.Context, hcp *hyperv1.
 func (r *HostedControlPlaneReconciler) ensureInfrastructure(ctx context.Context, hcp *hyperv1.HostedControlPlane) (InfrastructureStatus, error) {
 	status := InfrastructureStatus{}
 
-	targetNamespace := hcp.GetName()
+	targetNamespace := hcp.GetNamespace()
 	// Ensure that we can run privileged pods
 	if err := ensureVPNSCC(r, hcp, targetNamespace); err != nil {
 		return status, fmt.Errorf("failed to ensure privileged SCC for the new namespace: %w", err)
@@ -443,7 +443,7 @@ func (r *HostedControlPlaneReconciler) ensureInfrastructure(ctx context.Context,
 func (r *HostedControlPlaneReconciler) ensureControlPlane(ctx context.Context, hcp *hyperv1.HostedControlPlane, infraStatus InfrastructureStatus, releaseImage *releaseinfo.ReleaseImage) error {
 	r.Log.Info("ensuring control plane for cluster", "cluster", hcp.Name)
 
-	targetNamespace := hcp.GetName()
+	targetNamespace := hcp.GetNamespace()
 	version, err := semver.Parse(releaseImage.Version())
 	if err != nil {
 		return fmt.Errorf("cannot parse release version (%s): %v", releaseImage.Version(), err)
@@ -548,7 +548,7 @@ func (r *HostedControlPlaneReconciler) ensureControlPlane(ctx context.Context, h
 }
 
 func (r *HostedControlPlaneReconciler) generateControlPlaneManifests(ctx context.Context, hcp *hyperv1.HostedControlPlane, infraStatus InfrastructureStatus, releaseImage *releaseinfo.ReleaseImage) (map[string][]byte, error) {
-	targetNamespace := hcp.GetName()
+	targetNamespace := hcp.GetNamespace()
 
 	var sshKeyData []byte
 	if len(hcp.Spec.SSHKey.Name) > 0 {

--- a/hypershift-operator/controllers/hostedcluster/manifests/manifests.go
+++ b/hypershift-operator/controllers/hostedcluster/manifests/manifests.go
@@ -1,6 +1,8 @@
 package manifests
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -9,26 +11,10 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 )
 
-func HostedControlPlaneNamespaceName(hostedClusterName string) types.NamespacedName {
-	return types.NamespacedName{Name: hostedClusterName}
-}
-
-type HostedControlPlaneNamespace struct {
-	HostedCluster *hyperv1.HostedCluster
-}
-
-func (o HostedControlPlaneNamespace) Build() *corev1.Namespace {
-	name := HostedControlPlaneNamespaceName(o.HostedCluster.Name)
-	namespace := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Namespace",
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name.Name,
-		},
+func HostedControlPlaneNamespaceName(hostedClusterNamespace, hostedClusterName string) types.NamespacedName {
+	return types.NamespacedName{
+		Name: fmt.Sprintf("%s-%s", hostedClusterNamespace, hostedClusterName),
 	}
-	return namespace
 }
 
 func ProviderCredentialsName(hostedControlPlaneNamespace string) types.NamespacedName {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/machineimage"
 	hyperutil "github.com/openshift/hypershift/hypershift-operator/controllers/util"
 	capiv1 "github.com/openshift/hypershift/thirdparty/clusterapi/api/v1alpha4"
@@ -90,7 +91,7 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	targetNamespace := hcluster.GetName()
+	targetNamespace := manifests.HostedControlPlaneNamespaceName(hcluster.Namespace, hcluster.Name).Name
 	// Ignore deleted nodePools, this can happen when foregroundDeletion
 	// is enabled
 	if !nodePool.DeletionTimestamp.IsZero() {
@@ -173,7 +174,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	// Generate scalable resource for nodePool
-	targetNamespace := hcluster.GetName()
+	targetNamespace := manifests.HostedControlPlaneNamespaceName(hcluster.Namespace, hcluster.Name).Name
 	ami, err := r.ImageProvider.Image(hcluster)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to obtain AMI: %w", err)


### PR DESCRIPTION
Before this commit, control planes were created in a namespace named
the same as the HostedCluster, which is not unique in space. This commit
improves the situation by making the control plane namespace a function
of the HostedCluster namespace and name.