### PR TITLE
Fix namespace ref causing HCP deletion to hang

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -336,7 +336,7 @@ func (r *HostedControlPlaneReconciler) delete(ctx context.Context, hcp *hyperv1.
 	if err != nil {
 		return nil
 	}
-	if err := deleteManifests(ctx, r, r.Log, hcp.GetName(), manifests); err != nil {
+	if err := deleteManifests(ctx, r, r.Log, hcp.GetNamespace(), manifests); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Fix a broken namespace reference which causes delete to hang by preventing
the HCP controller from finding control plane resources.