### PR TITLE
Make HostedControlPlane image transition time field a pointer

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -113,7 +113,8 @@ type HostedControlPlaneStatus struct {
 
 	// lastReleaseImageTransitionTime is the time of the last update to the current
 	// releaseImage property.
-	LastReleaseImageTransitionTime metav1.Time `json:"lastReleaseImageTransitionTime"`
+	// +kubebuilder:validation:Optional
+	LastReleaseImageTransitionTime *metav1.Time `json:"lastReleaseImageTransitionTime,omitempty"`
 
 	// KubeConfig is a reference to the secret containing the default kubeconfig
 	// for this control plane.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -509,7 +509,10 @@ func (in *HostedControlPlaneStatus) DeepCopyInto(out *HostedControlPlaneStatus) 
 		**out = **in
 	}
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
-	in.LastReleaseImageTransitionTime.DeepCopyInto(&out.LastReleaseImageTransitionTime)
+	if in.LastReleaseImageTransitionTime != nil {
+		in, out := &in.LastReleaseImageTransitionTime, &out.LastReleaseImageTransitionTime
+		*out = (*in).DeepCopy()
+	}
 	if in.KubeConfig != nil {
 		in, out := &in.KubeConfig, &out.KubeConfig
 		*out = new(KubeconfigSecretRef)

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -273,7 +273,6 @@ spec:
                 type: string
             required:
             - conditions
-            - lastReleaseImageTransitionTime
             - ready
             type: object
         type: object

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -320,7 +320,8 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// the orchestration of upgrades works at all.
 	if hostedControlPlane.Status.ReleaseImage != hostedControlPlane.Spec.ReleaseImage {
 		hostedControlPlane.Status.ReleaseImage = hostedControlPlane.Spec.ReleaseImage
-		hostedControlPlane.Status.LastReleaseImageTransitionTime = metav1.NewTime(time.Now())
+		now := metav1.NewTime(time.Now())
+		hostedControlPlane.Status.LastReleaseImageTransitionTime = &now
 	}
 
 	r.Log.Info("Successfully reconciled")

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -683,7 +683,7 @@ func computeClusterVersionStatus(clock Clock, hcluster *hyperv1.HostedCluster, h
 	// The rollout is complete, so update the current history entry
 	version.History[0].State = configv1.CompletedUpdate
 	version.History[0].Version = hcp.Status.Version
-	if !hcp.Status.LastReleaseImageTransitionTime.IsZero() {
+	if hcp.Status.LastReleaseImageTransitionTime != nil {
 		version.History[0].CompletionTime = hcp.Status.LastReleaseImageTransitionTime.DeepCopy()
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -141,7 +141,7 @@ func TestComputeClusterVersionStatus(t *testing.T) {
 			},
 			ControlPlane: hyperv1.HostedControlPlane{
 				Spec:   hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
-				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0", LastReleaseImageTransitionTime: Later},
+				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0", LastReleaseImageTransitionTime: &Later},
 			},
 			ExpectedStatus: hyperv1.ClusterVersionStatus{
 				Desired: hyperv1.Release{Image: "a"},
@@ -164,7 +164,7 @@ func TestComputeClusterVersionStatus(t *testing.T) {
 			},
 			ControlPlane: hyperv1.HostedControlPlane{
 				Spec:   hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
-				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0", LastReleaseImageTransitionTime: Later},
+				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a", Version: "1.0.0", LastReleaseImageTransitionTime: &Later},
 			},
 			ExpectedStatus: hyperv1.ClusterVersionStatus{
 				Desired: hyperv1.Release{Image: "b"},


### PR DESCRIPTION
Change the HostedControlPlane LastReleaseImageTransitionTime field to be a
pointer because the field is optional and has no default value when the resource
is created. This fixes a brief status update error that occurs when first
syncing where no zero value is provided.