### PR TITLE
Dump cluster resources in e2e

### DIFF
--- a/cmd/cluster/dump.go
+++ b/cmd/cluster/dump.go
@@ -1,0 +1,218 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperapi "github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/manifests"
+	capiv1 "github.com/openshift/hypershift/thirdparty/clusterapi/api/v1alpha4"
+	capiaws "github.com/openshift/hypershift/thirdparty/clusterapiprovideraws/v1alpha3"
+)
+
+type DumpOptions struct {
+	Namespace   string
+	Name        string
+	ArtifactDir string
+}
+
+func NewDumpCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster",
+		Short: "Creates basic functional HostedCluster resources",
+	}
+
+	opts := &DumpOptions{
+		Namespace:   "clusters",
+		Name:        "example",
+		ArtifactDir: "",
+	}
+
+	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A namespace to contain the generated resources")
+	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A name for the cluster")
+	cmd.Flags().StringVar(&opts.ArtifactDir, "artifact-dir", opts.ArtifactDir, "Destination directory for dump files")
+
+	cmd.MarkFlagRequired("artifact-dir")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		if err := DumpCluster(ctx, opts); err != nil {
+			log.Error(err, "Error")
+		}
+		os.Exit(1)
+	}
+	return cmd
+}
+
+func DumpCluster(ctx context.Context, opts *DumpOptions) error {
+	ocCommand, err := exec.LookPath("oc")
+	if err != nil || len(ocCommand) == 0 {
+		return fmt.Errorf("cannot find oc command")
+	}
+	cfg := ctrl.GetConfigOrDie()
+	c, err := client.New(cfg, client.Options{Scheme: hyperapi.Scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create management cluster client: %w", err)
+	}
+	allNodePools := &hyperv1.NodePoolList{}
+	if err = c.List(ctx, allNodePools, client.InNamespace(opts.Namespace)); err != nil {
+		log.Error(err, "Cannot list nodepools")
+	}
+	nodePools := []*hyperv1.NodePool{}
+	for i := range allNodePools.Items {
+		if allNodePools.Items[i].Spec.ClusterName == opts.Name {
+			nodePools = append(nodePools, &allNodePools.Items[i])
+		}
+	}
+	cmd := OCAdmInspect{
+		oc:          ocCommand,
+		artifactDir: opts.ArtifactDir,
+	}
+	objectNames := make([]string, 0, len(nodePools)+1)
+	objectNames = append(objectNames, typedName(&hyperv1.HostedCluster{}, opts.Name))
+	for _, nodePool := range nodePools {
+		objectNames = append(objectNames, typedName(&hyperv1.NodePool{}, nodePool.Name))
+	}
+	cmd.WithNamespace(opts.Namespace).Run(objectNames...)
+
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespaceName(opts.Namespace, opts.Name).Name
+
+	resources := []client.Object{
+		&appsv1.DaemonSet{},
+		&appsv1.Deployment{},
+		&appsv1.ReplicaSet{},
+		&appsv1.StatefulSet{},
+		&batchv1.Job{},
+		&corev1.ConfigMap{},
+		&corev1.Endpoints{},
+		&corev1.Event{},
+		&corev1.PersistentVolumeClaim{},
+		&corev1.Pod{},
+		&corev1.ReplicationController{},
+		&corev1.Service{},
+		&capiv1.Cluster{},
+		&capiv1.MachineDeployment{},
+		&capiv1.Machine{},
+		&capiv1.MachineSet{},
+		&capiaws.AWSMachine{},
+		&capiaws.AWSMachineTemplate{},
+	}
+	resourceList := strings.Join(resourceTypes(resources), ",")
+	cmd.WithNamespace(controlPlaneNamespace).Run(resourceList)
+	cmd.WithNamespace(opts.Namespace).Run(resourceList)
+
+	podList := &corev1.PodList{}
+	if err = c.List(ctx, podList, client.InNamespace(controlPlaneNamespace)); err != nil {
+		log.Error(err, "Cannot list pods in controlplane namespace", "namespace", controlPlaneNamespace)
+	}
+	kubeClient := kubeclient.NewForConfigOrDie(cfg)
+	outputLogs(ctx, kubeClient, opts.ArtifactDir, podList)
+	return nil
+}
+
+type OCAdmInspect struct {
+	oc          string
+	artifactDir string
+	namespace   string
+}
+
+func (i *OCAdmInspect) WithNamespace(namespace string) *OCAdmInspect {
+	withNS := *i
+	withNS.namespace = namespace
+	return &withNS
+}
+
+func (i *OCAdmInspect) Run(cmdArgs ...string) {
+	allArgs := []string{"adm", "inspect", "--dest-dir", i.artifactDir}
+	if len(i.namespace) > 0 {
+		allArgs = append(allArgs, "-n", i.namespace)
+	}
+	allArgs = append(allArgs, cmdArgs...)
+	cmd := exec.Command(i.oc, allArgs...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	err := cmd.Run()
+	if err != nil {
+		log.Error(err, "error running inspect command")
+	}
+}
+
+func objectType(obj client.Object) string {
+	var kind, group string
+	gvks, _, err := hyperapi.Scheme.ObjectKinds(obj)
+	if err != nil || len(gvks) == 0 {
+		kind = "unknown"
+		group = "unknown"
+	} else {
+		kind = strings.ToLower(gvks[0].Kind)
+		group = gvks[0].Group
+	}
+	if len(group) > 0 {
+		return fmt.Sprintf("%s.%s", kind, group)
+	} else {
+		return kind
+	}
+}
+
+func resourceTypes(objs []client.Object) []string {
+	result := make([]string, 0, len(objs))
+	for _, obj := range objs {
+		result = append(result, objectType(obj))
+	}
+	return result
+}
+
+func typedName(obj client.Object, name string) string {
+	return fmt.Sprintf("%s/%s", objectType(obj), name)
+}
+
+func outputLogs(ctx context.Context, c kubeclient.Interface, artifactDir string, podList *corev1.PodList) {
+	for _, pod := range podList.Items {
+		dir := filepath.Join(artifactDir, "namespaces", pod.Namespace, "core", "pods", "logs")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			log.Error(err, "Cannot create directory", "directory", dir)
+			continue
+		}
+		for _, container := range pod.Spec.InitContainers {
+			outputLog(ctx, filepath.Join(dir, fmt.Sprintf("%s-%s.log", pod.Name, container.Name)),
+				c.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name}), false)
+			outputLog(ctx, filepath.Join(dir, fmt.Sprintf("%s-%s-previous.log", pod.Name, container.Name)),
+				c.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name, Previous: true}), true)
+		}
+		for _, container := range pod.Spec.Containers {
+			outputLog(ctx, filepath.Join(dir, fmt.Sprintf("%s-%s.log", pod.Name, container.Name)),
+				c.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name}), false)
+			outputLog(ctx, filepath.Join(dir, fmt.Sprintf("%s-%s-previous.log", pod.Name, container.Name)),
+				c.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name, Previous: true}), true)
+		}
+	}
+}
+
+func outputLog(ctx context.Context, fileName string, req *restclient.Request, skipLogErr bool) {
+	b, err := req.DoRaw(ctx)
+	if err != nil {
+		if !skipLogErr {
+			log.Error(err, "Failed to get pod log", "req", req.URL().String())
+		}
+		return
+	}
+	if err := ioutil.WriteFile(fileName, b, 0644); err != nil {
+		log.Error(err, "Failed to write file", "file", fileName)
+	}
+}

--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -1,0 +1,18 @@
+package dump
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/hypershift/cmd/cluster"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dump",
+		Short: "Commands for dumping resources for debugging",
+	}
+
+	cmd.AddCommand(cluster.NewDumpCommand())
+
+	return cmd
+}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 
 	createcmd "github.com/openshift/hypershift/cmd/create"
 	destroycmd "github.com/openshift/hypershift/cmd/destroy"
+	dumpcmd "github.com/openshift/hypershift/cmd/dump"
 	installcmd "github.com/openshift/hypershift/cmd/install"
 )
 
@@ -38,6 +39,7 @@ func main() {
 	cmd.AddCommand(installcmd.NewCommand())
 	cmd.AddCommand(createcmd.NewCommand())
 	cmd.AddCommand(destroycmd.NewCommand())
+	cmd.AddCommand(dumpcmd.NewCommand())
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -23,6 +23,7 @@ type ControlPlaneUpgradeOptions struct {
 	PullSecretFile     string
 	FromReleaseImage   string
 	ToReleaseImage     string
+	ArtifactDir        string
 }
 
 func NewControlPlaneUpgradeOptions(globalOptions *GlobalTestOptions) ControlPlaneUpgradeOptions {
@@ -31,6 +32,7 @@ func NewControlPlaneUpgradeOptions(globalOptions *GlobalTestOptions) ControlPlan
 		PullSecretFile:     globalOptions.PullSecretFile,
 		FromReleaseImage:   globalOptions.PreviousReleaseImage,
 		ToReleaseImage:     globalOptions.LatestReleaseImage,
+		ArtifactDir:        globalOptions.ArtifactDir,
 	}
 }
 
@@ -70,7 +72,7 @@ func TestControlPlaneUpgrade(t *testing.T) {
 			Namespace:          hostedCluster.Namespace,
 			Name:               hostedCluster.Name,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
-		})
+		}, opts.ArtifactDir)
 		DeleteNamespace(t, context.Background(), client, namespace.Name)
 	}()
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -28,6 +28,7 @@ type GlobalTestOptions struct {
 	PreviousReleaseImage string
 	IsRunningInCI        bool
 	UpgradeTestsEnabled  bool
+	ArtifactDir          string
 }
 
 var GlobalOptions = &GlobalTestOptions{}
@@ -37,6 +38,7 @@ func init() {
 	flag.StringVar(&GlobalOptions.PullSecretFile, "e2e.pull-secret-file", "", "path to pull secret")
 	flag.StringVar(&GlobalOptions.LatestReleaseImage, "e2e.latest-release-image", "", "The latest OCP release image for use by tests")
 	flag.StringVar(&GlobalOptions.PreviousReleaseImage, "e2e.previous-release-image", "", "The previous OCP release image relative to the latest")
+	flag.StringVar(&GlobalOptions.ArtifactDir, "e2e.artifact-dir", "", "The directory where cluster resources and logs should be dumped. If empty, nothing is dumped")
 }
 
 func (o *GlobalTestOptions) SetDefaults() error {
@@ -57,6 +59,10 @@ func (o *GlobalTestOptions) SetDefaults() error {
 	}
 
 	o.IsRunningInCI = os.Getenv("OPENSHIFT_CI") == "true"
+
+	if o.IsRunningInCI && len(o.ArtifactDir) == 0 {
+		o.ArtifactDir = os.Getenv("ARTIFACT_DIR")
+	}
 
 	return nil
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -38,7 +38,18 @@ func GenerateNamespace(t *testing.T, ctx context.Context, client crclient.Client
 	return namespace
 }
 
-func DestroyCluster(t *testing.T, ctx context.Context, opts *cmdcluster.DestroyOptions) {
+func DestroyCluster(t *testing.T, ctx context.Context, opts *cmdcluster.DestroyOptions, artifactDir string) {
+	if len(artifactDir) > 0 {
+		err := cmdcluster.DumpCluster(ctx, &cmdcluster.DumpOptions{
+			Namespace:   opts.Namespace,
+			Name:        opts.Name,
+			ArtifactDir: artifactDir,
+		})
+		if err != nil {
+			t.Logf("error dumping cluster contents: %s", err)
+		}
+	}
+
 	g := NewWithT(t)
 
 	t.Logf("Waiting for hostedcluster %s/%s to be destroyed", opts.Namespace, opts.Name)

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -20,6 +20,7 @@ type QuickStartOptions struct {
 	AWSCredentialsFile string
 	PullSecretFile     string
 	ReleaseImage       string
+	ArtifactDir        string
 }
 
 func NewQuickStartOptions(globalOptions *GlobalTestOptions) QuickStartOptions {
@@ -27,6 +28,7 @@ func NewQuickStartOptions(globalOptions *GlobalTestOptions) QuickStartOptions {
 		AWSCredentialsFile: globalOptions.AWSCredentialsFile,
 		PullSecretFile:     globalOptions.PullSecretFile,
 		ReleaseImage:       globalOptions.LatestReleaseImage,
+		ArtifactDir:        globalOptions.ArtifactDir,
 	}
 }
 
@@ -64,7 +66,7 @@ func TestQuickStart(t *testing.T) {
 			Namespace:          hostedCluster.Namespace,
 			Name:               hostedCluster.Name,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
-		})
+		}, opts.ArtifactDir)
 		DeleteNamespace(t, context.Background(), client, namespace.Name)
 	}()
 


### PR DESCRIPTION
Creates a new command `dump cluster` that outputs relevant resource yamls and pod logs for a given HostedCluster.
Invokes the command from e2e before destroying a cluster.