### PR TITLE
Add support for nodePools autorepair

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	NodePoolAutoscalingEnabledConditionType = "AutoscalingEnabled"
+	NodePoolAutorepairEnabledConditionType  = "AutorepairEnabled"
 	NodePoolAsExpectedConditionReason       = "AsExpected"
 	NodePoolValidationFailedConditionReason = "ValidationFailed"
 	NodePoolUpgradingConditionType          = "Upgrading"
@@ -25,6 +26,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".spec.clusterName",description="Cluster"
 // +kubebuilder:printcolumn:name="NodeCount",type="integer",JSONPath=".status.nodeCount",description="Available Nodes"
 // +kubebuilder:printcolumn:name="Autoscaling",type="string",JSONPath=".status.conditions[?(@.type==\"AutoscalingEnabled\")].status",description="Autoscaling Enabled"
+// +kubebuilder:printcolumn:name="Autorepair",type="string",JSONPath=".status.conditions[?(@.type==\"AutorepairEnabled\")].status",description="Node Autorepair Enabled"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="Current version"
 // +kubebuilder:printcolumn:name="Upgrading",type="string",JSONPath=".status.conditions[?(@.type==\"Upgrading\")].status",description="Upgrade in progress"
 type NodePool struct {
@@ -45,7 +47,7 @@ type NodePoolSpec struct {
 	AutoScaling *NodePoolAutoScaling `json:"autoScaling,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={maxSurge: 1, maxUnavailable: 0}
+	// +kubebuilder:default={maxSurge: 1, maxUnavailable: 0, autoRepair: false}
 	Management NodePoolManagement `json:"nodePoolManagement"`
 	Platform   NodePoolPlatform   `json:"platform"`
 
@@ -81,12 +83,17 @@ type NodePoolList struct {
 }
 
 type NodePoolManagement struct {
+	// +optional
 	// +kubebuilder:default=0
 	// +kubebuilder:validation:Minimum=0
 	MaxUnavailable int `json:"maxUnavailable"`
+	// +optional
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
 	MaxSurge int `json:"maxSurge"`
+
+	// +optional
+	AutoRepair bool `json:"autoRepair"`
 }
 
 type NodePoolAutoScaling struct {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -32,6 +32,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=="AutoscalingEnabled")].status
       name: Autoscaling
       type: string
+    - description: Node Autorepair Enabled
+      jsonPath: .status.conditions[?(@.type=="AutorepairEnabled")].status
+      name: Autorepair
+      type: string
     - description: Current version
       jsonPath: .status.version
       name: Version
@@ -73,9 +77,12 @@ spec:
                 type: integer
               nodePoolManagement:
                 default:
+                  autoRepair: false
                   maxSurge: 1
                   maxUnavailable: 0
                 properties:
+                  autoRepair:
+                    type: boolean
                   maxSurge:
                     default: 1
                     minimum: 0
@@ -84,9 +91,6 @@ spec:
                     default: 0
                     minimum: 0
                     type: integer
-                required:
-                - maxSurge
-                - maxUnavailable
                 type: object
               platform:
                 description: NodePoolPlatform is the platform-specific configuration for a node pool. Only one of the platforms should be set.


### PR DESCRIPTION
This introduce node autorepair in the nodePool API by managing opinionated MHCs.
The configuration is intentionally narrowed down to a bool. Once this is tested in a realistic scenario and we gather feedback we can reconsider exposing more config for flexibility in the nodePool API if we need to.

Follow up:
- Refactor nodePool controller to align with hostedCluster controller patterns.