### PR TITLE
Use non-deprecated registry for base go image and explicitly define empty array for status conditions on cluster create

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.16 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 as builder
 
 WORKDIR /hypershift
 

--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -185,6 +185,9 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				},
 			},
 		},
+		Status: hyperv1.HostedClusterStatus{
+			Conditions: []metav1.Condition{},
+		},
 	}
 
 	return &ExampleResources{


### PR DESCRIPTION
When using the render path for creating openshift clusters the hostedcluster resource has 

```
status:
  conditions: null
```

Which causes kube unable to apply it

```
error: error validating "/Users/krglosse@us.ibm.com/gopath/src/github.ibm.com/alchemy-containers/kodieshandyscripts/render": error validating data: ValidationError(HostedCluster.status.conditions): invalid type for io.openshift.hypershift.v1alpha1.HostedCluster.status.conditions: got "string", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false
```

By explicitly putting in an empty status condition it will template as:

```
status:
  conditions: []
```

instead. Allowing Kube to apply it. 