### PR TITLE
use infra region when creating IAM, as cluster-create does not require a region, and it will always be available in the infra struct

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -175,7 +175,7 @@ func CreateCluster(ctx context.Context, opts Options) error {
 		}
 	} else {
 		opt := awsinfra.CreateIAMOptions{
-			Region:             opts.Region,
+			Region:             infra.Region,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
 			InfraID:            infra.InfraID,
 		}


### PR DESCRIPTION
If you try to create a cluster without specifying region today, you get this error: 

```
Error: failed to create iam: AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'us-west-1'
	status code: 400, request id: TZAFPKN90NBKVF97, host id: OcpnjPSVOhxhsVw93Fns6xSj7KF8QQHzc7zVaJmUxbhT3c7LmIRIRhSkY3u6aUMFgwfq2erMh20=
```

With this change, creating IAM will use the region specified in infra. 