### PR TITLE
Refactor nodePool controller

### DIFF
--- a/hypershift-operator/controllers/machineconfigserver/machineconfigserver_controller.go
+++ b/hypershift-operator/controllers/machineconfigserver/machineconfigserver_controller.go
@@ -93,7 +93,7 @@ func (r *MachineConfigServerReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	ignitionRoute := MachineConfigServerIgnitionRoute(mcs.Namespace, mcs.Name)
 
-	userDataSecret := MachineConfigServerUserDataSecret(mcs.Namespace, mcs.Name)
+	userDataSecret := MachineConfigServerUserDataSecret(mcs)
 
 	// Return early if deleted
 	if !mcs.DeletionTimestamp.IsZero() {
@@ -213,7 +213,7 @@ func (r *MachineConfigServerReconciler) Reconcile(ctx context.Context, req ctrl.
 	if err != nil {
 		return ctrl.Result{}, nil
 	}
-	userDataSecret = MachineConfigServerUserDataSecret(mcs.Namespace, mcs.Name)
+	userDataSecret = MachineConfigServerUserDataSecret(mcs)
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, userDataSecret, func() error {
 		// For now, only create and never update this secret
 		if !userDataSecret.CreationTimestamp.IsZero() {

--- a/hypershift-operator/controllers/machineconfigserver/manifests.go
+++ b/hypershift-operator/controllers/machineconfigserver/manifests.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	routev1 "github.com/openshift/api/route/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -55,11 +56,11 @@ func MachineConfigServerIgnitionRoute(machineConfigServerNamespace, machineConfi
 	}
 }
 
-func MachineConfigServerUserDataSecret(machineConfigServerNamespace, machineConfigServerName string) *corev1.Secret {
+func MachineConfigServerUserDataSecret(mco *hyperv1.MachineConfigServer) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: machineConfigServerNamespace,
-			Name:      fmt.Sprintf("user-data-%s", machineConfigServerName),
+			Namespace: mco.GetNamespace(),
+			Name:      fmt.Sprintf("user-data-%s", mco.GetName()),
 		},
 	}
 }

--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -1,0 +1,106 @@
+package nodepool
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	capiv1 "github.com/openshift/hypershift/thirdparty/clusterapi/api/v1alpha4"
+	capiaws "github.com/openshift/hypershift/thirdparty/clusterapiprovideraws/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sutilspointer "k8s.io/utils/pointer"
+)
+
+func machineDeployment(nodePool *hyperv1.NodePool, mcs *hyperv1.MachineConfigServer, clusterName string) *capiv1.MachineDeployment {
+	resourcesName := generateName(clusterName, nodePool.Spec.ClusterName, nodePool.GetName())
+	return &capiv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourcesName,
+			Namespace: targetNamespace(nodePool),
+		},
+	}
+}
+
+func machineConfigServer(nodePool *hyperv1.NodePool) *hyperv1.MachineConfigServer {
+	return &hyperv1.MachineConfigServer{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodePool.GetName(),
+			Namespace: targetNamespace(nodePool),
+		},
+	}
+}
+
+func machineHealthCheck(nodePool *hyperv1.NodePool) *capiv1.MachineHealthCheck {
+	return &capiv1.MachineHealthCheck{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodePool.GetName(),
+			Namespace: targetNamespace(nodePool),
+		},
+	}
+}
+
+func AWSMachineTemplate(infraName, ami string, nodePool *hyperv1.NodePool) *capiaws.AWSMachineTemplate {
+	subnet := &capiaws.AWSResourceReference{}
+	if nodePool.Spec.Platform.AWS.Subnet != nil {
+		subnet.ID = nodePool.Spec.Platform.AWS.Subnet.ID
+		subnet.ARN = nodePool.Spec.Platform.AWS.Subnet.ARN
+		for k := range nodePool.Spec.Platform.AWS.Subnet.Filters {
+			filter := capiaws.Filter{
+				Name:   nodePool.Spec.Platform.AWS.Subnet.Filters[k].Name,
+				Values: nodePool.Spec.Platform.AWS.Subnet.Filters[k].Values,
+			}
+			subnet.Filters = append(subnet.Filters, filter)
+		}
+	}
+
+	securityGroups := []capiaws.AWSResourceReference{}
+	for _, sg := range nodePool.Spec.Platform.AWS.SecurityGroups {
+		filters := []capiaws.Filter{}
+		for _, f := range sg.Filters {
+			filters = append(filters, capiaws.Filter{
+				Name:   f.Name,
+				Values: f.Values,
+			})
+		}
+		securityGroups = append(securityGroups, capiaws.AWSResourceReference{
+			ARN:     sg.ARN,
+			ID:      sg.ID,
+			Filters: filters,
+		})
+	}
+
+	instanceProfile := fmt.Sprintf("%s-worker-profile", infraName)
+	if nodePool.Spec.Platform.AWS.InstanceProfile != "" {
+		instanceProfile = nodePool.Spec.Platform.AWS.InstanceProfile
+	}
+
+	instanceType := nodePool.Spec.Platform.AWS.InstanceType
+	resourcesName := generateName(infraName, nodePool.Spec.ClusterName, nodePool.GetName())
+
+	return &capiaws.AWSMachineTemplate{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourcesName,
+			Namespace: targetNamespace(nodePool),
+		},
+		Spec: capiaws.AWSMachineTemplateSpec{
+			Template: capiaws.AWSMachineTemplateResource{
+				Spec: capiaws.AWSMachineSpec{
+					UncompressedUserData: k8sutilspointer.BoolPtr(true),
+					CloudInit: capiaws.CloudInit{
+						InsecureSkipSecretsManager: true,
+						SecureSecretsBackend:       "secrets-manager",
+					},
+					IAMInstanceProfile: instanceProfile,
+					InstanceType:       instanceType,
+					AMI: capiaws.AWSResourceReference{
+						ID: k8sutilspointer.StringPtr(ami),
+					},
+					AdditionalSecurityGroups: securityGroups,
+					Subnet:                   subnet,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Refactor the nodePool controller to match common patterns:
- Manifest generation and reconciliation for managed resources.
- Drop explicit requeueing in favour of watching managed resources.