### PR TITLE
Make basedomain flag not required

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -96,7 +96,6 @@ func NewCreateCommand() *cobra.Command {
 
 	cmd.MarkFlagRequired("pull-secret")
 	cmd.MarkFlagRequired("aws-creds")
-	cmd.MarkFlagRequired("base-domain")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
The flag is only required when not specifying infra.json
Can be determined at runtime