### PR TITLE
Use bespoke, narrowly scoped AWS users for guest clusters

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -125,8 +125,7 @@ func CreateCluster(ctx context.Context, opts Options) error {
 		return fmt.Errorf("failed to read pull secret file: %w", err)
 	}
 
-	awsCredentials, err := ioutil.ReadFile(opts.AWSCredentialsFile)
-	if err != nil {
+	if _, err := ioutil.ReadFile(opts.AWSCredentialsFile); err != nil {
 		return fmt.Errorf("failed to read aws credentials: %w", err)
 	}
 
@@ -201,7 +200,6 @@ func CreateCluster(ctx context.Context, opts Options) error {
 		Name:             opts.Name,
 		ReleaseImage:     opts.ReleaseImage,
 		PullSecret:       pullSecret,
-		AWSCredentials:   awsCredentials,
 		SigningKey:       infra.ServiceAccountSigningKey,
 		IssuerURL:        infra.OIDCIssuerURL,
 		SSHKey:           sshKey,
@@ -236,6 +234,10 @@ func CreateCluster(ctx context.Context, opts Options) error {
 					Name:      "ebs-cloud-credentials",
 				},
 			},
+			KubeCloudControllerUserAccessKeyID:     infra.KubeCloudControllerUserAccessKeyID,
+			KubeCloudControllerUserAccessKeySecret: infra.KubeCloudControllerUserAccessKeySecret,
+			NodePoolManagementUserAccessKeyID:      infra.NodePoolManagementUserAccessKeyID,
+			NodePoolManagementUserAccessKeySecret:  infra.NodePoolManagementUserAccessKeySecret,
 		},
 	}.Resources().AsObjects()
 

--- a/cmd/infra/aws/cloudformation/cluster.yaml
+++ b/cmd/infra/aws/cloudformation/cluster.yaml
@@ -484,6 +484,167 @@ Resources:
         Value: !Join ["-", [!Ref InfrastructureName, "public"]]
       Name: !Ref Subdomain
 
+  CloudControllerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Join ["", [!Ref InfrastructureName, ".cloud-provider.hypershift.openshift.io"]]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Action:
+          - ec2:DescribeInstances
+          - ec2:DescribeImages
+          - ec2:DescribeRegions
+          - ec2:DescribeRouteTables
+          - ec2:DescribeSecurityGroups
+          - ec2:DescribeSubnets
+          - ec2:DescribeVolumes
+          - ec2:CreateSecurityGroup
+          - ec2:CreateTags
+          - ec2:CreateVolume
+          - ec2:ModifyInstanceAttribute
+          - ec2:ModifyVolume
+          - ec2:AttachVolume
+          - ec2:AuthorizeSecurityGroupIngress
+          - ec2:CreateRoute
+          - ec2:DeleteRoute
+          - ec2:DeleteSecurityGroup
+          - ec2:DeleteVolume
+          - ec2:DetachVolume
+          - ec2:RevokeSecurityGroupIngress
+          - ec2:DescribeVpcs
+          - elasticloadbalancing:AddTags
+          - elasticloadbalancing:AttachLoadBalancerToSubnets
+          - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
+          - elasticloadbalancing:CreateLoadBalancer
+          - elasticloadbalancing:CreateLoadBalancerPolicy
+          - elasticloadbalancing:CreateLoadBalancerListeners
+          - elasticloadbalancing:ConfigureHealthCheck
+          - elasticloadbalancing:DeleteLoadBalancer
+          - elasticloadbalancing:DeleteLoadBalancerListeners
+          - elasticloadbalancing:DescribeLoadBalancers
+          - elasticloadbalancing:DescribeLoadBalancerAttributes
+          - elasticloadbalancing:DetachLoadBalancerFromSubnets
+          - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
+          - elasticloadbalancing:ModifyLoadBalancerAttributes
+          - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+          - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
+          - elasticloadbalancing:AddTags
+          - elasticloadbalancing:CreateListener
+          - elasticloadbalancing:CreateTargetGroup
+          - elasticloadbalancing:DeleteListener
+          - elasticloadbalancing:DeleteTargetGroup
+          - elasticloadbalancing:DescribeListeners
+          - elasticloadbalancing:DescribeLoadBalancerPolicies
+          - elasticloadbalancing:DescribeTargetGroups
+          - elasticloadbalancing:DescribeTargetHealth
+          - elasticloadbalancing:ModifyListener
+          - elasticloadbalancing:ModifyTargetGroup
+          - elasticloadbalancing:RegisterTargets
+          - elasticloadbalancing:SetLoadBalancerPoliciesOfListener
+          - iam:CreateServiceLinkedRole
+          - kms:DescribeKey
+          Effect: Allow
+          Resource:
+          - '*'
+
+  NodePoolControllerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Join ["", [!Ref InfrastructureName, ".node-pool-controller.hypershift.openshift.io"]]
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Action:
+          - ec2:AllocateAddress
+          - ec2:AssociateRouteTable
+          - ec2:AttachInternetGateway
+          - ec2:AuthorizeSecurityGroupIngress
+          - ec2:CreateInternetGateway
+          - ec2:CreateNatGateway
+          - ec2:CreateRoute
+          - ec2:CreateRouteTable
+          - ec2:CreateSecurityGroup
+          - ec2:CreateSubnet
+          - ec2:CreateTags
+          - ec2:DeleteInternetGateway
+          - ec2:DeleteNatGateway
+          - ec2:DeleteRouteTable
+          - ec2:DeleteSecurityGroup
+          - ec2:DeleteSubnet
+          - ec2:DeleteTags
+          - ec2:DescribeAccountAttributes
+          - ec2:DescribeAddresses
+          - ec2:DescribeAvailabilityZones
+          - ec2:DescribeInstances
+          - ec2:DescribeInternetGateways
+          - ec2:DescribeNatGateways
+          - ec2:DescribeNetworkInterfaces
+          - ec2:DescribeNetworkInterfaceAttribute
+          - ec2:DescribeRouteTables
+          - ec2:DescribeSecurityGroups
+          - ec2:DescribeSubnets
+          - ec2:DescribeVpcs
+          - ec2:DescribeVpcAttribute
+          - ec2:DescribeVolumes
+          - ec2:DetachInternetGateway
+          - ec2:DisassociateRouteTable
+          - ec2:DisassociateAddress
+          - ec2:ModifyInstanceAttribute
+          - ec2:ModifyNetworkInterfaceAttribute
+          - ec2:ModifySubnetAttribute
+          - ec2:ReleaseAddress
+          - ec2:RevokeSecurityGroupIngress
+          - ec2:RunInstances
+          - ec2:TerminateInstances
+          - tag:GetResources
+          - ec2:CreateLaunchTemplate
+          - ec2:CreateLaunchTemplateVersion
+          - ec2:DescribeLaunchTemplates
+          - ec2:DescribeLaunchTemplateVersions
+          - ec2:DeleteLaunchTemplate
+          - ec2:DeleteLaunchTemplateVersions
+          Effect: Allow
+          Resource:
+          - '*'
+        - Action:
+          - iam:CreateServiceLinkedRole
+          Condition:
+            StringLike:
+              iam:AWSServiceName: elasticloadbalancing.amazonaws.com
+          Effect: Allow
+          Resource:
+          - arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing
+        - Action:
+          - iam:PassRole
+          Effect: Allow
+          Resource:
+          # TODO: Should our role be suffixed with something like this?
+          # arn:*:iam::*:role/*.cluster-api-provider-aws.sigs.k8s.io
+          - arn:*:iam::*:role/*-worker
+
+  KubeCloudControllerUser:
+    Type: AWS::IAM::User
+    Properties:
+      ManagedPolicyArns:
+      - !Ref CloudControllerPolicy
+
+  KubeCloudControllerUserAccessKey:
+    Type: AWS::IAM::AccessKey
+    Properties:
+      UserName: !Ref KubeCloudControllerUser
+
+  NodePoolManagementUser:
+    Type: AWS::IAM::User
+    Properties:
+      ManagedPolicyArns:
+      - !Ref NodePoolControllerPolicy
+
+  NodePoolManagementUserAccessKey:
+    Type: AWS::IAM::AccessKey
+    Properties:
+      UserName: !Ref NodePoolManagementUser
+
 Outputs:
   Region:
     Value: !Ref "AWS::Region"
@@ -526,3 +687,11 @@ Outputs:
     Value: !Join ["", ["https://s3.", !Ref "AWS::Region", ".amazonaws.com/", !Ref InfrastructureName]]
   OIDCBucketName:
     Value: !Ref OIDCBucket
+  KubeCloudControllerUserAccessKeyId:
+    Value: !Ref KubeCloudControllerUserAccessKey
+  KubeCloudControllerUserAccessKeySecret:
+    Value: !GetAtt KubeCloudControllerUserAccessKey.SecretAccessKey
+  NodePoolManagementUserAccessKeyId:
+    Value: !Ref NodePoolManagementUserAccessKey
+  NodePoolManagementUserAccessKeySecret:
+    Value: !GetAtt NodePoolManagementUserAccessKey.SecretAccessKey

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -46,26 +46,30 @@ type CreateInfraOptions struct {
 }
 
 type CreateInfraOutput struct {
-	StackID                  string `json:"stackID"`
-	Region                   string `json:"region"`
-	Zone                     string `json:"zone"`
-	InfraID                  string `json:"infraID"`
-	ComputeCIDR              string `json:"computeCIDR"`
-	VPCID                    string `json:"vpcID"`
-	PrivateSubnetID          string `json:"privateSubnetID"`
-	PublicSubnetID           string `json:"publicSubnetID"`
-	WorkerSecurityGroupID    string `json:"workerSecurityGroupID"`
-	WorkerInstanceProfileID  string `json:"workerInstanceProfileID"`
-	BaseDomainZoneID         string `json:"baseDomainZoneID"`
-	Subdomain                string `json:"subdomain"`
-	SubdomainPrivateZoneID   string `json:"subdomainPrivateZoneID"`
-	SubdomainPublicZoneID    string `json:"subdomainPublicZoneID"`
-	OIDCIngressRoleArn       string `json:"oidcIngressRoleArn"`
-	OIDCImageRegistryRoleArn string `json:"oidcImageRegistryRoleArn"`
-	OIDCCSIDriverRoleArn     string `json:"oidcCSIDriverRoleArn"`
-	OIDCIssuerURL            string `json:"oidcIssuerURL"`
-	OIDCBucketName           string `json:"oidcBucketName"`
-	ServiceAccountSigningKey []byte `json:"serviceAccountSigningKey"`
+	StackID                                string `json:"stackID"`
+	Region                                 string `json:"region"`
+	Zone                                   string `json:"zone"`
+	InfraID                                string `json:"infraID"`
+	ComputeCIDR                            string `json:"computeCIDR"`
+	VPCID                                  string `json:"vpcID"`
+	PrivateSubnetID                        string `json:"privateSubnetID"`
+	PublicSubnetID                         string `json:"publicSubnetID"`
+	WorkerSecurityGroupID                  string `json:"workerSecurityGroupID"`
+	WorkerInstanceProfileID                string `json:"workerInstanceProfileID"`
+	BaseDomainZoneID                       string `json:"baseDomainZoneID"`
+	Subdomain                              string `json:"subdomain"`
+	SubdomainPrivateZoneID                 string `json:"subdomainPrivateZoneID"`
+	SubdomainPublicZoneID                  string `json:"subdomainPublicZoneID"`
+	OIDCIngressRoleArn                     string `json:"oidcIngressRoleArn"`
+	OIDCImageRegistryRoleArn               string `json:"oidcImageRegistryRoleArn"`
+	OIDCCSIDriverRoleArn                   string `json:"oidcCSIDriverRoleArn"`
+	OIDCIssuerURL                          string `json:"oidcIssuerURL"`
+	OIDCBucketName                         string `json:"oidcBucketName"`
+	ServiceAccountSigningKey               []byte `json:"serviceAccountSigningKey"`
+	KubeCloudControllerUserAccessKeyID     string `json:"kubeCloudControllerUserAccessKeyID"`
+	KubeCloudControllerUserAccessKeySecret string `json:"kubeCloudControllerUserAccessKeySecret"`
+	NodePoolManagementUserAccessKeyID      string `json:"nodePoolManagementUserAccessKeyID"`
+	NodePoolManagementUserAccessKeySecret  string `json:"nodePoolManagementUserAccessKeySecret"`
 }
 
 func NewCreateCommand() *cobra.Command {
@@ -177,25 +181,29 @@ func (o *CreateInfraOptions) getOrCreateStack(ctx context.Context, cf *cloudform
 	}
 
 	output := &CreateInfraOutput{
-		InfraID:                  o.InfraID,
-		StackID:                  *stack.StackId,
-		Region:                   getStackOutput(stack, "Region"),
-		Zone:                     getStackOutput(stack, "Zone"),
-		ComputeCIDR:              getStackOutput(stack, "ComputeCIDR"),
-		VPCID:                    getStackOutput(stack, "VPCId"),
-		PrivateSubnetID:          getStackOutput(stack, "PrivateSubnetId"),
-		PublicSubnetID:           getStackOutput(stack, "PublicSubnetId"),
-		WorkerSecurityGroupID:    getStackOutput(stack, "WorkerSecurityGroupId"),
-		WorkerInstanceProfileID:  getStackOutput(stack, "WorkerInstanceProfileId"),
-		BaseDomainZoneID:         getStackOutput(stack, "BaseDomainHostedZoneId"),
-		Subdomain:                getStackOutput(stack, "Subdomain"),
-		SubdomainPrivateZoneID:   getStackOutput(stack, "SubdomainPrivateZoneId"),
-		SubdomainPublicZoneID:    getStackOutput(stack, "SubdomainPublicZoneId"),
-		OIDCIngressRoleArn:       getStackOutput(stack, "OIDCIngressRoleArn"),
-		OIDCImageRegistryRoleArn: getStackOutput(stack, "OIDCImageRegistryRoleArn"),
-		OIDCCSIDriverRoleArn:     getStackOutput(stack, "OIDCCSIDriverRoleArn"),
-		OIDCIssuerURL:            getStackOutput(stack, "OIDCIssuerURL"),
-		OIDCBucketName:           getStackOutput(stack, "OIDCBucketName"),
+		InfraID:                                o.InfraID,
+		StackID:                                *stack.StackId,
+		Region:                                 getStackOutput(stack, "Region"),
+		Zone:                                   getStackOutput(stack, "Zone"),
+		ComputeCIDR:                            getStackOutput(stack, "ComputeCIDR"),
+		VPCID:                                  getStackOutput(stack, "VPCId"),
+		PrivateSubnetID:                        getStackOutput(stack, "PrivateSubnetId"),
+		PublicSubnetID:                         getStackOutput(stack, "PublicSubnetId"),
+		WorkerSecurityGroupID:                  getStackOutput(stack, "WorkerSecurityGroupId"),
+		WorkerInstanceProfileID:                getStackOutput(stack, "WorkerInstanceProfileId"),
+		BaseDomainZoneID:                       getStackOutput(stack, "BaseDomainHostedZoneId"),
+		Subdomain:                              getStackOutput(stack, "Subdomain"),
+		SubdomainPrivateZoneID:                 getStackOutput(stack, "SubdomainPrivateZoneId"),
+		SubdomainPublicZoneID:                  getStackOutput(stack, "SubdomainPublicZoneId"),
+		OIDCIngressRoleArn:                     getStackOutput(stack, "OIDCIngressRoleArn"),
+		OIDCImageRegistryRoleArn:               getStackOutput(stack, "OIDCImageRegistryRoleArn"),
+		OIDCCSIDriverRoleArn:                   getStackOutput(stack, "OIDCCSIDriverRoleArn"),
+		OIDCIssuerURL:                          getStackOutput(stack, "OIDCIssuerURL"),
+		OIDCBucketName:                         getStackOutput(stack, "OIDCBucketName"),
+		KubeCloudControllerUserAccessKeyID:     getStackOutput(stack, "KubeCloudControllerUserAccessKeyId"),
+		KubeCloudControllerUserAccessKeySecret: getStackOutput(stack, "KubeCloudControllerUserAccessKeySecret"),
+		NodePoolManagementUserAccessKeyID:      getStackOutput(stack, "NodePoolManagementUserAccessKeyId"),
+		NodePoolManagementUserAccessKeySecret:  getStackOutput(stack, "NodePoolManagementUserAccessKeySecret"),
 	}
 
 	return output, nil

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -72,6 +72,7 @@ func TestControlPlaneUpgrade(t *testing.T) {
 			Namespace:          hostedCluster.Namespace,
 			Name:               hostedCluster.Name,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
+			ClusterGracePeriod: 15 * time.Minute,
 		}, opts.ArtifactDir)
 		DeleteNamespace(t, context.Background(), client, namespace.Name)
 	}()

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -58,6 +58,7 @@ func DestroyCluster(t *testing.T, ctx context.Context, opts *cmdcluster.DestroyO
 			Namespace:          opts.Namespace,
 			Name:               opts.Name,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
+			ClusterGracePeriod: opts.ClusterGracePeriod,
 		})
 		if err != nil {
 			t.Logf("error destroying cluster, will retry: %s", err)

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,6 +70,7 @@ func TestQuickStart(t *testing.T) {
 			Namespace:          hostedCluster.Namespace,
 			Name:               hostedCluster.Name,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
+			ClusterGracePeriod: 15 * time.Minute,
 		}, opts.ArtifactDir)
 		DeleteNamespace(t, context.Background(), client, namespace.Name)
 	}()


### PR DESCRIPTION
Before this commit, the admin's AWS credentials passed to `create cluster` were
copied into the guest cluster for use by each credentials context. The AWS
credentials passed to `create cluster` are assumed to be super-privileged and
not intended to be leaked into guest clusters.

Now, when creating a new cluster, OCP is given credentials for users created
specifically for that cluster as part of infra creation.

This is another step towards IAM isolation by introducing new policies for each
HostedCluster credentials context (KubeCloudControllerCreds and
NodePoolManagementCreds) and creating new users associated with each of those
policies. The CloudFormation template takes care of creating the policies and
users and exposes the credentials as outputs.