### PR TITLE
cli: Improve failed stack creation handling

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -28,21 +28,21 @@ import (
 var NoopReconcile controllerutil.MutateFn = func() error { return nil }
 
 type Options struct {
-	Namespace              string
-	Name                   string
-	ReleaseImage           string
-	PullSecretFile         string
-	AWSCredentialsFile     string
-	SSHKeyFile             string
-	NodePoolReplicas       int
-	Render                 bool
-	InfraID                string
-	InfrastructureJSON     string
-	InstanceType           string
-	Region                 string
-	BaseDomain             string
-	Overwrite              bool
-	PreserveInfraOnFailure bool
+	Namespace          string
+	Name               string
+	ReleaseImage       string
+	PullSecretFile     string
+	AWSCredentialsFile string
+	SSHKeyFile         string
+	NodePoolReplicas   int
+	Render             bool
+	InfraID            string
+	InfrastructureJSON string
+	InstanceType       string
+	Region             string
+	BaseDomain         string
+	Overwrite          bool
+	DeleteOnFailure    bool
 }
 
 func NewCreateCommand() *cobra.Command {
@@ -62,20 +62,20 @@ func NewCreateCommand() *cobra.Command {
 	}
 
 	opts := Options{
-		Namespace:              "clusters",
-		Name:                   "example",
-		ReleaseImage:           releaseImage,
-		PullSecretFile:         "",
-		AWSCredentialsFile:     "",
-		SSHKeyFile:             "",
-		NodePoolReplicas:       2,
-		Render:                 false,
-		InfrastructureJSON:     "",
-		Region:                 "us-east-1",
-		InfraID:                "",
-		InstanceType:           "m4.large",
-		Overwrite:              false,
-		PreserveInfraOnFailure: false,
+		Namespace:          "clusters",
+		Name:               "example",
+		ReleaseImage:       releaseImage,
+		PullSecretFile:     "",
+		AWSCredentialsFile: "",
+		SSHKeyFile:         "",
+		NodePoolReplicas:   2,
+		Render:             false,
+		InfrastructureJSON: "",
+		Region:             "us-east-1",
+		InfraID:            "",
+		InstanceType:       "m4.large",
+		Overwrite:          false,
+		DeleteOnFailure:    false,
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A namespace to contain the generated resources")
@@ -92,7 +92,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.InstanceType, "instance-type", opts.InstanceType, "Instance type for AWS instances.")
 	cmd.Flags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The base domain for the cluster")
 	cmd.Flags().BoolVar(&opts.Overwrite, "overwrite", opts.Overwrite, "If an existing cluster exists, overwrite it")
-	cmd.Flags().BoolVar(&opts.PreserveInfraOnFailure, "preserve-infra-on-failure", opts.PreserveInfraOnFailure, "Preserve infrastructure if creation fails and is rolled back")
+	cmd.Flags().BoolVar(&opts.DeleteOnFailure, "delete-infra-on-failure", opts.DeleteOnFailure, "Delete the infra stack if creation fails")
 
 	cmd.MarkFlagRequired("pull-secret")
 	cmd.MarkFlagRequired("aws-creds")
@@ -105,7 +105,11 @@ func NewCreateCommand() *cobra.Command {
 			<-sigs
 			cancel()
 		}()
-		return CreateCluster(ctx, opts)
+		err := CreateCluster(ctx, opts)
+		if err != nil {
+			return fmt.Errorf("failed to create cluster. Before trying to create it again, please run `destroy cluster`.\nInternal Error: %w", err)
+		}
+		return nil
 	}
 
 	return cmd
@@ -183,11 +187,11 @@ func CreateCluster(ctx context.Context, opts Options) error {
 			Region:             opts.Region,
 			BaseDomain:         opts.BaseDomain,
 			Subdomain:          subdomain,
-			PreserveOnFailure:  opts.PreserveInfraOnFailure,
+			DeleteOnFailure:    opts.DeleteOnFailure,
 		}
 		newInfra, err := opt.Run(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to create infra: %w", err)
+			return fmt.Errorf("failed to create infrastructure: %w", err)
 		}
 		infra = newInfra
 	}

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -41,7 +42,7 @@ type CreateInfraOptions struct {
 	Subdomain      string
 	AdditionalTags []string
 
-	PreserveOnFailure bool
+	DeleteOnFailure bool
 }
 
 type CreateInfraOutput struct {
@@ -74,8 +75,8 @@ func NewCreateCommand() *cobra.Command {
 	}
 
 	opts := CreateInfraOptions{
-		Region:            "us-east-1",
-		PreserveOnFailure: false,
+		Region:          "us-east-1",
+		DeleteOnFailure: false,
 	}
 
 	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Cluster ID with which to tag AWS resources (required)")
@@ -84,7 +85,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.AdditionalTags, "additional-tags", opts.AdditionalTags, "Additional tags to set on AWS resources")
 	cmd.Flags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The base domain for the cluster")
 	cmd.Flags().StringVar(&opts.Subdomain, "subdomain", opts.Subdomain, "The subdomain for the cluster")
-	cmd.Flags().BoolVar(&opts.PreserveOnFailure, "preserve-on-failure", opts.PreserveOnFailure, "Preserve the stack if creation fails and is rolled back")
+	cmd.Flags().BoolVar(&opts.DeleteOnFailure, "delete-on-failure", opts.DeleteOnFailure, "Delete the infra stack if creation fails")
 
 	cmd.MarkFlagRequired("infra-id")
 	cmd.MarkFlagRequired("aws-creds")
@@ -227,8 +228,10 @@ func (o *CreateInfraOptions) createStack(ctx context.Context, cf *cloudformation
 		},
 	}
 
-	if !o.PreserveOnFailure {
+	if o.DeleteOnFailure {
 		createStackInput.OnFailure = aws.String(cloudformation.OnFailureDelete)
+	} else {
+		createStackInput.OnFailure = aws.String(cloudformation.OnFailureRollback)
 	}
 
 	createStackOutput, err := cf.CreateStack(createStackInput)
@@ -261,6 +264,27 @@ func (o *CreateInfraOptions) createStack(ctx context.Context, cf *cloudformation
 		}
 	}, ctx.Done())
 	if err != nil {
+		// If anything went wrong and the stack exists, save te user a trip to AWS
+		// by dumping events which usually describe the specific failure.
+		if stack != nil {
+			if out, err := cf.DescribeStackEvents(&cloudformation.DescribeStackEventsInput{
+				StackName: stack.StackName,
+			}); err != nil {
+				log.Error(err, "failed to describe stack events")
+			} else {
+				events := sortableStackEvents(out.StackEvents)
+				sort.Sort(events)
+				for _, event := range events {
+					log.Info("found stack event",
+						"Timestamp", aws.TimeValue(event.Timestamp),
+						"ResourceType", aws.StringValue(event.ResourceType),
+						"LogicalResourceId", aws.StringValue(event.LogicalResourceId),
+						"ResourceStatus", aws.StringValue(event.ResourceStatus),
+						"ResourceStatusReason", aws.StringValue(event.ResourceStatusReason))
+				}
+			}
+		}
+
 		return nil, err
 	}
 	return stack, nil

--- a/cmd/infra/aws/util.go
+++ b/cmd/infra/aws/util.go
@@ -248,3 +248,17 @@ func vpcFilter(vpcID string) []*ec2.Filter {
 		},
 	}
 }
+
+type sortableStackEvents []*cloudformation.StackEvent
+
+func (e sortableStackEvents) Len() int {
+	return len(e)
+}
+
+func (e sortableStackEvents) Less(i, j int) bool {
+	return (*e[i].Timestamp).Before(*e[j].Timestamp)
+}
+
+func (e sortableStackEvents) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}


### PR DESCRIPTION
This commit tries to improve the failed stack creation handling by:

1. Preserving failed stacks by default unless otherwise specified by the `--delete-infra-on-failure` flag
2. Dumping stack events on failure so that specific resource creation failures can be identified without going to AWS