### PR TITLE
cli: Try to improve AWS client retry handling

### DIFF
--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -19,8 +19,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
@@ -120,13 +118,12 @@ func NewCreateCommand() *cobra.Command {
 }
 
 func (o *CreateInfraOptions) Run(ctx context.Context) (*CreateInfraOutput, error) {
-	awsConfig := aws.NewConfig().WithRegion(o.Region).WithCredentials(credentials.NewSharedCredentials(o.AWSCredentialsFile, "default"))
-	awsSession := session.Must(session.NewSession())
+	awsSession := newSession()
+	awsConfig := newConfig(o.AWSCredentialsFile, o.Region)
+	r53Config := newConfig(o.AWSCredentialsFile, "us-east-1")
+
 	cf := cloudformation.New(awsSession, awsConfig)
 	s3client := s3.New(awsSession, awsConfig)
-	// Route53 is weird about regions
-	// https://github.com/openshift/cluster-ingress-operator/blob/5660b43d66bd63bbe2dcb45fb40df98d8d91347e/pkg/dns/aws/dns.go#L163-L169
-	r53Config := aws.NewConfig().WithRegion("us-east-1").WithCredentials(credentials.NewSharedCredentials(o.AWSCredentialsFile, "default"))
 	r53 := route53.New(awsSession, r53Config)
 
 	// Create or get an existing stack

--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	awserrors "github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -67,15 +65,14 @@ func NewDestroyCommand() *cobra.Command {
 }
 
 func (o *DestroyInfraOptions) DestroyInfra(ctx context.Context) error {
-	awsConfig := aws.NewConfig().WithRegion(o.Region).WithCredentials(credentials.NewSharedCredentials(o.AWSCredentialsFile, "default"))
-	awsSession := session.Must(session.NewSession())
+	awsSession := newSession()
+	awsConfig := newConfig(o.AWSCredentialsFile, o.Region)
+	r53Config := newConfig(o.AWSCredentialsFile, "us-east-1")
+
 	cf := cloudformation.New(awsSession, awsConfig)
 	s3 := s3service.New(awsSession, awsConfig)
 	elbclient := elb.New(awsSession, awsConfig)
 	ec2client := ec2.New(awsSession, awsConfig)
-	// Route53 is weird about regions
-	// https://github.com/openshift/cluster-ingress-operator/blob/5660b43d66bd63bbe2dcb45fb40df98d8d91347e/pkg/dns/aws/dns.go#L163-L169
-	r53Config := aws.NewConfig().WithRegion("us-east-1").WithCredentials(credentials.NewSharedCredentials(o.AWSCredentialsFile, "default"))
 	r53 := route53.New(awsSession, r53Config)
 
 	stack, err := getStack(cf, o.InfraID)

--- a/cmd/infra/aws/util.go
+++ b/cmd/infra/aws/util.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	awserrors "github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -247,6 +251,27 @@ func vpcFilter(vpcID string) []*ec2.Filter {
 			Values: []*string{aws.String(vpcID)},
 		},
 	}
+}
+
+func newSession() *session.Session {
+	awsSession := session.Must(session.NewSession())
+	awsSession.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "openshift.io/hypershift",
+		Fn:   request.MakeAddToUserAgentHandler("openshift.io hypershift", "cli"),
+	})
+	return awsSession
+}
+
+func newConfig(credentialsFile, region string) *aws.Config {
+	awsConfig := aws.NewConfig().
+		WithRegion(region).
+		WithCredentials(credentials.NewSharedCredentials(credentialsFile, "default"))
+	awsConfig.Retryer = client.DefaultRetryer{
+		NumMaxRetries:    3,
+		MinRetryDelay:    5 * time.Second,
+		MinThrottleDelay: 5 * time.Second,
+	}
+	return awsConfig
 }
 
 type sortableStackEvents []*cloudformation.StackEvent


### PR DESCRIPTION
Consolidate AWS session and config handling and introduce a default
AWS SDK retry mechanism to hopefully help smooth out transient throttling
errors we often see in CI. Efficiacy of retries using the SDK seems to
vary by service, so we need to try this and observe how well it works in
the real world.