### PR TITLE
Revert "cli: add a --kubeconfig flag"

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -43,7 +43,6 @@ type Options struct {
 	BaseDomain         string
 	Overwrite          bool
 	DeleteOnFailure    bool
-	KubeConfig         string
 }
 
 func NewCreateCommand() *cobra.Command {
@@ -77,7 +76,6 @@ func NewCreateCommand() *cobra.Command {
 		InstanceType:       "m4.large",
 		Overwrite:          false,
 		DeleteOnFailure:    false,
-		KubeConfig:         os.Getenv("KUBECONFIG"),
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A namespace to contain the generated resources")
@@ -95,7 +93,6 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The base domain for the cluster")
 	cmd.Flags().BoolVar(&opts.Overwrite, "overwrite", opts.Overwrite, "If an existing cluster exists, overwrite it")
 	cmd.Flags().BoolVar(&opts.DeleteOnFailure, "delete-infra-on-failure", opts.DeleteOnFailure, "Delete the infra stack if creation fails")
-	cmd.Flags().StringVar(&opts.KubeConfig, "kubeconfig", opts.KubeConfig, "Path to kubeconfig")
 
 	cmd.MarkFlagRequired("pull-secret")
 	cmd.MarkFlagRequired("aws-creds")
@@ -121,10 +118,6 @@ func NewCreateCommand() *cobra.Command {
 func CreateCluster(ctx context.Context, opts Options) error {
 	if len(opts.ReleaseImage) == 0 {
 		return fmt.Errorf("release-image flag is required if default can not be fetched")
-	}
-
-	if err := os.Setenv("KUBECONFIG", opts.KubeConfig); err != nil {
-		return fmt.Errorf("failed to set kubeconfig")
 	}
 
 	pullSecret, err := ioutil.ReadFile(opts.PullSecretFile)

--- a/cmd/cluster/destroy.go
+++ b/cmd/cluster/destroy.go
@@ -31,7 +31,6 @@ type DestroyOptions struct {
 	Name               string
 	AWSCredentialsFile string
 	ClusterGracePeriod time.Duration
-	KubeConfig         string
 }
 
 func NewDestroyCommand() *cobra.Command {
@@ -45,14 +44,12 @@ func NewDestroyCommand() *cobra.Command {
 		Name:               "",
 		AWSCredentialsFile: "",
 		ClusterGracePeriod: 15 * time.Minute,
-		KubeConfig:         os.Getenv("KUBECONFIG"),
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A cluster namespace")
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A cluster name")
 	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
 	cmd.Flags().DurationVar(&opts.ClusterGracePeriod, "cluster-grace-period", opts.ClusterGracePeriod, "How long to wait for the cluster to be deleted before forcibly destroying its infra")
-	cmd.Flags().StringVar(&opts.KubeConfig, "kubeconfig", opts.KubeConfig, "Path to kubeconfig")
 
 	cmd.MarkFlagRequired("name")
 	cmd.MarkFlagRequired("aws-creds")
@@ -80,10 +77,6 @@ func NewDestroyCommand() *cobra.Command {
 }
 
 func DestroyCluster(ctx context.Context, o *DestroyOptions) error {
-	if err := os.Setenv("KUBECONFIG", o.KubeConfig); err != nil {
-		return fmt.Errorf("failed to set kubeconfig")
-	}
-
 	c, err := crclient.New(ctrl.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
 	if err != nil {
 		return fmt.Errorf("failed to create kube client: %w", err)


### PR DESCRIPTION
This reverts commit 2b1920278fc7cc53597dff0f167a3e5866ceb468.

We need to refactor client handling to fix this properly, and e2e
is broken due to an empty kubeconfig right now. So revert the
problematic fix and we can try again later.