### PR TITLE
Add progress and reason to hostedcluster printable columns

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -245,7 +245,9 @@ type ClusterVersionStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version.history[?(@.state==\"Completed\")].version",description="Version"
 // +kubebuilder:printcolumn:name="KubeConfig",type="string",JSONPath=".status.kubeconfig.name",description="KubeConfig Secret"
+// +kubebuilder:printcolumn:name="Progress",type="string",JSONPath=".status.version.history[?(@.state!=\"\")].state",description="Progress"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].status",description="Available"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].reason",description="Reason"
 // HostedCluster is the Schema for the hostedclusters API
 type HostedCluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -28,9 +28,17 @@ spec:
       jsonPath: .status.kubeconfig.name
       name: KubeConfig
       type: string
+    - description: Progress
+      jsonPath: .status.version.history[?(@.state!="")].state
+      name: Progress
+      type: string
     - description: Available
       jsonPath: .status.conditions[?(@.type=="Available")].status
       name: Available
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: Reason
       type: string
     name: v1alpha1
     schema:


### PR DESCRIPTION
Just added this to see what everyone thinks

Current looks like this:
```
NAME       VERSION   KUBECONFIG                        AVAILABLE 
example3                                               False        
```

Proposed:
While the cluster is coming up
```
NAME       VERSION   KUBECONFIG                        PROGRESS    AVAILABLE   REASON
example3   4.7.7                                       Partial     False       HostedClusterIsNotAvailable
```

When it's completed
```
NAME       VERSION   KUBECONFIG                        PROGRESS    AVAILABLE   REASON
example3   4.7.7     example3-admin-kubeconfig         Completed   True        HostedClusterIsAvailable
```
