### PR TITLE
Machine config server authentication

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/hosted-cluster-config-operator/cp-operator-role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/hosted-cluster-config-operator/cp-operator-role.yaml
@@ -7,6 +7,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   - pods
   verbs:
   - get
@@ -37,3 +38,12 @@ rules:
   - update
   - create
   - delete
+- apiGroups:
+    - hypershift.openshift.io
+  resources:
+    - machineconfigservers
+  verbs:
+    - get
+    - list
+    - patch
+    - update

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/machine-config-server/machine-config-server-haproxy-config-template-configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/machine-config-server/machine-config-server-haproxy-config-template-configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: machine-config-server-haproxy-config-template
+data:
+  haproxy.cfg: |
+    global
+      maxconn 7000
+    defaults
+      mode http
+      timeout client 10m
+      timeout server 10m
+      timeout connect 10s
+      timeout client-fin 5s
+      timeout server-fin 5s
+      timeout queue 5s
+      retries 3
+    backend machineconfigserverbackend
+        mode http
+        balance roundrobin
+        server server1 127.0.0.1:8080
+    frontend machineconfigserverfrontend
+        acl mcs_auth_header urlp(token) NODE_BOOTSTRAPPER_TOKEN_REPLACE
+        http-request deny unless mcs_auth_header
+        mode http
+        bind :8081 ssl crt /usr/local/etc/haproxy/tls.pem
+        default_backend machineconfigserverbackend

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -831,17 +831,32 @@ func (r *HostedControlPlaneReconciler) generateControlPlaneManifests(ctx context
 			return nil, fmt.Errorf("failed to read Root CA secret: %w", err)
 		}
 		pkiParams := &render.PKIParams{
-			ExternalAPIAddress:      infraStatus.APIAddress,
-			NodeInternalAPIServerIP: params.ExternalAPIAddress,
-			ExternalAPIPort:         params.ExternalAPIPort,
-			InternalAPIPort:         params.InternalAPIPort,
-			ServiceCIDR:             hcp.Spec.ServiceCIDR,
-			ExternalOauthAddress:    infraStatus.OAuthAddress,
-			IngressSubdomain:        "apps." + baseDomain,
-			ExternalOpenVPNAddress:  infraStatus.VPNAddress,
-			Namespace:               targetNamespace,
-			RootCACert:              rootCA.Data[pki.CASignerCertMapKey],
-			RootCAKey:               rootCA.Data[pki.CASignerKeyMapKey],
+			ExternalAPIAddress:         infraStatus.APIAddress,
+			NodeInternalAPIServerIP:    params.ExternalAPIAddress,
+			ExternalAPIPort:            params.ExternalAPIPort,
+			InternalAPIPort:            params.InternalAPIPort,
+			ServiceCIDR:                hcp.Spec.ServiceCIDR,
+			ExternalOauthAddress:       infraStatus.OAuthAddress,
+			MachineConfigServerAddress: infraStatus.APIAddress,
+			IngressSubdomain:           "apps." + baseDomain,
+			ExternalOpenVPNAddress:     infraStatus.VPNAddress,
+			Namespace:                  targetNamespace,
+			RootCACert:                 rootCA.Data[pki.CASignerCertMapKey],
+			RootCAKey:                  rootCA.Data[pki.CASignerKeyMapKey],
+		}
+		r.Log.Info("Checking if node port domain should be added to machine config server certs")
+		// TODO: note this assumes that all NodePort services share a common address which is virtually always the case in
+		// actual environments. Ideally this would be fetched from the MachineConfigServer CRD itself but there is a race
+		// condition between the creation of the MachineConfigServer CRD and the initial PKI creation that would result in the
+		// Machine Config Server not functioning in the node port deployment model.
+		if hcp.Spec.Services != nil {
+			for _, serviceItr := range hcp.Spec.Services {
+				if serviceItr.ServicePublishingStrategy.Type == hyperv1.NodePort && serviceItr.ServicePublishingStrategy.NodePort != nil {
+					r.Log.Info("Using node port address found in node port service", "serviceType", serviceItr.Service, "address", serviceItr.ServicePublishingStrategy.NodePort.Address)
+					pkiParams.MachineConfigServerAddress = serviceItr.ServicePublishingStrategy.NodePort.Address
+					break
+				}
+			}
 		}
 		r.Log.Info("generating PKI secret data")
 		data, err := renderpki.GeneratePKI(pkiParams)

--- a/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
@@ -256,6 +256,7 @@ func (c *clusterManifestContext) machineConfigServer() {
 		"machine-config-server/machine-config-server-configmap.yaml",
 		"machine-config-server/machine-config-server-secret.yaml",
 		"machine-config-server/machine-config-server-kubeconfig-secret.yaml",
+		"machine-config-server/machine-config-server-haproxy-config-template-configmap.yaml",
 	)
 }
 

--- a/hosted-cluster-config-operator/controllers/nodebootstrappertoken/nodebootstrappertoken_observer.go
+++ b/hosted-cluster-config-operator/controllers/nodebootstrappertoken/nodebootstrappertoken_observer.go
@@ -1,0 +1,175 @@
+package nodebootstrappertoken
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"net/url"
+	"strings"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	haproxyTemplateConfigmapName = "machine-config-server-haproxy-config-template"
+	haproxyConfigSecretName      = "machine-config-server-haproxy-config"
+	nodeBootstrapperTokenPrefix  = "node-bootstrapper-token"
+	machineConfigServerTLSSecret = "machine-config-server"
+)
+
+// NodeBootstrapperTokenObserver watches the node-bootstrapper service account:
+// It populates an haproxy config that the machine config server uses that enables
+// authorization on the ignition endpoint with the node-bootstrapper token.
+type NodeBootstrapperTokenObserver struct {
+
+	// Client is a client that allows access to the management cluster
+	Client client.Client
+
+	// TargetClient is a Kube client for the target cluster
+	TargetClient kubeclient.Interface
+
+	// Namespace is the namespace where the control plane of the cluster
+	// lives on the management server
+	Namespace string
+
+	// Log is the logger for this controller
+	Log logr.Logger
+}
+
+// Reconcile periodically watches for changes to the node-bootstrapper token and updates
+// the cluster machine config servers to use the value for authentication purposes.
+func (r *NodeBootstrapperTokenObserver) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
+	controllerLog := r.Log.WithValues("node-bootstrapper-token-observer", req.NamespacedName)
+	ctx := context.Background()
+	if req.Namespace != nodeBootstrapperTokenNamespace {
+		return ctrl.Result{}, nil
+	}
+
+	controllerLog.Info("syncing node bootstrapper token")
+	nodeBootstrapperToken, err := r.fetchBootstrapperToken(ctx, controllerLog)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	nodeBootstrapperTokenBase64 := base64.StdEncoding.EncodeToString(nodeBootstrapperToken)
+
+	controllerLog.Info("Fetching machine config server haproxy template")
+	var haproxyTemplateConfigMapData v1.ConfigMap
+	err = r.Client.Get(ctx, client.ObjectKey{Namespace: r.Namespace, Name: haproxyTemplateConfigmapName}, &haproxyTemplateConfigMapData)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	var haproxyConfigTemplateData string
+	var ok bool
+	if haproxyConfigTemplateData, ok = haproxyTemplateConfigMapData.Data["haproxy.cfg"]; !ok {
+		return ctrl.Result{}, fmt.Errorf("haproxy config not found")
+	}
+
+	controllerLog.Info("Fetching machine config server tls info")
+	var machineConfigServerSSLCerts v1.Secret
+	err = r.Client.Get(ctx, client.ObjectKey{Namespace: r.Namespace, Name: machineConfigServerTLSSecret}, &machineConfigServerSSLCerts)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	var machineConfigServerTLSCert, machineConfigServerTLSKey []byte
+	if machineConfigServerTLSCert, ok = machineConfigServerSSLCerts.Data["tls.crt"]; !ok {
+		return ctrl.Result{}, fmt.Errorf("machine config server tls.crt not found")
+	}
+	if machineConfigServerTLSKey, ok = machineConfigServerSSLCerts.Data["tls.key"]; !ok {
+		return ctrl.Result{}, fmt.Errorf("machine config server tls.crt not found")
+	}
+	machineConfigServerTLSCertHash := calculateHash(machineConfigServerTLSCert)
+	machineConfigServerTLSKeyHash := calculateHash(machineConfigServerTLSKey)
+	haproxyTLSPem := bytes.Join([][]byte{machineConfigServerTLSCert, machineConfigServerTLSKey}, []byte("\n"))
+	haproxyConfigData := bytes.Replace([]byte(haproxyConfigTemplateData), []byte("NODE_BOOTSTRAPPER_TOKEN_REPLACE"), []byte(url.QueryEscape(nodeBootstrapperTokenBase64)), -1)
+	haproxyConfigDataHash := calculateHash(haproxyConfigData)
+	controllerLog.Info("Creating/Updating machine config server haproxy secret")
+	haproxyConfigSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      haproxyConfigSecretName,
+			Namespace: r.Namespace,
+		},
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, haproxyConfigSecret, func() error {
+		haproxyConfigSecret.Type = v1.SecretTypeOpaque
+		haproxyConfigSecret.Data = map[string][]byte{
+			"node-bootstrapper-token": []byte(nodeBootstrapperToken),
+			"haproxy.cfg":             haproxyConfigData,
+			"tls.pem":                 haproxyTLSPem,
+		}
+		return nil
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	controllerLog.Info("Annotating MachineConfigServer CRDs in namespace to evaluate restart")
+	var machineConfigServerList = &hyperv1.MachineConfigServerList{}
+	err = r.Client.List(ctx, client.ObjectList(machineConfigServerList), client.InNamespace(r.Namespace))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if machineConfigServerList.Items != nil {
+		for _, machineConfigServer := range machineConfigServerList.Items {
+			if !(machineConfigServer.ObjectMeta.Annotations != nil &&
+				machineConfigServer.ObjectMeta.Annotations["haproxy-config-data-checksum"] == haproxyConfigDataHash &&
+				machineConfigServer.ObjectMeta.Annotations["machine-config-server-tls-key-checksum"] == machineConfigServerTLSKeyHash &&
+				machineConfigServer.ObjectMeta.Annotations["machine-config-server-tls-cert-checksum"] == machineConfigServerTLSCertHash) {
+				controllerLog.Info("Annotating MachineConfigServer CRD to trigger update to machine config servers", "name", machineConfigServer.Name)
+				if machineConfigServer.ObjectMeta.Annotations == nil {
+					machineConfigServer.ObjectMeta.Annotations = map[string]string{}
+				}
+				machineConfigServer.ObjectMeta.Annotations["haproxy-config-data-checksum"] = haproxyConfigDataHash
+				machineConfigServer.ObjectMeta.Annotations["machine-config-server-tls-key-checksum"] = machineConfigServerTLSKeyHash
+				machineConfigServer.ObjectMeta.Annotations["machine-config-server-tls-cert-checksum"] = machineConfigServerTLSCertHash
+				if err = r.Client.Update(ctx, &machineConfigServer); err != nil {
+					return ctrl.Result{}, err
+				}
+				controllerLog.Info("Annotated MachineConfigServer CRD", "name", machineConfigServer.Name)
+			}
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *NodeBootstrapperTokenObserver) fetchBootstrapperToken(ctx context.Context, logger logr.Logger) ([]byte, error) {
+	logger.Info("Fetching node bootstrapper service account info")
+	nodeBootstrapperSA, err := r.TargetClient.CoreV1().ServiceAccounts(nodeBootstrapperTokenNamespace).Get(ctx, nodeBootstrapperServiceAccountName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch node bootstrapper token service account: %v", err)
+	}
+	logger.Info("Fetched node bootstrapper service account info. Locating token secret in the service account")
+	secretToFetch := ""
+	for _, i := range nodeBootstrapperSA.Secrets {
+		if strings.HasPrefix(i.Name, nodeBootstrapperTokenPrefix) {
+			secretToFetch = i.Name
+			break
+		}
+	}
+	if len(secretToFetch) == 0 {
+		return nil, fmt.Errorf("service account token secret doesn't exist for node bootstrapper sa")
+	}
+	logger.Info("Fetching service account token secret")
+	secretData, err := r.TargetClient.CoreV1().Secrets(nodeBootstrapperTokenNamespace).Get(ctx, secretToFetch, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to node bootstrapper token secret data: %v", err)
+	}
+	var tokenData []byte
+	var ok bool
+	logger.Info("Fetched service account token secret. Ensuring token field is present")
+	if tokenData, ok = secretData.Data["token"]; !ok {
+		return nil, fmt.Errorf("token data could not be found in secret")
+	}
+	return tokenData, nil
+}
+
+func calculateHash(b []byte) string {
+	return fmt.Sprintf("%x", md5.Sum(b))
+}

--- a/hosted-cluster-config-operator/controllers/nodebootstrappertoken/setup.go
+++ b/hosted-cluster-config-operator/controllers/nodebootstrappertoken/setup.go
@@ -1,0 +1,46 @@
+package nodebootstrappertoken
+
+import (
+	"github.com/openshift/hypershift/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openshift/hypershift/hosted-cluster-config-operator/controllers"
+	"github.com/openshift/hypershift/hosted-cluster-config-operator/operator"
+)
+
+const (
+	nodeBootstrapperTokenNamespace     = "openshift-infra"
+	nodeBootstrapperServiceAccountName = "node-bootstrapper"
+)
+
+func Setup(cfg *operator.HostedClusterConfigOperatorConfig) error {
+	if err := setupNodeBootstrapperTokenObserver(cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupNodeBootstrapperTokenObserver(cfg *operator.HostedClusterConfigOperatorConfig) error {
+	informerFactory := cfg.TargetKubeInformersForNamespace(nodeBootstrapperTokenNamespace)
+	serviceAccounts := informerFactory.Core().V1().ServiceAccounts()
+	crdClient, err := client.New(cfg.Config(), client.Options{Scheme: api.Scheme})
+	if err != nil {
+		return err
+	}
+	reconciler := &NodeBootstrapperTokenObserver{
+		Client:       crdClient,
+		TargetClient: cfg.TargetKubeClient(),
+		Namespace:    cfg.Namespace(),
+		Log:          cfg.Logger().WithName("NodeBootstrapperTokenObserver"),
+	}
+	c, err := controller.New("node-bootstrapper-token-observer", cfg.Manager(), controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return err
+	}
+	if err := c.Watch(&source.Informer{Informer: serviceAccounts.Informer()}, controllers.NamedResourceHandler(nodeBootstrapperServiceAccountName)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/hosted-cluster-config-operator/main.go
+++ b/hosted-cluster-config-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/openshift/hypershift/hosted-cluster-config-operator/controllers/nodebootstrappertoken"
 	"io/ioutil"
 	"os"
 
@@ -50,8 +51,9 @@ var controllerFuncs = map[string]operator.ControllerSetupFunc{
 	"openshift-apiserver-monitor": openshiftapiservermonitor.Setup,
 	// TODO: non-essential, can't statically link to operator
 	//"openshift-controller-manager": openshiftcontrollermanager.Setup,
-	"infrastatus": infrastatus.Setup,
-	"node":        node.Setup,
+	"infrastatus":             infrastatus.Setup,
+	"node":                    node.Setup,
+	"node-bootstrapper-token": nodebootstrappertoken.Setup,
 }
 
 type HostedClusterConfigOperator struct {


### PR DESCRIPTION
Port of: https://github.com/openshift/hypershift/pull/92

Integrates a haproxy side car server with the machine config server that can enable it to do authentication using the node bootstrapper token.

Adds a controller that handles syncing any changes to the node bootstrapper token in a user cluster to the control plane and updating of the asssociated user-data secret to update the auth for the initial call workers use to auth to the ignition server.

Moves the ignition route to have E2E tls validation. CAs are passed to the user-data that workers use to make the initial ignition call to validate TLS.