### PR TITLE
Use common client function for CLI

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -20,7 +20,7 @@ import (
 	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
 	"github.com/openshift/hypershift/version"
 
-	cr "sigs.k8s.io/controller-runtime"
+	"github.com/openshift/hypershift/cmd/util"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -138,10 +138,7 @@ func CreateCluster(ctx context.Context, opts Options) error {
 		sshKey = key
 	}
 
-	client, err := crclient.New(cr.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
-	if err != nil {
-		return fmt.Errorf("failed to create client: %w", err)
-	}
+	client := util.GetClientOrDie()
 
 	// If creating the cluster directly, fail early unless overwrite is specified
 	// as updates aren't really part of the design intent and may not work.

--- a/cmd/cluster/dump.go
+++ b/cmd/cluster/dump.go
@@ -16,11 +16,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kubeclient "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperapi "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	capiv1 "github.com/openshift/hypershift/thirdparty/clusterapi/api/v1alpha4"
 	capiaws "github.com/openshift/hypershift/thirdparty/clusterapiprovideraws/v1alpha3"
@@ -65,11 +65,8 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 	if err != nil || len(ocCommand) == 0 {
 		return fmt.Errorf("cannot find oc command")
 	}
-	cfg := ctrl.GetConfigOrDie()
-	c, err := client.New(cfg, client.Options{Scheme: hyperapi.Scheme})
-	if err != nil {
-		return fmt.Errorf("failed to create management cluster client: %w", err)
-	}
+	cfg := util.GetConfigOrDie()
+	c := util.GetClientOrDie()
 	allNodePools := &hyperv1.NodePoolList{}
 	if err = c.List(ctx, allNodePools, client.InNamespace(opts.Namespace)); err != nil {
 		log.Error(err, "Cannot list nodepools")

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -25,9 +25,9 @@ import (
 
 	hyperapi "github.com/openshift/hypershift/api"
 	"github.com/openshift/hypershift/cmd/install/assets"
+	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/version"
 
-	cr "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -91,10 +91,7 @@ func render(objects []crclient.Object) {
 }
 
 func apply(ctx context.Context, objects []crclient.Object) error {
-	client, err := crclient.New(cr.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
-	if err != nil {
-		return fmt.Errorf("failed to create kube client: %w", err)
-	}
+	client := util.GetClientOrDie()
 	for _, object := range objects {
 		var objectBytes bytes.Buffer
 		err := hyperapi.YamlSerializer.Encode(object, &objectBytes)

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -14,12 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubejson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	hyperapi "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/util"
 )
 
 // TODO: NEXT: incorporate into an fzf workflow
@@ -68,11 +67,7 @@ func render(ctx context.Context) error {
 		kubejson.DefaultMetaFactory, scheme, scheme,
 		kubejson.SerializerOptions{Yaml: true, Pretty: true, Strict: true},
 	)
-	c, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: hyperapi.Scheme})
-	if err != nil {
-		return fmt.Errorf("failed to create kube client: %w", err)
-	}
-
+	c := util.GetClientOrDie()
 	kubeConfig, err := buildCombinedConfig(ctx, c)
 	if err != nil {
 		return fmt.Errorf("failed to make kubeconfig: %w", err)

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -12,13 +12,11 @@ import (
 
 	hyperapi "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	cr "sigs.k8s.io/controller-runtime"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type CreateNodePoolOptions struct {
@@ -64,13 +62,10 @@ func NewCreateCommand() *cobra.Command {
 }
 
 func (o *CreateNodePoolOptions) Run(ctx context.Context) error {
-	client, err := crclient.New(cr.GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
-	if err != nil {
-		return fmt.Errorf("failed to create kube client: %w", err)
-	}
+	client := util.GetClientOrDie()
 
 	hcluster := &hyperv1.HostedCluster{}
-	err = client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.ClusterName}, hcluster)
+	err := client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.ClusterName}, hcluster)
 	if err != nil {
 		return fmt.Errorf("failed to get HostedCluster %s/%s: %w", o.Namespace, o.Name, err)
 	}

--- a/cmd/util/client.go
+++ b/cmd/util/client.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/client-go/rest"
+	cr "sigs.k8s.io/controller-runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperapi "github.com/openshift/hypershift/api"
+)
+
+// GetConfigOrDie creates a REST config from current context
+func GetConfigOrDie() *rest.Config {
+	cfg := cr.GetConfigOrDie()
+	cfg.QPS = 100
+	cfg.Burst = 100
+	return cfg
+}
+
+// GetClientOrDie creates a controller-runtime client for Kubernetes
+func GetClientOrDie() crclient.Client {
+	client, err := crclient.New(GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to get kubernetes client: %v", err)
+		os.Exit(1)
+	}
+	return client
+}


### PR DESCRIPTION
Uses a common function to create a Kubernetes client in CLI and increases Burst and QPS for client config.
Gets rid of logs like:
```
I0420 16:48:16.574910 1636022 request.go:655] Throttling request took 1.001307884s, request: GET:https://api.cewong-dev.hypershift.cesarwong.com:6443/apis/flowcontrol.apiserver.k8s.io/v1beta1?timeout=32s
```