### PR TITLE
sync 4.8 rhcos build metadata

### DIFF
--- a/hypershift-operator/controllers/machineimage/static/4.8/rhcos-amd64.json
+++ b/hypershift-operator/controllers/machineimage/static/4.8/rhcos-amd64.json
@@ -1,0 +1,166 @@
+{
+    "amis": {
+        "af-south-1": {
+            "hvm": "ami-0d900e27af467146b"
+        },
+        "ap-east-1": {
+            "hvm": "ami-04ce7a22e5b7db487"
+        },
+        "ap-northeast-1": {
+            "hvm": "ami-0e17f3ea59669c5aa"
+        },
+        "ap-northeast-2": {
+            "hvm": "ami-097a16a749a789ad7"
+        },
+        "ap-northeast-3": {
+            "hvm": "ami-00b9f45cf617d16d3"
+        },
+        "ap-south-1": {
+            "hvm": "ami-065a7dfe2f6d654b6"
+        },
+        "ap-southeast-1": {
+            "hvm": "ami-099767a15280deaba"
+        },
+        "ap-southeast-2": {
+            "hvm": "ami-05279ea6c72022ebc"
+        },
+        "ca-central-1": {
+            "hvm": "ami-0f19fd857f6354c9e"
+        },
+        "eu-central-1": {
+            "hvm": "ami-04a51e4afa2f0c4f9"
+        },
+        "eu-north-1": {
+            "hvm": "ami-0e76d2ad5cc8d6487"
+        },
+        "eu-south-1": {
+            "hvm": "ami-027219dc7a7022b46"
+        },
+        "eu-west-1": {
+            "hvm": "ami-092fc96ee8ba499fe"
+        },
+        "eu-west-2": {
+            "hvm": "ami-0326391ca5b9f7a15"
+        },
+        "eu-west-3": {
+            "hvm": "ami-059a05f021a08421e"
+        },
+        "me-south-1": {
+            "hvm": "ami-0a29848408d8edfef"
+        },
+        "sa-east-1": {
+            "hvm": "ami-07c8e69e079f92c57"
+        },
+        "us-east-1": {
+            "hvm": "ami-0afb11ab25ba2b81f"
+        },
+        "us-east-2": {
+            "hvm": "ami-0de795e79298fc772"
+        },
+        "us-west-1": {
+            "hvm": "ami-0802d637f32f14e03"
+        },
+        "us-west-2": {
+            "hvm": "ami-00aff842e7221cbfe"
+        }
+    },
+    "azure": {
+        "image": "rhcos-48.84.202104271417-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202104271417-0-azure.x86_64.vhd"
+    },
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202104271417-0/x86_64/",
+    "buildid": "48.84.202104271417-0",
+    "gcp": {
+        "image": "rhcos-48-84-202104271417-0-gcp-x86-64",
+        "project": "rhcos-cloud",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202104271417-0-gcp-x86-64.tar.gz"
+    },
+    "images": {
+        "aws": {
+            "path": "rhcos-48.84.202104271417-0-aws.x86_64.vmdk.gz",
+            "sha256": "487cdf6cf9accd39603338c2791d9d75b2158b815422661f7c71e7cb3f624e7d",
+            "size": 1030356501,
+            "uncompressed-sha256": "baf10ab2cc15b574f5d18a5d6e1f46733372ba00700813b814a42152006ad69f",
+            "uncompressed-size": 1051378176
+        },
+        "azure": {
+            "path": "rhcos-48.84.202104271417-0-azure.x86_64.vhd.gz",
+            "sha256": "3aeba74d2ab0279c8a9c42b6ad1a8177a78914d4456450ef3a58a5222773e043",
+            "size": 1030351823,
+            "uncompressed-sha256": "4de96db9bc9b4c41ce5bc51f0fdab241ccf4dcd80c52e8c7b84b3b1486960f69",
+            "uncompressed-size": 17179869696
+        },
+        "gcp": {
+            "path": "rhcos-48.84.202104271417-0-gcp.x86_64.tar.gz",
+            "sha256": "3b724cebcc728caef98bc34868d4fe0912a2c914191b1c4508a817cc677c905d",
+            "size": 1015781085
+        },
+        "ibmcloud": {
+            "path": "rhcos-48.84.202104271417-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "7da8206083c2f5b8c7fc6c72fb40f8672adafd6fd9f2bd38143e126279a485bb",
+            "size": 1016145620,
+            "uncompressed-sha256": "03fe9243488bf12ecc5d9270af8dd69dc915d006984d67d12930d35c6f74b328",
+            "uncompressed-size": 2535784448
+        },
+        "live-initramfs": {
+            "path": "rhcos-48.84.202104271417-0-live-initramfs.x86_64.img",
+            "sha256": "d4bbf2f6d30619bf1b027e072c318481f7a3bc69c93f4fce615adaf5681a9d7c"
+        },
+        "live-iso": {
+            "path": "rhcos-48.84.202104271417-0-live.x86_64.iso",
+            "sha256": "53cf2d33743ac1ac307a7c848130afd2d8ece9c90287e082b26c388072ffc910"
+        },
+        "live-kernel": {
+            "path": "rhcos-48.84.202104271417-0-live-kernel-x86_64",
+            "sha256": "ee1e382beff1a32f35ebd4644bb4613e296690ce1c36d24b1bb2218e273274b2"
+        },
+        "live-rootfs": {
+            "path": "rhcos-48.84.202104271417-0-live-rootfs.x86_64.img",
+            "sha256": "dfabb47722be9cadee5c08dc045a21e2fe9495876d0f04addd51f749c91a07c0"
+        },
+        "metal": {
+            "path": "rhcos-48.84.202104271417-0-metal.x86_64.raw.gz",
+            "sha256": "1e9ae7980c6fb2cd7c7b7877926d318811f5070f8a5777da43f9a3d8977e717d",
+            "size": 1017835940,
+            "uncompressed-sha256": "fe534a6d263b36da45aff29d560ca9e8a1665bdbddfd1b1066189eb96980f625",
+            "uncompressed-size": 3960471552
+        },
+        "metal4k": {
+            "path": "rhcos-48.84.202104271417-0-metal4k.x86_64.raw.gz",
+            "sha256": "48072ad7baa1e138eb285c806c0c2fbbec197113813cc5d48ab7be2a9061136f",
+            "size": 1015445056,
+            "uncompressed-sha256": "e5b5ead286451b1c5f6e3938746e9a725a6bf6413eaaf830f86ad46f3f84752c",
+            "uncompressed-size": 3960471552
+        },
+        "openstack": {
+            "path": "rhcos-48.84.202104271417-0-openstack.x86_64.qcow2.gz",
+            "sha256": "bdab49e61715b72c5e937c54a232677cbf821ebcd71aeb3ba58028683cccad07",
+            "size": 1016145278,
+            "uncompressed-sha256": "ff31c2b4f1a51ef4ab36a0a9423dd15431f9778f8d5cda2721a6a19d8df9aa2f",
+            "uncompressed-size": 2535784448
+        },
+        "ostree": {
+            "path": "rhcos-48.84.202104271417-0-ostree.x86_64.tar",
+            "sha256": "5231c8a307523f21420792a1d4b71c3a78c16072b8400a50415b8993b60af833",
+            "size": 940738560
+        },
+        "qemu": {
+            "path": "rhcos-48.84.202104271417-0-qemu.x86_64.qcow2.gz",
+            "sha256": "7b073855c94f0fef43bef1a4a5ee63c0925a63c64765d42a1d1d7595d8647366",
+            "size": 1017332028,
+            "uncompressed-sha256": "04f36fce364cf54e5cee6994076b14319933d8fb983ca127c7960c95934f17e2",
+            "uncompressed-size": 2572156928
+        },
+        "vmware": {
+            "path": "rhcos-48.84.202104271417-0-vmware.x86_64.ova",
+            "sha256": "01718ad7d557ebf6396cd5bdb9e4049408ab3ca114a4f5eeef66cbae205f5015",
+            "size": 1051392000
+        }
+    },
+    "oscontainer": {
+        "digest": "sha256:7b17f6d85113b24a3df3d6fbd799890a84dc5ff6944f3abb31aa12388bc665f1",
+        "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+    },
+    "ostree-commit": "1dfb50d9fd2fa0fa9269827a443109b031f9e51dcdd169def9c800d31fffffd4",
+    "ostree-version": "48.84.202104271417-0"
+}

--- a/hypershift-operator/controllers/machineimage/static/assets.go
+++ b/hypershift-operator/controllers/machineimage/static/assets.go
@@ -3,6 +3,7 @@ package static
 import "embed"
 
 //go:embed 4.7/*
+//go:embed 4.8/*
 
 var content embed.FS
 

--- a/hypershift-operator/controllers/machineimage/static/provider.go
+++ b/hypershift-operator/controllers/machineimage/static/provider.go
@@ -25,8 +25,11 @@ func (p *StaticImageProvider) Image(cluster *hyperv1.HostedCluster) (string, err
 	if cluster.Spec.Platform.AWS == nil {
 		return "", fmt.Errorf("unsupported platform, only AWS is supported")
 	}
-	// TODO: Support other versions, other archs. Currently only 4.7 amd64 is supported.
-	imageData := MustAsset("4.7/rhcos-amd64.json")
+
+	// TODO: Support other versions, other archs. Currently only 4.8 amd64 is supported.
+	// This JSON document is synced with
+	// https://github.com/openshift/installer/blob/master/data/data/rhcos-amd64.json
+	imageData := MustAsset("4.8/rhcos-amd64.json")
 	images := &staticImages{}
 	if err := json.Unmarshal(imageData, images); err != nil {
 		return "", fmt.Errorf("cannot decode image data: %w", err)

--- a/hypershift-operator/controllers/machineimage/static/provider_test.go
+++ b/hypershift-operator/controllers/machineimage/static/provider_test.go
@@ -21,7 +21,7 @@ func TestImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if image != "ami-0d5f9982f029fbc14" {
+	if image != "ami-0afb11ab25ba2b81f" {
 		t.Fatalf("unexpected image: %s", image)
 	}
 }


### PR DESCRIPTION
Generated from build metadata for ART build 48.84.202104192217-0 using
https://github.com/openshift/installer/blob/release-4.8/hack/update-rhcos-bootimage.py

Installer is not yet updated
https://github.com/openshift/installer/blob/release-4.8/data/data/rhcos.json