### PR TITLE
iam: Create IAM users with policies to inject into clusters

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -1,6 +1,8 @@
 package fixtures
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -10,20 +12,22 @@ import (
 )
 
 type ExampleResources struct {
-	Namespace      *corev1.Namespace
-	PullSecret     *corev1.Secret
-	AWSCredentials *corev1.Secret
-	SigningKey     *corev1.Secret
-	SSHKey         *corev1.Secret
-	Cluster        *hyperv1.HostedCluster
+	Namespace                   *corev1.Namespace
+	PullSecret                  *corev1.Secret
+	KubeCloudControllerAWSCreds *corev1.Secret
+	NodePoolManagementAWSCreds  *corev1.Secret
+	SigningKey                  *corev1.Secret
+	SSHKey                      *corev1.Secret
+	Cluster                     *hyperv1.HostedCluster
 }
 
 func (o *ExampleResources) AsObjects() []crclient.Object {
 	objects := []crclient.Object{
 		o.Namespace,
 		o.PullSecret,
-		o.AWSCredentials,
 		o.SigningKey,
+		o.KubeCloudControllerAWSCreds,
+		o.NodePoolManagementAWSCreds,
 		o.Cluster,
 	}
 	if o.SSHKey != nil {
@@ -37,7 +41,6 @@ type ExampleOptions struct {
 	Name             string
 	ReleaseImage     string
 	PullSecret       []byte
-	AWSCredentials   []byte
 	SigningKey       []byte
 	IssuerURL        string
 	SSHKey           []byte
@@ -52,14 +55,18 @@ type ExampleOptions struct {
 }
 
 type ExampleAWSOptions struct {
-	Region          string
-	Zone            string
-	VPCID           string
-	SubnetID        string
-	SecurityGroupID string
-	InstanceProfile string
-	InstanceType    string
-	Roles           []hyperv1.AWSRoleCredentials
+	Region                                 string
+	Zone                                   string
+	VPCID                                  string
+	SubnetID                               string
+	SecurityGroupID                        string
+	InstanceProfile                        string
+	InstanceType                           string
+	Roles                                  []hyperv1.AWSRoleCredentials
+	KubeCloudControllerUserAccessKeyID     string
+	KubeCloudControllerUserAccessKeySecret string
+	NodePoolManagementUserAccessKeyID      string
+	NodePoolManagementUserAccessKeySecret  string
 }
 
 func (o ExampleOptions) Resources() *ExampleResources {
@@ -87,19 +94,32 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		},
 	}
 
-	awsCredsSecret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace.Name,
-			Name:      o.Name + "-provider-creds",
-		},
-		Data: map[string][]byte{
-			"credentials": o.AWSCredentials,
-		},
+	buildAWSCreds := func(name, id, key string) *corev1.Secret {
+		return &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace.Name,
+				Name:      name,
+			},
+			Data: map[string][]byte{
+				"credentials": []byte(fmt.Sprintf(`[default]
+aws_access_key_id = %s
+aws_secret_access_key = %s
+`, id, key)),
+			},
+		}
 	}
+	kubeCloudControllerCredsSecret := buildAWSCreds(
+		o.Name+"-cloud-ctrl-creds",
+		o.AWS.KubeCloudControllerUserAccessKeyID,
+		o.AWS.KubeCloudControllerUserAccessKeySecret)
+	nodePoolManagementCredsSecret := buildAWSCreds(
+		o.Name+"-node-mgmt-creds",
+		o.AWS.NodePoolManagementUserAccessKeyID,
+		o.AWS.NodePoolManagementUserAccessKeySecret)
 
 	signingKeySecret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -200,8 +220,8 @@ func (o ExampleOptions) Resources() *ExampleResources {
 						},
 						Zone: o.AWS.Zone,
 					},
-					KubeCloudControllerCreds: corev1.LocalObjectReference{Name: awsCredsSecret.Name},
-					NodePoolManagementCreds:  corev1.LocalObjectReference{Name: awsCredsSecret.Name},
+					KubeCloudControllerCreds: corev1.LocalObjectReference{Name: kubeCloudControllerCredsSecret.Name},
+					NodePoolManagementCreds:  corev1.LocalObjectReference{Name: nodePoolManagementCredsSecret.Name},
 				},
 			},
 		},
@@ -211,11 +231,12 @@ func (o ExampleOptions) Resources() *ExampleResources {
 	}
 
 	return &ExampleResources{
-		Namespace:      namespace,
-		PullSecret:     pullSecret,
-		AWSCredentials: awsCredsSecret,
-		SigningKey:     signingKeySecret,
-		SSHKey:         sshKeySecret,
-		Cluster:        cluster,
+		Namespace:                   namespace,
+		PullSecret:                  pullSecret,
+		KubeCloudControllerAWSCreds: kubeCloudControllerCredsSecret,
+		NodePoolManagementAWSCreds:  nodePoolManagementCredsSecret,
+		SigningKey:                  signingKeySecret,
+		SSHKey:                      sshKeySecret,
+		Cluster:                     cluster,
 	}
 }

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -112,10 +112,6 @@ func CreateCluster(ctx context.Context, opts Options) error {
 	if err != nil {
 		return fmt.Errorf("failed to read pull secret file: %w", err)
 	}
-	awsCredentials, err := ioutil.ReadFile(opts.AWSCredentialsFile)
-	if err != nil {
-		return fmt.Errorf("failed to read aws credentials: %w", err)
-	}
 	var sshKey []byte
 	if len(opts.SSHKeyFile) > 0 {
 		key, err := ioutil.ReadFile(opts.SSHKeyFile)
@@ -180,7 +176,7 @@ func CreateCluster(ctx context.Context, opts Options) error {
 			AWSCredentialsFile: opts.AWSCredentialsFile,
 			InfraID:            infra.InfraID,
 		}
-		iamInfo, err = opt.CreateIAM()
+		iamInfo, err = opt.CreateIAM(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create iam: %w", err)
 		}
@@ -191,7 +187,6 @@ func CreateCluster(ctx context.Context, opts Options) error {
 		Name:             infra.Name,
 		ReleaseImage:     opts.ReleaseImage,
 		PullSecret:       pullSecret,
-		AWSCredentials:   awsCredentials,
 		SigningKey:       iamInfo.ServiceAccountSigningKey,
 		IssuerURL:        iamInfo.IssuerURL,
 		SSHKey:           sshKey,
@@ -202,14 +197,18 @@ func CreateCluster(ctx context.Context, opts Options) error {
 		PublicZoneID:     infra.PublicZoneID,
 		PrivateZoneID:    infra.PrivateZoneID,
 		AWS: apifixtures.ExampleAWSOptions{
-			Region:          infra.Region,
-			Zone:            infra.Zone,
-			VPCID:           infra.VPCID,
-			SubnetID:        infra.PrivateSubnetID,
-			SecurityGroupID: infra.SecurityGroupID,
-			InstanceProfile: iamInfo.ProfileName,
-			InstanceType:    opts.InstanceType,
-			Roles:           iamInfo.Roles,
+			Region:                                 infra.Region,
+			Zone:                                   infra.Zone,
+			VPCID:                                  infra.VPCID,
+			SubnetID:                               infra.PrivateSubnetID,
+			SecurityGroupID:                        infra.SecurityGroupID,
+			InstanceProfile:                        iamInfo.ProfileName,
+			InstanceType:                           opts.InstanceType,
+			Roles:                                  iamInfo.Roles,
+			KubeCloudControllerUserAccessKeyID:     iamInfo.KubeCloudControllerUserAccessKeyID,
+			KubeCloudControllerUserAccessKeySecret: iamInfo.KubeCloudControllerUserAccessKeySecret,
+			NodePoolManagementUserAccessKeyID:      iamInfo.NodePoolManagementUserAccessKeyID,
+			NodePoolManagementUserAccessKeySecret:  iamInfo.NodePoolManagementUserAccessKeySecret,
 		},
 	}.Resources().AsObjects()
 

--- a/cmd/cluster/destroy.go
+++ b/cmd/cluster/destroy.go
@@ -126,7 +126,7 @@ func DestroyCluster(ctx context.Context, o *DestroyOptions) error {
 			AWSCredentialsFile: o.AWSCredentialsFile,
 			InfraID:            hostedCluster.Spec.InfraID,
 		}
-		err := destroyOpts.DestroyIAM()
+		err := destroyOpts.DestroyIAM(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to destroy IAM: %w", err)
 		}

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -139,6 +140,157 @@ const (
 		"iss",
 		"sub"
 	]
+}`
+
+	cloudControllerPolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeImages",
+        "ec2:DescribeRegions",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVolumes",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifyVolume",
+        "ec2:AttachVolume",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateRoute",
+        "ec2:DeleteRoute",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteVolume",
+        "ec2:DetachVolume",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:DescribeVpcs",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:AttachLoadBalancerToSubnets",
+        "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateLoadBalancerPolicy",
+        "elasticloadbalancing:CreateLoadBalancerListeners",
+        "elasticloadbalancing:ConfigureHealthCheck",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteLoadBalancerListeners",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DetachLoadBalancerFromSubnets",
+        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+        "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateTargetGroup",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeLoadBalancerPolicies",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+        "iam:CreateServiceLinkedRole",
+        "kms:DescribeKey"
+      ],
+      "Resource": [
+        "*"
+      ],
+      "Effect": "Allow"
+    }
+  ]
+}`
+
+	nodePoolPolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:AllocateAddress",
+        "ec2:AssociateRouteTable",
+        "ec2:AttachInternetGateway",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateInternetGateway",
+        "ec2:CreateNatGateway",
+        "ec2:CreateRoute",
+        "ec2:CreateRouteTable",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateSubnet",
+        "ec2:CreateTags",
+        "ec2:DeleteInternetGateway",
+        "ec2:DeleteNatGateway",
+        "ec2:DeleteRouteTable",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteSubnet",
+        "ec2:DeleteTags",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeNatGateways",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeNetworkInterfaceAttribute",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVolumes",
+        "ec2:DetachInternetGateway",
+        "ec2:DisassociateRouteTable",
+        "ec2:DisassociateAddress",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:ModifySubnetAttribute",
+        "ec2:ReleaseAddress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "tag:GetResources",
+        "ec2:CreateLaunchTemplate",
+        "ec2:CreateLaunchTemplateVersion",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:DescribeLaunchTemplateVersions",
+        "ec2:DeleteLaunchTemplate",
+        "ec2:DeleteLaunchTemplateVersions"
+      ],
+      "Resource": [
+        "*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Condition": {
+        "StringLike": {
+          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+        }
+      },
+      "Action": [
+        "iam:CreateServiceLinkedRole"
+      ],
+      "Resource": [
+        "arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": [
+        "arn:*:iam::*:role/*-worker-role"
+      ],
+      "Effect": "Allow"
+    }
+  ]
 }`
 )
 
@@ -448,6 +600,47 @@ func (o *CreateIAMOptions) CreateWorkerInstanceProfile(client iamiface.IAMAPI, p
 		log.Info("Created role policy", "name", rolePolicyName)
 	}
 	return nil
+}
+
+func (o *CreateIAMOptions) CreateCredentialedUserWithPolicy(ctx context.Context, client iamiface.IAMAPI, userName, policyDocument string) (*iam.AccessKey, error) {
+	var user *iam.User
+	if output, err := client.CreateUserWithContext(ctx, &iam.CreateUserInput{
+		UserName: aws.String(userName),
+		Tags:     iamTags(o.InfraID, userName),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to create user: %w", err)
+	} else {
+		user = output.User
+	}
+	log.Info("Created user", "user", userName)
+
+	var policy *iam.Policy
+	if output, err := client.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String(userName),
+		PolicyDocument: aws.String(policyDocument),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to create policy: %w", err)
+	} else {
+		policy = output.Policy
+	}
+	log.Info("Created policy", "name", aws.StringValue(policy.PolicyName), "arn", aws.StringValue(policy.Arn))
+
+	if _, err := client.AttachUserPolicyWithContext(ctx, &iam.AttachUserPolicyInput{
+		UserName:  user.UserName,
+		PolicyArn: policy.Arn,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to attach user policy: %w", err)
+	}
+	log.Info("Attached user to policy", "user", aws.StringValue(user.UserName), "policy", aws.StringValue(policy.Arn))
+
+	if output, err := client.CreateAccessKeyWithContext(ctx, &iam.CreateAccessKeyInput{
+		UserName: user.UserName,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to create access key: %w", err)
+	} else {
+		log.Info("Created access key", "user", aws.StringValue(user.UserName))
+		return output.AccessKey, nil
+	}
 }
 
 func existingRole(client iamiface.IAMAPI, roleName string) (*iam.Role, error) {


### PR DESCRIPTION
Before this commit, the admin's AWS credentials passed to create cluster were
copied into the guest cluster for use by each credentials context. The AWS
credentials passed to create cluster are assumed to be super-privileged and
not intended to be leaked into guest clusters.

Now, when creating a new cluster, OCP is given credentials for users created
specifically for that cluster as part of infra creation.

This is another step towards IAM isolation by introducing new policies for each
HostedCluster credentials context (KubeCloudControllerCreds and
NodePoolManagementCreds) and creating new users associated with each of those
policies. The CloudFormation template takes care of creating the policies and
users and exposes the credentials as outputs.

Reimplementation of https://github.com/openshift/hypershift/pull/154