### PR TITLE
cli: Add AWS Go SDK client retry handling tweaks

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -9,6 +9,16 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/spf13/cobra"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,6 +26,7 @@ import (
 	hyperapi "github.com/openshift/hypershift/api"
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/version"
 
 	"github.com/openshift/hypershift/cmd/util"
@@ -42,6 +53,12 @@ type Options struct {
 	BaseDomain         string
 	PublicZoneID       string
 	PrivateZoneID      string
+
+	EC2Client     ec2iface.EC2API
+	Route53Client route53iface.Route53API
+	ELBClient     elbiface.ELBAPI
+	IAMClient     iamiface.IAMAPI
+	S3Client      s3iface.S3API
 }
 
 func NewCreateCommand() *cobra.Command {
@@ -93,7 +110,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.MarkFlagRequired("pull-secret")
 	cmd.MarkFlagRequired("aws-creds")
 
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT)
@@ -101,7 +118,19 @@ func NewCreateCommand() *cobra.Command {
 			<-sigs
 			cancel()
 		}()
-		return CreateCluster(ctx, opts)
+
+		awsSession := awsutil.NewSession()
+		awsConfig := awsutil.NewConfig(opts.AWSCredentialsFile, opts.Region)
+		opts.IAMClient = iam.New(awsSession, awsConfig)
+		opts.S3Client = s3.New(awsSession, awsConfig)
+		opts.EC2Client = ec2.New(awsSession, awsConfig)
+		opts.ELBClient = elb.New(awsSession, awsConfig)
+		opts.Route53Client = route53.New(awsSession, awsutil.NewRoute53Config(opts.AWSCredentialsFile))
+
+		if err := CreateCluster(ctx, opts); err != nil {
+			log.Error(err, "Failed to create cluster")
+			os.Exit(1)
+		}
 	}
 
 	return cmd
@@ -153,8 +182,11 @@ func CreateCluster(ctx context.Context, opts Options) error {
 			AWSCredentialsFile: opts.AWSCredentialsFile,
 			Name:               opts.Name,
 			BaseDomain:         opts.BaseDomain,
+			EC2Client:          opts.EC2Client,
+			Route53Client:      opts.Route53Client,
+			ELBClient:          opts.ELBClient,
 		}
-		infra, err = opt.CreateInfra()
+		infra, err = opt.CreateInfra(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create infra: %w", err)
 		}
@@ -175,6 +207,8 @@ func CreateCluster(ctx context.Context, opts Options) error {
 			Region:             opts.Region,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
 			InfraID:            infra.InfraID,
+			IAMClient:          opts.IAMClient,
+			S3Client:           opts.S3Client,
 		}
 		iamInfo, err = opt.CreateIAM(ctx)
 		if err != nil {

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -1,13 +1,13 @@
 package aws
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -15,6 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/spf13/cobra"
+
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 )
 
 type CreateInfraOptions struct {
@@ -25,6 +27,10 @@ type CreateInfraOptions struct {
 	BaseDomain         string
 	OutputFile         string
 	AdditionalTags     []string
+
+	EC2Client     ec2iface.EC2API
+	Route53Client route53iface.Route53API
+	ELBClient     elbiface.ELBAPI
 
 	additionalEC2Tags []*ec2.Tag
 }
@@ -76,17 +82,32 @@ func NewCreateCommand() *cobra.Command {
 	cmd.MarkFlagRequired("base-domain")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		if err := opts.Run(); err != nil {
-			log.Error(err, "Error")
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		awsSession := awsutil.NewSession()
+		awsConfig := awsutil.NewConfig(opts.AWSCredentialsFile, opts.Region)
+		opts.EC2Client = ec2.New(awsSession, awsConfig)
+		opts.ELBClient = elb.New(awsSession, awsConfig)
+		opts.Route53Client = route53.New(awsSession, awsutil.NewRoute53Config(opts.AWSCredentialsFile))
+
+		if err := opts.Run(ctx); err != nil {
+			log.Error(err, "Failed to create infrastructure")
 			os.Exit(1)
 		}
+		log.Info("Successfully created infrastructure")
 	}
 
 	return cmd
 }
 
-func (o *CreateInfraOptions) Run() error {
-	result, err := o.CreateInfra()
+func (o *CreateInfraOptions) Run(ctx context.Context) error {
+	result, err := o.CreateInfra(ctx)
 	if err != nil {
 		return err
 	}
@@ -110,7 +131,7 @@ func (o *CreateInfraOptions) Run() error {
 	return nil
 }
 
-func (o *CreateInfraOptions) CreateInfra() (*CreateInfraOutput, error) {
+func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutput, error) {
 	log.Info("Creating infrastructure", "id", o.InfraID)
 
 	var err error
@@ -124,102 +145,56 @@ func (o *CreateInfraOptions) CreateInfra() (*CreateInfraOutput, error) {
 		Name:        o.Name,
 		BaseDomain:  o.BaseDomain,
 	}
-	client, err := ec2Client(o.AWSCredentialsFile, o.Region)
+	result.Zone, err = o.firstZone(o.EC2Client)
 	if err != nil {
 		return nil, err
 	}
-	result.Zone, err = o.firstZone(client)
+	result.VPCID, err = o.createVPC(o.EC2Client)
 	if err != nil {
 		return nil, err
 	}
-	result.VPCID, err = o.createVPC(client)
+	if err = o.CreateDHCPOptions(o.EC2Client, result.VPCID); err != nil {
+		return nil, err
+	}
+	result.PrivateSubnetID, err = o.CreatePrivateSubnet(o.EC2Client, result.VPCID, result.Zone)
 	if err != nil {
 		return nil, err
 	}
-	if err = o.CreateDHCPOptions(client, result.VPCID); err != nil {
-		return nil, err
-	}
-	result.PrivateSubnetID, err = o.CreatePrivateSubnet(client, result.VPCID, result.Zone)
+	result.PublicSubnetID, err = o.CreatePublicSubnet(o.EC2Client, result.VPCID, result.Zone)
 	if err != nil {
 		return nil, err
 	}
-	result.PublicSubnetID, err = o.CreatePublicSubnet(client, result.VPCID, result.Zone)
+	igwID, err := o.CreateInternetGateway(o.EC2Client, result.VPCID)
 	if err != nil {
 		return nil, err
 	}
-	igwID, err := o.CreateInternetGateway(client, result.VPCID)
+	natGatewayID, err := o.CreateNATGateway(o.EC2Client, result.PublicSubnetID, result.Zone)
 	if err != nil {
 		return nil, err
 	}
-	natGatewayID, err := o.CreateNATGateway(client, result.PublicSubnetID, result.Zone)
+	result.SecurityGroupID, err = o.CreateWorkerSecurityGroup(o.EC2Client, result.VPCID)
 	if err != nil {
 		return nil, err
 	}
-	result.SecurityGroupID, err = o.CreateWorkerSecurityGroup(client, result.VPCID)
+	privateRouteTable, err := o.CreatePrivateRouteTable(o.EC2Client, result.VPCID, natGatewayID, result.PrivateSubnetID, result.Zone)
 	if err != nil {
 		return nil, err
 	}
-	privateRouteTable, err := o.CreatePrivateRouteTable(client, result.VPCID, natGatewayID, result.PrivateSubnetID, result.Zone)
+	publicRouteTable, err := o.CreatePublicRouteTable(o.EC2Client, result.VPCID, igwID, result.PublicSubnetID, result.Zone)
 	if err != nil {
 		return nil, err
 	}
-	publicRouteTable, err := o.CreatePublicRouteTable(client, result.VPCID, igwID, result.PublicSubnetID, result.Zone)
+	err = o.CreateVPCS3Endpoint(o.EC2Client, result.VPCID, privateRouteTable, publicRouteTable)
 	if err != nil {
 		return nil, err
 	}
-	err = o.CreateVPCS3Endpoint(client, result.VPCID, privateRouteTable, publicRouteTable)
+	result.PublicZoneID, err = o.LookupPublicZone(o.Route53Client)
 	if err != nil {
 		return nil, err
 	}
-	r53client, err := route53Client(o.AWSCredentialsFile)
-	if err != nil {
-		return nil, err
-	}
-	result.PublicZoneID, err = o.LookupPublicZone(r53client)
-	if err != nil {
-		return nil, err
-	}
-	result.PrivateZoneID, err = o.CreatePrivateZone(r53client, result.VPCID)
+	result.PrivateZoneID, err = o.CreatePrivateZone(o.Route53Client, result.VPCID)
 	if err != nil {
 		return nil, err
 	}
 	return result, nil
-}
-
-func ec2Client(creds, region string) (ec2iface.EC2API, error) {
-	awsConfig := &aws.Config{
-		Region: aws.String(region),
-	}
-	awsConfig.Credentials = credentials.NewSharedCredentials(creds, "default")
-	s, err := session.NewSession(awsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client session: %w", err)
-	}
-	return ec2.New(s), nil
-}
-
-func route53Client(creds string) (route53iface.Route53API, error) {
-	awsConfig := &aws.Config{
-		// Route53 is weird about regions
-		// https://github.com/openshift/cluster-ingress-operator/blob/5660b43d66bd63bbe2dcb45fb40df98d8d91347e/pkg/dns/aws/dns.go#L163-L169
-		Region: aws.String("us-east-1"),
-	}
-	awsConfig.Credentials = credentials.NewSharedCredentials(creds, "default")
-	s, err := session.NewSession(awsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client session: %w", err)
-	}
-	return route53.New(s), nil
-}
-
-func elbClient(creds, region string) (elbiface.ELBAPI, error) {
-	awsConfig := &aws.Config{
-		Region: aws.String(region),
-	}
-	awsConfig.Credentials = credentials.NewSharedCredentials(creds, "default")
-	s, err := session.NewSession(awsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client session: %w", err)
-	}
-	return elb.New(s), nil
 }

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -17,12 +17,17 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 )
 
 type DestroyIAMOptions struct {
 	Region             string
 	AWSCredentialsFile string
 	InfraID            string
+
+	IAMClient iamiface.IAMAPI
+	S3Client  s3iface.S3API
 }
 
 func NewDestroyIAMCommand() *cobra.Command {
@@ -52,6 +57,12 @@ func NewDestroyIAMCommand() *cobra.Command {
 			<-sigs
 			cancel()
 		}()
+
+		awsSession := awsutil.NewSession()
+		awsConfig := awsutil.NewConfig(opts.AWSCredentialsFile, opts.Region)
+		opts.IAMClient = iam.New(awsSession, awsConfig)
+		opts.S3Client = s3.New(awsSession, awsConfig)
+
 		if err := opts.DestroyIAM(ctx); err != nil {
 			return err
 		}
@@ -75,19 +86,11 @@ func (o *DestroyIAMOptions) Run(ctx context.Context) error {
 
 func (o *DestroyIAMOptions) DestroyIAM(ctx context.Context) error {
 	var err error
-	iamClient, err := IAMClient(o.AWSCredentialsFile, o.Region)
+	err = o.DestroyOIDCResources(ctx, o.IAMClient, o.S3Client)
 	if err != nil {
 		return err
 	}
-	s3Client, err := S3Client(o.AWSCredentialsFile, o.Region)
-	if err != nil {
-		return err
-	}
-	err = o.DestroyOIDCResources(ctx, iamClient, s3Client)
-	if err != nil {
-		return err
-	}
-	err = o.DestroyWorkerInstanceProfile(iamClient)
+	err = o.DestroyWorkerInstanceProfile(o.IAMClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/infra/aws/util/util.go
+++ b/cmd/infra/aws/util/util.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+func NewSession() *session.Session {
+	awsSession := session.Must(session.NewSession())
+	awsSession.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "openshift.io/hypershift",
+		Fn:   request.MakeAddToUserAgentHandler("openshift.io hypershift", "cli"),
+	})
+	return awsSession
+}
+
+func NewConfig(credentialsFile, region string) *aws.Config {
+	awsConfig := aws.NewConfig().
+		WithRegion(region).
+		WithCredentials(credentials.NewSharedCredentials(credentialsFile, "default"))
+	awsConfig.Retryer = client.DefaultRetryer{
+		NumMaxRetries:    10,
+		MinRetryDelay:    5 * time.Second,
+		MinThrottleDelay: 5 * time.Second,
+	}
+	return awsConfig
+}
+
+func NewRoute53Config(credentialsFile string) *aws.Config {
+	awsConfig := NewConfig(credentialsFile, "us-east-1")
+	awsConfig.Retryer = client.DefaultRetryer{
+		NumMaxRetries:    10,
+		MinRetryDelay:    5 * time.Second,
+		MinThrottleDelay: 10 * time.Second,
+	}
+	return awsConfig
+}

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -71,7 +71,13 @@ func TestControlPlaneUpgrade(t *testing.T) {
 		DestroyCluster(t, context.Background(), &cmdcluster.DestroyOptions{
 			Namespace:          hostedCluster.Namespace,
 			Name:               hostedCluster.Name,
+			Region:             GlobalOptions.Region,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
+			EC2Client:          GlobalOptions.EC2Client,
+			Route53Client:      GlobalOptions.Route53Client,
+			ELBClient:          GlobalOptions.ELBClient,
+			IAMClient:          GlobalOptions.IAMClient,
+			S3Client:           GlobalOptions.S3Client,
 			ClusterGracePeriod: 15 * time.Minute,
 		}, opts.ArtifactDir)
 		DeleteNamespace(t, context.Background(), client, namespace.Name)
@@ -84,10 +90,15 @@ func TestControlPlaneUpgrade(t *testing.T) {
 		ReleaseImage:       opts.FromReleaseImage,
 		PullSecretFile:     opts.PullSecretFile,
 		AWSCredentialsFile: opts.AWSCredentialsFile,
+		Region:             GlobalOptions.Region,
+		EC2Client:          GlobalOptions.EC2Client,
+		Route53Client:      GlobalOptions.Route53Client,
+		ELBClient:          GlobalOptions.ELBClient,
+		IAMClient:          GlobalOptions.IAMClient,
+		S3Client:           GlobalOptions.S3Client,
 		// TODO: generate a key on the fly
 		SSHKeyFile:       "",
 		NodePoolReplicas: 0,
-		Region:           "us-east-1",
 		InstanceType:     "m4.large",
 	}
 	err = cmdcluster.CreateCluster(ctx, createClusterOpts)

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -54,12 +54,7 @@ func DestroyCluster(t *testing.T, ctx context.Context, opts *cmdcluster.DestroyO
 
 	t.Logf("Waiting for hostedcluster %s/%s to be destroyed", opts.Namespace, opts.Name)
 	err := wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
-		err := cmdcluster.DestroyCluster(ctx, &cmdcluster.DestroyOptions{
-			Namespace:          opts.Namespace,
-			Name:               opts.Name,
-			AWSCredentialsFile: opts.AWSCredentialsFile,
-			ClusterGracePeriod: opts.ClusterGracePeriod,
-		})
+		err := cmdcluster.DestroyCluster(ctx, opts)
 		if err != nil {
 			t.Logf("error destroying cluster, will retry: %s", err)
 			return false, nil

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -69,7 +69,14 @@ func TestQuickStart(t *testing.T) {
 		DestroyCluster(t, context.Background(), &cmdcluster.DestroyOptions{
 			Namespace:          hostedCluster.Namespace,
 			Name:               hostedCluster.Name,
+			Region:             GlobalOptions.Region,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
+			EC2Client:          GlobalOptions.EC2Client,
+			Route53Client:      GlobalOptions.Route53Client,
+			ELBClient:          GlobalOptions.ELBClient,
+			IAMClient:          GlobalOptions.IAMClient,
+			S3Client:           GlobalOptions.S3Client,
+			PreserveIAM:        false,
 			ClusterGracePeriod: 15 * time.Minute,
 		}, opts.ArtifactDir)
 		DeleteNamespace(t, context.Background(), client, namespace.Name)
@@ -82,10 +89,15 @@ func TestQuickStart(t *testing.T) {
 		ReleaseImage:       opts.ReleaseImage,
 		PullSecretFile:     opts.PullSecretFile,
 		AWSCredentialsFile: opts.AWSCredentialsFile,
+		Region:             GlobalOptions.Region,
+		EC2Client:          GlobalOptions.EC2Client,
+		Route53Client:      GlobalOptions.Route53Client,
+		ELBClient:          GlobalOptions.ELBClient,
+		IAMClient:          GlobalOptions.IAMClient,
+		S3Client:           GlobalOptions.S3Client,
 		// TODO: generate a key on the fly
 		SSHKeyFile:       "",
 		NodePoolReplicas: 2,
-		Region:           "us-east-1",
 		InstanceType:     "m4.large",
 		BaseDomain:       opts.BaseDomain,
 	}


### PR DESCRIPTION
This commit cleans up the AWS client handling throughout the CLI. From a given
entrypoint, AWS clients are now created exactly once and shared amongst all
components.

* Enables all the `create` and `destroy` commands to accept preallocated client
instances from the caller.
* Lifts all client creation up to the nearest entrypoint of each usage context
and injects them downwards from there.
* Consolidates all session and config creation into a single utilty package.
* Sets some new defaults for the SDK's built-in retry logic.

Further work should be done to tweak the SDK's built-in retry facilities, and
that can now be done centrally to start with and individual services can be
further tweaked as issues are identified.