### PR TITLE
Reconcile all control plane services

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/manifests.go
@@ -1,0 +1,70 @@
+package manifests
+
+import (
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	kubeAPIServerServiceName      = "kube-apiserver"
+	OauthServiceName              = "oauth-openshift"
+	oauthRouteName                = "oauth"
+	vpnServiceName                = "openvpn-server"
+	openshiftAPIServerServiceName = "openshift-apiserver"
+	oauthAPIServerName            = "openshift-oauth-apiserver"
+)
+
+func KubeAPIServerService(hostedClusterNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeAPIServerServiceName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
+func OauthServerService(hostedClusterNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      OauthServiceName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
+func OauthServerRoute(hostedClusterNamespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hostedClusterNamespace,
+			Name:      oauthRouteName,
+		},
+	}
+}
+
+func VPNServerService(hostedClusterNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vpnServiceName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
+func OpenshiftAPIServerService(hostedClusterNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      openshiftAPIServerServiceName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
+func OauthAPIServerService(hostedClusterNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oauthAPIServerName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/resources.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/resources.go
@@ -1,0 +1,84 @@
+package hostedcontrolplane
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	defaultAPIServerPort = 6443
+	vpnServicePort       = 1194
+)
+
+func OauthAPIServerServicePorts() []corev1.ServicePort {
+	return []corev1.ServicePort{
+		{
+			Name:       "https",
+			Port:       443,
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(8443),
+		},
+	}
+}
+
+func OauthAPIServerServiceSelector() map[string]string {
+	return map[string]string{"app": "openshift-oauth-apiserver"}
+}
+
+func OpenshiftAPIServerServicePorts() []corev1.ServicePort {
+	return []corev1.ServicePort{
+		{
+			Name:       "https",
+			Port:       443,
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(8443),
+		},
+	}
+}
+
+func OpenshiftAPIServerServiceSelector() map[string]string {
+	return map[string]string{"app": "openshift-apiserver"}
+}
+
+func VPNServerServicePorts() []corev1.ServicePort {
+	return []corev1.ServicePort{
+		{
+			Port:       vpnServicePort,
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(vpnServicePort),
+		},
+	}
+}
+
+func VPNServerServiceSelector() map[string]string {
+	return map[string]string{"app": "openvpn-server"}
+}
+
+func OauthServerServicePorts() []corev1.ServicePort {
+	return []corev1.ServicePort{
+		{
+			Name:       "https",
+			Port:       443,
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(6443),
+		},
+	}
+}
+
+func OauthServerServiceSelector() map[string]string {
+	return map[string]string{"app": "oauth-openshift"}
+}
+
+func KubeAPIServerServicePorts(securePort int32) []corev1.ServicePort {
+	return []corev1.ServicePort{
+		{
+			Port:       securePort,
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(int(securePort)),
+		},
+	}
+}
+
+func KubeAPIServerServiceSelector() map[string]string {
+	return map[string]string{"app": "kube-apiserver"}
+}

--- a/hypershift-operator/controllers/machineconfigserver/machineconfigserver_controller.go
+++ b/hypershift-operator/controllers/machineconfigserver/machineconfigserver_controller.go
@@ -16,7 +16,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	k8sutilspointer "k8s.io/utils/pointer"
@@ -179,7 +178,7 @@ func (r *MachineConfigServerReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	r.Log.Info("Reconciling MCS service")
-	reconcileResult, err := r.reconcileMCSService(ctx, mcs, mcsService, ignitionRoute)
+	reconcileResult, err := r.reconcileMCSServiceResources(ctx, mcs, mcsService, ignitionRoute)
 	if reconcileResult != nil {
 		return *reconcileResult, err
 	} else if err != nil {
@@ -227,33 +226,15 @@ func (r *MachineConfigServerReconciler) Reconcile(ctx context.Context, req ctrl.
 	return ctrl.Result{}, nil
 }
 
-func (r *MachineConfigServerReconciler) reconcileMCSServiceNodePort(ctx context.Context, mcs *hyperv1.MachineConfigServer, mcsService *corev1.Service) (*ctrl.Result, error) {
+func (r *MachineConfigServerReconciler) reconcileMCSServiceNodePortResources(ctx context.Context, mcs *hyperv1.MachineConfigServer, mcsService *corev1.Service) error {
 	r.Log.Info("Creating MCS Service")
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, mcsService, func() error {
-		mcsService.Spec.Ports = []corev1.ServicePort{
-			{
-				Name:       "http",
-				Protocol:   corev1.ProtocolTCP,
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			},
-		}
-		mcsService.Spec.Selector = map[string]string{
-			"app": fmt.Sprintf("machine-config-server-%s", mcs.Name),
-		}
-		mcsService.Spec.Type = corev1.ServiceTypeNodePort
-
-		// If there's user input nodePort and there's no existing one, we set it.
-		if (mcs.Spec.IgnitionService.NodePort != nil && mcs.Spec.IgnitionService.NodePort.Port > 0) &&
-			mcsService.Spec.Ports[0].NodePort <= 0 {
-			mcsService.Spec.Ports[0].NodePort = mcs.Spec.IgnitionService.NodePort.Port
-		}
-
-		return nil
+		return reconcileMCSServiceNodePort(mcsService, mcs)
 	})
-	if err != nil {
-		return &ctrl.Result{}, err
-	}
+	return err
+}
+
+func (r *MachineConfigServerReconciler) updateStatusMCSServiceNodePort(ctx context.Context, mcs *hyperv1.MachineConfigServer, mcsService *corev1.Service) (*ctrl.Result, error) {
 	r.Log.Info("Retrieving MCS Service to get node port value")
 	if err := r.Client.Get(ctx, ctrlclient.ObjectKeyFromObject(mcsService), mcsService); err != nil {
 		return &ctrl.Result{}, err
@@ -264,40 +245,39 @@ func (r *MachineConfigServerReconciler) reconcileMCSServiceNodePort(ctx context.
 	}
 	mcs.Status.Host = mcs.Spec.IgnitionService.NodePort.Address
 	mcs.Status.Port = mcsService.Spec.Ports[0].NodePort
+	r.Log.Info("Updated status for MCS")
 	return nil, nil
 }
 
-func (r *MachineConfigServerReconciler) reconcileMCSServiceRoute(ctx context.Context, mcs *hyperv1.MachineConfigServer, mcsService *corev1.Service, ignitionRoute *routev1.Route) (*ctrl.Result, error) {
+func reconcileMCSServiceNodePort(mcsService *corev1.Service, mcs *hyperv1.MachineConfigServer) error {
+	mcsService.Spec.Ports = MachineConfigServerServicePorts()
+	mcsService.Spec.Selector = MachineConfigServerServiceSelector(mcs.Name)
+	// If there's user input nodePort and there's no existing one, we set it.
+	if (mcs.Spec.IgnitionService.NodePort != nil && mcs.Spec.IgnitionService.NodePort.Port > 0) &&
+		mcsService.Spec.Ports[0].NodePort <= 0 {
+		mcsService.Spec.Ports[0].NodePort = mcs.Spec.IgnitionService.NodePort.Port
+	}
+	mcsService.Spec.Type = corev1.ServiceTypeNodePort
+	return nil
+}
+
+func (r *MachineConfigServerReconciler) reconcileMCSServiceRouteResources(ctx context.Context, mcs *hyperv1.MachineConfigServer, mcsService *corev1.Service, ignitionRoute *routev1.Route) error {
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, mcsService, func() error {
-		mcsService.Spec.Ports = []corev1.ServicePort{
-			{
-				Name:       "http",
-				Protocol:   corev1.ProtocolTCP,
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			},
-		}
-		mcsService.Spec.Selector = map[string]string{
-			"app": fmt.Sprintf("machine-config-server-%s", mcs.Name),
-		}
-		mcsService.Spec.Type = corev1.ServiceTypeClusterIP
-		return nil
+		return reconcileMCSServiceClusterIP(mcsService, mcs)
 	})
 	if err != nil {
-		return &ctrl.Result{}, err
+		return err
 	}
 	r.Log.Info("Creating ignition provider route")
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, ignitionRoute, func() error {
-		ignitionRoute.Spec.To = routev1.RouteTargetReference{
-			Kind: "Service",
-			Name: fmt.Sprintf("machine-config-server-%s", mcs.Name),
-		}
-		return nil
+		return reconcileMCSServiceRoute(ignitionRoute, mcs)
 	})
-	if err != nil {
-		return &ctrl.Result{}, err
-	}
-	if err := r.Get(ctx, ctrlclient.ObjectKeyFromObject(ignitionRoute), ignitionRoute); err != nil {
+	return err
+}
+
+func (r *MachineConfigServerReconciler) updateStatusMCSServiceRoute(ctx context.Context, mcs *hyperv1.MachineConfigServer, ignitionRoute *routev1.Route) (*ctrl.Result, error) {
+	r.Log.Info("Retrieving MCS Route to get address")
+	if err := r.Client.Get(ctx, ctrlclient.ObjectKeyFromObject(ignitionRoute), ignitionRoute); err != nil {
 		return &ctrl.Result{}, err
 	}
 	if ignitionRoute.Spec.Host == "" {
@@ -306,10 +286,26 @@ func (r *MachineConfigServerReconciler) reconcileMCSServiceRoute(ctx context.Con
 	}
 	mcs.Status.Host = ignitionRoute.Spec.Host
 	mcs.Status.Port = int32(80)
+	r.Log.Info("Updated status for MCS")
 	return nil, nil
 }
 
-func (r *MachineConfigServerReconciler) reconcileMCSService(ctx context.Context, mcs *hyperv1.MachineConfigServer, mcsService *corev1.Service, ignitionRoute *routev1.Route) (*ctrl.Result, error) {
+func reconcileMCSServiceClusterIP(mcsService *corev1.Service, mcs *hyperv1.MachineConfigServer) error {
+	mcsService.Spec.Ports = MachineConfigServerServicePorts()
+	mcsService.Spec.Selector = MachineConfigServerServiceSelector(mcs.Name)
+	mcsService.Spec.Type = corev1.ServiceTypeClusterIP
+	return nil
+}
+
+func reconcileMCSServiceRoute(ignitionRoute *routev1.Route, mcs *hyperv1.MachineConfigServer) error {
+	ignitionRoute.Spec.To = routev1.RouteTargetReference{
+		Kind: "Service",
+		Name: MachineConfigServerService(mcs.Namespace, mcs.Name).Name,
+	}
+	return nil
+}
+
+func (r *MachineConfigServerReconciler) reconcileMCSServiceResources(ctx context.Context, mcs *hyperv1.MachineConfigServer, mcsService *corev1.Service, ignitionRoute *routev1.Route) (*ctrl.Result, error) {
 	serviceType := mcs.Spec.IgnitionService.Type
 	switch serviceType {
 	case hyperv1.NodePort:
@@ -317,10 +313,16 @@ func (r *MachineConfigServerReconciler) reconcileMCSService(ctx context.Context,
 		if mcs.Spec.IgnitionService.NodePort == nil {
 			return &ctrl.Result{}, fmt.Errorf("nodePort metadata is not defined")
 		}
-		return r.reconcileMCSServiceNodePort(ctx, mcs, mcsService)
+		if err := r.reconcileMCSServiceNodePortResources(ctx, mcs, mcsService); err != nil {
+			return &ctrl.Result{}, fmt.Errorf("failed to reconcile mcs servicetype nodeport resources: %w", err)
+		}
+		return r.updateStatusMCSServiceNodePort(ctx, mcs, mcsService)
 	case hyperv1.Route:
 		r.Log.Info("Reconciling MCS route")
-		return r.reconcileMCSServiceRoute(ctx, mcs, mcsService, ignitionRoute)
+		if err := r.reconcileMCSServiceRouteResources(ctx, mcs, mcsService, ignitionRoute); err != nil {
+			return &ctrl.Result{}, fmt.Errorf("failed to reconcile mcs servicetype route resources: %w", err)
+		}
+		return r.updateStatusMCSServiceRoute(ctx, mcs, ignitionRoute)
 	default:
 		return &ctrl.Result{}, fmt.Errorf("unrecognized mcs serviceType: %s", serviceType)
 	}
@@ -376,15 +378,11 @@ oc get cm -l ignition-config="true" -n "${NAMESPACE}" --no-headers | awk '{ prin
 	deployment.Spec = appsv1.DeploymentSpec{
 		Replicas: k8sutilspointer.Int32Ptr(1),
 		Selector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"app": fmt.Sprintf("machine-config-server-%s", mcs.Name),
-			},
+			MatchLabels: MachineConfigServerServiceSelector(mcs.Name),
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"app": fmt.Sprintf("machine-config-server-%s", mcs.Name),
-				},
+				Labels: MachineConfigServerServiceSelector(mcs.Name),
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName:            sa.Name,

--- a/hypershift-operator/controllers/machineconfigserver/manifests.go
+++ b/hypershift-operator/controllers/machineconfigserver/manifests.go
@@ -2,7 +2,6 @@ package machineconfigserver
 
 import (
 	"fmt"
-
 	routev1 "github.com/openshift/api/route/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"

--- a/hypershift-operator/controllers/machineconfigserver/resources.go
+++ b/hypershift-operator/controllers/machineconfigserver/resources.go
@@ -1,0 +1,24 @@
+package machineconfigserver
+
+import (
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func MachineConfigServerServicePorts() []corev1.ServicePort {
+	return []corev1.ServicePort{
+		{
+			Name:       "http",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       80,
+			TargetPort: intstr.FromInt(8080),
+		},
+	}
+}
+
+func MachineConfigServerServiceSelector(machineConfigServerName string) map[string]string {
+	return map[string]string{
+		"app": fmt.Sprintf("machine-config-server-%s", machineConfigServerName),
+	}
+}


### PR DESCRIPTION
Moves all control plane services to be reconciled versus just created


Reviewer assistance:
Main path to trace:
**hostedControlPlane_controller.go**
ensureInfrastructure -> reconcileKubeAPIServerServiceNodePortResources -> reconcileKubeAPIServerServiceLoadBalancer

ensureInfrastructure -> reconcileKubeAPIServerServiceLoadBalancerResources -> reconcileKubeAPIServerServiceLoadBalancer


ensureInfrastructure -> reconcileVPNServerServiceNodePortResources -> reconcileVPNServerServiceNodePort

ensureInfrastructure -> reconcileVPNServerServiceLoadBalancerResources -> reconcileVPNServerServiceLoadBalancer


ensureInfrastructure -> reconcileOauthServiceNodePortResources -> reconcileOauthServiceNodePort

ensureInfrastructure -> reconcileOauthServerServiceRouteResources -> reconcileOauthServiceClusterIP, reconcileOauthServerRoute, 


**machineconfigserver_controller.go**
Reconcile -> reconcileMCSServiceResources -> reconcileMCSServiceNodePortResources -> reconcileMCSServiceNodePort


Reconcile -> reconcileMCSServiceResources -> reconcileMCSServiceRouteResources -> reconcileMCSServiceClusterIP, reconcileMCSServiceRoute