### PR TITLE
add optional tag and omitempty to autoscaling field

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -33,7 +33,8 @@ type HostedClusterSpec struct {
 	Networking ClusterNetworking `json:"networking"`
 
 	// Autoscaling for compute nodes only, does not cover control plane
-	Autoscaling ClusterAutoscaling `json:"autoscaling"`
+	// +optional
+	Autoscaling ClusterAutoscaling `json:"autoscaling,omitempty"`
 
 	Platform PlatformSpec `json:"platform"`
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -327,7 +327,6 @@ spec:
                     type: string
                 type: object
             required:
-            - autoscaling
             - initialComputeReplicas
             - issuerURL
             - networking

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,7 +25,8 @@ type HostedClusterSpec struct {
     Networking ClusterNetworking
 
     // Autoscaling for compute nodes only, does not cover control plane
-    Autoscaling ClusterAutoscaling
+    // +optional
+    Autoscaling ClusterAutoscaling `json:"autoscaling,omitempty"`
 
     // NOTE: This might not make sense as control plane
     // inputs can be specific to versions


### PR DESCRIPTION
This change makes autoscaling an optional field for hostedcluster
resources. Also updates docs and generated files.