### PR TITLE
cli: Add explicit retry/backoff handling to route53 calls

### DIFF
--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -189,11 +189,11 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 	if err != nil {
 		return nil, err
 	}
-	result.PublicZoneID, err = o.LookupPublicZone(o.Route53Client)
+	result.PublicZoneID, err = o.LookupPublicZone(ctx, o.Route53Client)
 	if err != nil {
 		return nil, err
 	}
-	result.PrivateZoneID, err = o.CreatePrivateZone(o.Route53Client, result.VPCID)
+	result.PrivateZoneID, err = o.CreatePrivateZone(ctx, o.Route53Client, result.VPCID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Route53 API calls to look up and manipulate zones often fail with throttling
issues in chaotic environments like the CI account. This commit adds explicit
retry/backoff handling for critical operations during infrastructure creation so
that transient errors don't fail the entire infrastructure creation attempt.