### PR TITLE
use image-registry managed s3 storage

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/registry/cluster-imageregistry-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/registry/cluster-imageregistry-config.yaml
@@ -24,5 +24,4 @@ spec:
       maxInQueue: 0
       maxRunning: 0
       maxWaitInQueue: 0s
-  storage:
-    emptyDir: {}
+  storage: {}


### PR DESCRIPTION
Currently `image-registry` operator in the guest cluster is `Degraded` with
```
Unable to apply resources: unable to sync storage configuration: exactly one storage type should be configured at the same time, got 2: [EmptyDir S3]
```
This is indeed the case
```
$ oc get configs.imageregistry.operator.openshift.io cluster -oyaml
...
  storage:
    emptyDir: {}
    s3:
      virtualHostedStyle: false
```
This PR removes our `emptyDir` storage block from the registry config and allows `image-registry-operator` to manage its own cloud provider based storage.

After this PR
```
$ oc get configs.imageregistry.operator.openshift.io cluster -oyaml
...
  storage:
    managementState: Managed
    s3:
      bucket: sjenning-dev-image-registry-us-west-1-siwglyeeqksfjhengjdgrlbq
      encrypt: true
      region: us-west-1
      virtualHostedStyle: false
```