### PR TITLE
WIP: Support control planes running on Kind

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -27,6 +27,7 @@ type HostedClusterSpec struct {
 
 	IssuerURL string `json:"issuerURL"`
 
+	// +optional
 	SSHKey corev1.LocalObjectReference `json:"sshKey"`
 
 	// Networking contains network-specific settings for this cluster
@@ -118,12 +119,14 @@ type ClusterNetworking struct {
 }
 
 // PlatformType is a specific supported infrastructure provider.
-// +kubebuilder:validation:Enum=AWS
+// +kubebuilder:validation:Enum=AWS;None
 type PlatformType string
 
 const (
 	// AWSPlatformType represents Amazon Web Services infrastructure.
 	AWSPlatform PlatformType = "AWS"
+
+	NonePlatform PlatformType = "None"
 )
 
 type PlatformSpec struct {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -249,6 +249,7 @@ spec:
                     description: Type is the underlying infrastructure provider for the cluster.
                     enum:
                     - AWS
+                    - None
                     type: string
                 required:
                 - type
@@ -335,7 +336,6 @@ spec:
             - release
             - services
             - signingKey
-            - sshKey
             type: object
           status:
             description: HostedClusterStatus defines the observed state of HostedCluster

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -212,6 +212,7 @@ spec:
                     description: Type is the underlying infrastructure provider for the cluster.
                     enum:
                     - AWS
+                    - None
                     type: string
                 required:
                 - type

--- a/hypershift-operator/controllers/externalinfracluster/externalinfracluster_controller.go
+++ b/hypershift-operator/controllers/externalinfracluster/externalinfracluster_controller.go
@@ -6,14 +6,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -35,7 +33,6 @@ const (
 type ExternalInfraClusterReconciler struct {
 	ctrlclient.Client
 	recorder record.EventRecorder
-	Infra    *configv1.Infrastructure
 	Log      logr.Logger
 }
 
@@ -50,12 +47,6 @@ func (r *ExternalInfraClusterReconciler) SetupWithManager(mgr ctrl.Manager) erro
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
-
-	var infra configv1.Infrastructure
-	if err := mgr.GetAPIReader().Get(context.Background(), client.ObjectKey{Name: "cluster"}, &infra); err != nil {
-		return fmt.Errorf("failed to get cluster infra: %w", err)
-	}
-	r.Infra = &infra
 
 	r.recorder = mgr.GetEventRecorderFor("external-infra-controller")
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -463,6 +463,8 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hcp.Spec.Platform.AWS.NodePoolManagementCreds = corev1.LocalObjectReference{
 			Name: manifests.AWSNodePoolManagementCreds(hcp.Namespace).Name,
 		}
+	case hyperv1.NonePlatform:
+		hcp.Spec.Platform.Type = hyperv1.NonePlatform
 	}
 
 	// Only update release image (triggering a new rollout) after existing rollouts


### PR DESCRIPTION
# 🚧 WIP 🚧 
Here's an example HostedCluster:

```yaml
apiVersion: hypershift.openshift.io/v1alpha1
kind: HostedCluster
metadata:
  namespace: clusters
  name: kind
spec:
  infraID: kind
  release:
    image: quay.io/openshift-release-dev/ocp-release:4.8.0-fc.0-x86_64
  platform:
    type: None
  initialComputeReplicas: 0
  issuerURL: "https://oauth.kind.hypershift.example.com"
  pullSecret:
    name: pull-secret
  signingKey:
    name: signing-key
  networking:
    serviceCIDR: "172.31.0.0/16"
    podCIDR:     "10.132.0.0/14"
    machineCIDR: "10.0.0.0/16"
  services:
  - service: APIServer
    servicePublishingStrategy:
      type: NodePort
      nodePort:
        address: 0.0.0.0
        port: 0
  - service: VPN
    servicePublishingStrategy:
      type: NodePort
      nodePort:
        address: 0.0.0.0
        port: 0
  - service: OAuthServer
    servicePublishingStrategy:
      type: NodePort
      nodePort:
        address: 0.0.0.0
        port: 0
  dns:
    baseDomain: kind.hypershift.example.com
```

Make sure your kind cluster has an OCP pull secret mounted — here's a kind cluster config:
```
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  extraMounts:
  - containerPath: /var/lib/kubelet/config.json
    hostPath: /my/pull-secret
```

Create a hosted cluster like this:
```
oc create namespace clusters
oc create secret generic --namespace clusters --from-file=.dockerconfigjson=/my/pull-secret pull-secret
oc create secret generic --namespace clusters --from-file=key=/my/signing-key signing-key
oc apply --namespace clusters -f /my/hostedcluster.yaml
```

Problems:

1. Autoscaler is crashing:
```
F0426 22:25:14.257900       1 main.go:408] Failed to get nodes from apiserver: Get "https://0.0.0.0:30358/api/v1/nodes": dial tcp 0.0.0.0:30358: connect: connection refused                                               │
│ goroutine 1 [running]:                                   
```
2. capa controller manager is running (bug: this should only be deployed when the platform is AWS)
3. KCM loses its lease frequently and crashes:
```
E0426 22:27:51.730417       1 leaderelection.go:325] error retrieving resource lock kube-system/kube-controller-manager: Get "https://kube-apiserver:6443/api/v1/namespaces/kube-system/configmaps/kube-controller-manager?timeout=5s": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```
Possibly related to...

4. My macbook turned into a jet engine and CPU usage is through the roof