### PR TITLE
CPO: use nodeport for external openvpn port

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -7,13 +7,14 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"math/big"
 	"math/rand"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
@@ -1128,7 +1129,7 @@ func (r *HostedControlPlaneReconciler) updateStatusVPNServerServiceNodePort(ctx 
 	}
 	r.Log.Info("Fetched vpn service nodePort", "nodePort", svc.Spec.Ports[0].NodePort)
 	status.VPNAddress = servicePublishingStrategyMapping.NodePort.Address
-	status.VPNPort = vpnServicePort
+	status.VPNPort = svc.Spec.Ports[0].NodePort
 	return nil
 }
 


### PR DESCRIPTION
Fix bug in https://github.com/openshift/hypershift/pull/180 that break KAS -> Node network communication when using a VPN Service of type NodePort