### PR TITLE
Initial API support for provider agnostic control planes

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -118,12 +118,14 @@ type ClusterNetworking struct {
 }
 
 // PlatformType is a specific supported infrastructure provider.
-// +kubebuilder:validation:Enum=AWS
+// +kubebuilder:validation:Enum=AWS;None
 type PlatformType string
 
 const (
 	// AWSPlatformType represents Amazon Web Services infrastructure.
 	AWSPlatform PlatformType = "AWS"
+
+	NonePlatform PlatformType = "None"
 )
 
 type PlatformSpec struct {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -249,6 +249,7 @@ spec:
                     description: Type is the underlying infrastructure provider for the cluster.
                     enum:
                     - AWS
+                    - None
                     type: string
                 required:
                 - type

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -212,6 +212,7 @@ spec:
                     description: Type is the underlying infrastructure provider for the cluster.
                     enum:
                     - AWS
+                    - None
                     type: string
                 required:
                 - type

--- a/hypershift-operator/controllers/externalinfracluster/externalinfracluster_controller.go
+++ b/hypershift-operator/controllers/externalinfracluster/externalinfracluster_controller.go
@@ -6,14 +6,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -35,7 +33,6 @@ const (
 type ExternalInfraClusterReconciler struct {
 	ctrlclient.Client
 	recorder record.EventRecorder
-	Infra    *configv1.Infrastructure
 	Log      logr.Logger
 }
 
@@ -50,12 +47,6 @@ func (r *ExternalInfraClusterReconciler) SetupWithManager(mgr ctrl.Manager) erro
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
-
-	var infra configv1.Infrastructure
-	if err := mgr.GetAPIReader().Get(context.Background(), client.ObjectKey{Name: "cluster"}, &infra); err != nil {
-		return fmt.Errorf("failed to get cluster infra: %w", err)
-	}
-	r.Infra = &infra
 
 	r.recorder = mgr.GetEventRecorderFor("external-infra-controller")
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -463,6 +463,8 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hcp.Spec.Platform.AWS.NodePoolManagementCreds = corev1.LocalObjectReference{
 			Name: manifests.AWSNodePoolManagementCreds(hcp.Namespace).Name,
 		}
+	case hyperv1.NonePlatform:
+		hcp.Spec.Platform.Type = hyperv1.NonePlatform
 	}
 
 	// Only update release image (triggering a new rollout) after existing rollouts


### PR DESCRIPTION
Introduce a `None` platform type which will allow for a provider agnostic
control plane. There's more work to do (some AWS stuff like CAPI is still
deployed) but this is enough to get started.