### PR TITLE
Prevent release image lookup failures from blocking deletion

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -150,10 +150,8 @@ func NewStartCommand() *cobra.Command {
 		if err := (&nodepool.NodePoolReconciler{
 			Client:        mgr.GetClient(),
 			ImageProvider: &static.StaticImageProvider{},
-			ReleaseProvider: &releaseinfo.StaticProviderDecorator{
-				Delegate: &releaseinfo.PodProvider{
-					Pods: kubeClient.CoreV1().Pods(namespace),
-				},
+			ReleaseProvider: &releaseinfo.PodProvider{
+				Pods: kubeClient.CoreV1().Pods(namespace),
 			},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "nodePool")
@@ -162,10 +160,8 @@ func NewStartCommand() *cobra.Command {
 
 		if err := (&machineconfigserver.MachineConfigServerReconciler{
 			Client: mgr.GetClient(),
-			ReleaseProvider: &releaseinfo.StaticProviderDecorator{
-				Delegate: &releaseinfo.PodProvider{
-					Pods: kubeClient.CoreV1().Pods(namespace),
-				},
+			ReleaseProvider: &releaseinfo.PodProvider{
+				Pods: kubeClient.CoreV1().Pods(namespace),
 			},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "machineConfigReconciler")


### PR DESCRIPTION
Before this patch, the node pool and machine config server controllers could
block forever during failed release image lookups, preventing further
reconcilation including deletion handling. The result is an invalid pull secret
for the specified image would prevent the cluster from ever finalizing.

This patch introduces fixed timeouts for the pod-based release image lookups and
also moves the lookup after deletion handling so that deletes will always be
handled.