### PR TITLE
e2e: Improve cluster destroy reliability

### DIFF
--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -70,6 +70,8 @@ func TestQuickStart(t *testing.T) {
 			Namespace:          hostedCluster.Namespace,
 			Name:               hostedCluster.Name,
 			Region:             GlobalOptions.Region,
+			InfraID:            hostedCluster.Name,
+			BaseDomain:         opts.BaseDomain,
 			AWSCredentialsFile: opts.AWSCredentialsFile,
 			EC2Client:          GlobalOptions.EC2Client,
 			Route53Client:      GlobalOptions.Route53Client,
@@ -86,6 +88,7 @@ func TestQuickStart(t *testing.T) {
 	createClusterOpts := cmdcluster.Options{
 		Namespace:          hostedCluster.Namespace,
 		Name:               hostedCluster.Name,
+		InfraID:            hostedCluster.Name,
 		ReleaseImage:       opts.ReleaseImage,
 		PullSecretFile:     opts.PullSecretFile,
 		AWSCredentialsFile: opts.AWSCredentialsFile,


### PR DESCRIPTION
Before this commit, if the e2e test failed to created the HostedCluster
resource, infrastructure could be leaked/orphaned. Now the create/destroy
options are provided with additional options which enable the destroy command to
tear down infrastructure even if the HostedCluster doesn't exist. This increases
the chance we'll cleanly destroy all infrastructure when test failures occur.