### PR TITLE
Allow KAS-provided or externally managed OIDC service account issuer discovery

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -195,6 +195,12 @@ aws_secret_access_key = %s
 						Type: hyperv1.Route,
 					},
 				},
+				hyperv1.ServicePublishingStrategyMapping{
+					Service: hyperv1.OIDC,
+					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+						Type: hyperv1.Route,
+					},
+				},
 			},
 			InfraID:    o.InfraID,
 			PullSecret: corev1.LocalObjectReference{Name: pullSecret.Name},

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -50,7 +50,7 @@ type HostedClusterSpec struct {
 // ServicePublishingStrategyMapping defines the service being published and  metadata about the publishing strategy.
 type ServicePublishingStrategyMapping struct {
 	// Service identifies the type of service being published
-	// +kubebuilder:validation:Enum=APIServer;VPN;OAuthServer
+	// +kubebuilder:validation:Enum=APIServer;VPN;OAuthServer;OIDC
 	Service                   ServiceType `json:"service"`
 	ServicePublishingStrategy `json:"servicePublishingStrategy"`
 }
@@ -58,7 +58,7 @@ type ServicePublishingStrategyMapping struct {
 // ServicePublishingStrategy defines metadata around how a service is published
 type ServicePublishingStrategy struct {
 	// Type defines the publishing strategy used for the service.
-	// +kubebuilder:validation:Enum=LoadBalancer;NodePort;Route
+	// +kubebuilder:validation:Enum=LoadBalancer;NodePort;Route;None
 	Type PublishingStrategyType `json:"type"`
 	// NodePort is used to define extra metadata for the NodePort publishing strategy.
 	NodePort *NodePortPublishingStrategy `json:"nodePort,omitempty"`
@@ -74,6 +74,8 @@ var (
 	NodePort PublishingStrategyType = "NodePort"
 	// Route exposes services with a Route + ClusterIP kube service.
 	Route PublishingStrategyType = "Route"
+	// None disables exposing the service
+	None PublishingStrategyType = "None"
 )
 
 // ServiceType defines what control plane services can be exposed from the management control plane
@@ -83,6 +85,7 @@ var (
 	APIServer   ServiceType = "APIServer"
 	VPN         ServiceType = "VPN"
 	OAuthServer ServiceType = "OAuthServer"
+	OIDC        ServiceType = "OIDC"
 )
 
 // NodePortPublishingStrategy defines the network endpoint that can be used to contact the NodePort service

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -51,6 +51,7 @@ type Options struct {
 	InstanceType       string
 	Region             string
 	BaseDomain         string
+	IssuerURL          string
 	PublicZoneID       string
 	PrivateZoneID      string
 
@@ -210,6 +211,7 @@ func CreateCluster(ctx context.Context, opts Options) error {
 			InfraID:            infra.InfraID,
 			IAMClient:          opts.IAMClient,
 			S3Client:           opts.S3Client,
+			IssuerURL:          opts.IssuerURL,
 		}
 		iamInfo, err = opt.CreateIAM(ctx)
 		if err != nil {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -287,6 +287,7 @@ spec:
                       - APIServer
                       - VPN
                       - OAuthServer
+                      - OIDC
                       type: string
                     servicePublishingStrategy:
                       description: ServicePublishingStrategy defines metadata around how a service is published
@@ -310,6 +311,7 @@ spec:
                           - LoadBalancer
                           - NodePort
                           - Route
+                          - None
                           type: string
                       required:
                       - type

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -241,6 +241,7 @@ spec:
                       - APIServer
                       - VPN
                       - OAuthServer
+                      - OIDC
                       type: string
                     servicePublishingStrategy:
                       description: ServicePublishingStrategy defines metadata around how a service is published
@@ -264,6 +265,7 @@ spec:
                           - LoadBalancer
                           - NodePort
                           - Route
+                          - None
                           type: string
                       required:
                       - type

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_machineconfigservers.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_machineconfigservers.yaml
@@ -66,6 +66,7 @@ spec:
                     - LoadBalancer
                     - NodePort
                     - Route
+                    - None
                     type: string
                 required:
                 - type

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -94,6 +94,7 @@ spec:
                     - LoadBalancer
                     - NodePort
                     - Route
+                    - None
                     type: string
                 required:
                 - type

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/service-account-issuer-discovery-clusterrolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/service-account-issuer-discovery-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:service-account-issuer-discovery-unauthenticated
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:service-account-issuer-discovery
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:unauthenticated

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/kube-apiserver/config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/kube-apiserver/config.yaml
@@ -170,6 +170,8 @@ apiServerArguments:
   - flowcontrol.apiserver.k8s.io/v1alpha1=true
   service-account-issuer:
   - {{ .IssuerURL }}
+  service-account-jwks-uri:
+  - {{ .IssuerURL }}/openid/v1/jwks
   service-account-lookup:
   - 'true'
   service-account-signing-key-file:

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/manifests.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	kubeAPIServerServiceName      = "kube-apiserver"
+	KubeAPIServerServiceName      = "kube-apiserver"
 	OauthServiceName              = "oauth-openshift"
 	oauthRouteName                = "oauth"
+	oidcRouteName                 = "oidc"
 	vpnServiceName                = "openvpn-server"
 	openshiftAPIServerServiceName = "openshift-apiserver"
 	oauthAPIServerName            = "openshift-oauth-apiserver"
@@ -18,7 +19,7 @@ const (
 func KubeAPIServerService(hostedClusterNamespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubeAPIServerServiceName,
+			Name:      KubeAPIServerServiceName,
 			Namespace: hostedClusterNamespace,
 		},
 	}
@@ -38,6 +39,15 @@ func OauthServerRoute(hostedClusterNamespace string) *routev1.Route {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedClusterNamespace,
 			Name:      oauthRouteName,
+		},
+	}
+}
+
+func OIDCRoute(hostedClusterNamespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hostedClusterNamespace,
+			Name:      oidcRouteName,
 		},
 	}
 }


### PR DESCRIPTION
The idea here is to eliminate the publicly readable s3 bucket and its contents from the infrastructure requirements.

https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery

`ServiceAccountIssuerDiscovery` went beta (default enabled) in 1.20 and GA in 1.21

A new `Route` to the KAS endpoint (not suitable for API call) will be used for exposing the OIDC discovery endpoint.

```
...
  services:
  - service: OIDC
    servicePublishingStrategy:
      type: Route
...
```

The OIDC Route can be disabled by setting the `servicePublishingStrategy.type` to `None`.

The combination of `issuerURL` and service account `SigningKey` on the HC spec makes a flexible API for both automated and externally managed OIDC setups.

The biggest point of contention is likely the addition of a `issuer-url` flag to `create iam`/`create cluster`.