### PR TITLE
Improve release image metadata lookup efficiency

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -150,8 +150,11 @@ func NewStartCommand() *cobra.Command {
 		if err := (&nodepool.NodePoolReconciler{
 			Client:        mgr.GetClient(),
 			ImageProvider: &static.StaticImageProvider{},
-			ReleaseProvider: &releaseinfo.PodProvider{
-				Pods: kubeClient.CoreV1().Pods(namespace),
+			ReleaseProvider: &releaseinfo.CachedProvider{
+				Inner: &releaseinfo.PodProvider{
+					Pods: kubeClient.CoreV1().Pods(namespace),
+				},
+				Cache: map[string]*releaseinfo.ReleaseImage{},
 			},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "nodePool")
@@ -160,8 +163,11 @@ func NewStartCommand() *cobra.Command {
 
 		if err := (&machineconfigserver.MachineConfigServerReconciler{
 			Client: mgr.GetClient(),
-			ReleaseProvider: &releaseinfo.PodProvider{
-				Pods: kubeClient.CoreV1().Pods(namespace),
+			ReleaseProvider: &releaseinfo.CachedProvider{
+				Inner: &releaseinfo.PodProvider{
+					Pods: kubeClient.CoreV1().Pods(namespace),
+				},
+				Cache: map[string]*releaseinfo.ReleaseImage{},
 			},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "machineConfigReconciler")


### PR DESCRIPTION
Before this commit, release image metadata lookups (synchronous calls that
launch a pod) were being performed in the reconcile path of the node pool and
machine config server controllers, causing excessive pod churn.

This commit:
- Updates the node pool and machine config server controllers to use the caching
provider.
- Makes a small improvement to the caching provider itself to periodically purge
its cache as a trivial memory leak mitigation.