### PR TITLE
Allow baremetal workers with Platform None

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -250,10 +250,14 @@ aws_secret_access_key = %s
 				},
 				NodeCount:   &o.NodePoolReplicas,
 				ClusterName: o.Name,
+				Platform: hyperv1.NodePoolPlatform{
+					Type: cluster.Spec.Platform.Type,
+				},
 			},
 		}
 
-		if cluster.Spec.Platform.Type == hyperv1.AWSPlatform {
+		switch nodePool.Spec.Platform.Type {
+		case hyperv1.AWSPlatform:
 			nodePool.Spec.Platform.AWS = cluster.Spec.Platform.AWS.NodePoolDefaults
 		}
 	}

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -111,6 +111,7 @@ type NodePoolAutoScaling struct {
 // NodePoolPlatform is the platform-specific configuration for a node
 // pool. Only one of the platforms should be set.
 type NodePoolPlatform struct {
+	Type PlatformType `json:"type"`
 	// AWS is the configuration used when installing on AWS.
 	AWS *AWSNodePoolPlatform `json:"aws,omitempty"`
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -197,6 +197,14 @@ spec:
                     required:
                     - instanceType
                     type: object
+                  type:
+                    description: PlatformType is a specific supported infrastructure provider.
+                    enum:
+                    - AWS
+                    - None
+                    type: string
+                required:
+                - type
                 type: object
               release:
                 description: Release specifies the release image to use for this NodePool For a nodePool a given version dictates the ignition config and an image artifact e.g an AMI in AWS. Release specifies the release image to use for this HostedCluster

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -93,9 +93,14 @@ func (o *CreateNodePoolOptions) Run(ctx context.Context) error {
 			ClusterName: o.ClusterName,
 			NodeCount:   &o.NodeCount,
 			Platform: hyperv1.NodePoolPlatform{
-				AWS: hcluster.Spec.Platform.AWS.NodePoolDefaults,
+				Type: hcluster.Spec.Platform.Type,
 			},
 		},
+	}
+
+	switch nodePool.Spec.Platform.Type {
+	case hyperv1.AWSPlatform:
+		nodePool.Spec.Platform.AWS = hcluster.Spec.Platform.AWS.NodePoolDefaults
 	}
 
 	if o.Render {

--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -11,7 +11,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func machineDeployment(nodePool *hyperv1.NodePool, mcs *hyperv1.MachineConfigServer, clusterName string) *capiv1.MachineDeployment {
+func machineDeployment(nodePool *hyperv1.NodePool, clusterName string) *capiv1.MachineDeployment {
 	resourcesName := generateName(clusterName, nodePool.Spec.ClusterName, nodePool.GetName())
 	return &capiv1.MachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR allows for the creation of baremetal workers

Remaining issues:
- cluster-api still deploys. `capa-controller-manager` stuck in `ContainerCreating` due to
`MountVolume.SetUp failed for volume "credentials" : secret "node-provider-creds" not found`
- `cluster-autoscaler` runs but continuous error in the logs `E0430 04:42:36.855542       1 reflector.go:138] k8s.io/client-go/dynamic/dynamicinformer/informer.go:91: Failed to watch *unstructured.Unstructured: failed to list *unstructured.Unstructured: machinedeployments.cluster.x-k8s.io is forbidden: User "system:serviceaccount:clusters-example:cluster-autoscaler" cannot list resource "machinedeployments" in API group "cluster.x-k8s.io" at the cluster scope`

example HostedCluster
```
apiVersion: hypershift.openshift.io/v1alpha1
kind: HostedCluster
metadata:
  creationTimestamp: null
  name: example
  namespace: clusters
spec:
  autoscaling: {}
  dns:
    baseDomain: hypershift.example.com
  infraID: example-dev
  initialComputeReplicas: 0
  issuerURL: https://kubernetes.default.svc
  networking:
    machineCIDR: 10.0.0.0/16
    podCIDR: 10.132.0.0/14
    serviceCIDR: 172.31.0.0/16
  platform:
    type: None
  pullSecret:
    name: example-pull-secret
  release:
    image: quay.io/openshift-release-dev/ocp-release:4.8.0-fc.1-x86_64
  services:
  - service: APIServer
    servicePublishingStrategy:
      type: NodePort
      nodePort:
        address: api.example.ocp.example.com
  - service: VPN
    servicePublishingStrategy:
      type: NodePort
      nodePort:
        address: api.example.ocp.example.com
  - service: OAuthServer
    servicePublishingStrategy:
      type: Route
  signingKey:
    name: example-signing-key
  sshKey:
    name: example-ssh-key
```
Create empty NodePool to create MCS
```
$ hypershift create nodepool --node-count=0
```
Resulting NodePool spec
```
apiVersion: v1
kind: NodePool
metadata:
  name: example
  namespace: clusters
spec:
  clusterName: example
  ignitionService:
    type: Route
  nodeCount: 0
  nodePoolManagement:
    autoRepair: false
    maxSurge: 0
    maxUnavailable: 0
  platform:
    type: None
  release:
    image: "" (this is set by the nodepool controller)
```