### PR TITLE
Fix private release image repository issues

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/openvpn/openvpn-serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/openvpn/openvpn-serviceaccount.yaml
@@ -2,3 +2,5 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: vpn
+imagePullSecrets:
+- name: pull-secret

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/roks-metrics/roks-metrics-serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/roks-metrics/roks-metrics-serviceaccount.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: roks-metrics
   namespace: openshift-roks-metrics
+imagePullSecrets:
+- name: pull-secret

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-serviceaccount.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: user-manifests-bootstrapper
+imagePullSecrets:
+- name: pull-secret


### PR DESCRIPTION
Before this patch, several components installed from the release image were
being used by pods whose service accounts did not include the associated pull
secret from the hosted cluster. So when the release image requires
authentication, these components would fail to launch with image pull errors.
This commit adds pull secret references to service accounts used for working
with the release image so that a private image can be specified.