### PR TITLE
Fix more private release image repository issues

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/kube-apiserver-proxy.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/kube-apiserver-proxy.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     k8s-app: kube-apiserver-proxy
 spec:
+  imagePullSecrets:
+  - name: pull-secret
   hostNetwork: true
   containers:
   - name: haproxy

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -14,6 +14,8 @@ spec:
         k8s-app: cluster-version-operator
         clusterID: "{{ .ClusterID }}"
     spec:
+      imagePullSecrets:
+      - name: pull-secret
       automountServiceAccountToken: false
       containers:
         - name: cluster-version-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
@@ -26,6 +26,8 @@ spec:
         openshift.io/restartedAt: "{{ .RestartDate }}"
 {{ end }}
     spec:
+      imagePullSecrets:
+      - name: pull-secret
       tolerations:
         - key: "multi-az-worker"
           operator: "Equal"

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/kube-scheduler/kube-scheduler-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/kube-scheduler/kube-scheduler-deployment.yaml
@@ -26,6 +26,8 @@ spec:
         openshift.io/restartedAt: "{{ .RestartDate }}"
 {{ end }}
     spec:
+      imagePullSecrets:
+      - name: pull-secret
       tolerations:
         - key: "multi-az-worker"
           operator: "Equal"

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
@@ -20,6 +20,8 @@ spec:
         app: openshift-oauth-apiserver
         clusterID: "{{ .ClusterID }}"
     spec:
+      imagePullSecrets:
+      - name: pull-secret
       automountServiceAccountToken: false
       containers:
       - name: oauth-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/oauth-openshift/oauth-server-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/oauth-openshift/oauth-server-deployment.yaml
@@ -26,6 +26,8 @@ spec:
         openshift.io/restartedAt: "{{ .RestartDate }}"
 {{ end }}
     spec:
+      imagePullSecrets:
+      - name: pull-secret
       tolerations:
       - key: "multi-az-worker"
         operator: "Equal"

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
@@ -26,6 +26,8 @@ spec:
         openshift.io/restartedAt: "{{ .RestartDate }}"
 {{ end }}
     spec:
+      imagePullSecrets:
+      - name: pull-secret
       tolerations:
         - key: "multi-az-worker"
           operator: "Equal"

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
@@ -26,6 +26,8 @@ spec:
         openshift.io/restartedAt: "{{ .RestartDate }}"
 {{ end }}
     spec:
+      imagePullSecrets:
+      - name: pull-secret
       tolerations:
         - key: "multi-az-worker"
           operator: "Equal"


### PR DESCRIPTION
This is a followup to #199 (73ddc4) to ensure pods and deployments
that don't specify a service account still use the pull secret provided
on the HostedCluster spec. This is to enable the use of private image
repositories for release images.