### PR TITLE
Add missing pull secret to deployment

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
@@ -26,6 +26,8 @@ spec:
         openshift.io/restartedAt: "{{ .RestartDate }}"
 {{ end }}
     spec:
+      imagePullSecrets:
+      - name: pull-secret
       tolerations:
         - key: "multi-az-worker"
           operator: "Equal"


### PR DESCRIPTION
Adds the release image pull secret reference to the OpenShift controller
manager deployment so that it works when using a private release image.