### PR TITLE
Remove initialComputeReplicas from HostedCluster

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -17,8 +17,6 @@ type HostedClusterSpec struct {
 	// Release specifies the release image to use for this HostedCluster
 	Release Release `json:"release"`
 
-	InitialComputeReplicas int `json:"initialComputeReplicas"`
-
 	// PullSecret is a pull secret injected into the container runtime of guest
 	// workers. It should have an ".dockerconfigjson" key containing the pull secret JSON.
 	PullSecret corev1.LocalObjectReference `json:"pullSecret"`

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -43,7 +43,7 @@ type Options struct {
 	PullSecretFile     string
 	AWSCredentialsFile string
 	SSHKeyFile         string
-	NodePoolReplicas   int
+	NodePoolReplicas   int32
 	Render             bool
 	InfraID            string
 	InfrastructureJSON string
@@ -99,7 +99,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Path to a pull secret (required)")
 	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
 	cmd.Flags().StringVar(&opts.SSHKeyFile, "ssh-key", opts.SSHKeyFile, "Path to an SSH key file")
-	cmd.Flags().IntVar(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If >0, create a default NodePool with this many replicas")
+	cmd.Flags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If >0, create a default NodePool with this many replicas")
 	cmd.Flags().BoolVar(&opts.Render, "render", opts.Render, "Render output as YAML to stdout instead of applying")
 	cmd.Flags().StringVar(&opts.InfrastructureJSON, "infra-json", opts.InfrastructureJSON, "Path to file containing infrastructure information for the cluster. If not specified, infrastructure will be created")
 	cmd.Flags().StringVar(&opts.IAMJSON, "iam-json", opts.IAMJSON, "Path to file containing IAM information for the cluster. If not specified, IAM will be created")

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -96,8 +96,6 @@ spec:
               infraID:
                 description: InfraID is used to identify the cluster in cloud platforms
                 type: string
-              initialComputeReplicas:
-                type: integer
               issuerURL:
                 type: string
               networking:
@@ -336,7 +334,6 @@ spec:
                     type: string
                 type: object
             required:
-            - initialComputeReplicas
             - issuerURL
             - networking
             - platform

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -322,20 +322,6 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Reconcile the default node pool
-	// TODO: Is this really a good idea to have on the API? If you want an initial
-	// node pool, create it through whatever user-oriented tool is consuming the
-	// API.
-	if hcluster.Spec.InitialComputeReplicas > 0 {
-		nodePool := manifests.DefaultNodePool(hcluster.Namespace, hcluster.Name)
-		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, nodePool, func() error {
-			return reconcileDefaultNodePool(nodePool, hcluster)
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile initial node pool: %w", err)
-		}
-	}
-
 	// Reconcile the CAPI ExternalInfraCluster
 	externalInfraCluster := controlplaneoperator.ExternalInfraCluster(controlPlaneNamespace.Name, hcluster.Name)
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, externalInfraCluster, func() error {
@@ -715,25 +701,6 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, hclus
 	return nil
 }
 
-func reconcileDefaultNodePool(nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster) error {
-	// This is a create-only resource, so never update it after it has been created.
-	if !nodePool.CreationTimestamp.IsZero() {
-		return nil
-	}
-	nodePool.Spec = hyperv1.NodePoolSpec{
-		ClusterName: hcluster.GetName(),
-		NodeCount:   k8sutilspointer.Int32Ptr(int32(hcluster.Spec.InitialComputeReplicas)),
-		IgnitionService: hyperv1.ServicePublishingStrategy{
-			Type: hyperv1.Route,
-		},
-	}
-	nodePool.Status = hyperv1.NodePoolStatus{}
-	if hcluster.Spec.Platform.AWS != nil {
-		nodePool.Spec.Platform.AWS = hcluster.Spec.Platform.AWS.NodePoolDefaults
-	}
-	return nil
-}
-
 func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, image string, sa *corev1.ServiceAccount) error {
 	deployment.Spec = appsv1.DeploymentSpec{
 		Replicas: k8sutilspointer.Int32Ptr(1),
@@ -908,8 +875,6 @@ func reconcileExternalInfraCluster(eic *hyperv1.ExternalInfraCluster, hcluster *
 	eic.Annotations = map[string]string{
 		hostedClusterAnnotation: ctrlclient.ObjectKeyFromObject(hcluster).String(),
 	}
-
-	eic.Spec.ComputeReplicas = hcluster.Spec.InitialComputeReplicas
 
 	if hcluster.Spec.Platform.AWS != nil {
 		eic.Spec.Region = hcluster.Spec.Platform.AWS.Region

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -152,10 +152,10 @@ func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Clien
 	return guestClient
 }
 
-func WaitForReadyNodes(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func WaitForReadyNodes(t *testing.T, ctx context.Context, client crclient.Client, nodePool *hyperv1.NodePool) {
 	g := NewWithT(t)
 
-	t.Logf("Waiting for hostedcluster %s/%s nodes to become ready", hostedCluster.Namespace, hostedCluster.Name)
+	t.Logf("Waiting for nodepool %s/%s nodes to become ready", nodePool.Namespace, nodePool.Name)
 	nodes := &corev1.NodeList{}
 	waitForNodesCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
@@ -175,7 +175,7 @@ func WaitForReadyNodes(t *testing.T, ctx context.Context, client crclient.Client
 				}
 			}
 		}
-		if len(readyNodes) != hostedCluster.Spec.InitialComputeReplicas {
+		if len(readyNodes) != int(*nodePool.Spec.NodeCount) {
 			return false, nil
 		}
 		t.Logf("found %d ready nodes", len(nodes.Items))
@@ -183,7 +183,7 @@ func WaitForReadyNodes(t *testing.T, ctx context.Context, client crclient.Client
 	}, waitForNodesCtx.Done())
 	g.Expect(err).NotTo(HaveOccurred(), "failed to ensure guest nodes became ready")
 
-	t.Logf("All %d nodes for hostedcluster %s/%s appear to be ready", hostedCluster.Spec.InitialComputeReplicas, hostedCluster.Namespace, hostedCluster.Name)
+	t.Logf("All %d nodes for nodepool %s/%s appear to be ready", int(*nodePool.Spec.NodeCount), nodePool.Namespace, nodePool.Name)
 }
 
 func WaitForReadyClusterOperators(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -112,10 +112,21 @@ func TestQuickStart(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 	t.Logf("Created hostedcluster %s/%s", hostedCluster.Namespace, hostedCluster.Name)
 
+	// Get the newly created nodepool
+	nodepool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hostedCluster.Namespace,
+			Name:      hostedCluster.Name,
+		},
+	}
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(nodepool), nodepool)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
+	t.Logf("Created nodepool %s/%s", nodepool.Namespace, nodepool.Name)
+
 	// Perform some very basic assertions about the guest cluster
 	guestClient := WaitForGuestClient(t, ctx, client, hostedCluster)
 
-	WaitForReadyNodes(t, ctx, guestClient, hostedCluster)
+	WaitForReadyNodes(t, ctx, guestClient, nodepool)
 
 	WaitForReadyClusterOperators(t, ctx, guestClient, hostedCluster)
 }


### PR DESCRIPTION
This PR removes the `initialComputeReplicas` field from the `HostedCluster` resource.

We've been talking about this for a while and this creates a clean conceptual break between the `HostedCluster` and the Nodes that join the `HostedControlPlane`.

`hypershift create cluster` has been modified to directly create the `NodePool` when `--node-pool-replicas` flag is greater than 0. This maintains the old behavior.