### PR TITLE
haproxy static pod cannot reference a pull secret

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/kube-apiserver-proxy.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/kube-apiserver-proxy.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     k8s-app: kube-apiserver-proxy
 spec:
-  imagePullSecrets:
-  - name: pull-secret
   hostNetwork: true
   containers:
   - name: haproxy


### PR DESCRIPTION
Static pods are not allowed to reference secrets.

The present behavior is that the kubelet is able to fetch the static pod image using the pull secret we lay down on the host in `/var/lib/kubelet/config.json`.

By referencing a secret, we launch the haproxy pod on the host, but the kubelet is rejected from mirroring the pod back to the API server.

```
"Failed creating a mirror pod for ... is forbidden: a mirror pod may not reference secrets"
```
