### PR TITLE
Simple CLI tracking and cleanup of generated secrets in clusters namespace

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -259,6 +259,7 @@ func CreateCluster(ctx context.Context, opts Options) error {
 	default:
 		for _, object := range exampleObjects {
 			key := crclient.ObjectKeyFromObject(object)
+			object.SetLabels(map[string]string{util.AutoInfraLabelName: infra.InfraID})
 			if err := client.Patch(ctx, object, crclient.Apply, crclient.ForceOwnership, crclient.FieldOwner("hypershift-cli")); err != nil {
 				return fmt.Errorf("failed to apply object %q: %w", key, err)
 			}

--- a/cmd/cluster/destroy.go
+++ b/cmd/cluster/destroy.go
@@ -19,10 +19,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
@@ -211,6 +213,18 @@ func DestroyCluster(ctx context.Context, o *DestroyOptions) error {
 		if err := destroyOpts.Run(ctx); err != nil {
 			return fmt.Errorf("failed to destroy IAM: %w", err)
 		}
+	}
+
+	//clean up CLI generated secrets
+	log.Info("Deleting Secrets", "namespace", o.Namespace)
+	if err := c.DeleteAllOf(ctx, &v1.Secret{}, client.InNamespace(o.Namespace), client.MatchingLabels{util.AutoInfraLabelName: o.InfraID}); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Secrets not found based on labels, skipping delete", "namespace", o.Namespace, "labels", util.AutoInfraLabelName+o.InfraID)
+		} else {
+			return fmt.Errorf("failed to clean up secrets in %s namespace: %w", o.Namespace, err)
+		}
+	} else {
+		log.Info("Deleted CLI generated secrets")
 	}
 
 	if hostedClusterExists {

--- a/cmd/util/client.go
+++ b/cmd/util/client.go
@@ -11,6 +11,10 @@ import (
 	hyperapi "github.com/openshift/hypershift/api"
 )
 
+const (
+	AutoInfraLabelName = "hypershift.openshift.io/auto-created-for-infra"
+)
+
 // GetConfigOrDie creates a REST config from current context
 func GetConfigOrDie() *rest.Config {
 	cfg := cr.GetConfigOrDie()


### PR DESCRIPTION
This PR adds a label based on `hypershift-cli-` + `InfraID` for uniqueness on `cluster create` command

```
kind: Secret
metadata:
  creationTimestamp: "2021-05-06T17:33:19Z"
  labels:
    createdby: hypershift-cli-sc45-trf25
```

and deletes the secrets on `cluster destroy` command

```
INFO[0079] Deleted role policy                           policy=sc42-hfvlp-worker-policy role=sc42-hfvlp-worker-role
INFO[0079] Deleted role                                  role=sc42-hfvlp-worker-role
INFO[0079] Deleting Secrets                              namespace=clusters
INFO[0079] Successfully destroyed cluster and infrastructure  infraID=sc42-hfvlp name=sc42 namespace=clusters
```