### PR TITLE
Fix node pool controller panic and release image API validation

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -177,19 +177,19 @@ aws_secret_access_key = %s
 				MachineCIDR: o.ComputeCIDR,
 			},
 			Services: []hyperv1.ServicePublishingStrategyMapping{
-				hyperv1.ServicePublishingStrategyMapping{
+				{
 					Service: hyperv1.APIServer,
 					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
 						Type: hyperv1.LoadBalancer,
 					},
 				},
-				hyperv1.ServicePublishingStrategyMapping{
+				{
 					Service: hyperv1.VPN,
 					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
 						Type: hyperv1.LoadBalancer,
 					},
 				},
-				hyperv1.ServicePublishingStrategyMapping{
+				{
 					Service: hyperv1.OAuthServer,
 					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
 						Type: hyperv1.Route,
@@ -228,9 +228,6 @@ aws_secret_access_key = %s
 				},
 			},
 		},
-		Status: hyperv1.HostedClusterStatus{
-			Conditions: []metav1.Condition{},
-		},
 	}
 
 	var nodePool *hyperv1.NodePool
@@ -250,6 +247,9 @@ aws_secret_access_key = %s
 				},
 				NodeCount:   &o.NodePoolReplicas,
 				ClusterName: o.Name,
+				Release: hyperv1.Release{
+					Image: o.ReleaseImage,
+				},
 				Platform: hyperv1.NodePoolPlatform{
 					Type: cluster.Spec.Platform.Type,
 				},

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -193,6 +193,7 @@ type AWSServiceEndpoint struct {
 type Release struct {
 	// Image is the release image pullspec for the control plane
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=^(\w+\S+)$
 	Image string `json:"image"`
 }
 

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -52,11 +52,12 @@ type NodePoolSpec struct {
 	Management NodePoolManagement `json:"nodePoolManagement"`
 	Platform   NodePoolPlatform   `json:"platform"`
 
-	// +kubebuilder:validation:Optional
 	// Release specifies the release image to use for this NodePool
 	// For a nodePool a given version dictates the ignition config and
 	// an image artifact e.g an AMI in AWS.
 	// Release specifies the release image to use for this HostedCluster
+	// +kubebuilder:validation:Required
+	// +required
 	Release Release `json:"release"`
 
 	// IgnitionService defines how the MachineConfigServer service is published in the management cluster

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -272,6 +272,7 @@ spec:
                 properties:
                   image:
                     description: Image is the release image pullspec for the control plane
+                    pattern: ^(\w+\S+)$
                     type: string
                 required:
                 - image
@@ -404,6 +405,7 @@ spec:
                     properties:
                       image:
                         description: Image is the release image pullspec for the control plane
+                        pattern: ^(\w+\S+)$
                         type: string
                     required:
                     - image

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -211,6 +211,7 @@ spec:
                 properties:
                   image:
                     description: Image is the release image pullspec for the control plane
+                    pattern: ^(\w+\S+)$
                     type: string
                 required:
                 - image
@@ -219,6 +220,7 @@ spec:
             - clusterName
             - ignitionService
             - platform
+            - release
             type: object
           status:
             description: NodePoolStatus defines the observed state of NodePool

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -20,11 +20,12 @@ import (
 )
 
 type CreateNodePoolOptions struct {
-	Name        string
-	Namespace   string
-	ClusterName string
-	NodeCount   int32
-	Render      bool
+	Name         string
+	Namespace    string
+	ClusterName  string
+	NodeCount    int32
+	ReleaseImage string
+	Render       bool
 }
 
 func NewCreateCommand() *cobra.Command {
@@ -35,16 +36,18 @@ func NewCreateCommand() *cobra.Command {
 	}
 
 	opts := CreateNodePoolOptions{
-		Name:        "example",
-		Namespace:   "clusters",
-		ClusterName: "example",
-		NodeCount:   2,
+		Name:         "example",
+		Namespace:    "clusters",
+		ClusterName:  "example",
+		NodeCount:    2,
+		ReleaseImage: "",
 	}
 
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "The name of the NodePool")
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace in which to create the NodePool")
 	cmd.Flags().Int32Var(&opts.NodeCount, "node-count", opts.NodeCount, "The number of nodes to create in the NodePool")
 	cmd.Flags().StringVar(&opts.ClusterName, "cluster-name", opts.ClusterName, "The name of the HostedCluster nodes in this pool will join")
+	cmd.Flags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes. If empty, defaults to the same release image as the HostedCluster.")
 
 	cmd.Flags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying")
 
@@ -77,6 +80,13 @@ func (o *CreateNodePoolOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("NodePool %s/%s already exists", o.Namespace, o.Name)
 	}
 
+	var releaseImage string
+	if len(o.ReleaseImage) > 0 {
+		releaseImage = o.ReleaseImage
+	} else {
+		releaseImage = hcluster.Spec.Release.Image
+	}
+
 	nodePool = &hyperv1.NodePool{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NodePool",
@@ -92,6 +102,9 @@ func (o *CreateNodePoolOptions) Run(ctx context.Context) error {
 			},
 			ClusterName: o.ClusterName,
 			NodeCount:   &o.NodeCount,
+			Release: hyperv1.Release{
+				Image: releaseImage,
+			},
 			Platform: hyperv1.NodePoolPlatform{
 				Type: hcluster.Spec.Platform.Type,
 			},

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -177,11 +177,6 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		return reconcile.Result{}, fmt.Errorf("error validating autoscaling parameters: %w", err)
 	}
 
-	// Default input: if release image is empty set it to the latest hostedCluster
-	if nodePool.Spec.Release.Image == "" {
-		nodePool.Spec.Release.Image = hcluster.Status.Version.History[0].Image
-	}
-
 	lookupCtx, lookupCancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer lookupCancel()
 	releaseImage, err := r.ReleaseProvider.Lookup(lookupCtx, nodePool.Spec.Release.Image)


### PR DESCRIPTION
Before this commit, the `release.image` API field of hostedcluster and nodepool
was incorrectly allowing empty string values for the release image. Then, some
code in the nodepool controller would panic trying to default the missing value
due to a missing `nil` check waiting for hostedcluster status.

This commit cleans up the mess by updating the API to validate the `image` field
be non-empty. The CLI code is updated to set the required value on nodepool, and
the controller-level defaulting is removed entirely as the value is the
responsibility of the client.

The `create nodepool` command now accepts a `--release-image` argument and
defaults to use the same value as the referenced HostedCluster.
