### PR TITLE
hypershift-operator: Ensure owner refs on controller-generated secret

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -373,6 +373,12 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				dest.Data = map[string][]byte{}
 			}
 			dest.Data["kubeconfig"] = srcData
+			dest.SetOwnerReferences([]metav1.OwnerReference{{
+				APIVersion: hyperv1.GroupVersion.String(),
+				Kind:       "HostedCluster",
+				Name:       hcluster.Name,
+				UID:        hcluster.UID,
+			}})
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
The hypershift-operator generates an admin kubeconfig secret in the
hostedcluster namespace for interfacing with the hosted control plane.

Before this commit, deleting the hostedcluster orphaned that secret, which
users don't manage. This commit introduces an owner reference from the secret
to the hostedcluster so that when the hostedcluster is deleted, so is the
secret. Otherwise this is basically a resource leak.