### PR TITLE
Let CAPI use internal network kubeconfig

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -22,6 +22,13 @@ func (p *KubeAPIServerParams) ReconcileServiceKubeconfigSecret(secret, cert, ca 
 	return reconcileKubeconfig(secret, cert, ca, svcURL, "", p.OwnerReference)
 }
 
+func (p *KubeAPIServerParams) ReconcileServiceCAPIKubeconfigSecret(secret, cert, ca *corev1.Secret) error {
+	svcURL := fmt.Sprintf("https://%s:%d", manifests.KASService(secret.Namespace).Name, p.APIServerPort)
+	// The client used by CAPI machine controller expects the kubeconfig to have this key
+	// https://github.com/kubernetes-sigs/cluster-api/blob/5c85a0a01ee44ecf7c8a3c3fdc867a88af87d73c/util/secret/secret.go#L29-L33
+	return reconcileKubeconfig(secret, cert, ca, svcURL, "value", p.OwnerReference)
+}
+
 func (p *KubeAPIServerParams) ReconcileLocalhostKubeconfigSecret(secret, cert, ca *corev1.Secret) error {
 	localhostURL := fmt.Sprintf("https://localhost:%d", p.APIServerPort)
 	return reconcileKubeconfig(secret, cert, ca, localhostURL, "", p.OwnerReference)

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -1,6 +1,8 @@
 package manifests
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +23,17 @@ func KASServiceKubeconfigSecret(controlPlaneNamespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "service-network-admin-kubeconfig",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
+// The client used by CAPI machine controller expects the kubeconfig to follow this naming convention
+// https://github.com/kubernetes-sigs/cluster-api/blob/5c85a0a01ee44ecf7c8a3c3fdc867a88af87d73c/util/secret/secret.go#L29-L33
+func KASServiceCAPIKubeconfigSecret(controlPlaneNamespace, infraID string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-kubeconfig", infraID),
 			Namespace: controlPlaneNamespace,
 		},
 	}


### PR DESCRIPTION
Before this PR we were setting hcp.Spec.Kubeconfig to satisfy capi controllers naming expectations, i.e https://github.com/kubernetes-sigs/cluster-api/blob/5c85a0a01ee44ecf7c8a3c3fdc867a88af87d73c/util/secret/secret.go#L29-L33. This secret is bubbled up to the HC CR and presented as the end user consumable and therefore it uses the public facing API Server.

This PR does two things:
- Drop the opinionated naming convention from hcp.Spec.Kubeconfig so it lets it use defaults to create the public facing API server kubeconfig secret.
- Hardcode and generate the CAPI naming compliant kubeconfig secret with the internal network API server. This secret has the same kubeconfig than service-network-admin-kubeconfig.

This results in one additional kubeconfig secret.