### PR TITLE
cp-controller: make KAS reconcile functions stateless

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -485,7 +485,7 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Con
 	p := kas.NewKubeAPIServerServiceParams(hcp)
 	apiServerService := manifests.KubeAPIServerService(hcp.Namespace)
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, apiServerService, func() error {
-		return p.ReconcileService(apiServerService, serviceStrategy)
+		return kas.ReconcileService(apiServerService, serviceStrategy, p.OwnerReference, p.APIServerPort)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile API server service: %w", err)
 	}
@@ -616,7 +616,7 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerServiceStatus(ctx conte
 		return
 	}
 	p := kas.NewKubeAPIServerServiceParams(hcp)
-	return p.ReconcileServiceStatus(svc, serviceStrategy)
+	return kas.ReconcileServiceStatus(svc, serviceStrategy, p.APIServerPort)
 }
 
 func (r *HostedControlPlaneReconciler) reconcileVPNServerServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, err error) {


### PR DESCRIPTION
This commit does a minor refactor to make some of the KAS reconciliation
functions stateless as an example of a refactoring we'd like to apply to
all of the other reconciliation functions as a matter of design principle.

There is no behavioral change in this commit.