### PR TITLE
cli: Make OIDC discovery retry until cancelled

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -208,7 +208,7 @@ func CreateCluster(ctx context.Context, opts Options) error {
 			IAMClient:          opts.IAMClient,
 			IssuerURL:          opts.IssuerURL,
 		}
-		iamInfo, err = opt.CreateIAM(ctx)
+		iamInfo, err = opt.CreateIAM(ctx, client)
 		if err != nil {
 			return fmt.Errorf("failed to create iam: %w", err)
 		}


### PR DESCRIPTION
Before this commit, the OIDC discovery phase of `create infra` would
fail immediately upon any error to get the cluster ingress config.

This patch improves robustness by making the lookup retry until the
context is cancelled, which should make the command more likely to
succeed in the face of transient error conditions.