### PR TITLE
Add e2e to the default build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-all: build
+all: build e2e
 
 build: hypershift-operator control-plane-operator hosted-cluster-config-operator hypershift
 


### PR DESCRIPTION
When building the entire project, include the e2e binary as well to
ensure it compiles.