### PR TITLE
fix nodeport reconciliation for Kube APIServer

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -28,7 +28,7 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 	case hyperv1.NodePort:
 		svc.Spec.Type = corev1.ServiceTypeNodePort
-		if portSpec.NodePort == 0 && strategy.NodePort != nil {
+		if portSpec.NodePort > 0 && strategy.NodePort != nil {
 			portSpec.NodePort = strategy.NodePort.Port
 		}
 	default:

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -35,7 +35,7 @@ func (p *OAuthServiceParams) ReconcileService(svc *corev1.Service, strategy *hyp
 	switch strategy.Type {
 	case hyperv1.NodePort:
 		svc.Spec.Type = corev1.ServiceTypeNodePort
-		if portSpec.NodePort == 0 && strategy.NodePort != nil {
+		if portSpec.NodePort > 0 && strategy.NodePort != nil {
 			portSpec.NodePort = strategy.NodePort.Port
 		}
 	case hyperv1.Route:

--- a/control-plane-operator/controllers/hostedcontrolplane/vpn/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/vpn/service.go
@@ -31,7 +31,7 @@ func (p *VPNServiceParams) ReconcileService(svc *corev1.Service, strategy *hyper
 		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 	case hyperv1.NodePort:
 		svc.Spec.Type = corev1.ServiceTypeNodePort
-		if portSpec.NodePort == 0 && strategy.NodePort != nil {
+		if portSpec.NodePort > 0 && strategy.NodePort != nil {
 			portSpec.NodePort = strategy.NodePort.Port
 		}
 	default:


### PR DESCRIPTION
without this: every reconciliation loop the node port changes on the service which will break network connectivity with the master

Also will cause constant fluctuation of iptable rules across nodes as nodeports change on every iteration