### PR TITLE
Temporarily change etcd operator image to one that works

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -47,8 +47,9 @@ func main() {
 }
 
 const (
-	openVPNImage      = "quay.io/hypershift/openvpn:latest"
-	etcdOperatorImage = "quay.io/coreos/etcd-operator:v0.9.4"
+	openVPNImage = "quay.io/hypershift/openvpn:latest"
+	// FIXME: Set to upstream image when DNS resolution is fixed for etcd service
+	etcdOperatorImage = "quay.io/hypershift/etcd-operator:v0.9.4-patched"
 )
 
 func NewStartCommand() *cobra.Command {


### PR DESCRIPTION
Use an image that contains https://github.com/openshift/etcd-operator/pull/1
This allows etcd to run in the latest CI version of OCP 4.8