### PR TITLE
Make recocile functions stateless (kcm, etcd, vpn)

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/config/network.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/config/network.go
@@ -29,3 +29,17 @@ func Network(hcp *hyperv1.HostedControlPlane) configv1.Network {
 		},
 	}
 }
+
+func ClusterCIDR(network *configv1.Network) string {
+	for _, entry := range network.Spec.ClusterNetwork {
+		return entry.CIDR
+	}
+	return ""
+}
+
+func ServiceCIDR(network *configv1.Network) string {
+	for _, entry := range network.Spec.ServiceNetwork {
+		return entry
+	}
+	return ""
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 
@@ -11,45 +10,42 @@ import (
 )
 
 type EtcdParams struct {
-	ClusterSize        int
-	ClusterVersion     string
-	EtcdOperatorImage  string
-	OwnerReference     *metav1.OwnerReference            `json:"ownerReference"`
-	OperatorScheduling config.Scheduling                 `json:"operatorScheduling"`
-	EtcdScheduling     config.Scheduling                 `json:"etcdScheduling"`
-	AdditionalLabels   config.AdditionalLabels           `json:"additionalLabels"`
-	SecurityContexts   config.SecurityContextSpec        `json:"securityContexts"`
-	LivenessProbes     config.LivenessProbes             `json:"livenessProbes"`
-	ReadinessProbes    config.ReadinessProbes            `json:"readinessProbes"`
-	Resources          config.ResourcesSpec              `json:"resources"`
-	PVCClaim           *corev1.PersistentVolumeClaimSpec `json:"pvcClaim"`
+	ClusterVersion           string
+	EtcdOperatorImage        string
+	OwnerRef                 config.OwnerRef `json:"ownerRef"`
+	OperatorDeploymentConfig config.DeploymentConfig
+	EtcdDeploymentConfig     config.DeploymentConfig
+	PVCClaim                 *corev1.PersistentVolumeClaimSpec `json:"pvcClaim"`
 }
 
 func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *EtcdParams {
 	p := &EtcdParams{
 		EtcdOperatorImage: images["etcd-operator"],
-		OwnerReference:    config.ControllerOwnerRef(hcp),
+		OwnerRef:          config.OwnerRefFrom(hcp),
 		ClusterVersion:    config.DefaultEtcdClusterVersion,
-		Resources: config.ResourcesSpec{
-			etcdOperatorContainer().Name: {
-				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("50Mi"),
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-				},
-			},
-			etcdContainer().Name: {
-				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("600Mi"),
-					corev1.ResourceCPU:    resource.MustParse("300m"),
-				},
+	}
+	p.OperatorDeploymentConfig.Resources = config.ResourcesSpec{
+		etcdOperatorContainer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
 			},
 		},
 	}
+	p.EtcdDeploymentConfig.Resources = config.ResourcesSpec{
+		etcdContainer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("600Mi"),
+				corev1.ResourceCPU:    resource.MustParse("300m"),
+			},
+		},
+	}
+	p.OperatorDeploymentConfig.Replicas = 1
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
-		p.ClusterSize = 3
+		p.EtcdDeploymentConfig.Replicas = 3
 	default:
-		p.ClusterSize = 1
+		p.EtcdDeploymentConfig.Replicas = 1
 	}
 	return p
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -230,17 +230,11 @@ func (p *KubeAPIServerParams) ExternalIPConfig() *configv1.ExternalIPConfig {
 }
 
 func (p *KubeAPIServerParams) ClusterNetwork() string {
-	for _, entry := range p.Network.Spec.ClusterNetwork {
-		return entry.CIDR
-	}
-	return ""
+	return config.ClusterCIDR(&p.Network)
 }
 
 func (p *KubeAPIServerParams) ServiceNetwork() string {
-	for _, entry := range p.Network.Spec.ServiceNetwork {
-		return entry
-	}
-	return ""
+	return config.ServiceCIDR(&p.Network)
 }
 
 func (p *KubeAPIServerParams) ConfigParams() KubeAPIServerConfigParams {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
@@ -10,8 +10,8 @@ import (
 
 	kcpv1 "github.com/openshift/api/kubecontrolplane/v1"
 
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/util"
 )
 
 const (
@@ -19,8 +19,8 @@ const (
 	ServiceServingCAKey            = "service-ca.crt"
 )
 
-func (p *KubeControllerManagerParams) ReconcileConfig(config, serviceServingCA *corev1.ConfigMap) error {
-	util.EnsureOwnerRef(config, p.OwnerReference)
+func ReconcileConfig(config, serviceServingCA *corev1.ConfigMap, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(config)
 	if config.Data == nil {
 		config.Data = map[string]string{}
 	}
@@ -54,7 +54,8 @@ func generateConfig(serviceServingCA *corev1.ConfigMap) (string, error) {
 	return string(b), nil
 }
 
-func (p *KubeControllerManagerParams) ReconcileKCMServiceServingCA(cm, combinedCA *corev1.ConfigMap) error {
+func ReconcileKCMServiceServingCA(cm, combinedCA *corev1.ConfigMap, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(cm)
 	if cm.Data == nil {
 		cm.Data = map[string]string{}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/vpn/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/vpn/params.go
@@ -3,7 +3,6 @@ package vpn
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -16,54 +15,59 @@ const (
 )
 
 type VPNParams struct {
-	Network          configv1.Network           `json:"network"`
-	MachineCIDR      string                     `json:"computeCIDR"`
-	VPNImage         string                     `json:"vpnImage"`
-	ExternalAddress  string                     `json:"externalAddress"`
-	ExternalPort     int32                      `json:"externalPort"`
-	SecurityContexts config.SecurityContextSpec `json:"securityContexts"`
-	Resources        config.ResourcesSpec       `json:"resources"`
-	ServerScheduling config.Scheduling          `json:"serverScheduling"`
-	ClientScheduling config.Scheduling          `json:"clientScheduling"`
-	OwnerReference   *metav1.OwnerReference     `json:"ownerReference"`
+	Network                      configv1.Network        `json:"network"`
+	MachineCIDR                  string                  `json:"computeCIDR"`
+	VPNImage                     string                  `json:"vpnImage"`
+	ExternalAddress              string                  `json:"externalAddress"`
+	ExternalPort                 int32                   `json:"externalPort"`
+	ServerDeploymentConfig       config.DeploymentConfig `json:"serverDeploymentConfig"`
+	WorkerClientDeploymentConfig config.DeploymentConfig `json:"workerClientDeploymentConfig"`
+	OwnerRef                     config.OwnerRef         `json:"ownerRef"`
 }
 
 func NewVPNParams(hcp *hyperv1.HostedControlPlane, images map[string]string, externalAddress string, externalPort int32) *VPNParams {
-	return &VPNParams{
+	p := &VPNParams{
 		Network:         config.Network(hcp),
 		MachineCIDR:     hcp.Spec.MachineCIDR,
 		VPNImage:        images["vpn"],
 		ExternalAddress: externalAddress,
 		ExternalPort:    externalPort,
-		SecurityContexts: config.SecurityContextSpec{
-			vpnContainerServer().Name: {
-				Privileged: pointer.BoolPtr(true),
-			},
-			vpnContainerClient().Name: {
-				Privileged: pointer.BoolPtr(true),
-			},
-		},
-		Resources: config.ResourcesSpec{
-			vpnContainerServer().Name: {
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("50m"),
-					corev1.ResourceMemory: resource.MustParse("50Mi"),
-				},
-			},
-		},
-		ServerScheduling: config.Scheduling{
-			PriorityClass: DefaultPriorityClass,
-		},
-		OwnerReference: config.ControllerOwnerRef(hcp),
 	}
+
+	p.ServerDeploymentConfig.Replicas = 1
+	p.ServerDeploymentConfig.SecurityContexts = config.SecurityContextSpec{
+		vpnContainerServer().Name: {
+			Privileged: pointer.BoolPtr(true),
+		},
+	}
+
+	p.WorkerClientDeploymentConfig.Replicas = 1
+	p.WorkerClientDeploymentConfig.SecurityContexts = config.SecurityContextSpec{
+		vpnContainerClient().Name: {
+			Privileged: pointer.BoolPtr(true),
+		},
+	}
+	p.ServerDeploymentConfig.Resources = config.ResourcesSpec{
+		vpnContainerServer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
+	}
+	p.ServerDeploymentConfig.Scheduling = config.Scheduling{
+		PriorityClass: DefaultPriorityClass,
+	}
+	p.OwnerRef = config.OwnerRefFrom(hcp)
+	return p
 }
 
 type VPNServiceParams struct {
-	OwnerReference *metav1.OwnerReference
+	OwnerRef config.OwnerRef
 }
 
 func NewVPNServiceParams(hcp *hyperv1.HostedControlPlane) *VPNServiceParams {
 	return &VPNServiceParams{
-		OwnerReference: config.ControllerOwnerRef(hcp),
+		OwnerRef: config.OwnerRefFrom(hcp),
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/vpn/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/vpn/service.go
@@ -7,15 +7,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/util"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config"
 )
 
 const (
 	VPNServerPort = 1194
 )
 
-func (p *VPNServiceParams) ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy) error {
-	util.EnsureOwnerRef(svc, p.OwnerReference)
+func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy) error {
+	ownerRef.ApplyTo(svc)
 	svc.Spec.Selector = vpnServerLabels
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
@@ -41,7 +41,7 @@ func (p *VPNServiceParams) ReconcileService(svc *corev1.Service, strategy *hyper
 	return nil
 }
 
-func (p *VPNServiceParams) ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy) (host string, port int32, err error) {
+func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy) (host string, port int32, err error) {
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {

--- a/control-plane-operator/controllers/hostedcontrolplane/vpn/serviceacct.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/vpn/serviceacct.go
@@ -4,11 +4,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/util"
 )
 
-func (p *VPNParams) ReconcileVPNServiceAccount(sa *corev1.ServiceAccount) error {
-	util.EnsureOwnerRef(sa, p.OwnerReference)
+func ReconcileVPNServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sa)
 	// Ensure that image pull secrets include the cluster's pull secret
 	util.EnsurePullSecret(sa, common.PullSecret(sa.Namespace).Name)
 	return nil


### PR DESCRIPTION
For individual reconcile functions, it is not clear to see what
parameters are required for each to do their job. This change modifies
reconcile functions for KCM, Etcd and VPN to explicitly pass parameters
for reconciliation.