### PR TITLE
Move olm to hypershift control plane

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/assets.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/assets.go
@@ -17,6 +17,8 @@ import "embed"
 //go:embed registry/*
 //go:embed roks-metrics/*
 //go:embed user-manifests-bootstrapper/*
+//go:embed olm/*
+//go:embed dnsmasq/*
 var content embed.FS
 
 func AssetDir(name string) ([]string, error) {

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -17,6 +17,43 @@ spec:
       imagePullSecrets:
       - name: pull-secret
       automountServiceAccountToken: false
+      initContainers:
+      - name: prepare-payload
+        image: {{ .ReleaseImage }}
+        imagePullPolicy: Always
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |-
+          cp -R /manifests /var/payload/
+          cp -R /release-manifests /var/payload/
+          # Delete any manifests you want to exclude from /var/payload/release-manifests
+          # ie. rm /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
+
+          # rm /var/payload/release-manifests/0000_50_olm_00-namespace.yaml
+          rm /var/payload/release-manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+          rm /var/payload/release-manifests/0000_50_olm_02-services.yaml
+          rm /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
+          rm /var/payload/release-manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+          rm /var/payload/release-manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+          rm /var/payload/release-manifests/0000_50_olm_99-operatorstatus.yaml
+          rm /var/payload/release-manifests/0000_90_olm_00-service-monitor.yaml
+          rm /var/payload/release-manifests/0000_90_olm_01-prometheus-rule.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_04_service_account.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_05_role.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_06_role_binding.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_07_configmap.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_08_service.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_09_operator-ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_09_operator.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_10_clusteroperator.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_11_service_monitor.yaml
+        volumeMounts:
+        - name: payload
+          mountPath: /var/payload
       containers:
         - name: cluster-version-operator
           image: {{ .ReleaseImage }}
@@ -39,7 +76,11 @@ spec:
             - mountPath: /etc/openshift/kubeconfig
               name: kubeconfig
               readOnly: true
+            - mountPath: /var/payload
+              name: payload
           env:
+            - name: PAYLOAD_OVERRIDE
+              value: /var/payload
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -71,3 +112,5 @@ spec:
         - name: kubeconfig
           secret:
             secretName: service-network-admin-kubeconfig
+        - name: payload
+          emptyDir: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/dnsmasq/dnsmasq-conf.configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/dnsmasq/dnsmasq-conf.configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dnsmasq-conf
+data:
+  dnsmasq.conf: |-
+    resolv-file=/etc/resolv.dnsmasq
+    conf-dir=/etc/dnsmasq.d
+    cache-size=0
+    no-negcache
+    strict-order

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/dnsmasq/resolv-dnsmasq.configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/dnsmasq/resolv-dnsmasq.configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: resolv-dnsmasq
+data:
+  resolv.dnsmasq: |-
+    nameserver  {{ dns .ServiceCIDR }}
+    nameserver  172.30.0.10

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified-operators-catalogsource-guest.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified-operators-catalogsource-guest.yaml
@@ -1,0 +1,16 @@
+apiVersion: "operators.coreos.com/v1alpha1"
+kind: "CatalogSource"
+metadata:
+  name: "certified-operators"
+  namespace: "openshift-marketplace"
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+spec:
+  sourceType: grpc
+  address: certified-operators:50051
+  displayName: "Certified Operators"
+  publisher: "Red Hat"
+  priority: -200
+  updateStrategy:
+    registryPoll:
+      interval: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: certified-operators-catalog
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    image.openshift.io/triggers: |-
+      [{"from":{"kind":"ImageStreamTag","name":"olm-certified-catalogs:v4.8"},"fieldPath":"spec.template.spec.containers[?(@.name==\"registry\")].image"}]
+spec:
+  selector:
+    matchLabels:
+      olm.catalogSource: certified-operators
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        olm.catalogSource: certified-operators
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: registry
+          image: registry.redhat.io/invalid:tag
+          ports:
+            - containerPort: 50051
+              name: grpc
+              protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          readinessProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.imagestream.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.imagestream.yaml
@@ -1,0 +1,15 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: olm-certified-catalogs
+spec:
+  dockerImageRepository: registry.redhat.io/redhat/certified-operator-index
+  tags:
+  - name: v4.8
+    from:
+      kind: DockerImage
+      name: 'registry.redhat.io/redhat/certified-operator-index:v4.8'
+    importPolicy:
+      scheduled: true
+    referencePolicy:
+      type: Source

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.service.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: certified-operators
+spec:
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50051
+      targetPort: 50051
+  selector:
+    olm.catalogSource: certified-operators
+  type: ClusterIP

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community-operators-catalogsource-guest.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community-operators-catalogsource-guest.yaml
@@ -1,0 +1,16 @@
+apiVersion: "operators.coreos.com/v1alpha1"
+kind: "CatalogSource"
+metadata:
+  name: "community-operators"
+  namespace: "openshift-marketplace"
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+spec:
+  sourceType: grpc
+  address: community-operators:50051
+  displayName: "Community Operators"
+  publisher: "Red Hat"
+  priority: -400
+  updateStrategy:
+    registryPoll:
+      interval: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: community-operators-catalog
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    image.openshift.io/triggers: |-
+      [{"from":{"kind":"ImageStreamTag","name":"olm-community-catalogs:v4.8"},"fieldPath":"spec.template.spec.containers[?(@.name==\"registry\")].image"}]
+spec:
+  selector:
+    matchLabels:
+      olm.catalogSource: community-operators
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        olm.catalogSource: community-operators
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: registry
+          image: registry.redhat.io/invalid:tag
+          ports:
+            - containerPort: 50051
+              name: grpc
+              protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          readinessProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.imagestream.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.imagestream.yaml
@@ -1,0 +1,15 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: olm-community-catalogs
+spec:
+  dockerImageRepository: registry.redhat.io/redhat/community-operator-index
+  tags:
+  - name: v4.8
+    from:
+      kind: DockerImage
+      name: 'registry.redhat.io/redhat/community-operator-index:v4.8'
+    importPolicy:
+      scheduled: true
+    referencePolicy:
+      type: Source

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.service.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: community-operators
+spec:
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50051
+      targetPort: 50051
+  selector:
+    olm.catalogSource: community-operators
+  type: ClusterIP

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-metrics-service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-metrics-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalog-operator-metrics
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  labels:
+    app: catalog-operator
+spec:
+  type: ClusterIP
+  ports:
+    - name: https-metrics
+      port: 8081
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app: catalog-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-operator-deployment.yaml
@@ -1,0 +1,157 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog-operator
+  labels:
+    app: catalog-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-operator
+  template:
+    metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: catalog-operator
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccount: vpn
+      dnsPolicy: None
+      dnsConfig:
+        # dnsmasq in the pod configured to check guest + host dns servers
+        nameservers:
+        - 127.0.0.1
+        # searches configured to match kube defaults
+        searches:
+        - {{ .Namespace }}.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+        - ec2.internal
+        options:
+        - name: ndots
+          value: '5'
+      containers:
+        - name: catalog-operator
+          command:
+            - /bin/catalog
+          args:
+            - '-namespace'
+            - openshift-marketplace
+            - -configmapServerImage={{ imageFor "operator-registry" }}
+            - -util-image
+            - {{ imageFor "operator-lifecycle-manager" }}
+            - -writeStatusName
+            - operator-lifecycle-manager-catalog
+            - -tls-cert
+            - /var/run/secrets/serving-cert/tls.crt
+            - -tls-key
+            - /var/run/secrets/serving-cert/tls.key
+            - -kubeconfig
+            - /etc/openshift/kubeconfig/kubeconfig
+          image: {{ imageFor "operator-lifecycle-manager" }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+            - containerPort: 8081
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          terminationMessagePolicy: FallbackToLogsOnError
+          env:
+            - name: RELEASE_VERSION
+              value: {{ version "release" }}
+            - name: KUBECONFIG
+              value: /etc/openshift/kubeconfig/kubeconfig
+          resources:
+            requests:
+              cpu: 10m
+              memory: 80Mi
+          volumeMounts:
+            - mountPath: /var/run/secrets/serving-cert
+              name: serving-cert
+            - mountPath: /etc/openshift/kubeconfig
+              name: kubeconfig
+              readOnly: true
+        - name: openvpn-client
+          terminationMessagePath: /dev/termination-log
+          command:
+            - /usr/sbin/openvpn
+          securityContext:
+            privileged: true
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: vpnsecret
+              mountPath: /etc/openvpn/secret
+            - name: vpnconfig
+              mountPath: /etc/openvpn/config
+          terminationMessagePolicy: File
+          image: 'quay.io/hypershift/openvpn:latest'
+          workingDir: /etc/openvpn/
+          args:
+            - '--config'
+            - /etc/openvpn/config/client.conf
+        - name: dnsmasq
+          securityContext:
+            privileged: true
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: dnsmasq-conf
+              mountPath: /etc/dnsmasq.conf
+              subPath: dnsmasq.conf
+            - name: resolv-dnsmasq
+              mountPath: /etc/resolv.dnsmasq
+              subPath: resolv.dnsmasq
+          terminationMessagePolicy: FallbackToLogsOnError
+          image: 4km3/dnsmasq
+      volumes:
+        - name: serving-cert
+          secret:
+            secretName: catalog-operator-serving-cert
+        - name: kubeconfig
+          secret:
+            secretName: service-network-admin-kubeconfig
+        - name: vpnconfig
+          configMap:
+            name: openvpn-kube-apiserver-client
+            defaultMode: 420
+        - name: vpnsecret
+          secret:
+            secretName: openvpn-kube-apiserver-client
+            defaultMode: 420
+        - name: dnsmasq-conf
+          configMap:
+            name: dnsmasq-conf
+            defaultMode: 420
+        - name: resolv-dnsmasq
+          configMap:
+            name: resolv-dnsmasq
+            defaultMode: 420
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace-catalogsource-guest.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace-catalogsource-guest.yaml
@@ -1,0 +1,16 @@
+apiVersion: "operators.coreos.com/v1alpha1"
+kind: "CatalogSource"
+metadata:
+  name: "redhat-marketplace"
+  namespace: "openshift-marketplace"
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+spec:
+  sourceType: grpc
+  address: redhat-marketplace:50051
+  displayName: "Red Hat Marketplace"
+  publisher: "Red Hat"
+  priority: -300
+  updateStrategy:
+    registryPoll:
+      interval: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redhat-marketplace-catalog
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    image.openshift.io/triggers: |-
+      [{"from":{"kind":"ImageStreamTag","name":"redhat-marketplace-catalogs:v4.8"},"fieldPath":"spec.template.spec.containers[?(@.name==\"registry\")].image"}]
+spec:
+  selector:
+    matchLabels:
+      olm.catalogSource: redhat-marketplace
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        olm.catalogSource: redhat-marketplace
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: registry
+          image: registry.redhat.io/invalid:tag
+          ports:
+            - containerPort: 50051
+              name: grpc
+              protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          readinessProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.imagestream.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.imagestream.yaml
@@ -1,0 +1,15 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: redhat-marketplace-catalogs
+spec:
+  dockerImageRepository: registry.redhat.io/redhat/redhat-marketplace-index
+  tags:
+  - name: v4.8
+    from:
+      kind: DockerImage
+      name: 'registry.redhat.io/redhat/redhat-marketplace-index:v4.8'
+    importPolicy:
+      scheduled: true
+    referencePolicy:
+      type: Source

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.service.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: redhat-marketplace
+spec:
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50051
+      targetPort: 50051
+  selector:
+    olm.catalogSource: redhat-marketplace
+  type: ClusterIP

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators-catalogsource-guest.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators-catalogsource-guest.yaml
@@ -1,0 +1,16 @@
+apiVersion: "operators.coreos.com/v1alpha1"
+kind: "CatalogSource"
+metadata:
+  name: "redhat-operators"
+  namespace: "openshift-marketplace"
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+spec:
+  sourceType: grpc
+  address: redhat-operators:50051
+  displayName: "Red Hat Operators"
+  publisher: "Red Hat"
+  priority: -100
+  updateStrategy:
+    registryPoll:
+      interval: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redhat-operators-catalog
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    image.openshift.io/triggers: |-
+      [{"from":{"kind":"ImageStreamTag","name":"redhat-operators-catalogs:v4.8"},"fieldPath":"spec.template.spec.containers[?(@.name==\"registry\")].image"}]
+spec:
+  selector:
+    matchLabels:
+      olm.catalogSource: redhat-operators
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        olm.catalogSource: redhat-operators
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: registry
+          image: registry.redhat.io/invalid:tag
+          ports:
+            - containerPort: 50051
+              name: grpc
+              protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          readinessProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.imagestream.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.imagestream.yaml
@@ -1,0 +1,15 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: redhat-operators-catalogs
+spec:
+  dockerImageRepository: registry.redhat.io/redhat/redhat-operator-index
+  tags:
+  - name: v4.8
+    from:
+      kind: DockerImage
+      name: 'registry.redhat.io/redhat/redhat-operator-index:v4.8'
+    importPolicy:
+      scheduled: true
+    referencePolicy:
+      type: Source

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.service.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: redhat-operators
+spec:
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50051
+      targetPort: 50051
+  selector:
+    olm.catalogSource: redhat-operators
+  type: ClusterIP

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/olm-metrics-service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/olm-metrics-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: olm-operator-metrics
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  labels:
+    app: olm-operator
+spec:
+  type: ClusterIP
+  ports:
+    - name: https-metrics
+      port: 8081
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app: olm-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/olm-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/olm-operator-deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: olm-operator
+  labels:
+    app: olm-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: olm-operator
+  template:
+    metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: olm-operator
+    spec:
+      priorityClassName: "system-cluster-critical"
+      containers:
+        - name: olm-operator
+          command:
+            - /bin/olm
+          args:
+            - --namespace
+            - $(OPERATOR_NAMESPACE)
+            - --writeStatusName
+            - operator-lifecycle-manager
+            - --writePackageServerStatusName
+            - "\"\""
+            - --tls-cert
+            - /var/run/secrets/serving-cert/tls.crt
+            - --tls-key
+            - /var/run/secrets/serving-cert/tls.key
+          image: {{ imageFor "operator-lifecycle-manager" }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+            - containerPort: 8081
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          terminationMessagePolicy: FallbackToLogsOnError
+          env:
+            - name: RELEASE_VERSION
+              value: {{ version "release" }}
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: olm-operator
+            - name: KUBECONFIG
+              value: /etc/openshift/kubeconfig/kubeconfig
+          resources:
+            requests:
+              cpu: 10m
+              memory: 160Mi
+          volumeMounts:
+            - mountPath: /var/run/secrets/serving-cert
+              name: serving-cert
+            - mountPath: /etc/openshift/kubeconfig
+              name: kubeconfig
+              readOnly: true
+      volumes:
+        - name: serving-cert
+          secret:
+            secretName: olm-operator-serving-cert
+        - name: kubeconfig
+          secret:
+            secretName: service-network-admin-kubeconfig
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-apiservice-template.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-apiservice-template.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1.packages.operators.coreos.com
+spec:
+  caBundle: {{ .PackageServerCABundle }}
+  group: packages.operators.coreos.com
+  groupPriorityMinimum: 2000
+  service:
+    name: packageserver
+    namespace: default
+    port: 443
+  version: v1
+  versionPriority: 15

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-deployment.yaml
@@ -1,0 +1,186 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: packageserver
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: packageserver
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        include.release.openshift.io/self-managed-high-availability: "true"
+      labels:
+        app: packageserver
+    spec:
+      serviceAccount: vpn
+      dnsPolicy: None
+      dnsConfig:
+        # dnsmasq in the pod configured to check guest + host dns servers
+        nameservers:
+        - 127.0.0.1
+        # searches configured to match kube defaults
+        searches:
+        - {{ .Namespace }}.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+        - ec2.internal
+        options:
+        - name: ndots
+          value: '5'
+      containers:
+      - command:
+        - /bin/package-server
+        - -v=4
+        - --secure-port
+        - "5443"
+        - --global-namespace
+        - openshift-marketplace
+        - --kubeconfig
+        - /etc/openshift/kubeconfig/kubeconfig
+        - --authentication-kubeconfig
+        - /etc/openshift/kubeconfig/kubeconfig
+        - --authorization-kubeconfig
+        - /etc/openshift/kubeconfig/kubeconfig
+        env:
+        - name: OPERATOR_CONDITION_NAME
+          value: packageserver
+        image: {{ imageFor "operator-lifecycle-manager" }}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 5443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: packageserver
+        ports:
+        - containerPort: 5443
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 5443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmpfs
+        - mountPath: /apiserver.local.config/certificates
+          name: apiservice-cert
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-cert
+        - mountPath: /etc/openshift/kubeconfig
+          name: kubeconfig
+          readOnly: true
+      - name: openvpn-client
+        terminationMessagePath: /dev/termination-log
+        command:
+          - /usr/sbin/openvpn
+        securityContext:
+          privileged: true
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: vpnsecret
+            mountPath: /etc/openvpn/secret
+          - name: vpnconfig
+            mountPath: /etc/openvpn/config
+        terminationMessagePolicy: File
+        image: 'quay.io/hypershift/openvpn:latest'
+        workingDir: /etc/openvpn/
+        args:
+          - '--config'
+          - /etc/openvpn/config/client.conf
+      - name: dnsmasq
+        securityContext:
+          privileged: true
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: dnsmasq-conf
+            mountPath: /etc/dnsmasq.conf
+            subPath: dnsmasq.conf
+          - name: resolv-dnsmasq
+            mountPath: /etc/resolv.dnsmasq
+            subPath: resolv.dnsmasq
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: 4km3/dnsmasq
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 120
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 120
+      volumes:
+      - emptyDir: {}
+        name: tmpfs
+      - name: apiservice-cert
+        secret:
+          defaultMode: 420
+          items:
+          - key: server.crt
+            path: apiserver.crt
+          - key: server.key
+            path: apiserver.key
+          secretName: packageserver
+      - name: webhook-cert
+        secret:
+          defaultMode: 420
+          items:
+          - key: server.crt
+            path: tls.crt
+          - key: server.key
+            path: tls.key
+          secretName: packageserver
+      - name: kubeconfig
+        secret:
+          secretName: service-network-admin-kubeconfig
+      - name: vpnconfig
+        configMap:
+          name: openvpn-kube-apiserver-client
+          defaultMode: 420
+      - name: vpnsecret
+        secret:
+          secretName: openvpn-kube-apiserver-client
+          defaultMode: 420
+      - name: dnsmasq-conf
+        configMap:
+          name: dnsmasq-conf
+          defaultMode: 420
+      - name: resolv-dnsmasq
+        configMap:
+          name: resolv-dnsmasq
+          defaultMode: 420

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-endpoint-guest.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-endpoint-guest.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: packageserver
+  namespace: default
+subsets:
+- addresses:
+  - ip: {{ .PackageServerAPIClusterIP }}
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-secret.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: packageserver
+data:
+  server.crt: {{ pki "secret" "packageserver-cert" "tls.crt" }}
+  server.key: {{ pki "secret" "packageserver-cert" "tls.key" }}

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-service-guest.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-service-guest.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: packageserver
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 443

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/prometheus-rule-guest.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/prometheus-rule-guest.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: olm-alert-rules
+  namespace: openshift-operator-lifecycle-manager
+  labels:
+    prometheus: alert-rules
+    role: alert-rules
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  groups:
+    - name: olm.csv_abnormal.rules
+      rules:
+        - alert: CsvAbnormalFailedOver2Min
+          expr: csv_abnormal{phase=~"^Failed$"}
+          for: 2m
+          labels:
+            severity: warning
+            namespace: "{{ $labels.namespace }}"
+          annotations:
+            message: Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Reason-{{ $labels.reason }}
+        - alert: CsvAbnormalOver30Min
+          expr: csv_abnormal{phase=~"(^Replacing$|^Pending$|^Deleting$|^Unknown$)"}
+          for: 30m
+          labels:
+            severity: warning
+            namespace: "{{ $labels.namespace }}"
+          annotations:
+            message: "Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Phase-{{ $labels.phase }} Reason-{{ $labels.reason }}"

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
@@ -14,6 +14,7 @@ const (
 	vpnServiceName                = "openvpn-server"
 	openshiftAPIServerServiceName = "openshift-apiserver"
 	oauthAPIServerName            = "openshift-oauth-apiserver"
+	packageServerServiceName      = "packageserver"
 )
 
 func KubeAPIServerService(hostedClusterNamespace string) *corev1.Service {
@@ -74,6 +75,15 @@ func OauthAPIServerService(hostedClusterNamespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      oauthAPIServerName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
+func OLMPackageServerService(hostedClusterNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      packageServerServiceName,
 			Namespace: hostedClusterNamespace,
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -202,3 +202,12 @@ func MachineConfigServerCert(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func OLMPackageServerCertSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "packageserver-cert",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/service.go
@@ -10,22 +10,28 @@ import (
 const (
 	OpenShiftAPIServerPort  = 8443
 	OpenShiftAPIServicePort = 443
+	OLMPackageServerPort    = 5443
 )
 
 var (
 	openshiftAPIServerLabels = map[string]string{"app": "openshift-apiserver"}
 	oauthAPIServerLabels     = map[string]string{"app": "openshift-oauth-apiserver"}
+	olmPackageServerLabels   = map[string]string{"app": "packageserver"}
 )
 
 func (p *OpenShiftAPIServerServiceParams) ReconcileOpenShiftAPIService(svc *corev1.Service) error {
-	return p.reconcileAPIService(svc, openshiftAPIServerLabels)
+	return p.reconcileAPIService(svc, openshiftAPIServerLabels, OpenShiftAPIServerPort)
 }
 
 func (p *OpenShiftAPIServerServiceParams) ReconcileOAuthAPIService(svc *corev1.Service) error {
-	return p.reconcileAPIService(svc, oauthAPIServerLabels)
+	return p.reconcileAPIService(svc, oauthAPIServerLabels, OpenShiftAPIServerPort)
 }
 
-func (p *OpenShiftAPIServerServiceParams) reconcileAPIService(svc *corev1.Service, labels map[string]string) error {
+func (p *OpenShiftAPIServerServiceParams) ReconcileOLMPackageServerService(svc *corev1.Service) error {
+	return p.reconcileAPIService(svc, olmPackageServerLabels, OLMPackageServerPort)
+}
+
+func (p *OpenShiftAPIServerServiceParams) reconcileAPIService(svc *corev1.Service, labels map[string]string, targetPort int) error {
 	util.EnsureOwnerRef(svc, p.OwnerReference)
 	svc.Spec.Selector = labels
 	var portSpec corev1.ServicePort
@@ -37,7 +43,7 @@ func (p *OpenShiftAPIServerServiceParams) reconcileAPIService(svc *corev1.Servic
 	portSpec.Name = "https"
 	portSpec.Port = int32(OpenShiftAPIServicePort)
 	portSpec.Protocol = corev1.ProtocolTCP
-	portSpec.TargetPort = intstr.FromInt(OpenShiftAPIServerPort)
+	portSpec.TargetPort = intstr.FromInt(targetPort)
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.Ports[0] = portSpec
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
@@ -36,3 +36,14 @@ func (p *PKIParams) ReconcileOpenShiftControllerManagerCertSecret(secret, ca *co
 	}
 	return p.reconcileSignedCertWithAddresses(secret, ca, "openshift-controller-manager", "openshift", X509SignerUsage, X509UsageClientServerAuth, dnsNames, nil)
 }
+
+func (p *PKIParams) ReconcileOLMPackageServerCertSecret(secret, ca *corev1.Secret) error {
+	dnsNames := []string{
+		"packageserver",
+		fmt.Sprintf("packageserver.%s.svc", p.Namespace),
+		fmt.Sprintf("packageserver.%s.svc.cluster.local", p.Namespace),
+		"packageserver.default.svc",
+		"packageserver.default.svc.cluster.local",
+	}
+	return p.reconcileSignedCertWithAddresses(secret, ca, "packageserver", "openshift", X509SignerUsage, X509UsageClientServerAuth, dnsNames, nil)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/render/funcs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/funcs.go
@@ -184,6 +184,17 @@ func cidrMask(cidr string) string {
 	return fmt.Sprintf("%d.%d.%d.%d", m[0], m[1], m[2], m[3])
 }
 
+func dnsForCidr(cidr string) string {
+	ip, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err.Error())
+	}
+	dnsAddr := ip.To4()
+	// dns for openshift mounts at x.x.x.10 in the service range by default
+	dnsAddr[3] = 10
+	return dnsAddr.String()
+}
+
 func iniValue(iniContent, section, key string) string {
 	f, err := ini.Load([]byte(iniContent))
 	if err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/render/types.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/types.go
@@ -44,30 +44,31 @@ type PKIParams struct {
 }
 
 type ClusterParams struct {
-	Namespace               string      `json:"namespace"`
-	ExternalAPIDNSName      string      `json:"externalAPIDNSName"`
-	ExternalAPIAddress      string      `json:"externalAPIAddress"`
-	ExternalAPIPort         uint        `json:"externalAPIPort"`
-	ExternalOpenVPNAddress  string      `json:"externalVPNAddress"`
-	ExternalOpenVPNPort     uint        `json:"externalVPNPort"`
-	ExternalOauthDNSName    string      `json:"externalOauthDNSName"`
-	ExternalOauthPort       uint        `json:"externalOauthPort"`
-	IdentityProviders       string      `json:"identityProviders"`
-	ServiceCIDR             string      `json:"serviceCIDR"`
-	MachineCIDR             string      `json:"machineCIDR"`
-	NamedCerts              []NamedCert `json:"namedCerts,omitempty"`
-	PodCIDR                 string      `json:"podCIDR"`
-	ReleaseImage            string      `json:"releaseImage"`
-	IngressSubdomain        string      `json:"ingressSubdomain"`
-	OpenShiftAPIClusterIP   string      `json:"openshiftAPIClusterIP"`
-	OauthAPIClusterIP       string      `json:"oauthAPIClusterIP"`
-	ImageRegistryHTTPSecret string      `json:"imageRegistryHTTPSecret"`
-	RouterNodePortHTTP      string      `json:"routerNodePortHTTP"`
-	RouterNodePortHTTPS     string      `json:"routerNodePortHTTPS"`
-	BaseDomain              string      `json:"baseDomain"`
-	PublicZoneID            string      `json:"publicZoneID,omitempty"`
-	PrivateZoneID           string      `json:"PrivateZoneID,omitempty"`
-	NetworkType             string      `json:"networkType"`
+	Namespace                 string      `json:"namespace"`
+	ExternalAPIDNSName        string      `json:"externalAPIDNSName"`
+	ExternalAPIAddress        string      `json:"externalAPIAddress"`
+	ExternalAPIPort           uint        `json:"externalAPIPort"`
+	ExternalOpenVPNAddress    string      `json:"externalVPNAddress"`
+	ExternalOpenVPNPort       uint        `json:"externalVPNPort"`
+	ExternalOauthDNSName      string      `json:"externalOauthDNSName"`
+	ExternalOauthPort         uint        `json:"externalOauthPort"`
+	IdentityProviders         string      `json:"identityProviders"`
+	ServiceCIDR               string      `json:"serviceCIDR"`
+	MachineCIDR               string      `json:"machineCIDR"`
+	NamedCerts                []NamedCert `json:"namedCerts,omitempty"`
+	PodCIDR                   string      `json:"podCIDR"`
+	ReleaseImage              string      `json:"releaseImage"`
+	IngressSubdomain          string      `json:"ingressSubdomain"`
+	OpenShiftAPIClusterIP     string      `json:"openshiftAPIClusterIP"`
+	OauthAPIClusterIP         string      `json:"oauthAPIClusterIP"`
+	PackageServerAPIClusterIP string      `json:"packageServerAPIClusterIP"`
+	ImageRegistryHTTPSecret   string      `json:"imageRegistryHTTPSecret"`
+	RouterNodePortHTTP        string      `json:"routerNodePortHTTP"`
+	RouterNodePortHTTPS       string      `json:"routerNodePortHTTPS"`
+	BaseDomain                string      `json:"baseDomain"`
+	PublicZoneID              string      `json:"publicZoneID,omitempty"`
+	PrivateZoneID             string      `json:"PrivateZoneID,omitempty"`
+	NetworkType               string      `json:"networkType"`
 	// APIAvailabilityPolicy defines the availability of components that support end-user facing API requests
 	APIAvailabilityPolicy AvailabilityPolicy `json:"apiAvailabilityPolicy"`
 	// ControllerAvailabilityPolicy defines the availability of controller components for the cluster
@@ -76,6 +77,7 @@ type ClusterParams struct {
 	OriginReleasePrefix                    string                 `json:"originReleasePrefix"`
 	OpenshiftAPIServerCABundle             string                 `json:"openshiftAPIServerCABundle"`
 	OauthAPIServerCABundle                 string                 `json:"oauthAPIServerCABundle"`
+	PackageServerCABundle                  string                 `json:"packageServerCABundle"`
 	CloudProvider                          string                 `json:"cloudProvider"`
 	CVOSetupImage                          string                 `json:"cvoSetupImage"`
 	IssuerURL                              string                 `json:"issuerURL"`

--- a/control-plane-operator/controllers/hostedcontrolplane/resources.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/resources.go
@@ -10,65 +10,6 @@ const (
 	vpnServicePort       = 1194
 )
 
-func OauthAPIServerServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{
-		{
-			Name:       "https",
-			Port:       443,
-			Protocol:   corev1.ProtocolTCP,
-			TargetPort: intstr.FromInt(8443),
-		},
-	}
-}
-
-func OauthAPIServerServiceSelector() map[string]string {
-	return map[string]string{"app": "openshift-oauth-apiserver"}
-}
-
-func OpenshiftAPIServerServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{
-		{
-			Name:       "https",
-			Port:       443,
-			Protocol:   corev1.ProtocolTCP,
-			TargetPort: intstr.FromInt(8443),
-		},
-	}
-}
-
-func OpenshiftAPIServerServiceSelector() map[string]string {
-	return map[string]string{"app": "openshift-apiserver"}
-}
-
-func VPNServerServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{
-		{
-			Port:       vpnServicePort,
-			Protocol:   corev1.ProtocolTCP,
-			TargetPort: intstr.FromInt(vpnServicePort),
-		},
-	}
-}
-
-func VPNServerServiceSelector() map[string]string {
-	return map[string]string{"app": "openvpn-server"}
-}
-
-func OauthServerServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{
-		{
-			Name:       "https",
-			Port:       443,
-			Protocol:   corev1.ProtocolTCP,
-			TargetPort: intstr.FromInt(6443),
-		},
-	}
-}
-
-func OauthServerServiceSelector() map[string]string {
-	return map[string]string{"app": "oauth-openshift"}
-}
-
 func KubeAPIServerServicePorts(securePort int32) []corev1.ServicePort {
 	return []corev1.ServicePort{
 		{

--- a/hosted-cluster-config-operator/controllers/clusteroperator/reconcile.go
+++ b/hosted-cluster-config-operator/controllers/clusteroperator/reconcile.go
@@ -233,6 +233,13 @@ var clusterOperators = []ClusterOperatorInfo{
 			},
 		},
 	},
+	{
+		Name: "operator-lifecycle-manager-packageserver",
+		VersionMapping: map[string]string{
+			"operator": "release",
+		},
+		RelatedObjects: []configv1.ObjectReference{},
+	},
 }
 
 var clusterOperatorNames sets.String

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -849,6 +849,11 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 			Resources: []string{"*"},
 			Verbs:     []string{"*"},
 		},
+		{
+			APIGroups: []string{"image.openshift.io"},
+			Resources: []string{"imagestreams"},
+			Verbs:     []string{"*"},
+		},
 	}
 	return nil
 }


### PR DESCRIPTION
Bring OLM to control-plane namespace

Also removes OLM resources from the CVO manifests as part of the cvo
init process so they are not created on the guest cluster.

Notable future work:
1) uses dns/vpn configuration to run the default catalog pods in the control plane
while making their grpc api available to the guest cluster.  This
will likely move to konnectivity in the future

2) the set of default catalog pods cannot currently be controlled, in
the future this needs to be controllerable by the deployer of the
guest cluster

3) no olm metric endpoints+alerting rules are currently defined
