### PR TITLE
Makes SigningKey and IssuerURL optional

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -21,10 +21,16 @@ type HostedClusterSpec struct {
 	// workers. It should have an ".dockerconfigjson" key containing the pull secret JSON.
 	PullSecret corev1.LocalObjectReference `json:"pullSecret"`
 
-	SigningKey corev1.LocalObjectReference `json:"signingKey"`
+	// SigningKey is a reference to a Secret containing a single key "key"
+	// +optional
+	SigningKey corev1.LocalObjectReference `json:"signingKey,omitempty"`
 
+	// +kubebuilder:default:="https://kubernetes.default.svc"
 	IssuerURL string `json:"issuerURL"`
 
+	// SSHKey is a reference to a Secret containing a single key "id_rsa.pub",
+	// whose value is the public part of an SSH key that can be used to access
+	// Nodes.
 	SSHKey corev1.LocalObjectReference `json:"sshKey"`
 
 	// Networking contains network-specific settings for this cluster

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -100,6 +100,7 @@ spec:
                 description: InfraID is used to identify the cluster in cloud platforms
                 type: string
               issuerURL:
+                default: https://kubernetes.default.svc
                 type: string
               networking:
                 description: Networking contains network-specific settings for this cluster
@@ -327,14 +328,14 @@ spec:
                   type: object
                 type: array
               signingKey:
-                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                description: SigningKey is a reference to a Secret containing a single key "key"
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
               sshKey:
-                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                description: SSHKey is a reference to a Secret containing a single key "id_rsa.pub", whose value is the public part of an SSH key that can be used to access Nodes.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -347,7 +348,6 @@ spec:
             - pullSecret
             - release
             - services
-            - signingKey
             - sshKey
             type: object
           status:

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -276,7 +276,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Reconcile the HostedControlPlane signing key by resolving the source secret
 	// reference from the HostedCluster and syncing the secret in the control plane namespace.
-	{
+	if len(hcluster.Spec.SigningKey.Name) > 0 {
 		var src corev1.Secret
 		if err := r.Client.Get(ctx, ctrlclient.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.SigningKey.Name}, &src); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get signing key %s: %w", hcluster.Spec.SigningKey.Name, err)
@@ -428,7 +428,9 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	}
 
 	hcp.Spec.PullSecret = corev1.LocalObjectReference{Name: controlplaneoperator.PullSecret(hcp.Namespace).Name}
-	hcp.Spec.SigningKey = corev1.LocalObjectReference{Name: controlplaneoperator.SigningKey(hcp.Namespace).Name}
+	if len(hcluster.Spec.SigningKey.Name) > 0 {
+		hcp.Spec.SigningKey = corev1.LocalObjectReference{Name: controlplaneoperator.SigningKey(hcp.Namespace).Name}
+	}
 	if len(hcluster.Spec.SSHKey.Name) > 0 {
 		hcp.Spec.SSHKey = corev1.LocalObjectReference{Name: controlplaneoperator.SSHKey(hcp.Namespace).Name}
 	}


### PR DESCRIPTION
When deploying with platform "None", SigningKey is not required, and
IssuerURL can use a default value.