### PR TITLE
update haproxy with logging and ability to specify multiple configs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/haproxy.cfg
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/haproxy.cfg
@@ -1,5 +1,7 @@
 global
   maxconn 7000
+  log stdout local0
+  log stdout local1 notice
 
 defaults
   mode tcp
@@ -13,8 +15,15 @@ defaults
 
 frontend local_apiserver
   bind {{ .ExternalAPIAddress }}:{{ .InternalAPIPort }}
+  log global
+  mode tcp
+  option tcplog
   default_backend remote_apiserver
 
 backend remote_apiserver
   mode tcp
+  log global
+  option httpchk GET /version
+  option log-health-checks
+  default-server inter 10s fall 3 rise 3
   server controlplane {{ .ExternalAPIDNSName }}:{{ .ExternalAPIPort }}

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/kube-apiserver-proxy.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/kube-apiserver-proxy.yaml
@@ -22,7 +22,7 @@ spec:
     command:
     - haproxy
     - -f
-    - /usr/local/etc/haproxy/haproxy.cfg
+    - /usr/local/etc/haproxy
     volumeMounts:
     - name: config
       mountPath: /usr/local/etc/haproxy


### PR DESCRIPTION
- Adds logging of connections processed by haproxy
- Adds health checks to log when connectivity fails to an apiserver. Health check queries /health route
- Specifies a directory for haproxy config which allows for additional haproxy confs to be placed in the directory and a merge of them will be done to have the final haproxy conf. Allows for additional endpoints through haproxy (IBM sends registry traffic through haproxy in certain private only configurations)