### PR TITLE
Sample integrations with mgmt cluster services

### DIFF
--- a/examples/cluster-logging/README.md
+++ b/examples/cluster-logging/README.md
@@ -1,0 +1,57 @@
+# Cluster Logging
+
+HyperShift hosts OpenShift control planes from an OpenShift management cluster.
+
+The hosted control plane is just a type of workload whose logs can be collected,
+forward, or visualized no differently than any other workload run on a cluster by
+a `cluster-admin`.
+
+## Logging Topology
+
+For simplicity, this example runs a converged log storage, visualization, and
+collector topology.  In production settings, it is anticipated that each management
+cluster will run with log collection enabled, but forward those logs to an off
+cluster location for further analysis.
+
+## How to install
+
+**Prerequisites:**
+
+* Admin access to an OpenShift cluster (version 4.7+) specified by the `KUBECONFIG` environment variable
+* The `hypershift` operator is installed on the target cluster.
+
+To install prerequisite operators for ElasticSearch and Cluster Logging:
+
+```shell
+oc apply -f ./manifests
+```
+
+Ensure all prereqs are succeeded.
+
+```shell
+$ oc get clusterserviceversion -n openshift-logging
+NAME                             DISPLAY                            VERSION    REPLACES                  PHASE
+cluster-logging.5.0.4-21         Red Hat OpenShift Logging          5.0.4-21   cluster-logging.5.0.3-6   Succeeded
+elasticsearch-operator.5.0.3-6   OpenShift Elasticsearch Operator   5.0.3-6                              Succeeded
+```
+
+To install Cluster Logging with a converged collector, storage, and visualization flow.
+
+```shell
+oc apply -f ./operator
+```
+
+Find the `kibana` route and login to the application with a user in `cluster-admin` role.
+
+```shell
+oc get routes -n openshift-logging
+```
+
+Login into the `kibana`, click `Management`, create `Index Pattern` with index name `app`, and use `@timestamp`
+for *Time filter field name*.
+
+Click `Discover`.
+
+Input into search box the following query: "kubernetes.namespace_name:clusters*" to find all logs in namespaces with prefix clusters.
+
+Edit the visualization to choose the columns to display, note `message` has the log body.

--- a/examples/cluster-logging/manifests/eo-namespace.yaml
+++ b/examples/cluster-logging/manifests/eo-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat 
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true" 

--- a/examples/cluster-logging/manifests/eo-operator-group.yaml
+++ b/examples/cluster-logging/manifests/eo-operator-group.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-operators-redhat
+  namespace: openshift-operators-redhat 
+spec: {}

--- a/examples/cluster-logging/manifests/eo-subscription.yaml
+++ b/examples/cluster-logging/manifests/eo-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: "elasticsearch-operator"
+  namespace: "openshift-operators-redhat" 
+spec:
+  channel: "5.0" 
+  installPlanApproval: "Automatic"
+  source: "redhat-operators" 
+  sourceNamespace: "openshift-marketplace"
+  name: "elasticsearch-operator"

--- a/examples/cluster-logging/manifests/ol-namespace.yaml
+++ b/examples/cluster-logging/manifests/ol-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/examples/cluster-logging/manifests/ol-operator-group.yaml
+++ b/examples/cluster-logging/manifests/ol-operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging 
+spec:
+  targetNamespaces:
+  - openshift-logging 

--- a/examples/cluster-logging/manifests/ol-subscription.yaml
+++ b/examples/cluster-logging/manifests/ol-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging 
+spec:
+  channel: "5.0" 
+  name: cluster-logging
+  source: redhat-operators 
+  sourceNamespace: openshift-marketplace

--- a/examples/cluster-logging/operator/cluster-logging.yaml
+++ b/examples/cluster-logging/operator/cluster-logging.yaml
@@ -1,0 +1,42 @@
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance" 
+  namespace: "openshift-logging"
+spec:
+  managementState: "Managed"  
+  logStore:
+    type: "elasticsearch"  
+    retentionPolicy: 
+      application:
+        maxAge: 1d
+      infra:
+        maxAge: 7d
+      audit:
+        maxAge: 7d
+    elasticsearch:
+      nodeCount: 3 
+      storage:
+        size: 200G
+      resources: 
+        requests:
+          memory: "8Gi"
+      proxy: 
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+             memory: 256Mi
+      redundancyPolicy: "SingleRedundancy"
+  visualization:
+    type: "kibana"  
+    kibana:
+      replicas: 1
+  curation:
+    type: "curator"
+    curator:
+      schedule: "30 3 * * *" 
+  collection:
+    logs:
+      type: "fluentd"  
+      fluentd: {}

--- a/examples/user-workload-monitoring/README.md
+++ b/examples/user-workload-monitoring/README.md
@@ -1,0 +1,53 @@
+# Monitoring
+
+HyperShift hosts OpenShift control planes from an OpenShift management cluster.
+
+The hosted control plane is just a type of workload that can be monitored via
+OpenShift user workload monitoring.
+
+## Topology
+
+For simplicity, this example enables user workload monitoring on an OpenShift
+cluster using defaults.  Once enabled, the hosted control plane component
+metrics are visible in Thanos querier.
+
+## How to install
+
+**Prerequisites:**
+
+* Admin access to an OpenShift cluster (version 4.7+) specified by the `KUBECONFIG` environment variable
+* The `hypershift` operator is installed on the target cluster.
+
+To install prerequisite operators for ElasticSearch and Cluster Logging:
+
+```shell
+oc apply -f ./manifests
+```
+
+Ensure all prereqs are succeeded.
+
+```shell
+$ oc get pods -n openshift-user-workload-monitoring
+```
+
+As `cluster-admin` visit the Thanos Querier route.
+
+```shell
+$ oc get routes -n openshift-monitoring thanos-querier
+```
+
+Execute following queries:
+
+Is HyperShift up?
+
+```shell
+up{namespace="hypershift"}
+```
+
+Is any HyperShift controller having a reconcile error?
+
+```shell
+controller_runtime_reconcile_errors_total{namespace="hypershift"}
+```
+
+TODO: add more queries

--- a/examples/user-workload-monitoring/manifests/user-workload-monitoring-config.yaml
+++ b/examples/user-workload-monitoring/manifests/user-workload-monitoring-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true


### PR DESCRIPTION
Adds two sets of documentation.

1. integration with mgmt cluster logging to view control plane logs across namespaces
2. integration with mgmt cluster user workload monitoring to view metrics of hosted control plane machinery

I assume we can grow each set of documentation over time.