### PR TITLE
fix olm deployment

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-operator-deployment.yaml
@@ -59,6 +59,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+              name: server
+              protocol: TCP
             - containerPort: 8081
               name: metrics
               protocol: TCP

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/olm-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/olm-operator-deployment.yaml
@@ -41,6 +41,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+              name: server
+              protocol: TCP
             - containerPort: 8081
               name: metrics
               protocol: TCP


### PR DESCRIPTION
error seen in a 4.6 management cluster:
```
2021-06-08T21:31:38.365Z	ERROR	controller-runtime.manager.controller.hostedcontrolplane	Reconciler error	{"reconciler group": "hypershift.openshift.io", "reconciler kind": "HostedControlPlane", "name": "tyler11", "namespace": "master-tyler11", "error": "failed to ensure control plane: failed to apply some manifests: [failed to apply manifest user-manifests-bootstrapper-pod.yaml: pods \"manifests-bootstrapper\" is forbidden: error looking up service account master-tyler11/user-manifests-bootstrapper: serviceaccount \"user-manifests-bootstrapper\" not found, failed to apply manifest catalog-operator-deployment.yaml: failed to create typed patch object: .spec.template.spec.containers[name=\"catalog-operator\"].ports: element 0: associative list with keys has an element that omits key field \"protocol\", failed to apply manifest olm-operator-deployment.yaml: failed to create typed patch object: .spec.template.spec.containers[name=\"olm-operator\"].ports: element 0: associative list with keys has an element that omits key field \"protocol\"]"}
```