### PR TITLE
Fix broken OCP release image API URL

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,8 @@ var (
 	HyperShiftImage = "registry.ci.openshift.org/hypershift/hypershift:latest"
 )
 
-const releaseURL = "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4-stable/latest"
+// https://docs.ci.openshift.org/docs/getting-started/useful-links/#services
+const releaseURL = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest"
 
 type OCPVersion struct {
 	Name        string `json:"name"`


### PR DESCRIPTION
The previous URL for looking up OCP images was deprecated and is now
defunct, causing image lookup failures. This commit fixes the URL to
point at the new location for OCP amd64 release metadata and should
fix image lookups.