### PR TITLE
cli: fix release image validation

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -134,6 +134,10 @@ func NewCreateCommand() *cobra.Command {
 }
 
 func CreateCluster(ctx context.Context, opts Options) error {
+	if len(opts.ReleaseImage) == 0 {
+		return fmt.Errorf("release image is required")
+	}
+
 	annotations := map[string]string{}
 	for _, s := range opts.Annotations {
 		pair := strings.SplitN(s, "=", 2)


### PR DESCRIPTION
Before this commit, if the release image couldn't be discovered and
no --release-image flag was provided, the CLI would blindly continue
creating cluster infra and an invalid HostedCluster resource.

This commit fixes validation so that if release image discovery fails,
the command fails fast and requires user input for thr release image.