### PR TITLE
cli: always create a NodePool with the desired replicas

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -239,7 +239,7 @@ aws_secret_access_key = %s
 	}
 
 	var nodePool *hyperv1.NodePool
-	if o.NodePoolReplicas > 0 {
+	if o.NodePoolReplicas > -1 {
 		nodePool = &hyperv1.NodePool{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "NodePool",

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -95,7 +95,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Path to a pull secret (required)")
 	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
 	cmd.Flags().StringVar(&opts.SSHKeyFile, "ssh-key", opts.SSHKeyFile, "Path to an SSH key file")
-	cmd.Flags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If >0, create a default NodePool with this many replicas")
+	cmd.Flags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If >-1, create a default NodePool with this many replicas")
 	cmd.Flags().BoolVar(&opts.Render, "render", opts.Render, "Render output as YAML to stdout instead of applying")
 	cmd.Flags().StringVar(&opts.InfrastructureJSON, "infra-json", opts.InfrastructureJSON, "Path to file containing infrastructure information for the cluster. If not specified, infrastructure will be created")
 	cmd.Flags().StringVar(&opts.IAMJSON, "iam-json", opts.IAMJSON, "Path to file containing IAM information for the cluster. If not specified, IAM will be created")


### PR DESCRIPTION
Before this commit, `create cluster` didn't create a NodePool if the
desired node pool replicas value is zero. However, a NodePool with
zero replicas is a valid and sometimes useful state.

This commit changes `create cluster` to always create a NodePool even
if the value is zero. To skip creating a NodePool entirely, use a replica
value of -1 instead.