### PR TITLE
Secure connection from ign server to MCS Service

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/machine-config-server/machine-config-server-secret.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/machine-config-server/machine-config-server-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: machine-config-server
-type: Opaque
-data:
-  tls.crt: {{ pki "secret" "mcs-crt" "tls.crt" }}
-  tls.key: {{ pki "secret" "mcs-crt" "tls.key" }}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1039,14 +1039,6 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		return fmt.Errorf("failed to reconcile ingress cert secret: %w", err)
 	}
 
-	// MCS Cert
-	machineConfigServerCert := manifests.MachineConfigServerCert(hcp.Namespace)
-	if _, err := controllerutil.CreateOrUpdate(ctx, r, machineConfigServerCert, func() error {
-		return p.ReconcileMachineConfigServerCert(machineConfigServerCert, rootCASecret)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile machine config server cert secret: %w", err)
-	}
-
 	// OLM PackageServer Cert
 	packageServerCertSecret := manifests.OLMPackageServerCertSecret(hcp.Namespace)
 	if _, err := controllerutil.CreateOrUpdate(ctx, r, packageServerCertSecret, func() error {

--- a/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
@@ -238,7 +238,6 @@ func (c *clusterManifestContext) clusterBootstrap() {
 func (c *clusterManifestContext) machineConfigServer() {
 	c.addManifestFiles(
 		"machine-config-server/machine-config-server-configmap.yaml",
-		"machine-config-server/machine-config-server-secret.yaml",
 		"machine-config-server/machine-config-server-kubeconfig-secret.yaml",
 	)
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -820,15 +820,15 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	}
 
 	// Reconcile service
-	// TODO (alberto): enable nodePort choice at the hostedClusterAPI
+	// TODO (alberto): enable nDNSNamesodePort choice at the hostedClusterAPI
 	ignitionServerService := ignitionserver.Service(controlPlaneNamespace.Name)
 	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, ignitionServerService, func() error {
 		ignitionServerService.Spec.Ports = []corev1.ServicePort{
 			{
-				Name:       "http",
+				Name:       "https",
 				Protocol:   corev1.ProtocolTCP,
-				Port:       80,
-				TargetPort: intstr.FromInt(9090),
+				Port:       443,
+				TargetPort: intstr.FromString("https"),
 			},
 		}
 		ignitionServerService.Spec.Selector = map[string]string{
@@ -868,6 +868,21 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	if len(ignitionServerRoute.Status.Ingress) == 0 || len(ignitionServerRoute.Status.Ingress[0].Host) == 0 {
 		r.Log.Info("ignition server reconciliation waiting for ignition server route to be assigned a host value")
 		return nil
+	}
+
+	// Reconcile a CA cert for trusting the server for the proxied requests to the MachineConfigServer Service.
+	// Uses https://github.com/openshift/service-ca-operator.
+	caCertProxyConfigMap := ignitionserver.IgnitionCACertProxyConfigMap(controlPlaneNamespace.Name)
+	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, caCertProxyConfigMap, func() error {
+		if caCertProxyConfigMap.Annotations == nil {
+			caCertProxyConfigMap.Annotations = make(map[string]string)
+		}
+		caCertProxyConfigMap.Annotations["service.beta.openshift.io/inject-cabundle"] = "true"
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ignition CA cert proxy configmap: %w", err)
+	} else {
+		r.Log.Info("reconciled ignition CA cert proxy configmap", "result", result)
 	}
 
 	// Reconcile a root CA for ignition serving certificates. We only create this
@@ -993,6 +1008,16 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 							},
 						},
 						{
+							Name: "ca-cert-proxy",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: caCertProxyConfigMap.Name,
+									},
+								},
+							},
+						},
+						{
 							Name: "token",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
@@ -1011,10 +1036,12 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 								"start",
 								"--cert-file", "/var/run/secrets/ignition/serving-cert/tls.crt",
 								"--key-file", "/var/run/secrets/ignition/serving-cert/tls.key",
+								"--ca-cert-proxy", "/var/run/secrets/ignition/ca-cert-proxy/service-ca.crt",
 								"--token-file", "/var/run/secrets/ignition/token/token",
 							},
 							Ports: []corev1.ContainerPort{
 								{
+									Name:          "https",
 									ContainerPort: 9090,
 								},
 							},
@@ -1022,6 +1049,10 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 								{
 									Name:      "serving-cert",
 									MountPath: "/var/run/secrets/ignition/serving-cert",
+								},
+								{
+									Name:      "ca-cert-proxy",
+									MountPath: "/var/run/secrets/ignition/ca-cert-proxy",
 								},
 								{
 									Name:      "token",

--- a/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
+++ b/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
@@ -69,3 +69,12 @@ func IgnitionTokenSecret(namespace string) *corev1.Secret {
 		},
 	}
 }
+
+func IgnitionCACertProxyConfigMap(namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ResourceName + "-ca-cert-proxy",
+			Namespace: namespace,
+		},
+	}
+}


### PR DESCRIPTION
This let only https connection from the ign server to the machine config server services.
It relies on https://github.com/openshift/service-ca-operator to get the CA and serving certs for the machineConfigServer Services.