### PR TITLE
Secure connection from ign server to MCS Service

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/machine-config-server/machine-config-server-secret.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/machine-config-server/machine-config-server-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: machine-config-server
-type: Opaque
-data:
-  tls.crt: {{ pki "secret" "mcs-crt" "tls.crt" }}
-  tls.key: {{ pki "secret" "mcs-crt" "tls.key" }}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1039,14 +1039,6 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		return fmt.Errorf("failed to reconcile ingress cert secret: %w", err)
 	}
 
-	// MCS Cert
-	machineConfigServerCert := manifests.MachineConfigServerCert(hcp.Namespace)
-	if _, err := controllerutil.CreateOrUpdate(ctx, r, machineConfigServerCert, func() error {
-		return p.ReconcileMachineConfigServerCert(machineConfigServerCert, rootCASecret)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile machine config server cert secret: %w", err)
-	}
-
 	// OLM PackageServer Cert
 	packageServerCertSecret := manifests.OLMPackageServerCertSecret(hcp.Namespace)
 	if _, err := controllerutil.CreateOrUpdate(ctx, r, packageServerCertSecret, func() error {

--- a/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
@@ -238,7 +238,6 @@ func (c *clusterManifestContext) clusterBootstrap() {
 func (c *clusterManifestContext) machineConfigServer() {
 	c.addManifestFiles(
 		"machine-config-server/machine-config-server-configmap.yaml",
-		"machine-config-server/machine-config-server-secret.yaml",
 		"machine-config-server/machine-config-server-kubeconfig-secret.yaml",
 	)
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -318,10 +318,10 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, mcsService, func() error {
 		mcsService.Spec.Ports = []corev1.ServicePort{
 			{
-				Name:       "http",
+				Name:       "https",
 				Protocol:   corev1.ProtocolTCP,
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
+				Port:       443,
+				TargetPort: intstr.FromString("https"),
 			},
 		}
 
@@ -1114,11 +1114,6 @@ oc get cm -l ignition-config="true" -n "${NAMESPACE}" --no-headers | awk '{ prin
 						},
 						Ports: []corev1.ContainerPort{
 							{
-								Name:          "http",
-								ContainerPort: 8080,
-								Protocol:      corev1.ProtocolTCP,
-							},
-							{
 								Name:          "https",
 								ContainerPort: 8443,
 								Protocol:      corev1.ProtocolTCP,
@@ -1158,7 +1153,7 @@ oc get cm -l ignition-config="true" -n "${NAMESPACE}" --no-headers | awk '{ prin
 						Name: "mcs-tls",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: "machine-config-server",
+								SecretName: ignitionserver.IgnitionServingCertSecret(deployment.Namespace).Name,
 							},
 						},
 					},

--- a/ignition-server/main.go
+++ b/ignition-server/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -17,6 +19,10 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	namespaceEnvVariable = "MY_NAMESPACE"
 )
 
 // We only match /ignition/$NodePoolName
@@ -47,10 +53,11 @@ func main() {
 }
 
 type Options struct {
-	Addr      string
-	CertFile  string
-	KeyFile   string
-	TokenFile string
+	Addr        string
+	CertFile    string
+	KeyFile     string
+	CACertProxy string
+	TokenFile   string
 }
 
 func NewStartCommand() *cobra.Command {
@@ -60,15 +67,17 @@ func NewStartCommand() *cobra.Command {
 	}
 
 	opts := Options{
-		Addr:      "0.0.0.0:9090",
-		CertFile:  "/var/run/secrets/ignition/tls.crt",
-		KeyFile:   "/var/run/secrets/ignition/tls.key",
-		TokenFile: "/var/run/secrets/ignition/token",
+		Addr:        "0.0.0.0:9090",
+		CertFile:    "/var/run/secrets/ignition/tls.crt",
+		KeyFile:     "/var/run/secrets/ignition/tls.key",
+		CACertProxy: "/var/run/secrets/ca-cert-proxy/tls.crt",
+		TokenFile:   "/var/run/secrets/ignition/token",
 	}
 
 	cmd.Flags().StringVar(&opts.Addr, "addr", opts.Addr, "Listen address")
 	cmd.Flags().StringVar(&opts.CertFile, "cert-file", opts.CertFile, "Path to the serving cert")
 	cmd.Flags().StringVar(&opts.KeyFile, "key-file", opts.KeyFile, "Path to the serving key")
+	cmd.Flags().StringVar(&opts.CACertProxy, "ca-cert-proxy", opts.CACertProxy, "Path to root CA used to trust target server proxied requests")
 	cmd.Flags().StringVar(&opts.TokenFile, "token-file", opts.TokenFile, "Path to the auth token")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
@@ -116,7 +125,8 @@ func run(ctx context.Context, opts Options) error {
 			return
 		}
 		nodePoolName := urlPathSplit[2]
-		targetURL := fmt.Sprintf("http://machine-config-server-%s/config/master", nodePoolName)
+		targetURL := fmt.Sprintf("https://machine-config-server-%s.%s/config/master",
+			nodePoolName, os.Getenv(namespaceEnvVariable))
 
 		// Authorize the request against the token
 		const bearerPrefix = "Bearer "
@@ -154,8 +164,25 @@ func run(ctx context.Context, opts Options) error {
 			}
 		}
 
+		// Get CA for proxy request.
+		ca, err := ioutil.ReadFile(opts.CACertProxy)
+		if err != nil {
+			log.Printf("Server internal error: %v", err)
+			http.Error(w, fmt.Sprintf("Server internal error: %v", err), http.StatusInternalServerError)
+		}
+		caPool := x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(ca) {
+			log.Printf("Server internal error: failed to setup CA for proxying request")
+			http.Error(w, fmt.Sprintf("Server internal error: failed to setup CA for proxying request"), http.StatusInternalServerError)
+		}
+
 		// Send proxy request.
 		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: caPool,
+				},
+			},
 			Timeout: 5 * time.Second,
 		}
 		resp, err := client.Do(proxyReq)


### PR DESCRIPTION
This adds support only https from the ign server to the machine config server services.
It reuses the ca and certificates used to authenticate the ignition server to authenticate the machine config server services.

Alternative to https://github.com/openshift/hypershift/pull/292