### PR TITLE
skip e2e binary during image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /hypershift
 
 COPY . .
 
-RUN make
+RUN make build
 
 FROM quay.io/openshift/origin-base:4.7
 COPY --from=builder /hypershift/bin/ignition-server /usr/bin/ignition-server


### PR DESCRIPTION
`make` was changed to build the e2e test binary after we broke it once and realized that e2e binary build was not covered by CI.

However, we do not need the e2e binary in the image builds for hypershift

This PR switches to a make target that doesn't build e2e.

@ironcladlou @enxebre 