### PR TITLE
Fix warning error in infra/iam destroy output

### DIFF
--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -87,7 +87,7 @@ func (o *DestroyInfraOptions) Run(ctx context.Context) error {
 	return wait.PollUntil(5*time.Second, func() (bool, error) {
 		err := o.DestroyInfra(ctx)
 		if err != nil {
-			log.Info("WARNING: error during destroy, will retry", "error", err)
+			log.Info("WARNING: error during destroy, will retry", "error", err.Error())
 			return false, nil
 		}
 		return true, nil

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -74,7 +74,7 @@ func (o *DestroyIAMOptions) Run(ctx context.Context) error {
 	return wait.PollUntil(5*time.Second, func() (bool, error) {
 		err := o.DestroyIAM(ctx)
 		if err != nil {
-			log.Info("WARNING: error during destroy, will retry", "error", err)
+			log.Info("WARNING: error during destroy, will retry", "error", err.Error())
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
Before this change, a warning message from the destroy command would
print something like:
```
msg="WARNING: error during destroy, will retry" error="[{},{},{}]"
```

With this PR, the actual error message is printed out