### PR TITLE
ign server

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -15,14 +15,10 @@ const (
 
 // The following are reasons for the IgnitionEndpointAvailable condition.
 const (
-	MachineConfigServerDeploymentAsExpected          = "IgnitionServerDeploymentAsExpected"
-	MachineConfigServerDeploymentStatusUnknownReason = "IgnitionServerDeploymentStatusUnknown"
-	MachineConfigServerDeploymentUnavailableReason   = "IgnitionServerDeploymentUnavailable"
-
 	IgnitionEndpointMissingReason string = "IgnitionEndpointMissing"
 	IgnitionCACertMissingReason   string = "IgnitionCACertMissing"
-	IgnitionTokenMissingReason    string = "IgnitionTokenMissing"
-	IgnitionPayloadErrorReason    string = "IgnitionPayloadError"
+	IgnitionTokenMissingError     string = "IgnitionTokenError"
+	IgnitionUserDataErrorReason   string = "IgnitionUserDataError"
 )
 
 func init() {

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/machine-config-server/machine-config-server-secret.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/machine-config-server/machine-config-server-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: machine-config-server
-type: Opaque
-data:
-  tls.crt: {{ pki "secret" "mcs-crt" "tls.crt" }}
-  tls.key: {{ pki "secret" "mcs-crt" "tls.key" }}

--- a/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
@@ -117,7 +117,6 @@ func (c *clusterManifestContext) clusterBootstrap() {
 func (c *clusterManifestContext) machineConfigServer() {
 	c.addManifestFiles(
 		"machine-config-server/machine-config-server-configmap.yaml",
-		"machine-config-server/machine-config-server-secret.yaml",
 		"machine-config-server/machine-config-server-kubeconfig-secret.yaml",
 	)
 }

--- a/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
+++ b/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
@@ -4,6 +4,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -59,13 +60,29 @@ func IgnitionServingCertSecret(namespace string) *corev1.Secret {
 	}
 }
 
-// IgnitionTokenSecret returns metadata for the ignition token secret. The key
-// of the secret must be "token".
-func IgnitionTokenSecret(namespace string) *corev1.Secret {
-	return &corev1.Secret{
+func ServiceAccount(namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      ResourceName + "-token",
+			Name:      ResourceName,
+		},
+	}
+}
+
+func Role(namespace string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      ResourceName,
+		},
+	}
+}
+
+func RoleBinding(namespace string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      ResourceName,
 		},
 	}
 }

--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -3,13 +3,10 @@ package nodepool
 import (
 	"fmt"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	capiv1 "github.com/openshift/hypershift/thirdparty/clusterapi/api/v1alpha4"
 	capiaws "github.com/openshift/hypershift/thirdparty/clusterapiprovideraws/v1alpha4"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sutilspointer "k8s.io/utils/pointer"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -105,47 +102,20 @@ func AWSMachineTemplate(infraName, ami string, nodePool *hyperv1.NodePool, contr
 	return awsMachineTemplate
 }
 
-func MachineConfigServerDeployment(machineConfigServerNamespace, machineConfigServerName string) *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: machineConfigServerNamespace,
-			Name:      fmt.Sprintf("machine-config-server-%s", machineConfigServerName),
-		},
-	}
-}
-
-func MachineConfigServerServiceAccount(machineConfigServerNamespace, machineConfigServerName string) *corev1.ServiceAccount {
-	return &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: machineConfigServerNamespace,
-			Name:      fmt.Sprintf("machine-config-server-%s", machineConfigServerName),
-		},
-	}
-}
-
-func MachineConfigServerRoleBinding(machineConfigServerNamespace, machineConfigServerName string) *rbacv1.RoleBinding {
-	return &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: machineConfigServerNamespace,
-			Name:      fmt.Sprintf("machine-config-server-%s", machineConfigServerName),
-		},
-	}
-}
-
-func MachineConfigServerService(machineConfigServerNamespace, machineConfigServerName string) *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: machineConfigServerNamespace,
-			Name:      fmt.Sprintf("machine-config-server-%s", machineConfigServerName),
-		},
-	}
-}
-
-func MachineConfigServerUserDataSecret(namespace, name string) *corev1.Secret {
+func IgnitionUserDataSecret(namespace, name, version string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      fmt.Sprintf("user-data-%s", name),
+			Name:      fmt.Sprintf("user-data-%s-%s", name, version),
+		},
+	}
+}
+
+func TokenSecret(namespace, name, version string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      fmt.Sprintf("token-%s-%s", name, version),
 		},
 	}
 }

--- a/ignition-server/controllers/cache.go
+++ b/ignition-server/controllers/cache.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"sync"
+	"time"
+)
+
+// ExpiringCache enables a cache of pairs "token: payload".
+// Any pair in the cache is expired once entry.expiry time is above the cache ttl.
+// The expiry time is renewed for an existing value on every Get operation.
+// Garbage collection of expired values happens on every Get operation.
+type ExpiringCache struct {
+	cache map[string]*entry
+	ttl   time.Duration
+	sync.RWMutex
+}
+
+type entry struct {
+	value  []byte
+	expiry time.Time
+}
+
+func (c *ExpiringCache) Get(key string) (value []byte, ok bool) {
+	c.RLock()
+	defer c.RUnlock()
+
+	c.garbageCollect()
+
+	result, ok := c.cache[key]
+	if !ok {
+		return nil, false
+	}
+
+	// Renew expiring time everytime time we Get.
+	result.expiry = time.Now().Add(c.ttl)
+	return result.value, ok
+}
+
+func (c *ExpiringCache) Set(key string, value []byte) {
+	c.Lock()
+	defer c.Unlock()
+
+	// Renew expiring time everytime time we Set.
+	c.cache[key] = &entry{
+		value:  value,
+		expiry: time.Now().Add(c.ttl),
+	}
+}
+
+func (c *ExpiringCache) Delete(key string) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.cache, key)
+}
+
+func (c *ExpiringCache) garbageCollect() {
+	for key, entry := range c.cache {
+		if time.Now().After(entry.expiry) {
+			c.Delete(key)
+		}
+	}
+}

--- a/ignition-server/controllers/machineconfigserver_ignitionprovider.go
+++ b/ignition-server/controllers/machineconfigserver_ignitionprovider.go
@@ -1,0 +1,400 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/openshift/hypershift/control-plane-operator/releaseinfo"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sutilspointer "k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ IgnitionProvider = (*MCSIgnitionProvider)(nil)
+
+const (
+	resourceGenerateName = "machine-config-server-"
+)
+
+// MCSIgnitionProvider is an IgnitionProvider that uses
+// MachineConfigServer pods to build ignition payload contents.
+type MCSIgnitionProvider struct {
+	Client          client.Client
+	ReleaseProvider releaseinfo.Provider
+	Namespace       string
+}
+
+func (p *MCSIgnitionProvider) GetPayload(ctx context.Context, releaseImage string) (payload []byte, err error) {
+	// TODO(alberto): If the MCS supports binding address
+	// https://github.com/openshift/machine-config-operator/pull/2630/files
+	// we could bind it to localhost and get the payload by execing
+	// https://zhimin-wen.medium.com/programing-exec-into-a-pod-5f2a70bd93bb
+	// Otherwise with the current approach the mcs pod is temporary exposed in the pod network every time a payload is generated.
+	img, err := p.ReleaseProvider.Lookup(ctx, releaseImage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up release image metadata: %w", err)
+	}
+
+	mcsServiceAccount := machineConfigServerServiceAccount(p.Namespace)
+	mcsRoleBinding := machineConfigServerRoleBinding(mcsServiceAccount)
+	mcsPod := machineConfigServerPod(p.Namespace, img, mcsServiceAccount)
+
+	// Launch the pod and ensure we clean up regardless of outcome
+	defer func() {
+		var deleteErrors []error
+		if err := p.Client.Delete(ctx, mcsServiceAccount); err != nil && !errors.IsNotFound(err) {
+			deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete machine config server ServiceAccount: %w", err))
+		}
+		if err := p.Client.Delete(ctx, mcsRoleBinding); err != nil && !errors.IsNotFound(err) {
+			deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete machine config server RoleBinding: %w", err))
+		}
+		if err := p.Client.Delete(ctx, mcsPod); err != nil && !errors.IsNotFound(err) {
+			deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete machine config server pod: %w", err))
+		}
+		// We return this in the named returned values.
+		if deleteErrors != nil {
+			err = utilerrors.NewAggregate(deleteErrors)
+		}
+	}()
+	if err := p.Client.Create(ctx, mcsServiceAccount); err != nil {
+		return nil, fmt.Errorf("failed to create machine config server ServiceAccount: %w", err)
+	}
+
+	mcsRoleBinding = machineConfigServerRoleBinding(mcsServiceAccount)
+	if err := p.Client.Create(ctx, mcsRoleBinding); err != nil {
+		return nil, fmt.Errorf("failed to create machine config server RoleBinding: %w", err)
+	}
+
+	mcsPod = machineConfigServerPod(p.Namespace, img, mcsServiceAccount)
+	if err := p.Client.Create(ctx, mcsPod); err != nil {
+		return nil, fmt.Errorf("failed to create machine config server Pod: %w", err)
+	}
+
+	// Wait for the pod server the payload.
+	if err := wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+		if err := p.Client.Get(ctx, ctrlclient.ObjectKeyFromObject(mcsPod), mcsPod); err != nil {
+			return false, err
+		}
+
+		// If the machine config server is not ready we return and wait for an update event to reconcile.
+		mcsReady := false
+		for _, cond := range mcsPod.Status.Conditions {
+			if cond.Type == corev1.ContainersReady && cond.Status == corev1.ConditionTrue {
+				mcsReady = true
+				break
+			}
+		}
+		if mcsPod.Status.PodIP == "" || !mcsReady {
+			return false, nil
+		}
+
+		// Build proxy request.
+		proxyReq, err := http.NewRequest("GET", fmt.Sprintf("http://%s:%s/config/master", mcsPod.Status.PodIP, "8080"), nil)
+		if err != nil {
+			return false, fmt.Errorf("error building http request for machine config server pod: %w", err)
+		}
+		// We pass expected Headers to return the right config version.
+		// https://www.iana.org/assignments/media-types/application/vnd.coreos.ignition+json
+		// https://github.com/coreos/ignition/blob/0cbe33fee45d012515479a88f0fe94ef58d5102b/internal/resource/url.go#L61-L64
+		// https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/server/api.go#L269
+		proxyReq.Header.Add("Accept", "application/vnd.coreos.ignition+json;version=3.1.0, */*;q=0.1")
+
+		// Send proxy request.
+		client := &http.Client{
+			Timeout: 5 * time.Second,
+		}
+		res, err := client.Do(proxyReq)
+		if err != nil {
+			return false, fmt.Errorf("error sending http request for machine config server pod: %w", err)
+		}
+
+		if res.StatusCode != http.StatusOK {
+			return false, fmt.Errorf("request to the machine config server did not returned a 200, this is unexpected")
+		}
+
+		defer res.Body.Close()
+		payload, err = ioutil.ReadAll(res.Body)
+		if err != nil {
+			return false, fmt.Errorf("error reading http request body for machine config server pod: %w", err)
+		}
+		if payload == nil {
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to get payload from machine config server Pod: %w", err)
+	}
+
+	// Return the named values if everything went ok
+	// so if any deletion in the defer call fails, the func returns an error.
+	return
+}
+
+func machineConfigServerPod(namespace string, releaseImage *releaseinfo.ReleaseImage, sa *corev1.ServiceAccount) *corev1.Pod {
+	images := releaseImage.ComponentImages()
+	bootstrapArgs := fmt.Sprintf(`
+mkdir -p /mcc-manifests/bootstrap/manifests
+mkdir -p /mcc-manifests/manifests
+exec machine-config-operator bootstrap \
+--root-ca=/assets/manifests/root-ca.crt \
+--kube-ca=/assets/manifests/combined-ca.crt \
+--machine-config-operator-image=%s \
+--machine-config-oscontent-image=%s \
+--infra-image=%s \
+--keepalived-image=%s \
+--coredns-image=%s \
+--mdns-publisher-image=%s \
+--haproxy-image=%s \
+--baremetal-runtimecfg-image=%s \
+--infra-config-file=/assets/manifests/cluster-infrastructure-02-config.yaml \
+--network-config-file=/assets/manifests/cluster-network-02-config.yaml \
+--proxy-config-file=/assets/manifests/cluster-proxy-01-config.yaml \
+--config-file=/assets/manifests/install-config.yaml \
+--dns-config-file=/assets/manifests/cluster-dns-02-config.yaml \
+--dest-dir=/mcc-manifests \
+--pull-secret=/assets/manifests/pull-secret.yaml
+
+# Use our own version of configpools that swap master and workers
+mv /mcc-manifests/bootstrap/manifests /mcc-manifests/bootstrap/manifests.tmp
+mkdir /mcc-manifests/bootstrap/manifests
+cp /mcc-manifests/bootstrap/manifests.tmp/* /mcc-manifests/bootstrap/manifests/
+cp /assets/manifests/*.machineconfigpool.yaml /mcc-manifests/bootstrap/manifests/`,
+		images["machine-config-operator"],
+		images["machine-os-content"],
+		images["pod"],
+		images["keepalived-ipfailover"],
+		images["coredns"],
+		images["mdns-publisher"],
+		images["haproxy-router"],
+		images["baremetal-runtimecfg"],
+	)
+
+	customMachineConfigArg := `
+cat <<"EOF" > "./copy-ignition-config.sh"
+#!/bin/bash
+name="${1}"
+oc get cm ${name} -n "${NAMESPACE}" -o jsonpath='{ .data.data }' > "/mcc-manifests/bootstrap/manifests/${name/#ignition-config-//}.yaml"
+EOF
+chmod +x ./copy-ignition-config.sh
+oc get cm -l ignition-config="true" -n "${NAMESPACE}" --no-headers | awk '{ print $1 }' | xargs -n1 ./copy-ignition-config.sh`
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace,
+			GenerateName: resourceGenerateName,
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName:            sa.Name,
+			TerminationGracePeriodSeconds: k8sutilspointer.Int64Ptr(10),
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "multi-az-worker",
+					Operator: "Equal",
+					Value:    "true",
+					Effect:   "NoSchedule",
+				},
+			},
+			InitContainers: []corev1.Container{
+				{
+					Image: images["machine-config-operator"],
+					Name:  "machine-config-operator-bootstrap",
+					Command: []string{
+						"/bin/bash",
+					},
+					Args: []string{
+						"-c",
+						bootstrapArgs,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "mcc-manifests",
+							MountPath: "/mcc-manifests",
+						},
+						{
+							Name:      "config",
+							MountPath: "/assets/manifests",
+						},
+					},
+				},
+				{
+					Image:           images["cli"],
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Name:            "inject-custom-machine-configs",
+					Env: []corev1.EnvVar{
+						{
+							Name: "NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+					},
+					WorkingDir: "/tmp",
+					Command: []string{
+						"/usr/bin/bash",
+					},
+					Args: []string{
+						"-c",
+						customMachineConfigArg,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "mcc-manifests",
+							MountPath: "/mcc-manifests",
+						},
+					},
+				},
+				{
+					Image:           images["machine-config-operator"],
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Name:            "machine-config-controller-bootstrap",
+					Command: []string{
+						"/usr/bin/machine-config-controller",
+					},
+					Args: []string{
+						"bootstrap",
+						"--manifest-dir=/mcc-manifests/bootstrap/manifests",
+						"--pull-secret=/mcc-manifests/bootstrap/manifests/machineconfigcontroller-pull-secret",
+						"--dest-dir=/mcs-manifests",
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "mcc-manifests",
+							MountPath: "/mcc-manifests",
+						},
+						{
+							Name:      "mcs-manifests",
+							MountPath: "/mcs-manifests",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Image:           images["machine-config-operator"],
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Name:            "machine-config-server",
+					Command: []string{
+						"/usr/bin/machine-config-server",
+					},
+					Args: []string{
+						"bootstrap",
+						"--bootstrap-kubeconfig=/etc/openshift/kubeconfig",
+						"--secure-port=8443",
+						"--insecure-port=8080",
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "kubeconfig",
+							ReadOnly:  true,
+							MountPath: "/etc/openshift",
+						},
+						{
+							Name:      "mcs-manifests",
+							MountPath: "/etc/mcs/bootstrap",
+						},
+						{
+							Name:      "mcc-manifests",
+							MountPath: "/etc/mcc/bootstrap",
+						},
+						{
+							Name:      "mcs-tls",
+							MountPath: "/etc/ssl/mcs",
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "kubeconfig",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "machine-config-server-kubeconfig",
+						},
+					},
+				},
+				{
+					Name: "mcs-tls",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "ignition-server-serving-cert",
+						},
+					},
+				},
+				{
+					Name: "mcs-manifests",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "mcc-manifests",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "machine-config-server",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func machineConfigServerServiceAccount(namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace,
+			GenerateName: resourceGenerateName,
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "pull-secret"},
+		},
+	}
+}
+
+func machineConfigServerRoleBinding(sa *corev1.ServiceAccount) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    sa.Namespace,
+			GenerateName: resourceGenerateName,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "edit",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		},
+	}
+}

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -1,0 +1,142 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	TokenSecretReleaseKey = "release"
+	TokenSecretTokenKey   = "token"
+	TokenSecretAnnotation = "hypershift.openshift.io/ignition-config"
+)
+
+func NewPayloadStore() *ExpiringCache {
+	return &ExpiringCache{
+		cache: make(map[string]*entry),
+		// Set the ttl 1h above the reconcile resync period so every existing
+		// token Secret has the chance to renew their expiry time on the PayloadStore.Get(token) operation
+		// while the non exiting ones get eventually garbageCollected.
+		// https://github.com/kubernetes-sigs/controller-runtime/blob/1e4d87c9f9e15e4a58bb81909dd787f30ede7693/pkg/cache/cache.go#L118
+		ttl:     time.Hour * 11,
+		RWMutex: sync.RWMutex{},
+	}
+}
+
+// IgnitionProvider can build ignition payload contents
+// for a given release image.
+type IgnitionProvider interface {
+	// GetPayload returns the ignition payload contents for
+	// the provided release. In the future the list of
+	// inputs may expand to incorporate user-provided ignition
+	// overlay contents.
+	GetPayload(ctx context.Context, payloadImage string) ([]byte, error)
+}
+
+// TokenSecretReconciler watches token Secrets
+// and uses an IgnitionProvider to get a payload out them
+// and stores it in the PayloadsStore.
+// A token Secret is by contractual convention:
+// type: Secret
+//   metadata:
+//   annotations:
+// 	   hypershift.openshift.io/ignition-config: "true"
+//	 data:
+//     token: <authz token>
+//     release: <release image string>
+type TokenSecretReconciler struct {
+	client.Client
+	IgnitionProvider IgnitionProvider
+	PayloadStore     *ExpiringCache
+}
+
+func tokenSecretAnnotationPredicate(ctx context.Context) predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return processIfMatchesAnnotation(ctrl.LoggerFrom(ctx).WithValues("predicate", "updateEvent"), e.ObjectNew, TokenSecretAnnotation)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return processIfMatchesAnnotation(ctrl.LoggerFrom(ctx).WithValues("predicate", "createEvent"), e.Object, TokenSecretAnnotation)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return processIfMatchesAnnotation(ctrl.LoggerFrom(ctx).WithValues("predicate", "deleteEvent"), e.Object, TokenSecretAnnotation)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return processIfMatchesAnnotation(ctrl.LoggerFrom(ctx).WithValues("predicate", "genericEvent"), e.Object, TokenSecretAnnotation)
+		},
+	}
+}
+func (r *TokenSecretReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	log := ctrl.Log.WithName("Setting up token controller")
+	log.Info("SetupWithManager", "ns", os.Getenv("MY_NAMESPACE"))
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).WithEventFilter(tokenSecretAnnotationPredicate(ctx)).
+		Complete(r)
+}
+
+func processIfMatchesAnnotation(logger logr.Logger, obj client.Object, annotation string) bool {
+	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
+	log := logger.WithValues("namespace", obj.GetNamespace(), kind, obj.GetName())
+
+	if _, ok := obj.GetAnnotations()[annotation]; ok {
+		log.V(3).Info("Resource matches annotation, will attempt to map resource")
+		return true
+	}
+
+	log.V(3).Info("Resource does not match annotation, will not attempt to map resource")
+	return false
+}
+
+func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Reconciling")
+
+	tokenSecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, req.NamespacedName, tokenSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("not found", "request", req.String())
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "error token Secret")
+		return ctrl.Result{}, err
+	}
+
+	if !tokenSecret.DeletionTimestamp.IsZero() {
+		// When this reconciler watch the deletion event
+		// and tries to get the Resource it might already be gone
+		// therefore this is unlikely to be reached.
+		// This is just a best effort to synchronous cleanup.
+		// The PayloadStore expiring mechanism takes care of consistently delete expired entries.
+		r.PayloadStore.Delete(string(tokenSecret.Data[TokenSecretTokenKey]))
+		return ctrl.Result{}, nil
+	}
+
+	token := string(tokenSecret.Data[TokenSecretTokenKey])
+	if _, ok := r.PayloadStore.Get(token); ok {
+		log.Info("Payload found in cache")
+		return ctrl.Result{}, nil
+	}
+
+	releaseImage := string(tokenSecret.Data[TokenSecretReleaseKey])
+	payload, err := r.IgnitionProvider.GetPayload(ctx, releaseImage)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error getting ignition payload: %v", err)
+	}
+
+	log.Info("IgnitionProvider generated payload")
+	r.PayloadStore.Set(token, payload)
+
+	return ctrl.Result{}, nil
+}


### PR DESCRIPTION
Initially we were running long living MCS per NodePool each of them exposed in a different endpoint.
openshift#269 enabled us to have one single ignition endpoint per cluster which was proxying requests to long living MCS.
openshift#275 secured the proxy server with a token and https.

Now this PR changes the proxy to be a server on its own which uses ephemeral MCS to generate payload for each NodePool and stores it in memory.
The process is as follows:
- For a new target version a NodePool generates a token Secret. A token Secret is by contractual convention:
```
// type: Secret
//   metadata:
//   annotations:
//     hypershift.io/ignition-config: "true"
//   data:
//     token: <authz token>
//     release: <release image string>
```
- The Ignition server runs a native Kubernetes (tokenSecret) controller which watches secrets annotated with `hypershift.io/ignition-config`.
- The tokenSecret controller delegates to an implementation of the IgnitionProvider interface to generate a payload for each token Secret and keeps a payloadStore map in memory structured as "token": "payload bytes".
- For a server request to succeed a token must be passed in the http Header and must exist in the payloadStore.

To manage the payloadStore I considered reusing https://github.com/kubernetes/client-go/blob/v0.21.2/tools/cache/expiration_cache.go#L117-L124 and https://github.com/openshift/hypershift/blob/main/vendor/k8s.io/apimachinery/pkg/util/cache/expiring.go. Both of them require to .Set to extend the TTL of an entry. This does not play well with our use case since we want a pair "token: payload" to be immutable during the lifecycle of the counterpart token Secret. Because of this I added our own cache implementation which extends TTL on .Get calls. This results on every existing token Secret getting its TTL extended every resync reconciling loop for the controller.

Fixes openshift#303