### PR TITLE
ensure ingress matches ibmcloud's current status in ROKS toolkit

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/cluster-default-ingress-controller.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/cluster-default-ingress-controller.yaml
@@ -5,7 +5,18 @@ metadata:
   namespace: openshift-ingress-operator
 spec:
   domain: {{ .IngressSubdomain }}
+{{ if eq .PlatformType "IBMCloud" }}
+  endpointPublishingStrategy:
+    type: LoadBalancerService
+    loadBalancer:
+      scope: External
+  nodePlacement:
+    tolerations:
+    - key: dedicated
+      value: edge
+{{ else }}
   endpointPublishingStrategy:
     type: LoadBalancerService
   defaultCertificate:
     name: default-ingress-cert
+{{ end }}


### PR DESCRIPTION
The ingress resource is different then the one listed in ROKS toolkit today:
https://github.com/openshift/ibm-roks-toolkit/blob/master/assets/cluster-bootstrap/cluster-ingresscontrollers-02-config.yaml#L10
Note that at least currently that is always set to External in IBM ROKS clusters. This ensures ibmcloud deployments are aligned with those values (ingress controller crashes otherwise)

Does not result in changes to other providers