### PR TITLE
Fix hostedcluster availability calculation relative to unmanaged etcd

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -333,20 +333,24 @@ const (
 	// IgnitionEndpointAvailable indicates whether the ignition server for the
 	// HostedCluster is available to handle ignition requests.
 	IgnitionEndpointAvailable ConditionType = "IgnitionEndpointAvailable"
+
+	// UnmanagedEtcdAvailable indicates whether a user-managed etcd cluster is
+	// healthy.
+	UnmanagedEtcdAvailable ConditionType = "UnmanagedEtcdAvailable"
 )
 
-// The following are reasons for the IgnitionEndpointAvailable condition.
 const (
-	IgnitionServerDeploymentAsExpected          = "IgnitionServerDeploymentAsExpected"
+	IgnitionServerDeploymentAsExpectedReason    = "IgnitionServerDeploymentAsExpected"
 	IgnitionServerDeploymentStatusUnknownReason = "IgnitionServerDeploymentStatusUnknown"
 	IgnitionServerDeploymentNotFoundReason      = "IgnitionServerDeploymentNotFound"
 	IgnitionServerDeploymentUnavailableReason   = "IgnitionServerDeploymentUnavailable"
-)
 
-// The following are reasons for the HostedClusterAvailable condition.
-const (
-	HostedClusterIsAvailable          = "HostedClusterIsAvailable"
-	HostedClusterInsufficientMetadata = "HostedClusterInsufficientMetadata"
+	HostedClusterAsExpectedReason          = "HostedClusterAsExpected"
+	HostedClusterUnhealthyComponentsReason = "UnhealthControlPlaneComponents"
+
+	UnmanagedEtcdStatusUnknownReason = "UnmanagedEtcdStatusUnknown"
+	UnmanagedEtcdMisconfiguredReason = "UnmanagedEtcdMisconfigured"
+	UnmanagedEtcdAsExpected          = "UnmanagedEtcdAsExpected"
 )
 
 // HostedClusterStatus defines the observed state of HostedCluster

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -200,52 +200,27 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		hcluster.Status.Version = computeClusterVersionStatus(r.Clock, hcluster, hcp)
 	}
 
-	// this secret is later used in the reconciliation process as well so storing value to prevent multiple
-	// network calls. This secret is only used in the unmanaged etcd strategy.
-	var unmanagedEtcdTLSClientSecret corev1.Secret
 	// Reconcile unmanaged etcd client tls secret validation error status. Note only update status on validation error case to
 	// provide clear status to the user on the resource without having to look at operator logs.
 	{
 		if hcluster.Spec.Etcd.ManagementType == hyperv1.Unmanaged {
-			r.Log.Info("Validating etcd client secret")
-			reportFailureOnHostedClusterFunc := func(message string) {
-				// condition for etcd failure case
-				newCondition := metav1.Condition{
-					Type:    string(hyperv1.HostedClusterAvailable),
-					Status:  metav1.ConditionFalse,
-					Reason:  hyperv1.HostedClusterInsufficientMetadata,
-					Message: message,
+			unmanagedEtcdTLSClientSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: hcluster.GetNamespace(),
+					Name:      hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name,
+				},
+			}
+			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(unmanagedEtcdTLSClientSecret), unmanagedEtcdTLSClientSecret); err != nil {
+				if apierrors.IsNotFound(err) {
+					unmanagedEtcdTLSClientSecret = nil
+				} else {
+					return ctrl.Result{}, fmt.Errorf("failed to get unmanaged etcd tls secret: %w", err)
 				}
-				newCondition.ObservedGeneration = hcluster.Generation
-				meta.SetStatusCondition(&hcluster.Status.Conditions, newCondition)
 			}
-			if hcluster.Spec.Etcd.Unmanaged == nil || len(hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name) == 0 || len(hcluster.Spec.Etcd.Unmanaged.Endpoint) == 0 {
-				msg := "etcd metadata not specified for unmanaged deployment"
-				reportFailureOnHostedClusterFunc(msg)
-				return ctrl.Result{}, fmt.Errorf(msg)
-			}
-			if err := r.Client.Get(ctx, ctrlclient.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name}, &unmanagedEtcdTLSClientSecret); err != nil {
-				wrappedError := fmt.Errorf("failed to get etcd client cert %s: %w", hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name, err)
-				reportFailureOnHostedClusterFunc(wrappedError.Error())
-				return ctrl.Result{}, wrappedError
-			}
-			if _, ok := unmanagedEtcdTLSClientSecret.Data["etcd-client.crt"]; !ok {
-				wrappedError := fmt.Errorf("etcd secret %s does not have client cert", hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name)
-				reportFailureOnHostedClusterFunc(wrappedError.Error())
-				return ctrl.Result{}, wrappedError
-			}
-			if _, ok := unmanagedEtcdTLSClientSecret.Data["etcd-client.key"]; !ok {
-				wrappedError := fmt.Errorf("etcd secret %s does not have client key", hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name)
-				reportFailureOnHostedClusterFunc(wrappedError.Error())
-				return ctrl.Result{}, wrappedError
-			}
-			if _, ok := unmanagedEtcdTLSClientSecret.Data["etcd-client-ca.crt"]; !ok {
-				wrappedError := fmt.Errorf("etcd secret %s does not have client ca", hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name)
-				reportFailureOnHostedClusterFunc(wrappedError.Error())
-				return ctrl.Result{}, wrappedError
-			}
+			meta.SetStatusCondition(&hcluster.Status.Conditions, computeUnmanagedEtcdAvailability(hcluster, unmanagedEtcdTLSClientSecret))
 		}
 	}
+
 	// Set the Available condition
 	// TODO: This is really setting something that could be more granular like
 	// HostedControlPlaneAvailable, and then the HostedCluster high-level Available
@@ -313,7 +288,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					newCondition = metav1.Condition{
 						Type:   string(hyperv1.IgnitionEndpointAvailable),
 						Status: metav1.ConditionTrue,
-						Reason: hyperv1.IgnitionServerDeploymentAsExpected,
+						Reason: hyperv1.IgnitionServerDeploymentAsExpectedReason,
 					}
 					break
 				}
@@ -507,13 +482,21 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Reconcile etcd client MTLS secret if the control plane is using an unmanaged etcd cluster
 	if hcluster.Spec.Etcd.ManagementType == hyperv1.Unmanaged {
+		unmanagedEtcdTLSClientSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: hcluster.GetNamespace(),
+				Name:      hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name,
+			},
+		}
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(unmanagedEtcdTLSClientSecret), unmanagedEtcdTLSClientSecret); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get unmanaged etcd tls secret: %w", err)
+		}
 		hostedControlPlaneEtcdClientSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: controlPlaneNamespace.Name,
-				Name:      unmanagedEtcdTLSClientSecret.Name,
+				Name:      hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name,
 			},
 		}
-		r.Log.Info("Reconciling etcd client mtls secret to control plane namespace", "namespace", hostedControlPlaneEtcdClientSecret.Namespace)
 		if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, hostedControlPlaneEtcdClientSecret, func() error {
 			if hostedControlPlaneEtcdClientSecret.Data == nil {
 				hostedControlPlaneEtcdClientSecret.Data = map[string][]byte{}
@@ -1993,13 +1976,19 @@ func computeHostedClusterAvailability(hcluster *hyperv1.HostedCluster, hcp *hype
 	// the kubeconfig as an argument help by making that dependency explicit?
 	kubeConfigAvailable := hcluster.Status.KubeConfig != nil
 
+	// Managed etcd availability isn't reported at this granularity yet, so always
+	// assume managed etcd is available. If etcd is configured as unmanaged, consider
+	// etcd available once the unmanaged available condition is true.
+	etcdAvailable := hcluster.Spec.Etcd.ManagementType == hyperv1.Managed ||
+		meta.IsStatusConditionTrue(hcluster.Status.Conditions, string(hyperv1.UnmanagedEtcdAvailable))
+
 	switch {
-	case hcpAvailable && kubeConfigAvailable:
+	case hcpAvailable && kubeConfigAvailable && etcdAvailable:
 		return metav1.Condition{
 			Type:               string(hyperv1.HostedClusterAvailable),
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: hcluster.Generation,
-			Reason:             hyperv1.HostedClusterIsAvailable,
+			Reason:             hyperv1.HostedClusterAsExpectedReason,
 		}
 	default:
 		var messages []string
@@ -2009,13 +1998,65 @@ func computeHostedClusterAvailability(hcluster *hyperv1.HostedCluster, hcp *hype
 		if !kubeConfigAvailable {
 			messages = append(messages, "the hosted control plane kubeconfig is unavailable")
 		}
+		if !etcdAvailable {
+			messages = append(messages, "etcd is unavailable")
+		}
 		return metav1.Condition{
 			Type:               string(hyperv1.HostedClusterAvailable),
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: hcluster.Generation,
-			Reason:             "HostedClusterIsUnavailable",
+			Reason:             hyperv1.HostedClusterUnhealthyComponentsReason,
 			Message:            strings.Join(messages, "; "),
 		}
+	}
+}
+
+// computeUnmanagedEtcdAvailability calculates the current status of unmanaged etcd.
+func computeUnmanagedEtcdAvailability(hcluster *hyperv1.HostedCluster, unmanagedEtcdTLSClientSecret *corev1.Secret) metav1.Condition {
+	if unmanagedEtcdTLSClientSecret == nil {
+		return metav1.Condition{
+			Type:    string(hyperv1.UnmanagedEtcdAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  hyperv1.UnmanagedEtcdMisconfiguredReason,
+			Message: fmt.Sprintf("missing TLS client secret %s", hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name),
+		}
+	}
+	if hcluster.Spec.Etcd.Unmanaged == nil || len(hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name) == 0 || len(hcluster.Spec.Etcd.Unmanaged.Endpoint) == 0 {
+		return metav1.Condition{
+			Type:    string(hyperv1.UnmanagedEtcdAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  hyperv1.UnmanagedEtcdMisconfiguredReason,
+			Message: "etcd metadata not specified for unmanaged deployment",
+		}
+	}
+	if _, ok := unmanagedEtcdTLSClientSecret.Data["etcd-client.crt"]; !ok {
+		return metav1.Condition{
+			Type:    string(hyperv1.UnmanagedEtcdAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  hyperv1.UnmanagedEtcdMisconfiguredReason,
+			Message: fmt.Sprintf("etcd secret %s does not have client cert", hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name),
+		}
+	}
+	if _, ok := unmanagedEtcdTLSClientSecret.Data["etcd-client.key"]; !ok {
+		return metav1.Condition{
+			Type:    string(hyperv1.UnmanagedEtcdAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  hyperv1.UnmanagedEtcdMisconfiguredReason,
+			Message: fmt.Sprintf("etcd secret %s does not have client key", hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name),
+		}
+	}
+	if _, ok := unmanagedEtcdTLSClientSecret.Data["etcd-client-ca.crt"]; !ok {
+		return metav1.Condition{
+			Type:    string(hyperv1.UnmanagedEtcdAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  hyperv1.UnmanagedEtcdMisconfiguredReason,
+			Message: fmt.Sprintf("etcd secret %s does not have client ca", hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name),
+		}
+	}
+	return metav1.Condition{
+		Type:   string(hyperv1.UnmanagedEtcdAvailable),
+		Status: metav1.ConditionTrue,
+		Reason: hyperv1.UnmanagedEtcdAsExpected,
 	}
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -32,7 +32,10 @@ func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 		"new controlplane has defaults matching hostedcluster": {
 			Cluster: hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: Now},
-				Spec:       hyperv1.HostedClusterSpec{Release: hyperv1.Release{Image: "a"}},
+				Spec: hyperv1.HostedClusterSpec{
+					Etcd:    hyperv1.EtcdSpec{ManagementType: hyperv1.Managed},
+					Release: hyperv1.Release{Image: "a"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: hyperv1.Release{Image: "a"},
@@ -51,7 +54,10 @@ func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 		"hostedcontrolplane rollout is deferred due to existing rollout": {
 			Cluster: hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: Now},
-				Spec:       hyperv1.HostedClusterSpec{Release: hyperv1.Release{Image: "b"}},
+				Spec: hyperv1.HostedClusterSpec{
+					Etcd:    hyperv1.EtcdSpec{ManagementType: hyperv1.Managed},
+					Release: hyperv1.Release{Image: "b"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: hyperv1.Release{Image: "a"},
@@ -71,7 +77,10 @@ func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 		"hostedcontrolplane rollout happens after existing rollout is complete": {
 			Cluster: hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: Now},
-				Spec:       hyperv1.HostedClusterSpec{Release: hyperv1.Release{Image: "b"}},
+				Spec: hyperv1.HostedClusterSpec{
+					Etcd:    hyperv1.EtcdSpec{ManagementType: hyperv1.Managed},
+					Release: hyperv1.Release{Image: "b"},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: hyperv1.Release{Image: "a"},
@@ -217,7 +226,9 @@ func TestComputeHostedClusterAvailability(t *testing.T) {
 	}{
 		"missing hostedcluster should cause unavailability": {
 			Cluster: hyperv1.HostedCluster{
-				Spec:   hyperv1.HostedClusterSpec{},
+				Spec: hyperv1.HostedClusterSpec{
+					Etcd: hyperv1.EtcdSpec{ManagementType: hyperv1.Managed},
+				},
 				Status: hyperv1.HostedClusterStatus{},
 			},
 			ControlPlane: nil,
@@ -228,7 +239,9 @@ func TestComputeHostedClusterAvailability(t *testing.T) {
 		},
 		"missing kubeconfig should cause unavailability": {
 			Cluster: hyperv1.HostedCluster{
-				Spec:   hyperv1.HostedClusterSpec{},
+				Spec: hyperv1.HostedClusterSpec{
+					Etcd: hyperv1.EtcdSpec{ManagementType: hyperv1.Managed},
+				},
 				Status: hyperv1.HostedClusterStatus{},
 			},
 			ControlPlane: &hyperv1.HostedControlPlane{
@@ -246,7 +259,9 @@ func TestComputeHostedClusterAvailability(t *testing.T) {
 		},
 		"should be available": {
 			Cluster: hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{},
+				Spec: hyperv1.HostedClusterSpec{
+					Etcd: hyperv1.EtcdSpec{ManagementType: hyperv1.Managed},
+				},
 				Status: hyperv1.HostedClusterStatus{
 					KubeConfig: &corev1.LocalObjectReference{Name: "foo"},
 				},


### PR DESCRIPTION
The a34f1881abe0730c0736ee4f8dee7d05eb0eece9 commit introduces an Unmanaged etcd
management type and incorporates the health of the unmanaged etcd configuration
into hostedcluster availability condition computation. However, the approach in
that commit violates the single source of truth invariant for hostedcluster
availability calculation, which makes it too easy to introduce bugs which cause
condition flapping or other inconsistencies.

This commit refactors the status handling to be consistent with the rest of the
controller by:

- Introducing a new condition type "UnmanagedEtcdAvailable" which is used to
track the status of unmanaged etcd which can be composed into more coarse
grained availability checks
- Updating the hostedcluster availability calculation to take into account the
new condition