### PR TITLE
ensure infrastructureName quoted

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/cluster-infrastructure-02-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/cluster-infrastructure-02-config.yaml
@@ -14,7 +14,7 @@ status:
   apiServerInternalURI: https://{{ .ExternalAPIDNSName }}:{{ .ExternalAPIPort }}
   apiServerURL: https://{{ .ExternalAPIDNSName }}:{{ .ExternalAPIPort }}
   etcdDiscoveryDomain: {{ .BaseDomain }}
-  infrastructureName: {{ .InfraID }}
+  infrastructureName: "{{ .InfraID }}"
   platform: {{ .PlatformType }}
   platformStatus:
     type: {{ .PlatformType }}


### PR DESCRIPTION
our automated testing uses travis build numbers and without the quotes this fails. An example travis build number is `52872630`