### PR TITLE
Expose MachineConfig in NodePools

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -11,6 +12,7 @@ const (
 	NodePoolAsExpectedConditionReason       = "AsExpected"
 	NodePoolValidationFailedConditionReason = "ValidationFailed"
 	NodePoolUpgradingConditionType          = "Upgrading"
+	NodePoolUpdatingConfigConditionType     = "UpdatingConfig"
 )
 
 // The following are reasons for the IgnitionEndpointAvailable condition.
@@ -54,6 +56,17 @@ type NodePoolSpec struct {
 	NodeCount *int32 `json:"nodeCount"`
 	// +optional
 	AutoScaling *NodePoolAutoScaling `json:"autoScaling,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// TODO (alberto): this ConfigMaps are meant to contain
+	// MachineConfig, KubeletConfig and ContainerRuntimeConfig but
+	// MCO only supports MachineConfig in bootstrap mode atm
+	// https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119
+	// By contractual convention the ConfigMap structure is as follow:
+	// type: ConfigMap
+	//   data:
+	//     config: |-
+	Config []v1.LocalObjectReference `json:"config,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={maxSurge: 1, maxUnavailable: 0, autoRepair: false}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -750,6 +750,11 @@ func (in *NodePoolSpec) DeepCopyInto(out *NodePoolSpec) {
 		*out = new(NodePoolAutoScaling)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Config != nil {
+		in, out := &in.Config, &out.Config
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	out.Management = in.Management
 	in.Platform.DeepCopyInto(&out.Platform)
 	out.Release = in.Release

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -72,6 +72,16 @@ spec:
               clusterName:
                 description: ClusterName is the name of the Cluster this object belongs to.
                 type: string
+              config:
+                description: 'TODO (alberto): this ConfigMaps are meant to contain MachineConfig, KubeletConfig and ContainerRuntimeConfig but MCO only supports MachineConfig in bootstrap mode atm https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119 By contractual convention the ConfigMap structure is as follow: type: ConfigMap   data:     config: |-'
+                items:
+                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
               nodeCount:
                 format: int32
                 type: integer

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1066,6 +1066,9 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 					"pods/log",
 					"serviceaccounts",
 					"pods",
+					// This is needed by the MCS ignitionProvider to create an ephemeral ConfigMap
+					// with the machine config to mount it into the MCS Pod that generates the final payload.
+					"configmaps",
 				},
 				Verbs: []string{"*"},
 			},

--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -102,20 +102,20 @@ func AWSMachineTemplate(infraName, ami string, nodePool *hyperv1.NodePool, contr
 	return awsMachineTemplate
 }
 
-func IgnitionUserDataSecret(namespace, name, version string) *corev1.Secret {
+func IgnitionUserDataSecret(namespace, name, payloadInputHash string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      fmt.Sprintf("user-data-%s-%s", name, version),
+			Name:      fmt.Sprintf("user-data-%s-%s", name, payloadInputHash),
 		},
 	}
 }
 
-func TokenSecret(namespace, name, version string) *corev1.Secret {
+func TokenSecret(namespace, name, payloadInputHash string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      fmt.Sprintf("token-%s-%s", name, version),
+			Name:      fmt.Sprintf("token-%s-%s", name, payloadInputHash),
 		},
 	}
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1,6 +1,8 @@
 package nodepool
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -26,7 +28,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/trace"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,13 +48,16 @@ import (
 )
 
 const (
-	finalizer               = "hypershift.openshift.io/finalizer"
-	autoscalerMaxAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
-	autoscalerMinAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
-	nodePoolAnnotation      = "hypershift.openshift.io/nodePool"
-	TokenSecretReleaseKey   = "release"
-	TokenSecretTokenKey     = "token"
-	TokenSecretAnnotation   = "hypershift.openshift.io/ignition-config"
+	finalizer                       = "hypershift.openshift.io/finalizer"
+	autoscalerMaxAnnotation         = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
+	autoscalerMinAnnotation         = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
+	nodePoolAnnotation              = "hypershift.openshift.io/nodePool"
+	nodePoolAnnotationConfig        = "hypershift.openshift.io/nodePoolConfig"
+	nodePoolAnnotationConfigVersion = "hypershift.openshift.io/nodePoolConfigVersion"
+	TokenSecretReleaseKey           = "release"
+	TokenSecretTokenKey             = "token"
+	TokenSecretConfigKey            = "config"
+	TokenSecretAnnotation           = "hypershift.openshift.io/ignition-config"
 )
 
 type NodePoolReconciler struct {
@@ -77,6 +81,7 @@ func (r *NodePoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(controller.Options{
 			RateLimiter: workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 10*time.Second),
 		}).
+		// TODO (alberto): Let ConfigMaps referenced by the spec.config and also the core ones to trigger reconciliation.
 		Build(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
@@ -118,10 +123,10 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Generate mcs manifests for the given release
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
-	// TODO (alberto): using odePool.Status.Version here gives a race: if a NodePool is deleted
+	// Fixme (alberto): using nodePool.Status.Version here gives a race: if a NodePool is deleted
 	// before the targeted version is the one in the status then the tokenSecret and userDataSecret would be leaked.
-	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, nodePool.Status.Version)
-	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), nodePool.Status.Version)
+	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, nodePool.GetAnnotations()[nodePoolAnnotationConfigVersion])
+	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), nodePool.GetAnnotations()[nodePoolAnnotationConfigVersion])
 	md := machineDeployment(nodePool, hcluster.Spec.InfraID, controlPlaneNamespace)
 	mhc := machineHealthCheck(nodePool, controlPlaneNamespace)
 
@@ -199,6 +204,21 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
+func compress(content []byte) ([]byte, error) {
+	if len(content) == 0 {
+		return nil, nil
+	}
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	if _, err := gz.Write(content); err != nil {
+		return nil, fmt.Errorf("failed to compress content: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("compress closure failure %w", err)
+	}
+	return b.Bytes(), nil
+}
+
 func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.HostedCluster, nodePool *hyperv1.NodePool) (ctrl.Result, error) {
 	var span trace.Span
 	ctx, span = r.tracer.Start(ctx, "update")
@@ -250,36 +270,76 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	targetVersion := releaseImage.Version()
 
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
-	if isUpgrading(nodePool, targetVersion) {
-		// Today only the version triggers a new token generation.
-		// Token Secrets are immutable and follow "prefixName-version" naming convention
-		// We'll likely add MachineConfig diffs to trigger token generation
-		// so instead of using "prefix-version" name as authoritative we'll need to use a config + version hash or similar.
+
+	// Create a hash from nodePool.Spec.Config content and
+	// Annotate NodePool with it.
+	var compressedConfig []byte
+	allConfigPlainText := ""
+	if nodePool.Spec.Config != nil {
+		for _, config := range nodePool.Spec.Config {
+			configConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      config.Name,
+					Namespace: nodePool.Namespace,
+				},
+			}
+			if err := r.Get(ctx, ctrlclient.ObjectKeyFromObject(configConfigMap), configConfigMap); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to get config ConfigMap: %w", err)
+			}
+
+			// TODO (alberto): validate ConfigMap ignition content here?
+			allConfigPlainText = allConfigPlainText + "\n---\n" + configConfigMap.Data[TokenSecretConfigKey]
+		}
+	}
+	targetConfigHash := hashStruct(allConfigPlainText)
+	targetConfigVersionHash := hashStruct(allConfigPlainText + targetVersion)
+	compressedConfig, err = compress([]byte(allConfigPlainText))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	isUpgrading := isUpgrading(nodePool, targetVersion)
+	isUpdatingConfig := isUpdatingConfig(nodePool, targetConfigHash)
+	if isUpgrading {
 		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
 			Type:    hyperv1.NodePoolUpgradingConditionType,
 			Status:  metav1.ConditionTrue,
 			Reason:  hyperv1.NodePoolAsExpectedConditionReason,
 			Message: fmt.Sprintf("Upgrade in progress. Target version: %v", targetVersion),
 		})
-		r.Log.Info("New nodePool version set. Upgrading", "targetVersion", targetVersion)
-
+		r.Log.Info("New nodePool version changed. A new token Secret will be generated",
+			"targetVersion", targetVersion)
+	}
+	if isUpdatingConfig {
+		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+			Type:    hyperv1.NodePoolUpdatingConfigConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  hyperv1.NodePoolAsExpectedConditionReason,
+			Message: fmt.Sprintf("Updating config in progress"),
+		})
+		r.Log.Info("New nodePool config changed, A new token Secret will be generated",
+			"targetVersion", targetVersion)
+	}
+	if isUpgrading || isUpdatingConfig {
+		// Token Secrets are immutable and follow "prefixName-version-configHash" naming convention
 		// Ensure old versioned resources are deleted, i.e token Secret and userdata Secret.
-		tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, nodePool.Status.Version)
+		tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, nodePool.GetAnnotations()[nodePoolAnnotationConfigVersion])
 		if err := r.Delete(ctx, tokenSecret); err != nil && !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, fmt.Errorf("failed to delete token Secret: %w", err)
 		}
 
-		userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), nodePool.Status.Version)
+		userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), nodePool.GetAnnotations()[nodePoolAnnotationConfigVersion])
 		if err := r.Delete(ctx, userDataSecret); err != nil && !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, fmt.Errorf("failed to delete token Secret: %w", err)
 		}
 	}
 
-	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, targetVersion)
-	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), targetVersion)
+	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, targetConfigVersionHash)
+	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), targetConfigVersionHash)
 
 	r.Log.Info("Reconciling token Secret")
 	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, tokenSecret, func() error {
+		tokenSecret.Immutable = k8sutilspointer.BoolPtr(true)
 		if tokenSecret.Annotations == nil {
 			tokenSecret.Annotations = make(map[string]string)
 		}
@@ -290,6 +350,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			tokenSecret.Data = map[string][]byte{}
 			tokenSecret.Data[TokenSecretTokenKey] = []byte(uuid.New().String())
 			tokenSecret.Data[TokenSecretReleaseKey] = []byte(nodePool.Spec.Release.Image)
+			tokenSecret.Data[TokenSecretConfigKey] = compressedConfig
 		}
 		return nil
 	}); err != nil {
@@ -323,6 +384,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, userDataSecret, func() error {
+		userDataSecret.Immutable = k8sutilspointer.BoolPtr(true)
 		if userDataSecret.Annotations == nil {
 			userDataSecret.Annotations = make(map[string]string)
 		}
@@ -472,7 +534,9 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 				md, nodePool,
 				userDataSecret,
 				awsMachineTemplate,
-				hcluster.Spec.InfraID, releaseImage)
+				hcluster.Spec.InfraID,
+				targetConfigHash, targetConfigVersionHash,
+				releaseImage)
 		}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile machineDeployment %q: %w",
 				ctrlclient.ObjectKeyFromObject(md).String(), err)
@@ -517,6 +581,10 @@ func isUpgrading(nodePool *hyperv1.NodePool, targetVersion string) bool {
 	return targetVersion != nodePool.Status.Version
 }
 
+func isUpdatingConfig(nodePool *hyperv1.NodePool, newConfigHash string) bool {
+	return newConfigHash != nodePool.GetAnnotations()[nodePoolAnnotationConfig]
+}
+
 func defaultNodePoolAMI(hcluster *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseImage) (string, error) {
 	// TODO: The architecture should be specified from the API
 	arch, foundArch := releaseImage.StreamMetadata.Architectures["x86_64"]
@@ -535,17 +603,9 @@ func defaultNodePoolAMI(hcluster *hyperv1.HostedCluster, releaseImage *releasein
 	return regionData.Image, nil
 }
 
-// DeploymentComplete considers a deployment to be complete once all of its desired replicas
+// MachineDeploymentComplete considers a MachineDeployment to be complete once all of its desired replicas
 // are updated and available, and no old machines are running.
 func MachineDeploymentComplete(deployment *capiv1.MachineDeployment) bool {
-	newStatus := &deployment.Status
-	return newStatus.UpdatedReplicas == *(deployment.Spec.Replicas) &&
-		newStatus.Replicas == *(deployment.Spec.Replicas) &&
-		newStatus.AvailableReplicas == *(deployment.Spec.Replicas) &&
-		newStatus.ObservedGeneration >= deployment.Generation
-}
-
-func DeploymentComplete(deployment *appsv1.Deployment) bool {
 	newStatus := &deployment.Status
 	return newStatus.UpdatedReplicas == *(deployment.Spec.Replicas) &&
 		newStatus.Replicas == *(deployment.Spec.Replicas) &&
@@ -701,6 +761,7 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(machineDeployment *capiv
 	userDataSecret *corev1.Secret,
 	awsMachineTemplate *capiaws.AWSMachineTemplate,
 	CAPIClusterName string,
+	targetConfigHash, targetConfigVersionHash string,
 	releaseImage *releaseinfo.ReleaseImage) error {
 
 	// Set annotations and labels
@@ -798,6 +859,11 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(machineDeployment *capiv
 				Message: "",
 			})
 		}
+		if nodePool.Annotations == nil {
+			nodePool.Annotations = make(map[string]string)
+		}
+		nodePool.Annotations[nodePoolAnnotationConfig] = targetConfigHash
+		nodePool.Annotations[nodePoolAnnotationConfigVersion] = targetConfigVersionHash
 	}
 
 	// Set wanted replicas:
@@ -901,10 +967,4 @@ func (r *NodePoolReconciler) listAWSMachineTemplates(nodePool *hyperv1.NodePool)
 		}
 	}
 	return filtered, nil
-}
-
-func MachineConfigServerServiceSelector(machineConfigServerName string) map[string]string {
-	return map[string]string{
-		"app": fmt.Sprintf("machine-config-server-%s", machineConfigServerName),
-	}
 }


### PR DESCRIPTION
This is to satisfy the following FR:
FR: Machine Config should be configurable in a NodePool resource day 1.
FR: Machine Config should support Re-create rolling upgrades day 2.

Machine config is exposed through a list of ConfigMaps in NodePools with the following contractual convention:

```
type: ConfigMap
	data:
		config: |-
```

Each ConfigMap is meant to contain a MachineConfig CR though not validation for this is included in this PR.
Any machine config change is rolled out according to the NodePool upgrade type and strategy in hand with a release image change at any point in time.
Changes to this ConfigMaps result in a new Token generation, see openshift#303.

A token Secret has now an additional key: `config`.