### PR TITLE
add annotation that will disable pki reconciliation

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -13,7 +13,8 @@ func init() {
 
 const (
 	// AuditWebhookKubeconfigKey is the key name in the AuditWebhook secret that stores audit webhook kubeconfig
-	AuditWebhookKubeconfigKey = "webhook-kubeconfig"
+	AuditWebhookKubeconfigKey          = "webhook-kubeconfig"
+	DisablePKIReconciliationAnnotation = "hypershift.openshift.io/disable-pki-reconciliation"
 )
 
 // HostedClusterSpec defines the desired state of HostedCluster

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -433,9 +433,11 @@ func (r *HostedControlPlaneReconciler) update(ctx context.Context, hostedControl
 	}
 
 	// Reconcile PKI
-	r.Log.Info("Reconciling PKI")
-	if err := r.reconcilePKI(ctx, hostedControlPlane, infraStatus); err != nil {
-		return fmt.Errorf("failed to reconcile PKI: %w", err)
+	if _, exists := hostedControlPlane.Annotations[hyperv1.DisablePKIReconciliationAnnotation]; !exists {
+		r.Log.Info("Reconciling PKI")
+		if err := r.reconcilePKI(ctx, hostedControlPlane, infraStatus); err != nil {
+			return fmt.Errorf("failed to reconcile PKI: %w", err)
+		}
 	}
 
 	// Reconcile Cloud Provider Config

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -648,6 +648,11 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	hcp.Annotations = map[string]string{
 		hostedClusterAnnotation: ctrlclient.ObjectKeyFromObject(hcluster).String(),
 	}
+	if hcluster.Annotations != nil {
+		if _, ok := hcluster.Annotations[hyperv1.DisablePKIReconciliationAnnotation]; ok {
+			hcp.Annotations[hyperv1.DisablePKIReconciliationAnnotation] = hcluster.Annotations[hyperv1.DisablePKIReconciliationAnnotation]
+		}
+	}
 
 	hcp.Spec.PullSecret = corev1.LocalObjectReference{Name: controlplaneoperator.PullSecret(hcp.Namespace).Name}
 	if len(hcluster.Spec.SigningKey.Name) > 0 {


### PR DESCRIPTION
this will be useful for debugging the current state of pki reconciliation logic in addition to allowing providers to bring their own certs in special situations where the default behavior of cert generation in hypershift is not sufficient 