### PR TITLE
update images to have proper tags initally.

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.deployment.yaml
@@ -20,7 +20,8 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/invalid:tag
+          image: registry.redhat.io/redhat/certified-operator-index:v4.8
+          imagePullPolicy: Always
           ports:
             - containerPort: 50051
               name: grpc

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.deployment.yaml
@@ -20,7 +20,8 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/invalid:tag
+          image: registry.redhat.io/redhat/community-operator-index:v4.8
+          imagePullPolicy: Always
           ports:
             - containerPort: 50051
               name: grpc

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.deployment.yaml
@@ -20,7 +20,8 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/invalid:tag
+          image: registry.redhat.io/redhat/redhat-marketplace-index:v4.8
+          imagePullPolicy: Always
           ports:
             - containerPort: 50051
               name: grpc

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.deployment.yaml
@@ -20,7 +20,8 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/invalid:tag
+          image: registry.redhat.io/redhat/redhat-operator-index:v4.8
+          imagePullPolicy: Always
           ports:
             - containerPort: 50051
               name: grpc


### PR DESCRIPTION
In my cluster all of these are failing due to ImagePullBackoff
```
redhat-marketplace-catalog-ccff47f6d-6nq82        0/1     ImagePullBackOff    0          7h42m
redhat-operators-catalog-6458cc5698-7f95v         0/1     ImagePullBackOff    0          7h42m
community-operators-catalog-bcdf6945-xcd2q        0/1     ImagePullBackOff    0          7h42m
certified-operators-catalog-566d4b7f97-xmvqh      0/1     ImagePullBackOff    0          7h42m
```

All do to failing to pull `registry.redhat.io/invalid:tag`

It's causing testing to fail. Is there anyway we could disable for now and enable when they are ready?