### PR TITLE
fix manifest bootstrapper to be nonroot 

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -12,6 +12,8 @@ spec:
     - image: {{ .ReleaseImage }}
       imagePullPolicy: IfNotPresent
       name: cluster-version-operator
+      securityContext:
+        runAsUser: 1000
       workingDir: /tmp
       command:
         - /bin/bash
@@ -19,7 +21,7 @@ spec:
         - -c
         - |-
           cd /tmp
-          mkdir output
+          mkdir -p output/manifests output/bootstrap
           /usr/bin/cluster-version-operator render --output-dir /tmp/output --release-image {{ .ReleaseImage }}
           # Exclude the CVO deployment manifest
           rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
@@ -31,6 +33,8 @@ spec:
     - image: {{ imageFor "cli" }}
       imagePullPolicy: IfNotPresent
       name: bootstrapper
+      securityContext:
+        runAsUser: 1000
       workingDir: /work
       command:
         - /bin/bash


### PR DESCRIPTION
by default it runs as anyuid without an explicit nonroot security context
```
Tylers-MacBook-Pro:hypershift tylerlisowski$ kubectl get pods -n master-tyler12 manifests-bootstrapper -o yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    cni.projectcalico.org/podIP: ""
    cni.projectcalico.org/podIPs: ""
    k8s.v1.cni.cncf.io/network-status: |-
      [{
          "name": "",
          "ips": [
              "172.30.64.135"
          ],
          "default": true,
          "dns": {}
      }]
    k8s.v1.cni.cncf.io/networks-status: |-
      [{
          "name": "",
          "ips": [
              "172.30.64.135"
          ],
          "default": true,
          "dns": {}
      }]
    openshift.io/scc: anyuid
  creationTimestamp: "2021-07-01T15:07:20Z"
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:spec:
        f:containers:
          k:{"name":"bootstrapper"}:
            .: {}
            f:args: {}
            f:command: {}
            f:image: {}
            f:imagePullPolicy: {}
            f:name: {}
            f:volumeMounts:
              k:{"mountPath":"/etc/openshift"}:
                .: {}
                f:mountPath: {}
                f:name: {}
                f:readOnly: {}
              k:{"mountPath":"/work"}:
                .: {}
                f:mountPath: {}
                f:name: {}
            f:workingDir: {}
        f:initContainers:
          k:{"name":"cluster-version-operator"}:
            .: {}
            f:args: {}
            f:command: {}
            f:image: {}
            f:imagePullPolicy: {}
            f:name: {}
            f:volumeMounts:
              k:{"mountPath":"/work"}:
                .: {}
                f:mountPath: {}
                f:name: {}
            f:workingDir: {}
        f:restartPolicy: {}
        f:serviceAccountName: {}
        f:tolerations: {}
        f:volumes:
          k:{"name":"kubeconfig"}:
            .: {}
            f:name: {}
            f:secret:
              f:secretName: {}
          k:{"name":"work"}:
            .: {}
            f:name: {}
    manager: control-plane-operator
    operation: Apply
    time: "2021-07-02T02:39:50Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          f:cni.projectcalico.org/podIP: {}
          f:cni.projectcalico.org/podIPs: {}
    manager: calico
    operation: Update
    time: "2021-07-01T15:07:21Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          f:k8s.v1.cni.cncf.io/network-status: {}
          f:k8s.v1.cni.cncf.io/networks-status: {}
    manager: multus
    operation: Update
    time: "2021-07-01T15:07:21Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:status:
        f:conditions:
          k:{"type":"ContainersReady"}:
            .: {}
            f:lastProbeTime: {}
            f:lastTransitionTime: {}
            f:reason: {}
            f:status: {}
            f:type: {}
          k:{"type":"Initialized"}:
            .: {}
            f:lastProbeTime: {}
            f:lastTransitionTime: {}
            f:reason: {}
            f:status: {}
            f:type: {}
          k:{"type":"Ready"}:
            .: {}
            f:lastProbeTime: {}
            f:lastTransitionTime: {}
            f:reason: {}
            f:status: {}
            f:type: {}
        f:containerStatuses: {}
        f:hostIP: {}
        f:initContainerStatuses: {}
        f:phase: {}
        f:podIP: {}
        f:podIPs:
          .: {}
          k:{"ip":"172.30.64.135"}:
            .: {}
            f:ip: {}
        f:startTime: {}
    manager: kubelet
    operation: Update
    time: "2021-07-01T15:09:44Z"
  name: manifests-bootstrapper
  namespace: master-tyler12
  resourceVersion: "1829970"
  selfLink: /api/v1/namespaces/master-tyler12/pods/manifests-bootstrapper
  uid: 4a7c0e29-fd44-49e9-b02a-ff97718508fc
spec:
  containers:
  - args:
    - -c
    - |-
      #!/bin/bash
      set -eu
      for name in $(oc get cm | grep '^user-manifest-' | awk '{ print $1 }'); do
         oc get cm ${name} -o jsonpath='{ .data.data }' > "${name}.yaml"
      done
      export KUBECONFIG=/etc/openshift/kubeconfig
      oc apply -f $(pwd)
      # Replace the global certs configmap here because it's too large to oc apply
      oc create configmap -n openshift-controller-manager openshift-global-ca --from-file ca-bundle.crt=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem --dry-run -o yaml > /tmp/openshift-global-ca
      oc replace -n openshift-controller-manager -f /tmp/openshift-global-ca --force
    command:
    - /bin/bash
    image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:79c8273da7f10dac38fbe38857dfa8a78f877124bd3444eb5f98af25cbe9678b
    imagePullPolicy: IfNotPresent
    name: bootstrapper
    resources: {}
    securityContext:
      capabilities:
        drop:
        - MKNOD
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /etc/openshift
      name: kubeconfig
      readOnly: true
    - mountPath: /work
      name: work
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: user-manifests-bootstrapper-token-n89sr
      readOnly: true
    workingDir: /work
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  imagePullSecrets:
  - name: pull-secret
  - name: user-manifests-bootstrapper-dockercfg-m7hgw
  initContainers:
  - args:
    - -c
    - |-
      cd /tmp
      mkdir output
      /usr/bin/cluster-version-operator render --output-dir /tmp/output --release-image registry.ng.bluemix.net/armada-master/ocp-release:4.8.0-fc.8-x86_64
      # Exclude the CVO deployment manifest
      rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
      cp /tmp/output/manifests/* /work
    command:
    - /bin/bash
    image: registry.ng.bluemix.net/armada-master/ocp-release:4.8.0-fc.8-x86_64
    imagePullPolicy: IfNotPresent
    name: cluster-version-operator
    resources: {}
    securityContext:
      capabilities:
        drop:
        - MKNOD
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /work
      name: work
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: user-manifests-bootstrapper-token-n89sr
      readOnly: true
    workingDir: /tmp
  nodeName: 10.5.188.175
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: OnFailure
  schedulerName: default-scheduler
  securityContext:
    seLinuxOptions:
      level: s0:c26,c15
  serviceAccount: user-manifests-bootstrapper
  serviceAccountName: user-manifests-bootstrapper
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoSchedule
    key: multi-az-worker
    operator: Equal
    value: "true"
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: kubeconfig
    secret:
      defaultMode: 420
      secretName: service-network-admin-kubeconfig
  - emptyDir: {}
    name: work
  - name: user-manifests-bootstrapper-token-n89sr
    secret:
      defaultMode: 420
      secretName: user-manifests-bootstrapper-token-n89sr
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2021-07-01T15:07:34Z"
    reason: PodCompleted
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2021-07-01T15:09:44Z"
    reason: PodCompleted
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2021-07-01T15:09:44Z"
    reason: PodCompleted
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2021-07-01T15:07:20Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: cri-o://99b6ed005917e96384abcdd236ffd10edf9ff385bf262d1bfe2c8327d7037610
    image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:79c8273da7f10dac38fbe38857dfa8a78f877124bd3444eb5f98af25cbe9678b
    imageID: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:79c8273da7f10dac38fbe38857dfa8a78f877124bd3444eb5f98af25cbe9678b
    lastState:
      terminated:
        containerID: cri-o://16b3fa55b25876d9502e15dccb87b0d7fae051d7be14b3016186a890786d8247
        exitCode: 1
        finishedAt: "2021-07-01T15:09:07Z"
        reason: Error
        startedAt: "2021-07-01T15:08:54Z"
    name: bootstrapper
    ready: false
    restartCount: 3
    started: false
    state:
      terminated:
        containerID: cri-o://99b6ed005917e96384abcdd236ffd10edf9ff385bf262d1bfe2c8327d7037610
        exitCode: 0
        finishedAt: "2021-07-01T15:09:43Z"
        reason: Completed
        startedAt: "2021-07-01T15:09:31Z"
  hostIP: 10.5.188.175
  initContainerStatuses:
  - containerID: cri-o://f97d95b4dbcd11e9989f37c5eaddad542b2e40eee0ea3e78564d3882e126c7c5
    image: registry.ng.bluemix.net/armada-master/ocp-release:4.8.0-fc.8-x86_64
    imageID: registry.ng.bluemix.net/armada-master/ocp-release@sha256:9d0d47c9ac6539183133fac9b0c5f6ff389ea2cc2fef115a9f77967f57d5d420
    lastState: {}
    name: cluster-version-operator
    ready: true
    restartCount: 0
    state:
      terminated:
        containerID: cri-o://f97d95b4dbcd11e9989f37c5eaddad542b2e40eee0ea3e78564d3882e126c7c5
        exitCode: 0
        finishedAt: "2021-07-01T15:07:33Z"
        reason: Completed
        startedAt: "2021-07-01T15:07:33Z"
  phase: Succeeded
  podIP: 172.30.64.135
  podIPs:
  - ip: 172.30.64.135
  qosClass: BestEffort
  startTime: "2021-07-01T15:07:20Z"
```