### PR TITLE
Refactor

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -7,21 +7,21 @@ import (
 )
 
 const (
-	NodePoolAMIDiscoveryFailed              = "AMIDiscoveryFailed"
+	NodePoolValidReleaseImageConditionType  = "ValidReleaseImage"
+	NodePoolValidAMIConditionType           = "ValidAMI"
+	NodePoolConfigFailedConditionType       = "ConfigFailed"
 	NodePoolAutoscalingEnabledConditionType = "AutoscalingEnabled"
 	NodePoolAutorepairEnabledConditionType  = "AutorepairEnabled"
+	NodePoolUpdatingVersionConditionType    = "UpdatingVersion"
+	NodePoolUpdatingConfigConditionType     = "UpdatingConfig"
 	NodePoolAsExpectedConditionReason       = "AsExpected"
 	NodePoolValidationFailedConditionReason = "ValidationFailed"
-	NodePoolUpgradingConditionType          = "Upgrading"
-	NodePoolUpdatingConfigConditionType     = "UpdatingConfig"
 )
 
 // The following are reasons for the IgnitionEndpointAvailable condition.
 const (
 	IgnitionEndpointMissingReason string = "IgnitionEndpointMissing"
 	IgnitionCACertMissingReason   string = "IgnitionCACertMissing"
-	IgnitionTokenMissingError     string = "IgnitionTokenError"
-	IgnitionUserDataErrorReason   string = "IgnitionUserDataError"
 )
 
 func init() {
@@ -40,7 +40,8 @@ func init() {
 // +kubebuilder:printcolumn:name="Autoscaling",type="string",JSONPath=".status.conditions[?(@.type==\"AutoscalingEnabled\")].status",description="Autoscaling Enabled"
 // +kubebuilder:printcolumn:name="Autorepair",type="string",JSONPath=".status.conditions[?(@.type==\"AutorepairEnabled\")].status",description="Node Autorepair Enabled"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="Current version"
-// +kubebuilder:printcolumn:name="Upgrading",type="string",JSONPath=".status.conditions[?(@.type==\"Upgrading\")].status",description="Upgrade in progress"
+// +kubebuilder:printcolumn:name="UpdatingVersion",type="string",JSONPath=".status.conditions[?(@.type==\"UpdatingVersion\")].status",description="UpdatingVersion in progress"
+// +kubebuilder:printcolumn:name="UpdatingConfig",type="string",JSONPath=".status.conditions[?(@.type==\"UpdatingConfig\")].status",description="UpdatingConfig in progress"
 type NodePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -40,9 +40,13 @@ spec:
       jsonPath: .status.version
       name: Version
       type: string
-    - description: Upgrade in progress
-      jsonPath: .status.conditions[?(@.type=="Upgrading")].status
-      name: Upgrading
+    - description: UpdatingVersion in progress
+      jsonPath: .status.conditions[?(@.type=="UpdatingVersion")].status
+      name: UpdatingVersion
+      type: string
+    - description: UpdatingConfig in progress
+      jsonPath: .status.conditions[?(@.type=="UpdatingConfig")].status
+      name: UpdatingConfig
       type: string
     name: v1alpha1
     schema:

--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -32,7 +32,7 @@ func machineHealthCheck(nodePool *hyperv1.NodePool, controlPlaneNamespace string
 	}
 }
 
-func AWSMachineTemplate(infraName, ami string, nodePool *hyperv1.NodePool, controlPlaneNamespace string) *capiaws.AWSMachineTemplate {
+func AWSMachineTemplate(infraName, ami string, nodePool *hyperv1.NodePool, controlPlaneNamespace string) (*capiaws.AWSMachineTemplate, string) {
 	subnet := &capiaws.AWSResourceReference{}
 	if nodePool.Spec.Platform.AWS.Subnet != nil {
 		subnet.ID = nodePool.Spec.Platform.AWS.Subnet.ID
@@ -99,7 +99,7 @@ func AWSMachineTemplate(infraName, ami string, nodePool *hyperv1.NodePool, contr
 	specHash := hashStruct(awsMachineTemplate.Spec.Template.Spec)
 	awsMachineTemplate.SetName(fmt.Sprintf("%s-%s", nodePool.GetName(), specHash))
 
-	return awsMachineTemplate
+	return awsMachineTemplate, specHash
 }
 
 func IgnitionUserDataSecret(namespace, name, payloadInputHash string) *corev1.Secret {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -14,6 +14,7 @@ import (
 	ignitionapi "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	api "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/releaseinfo"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -40,6 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -48,22 +50,22 @@ import (
 )
 
 const (
-	finalizer                       = "hypershift.openshift.io/finalizer"
-	autoscalerMaxAnnotation         = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
-	autoscalerMinAnnotation         = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
-	nodePoolAnnotation              = "hypershift.openshift.io/nodePool"
-	nodePoolAnnotationConfig        = "hypershift.openshift.io/nodePoolConfig"
-	nodePoolAnnotationConfigVersion = "hypershift.openshift.io/nodePoolConfigVersion"
-	TokenSecretReleaseKey           = "release"
-	TokenSecretTokenKey             = "token"
-	TokenSecretConfigKey            = "config"
-	TokenSecretAnnotation           = "hypershift.openshift.io/ignition-config"
+	finalizer                               = "hypershift.openshift.io/finalizer"
+	autoscalerMaxAnnotation                 = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
+	autoscalerMinAnnotation                 = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
+	nodePoolAnnotation                      = "hypershift.openshift.io/nodePool"
+	nodePoolAnnotationCurrentConfig         = "hypershift.openshift.io/nodePoolCurrentConfig"
+	nodePoolAnnotationCurrentConfigVersion  = "hypershift.openshift.io/nodePoolCurrentConfigVersion"
+	nodePoolAnnotationCurrentProviderConfig = "hypershift.openshift.io/nodePoolCurrentProviderConfig"
+	TokenSecretReleaseKey                   = "release"
+	TokenSecretTokenKey                     = "token"
+	TokenSecretConfigKey                    = "config"
+	TokenSecretAnnotation                   = "hypershift.openshift.io/ignition-config"
 )
 
 type NodePoolReconciler struct {
 	ctrlclient.Client
 	recorder        record.EventRecorder
-	Log             logr.Logger
 	ReleaseProvider releaseinfo.Provider
 
 	tracer trace.Tracer
@@ -101,18 +103,18 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	ctx, span = r.tracer.Start(ctx, "reconcile")
 	defer span.End()
 
-	r.Log = ctrl.LoggerFrom(ctx)
-	r.Log.Info("Reconciling")
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Reconciling")
 
 	// Fetch the nodePool instance
 	nodePool := &hyperv1.NodePool{}
 	err := r.Client.Get(ctx, req.NamespacedName, nodePool)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			r.Log.Info("not found", "request", req.String())
+			log.Info("not found", "request", req.String())
 			return ctrl.Result{}, nil
 		}
-		r.Log.Error(err, "error getting nodePool")
+		log.Error(err, "error getting nodePool")
 		return ctrl.Result{}, err
 	}
 
@@ -120,13 +122,12 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-
-	// Generate mcs manifests for the given release
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
+
 	// Fixme (alberto): using nodePool.Status.Version here gives a race: if a NodePool is deleted
 	// before the targeted version is the one in the status then the tokenSecret and userDataSecret would be leaked.
-	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, nodePool.GetAnnotations()[nodePoolAnnotationConfigVersion])
-	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), nodePool.GetAnnotations()[nodePoolAnnotationConfigVersion])
+	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfigVersion])
+	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfigVersion])
 	md := machineDeployment(nodePool, hcluster.Spec.InfraID, controlPlaneNamespace)
 	mhc := machineHealthCheck(nodePool, controlPlaneNamespace)
 
@@ -164,7 +165,7 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from NodePool: %w", err)
 			}
 		}
-		r.Log.Info("Deleted nodePool")
+		log.Info("Deleted nodePool")
 		span.AddEvent("Finished deleting nodePool")
 		return ctrl.Result{}, nil
 	}
@@ -185,10 +186,10 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	result, err := r.reconcile(ctx, hcluster, nodePool)
 	if err != nil {
-		r.Log.Error(err, "Failed to reconcile nodePool")
+		log.Error(err, "Failed to reconcile NodePool")
 		r.recorder.Eventf(nodePool, corev1.EventTypeWarning, "ReconcileError", "%v", err)
 		if err := patchHelper.Patch(ctx, nodePool); err != nil {
-			r.Log.Error(err, "failed to patch")
+			log.Error(err, "failed to patch")
 			return ctrl.Result{}, fmt.Errorf("failed to patch: %w", err)
 		}
 		return result, err
@@ -196,34 +197,22 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	span.AddEvent("Updating nodePool")
 	if err := patchHelper.Patch(ctx, nodePool); err != nil {
-		r.Log.Error(err, "failed to patch")
+		log.Error(err, "failed to patch")
 		return ctrl.Result{}, fmt.Errorf("failed to patch: %w", err)
 	}
 
-	r.Log.Info("Successfully reconciled")
+	log.Info("Successfully reconciled")
 	return ctrl.Result{}, nil
 }
 
-func compress(content []byte) ([]byte, error) {
-	if len(content) == 0 {
-		return nil, nil
-	}
-	var b bytes.Buffer
-	gz := gzip.NewWriter(&b)
-	if _, err := gz.Write(content); err != nil {
-		return nil, fmt.Errorf("failed to compress content: %w", err)
-	}
-	if err := gz.Close(); err != nil {
-		return nil, fmt.Errorf("compress closure failure %w", err)
-	}
-	return b.Bytes(), nil
-}
-
 func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.HostedCluster, nodePool *hyperv1.NodePool) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
 	var span trace.Span
 	ctx, span = r.tracer.Start(ctx, "update")
 	defer span.End()
 
+	// HostedCluster owns NodePools. This should ensure orphan NodePools are garbage collected when cascading deleting.
 	nodePool.OwnerReferences = util.EnsureOwnerRef(nodePool.OwnerReferences, metav1.OwnerReference{
 		APIVersion: hyperv1.GroupVersion.String(),
 		Kind:       "HostedCluster",
@@ -231,142 +220,43 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		UID:        hcluster.UID,
 	})
 
-	// Validate input
-	if err := validate(nodePool); err != nil {
-		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-			Type:    hyperv1.NodePoolAutoscalingEnabledConditionType,
-			Status:  metav1.ConditionFalse,
-			Reason:  hyperv1.NodePoolValidationFailedConditionReason,
-			Message: err.Error(),
-		})
-		return reconcile.Result{}, fmt.Errorf("error validating autoscaling parameters: %w", err)
-	}
+	// Get HostedCluster deps.
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
+	ignEndpoint := hcluster.Status.IgnitionEndpoint
+	infraID := hcluster.Spec.InfraID
 
-	if hcluster.Status.IgnitionEndpoint == "" {
+	// 1. - Reconcile conditions according to current state of the world.
+
+	// Validate autoscaling input.
+	if err := validateAutoscaling(nodePool); err != nil {
 		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-			Type:               string(hyperv1.IgnitionEndpointAvailable),
+			Type:               hyperv1.NodePoolAutoscalingEnabledConditionType,
 			Status:             metav1.ConditionFalse,
-			Reason:             hyperv1.IgnitionEndpointMissingReason,
+			Message:            err.Error(),
+			Reason:             hyperv1.NodePoolValidationFailedConditionReason,
 			ObservedGeneration: nodePool.Generation,
 		})
-		r.Log.Info("Ignition endpoint not available, waiting")
+		// We don't return the error here as reconciling won't solve the input problem.
+		// An update event will trigger reconciliation.
+		log.Error(err, "validating autoscaling parameters failed")
 		return reconcile.Result{}, nil
 	}
 
-	releaseImage, err := func(ctx context.Context) (*releaseinfo.ReleaseImage, error) {
-		ctx, span := r.tracer.Start(ctx, "image-lookup")
-		defer span.End()
-		lookupCtx, lookupCancel := context.WithTimeout(ctx, 1*time.Minute)
-		defer lookupCancel()
-		img, err := r.ReleaseProvider.Lookup(lookupCtx, nodePool.Spec.Release.Image)
-		if err != nil {
-			return nil, fmt.Errorf("failed to look up release image metadata: %w", err)
-		}
-		return img, nil
-	}(ctx)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to look up release image metadata: %w", err)
-	}
-	targetVersion := releaseImage.Version()
-
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
-
-	// Create a hash from nodePool.Spec.Config content and
-	// Annotate NodePool with it.
-	var compressedConfig []byte
-	allConfigPlainText := ""
-	if nodePool.Spec.Config != nil {
-		for _, config := range nodePool.Spec.Config {
-			configConfigMap := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      config.Name,
-					Namespace: nodePool.Namespace,
-				},
-			}
-			if err := r.Get(ctx, ctrlclient.ObjectKeyFromObject(configConfigMap), configConfigMap); err != nil {
-				return reconcile.Result{}, fmt.Errorf("failed to get config ConfigMap: %w", err)
-			}
-
-			// TODO (alberto): validate ConfigMap ignition content here?
-			allConfigPlainText = allConfigPlainText + "\n---\n" + configConfigMap.Data[TokenSecretConfigKey]
-		}
-	}
-	targetConfigHash := hashStruct(allConfigPlainText)
-	targetConfigVersionHash := hashStruct(allConfigPlainText + targetVersion)
-	compressedConfig, err = compress([]byte(allConfigPlainText))
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	isUpgrading := isUpgrading(nodePool, targetVersion)
-	isUpdatingConfig := isUpdatingConfig(nodePool, targetConfigHash)
-	if isUpgrading {
+	// Validate IgnitionEndpoint.
+	if ignEndpoint == "" {
 		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-			Type:    hyperv1.NodePoolUpgradingConditionType,
-			Status:  metav1.ConditionTrue,
-			Reason:  hyperv1.NodePoolAsExpectedConditionReason,
-			Message: fmt.Sprintf("Upgrade in progress. Target version: %v", targetVersion),
+			Type:               string(hyperv1.IgnitionEndpointAvailable),
+			Status:             metav1.ConditionFalse,
+			Message:            "Ignition endpoint not available, waiting",
+			Reason:             hyperv1.IgnitionEndpointMissingReason,
+			ObservedGeneration: nodePool.Generation,
 		})
-		r.Log.Info("New nodePool version changed. A new token Secret will be generated",
-			"targetVersion", targetVersion)
+		log.Info("Ignition endpoint not available, waiting")
+		return reconcile.Result{}, nil
 	}
-	if isUpdatingConfig {
-		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-			Type:    hyperv1.NodePoolUpdatingConfigConditionType,
-			Status:  metav1.ConditionTrue,
-			Reason:  hyperv1.NodePoolAsExpectedConditionReason,
-			Message: fmt.Sprintf("Updating config in progress"),
-		})
-		r.Log.Info("New nodePool config changed, A new token Secret will be generated",
-			"targetVersion", targetVersion)
-	}
-	if isUpgrading || isUpdatingConfig {
-		// Token Secrets are immutable and follow "prefixName-version-configHash" naming convention
-		// Ensure old versioned resources are deleted, i.e token Secret and userdata Secret.
-		tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, nodePool.GetAnnotations()[nodePoolAnnotationConfigVersion])
-		if err := r.Delete(ctx, tokenSecret); err != nil && !apierrors.IsNotFound(err) {
-			return reconcile.Result{}, fmt.Errorf("failed to delete token Secret: %w", err)
-		}
+	RemoveStatusCondition(&nodePool.Status.Conditions, string(hyperv1.IgnitionEndpointAvailable))
 
-		userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), nodePool.GetAnnotations()[nodePoolAnnotationConfigVersion])
-		if err := r.Delete(ctx, userDataSecret); err != nil && !apierrors.IsNotFound(err) {
-			return reconcile.Result{}, fmt.Errorf("failed to delete token Secret: %w", err)
-		}
-	}
-
-	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, targetConfigVersionHash)
-	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), targetConfigVersionHash)
-
-	r.Log.Info("Reconciling token Secret")
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, tokenSecret, func() error {
-		tokenSecret.Immutable = k8sutilspointer.BoolPtr(true)
-		if tokenSecret.Annotations == nil {
-			tokenSecret.Annotations = make(map[string]string)
-		}
-		tokenSecret.Annotations[TokenSecretAnnotation] = "true"
-		tokenSecret.Annotations[nodePoolAnnotation] = ctrlclient.ObjectKeyFromObject(nodePool).String()
-
-		if tokenSecret.Data == nil {
-			tokenSecret.Data = map[string][]byte{}
-			tokenSecret.Data[TokenSecretTokenKey] = []byte(uuid.New().String())
-			tokenSecret.Data[TokenSecretReleaseKey] = []byte(nodePool.Spec.Release.Image)
-			tokenSecret.Data[TokenSecretConfigKey] = compressedConfig
-		}
-		return nil
-	}); err != nil {
-		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-			Type:    string(hyperv1.IgnitionEndpointAvailable),
-			Status:  metav1.ConditionFalse,
-			Reason:  hyperv1.IgnitionTokenMissingError,
-			Message: err.Error(),
-		})
-		return ctrl.Result{}, err
-	} else {
-		span.AddEvent("reconciled token Secret", trace.WithAttributes(attribute.String("result", string(result))))
-		r.Log.Info("reconciled token Secret", "result", result)
-	}
-
-	r.Log.Info("Reconciling userdata Secret")
+	// Validate Ignition CA Secret.
 	caSecret := ignitionserver.IgnitionCACertSecret(controlPlaneNamespace)
 	if err := r.Get(ctx, ctrlclient.ObjectKeyFromObject(caSecret), caSecret); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -374,395 +264,329 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 				Type:               string(hyperv1.IgnitionEndpointAvailable),
 				Status:             metav1.ConditionFalse,
 				Reason:             hyperv1.IgnitionCACertMissingReason,
+				Message:            "still waiting for ignition CA cert Secret to exist",
 				ObservedGeneration: nodePool.Generation,
 			})
-			r.Log.Info("still waiting for ignition CA cert secret to exist")
+			log.Info("still waiting for ignition CA cert Secret to exist")
 			return ctrl.Result{}, nil
 		} else {
-			return ctrl.Result{}, fmt.Errorf("failed to get ignition CA secret: %w", err)
+			return ctrl.Result{}, fmt.Errorf("failed to get ignition CA Secret: %w", err)
+		}
+	}
+	RemoveStatusCondition(&nodePool.Status.Conditions, string(hyperv1.IgnitionEndpointAvailable))
+
+	caCertBytes, hasCACert := caSecret.Data[corev1.TLSCertKey]
+	if !hasCACert {
+		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+			Type:               string(hyperv1.IgnitionEndpointAvailable),
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.IgnitionCACertMissingReason,
+			Message:            "CA Secret is missing tls.crt key",
+			ObservedGeneration: nodePool.Generation,
+		})
+		log.Info("CA Secret is missing tls.crt key")
+		return ctrl.Result{}, nil
+	}
+	RemoveStatusCondition(&nodePool.Status.Conditions, hyperv1.IgnitionCACertMissingReason)
+
+	// Validate and get releaseImage.
+	releaseImage, err := r.getReleaseImage(ctx, nodePool.Spec.Release.Image)
+	if err != nil {
+		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+			Type:               hyperv1.NodePoolValidReleaseImageConditionType,
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.NodePoolValidationFailedConditionReason,
+			Message:            fmt.Sprintf("Failed to get release image: %v", err.Error()),
+			ObservedGeneration: nodePool.Generation,
+		})
+		return ctrl.Result{}, fmt.Errorf("failed to look up release image metadata: %w", err)
+	}
+	meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+		Type:               hyperv1.NodePoolValidReleaseImageConditionType,
+		Status:             metav1.ConditionTrue,
+		Reason:             hyperv1.NodePoolAsExpectedConditionReason,
+		Message:            fmt.Sprintf("Using release image: %s", nodePool.Spec.Release.Image),
+		ObservedGeneration: nodePool.Generation,
+	})
+
+	// Validate platform specific input.
+	var ami string
+	if nodePool.Spec.Platform.Type == hyperv1.AWSPlatform {
+		if hcluster.Spec.Platform.AWS == nil {
+			return ctrl.Result{}, fmt.Errorf("the HostedCluster for this NodePool has no .Spec.Platform.AWS, this is unsupported")
+		}
+		// TODO: Should the region be included in the NodePool platform information?
+		ami, err = getAMI(nodePool, hcluster.Spec.Platform.AWS.Region, releaseImage)
+		if err != nil {
+			meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+				Type:               hyperv1.NodePoolValidAMIConditionType,
+				Status:             metav1.ConditionFalse,
+				Reason:             hyperv1.NodePoolValidationFailedConditionReason,
+				Message:            fmt.Sprintf("Couldn't discover an AMI for release image %q: %s", nodePool.Spec.Release.Image, err.Error()),
+				ObservedGeneration: nodePool.Generation,
+			})
+			return ctrl.Result{}, fmt.Errorf("couldn't discover an AMI for release image: %w", err)
+		}
+	}
+	meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+		Type:               hyperv1.NodePoolValidAMIConditionType,
+		Status:             metav1.ConditionTrue,
+		Reason:             hyperv1.NodePoolAsExpectedConditionReason,
+		Message:            fmt.Sprintf("Bootstrap AMI is %q", ami),
+		ObservedGeneration: nodePool.Generation,
+	})
+
+	// Check if config needs to be updated.
+	config, err := r.getConfig(ctx, nodePool)
+	if err != nil {
+		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+			Type:               hyperv1.NodePoolConfigFailedConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             hyperv1.NodePoolValidationFailedConditionReason,
+			Message:            err.Error(),
+			ObservedGeneration: nodePool.Generation,
+		})
+		return ctrl.Result{}, fmt.Errorf("failed to get config: %w", err)
+	}
+	RemoveStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolConfigFailedConditionType)
+
+	targetConfigHash := hashStruct(config)
+	compressedConfig, err := compress([]byte(config))
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to compress config: %w", err)
+	}
+
+	isUpdatingConfig := isUpdatingConfig(nodePool, targetConfigHash)
+	if isUpdatingConfig {
+		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+			Type:               hyperv1.NodePoolUpdatingConfigConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             hyperv1.NodePoolAsExpectedConditionReason,
+			Message:            fmt.Sprintf("Updating config in progress. Target config: %s", targetConfigHash),
+			ObservedGeneration: nodePool.Generation,
+		})
+		log.Info("NodePool config is updating",
+			"current", nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfig],
+			"target", targetConfigHash)
+	} else {
+		RemoveStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolUpdatingConfigConditionType)
+	}
+
+	// Check if version needs to be updated.
+	targetVersion := releaseImage.Version()
+	isUpdatingVersion := isUpdatingVersion(nodePool, targetVersion)
+	if isUpdatingVersion {
+		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+			Type:               hyperv1.NodePoolUpdatingVersionConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             hyperv1.NodePoolAsExpectedConditionReason,
+			Message:            fmt.Sprintf("Updating version in progress. Target version: %s", targetVersion),
+			ObservedGeneration: nodePool.Generation,
+		})
+		log.Info("NodePool version is updating",
+			"current", nodePool.Status.Version, "target", targetVersion)
+	} else {
+		RemoveStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolUpdatingVersionConditionType)
+	}
+	targetConfigVersionHash := hashStruct(config + targetVersion)
+
+	// 2. - Reconcile towards expected state of the world.
+
+	// Token Secrets are immutable and follow "prefixName-configVersionHash" naming convention.
+	// Ensure old configVersionHash resources are deleted, i.e token Secret and userdata Secret.
+	if isUpdatingVersion || isUpdatingConfig {
+		tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfigVersion])
+		if err := r.Delete(ctx, tokenSecret); err != nil && !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, fmt.Errorf("failed to delete token Secret: %w", err)
+		}
+
+		userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfigVersion])
+		if err := r.Delete(ctx, userDataSecret); err != nil && !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, fmt.Errorf("failed to delete token Secret: %w", err)
 		}
 	}
 
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, userDataSecret, func() error {
-		userDataSecret.Immutable = k8sutilspointer.BoolPtr(true)
-		if userDataSecret.Annotations == nil {
-			userDataSecret.Annotations = make(map[string]string)
-		}
-		userDataSecret.Annotations[nodePoolAnnotation] = ctrlclient.ObjectKeyFromObject(nodePool).String()
-
-		caCertBytes, hasCACert := caSecret.Data[corev1.TLSCertKey]
-		if !hasCACert {
-			return fmt.Errorf("ca secret is missing tls.crt key")
-		}
-		tokenBytes, hasToken := tokenSecret.Data[TokenSecretTokenKey]
-		if !hasToken {
-			return fmt.Errorf("token secret is missing token key")
-		}
-		encodedCACert := base64.StdEncoding.EncodeToString(caCertBytes)
-		encodedToken := base64.StdEncoding.EncodeToString(tokenBytes)
-		ignConfig := ignitionapi.Config{
-			Ignition: ignitionapi.Ignition{
-				Version: "3.1.0",
-				Security: ignitionapi.Security{
-					TLS: ignitionapi.TLS{
-						CertificateAuthorities: []ignitionapi.Resource{
-							{
-								Source: k8sutilspointer.StringPtr(fmt.Sprintf("data:text/plain;base64,%s", encodedCACert)),
-							},
-						},
-					},
-				},
-				Config: ignitionapi.IgnitionConfig{
-					Merge: []ignitionapi.Resource{
-						{
-							Source: k8sutilspointer.StringPtr(fmt.Sprintf("https://%s/ignition", hcluster.Status.IgnitionEndpoint)),
-							HTTPHeaders: []ignitionapi.HTTPHeader{
-								{
-									Name:  "Authorization",
-									Value: k8sutilspointer.StringPtr(fmt.Sprintf("Bearer %s", encodedToken)),
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		userDataValue, err := json.Marshal(ignConfig)
-		if err != nil {
-			return fmt.Errorf("failed to marshal ignition config: %w", err)
-		}
-		userDataSecret.Data = map[string][]byte{
-			"disableTemplating": []byte(base64.StdEncoding.EncodeToString([]byte("true"))),
-			"value":             userDataValue,
-		}
-		return nil
+	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, targetConfigVersionHash)
+	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, tokenSecret, func() error {
+		return reconcileTokenSecret(tokenSecret, nodePool, compressedConfig)
 	}); err != nil {
-		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-			Type:    string(hyperv1.IgnitionEndpointAvailable),
-			Status:  metav1.ConditionFalse,
-			Reason:  hyperv1.IgnitionUserDataErrorReason,
-			Message: err.Error(),
-		})
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile token Secret: %w", err)
+	} else {
+		log.Info("Reconciled token Secret", "result", result)
+		span.AddEvent("reconciled token Secret", trace.WithAttributes(attribute.String("result", string(result))))
+	}
+
+	tokenBytes, hasToken := tokenSecret.Data[TokenSecretTokenKey]
+	if !hasToken {
+		// This should never happen by design.
+		return ctrl.Result{}, fmt.Errorf("token secret is missing token key")
+	}
+
+	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), targetConfigVersionHash)
+	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, userDataSecret, func() error {
+		return reconcileUserDataSecret(userDataSecret, nodePool, caCertBytes, tokenBytes, ignEndpoint)
+	}); err != nil {
 		return ctrl.Result{}, err
 	} else {
+		log.Info("Reconciled userData Secret", "result", result)
 		span.AddEvent("reconciled ignition user data secret", trace.WithAttributes(attribute.String("result", string(result))))
-		r.Log.Info("reconciled ignition user data secret", "result", result)
 	}
 
+	var machineTemplate client.Object
 	switch nodePool.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
-		var ami string
-		switch {
-		case len(nodePool.Spec.Platform.AWS.AMI) > 0:
-			ami = nodePool.Spec.Platform.AWS.AMI
-		default:
-			defaultAmi, err := defaultNodePoolAMI(hcluster, releaseImage)
-			if err != nil {
-				meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-					Type:    hyperv1.NodePoolAMIDiscoveryFailed,
-					Status:  metav1.ConditionTrue,
-					Reason:  hyperv1.NodePoolValidationFailedConditionReason,
-					Message: fmt.Sprintf("Couldn't discover an AMI for release image %q: %s", nodePool.Spec.Release.Image, err),
-				})
-				return ctrl.Result{}, fmt.Errorf("couldn't discover an AMI for release image: %w", err)
-			}
-			meta.RemoveStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolAMIDiscoveryFailed)
-			ami = defaultAmi
+		machineTemplate, err = r.reconcileAWSMachineTemplate(ctx, nodePool, infraID, ami, controlPlaneNamespace)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile AWSMachineTemplate: %w", err)
 		}
+		span.AddEvent("reconciled awsmachinetemplate", trace.WithAttributes(attribute.String("name", machineTemplate.GetName())))
+	}
 
-		md := machineDeployment(nodePool, hcluster.Spec.InfraID, controlPlaneNamespace)
-		awsMachineTemplate := AWSMachineTemplate(hcluster.Spec.InfraID, ami, nodePool, controlPlaneNamespace)
-		mhc := machineHealthCheck(nodePool, controlPlaneNamespace)
+	md := machineDeployment(nodePool, infraID, controlPlaneNamespace)
+	if result, err := controllerutil.CreateOrPatch(ctx, r.Client, md, func() error {
+		return r.reconcileMachineDeployment(
+			log,
+			md, nodePool,
+			userDataSecret,
+			machineTemplate,
+			infraID,
+			targetVersion, targetConfigHash, targetConfigVersionHash)
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile MachineDeployment %q: %w",
+			ctrlclient.ObjectKeyFromObject(md).String(), err)
+	} else {
+		log.Info("Reconciled MachineDeployment", "result", result)
+		span.AddEvent("reconciled machinedeployment", trace.WithAttributes(attribute.String("result", string(result))))
+	}
 
-		r.Log.Info("Reconciling AWSMachineTemplate")
-		// If a change happens to the nodePool AWSNodePoolPlatform we delete the existing awsMachineTemplate,
-		// create a new one with a new name
-		// and pass it to the machineDeployment. This will trigger a rolling upgrade.
-		currentMD := &capiv1.MachineDeployment{}
-		if err := r.Get(ctx, ctrlclient.ObjectKeyFromObject(md), currentMD); err != nil && !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to get machineDeployment: %w", err)
-		}
-
-		// If the machineDeployment has not been created yet, create new awsMachineTemplate.
-		if currentMD.CreationTimestamp.IsZero() {
-			r.Log.Info("Creating new AWSMachineTemplate", "AWSMachineTemplate", ctrlclient.ObjectKeyFromObject(awsMachineTemplate).String())
-			if result, err := controllerutil.CreateOrPatch(ctx, r.Client, awsMachineTemplate, func() error {
-				return nil
-			}); err != nil {
-				return ctrl.Result{}, fmt.Errorf("error creating new AWSMachineTemplate: %w", err)
-			} else {
-				span.AddEvent("reconciled aws machinetemplate", trace.WithAttributes(attribute.String("result", string(result))))
-			}
-		}
-
-		if !currentMD.CreationTimestamp.IsZero() {
-			currentAWSMachineTemplate := &capiaws.AWSMachineTemplate{}
-			if err := r.Get(ctx, client.ObjectKey{
-				Namespace: currentMD.Spec.Template.Spec.InfrastructureRef.Namespace,
-				Name:      currentMD.Spec.Template.Spec.InfrastructureRef.Name,
-			}, currentAWSMachineTemplate); err != nil && !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, err
-			}
-
-			if !equality.Semantic.DeepEqual(currentAWSMachineTemplate.Spec.Template.Spec, awsMachineTemplate.Spec.Template.Spec) {
-				r.Log.Info("AWS config has changed. This will trigger a rolling upgrade")
-				r.Log.Info("Creating new AWSMachineTemplate", "AWSMachineTemplate", ctrlclient.ObjectKeyFromObject(awsMachineTemplate).String())
-				// Create new template
-				if result, err := controllerutil.CreateOrPatch(ctx, r.Client, awsMachineTemplate, func() error {
-					return nil
-				}); err != nil {
-					return ctrl.Result{}, fmt.Errorf("error creating new AWSMachineTemplate: %w", err)
-				} else {
-					span.AddEvent("reconciled aws machinetemplate", trace.WithAttributes(attribute.String("result", string(result))))
-				}
-				// Delete existing template
-				r.Log.Info("Deleting existing AWSMachineTemplate", "AWSMachineTemplate", ctrlclient.ObjectKeyFromObject(currentAWSMachineTemplate).String())
-				if err := r.Delete(ctx, currentAWSMachineTemplate); err != nil && !apierrors.IsNotFound(err) {
-					return ctrl.Result{}, fmt.Errorf("error deleting existing AWSMachineTemplate: %w", err)
-				} else {
-					span.AddEvent("deleted aws machinetemplate", trace.WithAttributes(attribute.String("name", currentAWSMachineTemplate.Name)))
-				}
-			} else {
-				// We pass the existing one to reconcileMachineDeployment.
-				awsMachineTemplate = currentAWSMachineTemplate
-			}
-		}
-
-		r.Log.Info("Reconciling MachineDeployment")
-		if result, err := controllerutil.CreateOrPatch(ctx, r.Client, md, func() error {
-			return r.reconcileMachineDeployment(
-				md, nodePool,
-				userDataSecret,
-				awsMachineTemplate,
-				hcluster.Spec.InfraID,
-				targetConfigHash, targetConfigVersionHash,
-				releaseImage)
+	mhc := machineHealthCheck(nodePool, controlPlaneNamespace)
+	if nodePool.Spec.Management.AutoRepair {
+		if result, err := ctrl.CreateOrUpdate(ctx, r.Client, mhc, func() error {
+			return r.reconcileMachineHealthCheck(mhc, nodePool, infraID)
 		}); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile machineDeployment %q: %w",
-				ctrlclient.ObjectKeyFromObject(md).String(), err)
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile MachineHealthCheck %q: %w",
+				ctrlclient.ObjectKeyFromObject(mhc).String(), err)
 		} else {
-			span.AddEvent("reconciled machinedeployment", trace.WithAttributes(attribute.String("result", string(result))))
+			log.Info("Reconciled MachineHealthCheck", "result", result)
+			span.AddEvent("reconciled machinehealthchecks", trace.WithAttributes(attribute.String("result", string(result))))
 		}
-
-		// Reconcile MachineHealthCheck
-		if nodePool.Spec.Management.AutoRepair {
-			r.Log.Info("Reconciling MachineHealthChecks")
-			if result, err := ctrl.CreateOrUpdate(ctx, r.Client, mhc, func() error {
-				return r.reconcileMachineHealthCheck(mhc, nodePool, hcluster.Spec.InfraID)
-			}); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to reconcile machineHealthCheck %q: %w",
-					ctrlclient.ObjectKeyFromObject(mhc).String(), err)
-			} else {
-				span.AddEvent("reconciled machinehealthchecks", trace.WithAttributes(attribute.String("result", string(result))))
-			}
-			meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-				Type:   hyperv1.NodePoolAutorepairEnabledConditionType,
-				Status: metav1.ConditionTrue,
-				Reason: hyperv1.NodePoolAsExpectedConditionReason,
-			})
+		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+			Type:               hyperv1.NodePoolAutorepairEnabledConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             hyperv1.NodePoolAsExpectedConditionReason,
+			ObservedGeneration: nodePool.Generation,
+		})
+	} else {
+		if err := r.Client.Delete(ctx, mhc); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
 		} else {
-			if err := r.Client.Delete(ctx, mhc); err != nil && !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, err
-			} else {
-				span.AddEvent("deleted machinehealthcheck", trace.WithAttributes(attribute.String("name", mhc.Name)))
-			}
-			meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-				Type:   hyperv1.NodePoolAutorepairEnabledConditionType,
-				Status: metav1.ConditionFalse,
-				Reason: hyperv1.NodePoolAsExpectedConditionReason,
-			})
+			span.AddEvent("deleted machinehealthcheck", trace.WithAttributes(attribute.String("name", mhc.Name)))
 		}
+		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+			Type:               hyperv1.NodePoolAutorepairEnabledConditionType,
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.NodePoolAsExpectedConditionReason,
+			ObservedGeneration: nodePool.Generation,
+		})
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func isUpgrading(nodePool *hyperv1.NodePool, targetVersion string) bool {
-	return targetVersion != nodePool.Status.Version
+func (r NodePoolReconciler) reconcileAWSMachineTemplate(ctx context.Context,
+	nodePool *hyperv1.NodePool, infraID, ami, controlPlaneNamespace string) (*capiaws.AWSMachineTemplate, error) {
+
+	log := ctrl.LoggerFrom(ctx)
+	// Get target template and hash.
+	targetAWSMachineTemplate, targetTemplateHash := AWSMachineTemplate(infraID, ami, nodePool, controlPlaneNamespace)
+
+	// Get current template and hash.
+	currentTemplateHash := nodePool.GetAnnotations()[nodePoolAnnotationCurrentProviderConfig]
+	currentAWSMachineTemplate := &capiaws.AWSMachineTemplate{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", nodePool.GetName(), currentTemplateHash),
+			Namespace: controlPlaneNamespace,
+		},
+	}
+	if err := r.Get(ctx, ctrlclient.ObjectKeyFromObject(currentAWSMachineTemplate), currentAWSMachineTemplate); err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("error getting existing AWSMachineTemplate: %w", err)
+	}
+
+	// Template has not changed, return early.
+	// TODO(alberto): can we hash in a deterministic way so we could just compare hashes?
+	if equality.Semantic.DeepEqual(currentAWSMachineTemplate.Spec.Template.Spec, targetAWSMachineTemplate.Spec.Template.Spec) {
+		return currentAWSMachineTemplate, nil
+	}
+
+	// Otherwise create new template.
+	log.Info("The AWSMachineTemplate referenced by this NodePool has changed. Creating a new one")
+	if err := r.Create(ctx, targetAWSMachineTemplate); err != nil {
+		return nil, fmt.Errorf("error creating new AWSMachineTemplate: %w", err)
+	}
+
+	// TODO (alberto): Create a mechanism to cleanup old machineTemplates.
+	// We can't just delete the old AWSMachineTemplate because
+	// this would break the rolling upgrade process since the MachineSet
+	// being scaled down is still referencing the old AWSMachineTemplate.
+	// May be consider one single template the whole NodePool lifecycle. Modify it in place
+	// and trigger rolling update by e.g annotating the machineDeployment.
+
+	// Store new template hash.
+	if nodePool.Annotations == nil {
+		nodePool.Annotations = make(map[string]string)
+	}
+	nodePool.Annotations[nodePoolAnnotationCurrentProviderConfig] = targetTemplateHash
+
+	return targetAWSMachineTemplate, nil
 }
 
-func isUpdatingConfig(nodePool *hyperv1.NodePool, newConfigHash string) bool {
-	return newConfigHash != nodePool.GetAnnotations()[nodePoolAnnotationConfig]
-}
-
-func defaultNodePoolAMI(hcluster *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseImage) (string, error) {
-	// TODO: The architecture should be specified from the API
-	arch, foundArch := releaseImage.StreamMetadata.Architectures["x86_64"]
-	if !foundArch {
-		return "", fmt.Errorf("couldn't find OS metadata for architecture %q", "x64_64")
+func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.NodePool, CA, token []byte, ignEndpoint string) error {
+	userDataSecret.Immutable = k8sutilspointer.BoolPtr(true)
+	if userDataSecret.Annotations == nil {
+		userDataSecret.Annotations = make(map[string]string)
 	}
-	// TODO: Should the region be included in the NodePool platform information?
-	region := hcluster.Spec.Platform.AWS.Region
-	regionData, hasRegionData := arch.Images.AWS.Regions[region]
-	if !hasRegionData {
-		return "", fmt.Errorf("couldn't find AWS image for region %q", region)
+	userDataSecret.Annotations[nodePoolAnnotation] = ctrlclient.ObjectKeyFromObject(nodePool).String()
+
+	encodedCACert := base64.StdEncoding.EncodeToString(CA)
+	encodedToken := base64.StdEncoding.EncodeToString(token)
+	ignConfig := ignConfig(encodedCACert, encodedToken, ignEndpoint)
+	userDataValue, err := json.Marshal(ignConfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ignition config: %w", err)
 	}
-	if len(regionData.Image) == 0 {
-		return "", fmt.Errorf("release image metadata has no image for region %q", region)
+	userDataSecret.Data = map[string][]byte{
+		"disableTemplating": []byte(base64.StdEncoding.EncodeToString([]byte("true"))),
+		"value":             userDataValue,
 	}
-	return regionData.Image, nil
-}
-
-// MachineDeploymentComplete considers a MachineDeployment to be complete once all of its desired replicas
-// are updated and available, and no old machines are running.
-func MachineDeploymentComplete(deployment *capiv1.MachineDeployment) bool {
-	newStatus := &deployment.Status
-	return newStatus.UpdatedReplicas == *(deployment.Spec.Replicas) &&
-		newStatus.Replicas == *(deployment.Spec.Replicas) &&
-		newStatus.AvailableReplicas == *(deployment.Spec.Replicas) &&
-		newStatus.ObservedGeneration >= deployment.Generation
-}
-
-// GetHostedClusterByName finds and return a HostedCluster object using the specified params.
-func GetHostedClusterByName(ctx context.Context, c client.Client, namespace, name string) (*hyperv1.HostedCluster, error) {
-	hcluster := &hyperv1.HostedCluster{}
-	key := client.ObjectKey{
-		Namespace: namespace,
-		Name:      name,
-	}
-
-	if err := c.Get(ctx, key, hcluster); err != nil {
-		return nil, err
-	}
-
-	return hcluster, nil
-}
-
-func generateName(infraName, clusterName, suffix string) string {
-	return getName(fmt.Sprintf("%s-%s", infraName, clusterName), suffix, 43)
-}
-
-// getName returns a name given a base ("deployment-5") and a suffix ("deploy")
-// It will first attempt to join them with a dash. If the resulting name is longer
-// than maxLength: if the suffix is too long, it will truncate the base name and add
-// an 8-character hash of the [base]-[suffix] string.  If the suffix is not too long,
-// it will truncate the base, add the hash of the base and return [base]-[hash]-[suffix]
-func getName(base, suffix string, maxLength int) string {
-	if maxLength <= 0 {
-		return ""
-	}
-	name := fmt.Sprintf("%s-%s", base, suffix)
-	if len(name) <= maxLength {
-		return name
-	}
-
-	// length of -hash-
-	baseLength := maxLength - 10 - len(suffix)
-
-	// if the suffix is too long, ignore it
-	if baseLength < 0 {
-		prefix := base[0:min(len(base), max(0, maxLength-9))]
-		// Calculate hash on initial base-suffix string
-		shortName := fmt.Sprintf("%s-%s", prefix, hash(name))
-		return shortName[:min(maxLength, len(shortName))]
-	}
-
-	prefix := base[0:baseLength]
-	// Calculate hash on initial base-suffix string
-	return fmt.Sprintf("%s-%s-%s", prefix, hash(base), suffix)
-}
-
-// max returns the greater of its 2 inputs
-func max(a, b int) int {
-	if b > a {
-		return b
-	}
-	return a
-}
-
-// min returns the lesser of its 2 inputs
-func min(a, b int) int {
-	if b < a {
-		return b
-	}
-	return a
-}
-
-// hash calculates the hexadecimal representation (8-chars)
-// of the hash of the passed in string using the FNV-a algorithm
-func hash(s string) string {
-	hash := fnv.New32a()
-	hash.Write([]byte(s))
-	intHash := hash.Sum32()
-	result := fmt.Sprintf("%08x", intHash)
-	return result
-}
-
-func isAutoscalingEnabled(nodePool *hyperv1.NodePool) bool {
-	return nodePool.Spec.AutoScaling != nil
-}
-
-func validate(nodePool *hyperv1.NodePool) error {
-	if nodePool.Spec.NodeCount != nil && nodePool.Spec.AutoScaling != nil {
-		return fmt.Errorf("only one of nodePool.Spec.NodeCount or nodePool.Spec.AutoScaling can be set")
-	}
-
-	if nodePool.Spec.AutoScaling != nil {
-		max := nodePool.Spec.AutoScaling.Max
-		min := nodePool.Spec.AutoScaling.Min
-
-		if max == nil || min == nil {
-			return fmt.Errorf("max and min must be not nil. Max: %v, Min: %v", max, min)
-		}
-
-		if *max < *min {
-			return fmt.Errorf("max must be equal or greater than min. Max: %v, Min: %v", *max, *min)
-		}
-
-		if *max == 0 && *min == 0 {
-			return fmt.Errorf("max and min must be not zero. Max: %v, Min: %v", *max, *min)
-		}
-	}
-
 	return nil
 }
 
-func (r *NodePoolReconciler) enqueueNodePoolsForHostedCluster(obj ctrlclient.Object) []reconcile.Request {
-	var result []reconcile.Request
-
-	hc, ok := obj.(*hyperv1.HostedCluster)
-	if !ok {
-		panic(fmt.Sprintf("Expected a HostedCluster but got a %T", obj))
+func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool, compressedConfig []byte) error {
+	tokenSecret.Immutable = k8sutilspointer.BoolPtr(true)
+	if tokenSecret.Annotations == nil {
+		tokenSecret.Annotations = make(map[string]string)
 	}
+	tokenSecret.Annotations[TokenSecretAnnotation] = "true"
+	tokenSecret.Annotations[nodePoolAnnotation] = ctrlclient.ObjectKeyFromObject(nodePool).String()
 
-	nodePoolList := &hyperv1.NodePoolList{}
-	if err := r.List(context.Background(), nodePoolList); err != nil {
-		ctrl.LoggerFrom(context.Background()).Error(err, "Failed to list nodePools")
-		return result
+	if tokenSecret.Data == nil {
+		tokenSecret.Data = map[string][]byte{}
+		tokenSecret.Data[TokenSecretTokenKey] = []byte(uuid.New().String())
+		tokenSecret.Data[TokenSecretReleaseKey] = []byte(nodePool.Spec.Release.Image)
+		tokenSecret.Data[TokenSecretConfigKey] = compressedConfig
 	}
-
-	// Requeue all NodePools matching the HostedCluster name.
-	for key := range nodePoolList.Items {
-		if nodePoolList.Items[key].Spec.ClusterName == hc.GetName() {
-			result = append(result,
-				reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&nodePoolList.Items[key])},
-			)
-		}
-	}
-
-	return result
+	return nil
 }
 
-func enqueueParentNodePool(obj ctrlclient.Object) []reconcile.Request {
-	var nodePoolName string
-	if obj.GetAnnotations() != nil {
-		nodePoolName = obj.GetAnnotations()[nodePoolAnnotation]
-	}
-	if nodePoolName == "" {
-		return []reconcile.Request{}
-	}
-	return []reconcile.Request{
-		{NamespacedName: hyperutil.ParseNamespacedName(nodePoolName)},
-	}
-}
-
-func (r *NodePoolReconciler) reconcileMachineDeployment(machineDeployment *capiv1.MachineDeployment,
+func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
+	machineDeployment *capiv1.MachineDeployment,
 	nodePool *hyperv1.NodePool,
 	userDataSecret *corev1.Secret,
-	awsMachineTemplate *capiaws.AWSMachineTemplate,
+	machineTemplateCR client.Object,
 	CAPIClusterName string,
-	targetConfigHash, targetConfigVersionHash string,
-	releaseImage *releaseinfo.ReleaseImage) error {
+	targetVersion,
+	targetConfigHash, targetConfigVersionHash string) error {
 
 	// Set annotations and labels
 	if machineDeployment.GetAnnotations() == nil {
@@ -774,10 +598,10 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(machineDeployment *capiv
 	}
 	machineDeployment.Labels[capiv1.ClusterLabelName] = CAPIClusterName
 
-	// Set upgrade strategy
 	resourcesName := generateName(CAPIClusterName, nodePool.Spec.ClusterName, nodePool.GetName())
 	machineDeployment.Spec.MinReadySeconds = k8sutilspointer.Int32Ptr(int32(0))
 
+	// Set upgrade strategy.
 	// This is additional backend validation. API validation/default should
 	// prevent this from ever happening.
 
@@ -804,6 +628,11 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(machineDeployment *capiv
 		}
 	}
 
+	gvk, err := apiutil.GVKForObject(machineTemplateCR, api.Scheme)
+	if err != nil {
+		return err
+	}
+
 	// Set selector and template
 	machineDeployment.Spec.ClusterName = CAPIClusterName
 	if machineDeployment.Spec.Selector.MatchLabels == nil {
@@ -825,39 +654,42 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(machineDeployment *capiv
 		Spec: capiv1.MachineSpec{
 			ClusterName: CAPIClusterName,
 			Bootstrap: capiv1.Bootstrap{
-				DataSecretName: k8sutilspointer.StringPtr(userDataSecret.GetName()),
+				// Keep current user data for later check.
+				DataSecretName: machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName,
 			},
 			InfrastructureRef: corev1.ObjectReference{
-				Kind:       "AWSMachineTemplate",
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
-				Namespace:  awsMachineTemplate.GetNamespace(),
-				Name:       awsMachineTemplate.GetName(),
+				Kind:       gvk.Kind,
+				APIVersion: gvk.GroupVersion().String(),
+				Namespace:  machineTemplateCR.GetNamespace(),
+				Name:       machineTemplateCR.GetName(),
 			},
-			// don't stamp version given by the nodePool
+			// Keep current version for later check.
 			Version: machineDeployment.Spec.Template.Spec.Version,
 		},
 	}
 
-	// Propagate version to the machineDeployment.
-	targetVersion := releaseImage.Version()
-	if targetVersion == nodePool.Status.Version &&
-		targetVersion != k8sutilspointer.StringPtrDerefOr(machineDeployment.Spec.Template.Spec.Version, "") {
-		// This should never happen by design.
-		return fmt.Errorf("unexpected error. NodePool current version does not match machineDeployment version")
-	}
+	// Propagate version and userData Secret to the machineDeployment.
+	if userDataSecret.Name != k8sutilspointer.StringPtrDerefOr(machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName, "") {
+		log.Info("New user data Secret has been generated",
+			"current", machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName,
+			"target", userDataSecret.Name)
 
-	if targetVersion != k8sutilspointer.StringPtrDerefOr(machineDeployment.Spec.Template.Spec.Version, "") {
-		r.Log.Info("Propagating new version to the machineDeployment. Starting upgrade",
-			"releaseImage", nodePool.Spec.Release.Image, "targetVersion", targetVersion)
-		// TODO (alberto): Point to a new InfrastructureRef with the new version AMI
-		// https://github.com/openshift/enhancements/pull/201
+		if targetVersion != k8sutilspointer.StringPtrDerefOr(machineDeployment.Spec.Template.Spec.Version, "") {
+			log.Info("Starting version update: Propagating new version to the MachineDeployment",
+				"releaseImage", nodePool.Spec.Release.Image, "target", targetVersion)
+		}
+
+		if targetConfigHash != nodePool.Annotations[nodePoolAnnotationCurrentConfig] {
+			log.Info("Starting config update: Propagating new config to the MachineDeployment",
+				"current", nodePool.Annotations[nodePoolAnnotationCurrentConfig], "target", targetConfigHash)
+		}
 		machineDeployment.Spec.Template.Spec.Version = &targetVersion
 		machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName = k8sutilspointer.StringPtr(userDataSecret.Name)
 
-		// We return early here during a version upgrade to persist the resource.
-		// So in the next reconciling loop we get a new MachineDeployment.Generation
-		// and we do a legit MachineDeploymentComplete/MachineDeployment.Status.ObservedGeneration check.
-		// If the nodePool is brand new we want to make sure the replica number is set so the machineDeployment controller
+		// We return early here during a version/config update to persist the resource with new user data Secret,
+		// so in the next reconciling loop we get a new MachineDeployment.Generation
+		// and we can do a legit MachineDeploymentComplete/MachineDeployment.Status.ObservedGeneration check.
+		// Before persisting if the NodePool is brand new we want to make sure the replica number is set so the machineDeployment controller
 		// does not panic.
 		if machineDeployment.Spec.Replicas == nil {
 			machineDeployment.Spec.Replicas = k8sutilspointer.Int32Ptr(k8sutilspointer.Int32PtrDerefOr(nodePool.Spec.NodeCount, 1))
@@ -865,36 +697,33 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(machineDeployment *capiv
 		return nil
 	}
 
+	// If the MachineDeployment is no processing we know
+	// is at the expected version (spec.version) and config (userData Secret) so we reconcile status and annotation.
 	if MachineDeploymentComplete(machineDeployment) {
 		if nodePool.Status.Version != targetVersion {
+			log.Info("Version update complete",
+				"previous", nodePool.Status.Version, "new", targetVersion)
 			nodePool.Status.Version = targetVersion
-			r.Log.Info("Upgrade complete", "targetVersion", targetVersion)
-			meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-				Type:    hyperv1.NodePoolUpgradingConditionType,
-				Status:  metav1.ConditionFalse,
-				Reason:  hyperv1.NodePoolAsExpectedConditionReason,
-				Message: "",
-			})
 		}
-		if nodePool.Annotations == nil {
-			nodePool.Annotations = make(map[string]string)
+
+		if nodePool.Annotations[nodePoolAnnotationCurrentConfig] != targetConfigHash {
+			log.Info("Config update complete",
+				"previous", nodePool.Annotations[nodePoolAnnotationCurrentConfig], "new", targetConfigHash)
+			nodePool.Annotations[nodePoolAnnotationCurrentConfig] = targetConfigHash
 		}
-		nodePool.Annotations[nodePoolAnnotationConfig] = targetConfigHash
-		nodePool.Annotations[nodePoolAnnotationConfigVersion] = targetConfigVersionHash
+		nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion] = targetConfigVersionHash
 	}
 
 	// Set wanted replicas:
 	// If autoscaling is enabled we reconcile min/max annotations and leave replicas untouched.
+	// TODO (alberto): encapsulate this logic into fun unit testable func setReplicas.
 	if isAutoscalingEnabled(nodePool) {
-		r.Log.Info("NodePool autoscaling is enabled",
-			"Maximum nodes", *nodePool.Spec.AutoScaling.Max,
-			"Minimum nodes", *nodePool.Spec.AutoScaling.Min)
-
 		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-			Type:    hyperv1.NodePoolAutoscalingEnabledConditionType,
-			Status:  metav1.ConditionTrue,
-			Reason:  hyperv1.NodePoolAsExpectedConditionReason,
-			Message: fmt.Sprintf("Maximum nodes: %v, Minimum nodes: %v", *nodePool.Spec.AutoScaling.Max, *nodePool.Spec.AutoScaling.Min),
+			Type:               hyperv1.NodePoolAutoscalingEnabledConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             hyperv1.NodePoolAsExpectedConditionReason,
+			Message:            fmt.Sprintf("Maximum nodes: %v, Minimum nodes: %v", *nodePool.Spec.AutoScaling.Max, *nodePool.Spec.AutoScaling.Min),
+			ObservedGeneration: nodePool.Generation,
 		})
 
 		if !machineDeployment.CreationTimestamp.IsZero() {
@@ -909,9 +738,10 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(machineDeployment *capiv
 	// If autoscaling is NOT enabled we reset min/max annotations and reconcile replicas.
 	if !isAutoscalingEnabled(nodePool) {
 		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
-			Type:   hyperv1.NodePoolAutoscalingEnabledConditionType,
-			Status: metav1.ConditionFalse,
-			Reason: hyperv1.NodePoolAsExpectedConditionReason,
+			Type:               hyperv1.NodePoolAutoscalingEnabledConditionType,
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.NodePoolAsExpectedConditionReason,
+			ObservedGeneration: nodePool.Generation,
 		})
 
 		machineDeployment.Annotations[autoscalerMaxAnnotation] = "0"
@@ -962,11 +792,198 @@ func (r *NodePoolReconciler) reconcileMachineHealthCheck(mhc *capiv1.MachineHeal
 	return nil
 }
 
-func hashStruct(o interface{}) string {
-	hash := fnv.New32a()
-	hash.Write([]byte(fmt.Sprintf("%v", o)))
-	intHash := hash.Sum32()
-	return fmt.Sprintf("%08x", intHash)
+func getAMI(nodePool *hyperv1.NodePool, region string, releaseImage *releaseinfo.ReleaseImage) (string, error) {
+	if nodePool.Spec.Platform.AWS.AMI != "" {
+		return nodePool.Spec.Platform.AWS.AMI, nil
+	}
+
+	return defaultNodePoolAMI(region, releaseImage)
+}
+
+func ignConfig(encodedCACert, encodedToken, endpoint string) ignitionapi.Config {
+	return ignitionapi.Config{
+		Ignition: ignitionapi.Ignition{
+			Version: "3.1.0",
+			Security: ignitionapi.Security{
+				TLS: ignitionapi.TLS{
+					CertificateAuthorities: []ignitionapi.Resource{
+						{
+							Source: k8sutilspointer.StringPtr(fmt.Sprintf("data:text/plain;base64,%s", encodedCACert)),
+						},
+					},
+				},
+			},
+			Config: ignitionapi.IgnitionConfig{
+				Merge: []ignitionapi.Resource{
+					{
+						Source: k8sutilspointer.StringPtr(fmt.Sprintf("https://%s/ignition", endpoint)),
+						HTTPHeaders: []ignitionapi.HTTPHeader{
+							{
+								Name:  "Authorization",
+								Value: k8sutilspointer.StringPtr(fmt.Sprintf("Bearer %s", encodedToken)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *NodePoolReconciler) getConfig(ctx context.Context, nodePool *hyperv1.NodePool) (string, error) {
+	if nodePool.Spec.Config == nil {
+		return "", nil
+	}
+
+	allConfigPlainText := ""
+	for _, config := range nodePool.Spec.Config {
+		configConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.Name,
+				Namespace: nodePool.Namespace,
+			},
+		}
+		if err := r.Get(ctx, ctrlclient.ObjectKeyFromObject(configConfigMap), configConfigMap); err != nil {
+			return "", fmt.Errorf("failed to get config ConfigMap: %w", err)
+		}
+		// TODO (alberto): validate ConfigMap ignition content here?
+		allConfigPlainText = allConfigPlainText + "\n---\n" + configConfigMap.Data[TokenSecretConfigKey]
+	}
+
+	return allConfigPlainText, nil
+}
+
+func (r *NodePoolReconciler) getReleaseImage(ctx context.Context, releaseImage string) (*releaseinfo.ReleaseImage, error) {
+	ReleaseImage, err := func(ctx context.Context) (*releaseinfo.ReleaseImage, error) {
+		ctx, span := r.tracer.Start(ctx, "image-lookup")
+		defer span.End()
+		lookupCtx, lookupCancel := context.WithTimeout(ctx, 1*time.Minute)
+		defer lookupCancel()
+		img, err := r.ReleaseProvider.Lookup(lookupCtx, releaseImage)
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up release image metadata: %w", err)
+		}
+		return img, nil
+	}(ctx)
+	return ReleaseImage, err
+}
+
+func isUpdatingVersion(nodePool *hyperv1.NodePool, targetVersion string) bool {
+	return targetVersion != nodePool.Status.Version
+}
+
+func isUpdatingConfig(nodePool *hyperv1.NodePool, targetConfigHash string) bool {
+	return targetConfigHash != nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfig]
+}
+
+func isAutoscalingEnabled(nodePool *hyperv1.NodePool) bool {
+	return nodePool.Spec.AutoScaling != nil
+}
+
+func validateAutoscaling(nodePool *hyperv1.NodePool) error {
+	if nodePool.Spec.NodeCount != nil && nodePool.Spec.AutoScaling != nil {
+		return fmt.Errorf("only one of nodePool.Spec.NodeCount or nodePool.Spec.AutoScaling can be set")
+	}
+
+	if nodePool.Spec.AutoScaling != nil {
+		max := nodePool.Spec.AutoScaling.Max
+		min := nodePool.Spec.AutoScaling.Min
+
+		if max == nil || min == nil {
+			return fmt.Errorf("max and min must be not nil. Max: %v, Min: %v", max, min)
+		}
+
+		if *max < *min {
+			return fmt.Errorf("max must be equal or greater than min. Max: %v, Min: %v", *max, *min)
+		}
+
+		if *max == 0 && *min == 0 {
+			return fmt.Errorf("max and min must be not zero. Max: %v, Min: %v", *max, *min)
+		}
+	}
+
+	return nil
+}
+
+func defaultNodePoolAMI(region string, releaseImage *releaseinfo.ReleaseImage) (string, error) {
+	// TODO: The architecture should be specified from the API
+	arch, foundArch := releaseImage.StreamMetadata.Architectures["x86_64"]
+	if !foundArch {
+		return "", fmt.Errorf("couldn't find OS metadata for architecture %q", "x64_64")
+	}
+
+	regionData, hasRegionData := arch.Images.AWS.Regions[region]
+	if !hasRegionData {
+		return "", fmt.Errorf("couldn't find AWS image for region %q", region)
+	}
+	if len(regionData.Image) == 0 {
+		return "", fmt.Errorf("release image metadata has no image for region %q", region)
+	}
+	return regionData.Image, nil
+}
+
+// MachineDeploymentComplete considers a MachineDeployment to be complete once all of its desired replicas
+// are updated and available, and no old machines are running.
+func MachineDeploymentComplete(deployment *capiv1.MachineDeployment) bool {
+	newStatus := &deployment.Status
+	return newStatus.UpdatedReplicas == *(deployment.Spec.Replicas) &&
+		newStatus.Replicas == *(deployment.Spec.Replicas) &&
+		newStatus.AvailableReplicas == *(deployment.Spec.Replicas) &&
+		newStatus.ObservedGeneration >= deployment.Generation
+}
+
+// GetHostedClusterByName finds and return a HostedCluster object using the specified params.
+func GetHostedClusterByName(ctx context.Context, c client.Client, namespace, name string) (*hyperv1.HostedCluster, error) {
+	hcluster := &hyperv1.HostedCluster{}
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	if err := c.Get(ctx, key, hcluster); err != nil {
+		return nil, err
+	}
+
+	return hcluster, nil
+}
+
+func (r *NodePoolReconciler) enqueueNodePoolsForHostedCluster(obj ctrlclient.Object) []reconcile.Request {
+	var result []reconcile.Request
+
+	hc, ok := obj.(*hyperv1.HostedCluster)
+	if !ok {
+		panic(fmt.Sprintf("Expected a HostedCluster but got a %T", obj))
+	}
+
+	nodePoolList := &hyperv1.NodePoolList{}
+	if err := r.List(context.Background(), nodePoolList); err != nil {
+		ctrl.LoggerFrom(context.Background()).Error(err, "Failed to list nodePools")
+		return result
+	}
+
+	// Requeue all NodePools matching the HostedCluster name.
+	for key := range nodePoolList.Items {
+		if nodePoolList.Items[key].Spec.ClusterName == hc.GetName() {
+			result = append(result,
+				reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&nodePoolList.Items[key])},
+			)
+		}
+	}
+
+	return result
+}
+
+func enqueueParentNodePool(obj ctrlclient.Object) []reconcile.Request {
+	var nodePoolName string
+	if obj.GetAnnotations() != nil {
+		nodePoolName = obj.GetAnnotations()[nodePoolAnnotation]
+	}
+	if nodePoolName == "" {
+		return []reconcile.Request{}
+	}
+	return []reconcile.Request{
+		{NamespacedName: hyperutil.ParseNamespacedName(nodePoolName)},
+	}
 }
 
 func (r *NodePoolReconciler) listAWSMachineTemplates(nodePool *hyperv1.NodePool) ([]capiaws.AWSMachineTemplate, error) {
@@ -984,4 +1001,96 @@ func (r *NodePoolReconciler) listAWSMachineTemplates(nodePool *hyperv1.NodePool)
 		}
 	}
 	return filtered, nil
+}
+
+func compress(content []byte) ([]byte, error) {
+	if len(content) == 0 {
+		return nil, nil
+	}
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	if _, err := gz.Write(content); err != nil {
+		return nil, fmt.Errorf("failed to compress content: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("compress closure failure %w", err)
+	}
+	return b.Bytes(), nil
+}
+
+func hashStruct(o interface{}) string {
+	hash := fnv.New32a()
+	hash.Write([]byte(fmt.Sprintf("%v", o)))
+	intHash := hash.Sum32()
+	return fmt.Sprintf("%08x", intHash)
+}
+
+// TODO (alberto) drop this deterministic naming logic and get the name for child MachineDeployment from the status/annotation/label?
+func generateName(infraName, clusterName, suffix string) string {
+	return getName(fmt.Sprintf("%s-%s", infraName, clusterName), suffix, 43)
+}
+
+// getName returns a name given a base ("deployment-5") and a suffix ("deploy")
+// It will first attempt to join them with a dash. If the resulting name is longer
+// than maxLength: if the suffix is too long, it will truncate the base name and add
+// an 8-character hash of the [base]-[suffix] string.  If the suffix is not too long,
+// it will truncate the base, add the hash of the base and return [base]-[hash]-[suffix]
+func getName(base, suffix string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
+	name := fmt.Sprintf("%s-%s", base, suffix)
+	if len(name) <= maxLength {
+		return name
+	}
+
+	// length of -hash-
+	baseLength := maxLength - 10 - len(suffix)
+
+	// if the suffix is too long, ignore it
+	if baseLength < 0 {
+		prefix := base[0:min(len(base), max(0, maxLength-9))]
+		// Calculate hash on initial base-suffix string
+		shortName := fmt.Sprintf("%s-%s", prefix, hashStruct(name))
+		return shortName[:min(maxLength, len(shortName))]
+	}
+
+	prefix := base[0:baseLength]
+	// Calculate hash on initial base-suffix string
+	return fmt.Sprintf("%s-%s-%s", prefix, hashStruct(base), suffix)
+}
+
+// max returns the greater of its 2 inputs
+func max(a, b int) int {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// min returns the lesser of its 2 inputs
+func min(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+// TODO(alberto): user core apimachinery func once we update deps to fetch
+// https://github.com/kubernetes/apimachinery/commit/f0c829d684eec47c6334ae69941224e1c70f16d6#diff-e3bc08d3d017ceff366d1c1c6f16c745e576e41f711a482a08f97006d306bf2a
+// RemoveStatusCondition removes the corresponding conditionType from conditions.
+// conditions must be non-nil.
+func RemoveStatusCondition(conditions *[]metav1.Condition, conditionType string) {
+	if conditions == nil || len(*conditions) == 0 {
+		return
+	}
+
+	newConditions := make([]metav1.Condition, 0, len(*conditions)-1)
+	for _, condition := range *conditions {
+		if condition.Type != conditionType {
+			newConditions = append(newConditions, condition)
+		}
+	}
+
+	*conditions = newConditions
 }


### PR DESCRIPTION
Refactor NodePool controller

This PR is a first step to refactor the NodePool controller:
- Encapsulate subsets of logic into cohesive funcs to be unit tested.
- Reduce the lines of reconcile() for readibility.
- Similar to the HostedCluster controller it splits reconcile() (and fail early) into 1 - Reconcile conditions with current state of the world, 2 - reconcile towards expected state of the world.
- Fixed left over Failure conditions which are now cleaned up.
- Fixed RemoveStatusCondition, it was broken so it's duplicated until we update API machinery dep.
- Fixed logging to be consistent and not be redundant.
- Fixed an issue with MachineSets were failing to scale down during Rolling upgrades triggered by version updates that requierd a new bootstrap AMI and generated a new awstemplate.
- Pass MachineTemplate in a provider agnostic way to reconcileMachineDeployment.

Follow up:
tests, tests, tests...

/hold
needs
https://github.com/openshift/hypershift/pull/320
https://github.com/openshift/hypershift/pull/331
