### PR TITLE
Fix version reporting in control plane upgrades and add e2e tests

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -314,17 +314,6 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
 	}
 
-	if hostedControlPlane.Status.Version == "" {
-		lookupCtx, lookupCancel := context.WithTimeout(ctx, 2*time.Minute)
-		defer lookupCancel()
-		releaseImage, err := r.ReleaseProvider.Lookup(lookupCtx, hostedControlPlane.Spec.ReleaseImage)
-		if err != nil {
-			r.Log.Error(err, "failed to look up release image metadata")
-		} else {
-			hostedControlPlane.Status.Version = releaseImage.Version()
-		}
-	}
-
 	if hostedControlPlane.Spec.KubeConfig != nil {
 		hostedControlPlane.Status.KubeConfig = hostedControlPlane.Spec.KubeConfig
 	} else {
@@ -341,6 +330,14 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// state of any of the managed components. It's basically a placeholder to prove
 	// the orchestration of upgrades works at all.
 	if hostedControlPlane.Status.ReleaseImage != hostedControlPlane.Spec.ReleaseImage {
+		lookupCtx, lookupCancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer lookupCancel()
+		releaseImage, err := r.ReleaseProvider.Lookup(lookupCtx, hostedControlPlane.Spec.ReleaseImage)
+		if err != nil {
+			r.Log.Error(err, "failed to look up release image metadata")
+		} else {
+			hostedControlPlane.Status.Version = releaseImage.Version()
+		}
 		hostedControlPlane.Status.ReleaseImage = hostedControlPlane.Spec.ReleaseImage
 		now := metav1.NewTime(time.Now())
 		hostedControlPlane.Status.LastReleaseImageTransitionTime = &now

--- a/test/e2e/scenarios/create_cluster.go
+++ b/test/e2e/scenarios/create_cluster.go
@@ -94,6 +94,6 @@ func TestCreateCluster(ctx context.Context, o TestCreateClusterOptions) func(t *
 
 		e2eutil.WaitForReadyNodes(t, ctx, guestClient, nodepool)
 
-		e2eutil.WaitForReadyClusterOperators(t, ctx, guestClient, hostedCluster)
+		e2eutil.WaitForClusterOperators(t, ctx, guestClient, hostedCluster, e2eutil.OperatorIsReady())
 	}
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -223,7 +223,9 @@ func WaitForReadyNodes(t *testing.T, ctx context.Context, client crclient.Client
 	log.Info("all nodes for nodepool appear to be ready", "count", int(*nodePool.Spec.NodeCount), "namespace", nodePool.Namespace, "name", nodePool.Name)
 }
 
-func WaitForReadyClusterOperators(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+type WaitForOperatorPredicate func(operator *configv1.ClusterOperator) bool
+
+func WaitForClusterOperators(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, predicates ...WaitForOperatorPredicate) {
 	g := NewWithT(t)
 
 	log.Info("waiting for hostedcluster operators to become ready", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name)
@@ -239,26 +241,10 @@ func WaitForReadyClusterOperators(t *testing.T, ctx context.Context, client crcl
 		}
 		ready := true
 		for _, clusterOperator := range clusterOperators.Items {
-			available := false
-			degraded := true
-			for _, cond := range clusterOperator.Status.Conditions {
-				if cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionTrue {
-					available = true
+			for _, passes := range predicates {
+				if !passes(&clusterOperator) {
+					ready = false
 				}
-				if cond.Type == configv1.OperatorDegraded && cond.Status == configv1.ConditionFalse {
-					degraded = false
-				}
-				// TODO: This is a bug in the console operator where it doesn't do its route
-				// health check periodically https://bugzilla.redhat.com/show_bug.cgi?id=1945326
-				// Fortunately, the ingress operator also does a canary route check that ensures
-				// that direct ingress is working so we still have coverage.
-				if clusterOperator.GetName() == "console" {
-					degraded = false
-				}
-			}
-			if !available || degraded {
-				ready = false
-				break
 			}
 		}
 		if !ready {
@@ -270,6 +256,49 @@ func WaitForReadyClusterOperators(t *testing.T, ctx context.Context, client crcl
 	g.Expect(err).NotTo(HaveOccurred(), "failed to ensure guest cluster operators became ready")
 
 	log.Info("all cluster operators for hostedcluster appear to be ready", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name)
+}
+
+func OperatorIsReady() func(operator *configv1.ClusterOperator) bool {
+	return func(operator *configv1.ClusterOperator) bool {
+		available := false
+		degraded := true
+		for _, cond := range operator.Status.Conditions {
+			if cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionTrue {
+				available = true
+			}
+			if cond.Type == configv1.OperatorDegraded && cond.Status == configv1.ConditionFalse {
+				degraded = false
+			}
+			// TODO: This is a bug in the console operator where it doesn't do its route
+			// health check periodically https://bugzilla.redhat.com/show_bug.cgi?id=1945326
+			// Fortunately, the ingress operator also does a canary route check that ensures
+			// that direct ingress is working so we still have coverage.
+			if operator.Name == "console" {
+				degraded = false
+			}
+		}
+		matched := available && !degraded
+		if !matched {
+			log.Info("OperatorIsReady", "operator", operator.Name, "available", available, "degraded", degraded)
+		}
+		return matched
+	}
+}
+
+func OperatorAtVersion(version string) func(operator *configv1.ClusterOperator) bool {
+	return func(operator *configv1.ClusterOperator) bool {
+		matched := false
+		for _, actual := range operator.Status.Versions {
+			if actual.Name == "operator" && actual.Version == version {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			log.Info("OperatorAtVersion", "matched", matched, "version", version, "operator", operator.Name, "matched", matched, "versions", operator.Status.Versions)
+		}
+		return matched
+	}
 }
 
 func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, image string) {


### PR DESCRIPTION
Before this commit, the version of the hostedcluster's release image was
persisted exactly once for the life of the hostedcluster, causing the version to
be misreported following a rollout to a new release image.

The root cause of the problem is a bug in the control plane operator which
causes the hostedcontrolplane controller to only ever update the version on
status if it was never set before.

This commit fixes the problem by ensuring the version on hostedcontrolplane
status is updated atomically along with the corresponding release image driving
the rollout.

This commit also introduces expanded e2e test coverage for upgrades to perform
deeper inspections of the cluster operator and hosted cluster versions to assert
the versions eventually converge following an upgrade.

Note: The cluster operator version assertions in particular are probably not
appropriate to assert directly in the tests and instead should probably be
considered by the control plane operator and rolled up into availability/upgrade
status later on. Then, the tests could rely on condition checks to understand
when the operators are ready instead of probing the guest api server (which I
believe is a layering violation.).

In the meantime, these tests are better than nothing and caught the bug.
