### PR TITLE
Create a separate oauth server serving cert

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1056,6 +1056,16 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		return fmt.Errorf("failed to reconcile ingress cert secret: %w", err)
 	}
 
+	// OAuth server Cert
+	// For default installs, this is the same as the Ingress Cert because of the console's
+	// assumption that the oauth server is behind the default ingress controller.
+	oauthServerCert := manifests.OpenShiftOAuthServerCert(hcp.Namespace)
+	if _, err := controllerutil.CreateOrUpdate(ctx, r, oauthServerCert, func() error {
+		return p.ReconcileOAuthServerCert(oauthServerCert, ingressCert, rootCASecret)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile oauth cert secret: %w", err)
+	}
+
 	// MCS Cert
 	machineConfigServerCert := manifests.MachineConfigServerCert(hcp.Namespace)
 	if _, err := controllerutil.CreateOrUpdate(ctx, r, machineConfigServerCert, func() error {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -203,6 +203,15 @@ func IngressCert(ns string) *corev1.Secret {
 	}
 }
 
+func OpenShiftOAuthServerCert(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oauth-server-crt",
+			Namespace: ns,
+		},
+	}
+}
+
 func MachineConfigServerCert(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -132,7 +132,7 @@ func oauthVolumeServingCert() *corev1.Volume {
 
 func buildOAuthVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.IngressCert("").Name,
+		SecretName: manifests.OpenShiftOAuthServerCert("").Name,
 	}
 }
 func oauthVolumeSessionSecret() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ingress.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ingress.go
@@ -16,3 +16,9 @@ func (p *PKIParams) ReconcileIngressCert(secret, ca *corev1.Secret) error {
 	ingressHostNames = append(ingressHostNames, fmt.Sprintf("*.%s", p.IngressSubdomain))
 	return p.reconcileSignedCertWithAddresses(secret, ca, "openshift-ingress", "openshift", X509DefaultUsage, X509UsageClientServerAuth, ingressHostNames, ingressNumericIPs)
 }
+
+func (p *PKIParams) ReconcileOAuthServerCert(secret, sourceSecret, ca *corev1.Secret) error {
+	secret.Data = sourceSecret.Data
+	AnnotateWithCA(secret, ca)
+	return nil
+}


### PR DESCRIPTION
What this does: Adds a new PKI serving cert for the openshift oauth
server. By default, it duplicates the content of the ingress cert.

Why is it needed: For ROKS in which their own certs are generated, the
oauth serving cert should not be synced into the guest cluster like we
do with the ingress cert. This allows them to generate separate certs
for each. The reason we use the same cert by default as the ingress cert
is that the console validates its connection to the oauth server using
the default ingress cert. There is no setting on the console to use a
different cert.