### PR TITLE
Move core ign config into NodeNool controller

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/imagecontentsource.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/imagecontentsource.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	IgnitionConfigKey           = "data"
-	CoreIgnitionFieldLabelKey   = "ignition-config"
+	CoreIgnitionFieldLabelKey   = "hypershift.openshift.io/core-ignition-config"
 	CoreIgnitionFieldLabelValue = "true"
 )
 

--- a/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
@@ -138,9 +138,9 @@ kind: ConfigMap
 metadata:
   name: {{ .name }}
   labels:
-    ignition-config: "true"
+    hypershift.openshift.io/core-ignition-config: "true"
 data:
-  data: |-
+  config: |-
 {{ indent 4 .content }}
 `
 

--- a/ignition-server/controllers/machineconfigserver_ignitionprovider.go
+++ b/ignition-server/controllers/machineconfigserver_ignitionprovider.go
@@ -213,14 +213,6 @@ cp /assets/manifests/*.machineconfigpool.yaml /mcc-manifests/bootstrap/manifests
 	)
 
 	customMachineConfigArg := `
-cat <<"EOF" > "./copy-ignition-config.sh"
-#!/bin/bash
-set -eo pipefail
-name="${1}"
-oc get cm ${name} -n "${NAMESPACE}" -o jsonpath='{ .data.data }' > "/mcc-manifests/bootstrap/manifests/${name/#ignition-config-//}.yaml"
-EOF
-chmod +x ./copy-ignition-config.sh
-oc get cm -l ignition-config="true" -n "${NAMESPACE}" --no-headers | awk '{ print $1 }' | xargs -n1 ./copy-ignition-config.sh
 cat /tmp/custom-config/base64CompressedConfig | base64 -d | gunzip --force --stdout > /mcc-manifests/bootstrap/manifests/custom.yaml`
 
 	return &corev1.Pod{


### PR DESCRIPTION
This drops the pod bash hack in favour of putting the logic to fetch the core ignition config in the NodePool controller.
This makes the process and validation consistent fo any config, custom and core.