### PR TITLE
Fix reconciliation of openshift controller manager service ca manifest

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1627,7 +1627,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftControllerManager(ctx c
 
 	workerServiceCA := manifests.OpenShiftControllerManagerServiceCAWorkerManifest(hcp.Namespace)
 	if _, err := controllerutil.CreateOrUpdate(ctx, r, workerServiceCA, func() error {
-		return ocm.ReconcileOpenShiftControllerManagerNamespaceWorkerManifest(workerServiceCA, p.OwnerRef)
+		return ocm.ReconcileOpenShiftControllerManagerServiceCAWorkerManifest(workerServiceCA, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift controller manager worker service ca: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/serviceca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/serviceca.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/util"
 )
 
-func ReconcileOpenShiftControllerManagerServiceCAWorkerManifest(cm *corev1.ConfigMap, ownerRef *config.OwnerRef) error {
+func ReconcileOpenShiftControllerManagerServiceCAWorkerManifest(cm *corev1.ConfigMap, ownerRef config.OwnerRef) error {
 	ownerRef.ApplyTo(cm)
 	serviceCA := manifests.OpenShiftControllerManagerServiceCA()
 	reconcileServiceCA(serviceCA)


### PR DESCRIPTION
Fixes a bug introduced with the refactoring of the openshift controller manager where the service CA for the openshift controller manager is not getting reconciled