### PR TITLE
Add validating webhook for HostedClusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ FROM quay.io/openshift/origin-base:4.7
 COPY --from=builder /hypershift/bin/ignition-server /usr/bin/ignition-server
 COPY --from=builder /hypershift/bin/hypershift /usr/bin/hypershift
 COPY --from=builder /hypershift/bin/hypershift-operator /usr/bin/hypershift-operator
+COPY --from=builder /hypershift/bin/hypershift-webhook /usr/bin/hypershift-webhook
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/hosted-cluster-config-operator /usr/bin/hosted-cluster-config-operator
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 
 all: build e2e
 
-build: ignition-server hypershift-operator control-plane-operator hosted-cluster-config-operator hypershift
+build: ignition-server hypershift-operator hypershift-webhook control-plane-operator hosted-cluster-config-operator hypershift
 
 .PHONY: verify
 verify: deps api fmt vet
@@ -42,6 +42,11 @@ ignition-server:
 .PHONY: hypershift-operator
 hypershift-operator:
 	$(GO_BUILD_RECIPE) -o bin/hypershift-operator ./hypershift-operator
+
+# Build hypershift-webhook binary
+.PHONY: hypershift-webhook
+hypershift-webhook:
+	$(GO_BUILD_RECIPE) -o bin/hypershift-webhook ./hypershift-webhook
 
 .PHONY: control-plane-operator
 control-plane-operator:

--- a/api/v1alpha1/hostedcluster_webhook.go
+++ b/api/v1alpha1/hostedcluster_webhook.go
@@ -1,0 +1,56 @@
+package v1alpha1
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var log = ctrl.Log.WithName("hostedcluster")
+
+func (r *HostedCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+var _ webhook.Validator = &HostedCluster{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *HostedCluster) ValidateCreate() error {
+	log.Info("validate create", "name", r.Name)
+	return r.validateHostedCluster()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *HostedCluster) ValidateUpdate(old runtime.Object) error {
+	log.Info("validate update", "name", r.Name)
+	return r.validateHostedCluster()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *HostedCluster) ValidateDelete() error {
+	log.Info("validate delete", "name", r.Name)
+	return nil
+}
+
+func (r *HostedCluster) validateHostedCluster() error {
+	var allErrs field.ErrorList
+	if err := r.validateFIPS(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "hypershift.openshift.io", Kind: "HostedCluster"},
+		r.Name, allErrs)
+}
+
+func (r *HostedCluster) validateFIPS() *field.Error {
+	return nil
+}

--- a/cmd/install/assets/hypershift_webhook.go
+++ b/cmd/install/assets/hypershift_webhook.go
@@ -1,0 +1,301 @@
+package assets
+
+import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type HyperShiftWebhookDeployment struct {
+	Namespace      *corev1.Namespace
+	OperatorImage  string
+	ServiceAccount *corev1.ServiceAccount
+	Replicas       int32
+}
+
+func (o HyperShiftWebhookDeployment) Build() *appsv1.Deployment {
+	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook",
+			Namespace: o.Namespace.Name,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &o.Replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": "webhook",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name": "webhook",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: o.ServiceAccount.Name,
+					Containers: []corev1.Container{
+						{
+							Name:            "webhook",
+							Image:           o.OperatorImage,
+							ImagePullPolicy: corev1.PullAlways,
+							Command:         []string{"/usr/bin/hypershift-webhook"},
+							Args:            []string{"start"},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "webhook",
+									ContainerPort: 6443,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "metrics",
+									ContainerPort: 8080,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "serving-cert",
+									MountPath: "/var/run/secrets/serving-cert",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "serving-cert",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "webhook-serving-cert",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return deployment
+}
+
+type HyperShiftWebhookService struct {
+	Namespace *corev1.Namespace
+}
+
+func (o HyperShiftWebhookService) Build() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace.Name,
+			Name:      "webhook",
+			Annotations: map[string]string{
+				"prometheus.io/port":                                 "443",
+				"prometheus.io/scheme":                               "https",
+				"prometheus.io/scrape":                               "true",
+				"service.beta.openshift.io/serving-cert-secret-name": "webhook-serving-cert",
+			},
+			Labels: map[string]string{
+				"name": "webhook",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				"name": "webhook",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "webhook",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       443,
+					TargetPort: intstr.FromString("webhook"),
+				},
+				{
+					Name:       "metrics",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8080,
+					TargetPort: intstr.FromString("metrics"),
+				},
+			},
+		},
+	}
+}
+
+type HyperShiftWebhookServiceAccount struct {
+	Namespace *corev1.Namespace
+}
+
+func (o HyperShiftWebhookServiceAccount) Build() *corev1.ServiceAccount {
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace.Name,
+			Name:      "webhook",
+		},
+	}
+	return sa
+}
+
+type HyperShiftWebhookRole struct {
+	Namespace *corev1.Namespace
+}
+
+func (o HyperShiftWebhookRole) Build() *rbacv1.Role {
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Role",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace.Name,
+			Name:      "hypershift-webhook",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"hypershift.openshift.io"},
+				Resources: []string{
+					"hostedcluster",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+		},
+	}
+	return role
+}
+
+type HyperShiftWebhookRoleBinding struct {
+	Role           *rbacv1.Role
+	ServiceAccount *corev1.ServiceAccount
+}
+
+func (o HyperShiftWebhookRoleBinding) Build() *rbacv1.RoleBinding {
+	binding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.ServiceAccount.Namespace,
+			Name:      "hypershift-webhook",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     o.Role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      o.ServiceAccount.Name,
+				Namespace: o.ServiceAccount.Namespace,
+			},
+		},
+	}
+	return binding
+}
+
+type HyperShiftValidatingWebhookConfiguration struct {
+	Namespace *corev1.Namespace
+}
+
+func (o HyperShiftValidatingWebhookConfiguration) Build() *admissionregistrationv1.ValidatingWebhookConfiguration {
+	scope := admissionregistrationv1.NamespacedScope
+	path := "/validate-hypershift-openshift-io-v1alpha1-hostedcluster"
+	sideEffects := admissionregistrationv1.SideEffectClassNone
+	timeout := int32(10)
+	validatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ValidatingWebhookConfiguration",
+			APIVersion: admissionregistrationv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace.Name,
+			Name:      "hypershift.openshift.io",
+			Annotations: map[string]string{
+				"service.beta.openshift.io/inject-cabundle": "true",
+			},
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name: "hostedclusters.hypershift.openshift.io",
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Create,
+							admissionregistrationv1.Update,
+						},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{"hypershift.openshift.io"},
+							APIVersions: []string{"v1alpha1"},
+							Resources:   []string{"hostedclusters"},
+							Scope:       &scope,
+						},
+					},
+				},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: "hypershift",
+						Name:      "webhook",
+						Path:      &path,
+					},
+				},
+				SideEffects:             &sideEffects,
+				AdmissionReviewVersions: []string{"v1"},
+				TimeoutSeconds:          &timeout,
+			},
+		},
+	}
+	return validatingWebhookConfiguration
+}
+
+type HyperShiftWebhookServiceMonitor struct {
+	Namespace *corev1.Namespace
+}
+
+func (o HyperShiftWebhookServiceMonitor) Build() *unstructured.Unstructured {
+	serviceMonitorJSON := `
+{
+   "apiVersion": "monitoring.coreos.com/v1",
+   "kind": "ServiceMonitor",
+   "metadata": {
+      "name": "webhook"
+   },
+   "spec": {
+      "endpoints": [
+         {
+            "interval": "30s",
+            "port": "metrics"
+         }
+      ],
+      "jobLabel": "component",
+      "selector": {
+         "matchLabels": {
+            "name": "webhook"
+         }
+      }
+   }
+}
+`
+	obj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, []byte(serviceMonitorJSON))
+	if err != nil {
+		panic(err)
+	}
+	sm := obj.(*unstructured.Unstructured)
+	sm.SetNamespace(o.Namespace.Name)
+	return sm
+}

--- a/hypershift-webhook/main.go
+++ b/hypershift-webhook/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	hyperapi "github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+func main() {
+	cmd := &cobra.Command{
+		Use: "webhook",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+	cmd.AddCommand(NewStartCommand())
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+type Options struct {
+	Namespace string
+	CertDir   string
+}
+
+func NewStartCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Starts the Hypershift webhook",
+	}
+
+	opts := Options{
+		Namespace: "hypershift",
+		CertDir:   "/var/run/secrets/serving-cert",
+	}
+
+	cmd.Flags().StringVar(&opts.CertDir, "cert-dir", opts.CertDir, "Path to the serving key and cert")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		if err := run(ctx, opts); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	return cmd
+}
+
+func run(ctx context.Context, opts Options) error {
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Port:      6443,
+		CertDir:   opts.CertDir,
+		Scheme:    hyperapi.Scheme,
+		Namespace: "hypershift",
+	})
+	if err != nil {
+		return fmt.Errorf("unable to start manager: %w", err)
+	}
+
+	if err = (&hyperv1.HostedCluster{}).SetupWebhookWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller: %w", err)
+	}
+
+	return mgr.Start(ctx)
+}


### PR DESCRIPTION
This PR adds a new webhook binary to the hypershift image and creates the resources needed for carrying out admission-time validation of `HostedCluster` resources.

`hypershift install` now creates the following new resources in the `hypershift` namespace in the management cluster
```
ServiceAccount hypershift/webhook
Role hypershift/hypershift-webhook
RoleBinding hypershift/hypershift-webhook
Deployment hypershift/webhook
Service hypershift/webhook
ServiceMonitor hypershift/webhook
ValidatingWebhookConfiguration /hypershift.openshift.io
```

Currently the webhook does no validation.  This PR just gets the webhook in place for future functionality.

@csrwng