### PR TITLE
add resource requests and enhance livliness probe to issue https request

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/kube-apiserver-proxy.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/apiserver-haproxy/kube-apiserver-proxy.yaml
@@ -13,15 +13,29 @@ spec:
     priorityClassName: system-node-critical
     securityContext:
       runAsUser: 1001
+    resources:
+      limits:
+        cpu: 300m
+        memory: 512M
+      requests:
+        cpu: 13m
+        memory: 16M
     livenessProbe:
       failureThreshold: 3
       initialDelaySeconds: 120
       periodSeconds: 120
       successThreshold: 1
-      tcpSocket:
+      httpGet:
+        path: /version
+        scheme: HTTPS
         host: {{ .ExternalAPIAddress }}
         port: {{ .InternalAPIPort }}
       timeoutSeconds: 60
+    ports:
+    - containerPort: {{ .InternalAPIPort }}
+      hostPort: {{ .InternalAPIPort }}
+      protocol: TCP
+      name: apiserver
     command:
     - haproxy
     - -f


### PR DESCRIPTION
The port addition prevents the corner case where if a user tries to schedule a HostPort pod/daemonset and it adding conflicting ip table rules that will intercept all traffic from the apiserver pod, bringing down the node. 