### PR TITLE
default to emptyDir image registry storage for platform None

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/registry/cluster-imageregistry-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/registry/cluster-imageregistry-config.yaml
@@ -24,4 +24,9 @@ spec:
       maxInQueue: 0
       maxRunning: 0
       maxWaitInQueue: 0s
+{{- if eq .PlatformType "None" }}
+  storage:
+    emptyDir: {}
+{{- else }}
   storage: {}
+{{- end }}


### PR DESCRIPTION
@csrwng 

https://github.com/openshift/hypershift/pull/187 removed the emptyDir storage for image registry config so that the registry operator would configure storage appropriate for the platform.

However, for platform `None`, image-registry just deploys in a degraded state.

This PR configures emptyDir storage when for platform `None`.  After this PR, guest cluster deployment on baremetal workers works OOTB.