### PR TITLE
Add pull secret to release info provider interface

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -137,7 +137,8 @@ func NewStartCommand() *cobra.Command {
 		releaseProvider := &releaseinfo.StaticProviderDecorator{
 			Delegate: &releaseinfo.CachedProvider{
 				Inner: &releaseinfo.PodProvider{
-					Pods: kubeClient.CoreV1().Pods(namespace),
+					Pods:    kubeClient.CoreV1().Pods(namespace),
+					Secrets: kubeClient.CoreV1().Secrets(namespace),
 				},
 				Cache: map[string]*releaseinfo.ReleaseImage{},
 			},

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -172,7 +172,8 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		Client: mgr.GetClient(),
 		ReleaseProvider: &releaseinfo.CachedProvider{
 			Inner: &releaseinfo.PodProvider{
-				Pods: kubeClient.CoreV1().Pods(opts.Namespace),
+				Pods:    kubeClient.CoreV1().Pods(opts.Namespace),
+				Secrets: kubeClient.CoreV1().Secrets(opts.Namespace),
 			},
 			Cache: map[string]*releaseinfo.ReleaseImage{},
 		},

--- a/ignition-server/main.go
+++ b/ignition-server/main.go
@@ -118,13 +118,15 @@ func payloadStoreReconciler(ctx context.Context) error {
 		return fmt.Errorf("unable to create kube client: %w", err)
 	}
 
+	namespace := os.Getenv(namespaceEnvVariableName)
 	if err = (&controllers.TokenSecretReconciler{
 		Client:       mgr.GetClient(),
 		PayloadStore: payloadStore,
 		IgnitionProvider: &controllers.MCSIgnitionProvider{
 			ReleaseProvider: &releaseinfo.CachedProvider{
 				Inner: &releaseinfo.PodProvider{
-					Pods: kubeClient.CoreV1().Pods(os.Getenv(namespaceEnvVariableName)),
+					Pods:    kubeClient.CoreV1().Pods(namespace),
+					Secrets: kubeClient.CoreV1().Secrets(namespace),
 				},
 				Cache: map[string]*releaseinfo.ReleaseImage{},
 			},

--- a/releaseinfo/cached_provider.go
+++ b/releaseinfo/cached_provider.go
@@ -18,7 +18,7 @@ type CachedProvider struct {
 	once sync.Once
 }
 
-func (p *CachedProvider) Lookup(ctx context.Context, image string) (releaseImage *ReleaseImage, err error) {
+func (p *CachedProvider) Lookup(ctx context.Context, image string, pullSecret []byte) (releaseImage *ReleaseImage, err error) {
 	// Purge the cache every once in a while as a simple leak mitigation
 	p.once.Do(func() {
 		go func() {
@@ -40,7 +40,7 @@ func (p *CachedProvider) Lookup(ctx context.Context, image string) (releaseImage
 	if entry, ok := p.Cache[image]; ok {
 		return entry, nil
 	}
-	entry, err := p.Inner.Lookup(ctx, image)
+	entry, err := p.Inner.Lookup(ctx, image, pullSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/releaseinfo/pod_provider.go
+++ b/releaseinfo/pod_provider.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var _ Provider = (*PodProvider)(nil)
@@ -22,10 +24,40 @@ var _ Provider = (*PodProvider)(nil)
 // using the image and extracting the serialized ImageStream from the image
 // filesystem assumed to be present at /release-manifests/image-references.
 type PodProvider struct {
-	Pods v1.PodInterface
+	Pods    v1.PodInterface
+	Secrets v1.SecretInterface
 }
 
-func (p *PodProvider) Lookup(ctx context.Context, image string) (releaseImage *ReleaseImage, err error) {
+func (p *PodProvider) Lookup(ctx context.Context, image string, pullSecret []byte) (releaseImage *ReleaseImage, err error) {
+	log := ctrl.LoggerFrom(ctx, "image-lookup", image)
+
+	if len(image) == 0 {
+		return nil, fmt.Errorf("image pull reference is blank, a value is required")
+	}
+	if len(pullSecret) == 0 {
+		return nil, fmt.Errorf("pull secret is empty, a value is required")
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "image-lookup",
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: pullSecret,
+		},
+	}
+	secret, err = p.Secrets.Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create image lookup pull secret: %w", err)
+	}
+	defer func() {
+		err := p.Secrets.Delete(ctx, secret.Name, metav1.DeleteOptions{})
+		if err != nil {
+			log.Error(err, "failed to delete secret used for image lookup", "name", secret.Name, "namespace", secret.Namespace)
+		}
+	}()
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "image-lookup",
@@ -44,18 +76,23 @@ func (p *PodProvider) Lookup(ctx context.Context, image string) (releaseImage *R
 					Command: []string{"/usr/bin/cat", "/release-manifests/0000_50_installer_coreos-bootimages.yaml"},
 				},
 			},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{
+					Name: secret.Name,
+				},
+			},
 		},
 	}
 
 	// Launch the pod and ensure we clean up regardless of outcome
-	pod, err = p.Pods.Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err = p.Pods.Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create image lookup pod: %w", err)
 	}
 	defer func() {
 		err := p.Pods.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 		if err != nil {
-			err = fmt.Errorf("failed to delete image lookup pod %q: %w", pod.Name, err)
+			log.Error(err, "failed to delete image lookup pod", "name", pod.Name, "namespace", pod.Namespace)
 		}
 	}()
 

--- a/releaseinfo/releaseinfo.go
+++ b/releaseinfo/releaseinfo.go
@@ -17,7 +17,7 @@ import (
 // Provider knows how to find the release image metadata for an image referred
 // to by its pullspec.
 type Provider interface {
-	Lookup(ctx context.Context, image string) (*ReleaseImage, error)
+	Lookup(ctx context.Context, image string, pullSecret []byte) (*ReleaseImage, error)
 }
 
 // ReleaseImage wraps an ImageStream with some utilities that help the user

--- a/releaseinfo/static_provider.go
+++ b/releaseinfo/static_provider.go
@@ -21,11 +21,11 @@ type StaticProviderDecorator struct {
 	lock sync.Mutex
 }
 
-func (p *StaticProviderDecorator) Lookup(ctx context.Context, image string) (*ReleaseImage, error) {
+func (p *StaticProviderDecorator) Lookup(ctx context.Context, image string, pullSecret []byte) (*ReleaseImage, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	releaseImage, err := p.Delegate.Lookup(ctx, image)
+	releaseImage, err := p.Delegate.Lookup(ctx, image, pullSecret)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently the releaseinfo provider interface only takes an image name to
lookup release info. However, we should be using the pull secret that
was provided for that release to pull the image. This commit adds a
pull secret parameter to the provider lookup function and updates the
implementation of pod provider to use the pull secret.