### PR TITLE
Prefer to colocate control plane components by default

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -27,7 +27,6 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalCon
 		APIServer: globalConfig.APIServer,
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
-		AdditionalLabels: map[string]string{},
 		Scheduling: config.Scheduling{
 			PriorityClass: DefaultPriorityClass,
 		},
@@ -40,6 +39,7 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalCon
 			},
 		},
 	}
+	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(clusterPolicyControllerLabels)
 
 	switch hcp.Spec.ControllerAvailabilityPolicy {

--- a/control-plane-operator/controllers/hostedcontrolplane/config/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/config/deployment.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +36,50 @@ func (c *DeploymentConfig) SetMultizoneSpread(labels map[string]string) {
 				},
 			},
 		}
+}
+
+const colocationLabelKey = "hypershift.openshift.io/hosted-control-plane"
+
+func colocationLabel(hcp *hyperv1.HostedControlPlane) string {
+	return fmt.Sprintf("%s-%s", hcp.Namespace, hcp.Name)
+}
+
+// SetColocationAnchor sets labels on the deployment to establish pods of this
+// deployment as an anchor for other pods associated with hcp using pod affinity.
+func (c *DeploymentConfig) SetColocationAnchor(hcp *hyperv1.HostedControlPlane) {
+	if c.AdditionalLabels == nil {
+		c.AdditionalLabels = map[string]string{}
+	}
+	c.AdditionalLabels[colocationLabelKey] = colocationLabel(hcp)
+}
+
+// SetColocation sets labels and affinity rules for this deployment so that pods
+// of the deployment will prefer to group with pods of the anchor deployment as
+// established by SetColocationAnchor.
+func (c *DeploymentConfig) SetColocation(hcp *hyperv1.HostedControlPlane) {
+	if c.Scheduling.Affinity == nil {
+		c.Scheduling.Affinity = &corev1.Affinity{}
+	}
+	if c.Scheduling.Affinity.PodAffinity == nil {
+		c.Scheduling.Affinity.PodAffinity = &corev1.PodAffinity{}
+	}
+	if c.AdditionalLabels == nil {
+		c.AdditionalLabels = map[string]string{}
+	}
+	c.AdditionalLabels[colocationLabelKey] = colocationLabel(hcp)
+	c.Scheduling.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.WeightedPodAffinityTerm{
+		{
+			Weight: 100,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						colocationLabelKey: colocationLabel(hcp),
+					},
+				},
+				TopologyKey: corev1.LabelHostname,
+			},
+		},
+	}
 }
 
 func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -46,6 +46,7 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *E
 		},
 	}
 	p.EtcdDeploymentConfig.SetMultizoneSpread(etcdLabels)
+	p.EtcdDeploymentConfig.SetColocationAnchor(hcp)
 	p.OperatorDeploymentConfig.Replicas = 1
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -95,7 +95,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	default:
 		params.EtcdURL = config.DefaultEtcdURL
 	}
-	params.AdditionalLabels = map[string]string{}
 	params.Scheduling = config.Scheduling{
 		PriorityClass: config.DefaultPriorityClass,
 	}
@@ -139,6 +138,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			},
 		},
 	}
+	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(kasLabels)
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -45,7 +45,6 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 		ServiceCIDR:    hcp.Spec.ServiceCIDR,
 		PodCIDR:        hcp.Spec.PodCIDR,
 	}
-	params.AdditionalLabels = map[string]string{}
 	params.Scheduling = config.Scheduling{
 		PriorityClass: DefaultPriorityClass,
 	}
@@ -89,6 +88,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 			},
 		},
 	}
+	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(kcmLabels)
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -40,6 +40,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 		},
 	}
 	p.ServerDeploymentConfig.Replicas = 1
+	p.ServerDeploymentConfig.SetColocation(hcp)
 	p.ServerDeploymentConfig.SetMultizoneSpread(konnectivityServerLabels)
 	p.AgentDeploymentConfig.Resources = config.ResourcesSpec{
 		konnectivityAgentContainer().Name: {

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -42,7 +42,6 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 		IngressSubDomain:        config.IngressSubdomain(hcp),
 	}
 	params.OpenShiftAPIServerDeploymentConfig = config.DeploymentConfig{
-		AdditionalLabels: map[string]string{},
 		Scheduling: config.Scheduling{
 			PriorityClass: DefaultPriorityClass,
 		},
@@ -131,6 +130,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 			},
 		},
 	}
+	params.OpenShiftOAuthAPIServerDeploymentConfig.SetColocation(hcp)
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetMultizoneSpread(openShiftOAuthAPIServerLabels)
 	switch hcp.Spec.Etcd.ManagementType {
 	case hyperv1.Unmanaged:

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -2,7 +2,6 @@ package oauth
 
 import (
 	"context"
-
 	"encoding/json"
 	"strings"
 
@@ -89,6 +88,7 @@ func NewOAuthServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, 
 		},
 	}
 	p.DeploymentConfig.SetMultizoneSpread(oauthServerLabels)
+	p.DeploymentConfig.SetColocation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		p.Replicas = 3

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -31,7 +31,6 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, global
 		APIServer:                       globalConfig.APIServer,
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
-		AdditionalLabels: map[string]string{},
 		Scheduling: config.Scheduling{
 			PriorityClass: DefaultPriorityClass,
 		},
@@ -44,6 +43,7 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, global
 			},
 		},
 	}
+	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(openShiftControllerManagerLabels)
 
 	switch hcp.Spec.ControllerAvailabilityPolicy {

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -36,6 +36,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			},
 		},
 	}
+	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(schedulerLabels)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:


### PR DESCRIPTION
Before this commit, control plane component pods were scheduled arbitrarily
according to the default scheduling behavior. However, there's a need to limit
the impact of cross-node issues and optimize the communications paths between
component by making a best-effort attempt to colocate critical control plane
pods when possible.

This commit adds preferred pod affinity rules to to critical component pods to
enable colocation out of the box.