### PR TITLE
proper probes and resource requests for all components 

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/hosted-cluster-config-operator/cp-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/hosted-cluster-config-operator/cp-operator-deployment.yaml
@@ -33,9 +33,7 @@ spec:
           operator: "Equal"
           value: "true"
           effect: NoSchedule
-{{ if .MasterPriorityClass }}
-      priorityClassName: {{ .MasterPriorityClass }}
-{{ end }}
+      priorityClassName: "system-cluster-critical"
       containers:
       - image: {{ imageFor "hosted-cluster-config-operator" }}
         name: hosted-cluster-config-operator
@@ -59,15 +57,10 @@ spec:
         - "--namespace"
         - "$(POD_NAMESPACE)"{{range $controller := .HostedClusterConfigOperatorControllers }}
         - "--controllers={{$controller}}"{{end}}
-{{ if .HostedClusterConfigOperatorResources }}
-        resources:{{ range .HostedClusterConfigOperatorResources }}{{ range .ResourceRequest }}
-          requests: {{ if .CPU }}
-            cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
-            memory: {{ .Memory }}{{ end }}{{ end }}{{ range .ResourceLimit }}
-          limits: {{ if .CPU }}
-            cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
-            memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
-{{ end }}
+        resources:
+          requests:
+            cpu: 10m
+            memory: 60Mi
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-certified.deployment.yaml
@@ -50,4 +50,4 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 50Mi
+              memory: 60Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-community.deployment.yaml
@@ -50,4 +50,4 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 50Mi
+              memory: 160Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-operator-deployment.yaml
@@ -66,7 +66,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 80Mi
+              memory: 70Mi
           volumeMounts:
             - mountPath: /var/run/secrets/serving-cert
               name: serving-cert

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-marketplace.deployment.yaml
@@ -50,4 +50,4 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 50Mi
+              memory: 340Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/catalog-redhat-operators.deployment.yaml
@@ -50,4 +50,4 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 50Mi
+              memory: 420Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/olm-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/olm-operator-deployment.yaml
@@ -68,7 +68,7 @@ spec:
               value: /etc/openshift/kubeconfig/kubeconfig
           resources:
             requests:
-              cpu: 10m
+              cpu: 20m
               memory: 160Mi
           volumeMounts:
             - mountPath: /var/run/secrets/serving-cert

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/olm/packageserver-deployment.yaml
@@ -65,7 +65,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 50Mi
+            memory: 70Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -33,7 +33,7 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalCon
 		Resources: map[string]corev1.ResourceRequirements{
 			cpcContainerMain().Name: {
 				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("200Mi"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
 					corev1.ResourceCPU:    resource.MustParse("10m"),
 				},
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -104,11 +104,14 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 				HTTPGet: &corev1.HTTPGetAction{
 					Scheme: corev1.URISchemeHTTPS,
 					Port:   intstr.FromInt(int(params.APIServerPort)),
-					Path:   "livez",
+					Path:   "livez?exclude=etcd",
 				},
 			},
-			InitialDelaySeconds: 45,
-			TimeoutSeconds:      10,
+			InitialDelaySeconds: 300,
+			PeriodSeconds:       180,
+			TimeoutSeconds:      160,
+			FailureThreshold:    6,
+			SuccessThreshold:    1,
 		},
 	}
 	params.ReadinessProbes = config.ReadinessProbes{
@@ -120,8 +123,11 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 					Path:   "readyz",
 				},
 			},
-			InitialDelaySeconds: 10,
-			TimeoutSeconds:      10,
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       30,
+			TimeoutSeconds:      120,
+			FailureThreshold:    6,
+			SuccessThreshold:    1,
 		},
 	}
 	params.Resources = map[string]corev1.ResourceRequirements{
@@ -133,8 +139,8 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		},
 		kasContainerMain().Name: {
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
-				corev1.ResourceCPU:    resource.MustParse("265m"),
+				corev1.ResourceMemory: resource.MustParse("1500Mi"),
+				corev1.ResourceCPU:    resource.MustParse("350m"),
 			},
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -3,6 +3,7 @@ package konnectivity
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config"
@@ -10,6 +11,7 @@ import (
 
 const (
 	DefaultPriorityClass = "system-node-critical"
+	healthPort           = 2041
 )
 
 type KonnectivityParams struct {
@@ -31,6 +33,22 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 		ExternalPort:            externalPort,
 		OwnerRef:                config.OwnerRefFrom(hcp),
 	}
+	p.ServerDeploymentConfig.LivenessProbes = config.LivenessProbes{
+		konnectivityServerContainer().Name: {
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			InitialDelaySeconds: 120,
+			TimeoutSeconds:      30,
+			PeriodSeconds:       60,
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+		},
+	}
 	p.ServerDeploymentConfig.Resources = config.ResourcesSpec{
 		konnectivityServerContainer().Name: {
 			Requests: corev1.ResourceList{
@@ -46,8 +64,24 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 		konnectivityAgentContainer().Name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("40m"),
 			},
+		},
+	}
+	p.AgentDeploymentConfig.LivenessProbes = config.LivenessProbes{
+		konnectivityAgentContainer().Name: {
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			InitialDelaySeconds: 120,
+			TimeoutSeconds:      30,
+			PeriodSeconds:       60,
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
 		},
 	}
 	p.AgentDeploymentConfig.Replicas = 1
@@ -55,12 +89,28 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 		konnectivityAgentContainer().Name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("40m"),
 			},
 		},
 	}
 	p.AgentDeamonSetConfig.Scheduling = config.Scheduling{
 		PriorityClass: DefaultPriorityClass,
+	}
+	p.AgentDeamonSetConfig.LivenessProbes = config.LivenessProbes{
+		konnectivityAgentContainer().Name: {
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			InitialDelaySeconds: 120,
+			TimeoutSeconds:      30,
+			PeriodSeconds:       60,
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+		},
 	}
 	if hcp.Annotations != nil {
 		if _, ok := hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]; ok {

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -101,7 +101,8 @@ func buildKonnectivityServerContainer(image string) func(c *corev1.Container) {
 			strconv.Itoa(KonnectivityServerLocalPort),
 			"--agent-port",
 			strconv.Itoa(KonnectivityServerPort),
-			"--health-port=8092",
+			"--health-port",
+			strconv.Itoa(healthPort),
 			"--admin-port=8093",
 			"--mode=http-connect",
 			"--proxy-strategies=destHost,defaultRoute",
@@ -289,6 +290,8 @@ func buildKonnectivityWorkerAgentContainer(image, host string, port int32) func(
 			host,
 			"--proxy-server-port",
 			fmt.Sprint(port),
+			"--health-server-port",
+			fmt.Sprint(healthPort),
 			"--agent-identifiers=default-route=true",
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
@@ -349,6 +352,8 @@ func buildKonnectivityAgentContainer(image string, ips []string) func(c *corev1.
 			manifests.KonnectivityServerService("").Name,
 			"--proxy-server-port",
 			fmt.Sprint(KonnectivityServerPort),
+			"--health-server-port",
+			fmt.Sprint(healthPort),
 			"--agent-identifiers",
 			agentIDs.String(),
 		}


### PR DESCRIPTION
This takes a sample from a standard sized cluster 
(3 RHCOS nodes running all default scheduled workload of a 4.8 cluster)

and uses the live values from it in a steady state (after running for multiple hours) for the resource requests of components.

It also closes gaps on the liveliness probes/readiness probes of all critical components.

Net changes:
Adjust resource requests based on actual usage of a standard sized OCP 4.8 cluster
Ensure all critical components have livliness/readiness probes 