### PR TITLE
Enable isolation of Hypershift Control Plane workloads

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -42,6 +42,7 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalCon
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(clusterPolicyControllerLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:

--- a/control-plane-operator/controllers/hostedcontrolplane/config/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/config/deployment_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetRestartAnnotation(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{}
+	testDate := "01-01-2020"
+	hcp.Annotations = map[string]string{
+		hyperv1.RestartDateAnnotation: testDate,
+	}
+	cfg := &DeploymentConfig{}
+	cfg.SetRestartAnnotation(hcp.ObjectMeta)
+	if cfg.AdditionalAnnotations == nil {
+		t.Fatalf("Expecting additional annotations to be set")
+	}
+	value, isPresent := cfg.AdditionalAnnotations[hyperv1.RestartDateAnnotation]
+	if !isPresent {
+		t.Fatalf("Expected restart date annotation is not present")
+	}
+	if value != testDate {
+		t.Fatalf("Expected annotation value not set")
+	}
+}
+
+func TestSetMultizoneSpread(t *testing.T) {
+	labels := map[string]string{"app": "etcd"}
+	cfg := &DeploymentConfig{}
+	cfg.SetMultizoneSpread(labels)
+	if cfg.Scheduling.Affinity == nil {
+		t.Fatalf("Expecting affinity to be set on config")
+	}
+	if len(cfg.Scheduling.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) == 0 {
+		t.Fatalf("Expecting one required pod antiaffinity rule")
+	}
+	expectedTerm := corev1.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: labels,
+		},
+		TopologyKey: corev1.LabelTopologyZone,
+	}
+	if !reflect.DeepEqual(expectedTerm, cfg.Scheduling.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]) {
+		t.Fatalf("Unexpected anti-affinity term")
+	}
+}
+
+func TestSetColocation(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{}
+	hcp.Name = "hcp-name"
+	hcp.Namespace = "hcp-namespace"
+	cfg := &DeploymentConfig{}
+	cfg.SetColocation(hcp)
+
+	if cfg.Scheduling.Affinity == nil {
+		t.Fatalf("expecting affinity to be set on config")
+	}
+	if len(cfg.Scheduling.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution) == 0 {
+		t.Fatalf("expecting pod affinity rule")
+	}
+	expectedTerm := corev1.WeightedPodAffinityTerm{
+		PodAffinityTerm: corev1.PodAffinityTerm{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"hypershift.openshift.io/hosted-control-plane": "hcp-namespace"},
+			},
+			TopologyKey: corev1.LabelHostname,
+		},
+		Weight: 100,
+	}
+	if !reflect.DeepEqual(expectedTerm, cfg.Scheduling.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]) {
+		t.Fatalf("Unexpected affinity term %#v", cfg.Scheduling.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0])
+	}
+	expectedLabels := AdditionalLabels{
+		"hypershift.openshift.io/hosted-control-plane": "hcp-namespace",
+	}
+	if !reflect.DeepEqual(expectedLabels, cfg.AdditionalLabels) {
+		t.Fatalf("Unexpected additional labels")
+	}
+}
+
+func TestSetControlPlaneIsolation(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{}
+	hcp.Name = "hcp-name"
+	hcp.Namespace = "hcp-namespace"
+	cfg := &DeploymentConfig{}
+	cfg.SetControlPlaneIsolation(hcp)
+	if len(cfg.Scheduling.Tolerations) == 0 {
+		t.Fatalf("No tolerations were set")
+	}
+	expectedTolerations := []corev1.Toleration{
+		{
+			Key:      controlPlaneWorkloadTolerationKey,
+			Operator: corev1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "hypershift.openshift.io/cluster",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "hcp-namespace",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+	if !reflect.DeepEqual(expectedTolerations, cfg.Scheduling.Tolerations) {
+		t.Fatalf("unexpected tolerations")
+	}
+	expectedAffinityRules := []corev1.PreferredSchedulingTerm{
+		{
+			Weight: 50,
+			Preference: corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "hypershift.openshift.io/control-plane",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"true"},
+					},
+				},
+			},
+		},
+		{
+			Weight: 100,
+			Preference: corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "hypershift.openshift.io/cluster",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"hcp-namespace"},
+					},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedAffinityRules, cfg.Scheduling.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution) {
+		t.Fatalf("unexpected node affinity rules")
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -38,6 +38,7 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *E
 	}
 	p.OperatorDeploymentConfig.SetMultizoneSpread(etcdOperatorDeploymentLabels)
 	p.OperatorDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.OperatorDeploymentConfig.SetControlPlaneIsolation(hcp)
 	p.EtcdDeploymentConfig.Resources = config.ResourcesSpec{
 		etcdContainer().Name: {
 			Requests: corev1.ResourceList{
@@ -48,6 +49,7 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *E
 	}
 	p.EtcdDeploymentConfig.SetMultizoneSpread(etcdLabels)
 	p.EtcdDeploymentConfig.SetColocationAnchor(hcp)
+	p.EtcdDeploymentConfig.SetControlPlaneIsolation(hcp)
 	p.OperatorDeploymentConfig.Replicas = 1
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -147,6 +147,8 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(kasLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
+
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		params.CloudProvider = aws.Provider

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -91,6 +91,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(kcmLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		params.CloudProvider = aws.Provider

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -61,6 +61,8 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	p.ServerDeploymentConfig.SetColocation(hcp)
 	p.ServerDeploymentConfig.SetMultizoneSpread(konnectivityServerLabels)
 	p.ServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.ServerDeploymentConfig.SetControlPlaneIsolation(hcp)
+
 	p.AgentDeploymentConfig.Resources = config.ResourcesSpec{
 		konnectivityAgentContainer().Name: {
 			Requests: corev1.ResourceList{

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -87,6 +87,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 	}
 	params.OpenShiftAPIServerDeploymentConfig.SetMultizoneSpread(openShiftAPIServerLabels)
 	params.OpenShiftAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.OpenShiftAPIServerDeploymentConfig.SetControlPlaneIsolation(hcp)
 	params.OpenShiftOAuthAPIServerDeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
 			PriorityClass: DefaultPriorityClass,
@@ -134,6 +135,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetColocation(hcp)
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetMultizoneSpread(openShiftOAuthAPIServerLabels)
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.OpenShiftOAuthAPIServerDeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.Etcd.ManagementType {
 	case hyperv1.Unmanaged:
 		params.EtcdURL = hcp.Spec.Etcd.Unmanaged.Endpoint

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"encoding/json"
@@ -124,6 +125,7 @@ func NewOAuthServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, 
 	p.DeploymentConfig.SetMultizoneSpread(oauthServerLabels)
 	p.DeploymentConfig.SetColocation(hcp)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		p.Replicas = 3

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -46,6 +46,7 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, global
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(openShiftControllerManagerLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.DeploymentConfig.Replicas = 3

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -39,6 +39,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetMultizoneSpread(schedulerLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.Replicas = 3


### PR DESCRIPTION
Adds tolerations and soft affinity rules to control plane workloads to
enable isolation of nodes dedicated to running control planes in general
or workloads for a specific cluster.