### PR TITLE
Hardcode cli/e2e to the latest 4.8 release

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -15,7 +15,6 @@ import (
 	hyperapi "github.com/openshift/hypershift/api"
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
-	"github.com/openshift/hypershift/version"
 	"github.com/spf13/cobra"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
@@ -53,15 +52,22 @@ func NewCreateCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	var releaseImage string
-	defaultVersion, err := version.LookupDefaultOCPVersion()
-	if err != nil {
-		fmt.Println("WARN: Unable to lookup default OCP version with error:", err)
-		fmt.Println("WARN: The 'release-image' flag is required in this case.")
-		releaseImage = ""
-	} else {
-		releaseImage = defaultVersion.PullSpec
-	}
+	// FIXME: (cewong) The latest image can be used when we have the ability to run multiple minor
+	// versions of the control plane. For now, we will use the latest 4.8.x release.
+	/*
+
+		var releaseImage string
+		defaultVersion, err := version.LookupDefaultOCPVersion()
+		if err != nil {
+			fmt.Println("WARN: Unable to lookup default OCP version with error:", err)
+			fmt.Println("WARN: The 'release-image' flag is required in this case.")
+			releaseImage = ""
+		} else {
+			releaseImage = defaultVersion.PullSpec
+		}
+	*/
+
+	releaseImage := "quay.io/openshift-release-dev/ocp-release:4.8.6-x86_64"
 
 	opts := Options{
 		Namespace:          "clusters",

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -13,7 +13,6 @@ import (
 
 	e2elog "github.com/openshift/hypershift/test/e2e/log"
 	"github.com/openshift/hypershift/test/e2e/scenarios"
-	"github.com/openshift/hypershift/version"
 	"k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -127,11 +126,15 @@ type options struct {
 // up additional contextual defaulting.
 func (o *options) Complete() error {
 	if len(o.LatestReleaseImage) == 0 {
-		defaultVersion, err := version.LookupDefaultOCPVersion()
-		if err != nil {
-			return fmt.Errorf("couldn't look up default OCP version: %w", err)
-		}
-		o.LatestReleaseImage = defaultVersion.PullSpec
+		// FIXME: (cewong) Use default OCP version when we are able to
+		/*
+			defaultVersion, err := version.LookupDefaultOCPVersion()
+			if err != nil {
+				return fmt.Errorf("couldn't look up default OCP version: %w", err)
+			}
+			o.LatestReleaseImage = defaultVersion.PullSpec
+		*/
+		o.LatestReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.8.6-x86_64"
 	}
 	// TODO: This is actually basically a required field right now. Maybe the input
 	// to tests should be a small API spec that describes the tests and their


### PR DESCRIPTION
Hypershift control plane currently does not support the 4.9 release.
Until we can support more than one minor release with core Hypershift,
we will fix the release we use to the latest 4.8 release.