### PR TITLE
Preserve Kube APIServer resource requests

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -88,6 +88,18 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	ownerRef.ApplyTo(deployment)
 	maxSurge := intstr.FromInt(3)
 	maxUnavailable := intstr.FromInt(0)
+
+	// preserve existing resource requirements for main KAS container
+	mainContainer := findContainer(kasContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		resources := mainContainer.Resources
+		if len(resources.Requests) > 0 || len(resources.Limits) > 0 {
+			if deploymentConfig.Resources != nil {
+				deploymentConfig.Resources[kasContainerMain().Name] = resources
+			}
+		}
+	}
+
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: kasLabels,
@@ -505,4 +517,13 @@ func applyKASAuditWebhookConfigFileVolume(podSpec *corev1.PodSpec, auditWebhookR
 	}
 	container.VolumeMounts = append(container.VolumeMounts,
 		kasAuditWebhookConfigFileVolumeMount.ContainerMounts(kasContainerMain().Name)...)
+}
+
+func findContainer(name string, containers []corev1.Container) *corev1.Container {
+	for i, c := range containers {
+		if c.Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This satisfies the requirement by IBM Cloud of allowing adjustments to
resource requests of the Kube API server by preserving any changes made
to said resource requests and not stomping them with the defaults.