### PR TITLE
Fix e2e runtime regressions

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,17 +29,21 @@ var (
 
 // TestScenarios runs all the e2e tests. Any new tests need to be added to this
 // list in order for them to run.
+// TODO: For now, the UpgradeControlPlane test is being used for testing all
+// major functionality until we can do parallel tests; otherwise it's just too
+// slow to separate things out
 func TestScenarios(t *testing.T) {
 	tests := map[string]func(t *testing.T){
-		"CreateCluster": scenarios.TestCreateCluster(ctx,
-			scenarios.TestCreateClusterOptions{
-				AWSCredentialsFile: opts.AWSCredentialsFile,
-				AWSRegion:          opts.Region,
-				PullSecretFile:     opts.PullSecretFile,
-				ReleaseImage:       opts.LatestReleaseImage,
-				ArtifactDir:        opts.ArtifactDir,
-				BaseDomain:         opts.BaseDomain,
-			}),
+		// TODO: Re-enable once tests can be parallelized
+		//"CreateCluster": scenarios.TestCreateCluster(ctx,
+		//	scenarios.TestCreateClusterOptions{
+		//		AWSCredentialsFile: opts.AWSCredentialsFile,
+		//		AWSRegion:          opts.Region,
+		//		PullSecretFile:     opts.PullSecretFile,
+		//		ReleaseImage:       opts.LatestReleaseImage,
+		//		ArtifactDir:        opts.ArtifactDir,
+		//		BaseDomain:         opts.BaseDomain,
+		//	}),
 		"UpgradeControlPlane": scenarios.TestUpgradeControlPlane(ctx,
 			scenarios.TestUpgradeControlPlaneOptions{
 				AWSCredentialsFile: opts.AWSCredentialsFile,
@@ -51,15 +55,16 @@ func TestScenarios(t *testing.T) {
 				ArtifactDir:        opts.ArtifactDir,
 				Enabled:            opts.UpgradeTestsEnabled,
 			}),
-		"Autoscaling": scenarios.TestAutoscaling(ctx,
-			scenarios.TestAutoscalingOptions{
-				AWSCredentialsFile: opts.AWSCredentialsFile,
-				AWSRegion:          opts.Region,
-				PullSecretFile:     opts.PullSecretFile,
-				ReleaseImage:       opts.LatestReleaseImage,
-				ArtifactDir:        opts.ArtifactDir,
-				BaseDomain:         opts.BaseDomain,
-			}),
+		// TODO: Re-enable once tests can be parallelized
+		//"Autoscaling": scenarios.TestAutoscaling(ctx,
+		//	scenarios.TestAutoscalingOptions{
+		//		AWSCredentialsFile: opts.AWSCredentialsFile,
+		//		AWSRegion:          opts.Region,
+		//		PullSecretFile:     opts.PullSecretFile,
+		//		ReleaseImage:       opts.LatestReleaseImage,
+		//		ArtifactDir:        opts.ArtifactDir,
+		//		BaseDomain:         opts.BaseDomain,
+		//	}),
 	}
 
 	for name := range tests {

--- a/test/e2e/scenarios/control_plane_upgrade.go
+++ b/test/e2e/scenarios/control_plane_upgrade.go
@@ -4,11 +4,14 @@ package scenarios
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	cmdcluster "github.com/openshift/hypershift/cmd/cluster"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,7 +55,8 @@ func TestUpgradeControlPlane(ctx context.Context, o TestUpgradeControlPlaneOptio
 
 		// Ensure we clean up after the test
 		defer func() {
-			e2eutil.DumpGuestCluster(context.Background(), client, hostedCluster, o.ArtifactDir)
+			// TODO: Figure out why this is slow
+			//e2eutil.DumpGuestCluster(context.Background(), client, hostedCluster, o.ArtifactDir)
 			e2eutil.DumpAndDestroyHostedCluster(context.Background(), hostedCluster, o.AWSCredentialsFile, o.AWSRegion, o.BaseDomain, o.ArtifactDir)
 			e2eutil.DeleteNamespace(context.Background(), client, namespace.Name)
 		}()
@@ -115,5 +119,66 @@ func TestUpgradeControlPlane(ctx context.Context, o TestUpgradeControlPlaneOptio
 		e2eutil.WaitForImageRollout(t, ctx, client, hostedCluster, o.ToReleaseImage)
 		err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+
+		// TODO: This can be removed once the autoscaling scenario can be run in parallel
+		// Enable autoscaling.
+		err = client.Get(ctx, crclient.ObjectKeyFromObject(nodepool), nodepool)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
+		var max int32 = 3
+
+		nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, *nodepool.Spec.NodeCount)
+
+		// These Deployments have replicas=2 with
+		// anti-affinity rules resulting in scheduling constraints
+		// that prevent the cluster from ever scaling back down to 1:
+		// aws-ebs-csi-driver-controller
+		// console
+		// router-default
+		// thanos-querier
+		// prometheus-adapter
+		var min int32 = 2
+		nodepool.Spec.AutoScaling = &hyperv1.NodePoolAutoScaling{
+			Min: min,
+			Max: max,
+		}
+		nodepool.Spec.NodeCount = nil
+		err = client.Update(ctx, nodepool)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to update NodePool")
+		log.Info("Enabled autoscaling",
+			"namespace", nodepool.Namespace, "name", nodepool.Name, "min", min, "max", max)
+
+		// TODO (alberto): check autoscalingEnabled condition.
+
+		// Generate workload.
+		memCapacity := nodes[0].Status.Allocatable[corev1.ResourceMemory]
+		g.Expect(memCapacity).ShouldNot(BeNil())
+		g.Expect(memCapacity.String()).ShouldNot(BeEmpty())
+		bytes, ok := memCapacity.AsInt64()
+		g.Expect(ok).Should(BeTrue())
+
+		// Enforce max nodes creation.
+		// 60% - enough that the existing and new nodes will
+		// be used, not enough to have more than 1 pod per
+		// node.
+		workloadMemRequest := resource.MustParse(fmt.Sprintf("%v", 0.6*float32(bytes)))
+		workload := newWorkLoad(max, workloadMemRequest, "", o.ToReleaseImage)
+		err = guestClient.Create(ctx, workload)
+		g.Expect(err).NotTo(HaveOccurred())
+		log.Info("Created workload", "node", nodes[0].Name, "memcapacity", memCapacity.String())
+
+		// Wait for 3 nodes.
+		// TODO (alberto): have ability for NodePool to label Nodes and let workload target specific Nodes.
+		_ = e2eutil.WaitForNReadyNodes(t, ctx, guestClient, max)
+
+		// Delete workload.
+		cascadeDelete := metav1.DeletePropagationForeground
+		err = guestClient.Delete(ctx, workload, &crclient.DeleteOptions{
+			PropagationPolicy: &cascadeDelete,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		log.Info("Deleted workload")
+
+		// Wait for exactly 1 node.
+		_ = e2eutil.WaitForNReadyNodes(t, ctx, guestClient, min)
 	}
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -62,7 +62,8 @@ func DumpHostedCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster
 // DumpAndDestroyHostedCluster calls DumpHostedCluster and then destroys the HostedCluster,
 // logging any failures along the way.
 func DumpAndDestroyHostedCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster, awsCreds string, awsRegion string, baseDomain string, artifactDir string) {
-	DumpHostedCluster(ctx, hostedCluster, artifactDir)
+	// TODO: Figure out why this is slow
+	//DumpHostedCluster(ctx, hostedCluster, artifactDir)
 
 	opts := &cmdcluster.DestroyOptions{
 		Namespace:          hostedCluster.Namespace,


### PR DESCRIPTION
The e2e tests run serially are too slow, but we can't yet parallelize them because the log output becomes interleaved and unintelligable. Until we can run the tests in parallel, consolidate the existing scenarios into one to preserve the same coverage but with shorter total test duration.

Something's up with the `oc adm inspect` commands and they appear to be hanging for 30m+, so I'm preemptively disabling them as a bandaid/experiment because the CI timeouts are becoming an urgent issue to get anything merged.