### PR TITLE
run cvo with only one replica and account for multi replica deployment without rolling update params specified

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/config/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/config/deployment.go
@@ -168,6 +168,9 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 	if c.Replicas > 1 {
 		maxSurge := intstr.FromInt(3)
 		maxUnavailable := intstr.FromInt(1)
+		if deployment.Spec.Strategy.RollingUpdate == nil {
+			deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{}
+		}
 		deployment.Spec.Strategy.RollingUpdate.MaxSurge = &maxSurge
 		deployment.Spec.Strategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -37,11 +37,6 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane) *CVOParams {
 	p.DeploymentConfig.SetColocation(hcp)
 	p.DeploymentConfig.SetMultizoneSpread(cvoLabels)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	switch hcp.Spec.ControllerAvailabilityPolicy {
-	case hyperv1.HighlyAvailable:
-		p.DeploymentConfig.Replicas = 3
-	default:
-		p.DeploymentConfig.Replicas = 1
-	}
+	p.DeploymentConfig.Replicas = 1
 	return p
 }


### PR DESCRIPTION
Fixes current error where panic is occuring because CVO doesn't have a rolling update strategy defined
```
2021-08-25T21:36:08.633Z	INFO	controller-runtime.manager.controller.hostedcontrolplane	Reonciling Cluster Version Operator	{"reconciler group": "hypershift.openshift.io", "reconciler kind": "HostedControlPlane", "name": "55504957", "namespace": "master-55504957"}
E0825 21:36:08.655532       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 406 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x21f37e0, 0x31e39e0)
	/hypershift/control-plane-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x134
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/hypershift/control-plane-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0xc8
panic(0x21f37e0, 0x31e39e0)
	/usr/local/go/src/runtime/panic.go:971 +0x4c7
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config.(*DeploymentConfig).ApplyTo(0xc000f61a80, 0xc001087200)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/config/deployment.go:171 +0x173
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cvo.ReconcileDeployment(0xc001087200, 0xc000b658b0, 0x3, 0xc0013785a0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc001039770, ...)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go:84 +0x679
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane.(*HostedControlPlaneReconciler).reconcileClusterVersionOperator.func1(0x0, 0x0)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go:1794 +0x12c
sigs.k8s.io/controller-runtime/pkg/controller/controllerutil.mutate(0xc000f61ec0, 0xc00137b1e0, 0xf, 0x242c428, 0x18, 0x26c8308, 0xc001087200, 0x0, 0x0)
	/hypershift/control-plane-operator/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil/controllerutil.go:327 +0x47
sigs.k8s.io/controller-runtime/pkg/controller/controllerutil.CreateOrUpdate(0x26a7c68, 0xc000b86c60, 0x26b97c8, 0xc0006a48c0, 0x26c8308, 0xc001087200, 0xc000f61ec0, 0x0, 0x0, 0x0, ...)
	/hypershift/control-plane-operator/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil/controllerutil.go:203 +0x1aa
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane.(*HostedControlPlaneReconciler).reconcileClusterVersionOperator(0xc0006a48c0, 0x26a7c68, 0xc000b86c60, 0xc0001a4380, 0x0, 0x0)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go:1793 +0x159
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane.(*HostedControlPlaneReconciler).update(0xc0006a48c0, 0x26a7c68, 0xc000b86c60, 0xc0001a4380, 0x0, 0x0)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go:630 +0x326c
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane.(*HostedControlPlaneReconciler).Reconcile(0xc0006a48c0, 0x26a7c68, 0xc000b86c60, 0xc000399690, 0xf, 0xc000399670, 0x8, 0x175eb09ee0c4900, 0x0, 0x0, ...)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go:424 +0x1af1
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00063a1e0, 0x26a7c68, 0xc000b86c60, 0x225c7a0, 0xc000b82000)
	/hypershift/control-plane-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:297 +0x409
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00063a1e0, 0x26a7bc0, 0xc0008112c0, 0x0)
	/hypershift/control-plane-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:252 +0x35a
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2(0x26a7bc0, 0xc0008112c0)
	/hypershift/control-plane-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215 +0x4a
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
	/hypershift/control-plane-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185 +0x4b
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000843750)
	/hypershift/control-plane-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x63
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000f63f50, 0x2671f20, 0xc000b86bd0, 0x323fd01, 0xc00009c1e0)
	/hypershift/control-plane-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0x9a
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000843750, 0x3b9aca00, 0x0, 0xc000843701, 0xc00009c1e0)
	/hypershift/control-plane-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x9f
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext(0x26a7bc0, 0xc0008112c0, 0xc0006a9f60, 0x3b9aca00, 0x0, 0x1)
	/hypershift/control-plane-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185 +0xd5
k8s.io/apimachinery/pkg/util/wait.UntilWithContext(0x26a7bc0, 0xc0008112c0, 0xc0006a9f60, 0x3b9aca00)
	/hypershift/control-plane-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:99 +0x57
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/hypershift/control-plane-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:212 +0x8ba
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1deeb73]

goroutine 406 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
```

And also corrects the CVO to only be one replica as that I believe is expected.