### PR TITLE
adjust in cluster konnectivity deamonset to use system-node-critical priority class and not control plane only default class

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	healthPort = 2041
+	healthPort                      = 2041
+	systemNodeCriticalPriorityClass = "system-node-critical"
 )
 
 type KonnectivityParams struct {
@@ -97,7 +98,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 		},
 	}
 	p.AgentDeamonSetConfig.Scheduling = config.Scheduling{
-		PriorityClass: config.DefaultPriorityClass,
+		PriorityClass: systemNodeCriticalPriorityClass,
 	}
 	p.AgentDeamonSetConfig.LivenessProbes = config.LivenessProbes{
 		konnectivityAgentContainer().Name: {

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -144,7 +144,7 @@ func buildOASContainerMain(image string, etcdHostname string) func(c *corev1.Con
 			},
 			{
 				Name:  "HTTPS_PROXY",
-				Value: fmt.Sprintf("https://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("http://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
 			},
 			{
 				Name:  "NO_PROXY",


### PR DESCRIPTION
Current error being hit
```
    Environment:  <none>
    Mounts:
      /etc/konnectivity/agent from agent-certs (rw)
  Volumes:
   agent-certs:
    Type:               Secret (a volume populated by a Secret)
    SecretName:         konnectivity-agent
    Optional:           false
  Priority Class Name:  hypershift-control-plane
Events:
  Type     Reason        Age                    From                  Message
  ----     ------        ----                   ----                  -------
  Warning  FailedCreate  115m (x14 over 115m)   daemonset-controller  Error creating: pods "konnectivity-agent-" is forbidden: no PriorityClass with name hypershift-control-plane was found
  Warning  FailedCreate  3m11s (x35 over 114m)  daemonset-controller  Error creating: pods "konnectivity-agent-" is forbidden: no PriorityClass with name hypershift-control-plane was found
```

The classes aren't applicable in a user cluster

Also fixes an invalid https proxy variable 