### PR TITLE
remove duplicated mode option from konnectivity server

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -97,7 +97,6 @@ func buildKonnectivityServerContainer(image string) func(c *corev1.Container) {
 			cpath(konnectivityVolumeServerCerts().Name, corev1.TLSPrivateKeyKey),
 			"--server-ca-cert",
 			cpath(konnectivityVolumeServerCerts().Name, pki.CASignerCertMapKey),
-			"--mode=grpc",
 			"--server-port",
 			strconv.Itoa(KonnectivityServerLocalPort),
 			"--agent-port",


### PR DESCRIPTION
- it does not cause problem probably, just helps understanding the configuration