### PR TITLE
Narrow down enqueueNodePoolsForHostedCluster to the HC namespace

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1040,7 +1040,7 @@ func (r *NodePoolReconciler) enqueueNodePoolsForHostedCluster(obj client.Object)
 	}
 
 	nodePoolList := &hyperv1.NodePoolList{}
-	if err := r.List(context.Background(), nodePoolList); err != nil {
+	if err := r.List(context.Background(), nodePoolList, client.InNamespace(hc.Namespace)); err != nil {
 		ctrl.LoggerFrom(context.Background()).Error(err, "Failed to list nodePools")
 		return result
 	}


### PR DESCRIPTION
Before this commit a HostedCluster change in namespace "a" would trigger reconciliation for a NodePool living in Namespace "b" if it were pointing to a HostedCluster named the same way than the one in namespace "a"