### PR TITLE
Control plane pod scheduling fixes

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -36,13 +36,12 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalCon
 		},
 	}
 	params.DeploymentConfig.SetColocation(hcp)
-	params.DeploymentConfig.SetMultizoneSpread(clusterPolicyControllerLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
-
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.DeploymentConfig.Replicas = 3
+		params.DeploymentConfig.SetMultizoneSpread(clusterPolicyControllerLabels)
 	default:
 		params.DeploymentConfig.Replicas = 1
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -35,8 +35,8 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane) *CVOParams {
 		},
 	}
 	p.DeploymentConfig.SetColocation(hcp)
-	p.DeploymentConfig.SetMultizoneSpread(cvoLabels)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	p.DeploymentConfig.Replicas = 1
 	return p
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -36,7 +36,6 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *E
 			},
 		},
 	}
-	p.OperatorDeploymentConfig.SetMultizoneSpread(etcdOperatorDeploymentLabels)
 	p.OperatorDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	p.OperatorDeploymentConfig.SetControlPlaneIsolation(hcp)
 	p.EtcdDeploymentConfig.Resources = config.ResourcesSpec{
@@ -47,13 +46,13 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *E
 			},
 		},
 	}
-	p.EtcdDeploymentConfig.SetMultizoneSpread(etcdLabels)
 	p.EtcdDeploymentConfig.SetColocationAnchor(hcp)
 	p.EtcdDeploymentConfig.SetControlPlaneIsolation(hcp)
 	p.OperatorDeploymentConfig.Replicas = 1
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		p.EtcdDeploymentConfig.Replicas = 3
+		p.EtcdDeploymentConfig.SetMultizoneSpread(etcdLabels)
 	default:
 		p.EtcdDeploymentConfig.Replicas = 1
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -145,7 +145,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		},
 	}
 	params.DeploymentConfig.SetColocation(hcp)
-	params.DeploymentConfig.SetMultizoneSpread(kasLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 
@@ -161,6 +160,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.Replicas = 3
+		params.DeploymentConfig.SetMultizoneSpread(kasLabels)
 	default:
 		params.Replicas = 1
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -87,7 +87,6 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 		},
 	}
 	params.DeploymentConfig.SetColocation(hcp)
-	params.DeploymentConfig.SetMultizoneSpread(kcmLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.Platform.Type {
@@ -100,6 +99,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.Replicas = 3
+		params.DeploymentConfig.SetMultizoneSpread(kcmLabels)
 	default:
 		params.Replicas = 1
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -59,7 +59,6 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	}
 	p.ServerDeploymentConfig.Replicas = 1
 	p.ServerDeploymentConfig.SetColocation(hcp)
-	p.ServerDeploymentConfig.SetMultizoneSpread(konnectivityServerLabels)
 	p.ServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	p.ServerDeploymentConfig.SetControlPlaneIsolation(hcp)
 
@@ -89,6 +88,9 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	}
 	p.AgentDeploymentConfig.Replicas = 1
 	p.AgentDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.AgentDeploymentConfig.SetColocation(hcp)
+	p.AgentDeploymentConfig.SetControlPlaneIsolation(hcp)
+
 	p.AgentDeamonSetConfig.Resources = config.ResourcesSpec{
 		konnectivityAgentContainer().Name: {
 			Requests: corev1.ResourceList{

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -83,7 +83,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 			},
 		},
 	}
-	params.OpenShiftAPIServerDeploymentConfig.SetMultizoneSpread(openShiftAPIServerLabels)
+	params.OpenShiftAPIServerDeploymentConfig.SetColocation(hcp)
 	params.OpenShiftAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.OpenShiftAPIServerDeploymentConfig.SetControlPlaneIsolation(hcp)
 	params.OpenShiftOAuthAPIServerDeploymentConfig = config.DeploymentConfig{
@@ -131,7 +131,6 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 		},
 	}
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetColocation(hcp)
-	params.OpenShiftOAuthAPIServerDeploymentConfig.SetMultizoneSpread(openShiftOAuthAPIServerLabels)
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.Etcd.ManagementType {
@@ -146,6 +145,8 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 	case hyperv1.HighlyAvailable:
 		params.OpenShiftAPIServerDeploymentConfig.Replicas = 3
 		params.OpenShiftOAuthAPIServerDeploymentConfig.Replicas = 3
+		params.OpenShiftOAuthAPIServerDeploymentConfig.SetMultizoneSpread(openShiftOAuthAPIServerLabels)
+		params.OpenShiftAPIServerDeploymentConfig.SetMultizoneSpread(openShiftAPIServerLabels)
 	default:
 		params.OpenShiftAPIServerDeploymentConfig.Replicas = 1
 		params.OpenShiftOAuthAPIServerDeploymentConfig.Replicas = 1

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -122,12 +122,12 @@ func NewOAuthServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, 
 			SuccessThreshold:    1,
 		},
 	}
-	p.DeploymentConfig.SetMultizoneSpread(oauthServerLabels)
 	p.DeploymentConfig.SetColocation(hcp)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
+		p.DeploymentConfig.SetMultizoneSpread(oauthServerLabels)
 		p.Replicas = 3
 	default:
 		p.Replicas = 1

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -40,12 +40,12 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, global
 		},
 	}
 	params.DeploymentConfig.SetColocation(hcp)
-	params.DeploymentConfig.SetMultizoneSpread(openShiftControllerManagerLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.DeploymentConfig.Replicas = 3
+		params.DeploymentConfig.SetMultizoneSpread(openShiftControllerManagerLabels)
 	default:
 		params.DeploymentConfig.Replicas = 1
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -37,12 +37,12 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		},
 	}
 	params.DeploymentConfig.SetColocation(hcp)
-	params.DeploymentConfig.SetMultizoneSpread(schedulerLabels)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.Replicas = 3
+		params.DeploymentConfig.SetMultizoneSpread(schedulerLabels)
 	default:
 		params.Replicas = 1
 	}


### PR DESCRIPTION
- Multi-zone spread anti-affinity rules are only applied to deployments
  that are running in HA mode. If only a single pod is running for the
  deployment, having an anti-affinity rule means that when the
  deployment is rolled out, the second pod cannot be scheduled with the
  rest of the control plane. This results in scattered pods after a
  restart.
- Configures konnectivity agent with colocation and control plane
  isolation affinity rules and tolerations.
- Configures colocation for openshift apiserver
- Configures control plane isolation for CVO