### PR TITLE
Create separate cmd flag for platform none

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -61,6 +61,8 @@ type ExampleOptions struct {
 	NetworkType                      hyperv1.NetworkType
 	ControlPlaneAvailabilityPolicy   hyperv1.AvailabilityPolicy
 	InfrastructureAvailabilityPolicy hyperv1.AvailabilityPolicy
+	PlatformType                     string
+	APIServerAddress                 string
 }
 
 type ExampleAWSOptions struct {
@@ -192,38 +194,8 @@ aws_secret_access_key = %s
 				MachineCIDR: o.ComputeCIDR,
 				NetworkType: o.NetworkType,
 			},
-			Services: []hyperv1.ServicePublishingStrategyMapping{
-				{
-					Service: hyperv1.APIServer,
-					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-						Type: hyperv1.LoadBalancer,
-					},
-				},
-				{
-					Service: hyperv1.OAuthServer,
-					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-						Type: hyperv1.Route,
-					},
-				},
-				{
-					Service: hyperv1.OIDC,
-					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-						Type: hyperv1.Route,
-					},
-				},
-				{
-					Service: hyperv1.Konnectivity,
-					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-						Type: hyperv1.Route,
-					},
-				},
-				{
-					Service: hyperv1.Ignition,
-					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-						Type: hyperv1.Route,
-					},
-				},
-			},
+
+			Services:   []hyperv1.ServicePublishingStrategyMapping{},
 			InfraID:    o.InfraID,
 			PullSecret: corev1.LocalObjectReference{Name: pullSecret.Name},
 			IssuerURL:  o.IssuerURL,
@@ -236,24 +208,97 @@ aws_secret_access_key = %s
 			},
 			ControllerAvailabilityPolicy:     o.ControlPlaneAvailabilityPolicy,
 			InfrastructureAvailabilityPolicy: o.InfrastructureAvailabilityPolicy,
-			Platform: hyperv1.PlatformSpec{
-				Type: hyperv1.AWSPlatform,
-				AWS: &hyperv1.AWSPlatformSpec{
-					Region: o.AWS.Region,
-					Roles:  o.AWS.Roles,
-					CloudProviderConfig: &hyperv1.AWSCloudProviderConfig{
-						VPC: o.AWS.VPCID,
-						Subnet: &hyperv1.AWSResourceReference{
-							ID: &o.AWS.SubnetID,
-						},
-						Zone: o.AWS.Zone,
-					},
-					KubeCloudControllerCreds: corev1.LocalObjectReference{Name: kubeCloudControllerCredsSecret.Name},
-					NodePoolManagementCreds:  corev1.LocalObjectReference{Name: nodePoolManagementCredsSecret.Name},
-					ResourceTags:             o.AWS.ResourceTags,
+			Platform:                         hyperv1.PlatformSpec{},
+		},
+	}
+
+	switch o.PlatformType {
+	case string(hyperv1.AWSPlatform):
+		cluster.Spec.Platform.Type = hyperv1.AWSPlatform
+		cluster.Spec.Platform.AWS = &hyperv1.AWSPlatformSpec{
+			Region: o.AWS.Region,
+			Roles:  o.AWS.Roles,
+			CloudProviderConfig: &hyperv1.AWSCloudProviderConfig{
+				VPC: o.AWS.VPCID,
+				Subnet: &hyperv1.AWSResourceReference{
+					ID: &o.AWS.SubnetID,
+				},
+				Zone: o.AWS.Zone,
+			},
+			KubeCloudControllerCreds: corev1.LocalObjectReference{Name: kubeCloudControllerCredsSecret.Name},
+			NodePoolManagementCreds:  corev1.LocalObjectReference{Name: nodePoolManagementCredsSecret.Name},
+			ResourceTags:             o.AWS.ResourceTags,
+		}
+		cluster.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+			{
+				Service: hyperv1.APIServer,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.LoadBalancer,
 				},
 			},
-		},
+			{
+				Service: hyperv1.OAuthServer,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.Route,
+				},
+			},
+			{
+				Service: hyperv1.OIDC,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.Route,
+				},
+			},
+			{
+				Service: hyperv1.Konnectivity,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.LoadBalancer,
+				},
+			},
+			{
+				Service: hyperv1.Ignition,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.Route,
+				},
+			},
+		}
+
+	case string(hyperv1.NonePlatform):
+		cluster.Spec.Platform.Type = hyperv1.NonePlatform
+		cluster.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+			{
+				Service: hyperv1.APIServer,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.NodePort,
+					NodePort: &hyperv1.NodePortPublishingStrategy{
+						Address: o.APIServerAddress,
+					},
+				},
+			},
+			{
+				Service: hyperv1.OAuthServer,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.Route,
+				},
+			},
+			{
+				Service: hyperv1.OIDC,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.Route,
+				},
+			},
+			{
+				Service: hyperv1.Konnectivity,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.Route,
+				},
+			},
+			{
+				Service: hyperv1.Ignition,
+				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+					Type: hyperv1.Route,
+				},
+			},
+		}
 	}
 
 	var nodePool *hyperv1.NodePool

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -59,6 +59,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.ArtifactDir, "e2e.artifact-dir", "", "The directory where cluster resources and logs should be dumped. If empty, nothing is dumped")
 	flag.StringVar(&globalOpts.defaultClusterOptions.BaseDomain, "e2e.base-domain", "", "The ingress base domain for the cluster")
 	flag.StringVar(&globalOpts.defaultClusterOptions.ControlPlaneOperatorImage, "e2e.control-plane-operator-image", "", "The image to use for the control plane operator. If none specified, the default is used.")
+	flag.StringVar(&globalOpts.Platform, "e2e.platform", "", "The platform to use for the operator If none specified, the default is used.")
 	flag.Var(&globalOpts.additionalTags, "e2e.additional-tags", "Additional tags to set on AWS resources")
 
 	flag.Parse()
@@ -172,6 +173,7 @@ type options struct {
 
 	defaultClusterOptions cmdcluster.Options
 	additionalTags        stringSliceVar
+	Platform              string
 }
 
 func (o *options) DefaultClusterOptions() cmdcluster.Options {
@@ -217,6 +219,7 @@ func (o *options) Complete() error {
 	o.defaultClusterOptions.NetworkType = string(hyperv1.OpenShiftSDN)
 	o.defaultClusterOptions.RootVolumeSize = 64
 	o.defaultClusterOptions.RootVolumeType = "gp2"
+	o.defaultClusterOptions.Platform = string(hyperv1.AWSPlatform)
 	o.defaultClusterOptions.AdditionalTags = o.additionalTags
 
 	return nil


### PR DESCRIPTION
This pull request contains:

- Command create cluster with new flag "platform none" to avoid creating all the aws infra when you want to use platform none. 
- Basically hosted clusters will be deployed without any nodepool (by now) in the guest ocp cluster. 
- Using nodeport for kubeapi-server and konnectivity and getting dinamically the ip of master_0 guest node as annotation (to fit with SNO and multinode clusters)
- Don't need the aws credential because the control plane will be deployed in the guest ocp cluster.

Example of command to use with this PR:
- install the hypershift compiled previously: `[root@qct-d14u03 bin]# ./hypershift install --hypershift-image quay.io/amorgant/hypershift:v0.0.37`
- CLI command render manifests with the platform flag none and nodepool -2 to avoid using nodepool (by now): `./hypershift create cluster --pull-secret ../../pullsecret.json --ssh-key ~/.ssh/id_rsa.pub --base-domain alklabs.com --namespace clusters2 --node-pool-replicas -2 --release-image quay.io/openshift-release-dev/ocp-release:4.8.6-x86_64 --platform none --render`
- CLI command: `./hypershift create cluster --pull-secret ../../pullsecret.json --ssh-key ~/.ssh/id_rsa.pub --base-domain alklabs.com --namespace clusters2 --node-pool-replicas -2 --release-image quay.io/openshift-release-dev/ocp-release:4.8.6-x86_64 --platform none`
 
Results:  `[root@qct-d14u03 bin]#  oc get hostedclusters -n clusters2
NAME      VERSION   KUBECONFIG                 PROGRESS   AVAILABLE   REASON
example             example-admin-kubeconfig   Partial    True        HostedClusterAsExpected
[root@qct-d14u03 bin]#`