### PR TITLE
update config key to properly create core config

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/imagecontentsource.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/imagecontentsource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	IgnitionConfigKey           = "data"
+	IgnitionConfigKey           = "config"
 	CoreIgnitionFieldLabelKey   = "hypershift.openshift.io/core-ignition-config"
 	CoreIgnitionFieldLabelValue = "true"
 )


### PR DESCRIPTION
conforms to @enxebre new format for configs

Fixes bug where machine configs were looked up across all namespaces (needs to be scoped to control plane resource)
Updates tests to account for regressions in that case going forward