### PR TITLE
add Route ServicePublishingStrategy for Konnectivity

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -205,7 +205,7 @@ aws_secret_access_key = %s
 				{
 					Service: hyperv1.Konnectivity,
 					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-						Type: hyperv1.LoadBalancer,
+						Type: hyperv1.Route,
 					},
 				},
 				{

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
@@ -62,6 +62,15 @@ func KonnectivityServerService(hostedClusterNamespace string) *corev1.Service {
 	}
 }
 
+func KonnectivityServerRoute(hostedClusterNamespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      konnectivityServerServiceName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
 func OpenshiftAPIServerService(hostedClusterNamespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Add a Route ServicePublishingStrategy for Konnectivity and switches to use it by default.

The APIServer is the only service remaining that requires an LB.

@derekwaynecarr @csrwng 