### PR TITLE
machine config payload downloads over HTTPS/TLS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/pki/mcs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/mcs.go
@@ -10,9 +10,7 @@ import (
 
 func ReconcileMachineConfigServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
 	hostNames := []string{
-		"machine-config-server",
-		fmt.Sprintf("machine-config-server.%s.svc", secret.Namespace),
-		fmt.Sprintf("machine-config-server.%s.svc.cluster.local", secret.Namespace),
+		fmt.Sprintf("*.machine-config-server.%s.svc.cluster.local", secret.Namespace),
 	}
 	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "machine-config-server", "openshift", X509DefaultUsage, X509UsageClientServerAuth, hostNames, nil)
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -771,6 +771,11 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile ignition server: %w", err)
 	}
 
+	// Reconcile the machine config server
+	if err = r.reconcileMachineConfigServer(ctx, hcluster); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile machine config server: %w", err)
+	}
+
 	r.Log.Info("successfully reconciled")
 	return ctrl.Result{}, nil
 }
@@ -2445,4 +2450,47 @@ func enqueueParentHostedCluster(obj client.Object) []reconcile.Request {
 	return []reconcile.Request{
 		{NamespacedName: hyperutil.ParseNamespacedName(hostedClusterName)},
 	}
+}
+
+func (r *HostedClusterReconciler) reconcileMachineConfigServer(ctx context.Context, hcluster *hyperv1.HostedCluster) error {
+	var span trace.Span
+	ctx, span = r.tracer.Start(ctx, "reconcile-machine-config-server")
+	defer span.End()
+
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace); err != nil {
+		return fmt.Errorf("failed to get control plane namespace: %w", err)
+	}
+
+	// Reconcile service
+	mcsService := ignitionserver.MCSService(controlPlaneNamespace.Name)
+	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, mcsService, func() error {
+		return reconcileMachineConfigServerService(mcsService)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile machine config server service: %w", err)
+	} else {
+		span.AddEvent("reconciled machine config server service", trace.WithAttributes(attribute.String("result", string(result))))
+	}
+
+	return nil
+}
+
+func reconcileMachineConfigServerService(svc *corev1.Service) error {
+	svc.Spec.Selector = map[string]string{
+		"app": "machine-config-server",
+	}
+	var portSpec corev1.ServicePort
+	if len(svc.Spec.Ports) > 0 {
+		portSpec = svc.Spec.Ports[0]
+	} else {
+		svc.Spec.Ports = []corev1.ServicePort{portSpec}
+	}
+	portSpec.Port = int32(8443)
+	portSpec.Name = "https"
+	portSpec.Protocol = corev1.ProtocolTCP
+	portSpec.TargetPort = intstr.FromInt(8443)
+	svc.Spec.Ports[0] = portSpec
+	svc.Spec.Type = corev1.ServiceTypeClusterIP
+	svc.Spec.ClusterIP = corev1.ClusterIPNone
+	return nil
 }

--- a/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
+++ b/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
@@ -86,3 +86,12 @@ func RoleBinding(namespace string) *rbacv1.RoleBinding {
 		},
 	}
 }
+
+func MCSService(namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "machine-config-server",
+		},
+	}
+}


### PR DESCRIPTION
To enable tls for downloading ignition this creates a headless service for the mcs that the ign server can reach through https. The additional domains for the certs are also removed as they are not needed.Drop toleration from mcs pod

Complements of Sanjeev (picked up after he want on parental leave):
Ports this pr: https://github.com/openshift/hypershift/pull/457

With the additional comments