### PR TITLE
add cluster toleration to mcs pod to allow it to schedule on nodes that hold control plane components.

### DIFF
--- a/ignition-server/controllers/machineconfigserver_ignitionprovider.go
+++ b/ignition-server/controllers/machineconfigserver_ignitionprovider.go
@@ -252,6 +252,12 @@ cat /tmp/custom-config/base64CompressedConfig | base64 -d | gunzip --force --std
 			EnableServiceLinks:            k8sutilspointer.BoolPtr(true),
 			Subdomain:                     mcsPodSubdomain,
 			Hostname:                      podName,
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "hypershift.openshift.io/cluster",
+					Operator: corev1.TolerationOpExists,
+				},
+			},
 			InitContainers: []corev1.Container{
 				{
 					Image: images["machine-config-operator"],


### PR DESCRIPTION
Note: It does not include the "individual cluster" level taint for now. Mainly when that taint is added it's really meant for housing hot kube-apiservers/etcds. This taint is useful however as most of the nodes in the management cluster will have this taint and without the toleration: there will be a limited number of workers that can actually hold the mcs pods.