### PR TITLE
remove signingKey field from HostedCluster

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -16,7 +16,6 @@ type ExampleResources struct {
 	PullSecret                  *corev1.Secret
 	KubeCloudControllerAWSCreds *corev1.Secret
 	NodePoolManagementAWSCreds  *corev1.Secret
-	SigningKey                  *corev1.Secret
 	SSHKey                      *corev1.Secret
 	Cluster                     *hyperv1.HostedCluster
 	NodePool                    *hyperv1.NodePool
@@ -26,7 +25,6 @@ func (o *ExampleResources) AsObjects() []crclient.Object {
 	objects := []crclient.Object{
 		o.Namespace,
 		o.PullSecret,
-		o.SigningKey,
 		o.KubeCloudControllerAWSCreds,
 		o.NodePoolManagementAWSCreds,
 		o.Cluster,
@@ -45,7 +43,6 @@ type ExampleOptions struct {
 	Name             string
 	ReleaseImage     string
 	PullSecret       []byte
-	SigningKey       []byte
 	IssuerURL        string
 	SSHKey           []byte
 	NodePoolReplicas int32
@@ -127,20 +124,6 @@ aws_secret_access_key = %s
 		o.AWS.NodePoolManagementUserAccessKeyID,
 		o.AWS.NodePoolManagementUserAccessKeySecret)
 
-	signingKeySecret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace.Name,
-			Name:      o.Name + "-signing-key",
-		},
-		Data: map[string][]byte{
-			"key": o.SigningKey,
-		},
-	}
-
 	var sshKeySecret *corev1.Secret
 	var sshKeyReference corev1.LocalObjectReference
 	if len(o.SSHKey) > 0 {
@@ -217,7 +200,6 @@ aws_secret_access_key = %s
 			},
 			InfraID:    o.InfraID,
 			PullSecret: corev1.LocalObjectReference{Name: pullSecret.Name},
-			SigningKey: corev1.LocalObjectReference{Name: signingKeySecret.Name},
 			IssuerURL:  o.IssuerURL,
 			SSHKey:     sshKeyReference,
 			FIPS:       o.FIPS,
@@ -293,7 +275,6 @@ aws_secret_access_key = %s
 		PullSecret:                  pullSecret,
 		KubeCloudControllerAWSCreds: kubeCloudControllerCredsSecret,
 		NodePoolManagementAWSCreds:  nodePoolManagementCredsSecret,
-		SigningKey:                  signingKeySecret,
 		SSHKey:                      sshKeySecret,
 		Cluster:                     cluster,
 		NodePool:                    nodePool,

--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -27,7 +27,6 @@ type HostedControlPlane struct {
 type HostedControlPlaneSpec struct {
 	ReleaseImage string                      `json:"releaseImage"`
 	PullSecret   corev1.LocalObjectReference `json:"pullSecret"`
-	SigningKey   corev1.LocalObjectReference `json:"signingKey"`
 	IssuerURL    string                      `json:"issuerURL"`
 	ServiceCIDR  string                      `json:"serviceCIDR"`
 	PodCIDR      string                      `json:"podCIDR"`

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -60,10 +60,6 @@ type HostedClusterSpec struct {
 	// +optional
 	AuditWebhook *corev1.LocalObjectReference `json:"auditWebhook,omitempty"`
 
-	// SigningKey is a reference to a Secret containing a single key "key"
-	// +optional
-	SigningKey corev1.LocalObjectReference `json:"signingKey,omitempty"`
-
 	// +kubebuilder:default:="https://kubernetes.default.svc"
 	IssuerURL string `json:"issuerURL"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -459,7 +459,6 @@ func (in *HostedClusterSpec) DeepCopyInto(out *HostedClusterSpec) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
-	out.SigningKey = in.SigningKey
 	out.SSHKey = in.SSHKey
 	in.Networking.DeepCopyInto(&out.Networking)
 	in.Autoscaling.DeepCopyInto(&out.Autoscaling)
@@ -592,7 +591,6 @@ func (in *HostedControlPlaneList) DeepCopyObject() runtime.Object {
 func (in *HostedControlPlaneSpec) DeepCopyInto(out *HostedControlPlaneSpec) {
 	*out = *in
 	out.PullSecret = in.PullSecret
-	out.SigningKey = in.SigningKey
 	out.SSHKey = in.SSHKey
 	in.Platform.DeepCopyInto(&out.Platform)
 	out.DNS = in.DNS

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -222,7 +222,6 @@ func CreateCluster(ctx context.Context, opts Options) error {
 		Annotations:      annotations,
 		ReleaseImage:     opts.ReleaseImage,
 		PullSecret:       pullSecret,
-		SigningKey:       iamInfo.ServiceAccountSigningKey,
 		IssuerURL:        iamInfo.IssuerURL,
 		SSHKey:           sshKey,
 		NodePoolReplicas: opts.NodePoolReplicas,

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -33,12 +33,11 @@ type CreateIAMOptions struct {
 }
 
 type CreateIAMOutput struct {
-	Region                   string                       `json:"region"`
-	ProfileName              string                       `json:"profileName"`
-	InfraID                  string                       `json:"infraID"`
-	IssuerURL                string                       `json:"issuerURL"`
-	ServiceAccountSigningKey []byte                       `json:"serviceAccountSigningKey"`
-	Roles                    []hyperv1.AWSRoleCredentials `json:"roles"`
+	Region      string                       `json:"region"`
+	ProfileName string                       `json:"profileName"`
+	InfraID     string                       `json:"infraID"`
+	IssuerURL   string                       `json:"issuerURL"`
+	Roles       []hyperv1.AWSRoleCredentials `json:"roles"`
 
 	KubeCloudControllerUserAccessKeyID     string `json:"kubeCloudControllerUserAccessKeyID"`
 	KubeCloudControllerUserAccessKeySecret string `json:"kubeCloudControllerUserAccessKeySecret"`

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -3,12 +3,8 @@ package aws
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"net/url"
 	"strings"
@@ -264,18 +260,6 @@ func (o *CreateIAMOptions) CreateOIDCResources(iamClient iamiface.IAMAPI) (*Crea
 		InfraID:   o.InfraID,
 		IssuerURL: o.IssuerURL,
 	}
-
-	// Create the service account signing key
-	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		return nil, err
-	}
-
-	output.ServiceAccountSigningKey = pem.EncodeToMemory(&pem.Block{
-		Type:    "RSA PRIVATE KEY",
-		Headers: nil,
-		Bytes:   x509.MarshalPKCS1PrivateKey(privKey),
-	})
 
 	// Discover the thumbprint for the CA on the OIDC discovery endpoint
 	url, err := url.Parse(o.IssuerURL)

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -636,15 +636,6 @@ spec:
                   - servicePublishingStrategy
                   type: object
                 type: array
-              signingKey:
-                description: SigningKey is a reference to a Secret containing a single
-                  key "key"
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
               sshKey:
                 description: SSHKey is a reference to a Secret containing a single
                   key "id_rsa.pub", whose value is the public part of an SSH key that

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -565,15 +565,6 @@ spec:
                   - servicePublishingStrategy
                   type: object
                 type: array
-              signingKey:
-                description: LocalObjectReference contains enough information to let
-                  you locate the referenced object inside the same namespace.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
               sshKey:
                 description: LocalObjectReference contains enough information to let
                   you locate the referenced object inside the same namespace.
@@ -596,7 +587,6 @@ spec:
             - releaseImage
             - serviceCIDR
             - services
-            - signingKey
             - sshKey
             type: object
           status:

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1092,15 +1092,8 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 
 	// Service account signing key secret
 	serviceAccountSigningKeySecret := manifests.ServiceAccountSigningKeySecret(hcp.Namespace)
-	var signingKeySecret *corev1.Secret
-	if len(hcp.Spec.SigningKey.Name) > 0 {
-		signingKeySecret = &corev1.Secret{}
-		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcp.GetNamespace(), Name: hcp.Spec.SigningKey.Name}, signingKeySecret); err != nil {
-			return fmt.Errorf("failed to get signing key %s: %w", hcp.Spec.SigningKey.Name, err)
-		}
-	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r, serviceAccountSigningKeySecret, func() error {
-		return pki.ReconcileServiceAccountSigningKeySecret(serviceAccountSigningKeySecret, signingKeySecret, p.OwnerRef)
+		return pki.ReconcileServiceAccountSigningKeySecret(serviceAccountSigningKeySecret, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile api server service account key secret: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/sa.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/sa.go
@@ -1,7 +1,6 @@
 package pki
 
 import (
-	"crypto/rsa"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,38 +9,26 @@ import (
 	"github.com/openshift/hypershift/support/certs"
 )
 
-func ReconcileServiceAccountSigningKeySecret(secret, signingKey *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileServiceAccountSigningKeySecret(secret *corev1.Secret, ownerRef config.OwnerRef) error {
+	expectedKeys := []string{ServiceSignerPrivateKey, ServiceSignerPublicKey}
+	if secret != nil && SecretUpToDate(secret, expectedKeys) {
+		return nil
+	}
 	ownerRef.ApplyTo(secret)
 	secret.Type = corev1.SecretTypeOpaque
-	expectedKeys := []string{ServiceSignerPrivateKey, ServiceSignerPublicKey}
-	if !SecretUpToDate(secret, expectedKeys) {
-		var key *rsa.PrivateKey
-		var err error
-		if signingKey != nil {
-			signingKeySecretData, hasSigningKeySecretData := signingKey.Data["key"]
-			if !hasSigningKeySecretData {
-				return fmt.Errorf("signing key secret %s is missing the key key", signingKey.Name)
-			}
-			key, err = certs.PemToPrivateKey(signingKeySecretData)
-			if err != nil {
-				return fmt.Errorf("failed to PEM decode private key %s: %w", signingKey.Name, err)
-			}
-		} else {
-			key, err = certs.PrivateKey()
-			if err != nil {
-				return fmt.Errorf("failed generating a private key: %w", err)
-			}
-		}
-		keyBytes := certs.PrivateKeyToPem(key)
-		publicKeyBytes, err := certs.PublicKeyToPem(&key.PublicKey)
-		if err != nil {
-			return fmt.Errorf("failed to generate public key from private key: %w", err)
-		}
-		if secret.Data == nil {
-			secret.Data = map[string][]byte{}
-		}
-		secret.Data[ServiceSignerPrivateKey] = keyBytes
-		secret.Data[ServiceSignerPublicKey] = publicKeyBytes
+	key, err := certs.PrivateKey()
+	if err != nil {
+		return fmt.Errorf("failed generating a private key: %w", err)
 	}
+	keyBytes := certs.PrivateKeyToPem(key)
+	publicKeyBytes, err := certs.PublicKeyToPem(&key.PublicKey)
+	if err != nil {
+		return fmt.Errorf("failed to generate public key from private key: %w", err)
+	}
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+	secret.Data[ServiceSignerPrivateKey] = keyBytes
+	secret.Data[ServiceSignerPublicKey] = publicKeyBytes
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -516,31 +516,6 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Reconcile the HostedControlPlane signing key by resolving the source secret
-	// reference from the HostedCluster and syncing the secret in the control plane namespace.
-	if len(hcluster.Spec.SigningKey.Name) > 0 {
-		var src corev1.Secret
-		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.SigningKey.Name}, &src); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get signing key %s: %w", hcluster.Spec.SigningKey.Name, err)
-		}
-		dest := controlplaneoperator.SigningKey(controlPlaneNamespace.Name)
-		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, dest, func() error {
-			srcData, srcHasData := src.Data["key"]
-			if !srcHasData {
-				return fmt.Errorf("hostedcluster signing key %q must have a key key", src.Name)
-			}
-			dest.Type = corev1.SecretTypeOpaque
-			if dest.Data == nil {
-				dest.Data = map[string][]byte{}
-			}
-			dest.Data["key"] = srcData
-			return nil
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile signing key: %w", err)
-		}
-	}
-
 	// Reconcile the HostedControlPlane SSH secret by resolving the source secret reference
 	// from the HostedCluster and syncing the secret in the control plane namespace.
 	if len(hcluster.Spec.SSHKey.Name) > 0 {
@@ -806,9 +781,6 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		}
 	}
 	hcp.Spec.PullSecret = corev1.LocalObjectReference{Name: controlplaneoperator.PullSecret(hcp.Namespace).Name}
-	if len(hcluster.Spec.SigningKey.Name) > 0 {
-		hcp.Spec.SigningKey = corev1.LocalObjectReference{Name: controlplaneoperator.SigningKey(hcp.Namespace).Name}
-	}
 	if len(hcluster.Spec.SSHKey.Name) > 0 {
 		hcp.Spec.SSHKey = corev1.LocalObjectReference{Name: controlplaneoperator.SSHKey(hcp.Namespace).Name}
 	}


### PR DESCRIPTION
I was wandering around the HC spec today and I'm not sure that we need `signingKey` anymore.

Originally we needed to do this because we needed the CA that signed that key to be known at OIDC provider creation time.  However, since then, we switched to a `reencrypt` Route for the OIDC provider so we only need the thumbprint of the ingress CA, which we discover automatically at IAM create time.

We do not support NodePort publishing type on the OIDC service anymore so... I don't think we need this.

@csrwng @derekwaynecarr 