### PR TITLE
set default infrastructuretopology to ha

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -53,7 +53,7 @@ type HostedControlPlaneSpec struct {
 
 	// InfrastructureAvailabilityPolicy specifies whether to run infrastructure services that
 	// run on the guest cluster nodes in HA mode
-	// Defaults to SingleReplica when not set
+	// Defaults to HighlyAvailable when not set
 	// +optional
 	InfrastructureAvailabilityPolicy AvailabilityPolicy `json:"infrastructureAvailabilityPolicy,omitempty"`
 

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -95,7 +95,7 @@ type HostedClusterSpec struct {
 
 	// InfrastructureAvailabilityPolicy specifies whether to run infrastructure services that
 	// run on the guest cluster nodes in HA mode
-	// Defaults to SingleReplica when not set
+	// Defaults to HighlyAvailable when not set
 	// +optional
 	InfrastructureAvailabilityPolicy AvailabilityPolicy `json:"infrastructureAvailabilityPolicy,omitempty"`
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -381,7 +381,7 @@ spec:
               infrastructureAvailabilityPolicy:
                 description: InfrastructureAvailabilityPolicy specifies whether to
                   run infrastructure services that run on the guest cluster nodes
-                  in HA mode Defaults to SingleReplica when not set
+                  in HA mode Defaults to HighlyAvailable when not set
                 type: string
               issuerURL:
                 default: https://kubernetes.default.svc

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -339,7 +339,7 @@ spec:
               infrastructureAvailabilityPolicy:
                 description: InfrastructureAvailabilityPolicy specifies whether to
                   run infrastructure services that run on the guest cluster nodes
-                  in HA mode Defaults to SingleReplica when not set
+                  in HA mode Defaults to HighlyAvailable when not set
                 type: string
               issuerURL:
                 type: string

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1607,7 +1607,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftOAuthAPIServer(ctx cont
 
 func (r *HostedControlPlaneReconciler) reconcileDefaultIngressController(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	replicas := int32(2)
-	if hcp.Spec.InfrastructureAvailabilityPolicy != hyperv1.HighlyAvailable {
+	if hcp.Spec.InfrastructureAvailabilityPolicy == hyperv1.SingleReplica {
 		replicas = 1
 	}
 	ingressControllerManifest := manifests.IngressDefaultIngressControllerWorkerManifest(hcp.Namespace)
@@ -1828,9 +1828,9 @@ func (r *HostedControlPlaneReconciler) generateControlPlaneManifests(ctx context
 	params.NetworkType = hcp.Spec.NetworkType
 	params.ImageRegistryHTTPSecret = generateImageRegistrySecret()
 	params.APIAvailabilityPolicy = render.SingleReplica
-	params.InfrastructureAvailabilityPolicy = render.SingleReplica
-	if hcp.Spec.InfrastructureAvailabilityPolicy == hyperv1.HighlyAvailable {
-		params.InfrastructureAvailabilityPolicy = render.HighlyAvailable
+	params.InfrastructureAvailabilityPolicy = render.HighlyAvailable
+	if hcp.Spec.InfrastructureAvailabilityPolicy == hyperv1.SingleReplica {
+		params.InfrastructureAvailabilityPolicy = render.SingleReplica
 	}
 	params.SSHKey = string(sshKeyData)
 


### PR DESCRIPTION
Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>

Tests:
- [x] default will use HA for infrastructureTopology & ingresscontroller
- [x] `hypershift create --render` and set to singleReplica will use singleReplica