### PR TITLE
ensure control plane konnectivity agent deployment ha for traffic failover

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -87,6 +87,10 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 		},
 	}
 	p.AgentDeploymentConfig.Replicas = 1
+	if hcp.Spec.ControllerAvailabilityPolicy == hyperv1.HighlyAvailable {
+		p.AgentDeploymentConfig.Replicas = 3
+	}
+	p.AgentDeploymentConfig.SetMultizoneSpread(konnectivityAgentLabels)
 	p.AgentDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	p.AgentDeploymentConfig.SetColocation(hcp)
 	p.AgentDeploymentConfig.SetControlPlaneIsolation(hcp)


### PR DESCRIPTION
This should be done because APIServices do process some pretty important apis. Currently if anything goes wrong with the one agent there's no failover or attempt to use a different connection path. With multiple agents running there will be multiple redundant communication paths for traffic to flow for kube-apiserver -> openshift-apiserver or other control plane apiservices 