### PR TITLE
Add support for ign serve token rotation

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -598,7 +598,12 @@ func (r NodePoolReconciler) reconcileAWSMachineTemplate(ctx context.Context,
 }
 
 func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.NodePool, CA, token []byte, ignEndpoint string) error {
-	userDataSecret.Immutable = k8sutilspointer.BoolPtr(true)
+	// The token secret controller deletes expired token Secrets.
+	// When that happens the NodePool controller reconciles and create a new one.
+	// Then it reconciles the userData Secret with the new generated token.
+	// Therefore this secret is mutable.
+	userDataSecret.Immutable = k8sutilspointer.BoolPtr(false)
+
 	if userDataSecret.Annotations == nil {
 		userDataSecret.Annotations = make(map[string]string)
 	}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
-
-	capiv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
-
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/ignition-server/controllers/tokensecret_controller_test.go
+++ b/ignition-server/controllers/tokensecret_controller_test.go
@@ -1,0 +1,185 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	fakePayload = "test"
+)
+
+type fakeIgnitionProvider struct{}
+
+func (p *fakeIgnitionProvider) GetPayload(ctx context.Context, releaseImage string, config string) (payload []byte, err error) {
+	return []byte(fakePayload), nil
+}
+
+func TestReconcile(t *testing.T) {
+	compressedConfig, err := compress([]byte("compressedConfig"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name       string
+		secret     client.Object
+		validation func(t *testing.T, secret client.Object)
+	}{
+		{
+			name: "When a secret is non expired it reconciles it storing or deleting the payload",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						TokenSecretAnnotation: "true",
+					},
+					Finalizers: []string{
+						finalizer,
+					},
+					CreationTimestamp: metav1.Now(),
+				},
+				Immutable: nil,
+				Data: map[string][]byte{
+					TokenSecretTokenKey:   []byte(uuid.New().String()),
+					TokenSecretReleaseKey: []byte("release"),
+					TokenSecretConfigKey:  compressedConfig,
+				},
+			},
+			validation: func(t *testing.T, secret client.Object) {
+				ctx := context.Background()
+				r := TokenSecretReconciler{
+					Client:           fake.NewClientBuilder().WithObjects(secret).Build(),
+					IgnitionProvider: &fakeIgnitionProvider{},
+					PayloadStore:     NewPayloadStore(),
+				}
+				g := NewWithT(t)
+				_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(secret)})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Get the secret.
+				gotSecret := &corev1.Secret{}
+				err = r.Client.Get(ctx, client.ObjectKeyFromObject(secret), gotSecret)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Validate that secret is not intended to be deleted.
+				g.Expect(gotSecret.GetDeletionTimestamp().IsZero()).To(BeTrue())
+
+				// Validate that payload was stored in the cache.
+				token := gotSecret.Data[TokenSecretTokenKey]
+				value, found := r.PayloadStore.Get(string(token))
+				g.Expect(found).To(BeTrue())
+				g.Expect(value).To(BeEquivalentTo(fakePayload))
+
+				// Delete the secret.
+				err = r.Client.Delete(ctx, gotSecret)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Reconcile here should delete the payload from the cache
+				// and remove the finalizer.
+				_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(gotSecret)})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Validate the finalizer was removed and the CR is deleted.
+				gotSecret = &corev1.Secret{}
+				err = r.Client.Get(ctx, client.ObjectKeyFromObject(secret), gotSecret)
+				g.Expect(err).To(HaveOccurred())
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("expected notFound error, got: %v", err)
+				}
+
+				// Validate that payload was deleted from the cache.
+				value, found = r.PayloadStore.Get(string(token))
+				g.Expect(found).To(BeFalse())
+				g.Expect(value).To(BeEquivalentTo(""))
+			},
+		},
+		{
+			name: "When a secret is expired it deletes it",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						TokenSecretAnnotation: "true",
+					},
+					Finalizers: []string{
+						finalizer,
+					},
+					CreationTimestamp: metav1.NewTime(metav1.Now().Add(-ttl - 1*time.Hour)),
+				},
+				Immutable: nil,
+				Data: map[string][]byte{
+					TokenSecretTokenKey:   []byte(uuid.New().String()),
+					TokenSecretReleaseKey: []byte("release"),
+					TokenSecretConfigKey:  compressedConfig,
+				},
+			},
+			validation: func(t *testing.T, secret client.Object) {
+				ctx := context.Background()
+				r := TokenSecretReconciler{
+					Client:           fake.NewClientBuilder().WithObjects(secret).Build(),
+					IgnitionProvider: &fakeIgnitionProvider{},
+					PayloadStore:     NewPayloadStore(),
+				}
+				g := NewWithT(t)
+				_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(secret)})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Get the secret.
+				gotSecret := &corev1.Secret{}
+				err = r.Client.Get(ctx, client.ObjectKeyFromObject(secret), gotSecret)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Validate that secret is intended to be deleted.
+				g.Expect(gotSecret.GetDeletionTimestamp().IsZero()).To(BeFalse())
+
+				// Manually set the token in the cache.
+				token := gotSecret.Data[TokenSecretTokenKey]
+				r.PayloadStore.Set(string(token), []byte(fakePayload))
+				value, found := r.PayloadStore.Get(string(token))
+				g.Expect(found).To(BeTrue())
+				g.Expect(value).To(BeEquivalentTo(fakePayload))
+
+				// Reconcile here should delete the payload from the cache
+				// and remove the finalizer.
+				_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(secret)})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Validate the finalizer was removed and the CR is deleted.
+				gotSecret = &corev1.Secret{}
+				err = r.Client.Get(ctx, client.ObjectKeyFromObject(secret), gotSecret)
+				g.Expect(err).To(HaveOccurred())
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("expected notFound error, got: %v", err)
+				}
+
+				// Validate that payload was deleted from the cache.
+				token = gotSecret.Data[TokenSecretTokenKey]
+				value, found = r.PayloadStore.Get(string(token))
+				g.Expect(found).To(BeFalse())
+				g.Expect(value).To(BeEquivalentTo(""))
+			},
+		},
+	}
+
+	// Set the logger so the tested funcs log accordingly.
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.validation(t, tc.secret)
+		})
+	}
+}


### PR DESCRIPTION
This PR enables the token Secret controller to automatically delete token Secrets generated by the NodePool controller when the ttl is met by a secret.
The token Secret controller controller uses now a finalizer to ensure a token is removed from the payload cache when the token Secret is removed.
When that happens the NodePool controller reconciles and create a new token Secret.
Then it reconciles the userData Secret in place with the new generated token so new machines can join the cluster successfully. Therefore the userdata Secret is mutable.
Ref https://issues.redhat.com/browse/HOSTEDCP-209
