### PR TITLE
Wire up the authentication-token-webhook-config for the KAS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -108,6 +108,8 @@ func generateConfig(ns string, p KubeAPIServerConfigParams) *kcpv1.KubeAPIServer
 	args.Set("audit-log-maxsize", "100")
 	args.Set("audit-log-path", cpath(kasVolumeWorkLogs().Name, AuditLogFile))
 	args.Set("audit-policy-file", cpath(kasVolumeAuditConfig().Name, AuditPolicyConfigMapKey))
+	args.Set("authentication-token-webhook-config-file", cpath(kasVolumeAuthTokenWebhookConfig().Name, KubeconfigKey))
+	args.Set("authentication-token-webhook-version", "v1")
 	args.Set("authorization-mode", "Scope", "SystemMasters", "RBAC", "Node")
 	args.Set("client-ca-file", cpath(kasVolumeClientCA().Name, pki.CASignerCertMapKey))
 	if p.CloudProviderConfigRef != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -43,6 +43,7 @@ var (
 			kasVolumeEtcdClientCert().Name:         "/etc/kubernetes/certs/etcd",
 			kasVolumeServiceAccountKey().Name:      "/etc/kubernetes/secrets/svcacct-key",
 			kasVolumeOauthMetadata().Name:          "/etc/kubernetes/oauth",
+			kasVolumeAuthTokenWebhookConfig().Name: "/etc/kubernetes/auth-token-webhook",
 			kasVolumeKubeletClientCert().Name:      "/etc/kubernetes/certs/kubelet",
 			kasVolumeKubeletClientCA().Name:        "/etc/kubernetes/certs/kubelet-ca",
 			kasVolumeKonnectivityClientCert().Name: "/etc/kubernetes/certs/konnectivity-client",
@@ -146,6 +147,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 					util.BuildVolume(kasVolumeServiceAccountKey(), buildKASVolumeServiceAccountKey),
 					util.BuildVolume(kasVolumeEtcdClientCert(), buildKASVolumeEtcdClientCert),
 					util.BuildVolume(kasVolumeOauthMetadata(), buildKASVolumeOauthMetadata),
+					util.BuildVolume(kasVolumeAuthTokenWebhookConfig(), buildKASVolumeAuthTokenWebhookConfig),
 					util.BuildVolume(kasVolumeClientCA(), buildKASVolumeClientCA),
 					util.BuildVolume(kasVolumeKubeletClientCert(), buildKASVolumeKubeletClientCert),
 					util.BuildVolume(kasVolumeKubeletClientCA(), buildKASVolumeKubeletClientCA),
@@ -436,6 +438,16 @@ func kasVolumeOauthMetadata() *corev1.Volume {
 func buildKASVolumeOauthMetadata(v *corev1.Volume) {
 	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
 	v.ConfigMap.Name = manifests.KASOAuthMetadata("").Name
+}
+
+func kasVolumeAuthTokenWebhookConfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "auth-token-webhook-config",
+	}
+}
+func buildKASVolumeAuthTokenWebhookConfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{}
+	v.Secret.SecretName = manifests.KASAuthenticationTokenWebhookConfigSecret("").Name
 }
 
 func kasVolumeCloudConfig() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/oauth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/oauth.go
@@ -5,7 +5,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	clientcmd "k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 )
 
 func ReconcileOauthMetadata(cfg *corev1.ConfigMap, ownerRef config.OwnerRef, externalOAuthAddress string, externalOAuthPort int32) error {
@@ -43,3 +47,55 @@ const oauthMetadata = `{
   ]
 }
 `
+
+func ReconcileAuthenticationTokenWebhookConfigSecret(secret *corev1.Secret, ownerRef config.OwnerRef, authenticatorSecret *corev1.Secret) error {
+	ownerRef.ApplyTo(secret)
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+	var ca, crt, key []byte
+	var ok bool
+	if ca, ok = authenticatorSecret.Data[pki.CASignerCertMapKey]; !ok {
+		return fmt.Errorf("expected %s key in authenticator secret", pki.CASignerCertMapKey)
+	}
+	if crt, ok = authenticatorSecret.Data[corev1.TLSCertKey]; !ok {
+		return fmt.Errorf("expected %s key in authenticator secret", corev1.TLSCertKey)
+	}
+	if key, ok = authenticatorSecret.Data[corev1.TLSPrivateKeyKey]; !ok {
+		return fmt.Errorf("expected %s key in authenticator secret", corev1.TLSPrivateKeyKey)
+	}
+	url := fmt.Sprintf("https://openshift-oauth-apiserver.%s.svc:443/apis/oauth.openshift.io/v1/tokenreviews", secret.GetNamespace())
+	kubeConfigBytes, err := generateAuthenticationTokenWebhookConfig(url, crt, key, ca)
+	if err != nil {
+		return err
+	}
+	secret.Data[KubeconfigKey] = kubeConfigBytes
+	return nil
+}
+
+func generateAuthenticationTokenWebhookConfig(url string, crtBytes, keyBytes, caBytes []byte) ([]byte, error) {
+	kubeCfg := clientcmdapi.Config{
+		Kind:       "Config",
+		APIVersion: "v1",
+	}
+	kubeCfg.Clusters = map[string]*clientcmdapi.Cluster{
+		"local-cluster": {
+			Server:                   url,
+			CertificateAuthorityData: caBytes,
+		},
+	}
+	kubeCfg.AuthInfos = map[string]*clientcmdapi.AuthInfo{
+		"openshift-authenticator": {
+			ClientCertificateData: crtBytes,
+			ClientKeyData:         keyBytes,
+		},
+	}
+	kubeCfg.Contexts = map[string]*clientcmdapi.Context{
+		"local-context": {
+			Cluster:  "local-cluster",
+			AuthInfo: "openshift-authenticator",
+		},
+	}
+	kubeCfg.CurrentContext = "local-context"
+	return clientcmd.Write(kubeCfg)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -135,3 +135,12 @@ func KASOAuthMetadata(controlPlaneNamespace string) *corev1.ConfigMap {
 		},
 	}
 }
+
+func KASAuthenticationTokenWebhookConfigSecret(controlPlaneNamespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kas-authentication-token-webhook-config",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -131,6 +131,15 @@ func OpenShiftOAuthAPIServerCertSecret(ns string) *corev1.Secret {
 	}
 }
 
+func OpenshiftAuthenticatorCertSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-authenticator-cert",
+			Namespace: ns,
+		},
+	}
+}
+
 func OpenShiftControllerManagerCertSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -91,6 +91,7 @@ func buildOAuthContainerMain(p *OAuthDeploymentParams) func(c *corev1.Container)
 			fmt.Sprintf("--authentication-kubeconfig=%s", cpath(oauthVolumeKubeconfig().Name, kas.KubeconfigKey)),
 			fmt.Sprintf("--kubeconfig=%s", cpath(oauthVolumeKubeconfig().Name, kas.KubeconfigKey)),
 			fmt.Sprintf("--secure-port=%d", OpenShiftOAuthAPIServerPort),
+			fmt.Sprintf("--api-audiences=%s", p.ServiceAccountIssuerURL),
 			fmt.Sprintf("--audit-log-path=%s", cpath(oauthVolumeWorkLogs().Name, "audit.log")),
 			"--audit-log-format=json",
 			"--audit-log-maxsize=100",

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -11,9 +11,10 @@ import (
 )
 
 type OpenShiftAPIServerParams struct {
-	APIServer        *configv1.APIServer `json:"apiServer"`
-	IngressSubDomain string
-	EtcdURL          string `json:"etcdURL"`
+	APIServer               *configv1.APIServer `json:"apiServer"`
+	IngressSubDomain        string
+	EtcdURL                 string `json:"etcdURL"`
+	ServiceAccountIssuerURL string `json:"serviceAccountIssuerURL"`
 
 	OpenShiftAPIServerDeploymentConfig      config.DeploymentConfig `json:"openshiftAPIServerDeploymentConfig,inline"`
 	OpenShiftOAuthAPIServerDeploymentConfig config.DeploymentConfig `json:"openshiftOAuthAPIServerDeploymentConfig,inline"`
@@ -24,11 +25,12 @@ type OpenShiftAPIServerParams struct {
 }
 
 type OAuthDeploymentParams struct {
-	Image            string
-	EtcdURL          string
-	MinTLSVersion    string
-	CipherSuites     []string
-	DeploymentConfig config.DeploymentConfig
+	Image                   string
+	EtcdURL                 string
+	MinTLSVersion           string
+	CipherSuites            []string
+	ServiceAccountIssuerURL string
+	DeploymentConfig        config.DeploymentConfig
 }
 
 func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig config.GlobalConfig, images map[string]string) *OpenShiftAPIServerParams {
@@ -37,6 +39,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 		OAuthAPIServerImage:     images["oauth-apiserver"],
 		HaproxyImage:            images["haproxy-router"],
 		APIServer:               globalConfig.APIServer,
+		ServiceAccountIssuerURL: hcp.Spec.IssuerURL,
 		IngressSubDomain:        config.IngressSubdomain(hcp),
 	}
 	params.OpenShiftAPIServerDeploymentConfig = config.DeploymentConfig{
@@ -175,11 +178,12 @@ func (p *OpenShiftAPIServerParams) IngressDomain() string {
 
 func (p *OpenShiftAPIServerParams) OAuthAPIServerDeploymentParams() *OAuthDeploymentParams {
 	return &OAuthDeploymentParams{
-		Image:            p.OAuthAPIServerImage,
-		EtcdURL:          p.EtcdURL,
-		DeploymentConfig: p.OpenShiftOAuthAPIServerDeploymentConfig,
-		MinTLSVersion:    p.MinTLSVersion(),
-		CipherSuites:     p.CipherSuites(),
+		Image:                   p.OAuthAPIServerImage,
+		EtcdURL:                 p.EtcdURL,
+		ServiceAccountIssuerURL: p.ServiceAccountIssuerURL,
+		DeploymentConfig:        p.OpenShiftOAuthAPIServerDeploymentConfig,
+		MinTLSVersion:           p.MinTLSVersion(),
+		CipherSuites:            p.CipherSuites(),
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
@@ -30,6 +30,10 @@ func ReconcileOpenShiftOAuthAPIServerCertSecret(secret, ca *corev1.Secret, owner
 	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-oauth-apiserver", "openshift", X509SignerUsage, X509UsageClientServerAuth, dnsNames, nil)
 }
 
+func ReconcileOpenShiftAuthenticatorCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator", "openshift", X509SignerUsage, X509UsageClientAuth, nil, nil)
+}
+
 func ReconcileOpenShiftControllerManagerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
 	dnsNames := []string{
 		"openshift-controller-manager",


### PR DESCRIPTION
@csrwng 

Fixes the issue with non-cert-based authentication failing on `main` in 4.9.

Cause of the breakage is this change in OCP https://github.com/openshift/enhancements/blob/ce4d303db807622687159eb9d3248285a003fabb/enhancements/authentication/configuring-webhook-token-authenticators.md