### PR TITLE
Fix mco/mcs script bug that renders master ignition

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/20-apiserver-haproxy.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/20-apiserver-haproxy.yaml
@@ -3,7 +3,7 @@ kind: MachineConfig
 metadata:
   name: 20-apiserver-haproxy
   labels:
-    machineconfiguration.openshift.io/role: master
+    machineconfiguration.openshift.io/role: worker
 spec:
   config:
     ignition:

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/30-fips.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/30-fips.yaml
@@ -3,6 +3,6 @@ kind: MachineConfig
 metadata:
   name: 30-fips
   labels:
-    machineconfiguration.openshift.io/role: master
+    machineconfiguration.openshift.io/role: worker
 spec:
   fips: {{ .FIPS }}

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/99-worker-ssh.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/99-worker-ssh.yaml
@@ -3,7 +3,7 @@ kind: MachineConfig
 metadata:
   name: 99-worker-ssh
   labels:
-    machineconfiguration.openshift.io/role: master
+    machineconfiguration.openshift.io/role: worker
 spec:
   config:
     ignition:

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1915,6 +1915,9 @@ func (r *HostedControlPlaneReconciler) reconcileOIDCRouteResources(ctx context.C
 
 func (r *HostedControlPlaneReconciler) reconcileImageContentSourcePolicy(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	imageContentSource := manifests.ImageContentSourcePolicy()
+	imageContentSource.Labels = map[string]string{
+		"machineconfiguration.openshift.io/role": "worker",
+	}
 	imageContentSource.Spec.RepositoryDigestMirrors = []v1alpha1.RepositoryDigestMirrors{}
 	for _, imageContentSourceEntry := range hcp.Spec.ImageContentSources {
 		imageContentSource.Spec.RepositoryDigestMirrors = append(imageContentSource.Spec.RepositoryDigestMirrors, v1alpha1.RepositoryDigestMirrors{

--- a/ignition-server/controllers/machineconfigserver_ignitionprovider.go
+++ b/ignition-server/controllers/machineconfigserver_ignitionprovider.go
@@ -201,7 +201,7 @@ func machineConfigServerPod(namespace string, releaseImage *releaseinfo.ReleaseI
 	bootstrapArgs := fmt.Sprintf(`
 mkdir -p /mcc-manifests/bootstrap/manifests
 mkdir -p /mcc-manifests/manifests
-exec machine-config-operator bootstrap \
+machine-config-operator bootstrap \
 --root-ca=/assets/manifests/root-ca.crt \
 --kube-ca=/assets/manifests/combined-ca.crt \
 --machine-config-operator-image=%s \


### PR DESCRIPTION
The script to run mco in bootstrap mode uses 'exec' to call the mco
binary. The exec causes the mco process to take over the main container
process and when it exits, the container dies without executing the rest
of the script which swaps master/worker configs.

This PR fixes that problem and properly labels core machine configs with
the worker pool instead of the master pool.

Cherry-picks https://github.com/openshift/hypershift/pull/469
