### PR TITLE
set default volume size when nodepool root volume is empty

### DIFF
--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -50,7 +50,9 @@ func AWSMachineTemplate(infraName, ami string, nodePool *hyperv1.NodePool, contr
 			subnet.Filters = append(subnet.Filters, filter)
 		}
 	}
-	rootVolume := &capiaws.Volume{}
+	rootVolume := &capiaws.Volume{
+		Size: EC2VolumeDefaultSize,
+	}
 	if nodePool.Spec.Platform.AWS.RootVolume != nil {
 		if nodePool.Spec.Platform.AWS.RootVolume.Type != "" {
 			rootVolume.Type = capiaws.VolumeType(nodePool.Spec.Platform.AWS.RootVolume.Type)
@@ -59,8 +61,6 @@ func AWSMachineTemplate(infraName, ami string, nodePool *hyperv1.NodePool, contr
 		}
 		if nodePool.Spec.Platform.AWS.RootVolume.Size > 0 {
 			rootVolume.Size = int64(nodePool.Spec.Platform.AWS.RootVolume.Size)
-		} else {
-			rootVolume.Size = EC2VolumeDefaultSize
 		}
 		if nodePool.Spec.Platform.AWS.RootVolume.IOPS > 0 {
 			rootVolume.IOPS = int64(nodePool.Spec.Platform.AWS.RootVolume.IOPS)


### PR DESCRIPTION
Fixing the following error when nodePool.Spec.Platform.AWS.RootVolume == nil:
```
2021-09-21T19:37:40.118Z	ERROR	controller-runtime.manager.controller.nodepool	Reconciler error	{"reconciler group": "hypershift.openshift.io", "reconciler kind": "NodePool", "name": "han-hosted-4", "namespace": "clusters", "error": "failed to reconcile AWSMachineTemplate: error creating new AWSMachineTemplate: AWSMachineTemplate.infrastructure.cluster.x-k8s.io \"han-hosted-4-7fc38b31\" is invalid: spec.template.spec.rootVolume.size: Invalid value: 0: spec.template.spec.rootVolume.size in body should be greater than or equal to 8"}
```

Updates:
- always set default volume size 