### PR TITLE
E2E: Collect pod phase change timings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/openshift/api v0.0.0-20210713130143-be21c6cb1bea
 	github.com/openshift/client-go v0.0.0-20200929181438-91d71ef2122c
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0

--- a/test/e2e/podtimingcontroller/podtimingcontroller.go
+++ b/test/e2e/podtimingcontroller/podtimingcontroller.go
@@ -1,0 +1,90 @@
+//go:build e2e
+// +build e2e
+
+package podtimingcontroller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+func SetupWithManager(mgr ctrl.Manager, log logr.Logger, artifactDir string) error {
+	r := &podTimingReconciler{
+		client: mgr.GetClient(),
+		podEnterPhaseDurationSeconds: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "e2e_pod_enter_phase_seconds",
+		}, []string{"phase", "namespace", "name", "uid"}),
+		alreadyRecorded: sets.String{},
+	}
+	if err := prometheus.Register(r.podEnterPhaseDurationSeconds); err != nil {
+		return fmt.Errorf("failed to register e2e_pod_enter_phase_seconds metric: %w", err)
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Pod{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		Complete(r)
+}
+
+type podTimingReconciler struct {
+	client                       client.Client
+	podEnterPhaseDurationSeconds *prometheus.CounterVec
+	alreadyRecorded              sets.String
+	alreadyRecordedLock          sync.RWMutex
+}
+
+func (r *podTimingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return ctrl.Result{}, r.reconcile(ctx, req)
+}
+
+func (r *podTimingReconciler) reconcile(ctx context.Context, req ctrl.Request) error {
+	if !strings.HasPrefix(req.Namespace, "e2e-clusters-") {
+		return nil
+	}
+	var pod corev1.Pod
+	if err := r.client.Get(ctx, req.NamespacedName, &pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	phase := pod.Status.Phase
+	podPhaseIdentifier := string(phase) + pod.Namespace + pod.Name + string(pod.UID)
+	alreadyRecorded := func() bool {
+		r.alreadyRecordedLock.RLock()
+		defer r.alreadyRecordedLock.RUnlock()
+
+		return r.alreadyRecorded.Has(podPhaseIdentifier)
+	}()
+	if alreadyRecorded {
+		return nil
+	}
+
+	enterPhaseDuration := time.Since(pod.CreationTimestamp.Time).Seconds()
+	m, err := r.podEnterPhaseDurationSeconds.GetMetricWithLabelValues(string(phase), pod.Namespace, pod.Name, string(pod.UID))
+	if err != nil {
+		return fmt.Errorf("failed to get metric: %w", err)
+	}
+	m.Add(enterPhaseDuration)
+
+	// This looks like a possible race (We set the key after other worker did the alreadyRecorded check) but isn't, because the
+	// workqueue de-duplicates.
+	r.alreadyRecordedLock.Lock()
+	defer r.alreadyRecordedLock.Unlock()
+	r.alreadyRecorded.Insert(podPhaseIdentifier)
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -235,6 +235,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.11.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal


### PR DESCRIPTION
This change adds a simple controller that will collect all pod phase
changes and write a json document with them into artifacts. This allows
us to observe changes in there over time.

Sample data produced by this (from an e2e run that didn't finish because I am impatient):
<details>
{
  "e2e-clusters-rkfc5-example-p88l6/capa-controller-manager-c57dd776f-j7clr/78dc18cf-b397-424b-8688-88e2f4fb8276": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:14:50Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:14:53Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/catalog-operator-57bd7c5c58-4p8fm/872136f6-ae53-4c48-976a-0c1afcfa16df": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:21Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:25Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/certified-operators-catalog-5f896b6849-r6848/1571ff13-c043-4694-8726-97d7ac68ccc9": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:37Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:44Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/certified-operators-catalog-745d749457-dsx7w/421d34b1-fb28-4be3-add4-aebea6ee6643": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:20Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:25Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/cluster-api-7b6996c87-h88hl/912c97ba-ab01-4351-9d5d-d4610c494fc6": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:14:50Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:14:53Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/cluster-autoscaler-685dd7fc58-bvkhn/c172d79d-5f6a-4e9d-b42d-b930ed5759cb": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:44Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:52Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/cluster-policy-controller-6468bbfc44-xt4tq/521f27fa-b339-4509-a11c-3b9881d26f19": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:17Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:26Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/cluster-version-operator-68997cc5d8-kjjbh/a8465c91-2248-4a79-bc55-fde7055ffc43": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:17Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:26Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/community-operators-catalog-55fcbc74cf-cd8gl/efccd70a-03d8-4877-b0da-3d39080a8242": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:33Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:40Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/community-operators-catalog-79f457c57b-cfst6/b9f70597-f0b1-43b9-b107-ceea98363109": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:36Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:41Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/control-plane-operator-b449f564c-bm47k/b04820ee-73ec-4337-a381-3ed2cf412f8f": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:14:50Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:14:54Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/etcd-operator-6ff85549-k5mwk/a0bf99e8-b58a-4eb4-8204-8e5bb29d4c76": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:14Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:18Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/etcd-s2ghbxhvgv/bf8d3b3c-513b-444c-8175-ed80219971d3": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:17Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:27Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/hosted-cluster-config-operator-799454b4fb-zx6nb/ea3d59db-9b96-4191-a07b-a8dfd983fb9b": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:21Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:24Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/ignition-server-df4f7699b-vzmwj/130e7aa1-7172-4784-a0c6-2a98b5f99b11": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:14:53Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:14:56Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/konnectivity-agent-5678c5bf88-5jnf8/70d3027a-da3d-46a4-9ef2-da46bbdf5fc4": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:14Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:21Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/konnectivity-server-7b6c57799-m5267/22c3bed1-f6dd-4ea1-a785-be7502e7484e": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:14Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:22Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/kube-apiserver-5958944bd8-pffmh/88990cef-d1ef-4488-a507-c76846dd357f": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:15Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:24Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/kube-controller-manager-cb46844bd-x6sh7/b973298c-f0b4-4592-b837-62ec5bef1003": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:15Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:22Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/kube-scheduler-78d88f8d96-gwhwc/ff69516f-1871-46b3-926b-d5e5dc865fde": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:15Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:23Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/machine-config-server-2094889139/e0b1c0aa-4ef8-4d27-96ff-1f24ec6293b8": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:30Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:44Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/manifests-bootstrapper/3d853d6e-f6d3-4e03-a5b0-5542b4b435b1": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:23Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:36Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/oauth-openshift-746c676d59-42wfj/b12eaa92-e35d-458f-b259-393b5804bbc5": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:17:17Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:17:21Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/oauth-openshift-9c7dfff4f-8lxsz/973a6458-12cd-45a3-9d8b-fe3692e75682": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:16Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:24Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/olm-operator-668b469b95-c77dt/7c1ba93a-0f99-4c59-9b9a-2a11bbd46f4e": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:18Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:25Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/openshift-apiserver-6959db8-4spmn/86158730-a0d5-4b25-afc2-5a510e79ec5c": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:15Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:20Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/openshift-apiserver-7f59d6764d-87xjr/8fefb9de-17ea-43e5-a7f7-04614df914ce": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:17:19Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:17:23Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/openshift-controller-manager-7c978c6c9f-g9c5p/bcf4ad59-45f7-4def-80ee-093f675c069a": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:17Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:22Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/openshift-oauth-apiserver-847855f7c9-5zh6m/c8611874-ecc3-4301-92e0-3b1d00b1340e": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:16Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:38Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/packageserver-64579bf4b9-j5j8b/fc4ce8ce-7014-4fc5-89b9-fd0bd3cbc682": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:19Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:22Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/packageserver-64579bf4b9-k5sw2/4925ddff-1fb0-433e-a90f-8ca3bfc62577": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:19Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:22Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/redhat-marketplace-catalog-9ff69f8dc-fqsfr/8f4ba20d-6bc4-41e7-9c18-e0f8c9e3ef7d": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:20Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:32Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/redhat-marketplace-catalog-fcbc787c8-gcppk/929d1eca-8acd-46d8-be3a-8f989ac6a718": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:36Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:42Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/redhat-operators-catalog-657cdb574f-nfrfw/39f03598-d91f-496c-a9e5-2ef650ea5953": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:37Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:41Z"
    }
  ],
  "e2e-clusters-rkfc5-example-p88l6/redhat-operators-catalog-74d9cff44b-bt2zg/b18fd05c-3cc0-4175-9d3c-f9930158e276": [
    {
      "name": "Pending",
      "observerdAt": "2021-09-21T20:15:18Z"
    },
    {
      "name": "Running",
      "observerdAt": "2021-09-21T20:15:24Z"
    }
  ]
}

</details>