### PR TITLE
Infrastructure CR in guest cluster has fields that should be omitted

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/cluster-infrastructure-02-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/cluster-infrastructure-02-config.yaml
@@ -4,16 +4,12 @@ metadata:
   creationTimestamp: null
   name: cluster
 spec:
-  cloudConfig:
-    name: ""
 {{- if eq .PlatformType "AWS" }}
   platformSpec:
     aws: {}
 {{- end }}
 status:
-  apiServerInternalURI: https://{{ .ExternalAPIDNSName }}:{{ .ExternalAPIPort }}
   apiServerURL: https://{{ .ExternalAPIDNSName }}:{{ .ExternalAPIPort }}
-  etcdDiscoveryDomain: {{ .BaseDomain }}
   infrastructureName: "{{ .InfraID }}"
   platform: {{ .PlatformType }}
   controlPlaneTopology: HighlyAvailable


### PR DESCRIPTION
HyperShift projects pertinent information into the Infrastructure CR for guest cluster workloads.

It should only project fields that are pertinent to the topology.

This PR removes the following:
- apiServerInternalURI - not pertinent when control plane is externalized
- cloudConfig - not pertinent when control plane is externalized as kcm runs on mgmt cluster, kubelets dont use it.
- etcdDiscoveryDomain - not pertinent when control plane is externalized as etcd is not visible.
