### PR TITLE
Add control plane operator image flag to e2e

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -89,6 +89,8 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&opts.ArtifactDir, "e2e.artifact-dir", "", "The directory where cluster resources and logs should be dumped. If empty, nothing is dumped")
 	flag.StringVar(&opts.BaseDomain, "e2e.base-domain", "", "The ingress base domain for the cluster")
 	flag.BoolVar(&opts.UpgradeTestsEnabled, "e2e.upgrade-tests-enabled", false, "Enables upgrade tests")
+	flag.StringVar(&opts.ControlPlaneOperatorImage, "e2e.control-plane-operator-image", "", "The image to use for the control plane operator. If none specified, the default is used.")
+
 	flag.Parse()
 
 	// Set defaults for the test options
@@ -121,15 +123,16 @@ func TestMain(m *testing.M) {
 
 // options are global test options applicable to all scenarios.
 type options struct {
-	AWSCredentialsFile   string
-	Region               string
-	PullSecretFile       string
-	LatestReleaseImage   string
-	PreviousReleaseImage string
-	IsRunningInCI        bool
-	UpgradeTestsEnabled  bool
-	ArtifactDir          string
-	BaseDomain           string
+	AWSCredentialsFile        string
+	Region                    string
+	PullSecretFile            string
+	LatestReleaseImage        string
+	PreviousReleaseImage      string
+	IsRunningInCI             bool
+	UpgradeTestsEnabled       bool
+	ArtifactDir               string
+	BaseDomain                string
+	ControlPlaneOperatorImage string
 }
 
 // Complete is intended to be called after flags have been bound and sets

--- a/test/e2e/scenarios/autorepair.go
+++ b/test/e2e/scenarios/autorepair.go
@@ -27,6 +27,7 @@ type TestAutoRepairOptions struct {
 	ReleaseImage       string
 	ArtifactDir        string
 	BaseDomain         string
+	CPOImage           string
 }
 
 func TestAutoRepair(ctx context.Context, o TestAutoRepairOptions) func(t *testing.T) {
@@ -66,14 +67,15 @@ func TestAutoRepair(ctx context.Context, o TestAutoRepairOptions) func(t *testin
 			AWSCredentialsFile: o.AWSCredentialsFile,
 			Region:             o.AWSRegion,
 			// TODO: generate a key on the fly
-			SSHKeyFile:       "",
-			NodePoolReplicas: 3,
-			InstanceType:     "m4.large",
-			BaseDomain:       o.BaseDomain,
-			NetworkType:      string(hyperv1.OpenShiftSDN),
-			AutoRepair:       true,
-			RootVolumeSize:   64,
-			RootVolumeType:   "gp2",
+			SSHKeyFile:                "",
+			NodePoolReplicas:          3,
+			InstanceType:              "m4.large",
+			BaseDomain:                o.BaseDomain,
+			NetworkType:               string(hyperv1.OpenShiftSDN),
+			AutoRepair:                true,
+			RootVolumeSize:            64,
+			RootVolumeType:            "gp2",
+			ControlPlaneOperatorImage: o.CPOImage,
 		}
 		t.Logf("Creating a new cluster. Options: %v", createClusterOpts)
 		err := cmdcluster.CreateCluster(ctx, createClusterOpts)

--- a/test/e2e/scenarios/autoscaling.go
+++ b/test/e2e/scenarios/autoscaling.go
@@ -26,6 +26,7 @@ type TestAutoscalingOptions struct {
 	ReleaseImage       string
 	ArtifactDir        string
 	BaseDomain         string
+	CPOImage           string
 }
 
 func TestAutoscaling(ctx context.Context, o TestAutoscalingOptions) func(t *testing.T) {
@@ -65,13 +66,14 @@ func TestAutoscaling(ctx context.Context, o TestAutoscalingOptions) func(t *test
 			AWSCredentialsFile: o.AWSCredentialsFile,
 			Region:             o.AWSRegion,
 			// TODO: generate a key on the fly
-			SSHKeyFile:       "",
-			NodePoolReplicas: 2,
-			InstanceType:     "m4.large",
-			BaseDomain:       o.BaseDomain,
-			NetworkType:      string(hyperv1.OpenShiftSDN),
-			RootVolumeSize:   64,
-			RootVolumeType:   "gp2",
+			SSHKeyFile:                "",
+			NodePoolReplicas:          2,
+			InstanceType:              "m4.large",
+			BaseDomain:                o.BaseDomain,
+			NetworkType:               string(hyperv1.OpenShiftSDN),
+			RootVolumeSize:            64,
+			RootVolumeType:            "gp2",
+			ControlPlaneOperatorImage: o.CPOImage,
 		}
 		t.Logf("Creating a new cluster. Options: %v", createClusterOpts)
 		err := cmdcluster.CreateCluster(ctx, createClusterOpts)

--- a/test/e2e/scenarios/control_plane_upgrade.go
+++ b/test/e2e/scenarios/control_plane_upgrade.go
@@ -23,6 +23,7 @@ type TestUpgradeControlPlaneOptions struct {
 	ToReleaseImage     string
 	ArtifactDir        string
 	Enabled            bool
+	CPOImage           string
 }
 
 func TestUpgradeControlPlane(ctx context.Context, o TestUpgradeControlPlaneOptions) func(t *testing.T) {
@@ -68,13 +69,14 @@ func TestUpgradeControlPlane(ctx context.Context, o TestUpgradeControlPlaneOptio
 			AWSCredentialsFile: o.AWSCredentialsFile,
 			Region:             o.AWSRegion,
 			// TODO: generate a key on the fly
-			SSHKeyFile:       "",
-			NodePoolReplicas: 2,
-			InstanceType:     "m4.large",
-			BaseDomain:       o.BaseDomain,
-			NetworkType:      string(hyperv1.OpenShiftSDN),
-			RootVolumeSize:   64,
-			RootVolumeType:   "gp2",
+			SSHKeyFile:                "",
+			NodePoolReplicas:          2,
+			InstanceType:              "m4.large",
+			BaseDomain:                o.BaseDomain,
+			NetworkType:               string(hyperv1.OpenShiftSDN),
+			RootVolumeSize:            64,
+			RootVolumeType:            "gp2",
+			ControlPlaneOperatorImage: o.CPOImage,
 		}
 		err := cmdcluster.CreateCluster(ctx, createClusterOpts)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")

--- a/test/e2e/scenarios/create_cluster.go
+++ b/test/e2e/scenarios/create_cluster.go
@@ -22,6 +22,7 @@ type TestCreateClusterOptions struct {
 	ReleaseImage       string
 	ArtifactDir        string
 	BaseDomain         string
+	CPOImage           string
 }
 
 // TestCreateCluster implements a test that mimics the operation described in the
@@ -66,13 +67,14 @@ func TestCreateCluster(ctx context.Context, o TestCreateClusterOptions) func(t *
 			AWSCredentialsFile: o.AWSCredentialsFile,
 			Region:             o.AWSRegion,
 			// TODO: generate a key on the fly
-			SSHKeyFile:       "",
-			NodePoolReplicas: 2,
-			InstanceType:     "m4.large",
-			BaseDomain:       o.BaseDomain,
-			NetworkType:      string(hyperv1.OpenShiftSDN),
-			RootVolumeSize:   64,
-			RootVolumeType:   "gp2",
+			SSHKeyFile:                "",
+			NodePoolReplicas:          2,
+			InstanceType:              "m4.large",
+			BaseDomain:                o.BaseDomain,
+			NetworkType:               string(hyperv1.OpenShiftSDN),
+			RootVolumeSize:            64,
+			RootVolumeType:            "gp2",
+			ControlPlaneOperatorImage: o.CPOImage,
 		}
 		t.Logf("Creating a new cluster. Options: %v", createClusterOpts)
 		err := cmdcluster.CreateCluster(ctx, createClusterOpts)


### PR DESCRIPTION
The flag is needed for 4.8 e2e tests to specify an image under test for
e2e tests in that branch.