### PR TITLE
Fix ignition config template when multiple ssh keys are passed

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/99-worker-ssh.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/ignition-configs/99-worker-ssh.yaml
@@ -14,5 +14,5 @@ spec:
         {{ if .SSHKey }}
         sshAuthorizedKeys:
         - |-
-          {{ .SSHKey }}
+{{ indent 10 .SSHKey }}
         {{ end }}

--- a/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
@@ -28,7 +28,7 @@ type clusterManifestContext struct {
 	userManifests     map[string]string
 }
 
-func newClusterManifestContext(images, versions map[string]string, params interface{}, pullSecret []byte, secrets *corev1.SecretList, configMaps *corev1.ConfigMapList) *clusterManifestContext {
+func newClusterManifestContext(images, versions map[string]string, params *ClusterParams, pullSecret []byte, secrets *corev1.SecretList, configMaps *corev1.ConfigMapList) *clusterManifestContext {
 	ctx := &clusterManifestContext{
 		renderContext: newRenderContext(params),
 		userManifests: make(map[string]string),

--- a/control-plane-operator/controllers/hostedcontrolplane/render/manifests_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/manifests_test.go
@@ -1,0 +1,143 @@
+package render
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/yaml"
+)
+
+func TestIgnitionConfigRendering(t *testing.T) {
+	testCases := []struct {
+		name   string
+		params *ClusterParams
+	}{
+		{
+			name:   "No ssh key",
+			params: &ClusterParams{},
+		},
+		{
+			name:   "Single ssh key",
+			params: &ClusterParams{SSHKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7xaGqJaFd51jCl+MjZzgH1WfgKbNmn+AbvRXOabeNYNRTZiRNcFlWHQPxL/fFWiJ5rDkyTRm6dI49TflU5lMSOcKwoO0sZlMbrDrUeDf2cy/7KffpAto+Te8vB4udAERMJHY89v9/RF6GgMLpW+lbIT3Gyj+MbIF8aAz0vt6VJA8Ptwq2SlxWSPLbxoe5nNP1JaOubG4Arm6t75smJ+wvexV8d9duvFWig2MW5lMTAa6QpSAp6Gd03dWSUiH5++dk3vlNMR9hZMv7/DWqyauGi0MYtuywQqVWr3YMQve72VJTo/qVhvfFylKEFTKA0h5Cl3ziL0DbgM/RDsUqaLynB7b6jAJkhXd02wv6+IkHly02SEnLHGJs50uK7J7GdAWWbKfRByVGg5kP5DwiTEln357ukT7OH8Ys6PNd0Lzzy/oA4Gv+uDzI1RMMBsTcv3SwASuht+EZzQ5hoSCkM6QoEtpruSCEdCtvTEq9idcrVijKbYURtrDdH5WAN9ZYUF13s94870srbG3uavvT2G1IcWjBjiVVoJM8cifYnTHllHX/oPw9iZxhjlrC5Uc+dgRhnpoRYMar30Kg/No1GYj2EPEZgvHVde6KqActTFnD0K5xJEAUzKutu7TDUePm+MYREt4HMeT4LxsVUar9Aak5pgmUKLqKHLY8NeQxWtKMbQ== alvaro@localhost.localdomain"},
+		},
+		{
+			name: "Multiple ssh keys",
+			params: &ClusterParams{
+				SSHKey: `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7xaGqJaFd51jCl+MjZzgH1WfgKbNmn+AbvRXOabeNYNRTZiRNcFlWHQPxL/fFWiJ5rDkyTRm6dI49TflU5lMSOcKwoO0sZlMbrDrUeDf2cy/7KffpAto+Te8vB4udAERMJHY89v9/RF6GgMLpW+lbIT3Gyj+MbIF8aAz0vt6VJA8Ptwq2SlxWSPLbxoe5nNP1JaOubG4Arm6t75smJ+wvexV8d9duvFWig2MW5lMTAa6QpSAp6Gd03dWSUiH5++dk3vlNMR9hZMv7/DWqyauGi0MYtuywQqVWr3YMQve72VJTo/qVhvfFylKEFTKA0h5Cl3ziL0DbgM/RDsUqaLynB7b6jAJkhXd02wv6+IkHly02SEnLHGJs50uK7J7GdAWWbKfRByVGg5kP5DwiTEln357ukT7OH8Ys6PNd0Lzzy/oA4Gv+uDzI1RMMBsTcv3SwASuht+EZzQ5hoSCkM6QoEtpruSCEdCtvTEq9idcrVijKbYURtrDdH5WAN9ZYUF13s94870srbG3uavvT2G1IcWjBjiVVoJM8cifYnTHllHX/oPw9iZxhjlrC5Uc+dgRhnpoRYMar30Kg/No1GYj2EPEZgvHVde6KqActTFnD0K5xJEAUzKutu7TDUePm+MYREt4HMeT4LxsVUar9Aak5pgmUKLqKHLY8NeQxWtKMbQ== alvaro@localhost.localdomain
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7xaGqJaFd51jCl+MjZzgH1WfgKbNmn+AbvRXOabeNYNRTZiRNcFlWHQPxL/fFWiJ5rDkyTRm6dI49TflU5lMSOcKwoO0sZlMbrDrUeDf2cy/7KffpAto+Te8vB4udAERMJHY89v9/RF6GgMLpW+lbIT3Gyj+MbIF8aAz0vt6VJA8Ptwq2SlxWSPLbxoe5nNP1JaOubG4Arm6t75smJ+wvexV8d9duvFWig2MW5lMTAa6QpSAp6Gd03dWSUiH5++dk3vlNMR9hZMv7/DWqyauGi0MYtuywQqVWr3YMQve72VJTo/qVhvfFylKEFTKA0h5Cl3ziL0DbgM/RDsUqaLynB7b6jAJkhXd02wv6+IkHly02SEnLHGJs50uK7J7GdAWWbKfRByVGg5kP5DwiTEln357ukT7OH8Ys6PNd0Lzzy/oA4Gv+uDzI1RMMBsTcv3SwASuht+EZzQ5hoSCkM6QoEtpruSCEdCtvTEq9idcrVijKbYURtrDdH5WAN9ZYUF13s94870srbG3uavvT2G1IcWjBjiVVoJM8cifYnTHllHX/oPw9iZxhjlrC5Uc+dgRhnpoRYMar30Kg/No1GYj2EPEZgvHVde6KqActTFnD0K5xJEAUzKutu7TDUePm+MYREt4HMeT4LxsVUar9Aak5pgmUKLqKHLY8NeQxWtKMbQ== alvaro@localhost.localdomain`,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newClusterManifestContext(nil, map[string]string{"release": "1.2.3"}, tc.params, nil, nil, nil)
+			ctx.ignitionConfigs()
+			for name, value := range ctx.manifests {
+				CompareWithFixture(t, value, WithExtension(name))
+			}
+		})
+	}
+}
+
+// CompareWithFixture will compare output with a test fixture and allows to automatically update them
+// by setting the UPDATE env var.
+// If output is not a []byte or string, it will get serialized as yaml prior to the comparison.
+// The fixtures are stored in $PWD/testdata/prefix${testName}.yaml
+func CompareWithFixture(t *testing.T, output interface{}, opts ...Option) {
+	t.Helper()
+	options := &Options{
+		Extension: ".yaml",
+	}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	var serializedOutput []byte
+	switch v := output.(type) {
+	case []byte:
+		serializedOutput = v
+	case string:
+		serializedOutput = []byte(v)
+	default:
+		serialized, err := yaml.Marshal(v)
+		if err != nil {
+			t.Fatalf("failed to yaml marshal output of type %T: %v", output, err)
+		}
+		serializedOutput = serialized
+	}
+
+	golden, err := golden(t, options)
+	if err != nil {
+		t.Fatalf("failed to get absolute path to testdata file: %v", err)
+	}
+	if os.Getenv("UPDATE") != "" {
+		if err := os.MkdirAll(filepath.Dir(golden), 0755); err != nil {
+			t.Fatalf("failed to create fixture directory: %v", err)
+		}
+		if err := ioutil.WriteFile(golden, serializedOutput, 0644); err != nil {
+			t.Fatalf("failed to write updated fixture: %v", err)
+		}
+	}
+	expected, err := ioutil.ReadFile(golden)
+	if err != nil {
+		t.Fatalf("failed to read testdata file: %v", err)
+	}
+
+	if diff := cmp.Diff(string(expected), string(serializedOutput)); diff != "" {
+		t.Errorf("got diff between expected and actual result:\nfile: %s\ndiff:\n%s\n\nIf this is expected, re-run the test with `UPDATE=true go test ./...` to update the fixtures.", golden, diff)
+	}
+}
+
+type Options struct {
+	Prefix    string
+	Suffix    string
+	Extension string
+}
+
+type Option func(*Options)
+
+func WithPrefix(prefix string) Option {
+	return func(o *Options) {
+		o.Prefix = prefix
+	}
+}
+
+func WithSuffix(suffix string) Option {
+	return func(o *Options) {
+		o.Suffix = suffix
+	}
+}
+
+func WithExtension(extension string) Option {
+	return func(o *Options) {
+		o.Extension = extension
+	}
+}
+
+// golden determines the golden file to use
+func golden(t *testing.T, opts *Options) (string, error) {
+	if opts.Extension == "" {
+		opts.Extension = ".yaml"
+	}
+	return filepath.Abs(filepath.Join("testdata", sanitizeFilename(opts.Prefix+t.Name()+opts.Suffix)) + opts.Extension)
+}
+
+func sanitizeFilename(s string) string {
+	result := strings.Builder{}
+	for _, r := range s {
+		if (r >= 'a' && r < 'z') || (r >= 'A' && r < 'Z') || r == '_' || r == '.' || (r >= '0' && r <= '9') {
+			// The thing is documented as returning a nil error so lets just drop it
+			_, _ = result.WriteRune(r)
+			continue
+		}
+		if !strings.HasSuffix(result.String(), "_") {
+			result.WriteRune('_')
+		}
+	}
+	return "zz_fixture_" + result.String()
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Multiple_ssh_keysignition-config-20-apiserver-haproxy.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Multiple_ssh_keysignition-config-20-apiserver-haproxy.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-config-20-apiserver-haproxy
+  labels:
+    hypershift.openshift.io/core-ignition-config: "true"
+data:
+  config: |-
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 20-apiserver-haproxy
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      config:
+        ignition:
+          version: 2.2.0
+        storage:
+          files:
+          - filesystem: root
+            path: "/usr/local/bin/setup-apiserver-ip.sh"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLXgKaXAgYWRkciBhZGQgLzMyIGJyZCAgc2NvcGUgaG9zdCBkZXYgbG8KaXAgcm91dGUgYWRkIC8zMiBkZXYgbG8gc2NvcGUgbGluayBzcmMgCg=="
+              verification: {}
+            mode: 0755
+          - filesystem: root
+            path: "/usr/local/bin/teardown-apiserver-ip.sh"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLXgKaXAgYWRkciBkZWxldGUgLzMyIGRldiBsbwppcCByb3V0ZSBkZWwgLzMyIGRldiBsbyBzY29wZSBsaW5rIHNyYyAK"
+              verification: {}
+            mode: 0755
+          - filesystem: root
+            path: "/etc/kubernetes/apiserver-proxy-config/haproxy.cfg"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,Z2xvYmFsCiAgbWF4Y29ubiA3MDAwCiAgbG9nIHN0ZG91dCBsb2NhbDAKICBsb2cgc3Rkb3V0IGxvY2FsMSBub3RpY2UKCmRlZmF1bHRzCiAgbW9kZSB0Y3AKICB0aW1lb3V0IGNsaWVudCAxMG0KICB0aW1lb3V0IHNlcnZlciAxMG0KICB0aW1lb3V0IGNvbm5lY3QgMTBzCiAgdGltZW91dCBjbGllbnQtZmluIDVzCiAgdGltZW91dCBzZXJ2ZXItZmluIDVzCiAgdGltZW91dCBxdWV1ZSA1cwogIHJldHJpZXMgMwoKZnJvbnRlbmQgbG9jYWxfYXBpc2VydmVyCiAgYmluZCA6MAogIGxvZyBnbG9iYWwKICBtb2RlIHRjcAogIG9wdGlvbiB0Y3Bsb2cKICBkZWZhdWx0X2JhY2tlbmQgcmVtb3RlX2FwaXNlcnZlcgoKYmFja2VuZCByZW1vdGVfYXBpc2VydmVyCiAgbW9kZSB0Y3AKICBsb2cgZ2xvYmFsCiAgb3B0aW9uIGh0dHBjaGsgR0VUIC92ZXJzaW9uCiAgb3B0aW9uIGxvZy1oZWFsdGgtY2hlY2tzCiAgZGVmYXVsdC1zZXJ2ZXIgaW50ZXIgMTBzIGZhbGwgMyByaXNlIDMKICBzZXJ2ZXIgY29udHJvbHBsYW5lIDowCg=="
+              verification: {}
+            mode: 0644
+          - filesystem: root
+            path: "/etc/kubernetes/manifests/kube-apiserver-proxy.yaml"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogIG5hbWU6IGt1YmUtYXBpc2VydmVyLXByb3h5CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGs4cy1hcHA6IGt1YmUtYXBpc2VydmVyLXByb3h5CnNwZWM6CiAgaG9zdE5ldHdvcms6IHRydWUKICBjb250YWluZXJzOgogIC0gbmFtZTogaGFwcm94eQogICAgaW1hZ2U6IAogICAgcHJpb3JpdHlDbGFzc05hbWU6IHN5c3RlbS1ub2RlLWNyaXRpY2FsCiAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgIHJ1bkFzVXNlcjogMTAwMQogICAgcmVzb3VyY2VzOgogICAgICBsaW1pdHM6CiAgICAgICAgY3B1OiAzMDBtCiAgICAgICAgbWVtb3J5OiA1MTJNCiAgICAgIHJlcXVlc3RzOgogICAgICAgIGNwdTogMTNtCiAgICAgICAgbWVtb3J5OiAxNk0KICAgIGxpdmVuZXNzUHJvYmU6CiAgICAgIGZhaWx1cmVUaHJlc2hvbGQ6IDMKICAgICAgaW5pdGlhbERlbGF5U2Vjb25kczogMTIwCiAgICAgIHBlcmlvZFNlY29uZHM6IDEyMAogICAgICBzdWNjZXNzVGhyZXNob2xkOiAxCiAgICAgIGh0dHBHZXQ6CiAgICAgICAgcGF0aDogL3ZlcnNpb24KICAgICAgICBzY2hlbWU6IEhUVFBTCiAgICAgICAgaG9zdDogCiAgICAgICAgcG9ydDogMAogICAgICB0aW1lb3V0U2Vjb25kczogNjAKICAgIHBvcnRzOgogICAgLSBjb250YWluZXJQb3J0OiAwCiAgICAgIGhvc3RQb3J0OiAwCiAgICAgIHByb3RvY29sOiBUQ1AKICAgICAgbmFtZTogYXBpc2VydmVyCiAgICBjb21tYW5kOgogICAgLSBoYXByb3h5CiAgICAtIC1mCiAgICAtIC91c3IvbG9jYWwvZXRjL2hhcHJveHkKICAgIHZvbHVtZU1vdW50czoKICAgIC0gbmFtZTogY29uZmlnCiAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvaGFwcm94eQogIHZvbHVtZXM6CiAgLSBuYW1lOiBjb25maWcKICAgIGhvc3RQYXRoOgogICAgICBwYXRoOiAvZXRjL2t1YmVybmV0ZXMvYXBpc2VydmVyLXByb3h5LWNvbmZpZwo="
+              verification: {}
+            mode: 0644
+        systemd:
+          units:
+          - contents: |-
+              [Unit]
+              Description=Sets up local IP to proxy API server requests
+              Wants=network-online.target
+              After=network-online.target
+              
+              [Service]
+              Type=oneshot
+              ExecStart=/usr/local/bin/setup-apiserver-ip.sh
+              ExecStop=/usr/local/bin/teardown-apiserver-ip.sh
+              RemainAfterExit=yes
+              
+              [Install]
+              WantedBy=multi-user.target
+    
+            enabled: true
+            name: "apiserver-ip.service"
+    

--- a/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Multiple_ssh_keysignition-config-30-fips.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Multiple_ssh_keysignition-config-30-fips.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-config-30-fips
+  labels:
+    hypershift.openshift.io/core-ignition-config: "true"
+data:
+  config: |-
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 30-fips
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      fips: false
+    

--- a/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Multiple_ssh_keysignition-config-99-worker-ssh.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Multiple_ssh_keysignition-config-99-worker-ssh.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-config-99-worker-ssh
+  labels:
+    hypershift.openshift.io/core-ignition-config: "true"
+data:
+  config: |-
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 99-worker-ssh
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      config:
+        ignition:
+          version: 2.2.0
+        passwd:
+          users:
+          - name: core
+            
+            sshAuthorizedKeys:
+            - |-
+              ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7xaGqJaFd51jCl+MjZzgH1WfgKbNmn+AbvRXOabeNYNRTZiRNcFlWHQPxL/fFWiJ5rDkyTRm6dI49TflU5lMSOcKwoO0sZlMbrDrUeDf2cy/7KffpAto+Te8vB4udAERMJHY89v9/RF6GgMLpW+lbIT3Gyj+MbIF8aAz0vt6VJA8Ptwq2SlxWSPLbxoe5nNP1JaOubG4Arm6t75smJ+wvexV8d9duvFWig2MW5lMTAa6QpSAp6Gd03dWSUiH5++dk3vlNMR9hZMv7/DWqyauGi0MYtuywQqVWr3YMQve72VJTo/qVhvfFylKEFTKA0h5Cl3ziL0DbgM/RDsUqaLynB7b6jAJkhXd02wv6+IkHly02SEnLHGJs50uK7J7GdAWWbKfRByVGg5kP5DwiTEln357ukT7OH8Ys6PNd0Lzzy/oA4Gv+uDzI1RMMBsTcv3SwASuht+EZzQ5hoSCkM6QoEtpruSCEdCtvTEq9idcrVijKbYURtrDdH5WAN9ZYUF13s94870srbG3uavvT2G1IcWjBjiVVoJM8cifYnTHllHX/oPw9iZxhjlrC5Uc+dgRhnpoRYMar30Kg/No1GYj2EPEZgvHVde6KqActTFnD0K5xJEAUzKutu7TDUePm+MYREt4HMeT4LxsVUar9Aak5pgmUKLqKHLY8NeQxWtKMbQ== alvaro@localhost.localdomain
+              ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7xaGqJaFd51jCl+MjZzgH1WfgKbNmn+AbvRXOabeNYNRTZiRNcFlWHQPxL/fFWiJ5rDkyTRm6dI49TflU5lMSOcKwoO0sZlMbrDrUeDf2cy/7KffpAto+Te8vB4udAERMJHY89v9/RF6GgMLpW+lbIT3Gyj+MbIF8aAz0vt6VJA8Ptwq2SlxWSPLbxoe5nNP1JaOubG4Arm6t75smJ+wvexV8d9duvFWig2MW5lMTAa6QpSAp6Gd03dWSUiH5++dk3vlNMR9hZMv7/DWqyauGi0MYtuywQqVWr3YMQve72VJTo/qVhvfFylKEFTKA0h5Cl3ziL0DbgM/RDsUqaLynB7b6jAJkhXd02wv6+IkHly02SEnLHGJs50uK7J7GdAWWbKfRByVGg5kP5DwiTEln357ukT7OH8Ys6PNd0Lzzy/oA4Gv+uDzI1RMMBsTcv3SwASuht+EZzQ5hoSCkM6QoEtpruSCEdCtvTEq9idcrVijKbYURtrDdH5WAN9ZYUF13s94870srbG3uavvT2G1IcWjBjiVVoJM8cifYnTHllHX/oPw9iZxhjlrC5Uc+dgRhnpoRYMar30Kg/No1GYj2EPEZgvHVde6KqActTFnD0K5xJEAUzKutu7TDUePm+MYREt4HMeT4LxsVUar9Aak5pgmUKLqKHLY8NeQxWtKMbQ== alvaro@localhost.localdomain
+            
+    

--- a/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_No_ssh_keyignition-config-20-apiserver-haproxy.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_No_ssh_keyignition-config-20-apiserver-haproxy.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-config-20-apiserver-haproxy
+  labels:
+    hypershift.openshift.io/core-ignition-config: "true"
+data:
+  config: |-
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 20-apiserver-haproxy
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      config:
+        ignition:
+          version: 2.2.0
+        storage:
+          files:
+          - filesystem: root
+            path: "/usr/local/bin/setup-apiserver-ip.sh"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLXgKaXAgYWRkciBhZGQgLzMyIGJyZCAgc2NvcGUgaG9zdCBkZXYgbG8KaXAgcm91dGUgYWRkIC8zMiBkZXYgbG8gc2NvcGUgbGluayBzcmMgCg=="
+              verification: {}
+            mode: 0755
+          - filesystem: root
+            path: "/usr/local/bin/teardown-apiserver-ip.sh"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLXgKaXAgYWRkciBkZWxldGUgLzMyIGRldiBsbwppcCByb3V0ZSBkZWwgLzMyIGRldiBsbyBzY29wZSBsaW5rIHNyYyAK"
+              verification: {}
+            mode: 0755
+          - filesystem: root
+            path: "/etc/kubernetes/apiserver-proxy-config/haproxy.cfg"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,Z2xvYmFsCiAgbWF4Y29ubiA3MDAwCiAgbG9nIHN0ZG91dCBsb2NhbDAKICBsb2cgc3Rkb3V0IGxvY2FsMSBub3RpY2UKCmRlZmF1bHRzCiAgbW9kZSB0Y3AKICB0aW1lb3V0IGNsaWVudCAxMG0KICB0aW1lb3V0IHNlcnZlciAxMG0KICB0aW1lb3V0IGNvbm5lY3QgMTBzCiAgdGltZW91dCBjbGllbnQtZmluIDVzCiAgdGltZW91dCBzZXJ2ZXItZmluIDVzCiAgdGltZW91dCBxdWV1ZSA1cwogIHJldHJpZXMgMwoKZnJvbnRlbmQgbG9jYWxfYXBpc2VydmVyCiAgYmluZCA6MAogIGxvZyBnbG9iYWwKICBtb2RlIHRjcAogIG9wdGlvbiB0Y3Bsb2cKICBkZWZhdWx0X2JhY2tlbmQgcmVtb3RlX2FwaXNlcnZlcgoKYmFja2VuZCByZW1vdGVfYXBpc2VydmVyCiAgbW9kZSB0Y3AKICBsb2cgZ2xvYmFsCiAgb3B0aW9uIGh0dHBjaGsgR0VUIC92ZXJzaW9uCiAgb3B0aW9uIGxvZy1oZWFsdGgtY2hlY2tzCiAgZGVmYXVsdC1zZXJ2ZXIgaW50ZXIgMTBzIGZhbGwgMyByaXNlIDMKICBzZXJ2ZXIgY29udHJvbHBsYW5lIDowCg=="
+              verification: {}
+            mode: 0644
+          - filesystem: root
+            path: "/etc/kubernetes/manifests/kube-apiserver-proxy.yaml"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogIG5hbWU6IGt1YmUtYXBpc2VydmVyLXByb3h5CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGs4cy1hcHA6IGt1YmUtYXBpc2VydmVyLXByb3h5CnNwZWM6CiAgaG9zdE5ldHdvcms6IHRydWUKICBjb250YWluZXJzOgogIC0gbmFtZTogaGFwcm94eQogICAgaW1hZ2U6IAogICAgcHJpb3JpdHlDbGFzc05hbWU6IHN5c3RlbS1ub2RlLWNyaXRpY2FsCiAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgIHJ1bkFzVXNlcjogMTAwMQogICAgcmVzb3VyY2VzOgogICAgICBsaW1pdHM6CiAgICAgICAgY3B1OiAzMDBtCiAgICAgICAgbWVtb3J5OiA1MTJNCiAgICAgIHJlcXVlc3RzOgogICAgICAgIGNwdTogMTNtCiAgICAgICAgbWVtb3J5OiAxNk0KICAgIGxpdmVuZXNzUHJvYmU6CiAgICAgIGZhaWx1cmVUaHJlc2hvbGQ6IDMKICAgICAgaW5pdGlhbERlbGF5U2Vjb25kczogMTIwCiAgICAgIHBlcmlvZFNlY29uZHM6IDEyMAogICAgICBzdWNjZXNzVGhyZXNob2xkOiAxCiAgICAgIGh0dHBHZXQ6CiAgICAgICAgcGF0aDogL3ZlcnNpb24KICAgICAgICBzY2hlbWU6IEhUVFBTCiAgICAgICAgaG9zdDogCiAgICAgICAgcG9ydDogMAogICAgICB0aW1lb3V0U2Vjb25kczogNjAKICAgIHBvcnRzOgogICAgLSBjb250YWluZXJQb3J0OiAwCiAgICAgIGhvc3RQb3J0OiAwCiAgICAgIHByb3RvY29sOiBUQ1AKICAgICAgbmFtZTogYXBpc2VydmVyCiAgICBjb21tYW5kOgogICAgLSBoYXByb3h5CiAgICAtIC1mCiAgICAtIC91c3IvbG9jYWwvZXRjL2hhcHJveHkKICAgIHZvbHVtZU1vdW50czoKICAgIC0gbmFtZTogY29uZmlnCiAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvaGFwcm94eQogIHZvbHVtZXM6CiAgLSBuYW1lOiBjb25maWcKICAgIGhvc3RQYXRoOgogICAgICBwYXRoOiAvZXRjL2t1YmVybmV0ZXMvYXBpc2VydmVyLXByb3h5LWNvbmZpZwo="
+              verification: {}
+            mode: 0644
+        systemd:
+          units:
+          - contents: |-
+              [Unit]
+              Description=Sets up local IP to proxy API server requests
+              Wants=network-online.target
+              After=network-online.target
+              
+              [Service]
+              Type=oneshot
+              ExecStart=/usr/local/bin/setup-apiserver-ip.sh
+              ExecStop=/usr/local/bin/teardown-apiserver-ip.sh
+              RemainAfterExit=yes
+              
+              [Install]
+              WantedBy=multi-user.target
+    
+            enabled: true
+            name: "apiserver-ip.service"
+    

--- a/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_No_ssh_keyignition-config-30-fips.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_No_ssh_keyignition-config-30-fips.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-config-30-fips
+  labels:
+    hypershift.openshift.io/core-ignition-config: "true"
+data:
+  config: |-
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 30-fips
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      fips: false
+    

--- a/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_No_ssh_keyignition-config-99-worker-ssh.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_No_ssh_keyignition-config-99-worker-ssh.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-config-99-worker-ssh
+  labels:
+    hypershift.openshift.io/core-ignition-config: "true"
+data:
+  config: |-
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 99-worker-ssh
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      config:
+        ignition:
+          version: 2.2.0
+        passwd:
+          users:
+          - name: core
+            
+    

--- a/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Single_ssh_keyignition-config-20-apiserver-haproxy.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Single_ssh_keyignition-config-20-apiserver-haproxy.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-config-20-apiserver-haproxy
+  labels:
+    hypershift.openshift.io/core-ignition-config: "true"
+data:
+  config: |-
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 20-apiserver-haproxy
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      config:
+        ignition:
+          version: 2.2.0
+        storage:
+          files:
+          - filesystem: root
+            path: "/usr/local/bin/setup-apiserver-ip.sh"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLXgKaXAgYWRkciBhZGQgLzMyIGJyZCAgc2NvcGUgaG9zdCBkZXYgbG8KaXAgcm91dGUgYWRkIC8zMiBkZXYgbG8gc2NvcGUgbGluayBzcmMgCg=="
+              verification: {}
+            mode: 0755
+          - filesystem: root
+            path: "/usr/local/bin/teardown-apiserver-ip.sh"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLXgKaXAgYWRkciBkZWxldGUgLzMyIGRldiBsbwppcCByb3V0ZSBkZWwgLzMyIGRldiBsbyBzY29wZSBsaW5rIHNyYyAK"
+              verification: {}
+            mode: 0755
+          - filesystem: root
+            path: "/etc/kubernetes/apiserver-proxy-config/haproxy.cfg"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,Z2xvYmFsCiAgbWF4Y29ubiA3MDAwCiAgbG9nIHN0ZG91dCBsb2NhbDAKICBsb2cgc3Rkb3V0IGxvY2FsMSBub3RpY2UKCmRlZmF1bHRzCiAgbW9kZSB0Y3AKICB0aW1lb3V0IGNsaWVudCAxMG0KICB0aW1lb3V0IHNlcnZlciAxMG0KICB0aW1lb3V0IGNvbm5lY3QgMTBzCiAgdGltZW91dCBjbGllbnQtZmluIDVzCiAgdGltZW91dCBzZXJ2ZXItZmluIDVzCiAgdGltZW91dCBxdWV1ZSA1cwogIHJldHJpZXMgMwoKZnJvbnRlbmQgbG9jYWxfYXBpc2VydmVyCiAgYmluZCA6MAogIGxvZyBnbG9iYWwKICBtb2RlIHRjcAogIG9wdGlvbiB0Y3Bsb2cKICBkZWZhdWx0X2JhY2tlbmQgcmVtb3RlX2FwaXNlcnZlcgoKYmFja2VuZCByZW1vdGVfYXBpc2VydmVyCiAgbW9kZSB0Y3AKICBsb2cgZ2xvYmFsCiAgb3B0aW9uIGh0dHBjaGsgR0VUIC92ZXJzaW9uCiAgb3B0aW9uIGxvZy1oZWFsdGgtY2hlY2tzCiAgZGVmYXVsdC1zZXJ2ZXIgaW50ZXIgMTBzIGZhbGwgMyByaXNlIDMKICBzZXJ2ZXIgY29udHJvbHBsYW5lIDowCg=="
+              verification: {}
+            mode: 0644
+          - filesystem: root
+            path: "/etc/kubernetes/manifests/kube-apiserver-proxy.yaml"
+            contents:
+              source: "data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogIG5hbWU6IGt1YmUtYXBpc2VydmVyLXByb3h5CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGs4cy1hcHA6IGt1YmUtYXBpc2VydmVyLXByb3h5CnNwZWM6CiAgaG9zdE5ldHdvcms6IHRydWUKICBjb250YWluZXJzOgogIC0gbmFtZTogaGFwcm94eQogICAgaW1hZ2U6IAogICAgcHJpb3JpdHlDbGFzc05hbWU6IHN5c3RlbS1ub2RlLWNyaXRpY2FsCiAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgIHJ1bkFzVXNlcjogMTAwMQogICAgcmVzb3VyY2VzOgogICAgICBsaW1pdHM6CiAgICAgICAgY3B1OiAzMDBtCiAgICAgICAgbWVtb3J5OiA1MTJNCiAgICAgIHJlcXVlc3RzOgogICAgICAgIGNwdTogMTNtCiAgICAgICAgbWVtb3J5OiAxNk0KICAgIGxpdmVuZXNzUHJvYmU6CiAgICAgIGZhaWx1cmVUaHJlc2hvbGQ6IDMKICAgICAgaW5pdGlhbERlbGF5U2Vjb25kczogMTIwCiAgICAgIHBlcmlvZFNlY29uZHM6IDEyMAogICAgICBzdWNjZXNzVGhyZXNob2xkOiAxCiAgICAgIGh0dHBHZXQ6CiAgICAgICAgcGF0aDogL3ZlcnNpb24KICAgICAgICBzY2hlbWU6IEhUVFBTCiAgICAgICAgaG9zdDogCiAgICAgICAgcG9ydDogMAogICAgICB0aW1lb3V0U2Vjb25kczogNjAKICAgIHBvcnRzOgogICAgLSBjb250YWluZXJQb3J0OiAwCiAgICAgIGhvc3RQb3J0OiAwCiAgICAgIHByb3RvY29sOiBUQ1AKICAgICAgbmFtZTogYXBpc2VydmVyCiAgICBjb21tYW5kOgogICAgLSBoYXByb3h5CiAgICAtIC1mCiAgICAtIC91c3IvbG9jYWwvZXRjL2hhcHJveHkKICAgIHZvbHVtZU1vdW50czoKICAgIC0gbmFtZTogY29uZmlnCiAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvaGFwcm94eQogIHZvbHVtZXM6CiAgLSBuYW1lOiBjb25maWcKICAgIGhvc3RQYXRoOgogICAgICBwYXRoOiAvZXRjL2t1YmVybmV0ZXMvYXBpc2VydmVyLXByb3h5LWNvbmZpZwo="
+              verification: {}
+            mode: 0644
+        systemd:
+          units:
+          - contents: |-
+              [Unit]
+              Description=Sets up local IP to proxy API server requests
+              Wants=network-online.target
+              After=network-online.target
+              
+              [Service]
+              Type=oneshot
+              ExecStart=/usr/local/bin/setup-apiserver-ip.sh
+              ExecStop=/usr/local/bin/teardown-apiserver-ip.sh
+              RemainAfterExit=yes
+              
+              [Install]
+              WantedBy=multi-user.target
+    
+            enabled: true
+            name: "apiserver-ip.service"
+    

--- a/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Single_ssh_keyignition-config-30-fips.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Single_ssh_keyignition-config-30-fips.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-config-30-fips
+  labels:
+    hypershift.openshift.io/core-ignition-config: "true"
+data:
+  config: |-
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 30-fips
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      fips: false
+    

--- a/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Single_ssh_keyignition-config-99-worker-ssh.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/testdata/zz_fixture_TestIgnitionConfigRendering_Single_ssh_keyignition-config-99-worker-ssh.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ignition-config-99-worker-ssh
+  labels:
+    hypershift.openshift.io/core-ignition-config: "true"
+data:
+  config: |-
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 99-worker-ssh
+      labels:
+        machineconfiguration.openshift.io/role: worker
+    spec:
+      config:
+        ignition:
+          version: 2.2.0
+        passwd:
+          users:
+          - name: core
+            
+            sshAuthorizedKeys:
+            - |-
+              ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7xaGqJaFd51jCl+MjZzgH1WfgKbNmn+AbvRXOabeNYNRTZiRNcFlWHQPxL/fFWiJ5rDkyTRm6dI49TflU5lMSOcKwoO0sZlMbrDrUeDf2cy/7KffpAto+Te8vB4udAERMJHY89v9/RF6GgMLpW+lbIT3Gyj+MbIF8aAz0vt6VJA8Ptwq2SlxWSPLbxoe5nNP1JaOubG4Arm6t75smJ+wvexV8d9duvFWig2MW5lMTAa6QpSAp6Gd03dWSUiH5++dk3vlNMR9hZMv7/DWqyauGi0MYtuywQqVWr3YMQve72VJTo/qVhvfFylKEFTKA0h5Cl3ziL0DbgM/RDsUqaLynB7b6jAJkhXd02wv6+IkHly02SEnLHGJs50uK7J7GdAWWbKfRByVGg5kP5DwiTEln357ukT7OH8Ys6PNd0Lzzy/oA4Gv+uDzI1RMMBsTcv3SwASuht+EZzQ5hoSCkM6QoEtpruSCEdCtvTEq9idcrVijKbYURtrDdH5WAN9ZYUF13s94870srbG3uavvT2G1IcWjBjiVVoJM8cifYnTHllHX/oPw9iZxhjlrC5Uc+dgRhnpoRYMar30Kg/No1GYj2EPEZgvHVde6KqActTFnD0K5xJEAUzKutu7TDUePm+MYREt4HMeT4LxsVUar9Aak5pgmUKLqKHLY8NeQxWtKMbQ== alvaro@localhost.localdomain
+            
+    


### PR DESCRIPTION
Fixes the indent when multiple ssh keys are passed. Sample generated
configmap:

```
$ k get configmap ignition-config-99-worker-ssh -ojson|jq .data.config -r
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  name: 99-worker-ssh
  labels:
    machineconfiguration.openshift.io/role: worker
spec:
  config:
    ignition:
      version: 2.2.0
    passwd:
      users:
      - name: core

        sshAuthorizedKeys:
        - |-
          ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDHBgwMTqA8AFS3UhHUXkYZ7pkWnGdFqB18uz/5Ai0mT0qgN1aY4kiGruI2uDgiTu1s3ypBrPr8Zg8Vqurrvr4p+BM0lfWQyslG+Q/UecYy0g6qAs9NriT2iWLlCUb9oFJ8Um30Lmj5I00DjnxjEDAY+nTijJvOK0fd+0HYwKmAWYLEDrGNXxW1EVoKmYoO0+Xp3p+K2xJ/7KIiKMyLVcYs5qbNHkTgywjsIW7DLhEkLIRXeubjwV1YHgsxg+8v4jCHYCrabRtG/gMLCQ7+CFST6IxwTKQB1u7U+2zjRpafOLJf/DHCGiQavqVDEZ36xYYvs67hlf3Fs3fwK4VJ0cuh Alvaro Aleman <wouldntyouliketoknow@gmail.com>
          ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7xaGqJaFd51jCl+MjZzgH1WfgKbNmn+AbvRXOabeNYNRTZiRNcFlWHQPxL/fFWiJ5rDkyTRm6dI49TflU5lMSOcKwoO0sZlMbrDrUeDf2cy/7KffpAto+Te8vB4udAERMJHY89v9/RF6GgMLpW+lbIT3Gyj+MbIF8aAz0vt6VJA8Ptwq2SlxWSPLbxoe5nNP1JaOubG4Arm6t75smJ+wvexV8d9duvFWig2MW5lMTAa6QpSAp6Gd03dWSUiH5++dk3vlNMR9hZMv7/DWqyauGi0MYtuywQqVWr3YMQve72VJTo/qVhvfFylKEFTKA0h5Cl3ziL0DbgM/RDsUqaLynB7b6jAJkhXd02wv6+IkHly02SEnLHGJs50uK7J7GdAWWbKfRByVGg5kP5DwiTEln357ukT7OH8Ys6PNd0Lzzy/oA4Gv+uDzI1RMMBsTcv3SwASuht+EZzQ5hoSCkM6QoEtpruSCEdCtvTEq9idcrVijKbYURtrDdH5WAN9ZYUF13s94870srbG3uavvT2G1IcWjBjiVVoJM8cifYnTHllHX/oPw9iZxhjlrC5Uc+dgRhnpoRYMar30Kg/No1GYj2EPEZgvHVde6KqActTFnD0K5xJEAUzKutu7TDUePm+MYREt4HMeT4LxsVUar9Aak5pgmUKLqKHLY8NeQxWtKMbQ== alvaro@localhost.localdomain
```

Fixes https://github.com/openshift/hypershift/issues/476
/cc @sjenning @enxebre 