### PR TITLE
WIP: E2E improvements

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -32,6 +32,8 @@ var (
 // list in order for them to run.
 func TestScenarios(t *testing.T) {
 	tests := map[string]func(t *testing.T){
+		// Not included in presumbit set because it is a subset of UpgradeControlPlane
+		// However, it can be invoked directly with test.run flag
 		"CreateCluster": scenarios.TestCreateCluster(ctx,
 			scenarios.TestCreateClusterOptions{
 				AWSCredentialsFile: opts.AWSCredentialsFile,
@@ -41,7 +43,7 @@ func TestScenarios(t *testing.T) {
 				ArtifactDir:        opts.ArtifactDir,
 				BaseDomain:         opts.BaseDomain,
 			}),
-		"UpgradeControlPlane": scenarios.TestUpgradeControlPlane(ctx,
+		"UpgradeControlPlane [presubmit]": scenarios.TestUpgradeControlPlane(ctx,
 			scenarios.TestUpgradeControlPlaneOptions{
 				AWSCredentialsFile: opts.AWSCredentialsFile,
 				AWSRegion:          opts.Region,
@@ -51,7 +53,7 @@ func TestScenarios(t *testing.T) {
 				ToReleaseImage:     opts.LatestReleaseImage,
 				ArtifactDir:        opts.ArtifactDir,
 			}),
-		"Autoscaling": scenarios.TestAutoscaling(ctx,
+		"Autoscaling [nodepool]": scenarios.TestAutoscaling(ctx,
 			scenarios.TestAutoscalingOptions{
 				AWSCredentialsFile: opts.AWSCredentialsFile,
 				AWSRegion:          opts.Region,
@@ -60,7 +62,7 @@ func TestScenarios(t *testing.T) {
 				ArtifactDir:        opts.ArtifactDir,
 				BaseDomain:         opts.BaseDomain,
 			}),
-		"AutoRepair": scenarios.TestAutoRepair(ctx,
+		"AutoRepair [nodepool]": scenarios.TestAutoRepair(ctx,
 			scenarios.TestAutoRepairOptions{
 				AWSCredentialsFile: opts.AWSCredentialsFile,
 				AWSRegion:          opts.Region,
@@ -71,8 +73,7 @@ func TestScenarios(t *testing.T) {
 			}),
 	}
 
-	for name := range tests {
-		fn := tests[name]
+	for name, fn := range tests {
 		t.Run(name, fn)
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -50,7 +50,6 @@ func TestScenarios(t *testing.T) {
 				FromReleaseImage:   opts.PreviousReleaseImage,
 				ToReleaseImage:     opts.LatestReleaseImage,
 				ArtifactDir:        opts.ArtifactDir,
-				Enabled:            opts.UpgradeTestsEnabled,
 			}),
 		"Autoscaling": scenarios.TestAutoscaling(ctx,
 			scenarios.TestAutoscalingOptions{
@@ -88,7 +87,6 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&opts.PreviousReleaseImage, "e2e.previous-release-image", "", "The previous OCP release image relative to the latest")
 	flag.StringVar(&opts.ArtifactDir, "e2e.artifact-dir", "", "The directory where cluster resources and logs should be dumped. If empty, nothing is dumped")
 	flag.StringVar(&opts.BaseDomain, "e2e.base-domain", "", "The ingress base domain for the cluster")
-	flag.BoolVar(&opts.UpgradeTestsEnabled, "e2e.upgrade-tests-enabled", false, "Enables upgrade tests")
 	flag.StringVar(&opts.ControlPlaneOperatorImage, "e2e.control-plane-operator-image", "", "The image to use for the control plane operator. If none specified, the default is used.")
 
 	flag.Parse()
@@ -129,7 +127,6 @@ type options struct {
 	LatestReleaseImage        string
 	PreviousReleaseImage      string
 	IsRunningInCI             bool
-	UpgradeTestsEnabled       bool
 	ArtifactDir               string
 	BaseDomain                string
 	ControlPlaneOperatorImage string

--- a/test/e2e/scenarios/control_plane_upgrade.go
+++ b/test/e2e/scenarios/control_plane_upgrade.go
@@ -22,16 +22,11 @@ type TestUpgradeControlPlaneOptions struct {
 	FromReleaseImage   string
 	ToReleaseImage     string
 	ArtifactDir        string
-	Enabled            bool
 	CPOImage           string
 }
 
 func TestUpgradeControlPlane(ctx context.Context, o TestUpgradeControlPlaneOptions) func(t *testing.T) {
 	return func(t *testing.T) {
-		//if !o.Enabled {
-		//	t.Skipf("upgrade test is disabled")
-		//}
-
 		t.Parallel()
 		g := NewWithT(t)
 


### PR DESCRIPTION
First commit removes unused `e2e.upgrade-tests-enabled` flag and second separates the scenarios into two groups with a new `e2e.run-all-tests` flag.  If it is false, only the `CreateCluster` scenario is run (e.g. presubmit).  If it is true, all scenarios are run (e.g. periodic).

@csrwng @ironcladlou @enxebre 