### PR TITLE
Hostedcontrolplane: Limit write perms in hypershift apigroup to hostedcontrolplane/status

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1783,7 +1783,12 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 		{
 			APIGroups: []string{"hypershift.openshift.io"},
 			Resources: []string{"*"},
-			Verbs:     []string{"*"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"hypershift.openshift.io"},
+			Resources: []string{"hostedcontrolplanes/status"},
+			Verbs:     []string{"update", "patch"},
 		},
 		{
 			APIGroups: []string{


### PR DESCRIPTION
It is possible that the api go types of the hostedcontrolplane operator
differ from the ones in the hypershift operator. This is perfectly fine
during deserialization, as additional fields will get dropped. On Update
however, those fields will get removed. This could lead to the
hostedcontrolplaneoperator racing with the hypershift oeprator.

This change limits the rbac of the hostedcontrolplane operator in the
hypershift apigroup to be readonly, except for the status subresource in
the hostedcontrolplane resource to not make that situation possible.