### PR TITLE
Create cluster and IAM: Add AdditionalTags setting

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -30,6 +30,7 @@ type Options struct {
 	PullSecretFile                   string
 	ControlPlaneOperatorImage        string
 	AWSCredentialsFile               string
+	AdditionalTags                   []string
 	SSHKeyFile                       string
 	NodePoolReplicas                 int32
 	Render                           bool
@@ -119,6 +120,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().Int64Var(&opts.RootVolumeSize, "root-volume-size", opts.RootVolumeSize, "The size of the root volume (default: 16, min: 8) for machines in the NodePool")
 	cmd.Flags().StringVar(&opts.ControlPlaneAvailabilityPolicy, "control-plane-availability-policy", opts.ControlPlaneAvailabilityPolicy, "Availability policy for hosted cluster components. Supported options: SingleReplica, HighlyAvailable")
 	cmd.Flags().StringVar(&opts.InfrastructureAvailabilityPolicy, "infra-availability-policy", opts.InfrastructureAvailabilityPolicy, "Availability policy for infrastructure services in guest cluster. Supported options: SingleReplica, HighlyAvailable")
+	cmd.Flags().StringSliceVar(&opts.AdditionalTags, "additional-tags", opts.AdditionalTags, "Additional tags to set on AWS resources")
 
 	cmd.MarkFlagRequired("pull-secret")
 	cmd.MarkFlagRequired("aws-creds")
@@ -205,6 +207,7 @@ func CreateCluster(ctx context.Context, opts Options) error {
 			AWSCredentialsFile: opts.AWSCredentialsFile,
 			Name:               opts.Name,
 			BaseDomain:         opts.BaseDomain,
+			AdditionalTags:     opts.AdditionalTags,
 		}
 		infra, err = opt.CreateInfra(ctx)
 		if err != nil {
@@ -228,6 +231,7 @@ func CreateCluster(ctx context.Context, opts Options) error {
 			AWSCredentialsFile: opts.AWSCredentialsFile,
 			InfraID:            infra.InfraID,
 			IssuerURL:          opts.IssuerURL,
+			AdditionalTags:     opts.AdditionalTags,
 		}
 		iamInfo, err = opt.CreateIAM(ctx, client)
 		if err != nil {

--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -65,6 +66,7 @@ func TestAutoRepair(t *testing.T) {
 		RootVolumeSize:            64,
 		RootVolumeType:            "gp2",
 		ControlPlaneOperatorImage: globalOpts.ControlPlaneOperatorImage,
+		AdditionalTags:            globalOpts.AdditionalTags,
 	}
 	t.Logf("Creating a new cluster. Options: %v", createClusterOpts)
 	err := cmdcluster.CreateCluster(testContext, createClusterOpts)

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -63,6 +64,7 @@ func TestAutoscaling(t *testing.T) {
 		RootVolumeSize:            64,
 		RootVolumeType:            "gp2",
 		ControlPlaneOperatorImage: globalOpts.ControlPlaneOperatorImage,
+		AdditionalTags:            globalOpts.AdditionalTags,
 	}
 	t.Logf("Creating a new cluster. Options: %v", createClusterOpts)
 	err := cmdcluster.CreateCluster(testContext, createClusterOpts)

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -64,6 +65,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 		RootVolumeSize:            64,
 		RootVolumeType:            "gp2",
 		ControlPlaneOperatorImage: globalOpts.ControlPlaneOperatorImage,
+		AdditionalTags:            globalOpts.AdditionalTags,
 	}
 	err := cmdcluster.CreateCluster(testContext, createClusterOpts)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -64,6 +65,7 @@ func TestCreateCluster(t *testing.T) {
 		RootVolumeSize:            64,
 		RootVolumeType:            "gp2",
 		ControlPlaneOperatorImage: globalOpts.ControlPlaneOperatorImage,
+		AdditionalTags:            globalOpts.AdditionalTags,
 	}
 	t.Logf("Creating a new cluster. Options: %v", createClusterOpts)
 	err := cmdcluster.CreateCluster(testContext, createClusterOpts)


### PR DESCRIPTION
This change adds an additionalTag setting to the create cluster and
create AWS IAM commands and plugs it into the e2e tests. This allows us
to identify resources created by test clusters and subsequently clean
them up automatically.

Ref https://issues.redhat.com/browse/HOSTEDCP-228

/cc @csrwng 