### PR TITLE
Fix nodepool deletion

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -143,7 +143,7 @@ type NodePoolManagement struct {
 	UpgradeType UpgradeType `json:"upgradeType"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={strategy: "RollingUpdate", rollingUpdate: {maxSurge: 1, maxUnavailable: 0 }}
-	Replace *ReplaceUpgrade `json:"recreate,omitempty"`
+	Replace *ReplaceUpgrade `json:"replace,omitempty"`
 	// +kubebuilder:validation:Optional
 	InPlace *InPlaceUpgrade `json:"inPlace,omitempty"`
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -111,7 +111,7 @@ spec:
                     type: boolean
                   inPlace:
                     type: object
-                  recreate:
+                  replace:
                     default:
                       rollingUpdate:
                         maxSurge: 1


### PR DESCRIPTION
Before this commit if a NodePool was deleted before having the nodePoolAnnotationCurrentConfigVersion annotation then the token and userdata Secrets would be leaked as the value of this annotation was used as part of a naming convention to create and find the secrets.
This PR let the NodePool controller fetch the secrets that are annotated with the nodePoolAnnotation instead which eliminates any possible race.