### PR TITLE
[release-4.8] Portieris enablement

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -41,6 +41,9 @@ const (
 	AWSKMSProviderImage = "hypershift.openshift.io/aws-kms-provider-image"
 	// IBMCloudKMSProviderImage is an annotation that allows the specification of the IBM Cloud kms provider image.
 	IBMCloudKMSProviderImage = "hypershift.openshift.io/ibmcloud-kms-provider-image"
+	// PortierisImageAnnotation is an annotation that allows the specification of the portieries component
+	// (performs container image verification).
+	PortierisImageAnnotation = "hypershift.openshift.io/portieris-image"
 
 	// AESCBCKeySecretKey defines the Kubernetes secret key name that contains the aescbc encryption key
 	// in the AESCBC secret encryption strategy

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1891,7 +1891,6 @@ func (r *HostedControlPlaneReconciler) generateControlPlaneManifests(ctx context
 		params.InternalAPIPort = defaultAPIServerPort
 	}
 	params.IssuerURL = hcp.Spec.IssuerURL
-
 	params.NetworkType = hcp.Spec.NetworkType
 	params.ImageRegistryHTTPSecret = generateImageRegistrySecret()
 	params.APIAvailabilityPolicy = render.SingleReplica

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -155,6 +155,9 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 			},
 		},
 	}
+	if len(images.Portieris) > 0 {
+		applyPortieriesConfig(&deployment.Spec.Template.Spec, images.Portieris)
+	}
 	applyNamedCertificateMounts(namedCertificates, &deployment.Spec.Template.Spec)
 	applyCloudConfigVolumeMount(cloudProviderConfigRef, &deployment.Spec.Template.Spec)
 	if auditWebhookRef != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/portieries.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/portieries.go
@@ -1,0 +1,63 @@
+package kas
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/util"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const portierisPort = 8000
+
+var (
+	portieriesVolumeMounts = util.PodVolumeMounts{
+		kasContainerPortieries().Name: {
+			kasVolumeLocalhostKubeconfig().Name: "/etc/openshift/kubeconfig",
+			kasVolumePortierisCerts().Name:      "/etc/certs",
+		},
+	}
+)
+
+func applyPortieriesConfig(podSpec *corev1.PodSpec, portieriesImage string) {
+	podSpec.Containers = append(podSpec.Containers, util.BuildContainer(kasContainerPortieries(), buildKASContainerPortieries(portieriesImage)))
+	podSpec.Volumes = append(podSpec.Volumes, util.BuildVolume(kasVolumePortierisCerts(), buildKASVolumePortierisCerts))
+}
+
+func kasContainerPortieries() *corev1.Container {
+	return &corev1.Container{
+		Name: "portieris",
+	}
+}
+
+func buildKASContainerPortieries(image string) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.ImagePullPolicy = corev1.PullAlways
+		c.Command = []string{
+			"/portieris",
+		}
+		c.Args = []string{
+			"--kubeconfig=/etc/openshift/kubeconfig/kubeconfig",
+			"--alsologtostderr",
+			"-v=4",
+		}
+		c.Ports = []corev1.ContainerPort{
+			{
+				Name:          "http",
+				ContainerPort: portierisPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		}
+		c.VolumeMounts = portieriesVolumeMounts.ContainerMounts(c.Name)
+	}
+}
+
+func kasVolumePortierisCerts() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "portieris-certs",
+	}
+}
+
+func buildKASVolumePortierisCerts(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: v.Name,
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -934,6 +934,8 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 			hcp.Annotations[annotationKey] = hcluster.Annotations[annotationKey]
 		} else if annotationKey == hyperv1.IBMCloudKMSProviderImage || annotationKey == hyperv1.AWSKMSProviderImage {
 			hcp.Annotations[annotationKey] = hcluster.Annotations[annotationKey]
+		} else if annotationKey == hyperv1.PortierisImageAnnotation {
+			hcp.Annotations[hyperv1.PortierisImageAnnotation] = hcluster.Annotations[hyperv1.PortierisImageAnnotation]
 		}
 	}
 	hcp.Spec.PullSecret = corev1.LocalObjectReference{Name: controlplaneoperator.PullSecret(hcp.Namespace).Name}
@@ -972,7 +974,6 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	if hcluster.Spec.SecretEncryption != nil {
 		hcp.Spec.SecretEncryption = hcluster.Spec.SecretEncryption.DeepCopy()
 	}
-
 	switch hcluster.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		hcp.Spec.Platform.Type = hyperv1.AWSPlatform


### PR DESCRIPTION
portieries support to verify image signatures of images in cluster (important for ibm compliance posture)