### PR TITLE
read route hostname from status RouterCanonicalHostname

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -231,11 +231,11 @@ func ReconcileServerServiceStatus(svc *corev1.Service, route *routev1.Route, str
 		port = svc.Spec.Ports[0].NodePort
 		host = strategy.NodePort.Address
 	case hyperv1.Route:
-		if route.Spec.Host == "" {
+		if len(route.Status.Ingress) == 0 {
 			return
 		}
 		port = 443
-		host = route.Spec.Host
+		host = route.Status.Ingress[0].RouterCanonicalHostname
 	}
 	return
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -52,11 +52,11 @@ func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *h
 func ReconcileServiceStatus(svc *corev1.Service, route *routev1.Route, strategy *hyperv1.ServicePublishingStrategy) (host string, port int32, err error) {
 	switch strategy.Type {
 	case hyperv1.Route:
-		if route.Spec.Host == "" {
+		if len(route.Status.Ingress) == 0 {
 			return
 		}
 		port = RouteExternalPort
-		host = route.Spec.Host
+		host = route.Status.Ingress[0].RouterCanonicalHostname
 	case hyperv1.NodePort:
 		if strategy.NodePort == nil {
 			err = fmt.Errorf("strategy details not specified for OAuth nodeport type service")

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -309,8 +309,8 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					return ctrl.Result{}, fmt.Errorf("failed to get ignitionServerRoute: %w", err)
 				}
 			}
-			if err == nil && ignitionServerRoute.Spec.Host != "" {
-				hcluster.Status.IgnitionEndpoint = ignitionServerRoute.Spec.Host
+			if err == nil && len(ignitionServerRoute.Status.Ingress) != 0 {
+				hcluster.Status.IgnitionEndpoint = ignitionServerRoute.Status.Ingress[0].RouterCanonicalHostname
 			}
 		case hyperv1.NodePort:
 			if serviceStrategy.NodePort == nil {


### PR DESCRIPTION
@csrwng 

`spec.host` always uses the default ingress domain.  This causes and issue when the Route is admitted by a non-default ingress controller, as likely will be needed with AWS private clusters.  Instead, read from `status.ingress[0].routerCanonicalHostname` once the route is admitted.