### PR TITLE
Destroy cluster: Better deal with invalid credentials file

### DIFF
--- a/cmd/cluster/destroy.go
+++ b/cmd/cluster/destroy.go
@@ -145,7 +145,7 @@ func DestroyCluster(ctx context.Context, o *DestroyOptions) error {
 		// which should indicate the cluster was successfully torn down.
 		clusterDeleteCtx, clusterDeleteCtxCancel := context.WithTimeout(ctx, o.ClusterGracePeriod)
 		defer clusterDeleteCtxCancel()
-		err := wait.PollUntil(1*time.Second, func() (bool, error) {
+		err := wait.PollImmediateUntil(1*time.Second, func() (bool, error) {
 			if err := c.Get(clusterDeleteCtx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {
 				if apierrors.IsNotFound(err) {
 					return true, nil

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -126,7 +126,7 @@ func (o *CreateIAMOptions) CreateIAM(ctx context.Context, client crclient.Client
 		},
 	}
 
-	err = wait.PollUntil(5*time.Second, func() (bool, error) {
+	err = wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 		if err = client.Get(ctx, crclient.ObjectKeyFromObject(ingressConfig), ingressConfig); err != nil {
 			log.Error(err, "failed to get ingress config")
 			return false, nil

--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -75,10 +75,13 @@ func NewDestroyCommand() *cobra.Command {
 }
 
 func (o *DestroyInfraOptions) Run(ctx context.Context) error {
-	return wait.PollUntil(5*time.Second, func() (bool, error) {
+	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 		err := o.DestroyInfra(ctx)
 		if err != nil {
-			log.Info("WARNING: error during destroy, will retry", "error", err.Error())
+			if !isErrorRetryable(err) {
+				return false, err
+			}
+			log.Info("WARNING: error during destroy, will retry", "error", err.Error(), "type", fmt.Sprintf("%T,%+v", err, err))
 			return false, nil
 		}
 		return true, nil

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -65,9 +65,12 @@ func NewDestroyIAMCommand() *cobra.Command {
 }
 
 func (o *DestroyIAMOptions) Run(ctx context.Context) error {
-	return wait.PollUntil(5*time.Second, func() (bool, error) {
+	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 		err := o.DestroyIAM(ctx)
 		if err != nil {
+			if !isErrorRetryable(err) {
+				return false, err
+			}
 			log.Info("WARNING: error during destroy, will retry", "error", err.Error())
 			return false, nil
 		}

--- a/cmd/infra/aws/errors.go
+++ b/cmd/infra/aws/errors.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func isErrorRetryable(err error) bool {
+	if aggregate, isAggregate := err.(utilerrors.Aggregate); isAggregate {
+		if len(aggregate.Errors()) == 1 {
+			err = aggregate.Errors()[0]
+		} else {
+			// We aggregate all errors, utilerrors.Aggregate does for safety reasons not support
+			// errors.As (As it can't know what to do when there are multiple matches), so we
+			// iterate and bail out if there are only credential load errors
+			hasOnlyCredentialLoadErrors := true
+			for _, err := range aggregate.Errors() {
+				if !isCredentialLoadError(err) {
+					hasOnlyCredentialLoadErrors = false
+					break
+				}
+			}
+			if hasOnlyCredentialLoadErrors {
+				return false
+			}
+
+		}
+	}
+
+	if isCredentialLoadError(err) {
+		return false
+	}
+	return true
+}
+
+func isCredentialLoadError(err error) bool {
+	if awsErr := awserr.Error(nil); errors.As(err, &awsErr) && awsErr.Code() == "SharedCredsLoad" {
+		return true
+	}
+
+	return false
+}

--- a/cmd/infra/aws/route53.go
+++ b/cmd/infra/aws/route53.go
@@ -227,7 +227,10 @@ func retryRoute53WithBackoff(ctx context.Context, fn func() error) error {
 		Steps:    10,
 		Factor:   1.5,
 	}
-	retriable := func(error) bool {
+	retriable := func(e error) bool {
+		if !isErrorRetryable(e) {
+			return false
+		}
 		select {
 		case <-ctx.Done():
 			return false


### PR DESCRIPTION
I accidentelly specified an invalid credentials file to the `destroy
cluster` command which resulted in being stuck in `Destroying
infrastructure` for four minutes and then telling me there was an error
loading the file and that it will retry. Looking at the code, this
happens because:
* We use `RetryUntil` which always waits Interval time before starting
* In the DNS zone cleanup we always retry all errors with an exponential
  backoff starting with one second, a 1.5 factor and 10 tries - For both
  public and private zone

This change fixes that by adding a function to check for credential load
errors and not retry them anywhere. It also replaces the wait.RetryUntil
with wait.RetryImmediateUntil to prevent the initial wait which we don't
need.