### PR TITLE
Podtimingcontroller: Track readyness condition

### DIFF
--- a/test/e2e/podtimingcontroller/podtimingcontroller.go
+++ b/test/e2e/podtimingcontroller/podtimingcontroller.go
@@ -23,13 +23,13 @@ import (
 func SetupWithManager(mgr ctrl.Manager, log logr.Logger, artifactDir string) error {
 	r := &podTimingReconciler{
 		client: mgr.GetClient(),
-		podEnterPhaseDurationSeconds: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "e2e_pod_enter_phase_seconds",
-		}, []string{"phase", "namespace", "name", "uid"}),
+		podBecomesReadyDurationSeconds: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "e2e_pod_becomes_ready_duration_seconds",
+		}, []string{"namespace", "name", "uid"}),
 		alreadyRecorded: sets.String{},
 	}
-	if err := prometheus.Register(r.podEnterPhaseDurationSeconds); err != nil {
-		return fmt.Errorf("failed to register e2e_pod_enter_phase_seconds metric: %w", err)
+	if err := prometheus.Register(r.podBecomesReadyDurationSeconds); err != nil {
+		return fmt.Errorf("failed to register e2e_pod_becomes_ready_duration_seconds metric: %w", err)
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -39,10 +39,10 @@ func SetupWithManager(mgr ctrl.Manager, log logr.Logger, artifactDir string) err
 }
 
 type podTimingReconciler struct {
-	client                       client.Client
-	podEnterPhaseDurationSeconds *prometheus.CounterVec
-	alreadyRecorded              sets.String
-	alreadyRecordedLock          sync.RWMutex
+	client                         client.Client
+	podBecomesReadyDurationSeconds *prometheus.CounterVec
+	alreadyRecorded                sets.String
+	alreadyRecordedLock            sync.RWMutex
 }
 
 func (r *podTimingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -61,30 +61,43 @@ func (r *podTimingReconciler) reconcile(ctx context.Context, req ctrl.Request) e
 		return err
 	}
 
-	phase := pod.Status.Phase
-	podPhaseIdentifier := string(phase) + pod.Namespace + pod.Name + string(pod.UID)
+	if !isPodReady(&pod) {
+		return nil
+	}
+
+	podIdentifier := pod.Namespace + pod.Name + string(pod.UID)
 	alreadyRecorded := func() bool {
 		r.alreadyRecordedLock.RLock()
 		defer r.alreadyRecordedLock.RUnlock()
 
-		return r.alreadyRecorded.Has(podPhaseIdentifier)
+		return r.alreadyRecorded.Has(podIdentifier)
 	}()
 	if alreadyRecorded {
 		return nil
 	}
 
-	enterPhaseDuration := time.Since(pod.CreationTimestamp.Time).Seconds()
-	m, err := r.podEnterPhaseDurationSeconds.GetMetricWithLabelValues(string(phase), pod.Namespace, pod.Name, string(pod.UID))
+	becomesReadyDuration := time.Since(pod.CreationTimestamp.Time).Seconds()
+	m, err := r.podBecomesReadyDurationSeconds.GetMetricWithLabelValues(pod.Namespace, pod.Name, string(pod.UID))
 	if err != nil {
 		return fmt.Errorf("failed to get metric: %w", err)
 	}
-	m.Add(enterPhaseDuration)
+	m.Add(becomesReadyDuration)
 
 	// This looks like a possible race (We set the key after other worker did the alreadyRecorded check) but isn't, because the
 	// workqueue de-duplicates.
 	r.alreadyRecordedLock.Lock()
 	defer r.alreadyRecordedLock.Unlock()
-	r.alreadyRecorded.Insert(podPhaseIdentifier)
+	r.alreadyRecorded.Insert(podIdentifier)
 
 	return nil
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
When building this I incorrectly assumed that phase==Running means the
pod is ready. This is not the case, a crashlooping pod for example will
be in the Running phase. What indicates readyness is the corresponding
condition, so track that instead.
