### PR TITLE
OLM refactor follow up

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2048,7 +2048,7 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 
 	packageServerDeployment := manifests.OLMPackageServerDeployment(hcp.Namespace)
 	if _, err := controllerutil.CreateOrUpdate(ctx, r, packageServerDeployment, func() error {
-		return olm.ReconcilePackageServerDeployment(packageServerDeployment, p.OwnerRef, p.OLMImage, p.PackageServerConfig)
+		return olm.ReconcilePackageServerDeployment(packageServerDeployment, p.OwnerRef, p.OLMImage, p.ReleaseVersion, p.PackageServerConfig)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile packageserver deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/olm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/olm.go
@@ -13,7 +13,7 @@ import (
 func CertifiedOperatorsCatalogSourceWorkerManifest(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-data-olm-certified-operators-catalog-source",
+			Name:      "user-manifest-olm-certified-operators-catalog-source",
 			Namespace: ns,
 		},
 	}
@@ -51,7 +51,7 @@ func CertifiedOperatorsCronJob(ns string) *batchv1.CronJob {
 func CommunityOperatorsCatalogSourceWorkerManifest(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-data-olm-community-operators-catalog-source",
+			Name:      "user-manifest-olm-community-operators-catalog-source",
 			Namespace: ns,
 		},
 	}
@@ -89,7 +89,7 @@ func CommunityOperatorsCronJob(ns string) *batchv1.CronJob {
 func RedHatMarketplaceOperatorsCatalogSourceWorkerManifest(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-data-olm-redhat-marketplace-operators-catalog-source",
+			Name:      "user-manifest-olm-redhat-marketplace-operators-catalog-source",
 			Namespace: ns,
 		},
 	}
@@ -127,7 +127,7 @@ func RedHatMarketplaceOperatorsCronJob(ns string) *batchv1.CronJob {
 func RedHatOperatorsCatalogSourceWorkerManifest(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-data-olm-redhat-operators-catalog-source",
+			Name:      "user-manifest-olm-redhat-operators-catalog-source",
 			Namespace: ns,
 		},
 	}
@@ -243,7 +243,7 @@ func OLMPackageServerDeployment(ns string) *appsv1.Deployment {
 func OLMPackageServerWorkerAPIServiceManifest(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-data-olm-packageserver-apiservice",
+			Name:      "user-manifest-olm-packageserver-apiservice",
 			Namespace: ns,
 		},
 	}
@@ -252,7 +252,7 @@ func OLMPackageServerWorkerAPIServiceManifest(ns string) *corev1.ConfigMap {
 func OLMPackageServerWorkerServiceManifest(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-data-olm-packageserver-service",
+			Name:      "user-manifest-olm-packageserver-service",
 			Namespace: ns,
 		},
 	}
@@ -261,7 +261,7 @@ func OLMPackageServerWorkerServiceManifest(ns string) *corev1.ConfigMap {
 func OLMPackageServerWorkerEndpointsManifest(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-data-olm-packageserver-endpoints",
+			Name:      "user-manifest-olm-packageserver-endpoints",
 			Namespace: ns,
 		},
 	}
@@ -270,7 +270,7 @@ func OLMPackageServerWorkerEndpointsManifest(ns string) *corev1.ConfigMap {
 func OLMAlertRulesWorkerManifest(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-data-olm-alert-rules",
+			Name:      "user-manifest-olm-alert-rules",
 			Namespace: ns,
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
@@ -16,10 +16,16 @@ var (
 	packageServerEndpoints  = MustEndpoints("assets/packageserver-endpoint-guest.yaml")
 )
 
-func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage string, dc config.DeploymentConfig) error {
+func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, releaseVersion string, dc config.DeploymentConfig) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = packageServerDeployment.DeepCopy().Spec
 	deployment.Spec.Template.Spec.Containers[0].Image = olmImage
+	for i, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+		switch env.Name {
+		case "RELEASE_VERSION":
+			deployment.Spec.Template.Spec.Containers[0].Env[i].Value = releaseVersion
+		}
+	}
 	dc.ApplyTo(deployment)
 	return nil
 }


### PR DESCRIPTION
- RELEASE_VERSION was not getting set in the packageserver deployment
  env vars
- Guest cluster manifests had the wrong prefix (user-data instead of
  user-manifests)