### PR TITLE
Re-enable hosted cluster dump in e2e

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -62,8 +62,7 @@ func DumpHostedCluster(t *testing.T, ctx context.Context, hostedCluster *hyperv1
 // DumpAndDestroyHostedCluster calls DumpHostedCluster and then destroys the HostedCluster,
 // logging any failures along the way.
 func DumpAndDestroyHostedCluster(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, awsCreds string, awsRegion string, baseDomain string, artifactDir string) {
-	// TODO: Figure out why this is slow
-	//DumpHostedCluster(ctx, hostedCluster, artifactDir)
+	DumpHostedCluster(t, ctx, hostedCluster, artifactDir)
 
 	opts := &cmdcluster.DestroyOptions{
 		Namespace:          hostedCluster.Namespace,


### PR DESCRIPTION
Recent measurement shows that the HostedCluster dump itself takes about 6 min. Re-enabling this while we investigate why guest cluster dump is slow.