### PR TITLE
Ensure CPO runs in HA mode

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -90,7 +90,6 @@ func NewStartCommand() *cobra.Command {
 			MetricsBindAddress: metricsAddr,
 			Port:               9443,
 			LeaderElection:     enableLeaderElection,
-			LeaderElectionID:   "b2ed43cb.hypershift.openshift.io",
 			Namespace:          namespace,
 			// Use a non-caching client everywhere. The default split client does not
 			// promise to invalidate the cache during writes (nor does it promise


### PR DESCRIPTION
This PR ensures the CPO deployment runs 3 replicas and use leader election when in HA mode.