### PR TITLE
E2E Ensure no crashing pods: Add exception for capa cm

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -329,6 +330,12 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 		for _, pod := range podList.Items {
 			// It needs some specific apis, we currently don't have checking for this
 			if pod.Name == "manifests-bootstrapper" {
+				continue
+			}
+
+			// TODO: This is needed because of an upstream NPD, see e.G. here: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_hypershift/486/pull-ci-openshift-hypershift-main-e2e-aws-pooled/1445408206435127296/artifacts/e2e-aws-pooled/test-e2e/artifacts/namespaces/e2e-clusters-slgzn-example-f748r/core/pods/logs/capa-controller-manager-f66fd8977-knt6h-manager-previous.log
+			// remove this exception once upstream is fixed and we have the fix
+			if strings.HasPrefix(pod.Name, "capa-controller-manager") {
 				continue
 			}
 			for _, containerStatus := range pod.Status.ContainerStatuses {


### PR DESCRIPTION
It has a NPD bug, so we need to except it for now.