### PR TITLE
CLI command to create/destroy AWS bastion instance

### DIFF
--- a/cmd/bastion/aws/create.go
+++ b/cmd/bastion/aws/create.go
@@ -1,0 +1,568 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"regexp"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/spf13/cobra"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
+	"github.com/openshift/hypershift/cmd/util"
+)
+
+type createBastionOpts struct {
+	Namespace          string
+	Name               string
+	InfraID            string
+	Region             string
+	SSHKeyFile         string
+	AWSCredentialsFile string
+	Wait               bool
+}
+
+func NewCreateCommand() *cobra.Command {
+	opts := &createBastionOpts{
+		Namespace: "clusters",
+		Wait:      true,
+	}
+
+	cmd := &cobra.Command{
+		Use:          "aws",
+		Short:        "Creates AWS bastion instance",
+		SilenceUsage: true,
+	}
+	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace of the hostedcluster")
+	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "The name of the hostedcluster")
+	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "The infra ID to use for creating the bastion")
+	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "The region to use for creating the bastion")
+	cmd.Flags().StringVar(&opts.SSHKeyFile, "ssh-key-file", opts.SSHKeyFile, "File with public SSH key to use for bastion instance")
+	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "File with AWS credentials")
+	cmd.Flags().BoolVar(&opts.Wait, "wait", opts.Wait, "Wait for instance to be running")
+
+	cmd.MarkFlagRequired("aws-creds")
+
+	cmd.MarkFlagFilename("ssh-key-file")
+	cmd.MarkFlagFilename("aws-creds")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		if err := opts.Validate(); err != nil {
+			log.Error(err, "Invalid arguments")
+			cmd.Usage()
+			return
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		if instanceID, publicIP, err := opts.Run(ctx); err != nil {
+			log.Error(err, "Failed to create bastion")
+			os.Exit(1)
+		} else {
+			log.Info("Successfully created bastion", "id", instanceID, "publicIP", publicIP)
+		}
+	}
+	return cmd
+}
+
+func (o *createBastionOpts) Validate() error {
+	if len(o.Name) > 0 {
+		if len(o.Namespace) == 0 {
+			return fmt.Errorf("a namespace must be specified if specifying a hosted cluster name")
+		}
+		if len(o.InfraID) > 0 || len(o.Region) > 0 {
+			return fmt.Errorf("infra id and region cannot be specified when specifying a hosted cluster name")
+		}
+	} else {
+		if len(o.InfraID) == 0 || len(o.Region) == 0 {
+			return fmt.Errorf("infra id and region must be specified when not specifying a hosted cluster name")
+		}
+		if len(o.SSHKeyFile) == 0 {
+			return fmt.Errorf("ssh-key-file must be specified when not specifying a hosted cluster name")
+		}
+	}
+	return nil
+}
+
+func (o *createBastionOpts) Run(ctx context.Context) (string, string, error) {
+
+	var infraID, region string
+	var sshPublicKey []byte
+
+	if len(o.Name) > 0 {
+		// Find HostedCluster and get AWS creds
+		c := util.GetClientOrDie()
+
+		var hostedCluster hyperv1.HostedCluster
+		if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {
+			return "", "", fmt.Errorf("failed to get hostedcluster: %w", err)
+		}
+		if hostedCluster.Spec.Platform.AWS == nil {
+			return "", "", fmt.Errorf("hosted cluster's platform is not AWS")
+		}
+
+		infraID = hostedCluster.Spec.InfraID
+		region = hostedCluster.Spec.Platform.AWS.Region
+		log.Info("Found hosted cluster", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name, "infraID", infraID, "region", region)
+
+		if len(o.SSHKeyFile) == 0 {
+			if len(hostedCluster.Spec.SSHKey.Name) == 0 {
+				return "", "", fmt.Errorf("hosted cluster does not have a public SSH key and no SSH key file was specified")
+			}
+			sshKeySecret := &corev1.Secret{}
+			if err := c.Get(ctx, types.NamespacedName{Name: hostedCluster.Spec.SSHKey.Name, Namespace: o.Namespace}, sshKeySecret); err != nil {
+				return "", "", fmt.Errorf("cannot get secret with SSH key (%s/%s): %w", o.Namespace, hostedCluster.Spec.SSHKey.Name, err)
+			}
+			sshPublicKey = sshKeySecret.Data["id_rsa.pub"]
+		}
+	} else {
+		infraID = o.InfraID
+		region = o.Region
+	}
+
+	// Read SSH public key
+	if len(o.SSHKeyFile) > 0 {
+		var err error
+		sshPublicKey, err = ioutil.ReadFile(o.SSHKeyFile)
+		if err != nil {
+			return "", "", fmt.Errorf("cannot read SSH public key from %s: %v", o.SSHKeyFile, err)
+		}
+	}
+
+	awsSession := awsutil.NewSession("cli-create-bastion")
+	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, region)
+	ec2Client := ec2.New(awsSession, awsConfig)
+
+	// Ensure security group exists
+	sgID, err := ensureBastionSecurityGroup(ctx, ec2Client, infraID)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to ensure security group for bastion: %w", err)
+	}
+
+	// Ensure keypair exists
+	if err := ensureBastionKeyPair(ctx, ec2Client, infraID, sshPublicKey); err != nil {
+		return "", "", fmt.Errorf("failed to ensure bastion keypair: %w", err)
+	}
+
+	// Create ec2 instance
+	instanceID, err := runEC2BastionInstance(ctx, ec2Client, sgID, infraID)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to run bastion machine instance: %w", err)
+	}
+
+	// Waiting for instance to be running
+	var publicIP string
+	if o.Wait {
+		publicIP, err = waitForInstanceRunning(ctx, ec2Client, instanceID)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to wait for instance to be running: %w", err)
+		}
+	}
+
+	return instanceID, publicIP, nil
+}
+
+func ensureBastionSecurityGroup(ctx context.Context, ec2Client *ec2.EC2, infraID string) (string, error) {
+	// find VPC
+	vpcID, err := existingVPC(ctx, ec2Client, infraID)
+	if err != nil {
+		return "", err
+	}
+	if vpcID == "" {
+		return "", fmt.Errorf("cannot find vpc associated with cluster")
+	}
+	sg, err := existingSecurityGroup(ctx, ec2Client, infraID)
+	if err != nil {
+		return "", err
+	}
+	if sg == nil {
+		name := securityGroupName(infraID)
+		sgCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
+		result, err := ec2Client.CreateSecurityGroupWithContext(sgCtx, &ec2.CreateSecurityGroupInput{
+			GroupName:   aws.String(name),
+			Description: aws.String("bastion security group"),
+			VpcId:       aws.String(vpcID),
+			TagSpecifications: []*ec2.TagSpecification{
+				{
+					ResourceType: aws.String("security-group"),
+					Tags: []*ec2.Tag{
+						{
+							Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", infraID)),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String(name),
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to create bastion security group: %w", err)
+		}
+		backoff := wait.Backoff{
+			Steps:    10,
+			Duration: 3 * time.Second,
+			Factor:   1.0,
+			Jitter:   0.1,
+		}
+		var sgResult *ec2.DescribeSecurityGroupsOutput
+		err = retry.OnError(backoff, func(error) bool { return true }, func() error {
+			var err error
+			describeCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+			defer cancel()
+			sgResult, err = ec2Client.DescribeSecurityGroupsWithContext(describeCtx, &ec2.DescribeSecurityGroupsInput{
+				GroupIds: []*string{result.GroupId},
+			})
+			if err != nil || len(sgResult.SecurityGroups) == 0 {
+				return fmt.Errorf("not found yet")
+			}
+			return nil
+		})
+		if err != nil {
+			return "", fmt.Errorf("cannot find security group that was just created (%s)", aws.StringValue(result.GroupId))
+		}
+		sg = sgResult.SecurityGroups[0]
+		log.Info("Created security group", "name", name, "id", aws.StringValue(sg.GroupId))
+	} else {
+		log.Info("Found existing security group", "name", aws.StringValue(sg.GroupName), "id", aws.StringValue(sg.GroupId))
+	}
+
+	permission := &ec2.IpPermission{
+		IpProtocol: aws.String("tcp"),
+		IpRanges: []*ec2.IpRange{
+			{
+				CidrIp: aws.String("0.0.0.0/0"),
+			},
+		},
+		FromPort: aws.Int64(22),
+		ToPort:   aws.Int64(22),
+	}
+
+	shouldAdd := true
+	for _, p := range sg.IpPermissions {
+		if p.String() == permission.String() {
+			shouldAdd = false
+		}
+	}
+	if shouldAdd {
+		authCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
+		_, err = ec2Client.AuthorizeSecurityGroupIngressWithContext(authCtx, &ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId:       sg.GroupId,
+			IpPermissions: []*ec2.IpPermission{permission},
+		})
+		if err != nil {
+			return "", fmt.Errorf("cannot authorize ssh access on security group: %w", err)
+		}
+	}
+	return aws.StringValue(sg.GroupId), nil
+}
+
+func existingSecurityGroup(ctx context.Context, ec2Client *ec2.EC2, infraID string) (*ec2.SecurityGroup, error) {
+	filters := []*ec2.Filter{
+		{
+			Name:   aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", infraID)),
+			Values: []*string{aws.String("owned")},
+		},
+		{
+			Name:   aws.String("tag:Name"),
+			Values: []*string{aws.String(securityGroupName(infraID))},
+		},
+	}
+	sgCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	result, err := ec2Client.DescribeSecurityGroupsWithContext(sgCtx, &ec2.DescribeSecurityGroupsInput{Filters: filters})
+	if err != nil {
+		return nil, fmt.Errorf("cannot list security groups: %w", err)
+	}
+	for _, sg := range result.SecurityGroups {
+		return sg, nil
+	}
+	return nil, nil
+}
+
+func existingVPC(ctx context.Context, ec2Client *ec2.EC2, infraID string) (string, error) {
+	var vpcID string
+	vpcCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	vpcFilter := []*ec2.Filter{
+		{
+			Name:   aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", infraID)),
+			Values: []*string{aws.String("owned")},
+		},
+		{
+			Name:   aws.String("tag:Name"),
+			Values: []*string{aws.String(vpcName(infraID))},
+		},
+	}
+	result, err := ec2Client.DescribeVpcsWithContext(vpcCtx, &ec2.DescribeVpcsInput{Filters: vpcFilter})
+	if err != nil {
+		return "", fmt.Errorf("cannot list vpcs: %w", err)
+	}
+	for _, vpc := range result.Vpcs {
+		vpcID = aws.StringValue(vpc.VpcId)
+		break
+	}
+	return vpcID, nil
+}
+
+func ensureBastionKeyPair(ctx context.Context, ec2Client *ec2.EC2, infraID string, publicKey []byte) error {
+	keyPairID, err := existingKeyPair(ctx, ec2Client, infraID)
+	if err != nil {
+		return fmt.Errorf("failed to check for existing keypair: %w", err)
+	}
+	if keyPairID != "" {
+		log.Info("Found existing key pair", "id", keyPairID, "name", keyPairName(infraID))
+		return nil
+	}
+	kpCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	result, err := ec2Client.ImportKeyPairWithContext(kpCtx, &ec2.ImportKeyPairInput{
+		KeyName:           aws.String(keyPairName(infraID)),
+		PublicKeyMaterial: publicKey,
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("key-pair"),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", infraID)),
+						Value: aws.String("owned"),
+					},
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String(keyPairName(infraID)),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to import keypair: %w", err)
+	}
+	log.Info("Created key pair", "id", aws.StringValue(result.KeyPairId), "name", aws.StringValue(result.KeyName))
+	return nil
+}
+
+func existingKeyPair(ctx context.Context, ec2Client *ec2.EC2, infraID string) (string, error) {
+	kpCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	result, err := ec2Client.DescribeKeyPairsWithContext(kpCtx, &ec2.DescribeKeyPairsInput{
+		KeyNames: []*string{aws.String(keyPairName(infraID))},
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "InvalidKeyPair.NotFound" {
+				return "", nil
+			}
+		}
+		return "", err
+	}
+	var keyPairID string
+	for _, kp := range result.KeyPairs {
+		keyPairID = aws.StringValue(kp.KeyPairId)
+	}
+	return keyPairID, nil
+}
+
+func runEC2BastionInstance(ctx context.Context, ec2Client *ec2.EC2, sgID, infraID string) (string, error) {
+	// find existing instance
+	instanceID, err := existingInstance(ctx, ec2Client, infraID)
+	if err != nil {
+		return "", fmt.Errorf("cannot check for existing instances: %w", err)
+	}
+	if len(instanceID) > 0 {
+		log.Info("Found existing instance", "id", instanceID)
+		return instanceID, nil
+	}
+
+	// find public subnet
+	subnetID, err := existingSubnet(ctx, ec2Client, infraID)
+	if err != nil {
+		return "", fmt.Errorf("cannot lookup existing subnet: %w", err)
+	}
+	if len(subnetID) == 0 {
+		return "", fmt.Errorf("no public subnet was found")
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	result, err := ec2Client.RunInstancesWithContext(runCtx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"),
+		MaxCount:     aws.Int64(1),
+		MinCount:     aws.Int64(1),
+		InstanceType: aws.String("t2.micro"),
+		KeyName:      aws.String(keyPairName(infraID)),
+		NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
+			{
+				DeviceIndex:              aws.Int64(0),
+				AssociatePublicIpAddress: aws.Bool(true),
+				SubnetId:                 aws.String(subnetID),
+				Groups:                   []*string{aws.String(sgID)},
+			},
+		},
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("instance"),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", infraID)),
+						Value: aws.String("owned"),
+					},
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String(instanceName(infraID)),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to launch bastion instance: %w", err)
+	}
+	for _, instance := range result.Instances {
+		instanceID := aws.StringValue(instance.InstanceId)
+		log.Info("Created ec2 instance", "id", instanceID, "name", instanceName(infraID))
+		return instanceID, nil
+	}
+	return "", fmt.Errorf("no instances were created")
+}
+
+func existingSubnet(ctx context.Context, ec2Client *ec2.EC2, infraID string) (string, error) {
+	var subnetID string
+	subCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	subnetFilter := []*ec2.Filter{
+		{
+			Name:   aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", infraID)),
+			Values: []*string{aws.String("owned")},
+		},
+	}
+	result, err := ec2Client.DescribeSubnetsWithContext(subCtx, &ec2.DescribeSubnetsInput{
+		Filters: subnetFilter,
+	})
+	if err != nil {
+		return "", fmt.Errorf("cannot list subnets: %w", err)
+	}
+	nameRe := regexp.MustCompile(fmt.Sprintf("%s-public-[a-z,0-9,-]+", infraID))
+	for _, subnet := range result.Subnets {
+		var name string
+		for _, tag := range subnet.Tags {
+			if aws.StringValue(tag.Key) == "Name" {
+				name = aws.StringValue(tag.Value)
+				break
+			}
+		}
+		if len(name) == 0 {
+			continue
+		}
+		if nameRe.MatchString(name) {
+			subnetID = aws.StringValue(subnet.SubnetId)
+			break
+		}
+	}
+	return subnetID, nil
+}
+
+func existingInstance(ctx context.Context, ec2Client *ec2.EC2, infraID string) (string, error) {
+	instanceCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	instanceFilter := []*ec2.Filter{
+		{
+			Name:   aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", infraID)),
+			Values: []*string{aws.String("owned")},
+		},
+		{
+			Name:   aws.String("tag:Name"),
+			Values: []*string{aws.String(instanceName(infraID))},
+		},
+	}
+	result, err := ec2Client.DescribeInstancesWithContext(instanceCtx, &ec2.DescribeInstancesInput{
+		Filters: instanceFilter,
+	})
+	if err != nil {
+		return "", err
+	}
+	for _, reservation := range result.Reservations {
+		for _, instance := range reservation.Instances {
+			if aws.StringValue(instance.State.Name) == "terminated" {
+				continue
+			}
+			return aws.StringValue(instance.InstanceId), nil
+		}
+	}
+	return "", nil
+}
+
+func waitForInstanceRunning(ctx context.Context, ec2Client *ec2.EC2, instanceID string) (string, error) {
+
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	err := wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+		err := ec2Client.WaitUntilInstanceRunningWithContext(ctx, &ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(instanceID)},
+		})
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == "ResourceNotReady" {
+					return false, nil
+				}
+			}
+			return false, fmt.Errorf("error waiting for intance running: %w", err)
+		}
+		return true, nil
+	}, waitCtx.Done())
+	if err != nil {
+		return "", err
+	}
+	describeCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	result, err := ec2Client.DescribeInstancesWithContext(describeCtx, &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{aws.String(instanceID)},
+	})
+	if err != nil {
+		return "", err
+	}
+	for _, res := range result.Reservations {
+		for _, instance := range res.Instances {
+			return aws.StringValue(instance.PublicIpAddress), nil
+		}
+	}
+	return "", nil
+}
+
+func securityGroupName(infraID string) string {
+	return fmt.Sprintf("%s-bastion-sg", infraID)
+}
+
+func vpcName(infraID string) string {
+	return fmt.Sprintf("%s-vpc", infraID)
+}
+
+func keyPairName(infraID string) string {
+	return fmt.Sprintf("%s-bastion", infraID)
+}
+
+func instanceName(infraID string) string {
+	return fmt.Sprintf("%s-bastion", infraID)
+}

--- a/cmd/bastion/aws/destroy.go
+++ b/cmd/bastion/aws/destroy.go
@@ -1,0 +1,202 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
+	"github.com/openshift/hypershift/cmd/util"
+)
+
+type destroyBastionOpts struct {
+	Namespace          string
+	Name               string
+	InfraID            string
+	Region             string
+	AWSCredentialsFile string
+}
+
+func NewDestroyCommand() *cobra.Command {
+	opts := destroyBastionOpts{
+		Namespace: "clusters",
+	}
+	cmd := &cobra.Command{
+		Use:          "aws",
+		Short:        "Destroys AWS bastion instance",
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace of the hostedcluster")
+	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "The name of the hostedcluster")
+	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "The infra ID to use for creating the bastion")
+	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "The region to use for creating the bastion")
+	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "File with AWS credentials")
+
+	cmd.MarkFlagRequired("aws-creds")
+	cmd.MarkFlagFilename("aws-creds")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		if err := opts.Validate(); err != nil {
+			log.Error(err, "Invalid arguments")
+			cmd.Usage()
+			return
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		if err := opts.Run(ctx); err != nil {
+			log.Error(err, "Failed to create bastion")
+			os.Exit(1)
+		} else {
+			log.Info("Successfully destroyed bastion")
+		}
+	}
+
+	return cmd
+}
+
+func (o *destroyBastionOpts) Validate() error {
+	if len(o.Name) > 0 {
+		if len(o.Namespace) == 0 {
+			return fmt.Errorf("a namespace must be specified if specifying a hosted cluster name")
+		}
+		if len(o.InfraID) > 0 || len(o.Region) > 0 {
+			return fmt.Errorf("infra id and region cannot be specified when specifying a hosted cluster name")
+		}
+	} else {
+		if len(o.InfraID) == 0 || len(o.Region) == 0 {
+			return fmt.Errorf("infra id and region must be specified when not specifying a hosted cluster name")
+		}
+	}
+	return nil
+}
+
+func (o *destroyBastionOpts) Run(ctx context.Context) error {
+
+	var infraID, region string
+
+	if len(o.Name) > 0 {
+		// Find HostedCluster and get AWS creds
+		c := util.GetClientOrDie()
+
+		var hostedCluster hyperv1.HostedCluster
+		if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {
+			return fmt.Errorf("failed to get hostedcluster: %w", err)
+		}
+		if hostedCluster.Spec.Platform.AWS == nil {
+			return fmt.Errorf("hosted cluster's platform is not AWS")
+		}
+
+		infraID = hostedCluster.Spec.InfraID
+		region = hostedCluster.Spec.Platform.AWS.Region
+		log.Info("Found hosted cluster", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name, "infraID", infraID, "region", region)
+	} else {
+		infraID = o.InfraID
+		region = o.Region
+	}
+
+	awsSession := awsutil.NewSession("cli-destroy-bastion")
+	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, region)
+	ec2Client := ec2.New(awsSession, awsConfig)
+
+	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+		err := destroyBastion(ctx, ec2Client, infraID)
+		if err != nil {
+			if !awsutil.IsErrorRetryable(err) {
+				return false, err
+			}
+			log.Info("WARNING: error during destroy, will retry", "error", err.Error(), "type", fmt.Sprintf("%T,%+v", err, err))
+			return false, nil
+		}
+		return true, nil
+	}, ctx.Done())
+}
+
+func destroyBastion(ctx context.Context, ec2Client *ec2.EC2, infraID string) error {
+	if err := destroyEC2Instance(ctx, ec2Client, infraID); err != nil {
+		return err
+	}
+	if err := destroySecurityGroup(ctx, ec2Client, infraID); err != nil {
+		return err
+	}
+	if err := destroyKeyPair(ctx, ec2Client, infraID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func destroyEC2Instance(ctx context.Context, ec2Client *ec2.EC2, infraID string) error {
+	instanceID, err := existingInstance(ctx, ec2Client, infraID)
+	if err != nil {
+		return err
+	}
+	if len(instanceID) == 0 {
+		return nil
+	}
+	terminateCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	_, err = ec2Client.TerminateInstancesWithContext(terminateCtx, &ec2.TerminateInstancesInput{
+		InstanceIds: []*string{aws.String(instanceID)},
+	})
+	if err != nil {
+		return fmt.Errorf("error deleting instance: %w", err)
+	}
+	log.Info("Deleted bastion instance", "id", instanceID, "name", instanceName(infraID))
+	return nil
+}
+
+func destroySecurityGroup(ctx context.Context, ec2Client *ec2.EC2, infraID string) error {
+	sg, err := existingSecurityGroup(ctx, ec2Client, infraID)
+	if err != nil {
+		return err
+	}
+	if sg == nil {
+		return nil
+	}
+	sgCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	_, err = ec2Client.DeleteSecurityGroupWithContext(sgCtx, &ec2.DeleteSecurityGroupInput{
+		GroupId: sg.GroupId,
+	})
+	if err != nil {
+		return fmt.Errorf("error deleting security group: %w", err)
+	}
+	log.Info("Deleted security group", "id", aws.StringValue(sg.GroupId), "name", securityGroupName(infraID))
+	return nil
+}
+
+func destroyKeyPair(ctx context.Context, ec2Client *ec2.EC2, infraID string) error {
+	keyPairID, err := existingKeyPair(ctx, ec2Client, infraID)
+	if err != nil {
+		return err
+	}
+	if len(keyPairID) == 0 {
+		return nil
+	}
+	kpCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	_, err = ec2Client.DeleteKeyPairWithContext(kpCtx, &ec2.DeleteKeyPairInput{
+		KeyPairId: aws.String(keyPairID),
+	})
+	if err != nil {
+		return fmt.Errorf("error deleting keypair: %w", err)
+	}
+	log.Info("Deleted keypair", "id", keyPairID, "name", keyPairName(infraID))
+	return nil
+}

--- a/cmd/bastion/aws/logging.go
+++ b/cmd/bastion/aws/logging.go
@@ -1,0 +1,8 @@
+package aws
+
+import (
+	"github.com/bombsimon/logrusr"
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrusr.NewLogger(logrus.New())

--- a/cmd/bastion/create.go
+++ b/cmd/bastion/create.go
@@ -1,0 +1,19 @@
+package bastion
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/hypershift/cmd/bastion/aws"
+)
+
+func NewCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "bastion",
+		Short:        "Commands for creating bastion instances",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(aws.NewCreateCommand())
+
+	return cmd
+}

--- a/cmd/bastion/destroy.go
+++ b/cmd/bastion/destroy.go
@@ -1,0 +1,19 @@
+package bastion
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/hypershift/cmd/bastion/aws"
+)
+
+func NewDestroyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "bastion",
+		Short:        "Commands for destroying bastion instances",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(aws.NewDestroyCommand())
+
+	return cmd
+}

--- a/cmd/cluster/dump.go
+++ b/cmd/cluster/dump.go
@@ -44,8 +44,8 @@ func NewDumpCommand() *cobra.Command {
 		ArtifactDir: "",
 	}
 
-	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A namespace to contain the generated resources")
-	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A name for the cluster")
+	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace of the hostedcluster to dump")
+	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "The name of the hostedcluster to dump")
 	cmd.Flags().StringVar(&opts.ArtifactDir, "artifact-dir", opts.ArtifactDir, "Destination directory for dump files")
 
 	cmd.MarkFlagRequired("artifact-dir")

--- a/cmd/consolelogs/aws/getlogs.go
+++ b/cmd/consolelogs/aws/getlogs.go
@@ -78,7 +78,7 @@ func (o *ConsoleLogOpts) Run(ctx context.Context) error {
 	}
 	infraID := hostedCluster.Spec.InfraID
 	region := hostedCluster.Spec.Platform.AWS.Region
-	awsSession := awsutil.NewSession("cli-create-infra")
+	awsSession := awsutil.NewSession("cli-console-logs")
 	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, region)
 	ec2Client := ec2.New(awsSession, awsConfig)
 

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hypershift/cmd/bastion"
 	"github.com/openshift/hypershift/cmd/cluster"
 	"github.com/openshift/hypershift/cmd/infra"
 	"github.com/openshift/hypershift/cmd/kubeconfig"
@@ -21,6 +22,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(infra.NewCreateIAMCommand())
 	cmd.AddCommand(kubeconfig.NewCreateCommand())
 	cmd.AddCommand(nodepool.NewCreateCommand())
+	cmd.AddCommand(bastion.NewCreateCommand())
 
 	return cmd
 }

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -3,6 +3,7 @@ package create
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hypershift/cmd/bastion"
 	"github.com/openshift/hypershift/cmd/cluster"
 	"github.com/openshift/hypershift/cmd/infra"
 )
@@ -17,6 +18,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(infra.NewDestroyCommand())
 	cmd.AddCommand(infra.NewDestroyIAMCommand())
 	cmd.AddCommand(cluster.NewDestroyCommand())
+	cmd.AddCommand(bastion.NewDestroyCommand())
 
 	return cmd
 }

--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -78,7 +78,7 @@ func (o *DestroyInfraOptions) Run(ctx context.Context) error {
 	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 		err := o.DestroyInfra(ctx)
 		if err != nil {
-			if !isErrorRetryable(err) {
+			if !awsutil.IsErrorRetryable(err) {
 				return false, err
 			}
 			log.Info("WARNING: error during destroy, will retry", "error", err.Error(), "type", fmt.Sprintf("%T,%+v", err, err))

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -68,7 +68,7 @@ func (o *DestroyIAMOptions) Run(ctx context.Context) error {
 	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 		err := o.DestroyIAM(ctx)
 		if err != nil {
-			if !isErrorRetryable(err) {
+			if !awsutil.IsErrorRetryable(err) {
 				return false, err
 			}
 			log.Info("WARNING: error during destroy, will retry", "error", err.Error())

--- a/cmd/infra/aws/route53.go
+++ b/cmd/infra/aws/route53.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
@@ -228,7 +229,7 @@ func retryRoute53WithBackoff(ctx context.Context, fn func() error) error {
 		Factor:   1.5,
 	}
 	retriable := func(e error) bool {
-		if !isErrorRetryable(e) {
+		if !awsutil.IsErrorRetryable(e) {
 			return false
 		}
 		select {

--- a/cmd/infra/aws/util/errors.go
+++ b/cmd/infra/aws/util/errors.go
@@ -1,4 +1,4 @@
-package aws
+package util
 
 import (
 	"errors"
@@ -7,7 +7,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-func isErrorRetryable(err error) bool {
+func IsErrorRetryable(err error) bool {
 	if aggregate, isAggregate := err.(utilerrors.Aggregate); isAggregate {
 		if len(aggregate.Errors()) == 1 {
 			err = aggregate.Errors()[0]


### PR DESCRIPTION
Adds command to CLI to create a bastion machine with a public IP that
allows ssh access to private machines for a cluster.
The command works for Hypershift clusters as well as regular OCP
clusters.