### PR TITLE
Prevent no-op updates of Kube objects

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -43,6 +43,7 @@ type HyperShiftOperatorDeployment struct {
 	ServiceAccount             *corev1.ServiceAccount
 	Replicas                   int32
 	EnableOCPClusterMonitoring bool
+	EnableCIDebugOutput        bool
 }
 
 func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
@@ -92,7 +93,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 								},
 							},
 							Command: []string{"/usr/bin/hypershift-operator"},
-							Args:    []string{"run", "--namespace=$(MY_NAMESPACE)", "--deployment-name=operator", "--metrics-addr=:9000", fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", o.EnableOCPClusterMonitoring)},
+							Args:    []string{"run", "--namespace=$(MY_NAMESPACE)", "--deployment-name=operator", "--metrics-addr=:9000", fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", o.EnableOCPClusterMonitoring), fmt.Sprintf("--enable-ci-debug-output=%t", o.EnableCIDebugOutput)},
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "metrics",

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -44,6 +44,7 @@ type Options struct {
 	Render                     bool
 	ExcludeEtcdManifests       bool
 	EnableOCPClusterMonitoring bool
+	EnableCIDebugOutput        bool
 }
 
 func NewCommand() *cobra.Command {
@@ -56,6 +57,7 @@ func NewCommand() *cobra.Command {
 	var opts Options
 	if os.Getenv("CI") == "true" {
 		opts.EnableOCPClusterMonitoring = true
+		opts.EnableCIDebugOutput = true
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", "hypershift", "The namespace in which to install HyperShift")
@@ -64,6 +66,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying")
 	cmd.Flags().BoolVar(&opts.ExcludeEtcdManifests, "exclude-etcd", false, "Leave out etcd manifests")
 	cmd.Flags().BoolVar(&opts.EnableOCPClusterMonitoring, "enable-ocp-cluster-monitoring", opts.EnableOCPClusterMonitoring, "Development-only option that will make your OCP cluster unsupported: If the cluster Prometheus should be configured to scrape metrics")
+	cmd.Flags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", opts.EnableCIDebugOutput, "If extra CI debug output should be enabled")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -165,6 +168,7 @@ func hyperShiftOperatorManifests(opts Options) []crclient.Object {
 		ServiceAccount:             operatorServiceAccount,
 		Replicas:                   opts.HyperShiftOperatorReplicas,
 		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
+		EnableCIDebugOutput:        opts.EnableCIDebugOutput,
 	}.Build()
 	operatorService := assets.HyperShiftOperatorService{
 		Namespace: operatorNamespace,

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/status.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/status.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	etcdv1 "github.com/openshift/hypershift/control-plane-operator/thirdparty/etcd/v1beta2"
+	etcdv1beta2 "github.com/openshift/hypershift/control-plane-operator/thirdparty/etcd/v1beta2"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 	EtcdReasonScaling = "EtcdScalingUp"
 )
 
-func etcdClusterConditionByType(conditions []etcdv1.ClusterCondition, t etcdv1.ClusterConditionType) *etcdv1.ClusterCondition {
+func etcdClusterConditionByType(conditions []etcdv1beta2.ClusterCondition, t etcdv1beta2.ClusterConditionType) *etcdv1beta2.ClusterCondition {
 	for i, cond := range conditions {
 		if cond.Type == t {
 			return &conditions[i]
@@ -31,8 +31,8 @@ func etcdClusterConditionByType(conditions []etcdv1.ClusterCondition, t etcdv1.C
 	return nil
 }
 
-func ComputeEtcdClusterStatus(ctx context.Context, c client.Client, cluster *etcdv1.EtcdCluster) (metav1.Condition, error) {
-	availableCondition := etcdClusterConditionByType(cluster.Status.Conditions, etcdv1.ClusterConditionAvailable)
+func ComputeEtcdClusterStatus(ctx context.Context, c client.Client, cluster *etcdv1beta2.EtcdCluster) (metav1.Condition, error) {
+	availableCondition := etcdClusterConditionByType(cluster.Status.Conditions, etcdv1beta2.ClusterConditionAvailable)
 
 	var cond metav1.Condition
 	switch {
@@ -83,7 +83,7 @@ func ComputeEtcdClusterStatus(ctx context.Context, c client.Client, cluster *etc
 	return cond, nil
 }
 
-func etcdClusterHasTerminatedPods(ctx context.Context, c client.Client, cluster *etcdv1.EtcdCluster) (bool, error) {
+func etcdClusterHasTerminatedPods(ctx context.Context, c client.Client, cluster *etcdv1beta2.EtcdCluster) (bool, error) {
 	// If only one member ready and waiting for another to come up, check pod status
 	etcdPods := &corev1.PodList{}
 	err := c.List(ctx, etcdPods, client.MatchingLabels{etcdClusterLabel: cluster.Name})

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -41,6 +41,7 @@ import (
 	hyperutil "github.com/openshift/hypershift/hypershift-operator/controllers/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/upsert"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -111,6 +112,10 @@ type HostedClusterReconciler struct {
 	tracer trace.Tracer
 
 	EnableOCPClusterMonitoring bool
+
+	upsert.CreateOrUpdateProvider
+
+	EnableCIDebugOutput bool
 }
 
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters,verbs=get;list;watch;create;update;patch;delete
@@ -431,7 +436,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get cloud controller provider creds %s: %w", hcluster.Spec.Platform.AWS.KubeCloudControllerCreds.Name, err)
 		}
 		dest := manifests.AWSKubeCloudControllerCreds(controlPlaneNamespace.Name)
-		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, dest, func() error {
+		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
 			srcData, srcHasData := src.Data["credentials"]
 			if !srcHasData {
 				return fmt.Errorf("hostedcluster cloud controller provider credentials secret %q must have a credentials key", src.Name)
@@ -459,7 +464,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get node pool provider creds %s: %w", hcluster.Spec.Platform.AWS.NodePoolManagementCreds.Name, err)
 		}
 		dest := manifests.AWSNodePoolManagementCreds(controlPlaneNamespace.Name)
-		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, dest, func() error {
+		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
 			srcData, srcHasData := src.Data["credentials"]
 			if !srcHasData {
 				return fmt.Errorf("node pool provider credentials secret %q is missing credentials key", src.Name)
@@ -484,7 +489,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get pull secret %s: %w", hcluster.Spec.PullSecret.Name, err)
 		}
 		dst := controlplaneoperator.PullSecret(controlPlaneNamespace.Name)
-		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, dst, func() error {
+		_, err = r.CreateOrUpdate(ctx, r.Client, dst, func() error {
 			srcData, srcHasData := src.Data[".dockerconfigjson"]
 			if !srcHasData {
 				return fmt.Errorf("hostedcluster pull secret %q must have a .dockerconfigjson key", src.Name)
@@ -526,7 +531,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					Name:      src.Name,
 				},
 			}
-			_, err = controllerutil.CreateOrUpdate(ctx, r.Client, hostedControlPlaneActiveKeySecret, func() error {
+			_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneActiveKeySecret, func() error {
 				if hostedControlPlaneActiveKeySecret.Data == nil {
 					hostedControlPlaneActiveKeySecret.Data = map[string][]byte{}
 				}
@@ -553,7 +558,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 						Name:      src.Name,
 					},
 				}
-				_, err = controllerutil.CreateOrUpdate(ctx, r.Client, hostedControlPlaneBackupKeySecret, func() error {
+				_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneBackupKeySecret, func() error {
 					if hostedControlPlaneBackupKeySecret.Data == nil {
 						hostedControlPlaneBackupKeySecret.Data = map[string][]byte{}
 					}
@@ -599,7 +604,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 							Name:      src.Name,
 						},
 					}
-					_, err = controllerutil.CreateOrUpdate(ctx, r.Client, hostedControlPlaneIBMCloudKMSAuthSecret, func() error {
+					_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneIBMCloudKMSAuthSecret, func() error {
 						if hostedControlPlaneIBMCloudKMSAuthSecret.Data == nil {
 							hostedControlPlaneIBMCloudKMSAuthSecret.Data = map[string][]byte{}
 						}
@@ -632,7 +637,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 						Name:      src.Name,
 					},
 				}
-				_, err = controllerutil.CreateOrUpdate(ctx, r.Client, hostedControlPlaneAWSKMSAuthSecret, func() error {
+				_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneAWSKMSAuthSecret, func() error {
 					if hostedControlPlaneAWSKMSAuthSecret.Data == nil {
 						hostedControlPlaneAWSKMSAuthSecret.Data = map[string][]byte{}
 					}
@@ -674,7 +679,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					Name:      src.Name,
 				},
 			}
-			_, err = controllerutil.CreateOrUpdate(ctx, r.Client, hostedControlPlaneAuditWebhookSecret, func() error {
+			_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneAuditWebhookSecret, func() error {
 				if hostedControlPlaneAuditWebhookSecret.Data == nil {
 					hostedControlPlaneAuditWebhookSecret.Data = map[string][]byte{}
 				}
@@ -697,7 +702,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get hostedcluster SSH key secret %s: %w", hcluster.Spec.SSHKey.Name, err)
 		}
 		dest := controlplaneoperator.SSHKey(controlPlaneNamespace.Name)
-		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, dest, func() error {
+		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
 			srcData, srcHasData := src.Data["id_rsa.pub"]
 			if !srcHasData {
 				return fmt.Errorf("hostedcluster ssh key secret %q must have a id_rsa.pub key", src.Name)
@@ -731,7 +736,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				Name:      hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name,
 			},
 		}
-		if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, hostedControlPlaneEtcdClientSecret, func() error {
+		if result, err := r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneEtcdClientSecret, func() error {
 			if hostedControlPlaneEtcdClientSecret.Data == nil {
 				hostedControlPlaneEtcdClientSecret.Data = map[string][]byte{}
 			}
@@ -756,7 +761,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				destCM := &corev1.ConfigMap{}
 				destCM.Name = sourceCM.Name
 				destCM.Namespace = controlPlaneNamespace.Name
-				if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, destCM, func() error {
+				if _, err := r.CreateOrUpdate(ctx, r.Client, destCM, func() error {
 					destCM.Annotations = sourceCM.Annotations
 					destCM.Labels = sourceCM.Labels
 					destCM.Data = sourceCM.Data
@@ -776,7 +781,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				destSecret := &corev1.Secret{}
 				destSecret.Name = sourceSecret.Name
 				destSecret.Namespace = controlPlaneNamespace.Name
-				if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, destSecret, func() error {
+				if _, err := r.CreateOrUpdate(ctx, r.Client, destSecret, func() error {
 					destSecret.Annotations = sourceSecret.Annotations
 					destSecret.Labels = sourceSecret.Labels
 					destSecret.Data = sourceSecret.Data
@@ -792,7 +797,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Reconcile the HostedControlPlane
 	hcp := controlplaneoperator.HostedControlPlane(controlPlaneNamespace.Name, hcluster.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, hcp, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, hcp, func() error {
 		return reconcileHostedControlPlane(hcp, hcluster)
 	})
 	if err != nil {
@@ -826,7 +831,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		ibmCluster := controlplaneoperator.IBMCloudCluster(controlPlaneNamespace.Name, hcluster.Name)
-		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, ibmCluster, func() error {
+		_, err = r.CreateOrUpdate(ctx, r.Client, ibmCluster, func() error {
 			return reconcileIBMCloudCluster(ibmCluster, hcluster, hcp.Status.ControlPlaneEndpoint)
 		})
 		if err != nil {
@@ -846,7 +851,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Reconcile the CAPI Cluster resource
 	capiCluster := controlplaneoperator.CAPICluster(controlPlaneNamespace.Name, hcluster.Spec.InfraID)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiCluster, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiCluster, func() error {
 		return reconcileCAPICluster(capiCluster, hcluster, hcp, infraCR)
 	})
 	if err != nil {
@@ -866,7 +871,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get controlplane kubeconfig secret %q: %w", client.ObjectKeyFromObject(src), err)
 		}
 		dest := manifests.KubeConfigSecret(hcluster.Namespace, hcluster.Name)
-		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, dest, func() error {
+		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
 			key := hcp.Status.KubeConfig.Key
 			srcData, srcHasData := src.Data[key]
 			if !srcHasData {
@@ -1033,7 +1038,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI webhooks TLS secret
 	capiWebhooksTLSSecret := clusterapi.CAPIWebhooksTLSSecret(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiWebhooksTLSSecret, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiWebhooksTLSSecret, func() error {
 		_, hasTLSPrivateKeyKey := capiWebhooksTLSSecret.Data[corev1.TLSPrivateKeyKey]
 		_, hasTLSCertKey := capiWebhooksTLSSecret.Data[corev1.TLSCertKey]
 		if hasTLSPrivateKeyKey && hasTLSCertKey {
@@ -1067,14 +1072,14 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI manager service account
 	capiManagerServiceAccount := clusterapi.CAPIManagerServiceAccount(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiManagerServiceAccount, NoopReconcile)
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerServiceAccount, NoopReconcile)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile capi manager service account: %w", err)
 	}
 
 	// Reconcile CAPI manager cluster role
 	capiManagerClusterRole := clusterapi.CAPIManagerClusterRole(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiManagerClusterRole, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerClusterRole, func() error {
 		return reconcileCAPIManagerClusterRole(capiManagerClusterRole)
 	})
 	if err != nil {
@@ -1083,7 +1088,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI manager cluster role binding
 	capiManagerClusterRoleBinding := clusterapi.CAPIManagerClusterRoleBinding(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiManagerClusterRoleBinding, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerClusterRoleBinding, func() error {
 		return reconcileCAPIManagerClusterRoleBinding(capiManagerClusterRoleBinding, capiManagerClusterRole, capiManagerServiceAccount)
 	})
 	if err != nil {
@@ -1092,7 +1097,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI manager role
 	capiManagerRole := clusterapi.CAPIManagerRole(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiManagerRole, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerRole, func() error {
 		return reconcileCAPIManagerRole(capiManagerRole)
 	})
 	if err != nil {
@@ -1101,7 +1106,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI manager role binding
 	capiManagerRoleBinding := clusterapi.CAPIManagerRoleBinding(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiManagerRoleBinding, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerRoleBinding, func() error {
 		return reconcileCAPIManagerRoleBinding(capiManagerRoleBinding, capiManagerRole, capiManagerServiceAccount)
 	})
 	if err != nil {
@@ -1114,7 +1119,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 		capiImage = hcluster.Annotations[hyperv1.ClusterAPIManagerImage]
 	}
 	capiManagerDeployment := clusterapi.ClusterAPIManagerDeployment(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiManagerDeployment, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerDeployment, func() error {
 		// TODO (alberto): This image builds from https://github.com/kubernetes-sigs/cluster-api/pull/4709
 		// We need to build from main branch and push to quay.io/hypershift once this is merged or otherwise enable webhooks.
 		return reconcileCAPIManagerDeployment(capiManagerDeployment, hcluster, capiManagerServiceAccount, capiImage)
@@ -1137,7 +1142,7 @@ func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, 
 
 	// Reconcile CAPI AWS provider role
 	capiAwsProviderRole := clusterapi.CAPIAWSProviderRole(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiAwsProviderRole, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiAwsProviderRole, func() error {
 		return reconcileCAPIAWSProviderRole(capiAwsProviderRole)
 	})
 	if err != nil {
@@ -1146,14 +1151,14 @@ func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, 
 
 	// Reconcile CAPI AWS provider service account
 	capiAwsProviderServiceAccount := clusterapi.CAPIAWSProviderServiceAccount(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiAwsProviderServiceAccount, NoopReconcile)
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiAwsProviderServiceAccount, NoopReconcile)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile capi aws provider service account: %w", err)
 	}
 
 	// Reconcile CAPI AWS provider role binding
 	capiAwsProviderRoleBinding := clusterapi.CAPIAWSProviderRoleBinding(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiAwsProviderRoleBinding, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiAwsProviderRoleBinding, func() error {
 		return reconcileCAPIAWSProviderRoleBinding(capiAwsProviderRoleBinding, capiAwsProviderRole, capiAwsProviderServiceAccount)
 	})
 	if err != nil {
@@ -1162,7 +1167,7 @@ func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, 
 
 	// Reconcile CAPI AWS provider deployment
 	capiAwsProviderDeployment := clusterapi.CAPIAWSProviderDeployment(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, capiAwsProviderDeployment, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, capiAwsProviderDeployment, func() error {
 		// TODO (alberto): This image builds from https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2453
 		// We need to build from main branch and push to quay.io/hypershift once this is merged or otherwise enable webhooks.
 		return reconcileCAPIAWSProviderDeployment(capiAwsProviderDeployment, hcluster, capiAwsProviderServiceAccount)
@@ -1185,14 +1190,14 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 
 	// Reconcile operator service account
 	controlPlaneOperatorServiceAccount := controlplaneoperator.OperatorServiceAccount(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorServiceAccount, NoopReconcile)
+	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorServiceAccount, NoopReconcile)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator service account: %w", err)
 	}
 
 	// Reconcile operator cluster role
 	controlPlaneOperatorClusterRole := controlplaneoperator.OperatorClusterRole()
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRole, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRole, func() error {
 		return reconcileControlPlaneOperatorClusterRole(controlPlaneOperatorClusterRole)
 	})
 	if err != nil {
@@ -1201,7 +1206,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 
 	// Reconcile operator cluster role binding
 	controlPlaneOperatorClusterRoleBinding := controlplaneoperator.OperatorClusterRoleBinding(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRoleBinding, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRoleBinding, func() error {
 		return reconcileControlPlaneOperatorClusterRoleBinding(controlPlaneOperatorClusterRoleBinding, controlPlaneOperatorClusterRole, controlPlaneOperatorServiceAccount)
 	})
 	if err != nil {
@@ -1210,7 +1215,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 
 	// Reconcile operator role
 	controlPlaneOperatorRole := controlplaneoperator.OperatorRole(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorRole, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorRole, func() error {
 		return reconcileControlPlaneOperatorRole(controlPlaneOperatorRole)
 	})
 	if err != nil {
@@ -1219,7 +1224,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 
 	// Reconcile operator role binding
 	controlPlaneOperatorRoleBinding := controlplaneoperator.OperatorRoleBinding(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorRoleBinding, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorRoleBinding, func() error {
 		return reconcileControlPlaneOperatorRoleBinding(controlPlaneOperatorRoleBinding, controlPlaneOperatorRole, controlPlaneOperatorServiceAccount)
 	})
 	if err != nil {
@@ -1240,8 +1245,8 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 		return err
 	}
 	controlPlaneOperatorDeployment := controlplaneoperator.OperatorDeployment(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
-		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, controlPlaneOperatorServiceAccount)
+	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
+		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator deployment: %w", err)
@@ -1329,7 +1334,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	}
 	// Reconcile service
 	ignitionServerService := ignitionserver.Service(controlPlaneNamespace.Name)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, ignitionServerService, func() error {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, ignitionServerService, func() error {
 		return reconcileIgnitionServerService(ignitionServerService, serviceStrategy)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition service: %w", err)
@@ -1341,7 +1346,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	case hyperv1.Route:
 		// Reconcile route
 		ignitionServerRoute := ignitionserver.Route(controlPlaneNamespace.Name)
-		if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, ignitionServerRoute, func() error {
+		if result, err := r.CreateOrUpdate(ctx, r.Client, ignitionServerRoute, func() error {
 			if ignitionServerRoute.Annotations == nil {
 				ignitionServerRoute.Annotations = map[string]string{}
 			}
@@ -1379,7 +1384,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	// Reconcile a root CA for ignition serving certificates. We only create this
 	// and don't update it for now.
 	caCertSecret := ignitionserver.IgnitionCACertSecret(controlPlaneNamespace.Name)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, caCertSecret, func() error {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, caCertSecret, func() error {
 		if caCertSecret.CreationTimestamp.IsZero() {
 			cfg := &certs.CertCfg{
 				Subject:   pkix.Name{CommonName: "ignition-root-ca", OrganizationalUnit: []string{"openshift"}},
@@ -1408,7 +1413,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	// Reconcile a ignition serving certificate issued by the generated root CA. We
 	// only create this and don't update it for now.
 	servingCertSecret := ignitionserver.IgnitionServingCertSecret(controlPlaneNamespace.Name)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, servingCertSecret, func() error {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, servingCertSecret, func() error {
 		if servingCertSecret.CreationTimestamp.IsZero() {
 			caCert, err := certs.PemToCertificate(caCertSecret.Data[corev1.TLSCertKey])
 			if err != nil {
@@ -1443,7 +1448,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	}
 
 	role := ignitionserver.Role(controlPlaneNamespace.Name)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, role, func() error {
 		role.Rules = []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
@@ -1475,14 +1480,14 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	}
 
 	sa := ignitionserver.ServiceAccount(controlPlaneNamespace.Name)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, NoopReconcile); err != nil {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, sa, NoopReconcile); err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator service account: %w", err)
 	} else {
 		span.AddEvent("reconciled ignition ServiceAccount", trace.WithAttributes(attribute.String("result", string(result))))
 	}
 
 	roleBinding := ignitionserver.RoleBinding(controlPlaneNamespace.Name)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, roleBinding, func() error {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, roleBinding, func() error {
 		roleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
@@ -1505,7 +1510,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 
 	// Reconcile deployment
 	ignitionServerDeployment := ignitionserver.Deployment(controlPlaneNamespace.Name)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, ignitionServerDeployment, func() error {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, ignitionServerDeployment, func() error {
 		if ignitionServerDeployment.Annotations == nil {
 			ignitionServerDeployment.Annotations = map[string]string{}
 		}
@@ -1650,7 +1655,7 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, hclus
 
 	// Reconcile autoscaler role
 	autoScalerRole := autoscaler.AutoScalerRole(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, autoScalerRole, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, autoScalerRole, func() error {
 		return reconcileAutoScalerRole(autoScalerRole)
 	})
 	if err != nil {
@@ -1659,14 +1664,14 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, hclus
 
 	// Reconcile autoscaler service account
 	autoScalerServiceAccount := autoscaler.AutoScalerServiceAccount(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, autoScalerServiceAccount, NoopReconcile)
+	_, err = r.CreateOrUpdate(ctx, r.Client, autoScalerServiceAccount, NoopReconcile)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile autoscaler service account: %w", err)
 	}
 
 	// Reconcile autoscaler role binding
 	autoScalerRoleBinding := autoscaler.AutoScalerRoleBinding(controlPlaneNamespace.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, autoScalerRoleBinding, func() error {
+	_, err = r.CreateOrUpdate(ctx, r.Client, autoScalerRoleBinding, func() error {
 		return reconcileAutoScalerRoleBinding(autoScalerRoleBinding, autoScalerRole, autoScalerServiceAccount)
 	})
 	if err != nil {
@@ -1694,7 +1699,7 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, hclus
 			clusterAutoScalerImage = hcluster.Annotations[hyperv1.ClusterAutoscalerImage]
 		}
 		autoScalerDeployment := autoscaler.AutoScalerDeployment(controlPlaneNamespace.Name)
-		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, autoScalerDeployment, func() error {
+		_, err = r.CreateOrUpdate(ctx, r.Client, autoScalerDeployment, func() error {
 			return reconcileAutoScalerDeployment(autoScalerDeployment, hcluster, autoScalerServiceAccount, capiKubeConfigSecret, hcluster.Spec.Autoscaling, clusterAutoScalerImage, r.HypershiftOperatorImage)
 		})
 		if err != nil {
@@ -1729,7 +1734,7 @@ func getControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 	}
 }
 
-func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, image string, sa *corev1.ServiceAccount) error {
+func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, image string, sa *corev1.ServiceAccount, enableCIDebugOutput bool) error {
 	deployment.Spec = appsv1.DeploymentSpec{
 		Replicas: k8sutilspointer.Int32Ptr(1),
 		Selector: &metav1.LabelSelector{
@@ -1767,7 +1772,7 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 							RunAsUser: k8sutilspointer.Int64Ptr(1000),
 						},
 						Command: []string{"/usr/bin/control-plane-operator"},
-						Args:    []string{"run", "--namespace", "$(MY_NAMESPACE)", "--deployment-name", "control-plane-operator", "--metrics-addr", "0.0.0.0:8080"},
+						Args:    []string{"run", "--namespace", "$(MY_NAMESPACE)", "--deployment-name", "control-plane-operator", "--metrics-addr", "0.0.0.0:8080", fmt.Sprintf("--enable-ci-debug-output=%t", enableCIDebugOutput)},
 						Ports:   []corev1.ContainerPort{{Name: "metrics", ContainerPort: 8080}},
 					},
 				},
@@ -2770,7 +2775,7 @@ func (r *HostedClusterReconciler) reconcileMachineConfigServer(ctx context.Conte
 
 	// Reconcile service
 	mcsService := ignitionserver.MCSService(controlPlaneNamespace.Name)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, mcsService, func() error {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, mcsService, func() error {
 		return reconcileMachineConfigServerService(mcsService)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile machine config server service: %w", err)

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	hyperutil "github.com/openshift/hypershift/hypershift-operator/controllers/util"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/upsert"
 	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
@@ -74,6 +75,8 @@ type NodePoolReconciler struct {
 	ReleaseProvider releaseinfo.Provider
 
 	tracer trace.Tracer
+
+	upsert.CreateOrUpdateProvider
 }
 
 func (r *NodePoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -462,7 +465,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, targetConfigVersionHash)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, tokenSecret, func() error {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, tokenSecret, func() error {
 		return reconcileTokenSecret(tokenSecret, nodePool, compressedConfig)
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile token Secret: %w", err)
@@ -478,7 +481,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), targetConfigVersionHash)
-	if result, err := controllerutil.CreateOrUpdate(ctx, r.Client, userDataSecret, func() error {
+	if result, err := r.CreateOrUpdate(ctx, r.Client, userDataSecret, func() error {
 		return reconcileUserDataSecret(userDataSecret, nodePool, caCertBytes, tokenBytes, ignEndpoint)
 	}); err != nil {
 		return ctrl.Result{}, err

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/upsert"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp"
@@ -69,6 +70,7 @@ type StartOptions struct {
 	IgnitionServerImage        string
 	OpenTelemetryEndpoint      string
 	EnableOCPClusterMonitoring bool
+	EnableCIDebugOutput        bool
 }
 
 func NewStartCommand() *cobra.Command {
@@ -97,6 +99,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.IgnitionServerImage, "ignition-server-image", opts.IgnitionServerImage, "An ignition server image to use (defaults to match this operator if running in a deployment)")
 	cmd.Flags().StringVar(&opts.OpenTelemetryEndpoint, "otlp-endpoint", opts.OpenTelemetryEndpoint, "An OpenTelemetry collector endpoint (e.g. localhost:4317). If specified, OTLP traces will be exported to this endpoint.")
 	cmd.Flags().BoolVar(&opts.EnableOCPClusterMonitoring, "enable-ocp-cluster-monitoring", opts.EnableOCPClusterMonitoring, "Development-only option that will make your OCP cluster unsupported: If the cluster Prometheus should be configured to scrape metrics")
+	cmd.Flags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", false, "If extra CI debug output should be enabled")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
@@ -170,6 +173,8 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	}
 	log.Info("using ignition server image", "image", ignitionServerImage)
 
+	createOrUpdate := upsert.New(opts.EnableCIDebugOutput)
+
 	if err = (&hostedcluster.HostedClusterReconciler{
 		Client:                  mgr.GetClient(),
 		HypershiftOperatorImage: operatorImage,
@@ -179,6 +184,8 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 			Cache: map[string]*releaseinfo.ReleaseImage{},
 		},
 		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
+		CreateOrUpdateProvider:     createOrUpdate,
+		EnableCIDebugOutput:        opts.EnableCIDebugOutput,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}
@@ -189,6 +196,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 			Inner: &releaseinfo.RegistryClientProvider{},
 			Cache: map[string]*releaseinfo.ReleaseImage{},
 		},
+		CreateOrUpdateProvider: createOrUpdate,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}

--- a/support/upsert/loopdetector.go
+++ b/support/upsert/loopdetector.go
@@ -1,0 +1,75 @@
+package upsert
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/bombsimon/logrusr"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newUpdateLoopDetector() *updateLoopDetector {
+	return &updateLoopDetector{
+		hasNoOpUpdate:    sets.String{},
+		updateEventCount: map[string]int{},
+		log:              logrusr.NewLogger(func() logrus.FieldLogger { l := logrus.New(); l.SetFormatter(&logrus.JSONFormatter{}); return l }()),
+	}
+}
+
+// LoopDetectorWarningMessage is logged whenever we detect multiple updates of the same object
+// without observering a no-op update.
+const LoopDetectorWarningMessage = "WARNING: Object got updated more than one time without a no-op update, this indicates hypershift incorrectly reverting defaulted values"
+
+// If an object got updated more than once a no-op update, we assume it is a bug in our
+// code. This is a heuristic that currently happens to work out but might need adjustment
+// in the future.
+// Once we did a no-op update, we will ignore the object because we assume that if we have
+// a bug in the defaulting, we will end up always updating.
+const updateLoopThreshold = 1
+
+type updateLoopDetector struct {
+	hasNoOpUpdate    sets.String
+	lock             sync.RWMutex
+	updateEventCount map[string]int
+	log              logr.Logger
+}
+
+func (*updateLoopDetector) keyFor(obj runtime.Object, key crclient.ObjectKey) string {
+	return fmt.Sprintf("%T %s", obj, key.String())
+}
+
+func (uld *updateLoopDetector) recordNoOpUpdate(obj crclient.Object, key crclient.ObjectKey) {
+	uld.lock.Lock()
+	defer uld.lock.Unlock()
+	uld.hasNoOpUpdate.Insert(uld.keyFor(obj, key))
+}
+
+func (uld *updateLoopDetector) recordActualUpdate(original, modified runtime.Object, key crclient.ObjectKey) {
+	cacheKey := uld.keyFor(original, key)
+	uld.lock.RLock()
+	hasNoOpUpdate := uld.hasNoOpUpdate.Has(cacheKey)
+	uld.lock.RUnlock()
+
+	if hasNoOpUpdate {
+		return
+	}
+
+	uld.lock.Lock()
+	uld.updateEventCount[cacheKey]++
+	updateEventCount := uld.updateEventCount[cacheKey]
+	uld.lock.Unlock()
+
+	if updateEventCount < updateLoopThreshold {
+		return
+	}
+
+	diff := cmp.Diff(original, modified)
+	semanticDeepEqual := equality.Semantic.DeepEqual(original, modified)
+	uld.log.Info(LoopDetectorWarningMessage, "type", fmt.Sprintf("%T", modified), "name", key.String(), "diff", diff, "semanticDeepEqual", semanticDeepEqual, "updateCount", updateEventCount)
+}

--- a/support/upsert/upsert.go
+++ b/support/upsert/upsert.go
@@ -1,0 +1,329 @@
+package upsert
+
+import (
+	"context"
+	"fmt"
+
+	routev1 "github.com/openshift/api/route/v1"
+	etcdv1beta2 "github.com/openshift/hypershift/control-plane-operator/thirdparty/etcd/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type CreateOrUpdateProvider interface {
+	CreateOrUpdate(ctx context.Context, c crclient.Client, obj crclient.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error)
+}
+
+func New(enableUpdateLoopDetector bool) CreateOrUpdateProvider {
+	p := &createOrUpdateProvider{}
+	if enableUpdateLoopDetector {
+		p.loopDetector = newUpdateLoopDetector()
+	}
+	return p
+}
+
+type createOrUpdateProvider struct {
+	loopDetector *updateLoopDetector
+}
+
+// CreateOrUpdate is a copy of controllerutil.CreateOrUpdate with
+// an important difference: It copies a number of fields from the object
+// on the server to the mutated object if unset in the latter. This
+// avoids unnecessary updates when our code sets a whole struct that
+// has fields that get defaulted by the server.
+func (p *createOrUpdateProvider) CreateOrUpdate(ctx context.Context, c crclient.Client, obj crclient.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	key := client.ObjectKeyFromObject(obj)
+	if err := c.Get(ctx, key, obj); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return controllerutil.OperationResultNone, err
+		}
+		if err := mutate(f, key, obj); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		if err := c.Create(ctx, obj); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		return controllerutil.OperationResultCreated, nil
+	}
+
+	existing := obj.DeepCopyObject() //nolint
+	if err := mutate(f, key, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+
+	switch existingTyped := existing.(type) {
+	case *appsv1.Deployment:
+		defaultDeploymentSpec(&existingTyped.Spec, &obj.(*appsv1.Deployment).Spec)
+	case *batchv1.CronJob:
+		defaultCronJobSpec(&existingTyped.Spec, &obj.(*batchv1.CronJob).Spec)
+	case *corev1.Service:
+		defaultServiceSpec(&existingTyped.Spec, &obj.(*corev1.Service).Spec)
+	case *routev1.Route:
+		defaultRouteSpec(&existingTyped.Spec, &obj.(*routev1.Route).Spec)
+	case *etcdv1beta2.EtcdCluster:
+		defaultEtcdClusterSpec(&existingTyped.Spec, &obj.(*etcdv1beta2.EtcdCluster).Spec)
+	}
+
+	if equality.Semantic.DeepEqual(existing, obj) {
+		if p.loopDetector != nil {
+			p.loopDetector.recordNoOpUpdate(obj, key)
+		}
+		return controllerutil.OperationResultNone, nil
+	}
+	if p.loopDetector != nil {
+		p.loopDetector.recordActualUpdate(existing, obj, key)
+	}
+
+	if err := c.Update(ctx, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+	return controllerutil.OperationResultUpdated, nil
+}
+
+// mutate wraps a MutateFn and applies validation to its result.
+func mutate(f controllerutil.MutateFn, key crclient.ObjectKey, obj crclient.Object) error {
+	if err := f(); err != nil {
+		return err
+	}
+	if newKey := crclient.ObjectKeyFromObject(obj); key != newKey {
+		return fmt.Errorf("MutateFn cannot mutate object name and/or object namespace")
+	}
+	return nil
+}
+
+// Below defaulting funcs. Their code is based on upstream code that is unfortunatelly
+// not in staging so we can't import it:
+// * https://github.com/kubernetes/kubernetes/blob/e5976909c6fb129228a67515e0f86336a53884f0/pkg/apis/core/v1/zz_generated.defaults.go
+// * https://github.com/kubernetes/kubernetes/blob/e5976909c6fb129228a67515e0f86336a53884f0/pkg/apis/apps/v1/zz_generated.defaults.go
+// * https://github.com/openshift/openshift-apiserver/blob/c3b45895167907f149184fb170e4cae1bf28576f/pkg/route/apis/route/v1/defaults.go
+// * https://github.com/kubernetes/kubernetes/blob/e5976909c6fb129228a67515e0f86336a53884f0/pkg/apis/batch/v1/zz_generated.defaults.go
+
+func defaultEtcdClusterSpec(original, mutated *etcdv1beta2.ClusterSpec) {
+	if mutated.Repository == "" {
+		mutated.Repository = original.Repository
+	}
+}
+
+func defaultRouteSpec(original, mutated *routev1.RouteSpec) {
+	if mutated.To.Weight == nil {
+		mutated.To.Weight = original.To.Weight
+	}
+	if mutated.WildcardPolicy == "" {
+		mutated.WildcardPolicy = original.WildcardPolicy
+	}
+}
+
+func defaultServiceSpec(original, mutated *corev1.ServiceSpec) {
+	if mutated.ClusterIP == "" {
+		mutated.ClusterIP = original.ClusterIP
+	}
+	if mutated.ClusterIPs == nil {
+		mutated.ClusterIPs = original.ClusterIPs
+	}
+	if mutated.IPFamilies == nil {
+		mutated.IPFamilies = original.IPFamilies
+	}
+	if mutated.IPFamilyPolicy == nil {
+		mutated.IPFamilyPolicy = original.IPFamilyPolicy
+	}
+	for i := range original.Ports {
+		if i >= len(mutated.Ports) {
+			break
+		}
+		if mutated.Ports[i].Protocol == "" {
+			mutated.Ports[i].Protocol = original.Ports[i].Protocol
+		}
+	}
+	if mutated.SessionAffinity == "" {
+		mutated.SessionAffinity = original.SessionAffinity
+	}
+	if mutated.Type == "" {
+		mutated.Type = original.Type
+	}
+}
+
+func defaultCronJobSpec(original, mutated *batchv1.CronJobSpec) {
+	if mutated.ConcurrencyPolicy == "" {
+		mutated.ConcurrencyPolicy = original.ConcurrencyPolicy
+	}
+	if mutated.FailedJobsHistoryLimit == nil {
+		mutated.FailedJobsHistoryLimit = original.FailedJobsHistoryLimit
+	}
+	if mutated.JobTemplate.Spec.ActiveDeadlineSeconds == nil {
+		mutated.JobTemplate.Spec.ActiveDeadlineSeconds = original.JobTemplate.Spec.ActiveDeadlineSeconds
+	}
+	if mutated.JobTemplate.Spec.BackoffLimit == nil {
+		mutated.JobTemplate.Spec.BackoffLimit = original.JobTemplate.Spec.BackoffLimit
+	}
+	if mutated.StartingDeadlineSeconds == nil {
+		mutated.StartingDeadlineSeconds = original.StartingDeadlineSeconds
+	}
+	if mutated.SuccessfulJobsHistoryLimit == nil {
+		mutated.SuccessfulJobsHistoryLimit = original.SuccessfulJobsHistoryLimit
+	}
+	if mutated.Suspend == nil {
+		mutated.Suspend = original.Suspend
+	}
+
+	defaultPodSpec(&original.JobTemplate.Spec.Template.Spec, &mutated.JobTemplate.Spec.Template.Spec)
+}
+
+func defaultDeploymentSpec(original, mutated *appsv1.DeploymentSpec) {
+	if mutated.ProgressDeadlineSeconds == nil {
+		mutated.ProgressDeadlineSeconds = original.ProgressDeadlineSeconds
+	}
+	if mutated.Replicas == nil {
+		mutated.Replicas = original.Replicas
+	}
+	if mutated.Strategy.Type == "" {
+		mutated.Strategy.Type = original.Strategy.Type
+	}
+	if mutated.Strategy.RollingUpdate == nil && original.Strategy.RollingUpdate != nil {
+		mutated.Strategy.RollingUpdate = original.Strategy.RollingUpdate
+	}
+	if mutated.Strategy.RollingUpdate != nil && original.Strategy.RollingUpdate != nil {
+		if mutated.Strategy.RollingUpdate.MaxSurge == nil {
+			mutated.Strategy.RollingUpdate.MaxSurge = original.Strategy.RollingUpdate.MaxSurge
+		}
+		if mutated.Strategy.RollingUpdate.MaxUnavailable == nil {
+			mutated.Strategy.RollingUpdate.MaxUnavailable = original.Strategy.RollingUpdate.MaxUnavailable
+		}
+	}
+	if mutated.RevisionHistoryLimit == nil {
+		mutated.RevisionHistoryLimit = original.RevisionHistoryLimit
+	}
+
+	defaultPodSpec(&original.Template.Spec, &mutated.Template.Spec)
+}
+
+func defaultPodSpec(original, mutated *corev1.PodSpec) {
+	for i := range original.InitContainers {
+		if i >= len(mutated.InitContainers) {
+			break
+		}
+		defaultContainer(&original.InitContainers[i], &mutated.InitContainers[i])
+	}
+	for i := range original.Containers {
+		if i >= len(mutated.Containers) {
+			break
+		}
+		defaultContainer(&original.Containers[i], &mutated.Containers[i])
+	}
+	if mutated.DNSPolicy == "" {
+		mutated.DNSPolicy = original.DNSPolicy
+	}
+	if mutated.ServiceAccountName == "" {
+		mutated.ServiceAccountName = original.ServiceAccountName
+	}
+	if mutated.DeprecatedServiceAccount == "" {
+		mutated.DeprecatedServiceAccount = original.DeprecatedServiceAccount
+	}
+	if mutated.RestartPolicy == "" {
+		mutated.RestartPolicy = original.RestartPolicy
+	}
+	if mutated.SchedulerName == "" {
+		mutated.SchedulerName = original.SchedulerName
+	}
+	if mutated.TerminationGracePeriodSeconds == nil {
+		mutated.TerminationGracePeriodSeconds = original.TerminationGracePeriodSeconds
+	}
+
+	for i := range original.Volumes {
+		if i >= len(mutated.Volumes) {
+			break
+		}
+		defaultVolume(&original.Volumes[i], &mutated.Volumes[i])
+	}
+
+	if mutated.SecurityContext == nil {
+		mutated.SecurityContext = original.SecurityContext
+	}
+}
+
+func defaultContainer(original, mutated *corev1.Container) {
+	if mutated.ImagePullPolicy == "" {
+		mutated.ImagePullPolicy = original.ImagePullPolicy
+	}
+	if mutated.TerminationMessagePath == "" {
+		mutated.TerminationMessagePath = original.TerminationMessagePath
+	}
+	if mutated.TerminationMessagePolicy == "" {
+		mutated.TerminationMessagePolicy = original.TerminationMessagePolicy
+	}
+
+	if original.LivenessProbe != nil && mutated.LivenessProbe != nil {
+		defaultProbe(original.LivenessProbe, mutated.LivenessProbe)
+	}
+
+	if original.ReadinessProbe != nil && mutated.ReadinessProbe != nil {
+		defaultProbe(original.ReadinessProbe, mutated.ReadinessProbe)
+	}
+
+	for i := range original.Env {
+		if i >= len(mutated.Env) {
+			break
+		}
+		defaultEnv(&original.Env[i], &mutated.Env[i])
+	}
+
+	for i := range original.Ports {
+		if i >= len(mutated.Ports) {
+			break
+		}
+		defaultContainerPort(&original.Ports[i], &mutated.Ports[i])
+	}
+
+	if original.SecurityContext != nil && mutated.SecurityContext == nil {
+		mutated.SecurityContext = original.SecurityContext
+	}
+	if original.SecurityContext != nil && mutated.SecurityContext != nil {
+		if mutated.SecurityContext.RunAsUser == nil && original.SecurityContext.RunAsUser != nil {
+			mutated.SecurityContext.RunAsUser = original.SecurityContext.RunAsUser
+		}
+	}
+}
+
+func defaultProbe(original, mutated *corev1.Probe) {
+	if mutated.TimeoutSeconds == 0 {
+		mutated.TimeoutSeconds = original.TimeoutSeconds
+	}
+	if mutated.PeriodSeconds == 0 {
+		mutated.PeriodSeconds = original.PeriodSeconds
+	}
+	if mutated.SuccessThreshold == 0 {
+		mutated.SuccessThreshold = original.SuccessThreshold
+	}
+	if mutated.FailureThreshold == 0 {
+		mutated.FailureThreshold = original.FailureThreshold
+	}
+	if mutated.HTTPGet != nil && original.HTTPGet != nil && mutated.HTTPGet.Scheme == "" {
+		mutated.HTTPGet.Scheme = original.HTTPGet.Scheme
+	}
+}
+
+func defaultVolume(original, mutated *corev1.Volume) {
+	if mutated.VolumeSource.Secret != nil && original.VolumeSource.Secret != nil && mutated.VolumeSource.Secret.DefaultMode == nil {
+		mutated.VolumeSource.Secret.DefaultMode = original.VolumeSource.Secret.DefaultMode
+	}
+	if mutated.VolumeSource.ConfigMap != nil && original.VolumeSource.ConfigMap != nil && mutated.VolumeSource.ConfigMap.DefaultMode == nil {
+		mutated.VolumeSource.ConfigMap.DefaultMode = original.VolumeSource.ConfigMap.DefaultMode
+	}
+}
+
+func defaultEnv(original, mutated *corev1.EnvVar) {
+	if mutated.ValueFrom != nil && original.ValueFrom != nil && mutated.ValueFrom.FieldRef != nil && original.ValueFrom.FieldRef != nil && mutated.ValueFrom.FieldRef.APIVersion == "" {
+		mutated.ValueFrom.FieldRef.APIVersion = original.ValueFrom.FieldRef.APIVersion
+	}
+}
+
+func defaultContainerPort(original, mutated *corev1.ContainerPort) {
+	if mutated.Protocol == "" {
+		mutated.Protocol = original.Protocol
+	}
+}

--- a/support/upsert/upsert_test.go
+++ b/support/upsert/upsert_test.go
@@ -1,0 +1,32 @@
+package upsert
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ CreateOrUpdateProvider = &createOrUpdateProvider{}
+
+func TestCreateOrUpdate(t *testing.T) {
+	client := fake.NewFakeClient(&appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{ServiceAccountName: "service-account"},
+			},
+		},
+	})
+
+	deployment := &appsv1.Deployment{}
+	result, err := (&createOrUpdateProvider{}).CreateOrUpdate(context.Background(), client, deployment, func() error { return nil })
+	if err != nil {
+		t.Fatalf("CreateOrUpdate failed: %v", err)
+	}
+	if result != controllerutil.OperationResultNone {
+		t.Errorf("expected result %s, got %s", controllerutil.OperationResultNone, result)
+	}
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -26,6 +27,7 @@ import (
 	cmdcluster "github.com/openshift/hypershift/cmd/cluster"
 	consolelogsaws "github.com/openshift/hypershift/cmd/consolelogs/aws"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/support/upsert"
 )
 
 func GenerateNamespace(t *testing.T, ctx context.Context, client crclient.Client, prefix string) *corev1.Namespace {
@@ -52,10 +54,16 @@ func DumpHostedCluster(t *testing.T, ctx context.Context, hostedCluster *hyperv1
 		t.Logf("Skipping cluster dump because no artifact dir was provided")
 		return
 	}
+	findKubeObjectUpdateLoops := func(filename string, content []byte) {
+		if bytes.Contains(content, []byte(upsert.LoopDetectorWarningMessage)) {
+			t.Errorf("Found %s messages in file %s", upsert.LoopDetectorWarningMessage, filename)
+		}
+	}
 	err := cmdcluster.DumpCluster(ctx, &cmdcluster.DumpOptions{
 		Namespace:   hostedCluster.Namespace,
 		Name:        hostedCluster.Name,
 		ArtifactDir: artifactDir,
+		LogCheckers: []cmdcluster.LogChecker{findKubeObjectUpdateLoops},
 	})
 	if err != nil {
 		t.Errorf("Failed to dump cluster: %v", err)


### PR DESCRIPTION
We are currently doing a lot of Update calls for Kube objects that don't
actually change anything and happen because the server defaults fields
and our code resets them to be empty. We prevent this by implementing a
custom CreateOrUpdate that will copy fields that get defaulted from the
object on the server to the locally-modified object, if unset in the
latter.

Additinally, we will log if we detect multiple updates to the same
object without an attempted update that resulted in a no-op. We then
verify in the e2e tests that we don't log this to detect regressions.

Ref https://issues.redhat.com/browse/HOSTEDCP-237