### PR TITLE
Set imagePullPolicy to Always for containers using hypershift image

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -41,6 +41,7 @@ func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef 
 			deployment.Spec.Template.Spec.Containers[i].Image = olmImage
 		case "socks5-proxy":
 			deployment.Spec.Template.Spec.Containers[i].Image = socks5ProxyImage
+			deployment.Spec.Template.Spec.Containers[i].ImagePullPolicy = corev1.PullAlways
 		}
 	}
 	for i, env := range deployment.Spec.Template.Spec.Containers[0].Env {
@@ -81,6 +82,7 @@ func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef conf
 			deployment.Spec.Template.Spec.Containers[i].Image = olmImage
 		case "socks5-proxy":
 			deployment.Spec.Template.Spec.Containers[i].Image = socks5ProxyImage
+			deployment.Spec.Template.Spec.Containers[i].ImagePullPolicy = corev1.PullAlways
 		}
 	}
 	for i, env := range deployment.Spec.Template.Spec.Containers[0].Env {

--- a/control-plane-operator/controllers/hostedcontrolplane/util/containers.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/util/containers.go
@@ -17,8 +17,9 @@ const AvailabilityProberImageName = "availability-prober"
 
 func AvailabilityProber(target string, image string, spec *corev1.PodSpec) {
 	availabilityProberContainer := corev1.Container{
-		Name:  "availability-prober",
-		Image: image,
+		Name:            "availability-prober",
+		Image:           image,
+		ImagePullPolicy: corev1.PullAlways,
 		Command: []string{
 			"/usr/bin/availability-prober",
 			"--target",


### PR DESCRIPTION
Dev workflows can reuse the same hypershift tags resulting in the new image not being used

@csrwng @alvaroaleman @ironcladlou 