### PR TITLE
Testing: scripts to setup nodeport public IP

### DIFF
--- a/test/hack/nodeport-ip-aws/README.md
+++ b/test/hack/nodeport-ip-aws/README.md
@@ -1,0 +1,46 @@
+# Configure NodePort public IP on AWS management cluster
+
+## Overview
+The scripts in this directory create a bastion machine for a management cluster on AWS
+that forwards the standard service port range (32000-32767) to a master machine on the
+cluster.
+
+This makes it possible to test a NodePort publishing strategy for Hypershift clusters
+on management clusters created as standalone OCP clusters.
+
+## Prerequisites
+
+- `hypershift` - the [hypershift CLI](https://github.com/openshift/hypershift)
+- `oc` - the standard [openshift CLI](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz)
+- `aws` - the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) and account credentials
+- `jq` - [json query tool](https://stedolan.github.io/jq/download/)
+- `ssh`
+
+## Setup
+
+Ensure a `KUBECONFIG` variable is configured that is pointing to your management cluster.
+
+If necessary, add your private SSH key to your SSH agent. This is so the setup script
+can SSH to the bastion machine.
+```
+ssh-add PRIVATEKEY_FILE
+```
+
+Invoke the `setup.sh` script in this directory, first exporting any
+environment variables that you need to change from the default.
+
+Variables used in the script:
+
+- `AWSCREDS` - AWS credentials file (defaults to `~/.aws/credentials`)
+- `SSHPUBLICKEY` - SSH public key to use for bastion (defaults to `~/.ssh/id_rsa.pub`)
+- `HYPERSHIFT` - location of the hypershift binary (defaults to `./bin/hypershift`)
+
+
+## Teardown
+
+Invoke the `teardown.sh` script in this directory, changing any variables as needed.
+
+Variables used in the script:
+
+- `AWSCREDS` - AWS credentials file (defaults to `~/.aws/credentials`)
+- `HYPERSHIFT` - location of the hypershift binary (defaults to `./bin/hypershift)

--- a/test/hack/nodeport-ip-aws/setup.sh
+++ b/test/hack/nodeport-ip-aws/setup.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Adjust to point to your AWS credentials file
+AWSCREDS="${AWSCREDS:-${HOME}/.aws/credentials}"
+
+# Adjust to point to your desired SSH public and private key file
+SSHPUBLICKEY="${SSHPUBLICKEY:-${HOME}/.ssh/id_rsa.pub}"
+
+# Adjust to point to the right hypershift binary
+HYPERSHIFT="${HYPERSHIFT:-./bin/hypershift}"
+
+# Obtain the infra-id and region from the current management cluster
+INFRAID="$(oc get infrastructure/cluster -o jsonpath='{ .status.infrastructureName }')"
+REGION="$(oc get infrastructure/cluster -o jsonpath='{ .status.platformStatus.aws.region }')"
+
+export AWS_SHARED_CREDENTIALS_FILE="${AWSCREDS}"
+
+# Create a bastion machine for the management cluster
+${HYPERSHIFT} create bastion aws \
+   --aws-creds "${AWSCREDS}" \
+   --infra-id "${INFRAID}" \
+   --region "${REGION}" \
+   --ssh-key-file "${SSHPUBLICKEY}"
+
+# Query a description of the bastion machine
+INSTANCEFILE="$(mktemp)"
+aws ec2 describe-instances --filters "Name=tag:Name,Values=${INFRAID}-bastion" > "${INSTANCEFILE}"
+
+# Obtain the machine's public IP
+PUBLICIP="$(cat "${INSTANCEFILE}" | jq -r '.Reservations[].Instances[] | select(.State.Name == "running") | .PublicIpAddress')"
+
+# Obtain the machine's security group
+SGID="$(cat "${INSTANCEFILE}" | jq -r '.Reservations[].Instances[] | select(.State.Name == "running") | .SecurityGroups[0].GroupId')"
+
+# Add permission for service port range to security group
+aws ec2 authorize-security-group-ingress \
+   --group-id "${SGID}" \
+   --protocol tcp \
+   --port 32000-32767 \
+   --cidr "0.0.0.0/0"
+
+# Find the master machines security group
+MASTERSGID="$(aws ec2 describe-security-groups --filters "Name=tag:Name,Values=${INFRAID}-master-sg" | jq -r '.SecurityGroups[0].GroupId')"
+
+# Allow the master machines access from the bastion sg
+aws ec2 authorize-security-group-ingress \
+   --group-id "${MASTERSGID}" \
+   --protocol tcp \
+   --port 32000-32767 \
+   --source-group "${SGID}"
+
+# Find IP of a master machine
+MASTERIP="$(aws ec2 describe-instances --filters Name=tag:Name,Values=${INFRAID}-master-0 | jq -r '.Reservations[].Instances[0].PrivateIpAddress')"
+
+# Enable IP forwarding on bastion machine
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ec2-user@${PUBLICIP}" \
+  sudo sysctl -w net.ipv4.ip_forward=1
+
+# Install HA Proxy on bastion machine
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ec2-user@${PUBLICIP}" \
+  sudo yum -y install haproxy
+
+# Configure HA Proxy on bastion machine
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ec2-user@${PUBLICIP}" \
+  "sudo cat << EOF | sudo tee /etc/haproxy/haproxy.cfg
+listen  router *:32000-32767
+    timeout connect         10s
+    timeout client          1m
+    timeout server          1m
+    mode tcp
+    server master ${MASTERIP}
+EOF"
+
+# Restart haproxy on bastion machine
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ec2-user@${PUBLICIP}" \
+  sudo systemctl restart haproxy
+
+echo "Setup successful."
+echo "Your nodeport address is ${PUBLICIP}"

--- a/test/hack/nodeport-ip-aws/teardown.sh
+++ b/test/hack/nodeport-ip-aws/teardown.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+# Adjust to point to your AWS credentials file
+AWSCREDS="${AWSCREDS:-${HOME}/.aws/credentials}" 
+
+# Adjust to point to the right hypershift binary
+HYPERSHIFT="${HYPERSHIFT:-./bin/hypershift}"
+
+# Obtain the infra-id and region from the current management cluster
+INFRAID="$(oc get infrastructure/cluster -o jsonpath='{ .status.infrastructureName }')"
+REGION="$(oc get infrastructure/cluster -o jsonpath='{ .status.platformStatus.aws.region }')"
+
+export AWS_SHARED_CREDENTIALS_FILE="${AWSCREDS}"
+
+SGID="$(aws ec2 describe-security-groups --filters Name=tag:Name,Values=${INFRAID}-bastion-sg | jq -r '.SecurityGroups[].GroupId')"
+
+if [[ ! -z "$SGID" ]]; then
+  # Find the master machines security group
+  MASTERSGID="$(aws ec2 describe-security-groups --filters "Name=tag:Name,Values=${INFRAID}-master-sg" | jq -r '.SecurityGroups[0].GroupId')"
+
+  # Allow the master machines access from the bastion sg
+  aws ec2 revoke-security-group-ingress \
+    --group-id "${MASTERSGID}" \
+    --protocol tcp \
+    --port 32000-32767 \
+    --source-group "${SGID}"
+fi
+
+${HYPERSHIFT} destroy bastion aws --aws-creds "${AWSCREDS}" --infra-id "${INFRAID}" --region "${REGION}"


### PR DESCRIPTION
Scripts to setup a bastion machine with a public IP that can forward
nodeports to a management cluster.