### PR TITLE
Add control plane CPU metrics recording rule

### DIFF
--- a/cmd/install/assets/assets.go
+++ b/cmd/install/assets/assets.go
@@ -19,6 +19,14 @@ import (
 //go:embed etcd/*
 var crds embed.FS
 
+//go:embed recordingrules/*.promql
+var recordingRules embed.FS
+
+var recordingRulesByName = map[string]string{
+	"hypershift:controlplane:component_memory_usage":      "recordingrules/controlplane_memory_usage.promql",
+	"hypershift:controlplane:component_cpu_usage_seconds": "recordingrules/controlplane_cpu_usage.promql",
+}
+
 const capiLabel = "cluster.x-k8s.io/v1beta1"
 
 // capiResources specifies which CRDs should get labelled with capiLabel

--- a/cmd/install/assets/recordingrules/controlplane_cpu_usage.promql
+++ b/cmd/install/assets/recordingrules/controlplane_cpu_usage.promql
@@ -1,0 +1,19 @@
+avg by (app, namespace) (
+  sum(
+    rate(
+      container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
+    )
+  ) by (pod, namespace)
+  * on (pod) group_left(app)
+	label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""}, "app", "$1", "label_app", "(.*)")
+)
+/
+count by (app, namespace) (
+  sum(
+    rate(
+      container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
+    )
+  ) by (pod, namespace)
+  * on (pod) group_left(app)
+	label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""}, "app", "$1", "label_app", "(.*)")
+)

--- a/cmd/install/assets/recordingrules/controlplane_memory_usage.promql
+++ b/cmd/install/assets/recordingrules/controlplane_memory_usage.promql
@@ -1,0 +1,5 @@
+sum by (app, namespace) (
+	sum(container_memory_usage_bytes{container!="POD",container!=""}) by (pod, namespace)
+* on (pod) group_left(app)
+	label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""}, "app", "$1", "label_app", "(.*)")
+)


### PR DESCRIPTION
Collect control plane CPU metrics into a new recording rule:

  `hypershift:controlplane:component_cpu_usage_seconds`

This metric should be automatically selected for remote export if monitoring
is configured for export.