### PR TITLE
Export api request counters in CI

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -60,6 +60,9 @@ const (
 
 	// ControlPlaneComponent identifies a resource as belonging to a hosted control plane.
 	ControlPlaneComponent = "hypershift.openshift.io/control-plane-component"
+
+	// OperatorComponent identifies a component as belonging to the operator.
+	OperatorComponent = "hypershift.openshift.io/operator-component"
 )
 
 // HostedClusterSpec defines the desired state of HostedCluster

--- a/cmd/install/assets/assets.go
+++ b/cmd/install/assets/assets.go
@@ -23,8 +23,10 @@ var crds embed.FS
 var recordingRules embed.FS
 
 var recordingRulesByName = map[string]string{
-	"hypershift:controlplane:component_memory_usage":      "recordingrules/controlplane_memory_usage.promql",
-	"hypershift:controlplane:component_cpu_usage_seconds": "recordingrules/controlplane_cpu_usage.promql",
+	"hypershift:controlplane:component_memory_usage":       "recordingrules/controlplane_memory_usage.promql",
+	"hypershift:controlplane:component_cpu_usage_seconds":  "recordingrules/controlplane_cpu_usage.promql",
+	"hypershift:controlplane:component_api_requests_total": "recordingrules/controlplane_api_requests.promql",
+	"hypershift:operator:component_api_requests_total":     "recordingrules/operator_api_requests.promql",
 }
 
 const capiLabel = "cluster.x-k8s.io/v1beta1"

--- a/cmd/install/assets/recordingrules/controlplane_api_requests.promql
+++ b/cmd/install/assets/recordingrules/controlplane_api_requests.promql
@@ -1,0 +1,5 @@
+sum by (app, namespace, code, method) (
+  sum(rest_client_requests_total) by (pod, namespace, code, method)
+* on (pod) group_left(app)
+  label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""}, "app", "$1", "label_app", "(.*)")
+)

--- a/cmd/install/assets/recordingrules/operator_api_requests.promql
+++ b/cmd/install/assets/recordingrules/operator_api_requests.promql
@@ -1,0 +1,5 @@
+sum by (app, namespace, code, method) (
+  sum(rest_client_requests_total) by (pod, namespace, code, method)
+* on (pod) group_left(app)
+  label_replace(kube_pod_labels{label_hypershift_openshift_io_operator_component!=""}, "app", "$1", "label_app", "(.*)")
+)

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -62,12 +62,13 @@ func main() {
 }
 
 type StartOptions struct {
-	Namespace             string
-	DeploymentName        string
-	MetricsAddr           string
-	EnableLeaderElection  bool
-	IgnitionServerImage   string
-	OpenTelemetryEndpoint string
+	Namespace                  string
+	DeploymentName             string
+	MetricsAddr                string
+	EnableLeaderElection       bool
+	IgnitionServerImage        string
+	OpenTelemetryEndpoint      string
+	EnableOCPClusterMonitoring bool
 }
 
 func NewStartCommand() *cobra.Command {
@@ -95,6 +96,7 @@ func NewStartCommand() *cobra.Command {
 			"Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().StringVar(&opts.IgnitionServerImage, "ignition-server-image", opts.IgnitionServerImage, "An ignition server image to use (defaults to match this operator if running in a deployment)")
 	cmd.Flags().StringVar(&opts.OpenTelemetryEndpoint, "otlp-endpoint", opts.OpenTelemetryEndpoint, "An OpenTelemetry collector endpoint (e.g. localhost:4317). If specified, OTLP traces will be exported to this endpoint.")
+	cmd.Flags().BoolVar(&opts.EnableOCPClusterMonitoring, "enable-ocp-cluster-monitoring", opts.EnableOCPClusterMonitoring, "Development-only option that will make your OCP cluster unsupported: If the cluster Prometheus should be configured to scrape metrics")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
@@ -176,6 +178,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 			Inner: &releaseinfo.RegistryClientProvider{},
 			Cache: map[string]*releaseinfo.ReleaseImage{},
 		},
+		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}

--- a/test/setup/cluster-monitoring-config.yaml
+++ b/test/setup/cluster-monitoring-config.yaml
@@ -22,4 +22,8 @@ prometheusk8s:
       replacement: __replica__
     - action: labeldrop
       regex: (prometheus|prometheus_replica)
+{{- if .ProwJobID }}
+    - target_label: prowjob_id
+      replacement: "{{ .ProwJobID }}"
+{{end -}}
 {{end -}}

--- a/test/setup/main.go
+++ b/test/setup/main.go
@@ -62,6 +62,8 @@ type MonitoringOptions struct {
 
 	RemoteWriteUsernameFile string
 	RemoteWritePasswordFile string
+
+	ProwJobID string
 }
 
 func monitoringCommand() *cobra.Command {
@@ -70,13 +72,14 @@ func monitoringCommand() *cobra.Command {
 		Short: "Configures a management cluster for e2e monitoring integration",
 	}
 
-	opts := &MonitoringOptions{}
+	opts := &MonitoringOptions{ProwJobID: os.Getenv("PROW_JOB_ID")}
 
 	cmd.Flags().StringVar(&opts.RemoteWriteURL, "remote-write-url", opts.RemoteWriteURL, "Remote write URL. If specified, configures monitoring for remote write.")
 	cmd.Flags().StringVar(&opts.RemoteWriteUsername, "remote-write-username", opts.RemoteWriteUsername, "Remote write username")
 	cmd.Flags().StringVar(&opts.RemoteWritePassword, "remote-write-password", opts.RemoteWritePassword, "Remote write password")
 	cmd.Flags().StringVar(&opts.RemoteWriteUsernameFile, "remote-write-username-file", opts.RemoteWriteUsernameFile, "Remote write username file")
 	cmd.Flags().StringVar(&opts.RemoteWritePasswordFile, "remote-write-password-file", opts.RemoteWritePasswordFile, "Remote write password file")
+	cmd.Flags().StringVar(&opts.ProwJobID, "prow-job-id", opts.ProwJobID, "The ProwJobID. If set, it will be added as a static label to the remote_write config.")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctrl.SetLogger(zap.New(zap.UseDevMode(true)))

--- a/test/setup/user-workload-monitoring-config.yaml
+++ b/test/setup/user-workload-monitoring-config.yaml
@@ -21,4 +21,8 @@ prometheus:
       replacement: __replica__
     - action: labeldrop
       regex: (prometheus|prometheus_replica)
+{{- if .ProwJobID }}
+    - target_label: prowjob_id
+      replacement: "{{ .ProwJobID }}"
+{{end -}}
 {{end -}}


### PR DESCRIPTION


This PR makes us export api request counts in ci by:
* Adding a flag to use the cluster prometheus instead of the UWM one
  and defaulting it to `true` in CI. This is needed because the UWM
  prometheus can not remote_write recording rules
* Set up namespace label and RBAC if the above flag is set
* Adding a `prowjob` label in the hypershift operator service
  monitor when running in CI. This is to ensure uniqueness across
  testruns which is otherwise only guaranteed through the namespace
  which doesn't work here, because the operator always runs in the same
  namespace
* Add a recordingrule to gather the request rate increase over a 5h interval
  and sum it by status code, component, method, namespace and prowjob.
  The 5h interval is used because it exceeds the timeout for prowjobs.

Ref https://issues.redhat.com/browse/HOSTEDCP-237

Result looks like this:

<img width="1890" alt="api_requests_total" src="https://user-images.githubusercontent.com/6496100/137017739-cf78553e-ba07-4d69-87cd-1fe43200c7b7.png">