### PR TITLE
AWS: Fix recognizing existing instances for a machine

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1906,6 +1906,10 @@ func reconcileAWSCluster(awsCluster *capiawsv1.AWSCluster, hcluster *hyperv1.Hos
 	if hcluster.Spec.Platform.AWS != nil {
 		awsCluster.Spec.Region = hcluster.Spec.Platform.AWS.Region
 
+		if hcluster.Spec.Platform.AWS.CloudProviderConfig != nil {
+			awsCluster.Spec.NetworkSpec.VPC.ID = hcluster.Spec.Platform.AWS.CloudProviderConfig.VPC
+		}
+
 		if len(hcluster.Spec.Platform.AWS.ResourceTags) > 0 {
 			awsCluster.Spec.AdditionalTags = capiawsv1.Tags{}
 		}


### PR DESCRIPTION
The aws capa machine reconciler uses a couple of filters[0] to find
existing instances for a machine. Among these is one for the VPC. The
VPC ID in turn is populated from the AWSCluster object[1].

Unfortunatelly, we never set the VPC ID on the AWSCluster object,
resulting in us never recognizing existing instances and in turn always
creating a new instance if the awsmachine's .spec.providerID field is
empty or invalid.

[0]: https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/aa68f949dc496116155c73fd61ea5760f493f6cb/pkg/cloud/services/ec2/instances.go#L50-L55
[1]: https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/aa68f949dc496116155c73fd61ea5760f493f6cb/pkg/cloud/scope/cluster.go#L107

/cc @enxebre 

Should we add an e2e test for this? If so it would probably rely on some implementation details, specifically capa using .spec.providerID to recognize an instance..?