### PR TITLE
Fixes for nodeport publishing strategy

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1215,7 +1215,7 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 	// OAuth server Cert
 	oauthServerCert := manifests.OpenShiftOAuthServerCert(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, oauthServerCert, func() error {
-		return p.ReconcileOAuthServerCert(oauthServerCert, rootCASecret, p.OwnerRef, p.ExternalOauthAddress)
+		return pki.ReconcileOAuthServerCert(oauthServerCert, rootCASecret, p.OwnerRef, p.ExternalOauthAddress)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile oauth cert secret: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/oauth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/oauth.go
@@ -1,11 +1,19 @@
 package pki
 
 import (
+	"net"
+
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (p *PKIParams) ReconcileOAuthServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalOAuthAddress string) error {
-	oauthHostNames := []string{externalOAuthAddress}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-oauth", []string{"openshift"}, X509DefaultUsage, X509UsageClientServerAuth, oauthHostNames, nil)
+func ReconcileOAuthServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalOAuthAddress string) error {
+	var dnsNames, ips []string
+	oauthIP := net.ParseIP(externalOAuthAddress)
+	if oauthIP != nil {
+		ips = append(ips, externalOAuthAddress)
+	} else {
+		dnsNames = append(dnsNames, externalOAuthAddress)
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-oauth", []string{"openshift"}, X509DefaultUsage, X509UsageClientServerAuth, dnsNames, ips)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/oauth_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/oauth_test.go
@@ -1,0 +1,82 @@
+package pki
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config"
+	"github.com/openshift/hypershift/support/certs"
+)
+
+func TestReconcileOAuthServerCert(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		address  string
+		expectIP bool
+	}{
+		{
+			name:     "host name",
+			address:  "www.example.com",
+			expectIP: false,
+		},
+		{
+			name:     "numeric ip",
+			address:  "100.100.100.1",
+			expectIP: true,
+		},
+	}
+
+	ownerRef := config.OwnerRef{
+		Reference: &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Deployment",
+			Name:       "dummy",
+			UID:        types.UID("12345abcdef"),
+			Controller: pointer.BoolPtr(true),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ca := &corev1.Secret{}
+			ca.Name = "test-ca"
+			ca.Namespace = "dummy"
+			err := reconcileSelfSignedCA(ca, ownerRef, "foo", "bar")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			secret := &corev1.Secret{}
+			secret.Name = "cert"
+			secret.Namespace = "dummy"
+			err = ReconcileOAuthServerCert(secret, ca, ownerRef, test.address)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			cert, err := certs.PemToCertificate(secret.Data[corev1.TLSCertKey])
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if test.expectIP {
+				if len(cert.DNSNames) > 0 {
+					t.Errorf("cert has dns names, none expected")
+				}
+				if len(cert.IPAddresses) == 0 {
+					t.Errorf("expected cert to have IP addresses, got none")
+				}
+			} else {
+				if len(cert.DNSNames) == 0 {
+					t.Errorf("expected cert to have DNS names, got none")
+				}
+				if len(cert.IPAddresses) > 0 {
+					t.Errorf("cert has IP addresses, expected none")
+				}
+			}
+		})
+	}
+}

--- a/test/hack/nodeport-ip-aws/setup.sh
+++ b/test/hack/nodeport-ip-aws/setup.sh
@@ -38,7 +38,7 @@ SGID="$(cat "${INSTANCEFILE}" | jq -r '.Reservations[].Instances[] | select(.Sta
 aws ec2 authorize-security-group-ingress \
    --group-id "${SGID}" \
    --protocol tcp \
-   --port 32000-32767 \
+   --port 30000-32767 \
    --cidr "0.0.0.0/0"
 
 # Find the master machines security group
@@ -48,7 +48,7 @@ MASTERSGID="$(aws ec2 describe-security-groups --filters "Name=tag:Name,Values=$
 aws ec2 authorize-security-group-ingress \
    --group-id "${MASTERSGID}" \
    --protocol tcp \
-   --port 32000-32767 \
+   --port 30000-32767 \
    --source-group "${SGID}"
 
 # Find IP of a master machine
@@ -65,7 +65,7 @@ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ec2-user@${PUBL
 # Configure HA Proxy on bastion machine
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ec2-user@${PUBLICIP}" \
   "sudo cat << EOF | sudo tee /etc/haproxy/haproxy.cfg
-listen  router *:32000-32767
+listen  router *:30000-32767
     timeout connect         10s
     timeout client          1m
     timeout server          1m

--- a/test/hack/nodeport-ip-aws/teardown.sh
+++ b/test/hack/nodeport-ip-aws/teardown.sh
@@ -25,7 +25,7 @@ if [[ ! -z "$SGID" ]]; then
   aws ec2 revoke-security-group-ingress \
     --group-id "${MASTERSGID}" \
     --protocol tcp \
-    --port 32000-32767 \
+    --port 30000-32767 \
     --source-group "${SGID}"
 fi
 


### PR DESCRIPTION
Fixes the script that sets up a nodeport ip bastion and PKI generation to take into consideration external numeric IPs