### PR TITLE
PackageServer supports custom catalog sources

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2051,7 +2051,7 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 
 	packageServerDeployment := manifests.OLMPackageServerDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, packageServerDeployment, func() error {
-		return olm.ReconcilePackageServerDeployment(packageServerDeployment, p.OwnerRef, p.OLMImage, p.ReleaseVersion, p.PackageServerConfig, p.AvailabilityProberImage)
+		return olm.ReconcilePackageServerDeployment(packageServerDeployment, p.OwnerRef, p.OLMImage, p.ProxyImage, p.ReleaseVersion, p.PackageServerConfig, p.AvailabilityProberImage)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile packageserver deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
@@ -21,6 +21,24 @@ spec:
         hypershift.openshift.io/control-plane-component: packageserver
     spec:
       containers:
+      - name: socks5-proxy
+        command:
+          - "/usr/bin/konnectivity-socks5-proxy"
+        args:
+          - run
+        image: SOCKS5_PROXY_IMAGE
+        env:
+          - name: KUBECONFIG
+            value: /etc/openshift/kubeconfig/kubeconfig
+        ports:
+          - containerPort: 8090
+        volumeMounts:
+          - mountPath: /etc/konnectivity-proxy-tls
+            name: oas-konnectivity-proxy-cert
+            readOnly: true
+          - mountPath: /etc/openshift/kubeconfig
+            name: kubeconfig
+            readOnly: true
       - command:
         - /bin/package-server
         - -v=4
@@ -37,6 +55,10 @@ spec:
         env:
         - name: OPERATOR_CONDITION_NAME
           value: packageserver
+        - name: GRPC_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: NO_PROXY
+          value: kube-apiserver,redhat-operators,certified-operators,community-operators,redhat-marketplace
         image: OLM_OPERATOR_IMAGE
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -99,3 +121,6 @@ spec:
       - name: kubeconfig
         secret:
           secretName: service-network-admin-kubeconfig
+      - name: oas-konnectivity-proxy-cert
+        secret:
+          secretName: konnectivity-client

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
@@ -17,10 +17,18 @@ var (
 	packageServerEndpoints  = MustEndpoints("assets/packageserver-endpoint-guest.yaml")
 )
 
-func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string) error {
+func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = packageServerDeployment.DeepCopy().Spec
-	deployment.Spec.Template.Spec.Containers[0].Image = olmImage
+	for i, container := range deployment.Spec.Template.Spec.Containers {
+		switch container.Name {
+		case "packageserver":
+			deployment.Spec.Template.Spec.Containers[i].Image = olmImage
+		case "socks5-proxy":
+			deployment.Spec.Template.Spec.Containers[i].Image = socks5ProxyImage
+			deployment.Spec.Template.Spec.Containers[i].ImagePullPolicy = corev1.PullAlways
+		}
+	}
 	for i, env := range deployment.Spec.Template.Spec.Containers[0].Env {
 		switch env.Name {
 		case "RELEASE_VERSION":


### PR DESCRIPTION
This commit introduces a change that allows the PackageServer
to connect with catalog sources defined on guest clusters.

GRPC connections to the guest clusters will be tunneled through
the konnectivity server via a proxy running as a sidecar container
in the PackageServer deployment.