### PR TITLE
Update default catalogs to v4.9

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/certified-operator-index:v4.8
+          image: registry.redhat.io/redhat/certified-operator-index:v4.9
           imagePullPolicy: Always
           ports:
             - containerPort: 50051

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/community-operator-index:v4.8
+          image: registry.redhat.io/redhat/community-operator-index:v4.9
           imagePullPolicy: Always
           ports:
             - containerPort: 50051

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/redhat-marketplace-index:v4.8
+          image: registry.redhat.io/redhat/redhat-marketplace-index:v4.9
           imagePullPolicy: Always
           ports:
             - containerPort: 50051

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/redhat-operator-index:v4.8
+          image: registry.redhat.io/redhat/redhat-operator-index:v4.9
           imagePullPolicy: Always
           ports:
             - containerPort: 50051


### PR DESCRIPTION
This commit introduces a change that updates
default catalogSources to use the v4.9 image
tags.