### PR TITLE
Fixes for 4.10 compatibility

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
@@ -13,3 +13,12 @@ func PullSecret(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func DefaultServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: ns,
+		},
+	}
+}

--- a/ignition-server/controllers/machineconfigserver_ignitionprovider.go
+++ b/ignition-server/controllers/machineconfigserver_ignitionprovider.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"text/template"
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
@@ -196,23 +197,22 @@ func (p *MCSIgnitionProvider) GetPayload(ctx context.Context, releaseImage strin
 	return
 }
 
-func machineConfigServerPod(namespace string, releaseImage *releaseinfo.ReleaseImage, sa *corev1.ServiceAccount,
-	config *corev1.ConfigMap) *corev1.Pod {
-	images := releaseImage.ComponentImages()
-	bootstrapArgs := fmt.Sprintf(`
+const mcoBootstrapScript = `#!/bin/bash
 mkdir -p /mcc-manifests/bootstrap/manifests
 mkdir -p /mcc-manifests/manifests
 machine-config-operator bootstrap \
 --root-ca=/assets/manifests/root-ca.crt \
 --kube-ca=/assets/manifests/combined-ca.crt \
---machine-config-operator-image=%s \
---machine-config-oscontent-image=%s \
---infra-image=%s \
---keepalived-image=%s \
---coredns-image=%s \
---mdns-publisher-image=%s \
---haproxy-image=%s \
---baremetal-runtimecfg-image=%s \
+--machine-config-operator-image={{ .mcoImage }} \
+--machine-config-oscontent-image={{ .osContentImage }} \
+--infra-image={{ .podImage }} \
+--keepalived-image={{ .keepAlivedImage }} \
+--coredns-image={{ .coreDNSImage }} \
+{{ if .mdnsImage -}}
+--mdns-publisher-image={{ .mdnsImage }} \
+{{ end -}}
+--haproxy-image={{ .haproxyImage }} \
+--baremetal-runtimecfg-image={{ .baremetalRuntimeCfgImage }} \
 --infra-config-file=/assets/manifests/cluster-infrastructure-02-config.yaml \
 --network-config-file=/assets/manifests/cluster-network-02-config.yaml \
 --proxy-config-file=/assets/manifests/cluster-proxy-01-config.yaml \
@@ -224,17 +224,27 @@ machine-config-operator bootstrap \
 mv /mcc-manifests/bootstrap/manifests /mcc-manifests/bootstrap/manifests.tmp
 mkdir /mcc-manifests/bootstrap/manifests
 cp /mcc-manifests/bootstrap/manifests.tmp/* /mcc-manifests/bootstrap/manifests/
-cp /assets/manifests/*.machineconfigpool.yaml /mcc-manifests/bootstrap/manifests/`,
-		images["machine-config-operator"],
-		images["machine-os-content"],
-		images["pod"],
-		images["keepalived-ipfailover"],
-		images["coredns"],
-		images["mdns-publisher"],
-		images["haproxy-router"],
-		images["baremetal-runtimecfg"],
-	)
+cp /assets/manifests/*.machineconfigpool.yaml /mcc-manifests/bootstrap/manifests/`
 
+var mcoBootstrapScriptTemplate = template.Must(template.New("mcoBootstrap").Parse(mcoBootstrapScript))
+
+func machineConfigServerPod(namespace string, releaseImage *releaseinfo.ReleaseImage, sa *corev1.ServiceAccount,
+	config *corev1.ConfigMap) *corev1.Pod {
+	images := releaseImage.ComponentImages()
+	scriptArgs := map[string]string{
+		"mcoImage":                 images["machine-config-operator"],
+		"osContentImage":           images["machine-os-content"],
+		"podImage":                 images["pod"],
+		"keepAlivedImage":          images["keepalived-ipfailover"],
+		"coreDNSImage":             images["coredns"],
+		"mdnsImage":                images["mdns-publisher"],
+		"haproxyImage":             images["haproxy-router"],
+		"baremetalRuntimeCfgImage": images["baremetal-runtimecfg"],
+	}
+	bootstrapScriptBytes := &bytes.Buffer{}
+	if err := mcoBootstrapScriptTemplate.Execute(bootstrapScriptBytes, scriptArgs); err != nil {
+		panic(fmt.Sprintf("unexpected error executing bootstrap script: %v", err))
+	}
 	customMachineConfigArg := `
 cat /tmp/custom-config/base64CompressedConfig | base64 -d | gunzip --force --stdout > /mcc-manifests/bootstrap/manifests/custom.yaml`
 
@@ -269,7 +279,7 @@ cat /tmp/custom-config/base64CompressedConfig | base64 -d | gunzip --force --std
 					},
 					Args: []string{
 						"-c",
-						bootstrapArgs,
+						bootstrapScriptBytes.String(),
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/support/upsert/loopdetector.go
+++ b/support/upsert/loopdetector.go
@@ -31,7 +31,7 @@ const LoopDetectorWarningMessage = "WARNING: Object got updated more than one ti
 // in the future.
 // Once we did a no-op update, we will ignore the object because we assume that if we have
 // a bug in the defaulting, we will end up always updating.
-const updateLoopThreshold = 1
+const updateLoopThreshold = 2
 
 type updateLoopDetector struct {
 	hasNoOpUpdate    sets.String


### PR DESCRIPTION
Ensures that the hosted cluster's pull secret is used by the default service account in a control plane namespace and 
fixes error in mco bootstrap init container. See individual commit messages.