### PR TITLE
Let the hostedcluster controller succeed a reconcile on None platforms

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -498,6 +498,9 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile AWSMachineTemplate: %w", err)
 		}
 		span.AddEvent("reconciled awsmachinetemplate", trace.WithAttributes(attribute.String("name", machineTemplate.GetName())))
+	case hyperv1.NonePlatform:
+		// TODO: When fleshing out platform None design revisit the right semantic to signal this as conditions in a NodePool.
+		return ctrl.Result{}, nil
 	}
 
 	md := machineDeployment(nodePool, infraID, controlPlaneNamespace)


### PR DESCRIPTION
The none platform does not provide a machine template. Therefore return
at the right moment instead of continuing reconciliation with a nil
machinetemplate value which will make the controller panic in
apiutil.GVKForObject with

```
expected pointer, but got invalid kind
```