### PR TITLE
Make management of bootstrapper SA idempotent

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-serviceaccount.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: user-manifests-bootstrapper
-imagePullSecrets:
-- name: pull-secret

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1002,6 +1002,14 @@ func (r *HostedControlPlaneReconciler) ensureControlPlane(ctx context.Context, h
 		}
 	}
 
+	userManifestBoostrapperServiceAccount := manifests.ManifestBootstrapperServiceAccount(targetNamespace)
+	if _, err := r.CreateOrUpdate(ctx, r.Client, userManifestBoostrapperServiceAccount, func() error {
+		cpoutil.EnsurePullSecret(userManifestBoostrapperServiceAccount, common.PullSecret(targetNamespace).Name)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to apply userManifestBoostrapperServiceAccount: %w", err)
+	}
+
 	manifests, err := r.generateControlPlaneManifests(ctx, hcp, infraStatus, releaseImage)
 	if err != nil {
 		return err

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/bootstrapper.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/bootstrapper.go
@@ -1,0 +1,15 @@
+package manifests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ManifestBootstrapperServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-manifests-bootstrapper",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/render/manifests.go
@@ -87,7 +87,6 @@ func (c *clusterManifestContext) machineConfigServer() {
 
 func (c *clusterManifestContext) userManifestsBootstrapper() {
 	c.addManifestFiles(
-		"user-manifests-bootstrapper/user-manifests-bootstrapper-serviceaccount.yaml",
 		"user-manifests-bootstrapper/user-manifests-bootstrapper-rolebinding.yaml",
 		"user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml",
 	)


### PR DESCRIPTION
We currently specify the ImagePullSecret field which also gets an entry
from the cluster, thus making us race with that clusters controller and
removing the pull secret it adds on every reconciliaton just for it to
get added back.

Found while working on https://github.com/openshift/hypershift/pull/574
/cc @csrwng 