### PR TITLE
create kubeconfig: allow name not to be specified

### DIFF
--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -59,8 +59,6 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A hostedcluster namespace")
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A hostedcluster name")
 
-	cmd.MarkFlagRequired("name")
-
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
 		sigs := make(chan os.Signal, 1)


### PR DESCRIPTION
It should be possible to call `create kubeconfig` without
a name parameter. This should result in a kubeconfig that has contexts
for all hostedclusters in the management cluster.