### PR TITLE
KAS and Konnektivity svc: Fix idempotency

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -71,9 +71,11 @@ var (
 	}
 )
 
-var kasLabels = map[string]string{
-	"app":                         "kube-apiserver",
-	hyperv1.ControlPlaneComponent: "kube-apiserver",
+func kasLabels() map[string]string {
+	return map[string]string{
+		"app":                         "kube-apiserver",
+		hyperv1.ControlPlaneComponent: "kube-apiserver",
+	}
 }
 
 func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
@@ -110,7 +112,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	}
 
 	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: kasLabels,
+		MatchLabels: kasLabels(),
 	}
 	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
 		Type: appsv1.RollingUpdateDeploymentStrategyType,
@@ -121,7 +123,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	}
 	deployment.Spec.Template = corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: kasLabels,
+			Labels: kasLabels(),
 			Annotations: map[string]string{
 				configHashAnnotation: configHash,
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -284,7 +284,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.Replicas = 3
-		params.DeploymentConfig.SetMultizoneSpread(kasLabels)
+		params.DeploymentConfig.SetMultizoneSpread(kasLabels())
 	default:
 		params.Replicas = 1
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -13,7 +13,7 @@ import (
 
 func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy, owner *metav1.OwnerReference, apiServerPort int) error {
 	util.EnsureOwnerRef(svc, owner)
-	svc.Spec.Selector = kasLabels
+	svc.Spec.Selector = kasLabels()
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -92,7 +92,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	if hcp.Spec.ControllerAvailabilityPolicy == hyperv1.HighlyAvailable {
 		p.AgentDeploymentConfig.Replicas = 3
 	}
-	p.AgentDeploymentConfig.SetMultizoneSpread(konnectivityAgentLabels)
+	p.AgentDeploymentConfig.SetMultizoneSpread(konnectivityAgentLabels())
 	p.AgentDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	p.AgentDeploymentConfig.SetColocation(hcp)
 	p.AgentDeploymentConfig.SetControlPlaneIsolation(hcp)

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -32,15 +32,21 @@ var (
 			konnectivityVolumeAgentCerts().Name: "/etc/konnectivity/agent",
 		},
 	}
-	konnectivityServerLabels = map[string]string{
+)
+
+func konnectivityServerLabels() map[string]string {
+	return map[string]string{
 		"app":                         "konnectivity-server",
 		hyperv1.ControlPlaneComponent: "konnectivity-server",
 	}
-	konnectivityAgentLabels = map[string]string{
+}
+
+func konnectivityAgentLabels() map[string]string {
+	return map[string]string{
 		"app":                         "konnectivity-agent",
 		hyperv1.ControlPlaneComponent: "konnectivity-agent",
 	}
-)
+}
 
 const (
 	KubeconfigKey = "kubeconfig"
@@ -50,11 +56,11 @@ func ReconcileServerDeployment(deployment *appsv1.Deployment, ownerRef config.Ow
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
-			MatchLabels: konnectivityServerLabels,
+			MatchLabels: konnectivityServerLabels(),
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: konnectivityServerLabels,
+				Labels: konnectivityServerLabels(),
 			},
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.BoolPtr(false),
@@ -146,7 +152,7 @@ const (
 
 func ReconcileServerLocalService(svc *corev1.Service, ownerRef config.OwnerRef) error {
 	ownerRef.ApplyTo(svc)
-	svc.Spec.Selector = konnectivityServerLabels
+	svc.Spec.Selector = konnectivityServerLabels()
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]
@@ -163,7 +169,7 @@ func ReconcileServerLocalService(svc *corev1.Service, ownerRef config.OwnerRef) 
 
 func ReconcileServerService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy) error {
 	ownerRef.ApplyTo(svc)
-	svc.Spec.Selector = konnectivityServerLabels
+	svc.Spec.Selector = konnectivityServerLabels()
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]
@@ -254,11 +260,11 @@ func ReconcileWorkerAgentDaemonSet(cm *corev1.ConfigMap, ownerRef config.OwnerRe
 func reconcileWorkerAgentDaemonSet(daemonset *appsv1.DaemonSet, deploymentConfig config.DeploymentConfig, image string, host string, port int32) error {
 	daemonset.Spec = appsv1.DaemonSetSpec{
 		Selector: &metav1.LabelSelector{
-			MatchLabels: konnectivityAgentLabels,
+			MatchLabels: konnectivityAgentLabels(),
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: konnectivityAgentLabels,
+				Labels: konnectivityAgentLabels(),
 			},
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.BoolPtr(false),
@@ -331,11 +337,11 @@ func ReconcileAgentDeployment(deployment *appsv1.Deployment, ownerRef config.Own
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
-			MatchLabels: konnectivityAgentLabels,
+			MatchLabels: konnectivityAgentLabels(),
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: konnectivityAgentLabels,
+				Labels: konnectivityAgentLabels(),
 			},
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.BoolPtr(false),


### PR DESCRIPTION
I noticed that the KAS and Konnektivity service are always updated twice
when restarting the CPO. It turns out this happens because:
* They reference a package-level variable for their selector
* The same variable is used in the Deployments selector
* The deployments label selector is manipulated through the
  DeploymentConfigs by setting the colocation label, which ends up
  propagating back to the package-level variable
* Because the service is created before the deployment, we always remove
  that label and then re-add it.

This happened to not be noticed by the update loop detector because on
cluster create, we first create those services and then wait for the
infra to be ready by returning in the Reconcile. This means that on the
next iteration we go through the service upsert code again and do a
no-op update there, resulting in the loop detector being disabled for
these objects.

/cc @csrwng 