### PR TITLE
Refactor e2e cluster setup code

### DIFF
--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	cmdcluster "github.com/openshift/hypershift/cmd/cluster"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,54 +26,14 @@ func TestAutoRepair(t *testing.T) {
 
 	client := e2eutil.GetClientOrDie()
 
-	// Create a namespace in which to place hostedclusters
-	namespace := e2eutil.GenerateNamespace(t, testContext, client, "e2e-clusters-")
-	name := e2eutil.SimpleNameGenerator.GenerateName("example-")
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
 
-	// Define the cluster we'll be testing
-	hostedCluster := &hyperv1.HostedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace.Name,
-			Name:      name,
-		},
-	}
+	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts.NodePoolReplicas = 3
+	clusterOpts.AutoRepair = true
 
-	// Ensure we clean up after the test
-	defer func() {
-		// TODO: Figure out why this is slow
-		//e2eutil.DumpGuestCluster(context.Background(), client, hostedCluster, globalOpts.ArtifactDir)
-		e2eutil.DumpAndDestroyHostedCluster(t, context.Background(), hostedCluster, globalOpts.AWSCredentialsFile, globalOpts.Region, globalOpts.BaseDomain, globalOpts.ArtifactDir)
-		e2eutil.DeleteNamespace(t, context.Background(), client, namespace.Name)
-	}()
-
-	// Create the cluster
-	createClusterOpts := cmdcluster.Options{
-		Namespace:                 hostedCluster.Namespace,
-		Name:                      hostedCluster.Name,
-		InfraID:                   hostedCluster.Name,
-		ReleaseImage:              globalOpts.LatestReleaseImage,
-		PullSecretFile:            globalOpts.PullSecretFile,
-		AWSCredentialsFile:        globalOpts.AWSCredentialsFile,
-		Region:                    globalOpts.Region,
-		GenerateSSH:               true,
-		NodePoolReplicas:          3,
-		InstanceType:              "m4.large",
-		BaseDomain:                globalOpts.BaseDomain,
-		NetworkType:               string(hyperv1.OpenShiftSDN),
-		AutoRepair:                true,
-		RootVolumeSize:            64,
-		RootVolumeType:            "gp2",
-		ControlPlaneOperatorImage: globalOpts.ControlPlaneOperatorImage,
-		AdditionalTags:            globalOpts.AdditionalTags,
-	}
-	t.Logf("Creating a new cluster. Options: %v", createClusterOpts)
-	err := cmdcluster.CreateCluster(testContext, createClusterOpts)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")
-
-	// Get the newly created cluster
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
-	t.Logf("Found the new hostedcluster: %s", crclient.ObjectKeyFromObject(hostedCluster))
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, globalOpts.ArtifactDir)
 
 	// Get the newly created nodepool
 	nodepool := &hyperv1.NodePool{
@@ -83,7 +42,7 @@ func TestAutoRepair(t *testing.T) {
 			Name:      hostedCluster.Name,
 		},
 	}
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
+	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
 	t.Logf("Created nodepool: %s", crclient.ObjectKeyFromObject(nodepool))
 
@@ -102,7 +61,7 @@ func TestAutoRepair(t *testing.T) {
 	g.Expect(len(awsSpec)).NotTo(BeZero())
 	instanceID := awsSpec[strings.LastIndex(awsSpec, "/")+1:]
 	t.Logf("Terminating AWS instance: %s", instanceID)
-	ec2client := ec2Client(globalOpts.AWSCredentialsFile, globalOpts.Region)
+	ec2client := ec2Client(clusterOpts.AWSCredentialsFile, clusterOpts.Region)
 	_, err = ec2client.TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: []*string{aws.String(instanceID)},
 	})
@@ -120,6 +79,8 @@ func TestAutoRepair(t *testing.T) {
 		return true, nil
 	}, testContext.Done())
 	g.Expect(err).NotTo(HaveOccurred(), "failed to wait for new node to become available")
+
+	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 }
 
 func ec2Client(awsCredsFile, region string) *ec2.EC2 {

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -10,7 +10,6 @@ import (
 
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	cmdcluster "github.com/openshift/hypershift/cmd/cluster"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,53 +25,12 @@ func TestAutoscaling(t *testing.T) {
 
 	client := e2eutil.GetClientOrDie()
 
-	// Create a namespace in which to place hostedclusters
-	namespace := e2eutil.GenerateNamespace(t, testContext, client, "e2e-clusters-")
-	name := e2eutil.SimpleNameGenerator.GenerateName("example-")
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
 
-	// Define the cluster we'll be testing
-	hostedCluster := &hyperv1.HostedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace.Name,
-			Name:      name,
-		},
-	}
+	clusterOpts := globalOpts.DefaultClusterOptions()
 
-	// Ensure we clean up after the test
-	defer func() {
-		// TODO: Figure out why this is slow
-		//e2eutil.DumpGuestCluster(context.Background(), client, hostedCluster, globalOpts.ArtifactDir)
-		e2eutil.DumpAndDestroyHostedCluster(t, context.Background(), hostedCluster, globalOpts.AWSCredentialsFile, globalOpts.Region, globalOpts.BaseDomain, globalOpts.ArtifactDir)
-		e2eutil.DeleteNamespace(t, context.Background(), client, namespace.Name)
-	}()
-
-	// Create the cluster
-	createClusterOpts := cmdcluster.Options{
-		Namespace:                 hostedCluster.Namespace,
-		Name:                      hostedCluster.Name,
-		InfraID:                   hostedCluster.Name,
-		ReleaseImage:              globalOpts.LatestReleaseImage,
-		PullSecretFile:            globalOpts.PullSecretFile,
-		AWSCredentialsFile:        globalOpts.AWSCredentialsFile,
-		Region:                    globalOpts.Region,
-		GenerateSSH:               true,
-		NodePoolReplicas:          2,
-		InstanceType:              "m4.large",
-		BaseDomain:                globalOpts.BaseDomain,
-		NetworkType:               string(hyperv1.OpenShiftSDN),
-		RootVolumeSize:            64,
-		RootVolumeType:            "gp2",
-		ControlPlaneOperatorImage: globalOpts.ControlPlaneOperatorImage,
-		AdditionalTags:            globalOpts.AdditionalTags,
-	}
-	t.Logf("Creating a new cluster. Options: %v", createClusterOpts)
-	err := cmdcluster.CreateCluster(testContext, createClusterOpts)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")
-
-	// Get the newly created cluster
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
-	t.Logf("Found the new hostedcluster. Namespace: %s, name: %s", hostedCluster.Namespace, name)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, globalOpts.ArtifactDir)
 
 	// Get the newly created nodepool
 	nodepool := &hyperv1.NodePool{
@@ -81,7 +39,7 @@ func TestAutoscaling(t *testing.T) {
 			Name:      hostedCluster.Name,
 		},
 	}
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
+	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
 	t.Logf("Created nodepool. Namespace: %s, name: %s", nodepool.Namespace, nodepool.Name)
 
@@ -146,6 +104,8 @@ func TestAutoscaling(t *testing.T) {
 
 	// Wait for exactly 1 node.
 	_ = e2eutil.WaitForNReadyNodes(t, testContext, guestClient, min)
+
+	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 }
 
 func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, image string) *batchv1.Job {

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -13,7 +13,6 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	cmdcluster "github.com/openshift/hypershift/cmd/cluster"
 )
 
 // TestCreateCluster implements a test that mimics the operation described in the
@@ -25,57 +24,14 @@ func TestCreateCluster(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
 	client := e2eutil.GetClientOrDie()
 
-	// Create a namespace in which to place hostedclusters
-	namespace := e2eutil.GenerateNamespace(t, testContext, client, "e2e-clusters-")
-	name := e2eutil.SimpleNameGenerator.GenerateName("example-")
+	clusterOpts := globalOpts.DefaultClusterOptions()
 
-	// Define the cluster we'll be testing
-	hostedCluster := &hyperv1.HostedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace.Name,
-			Name:      name,
-		},
-	}
-
-	// Ensure we clean up after the test
-	defer func() {
-		e2eutil.SaveMachineConsoleLogs(t, context.Background(), hostedCluster, globalOpts.AWSCredentialsFile, globalOpts.ArtifactDir)
-		e2eutil.EnsureNoCrashingPods(t, context.Background(), client, hostedCluster)
-		// TODO: Figure out why this is slow
-		//e2eutil.DumpGuestCluster(context.Background(), client, hostedCluster, globalOpts.ArtifactDir)
-		e2eutil.DumpAndDestroyHostedCluster(t, context.Background(), hostedCluster, globalOpts.AWSCredentialsFile, globalOpts.Region, globalOpts.BaseDomain, globalOpts.ArtifactDir)
-		e2eutil.DeleteNamespace(t, context.Background(), client, namespace.Name)
-	}()
-
-	// Create the cluster
-	createClusterOpts := cmdcluster.Options{
-		Namespace:                 hostedCluster.Namespace,
-		Name:                      hostedCluster.Name,
-		InfraID:                   hostedCluster.Name,
-		ReleaseImage:              globalOpts.LatestReleaseImage,
-		PullSecretFile:            globalOpts.PullSecretFile,
-		AWSCredentialsFile:        globalOpts.AWSCredentialsFile,
-		Region:                    globalOpts.Region,
-		GenerateSSH:               true,
-		NodePoolReplicas:          2,
-		InstanceType:              "m4.large",
-		BaseDomain:                globalOpts.BaseDomain,
-		NetworkType:               string(hyperv1.OpenShiftSDN),
-		RootVolumeSize:            64,
-		RootVolumeType:            "gp2",
-		ControlPlaneOperatorImage: globalOpts.ControlPlaneOperatorImage,
-		AdditionalTags:            globalOpts.AdditionalTags,
-	}
-	t.Logf("Creating a new cluster. Options: %v", createClusterOpts)
-	err := cmdcluster.CreateCluster(testContext, createClusterOpts)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")
-
-	// Get the newly created cluster
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
-	t.Logf("Found the new hostedcluster. Namespace: %s, name: %s", hostedCluster.Namespace, hostedCluster.Name)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, globalOpts.ArtifactDir)
 
 	// Get the newly created nodepool
 	nodepool := &hyperv1.NodePool{
@@ -84,7 +40,7 @@ func TestCreateCluster(t *testing.T) {
 			Name:      hostedCluster.Name,
 		},
 	}
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
+	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
 	t.Logf("Created nodepool. Namespace: %s, name: %s", nodepool.Namespace, nodepool.Name)
 
@@ -97,4 +53,5 @@ func TestCreateCluster(t *testing.T) {
 	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
 
 	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, crclient.ObjectKeyFromObject(nodepool))
+	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -51,16 +51,15 @@ func init() {
 // TestMain deals with global options and setting up a signal-bound context
 // for all tests to use.
 func TestMain(m *testing.M) {
-	flag.StringVar(&globalOpts.AWSCredentialsFile, "e2e.aws-credentials-file", "", "path to AWS credentials")
-	flag.StringVar(&globalOpts.Region, "e2e.aws-region", "us-east-1", "AWS region for clusters")
-	flag.StringVar(&globalOpts.PullSecretFile, "e2e.pull-secret-file", "", "path to pull secret")
+	flag.StringVar(&globalOpts.defaultClusterOptions.AWSCredentialsFile, "e2e.aws-credentials-file", "", "path to AWS credentials")
+	flag.StringVar(&globalOpts.defaultClusterOptions.Region, "e2e.aws-region", "us-east-1", "AWS region for clusters")
+	flag.StringVar(&globalOpts.defaultClusterOptions.PullSecretFile, "e2e.pull-secret-file", "", "path to pull secret")
 	flag.StringVar(&globalOpts.LatestReleaseImage, "e2e.latest-release-image", "", "The latest OCP release image for use by tests")
 	flag.StringVar(&globalOpts.PreviousReleaseImage, "e2e.previous-release-image", "", "The previous OCP release image relative to the latest")
 	flag.StringVar(&globalOpts.ArtifactDir, "e2e.artifact-dir", "", "The directory where cluster resources and logs should be dumped. If empty, nothing is dumped")
-	flag.StringVar(&globalOpts.BaseDomain, "e2e.base-domain", "", "The ingress base domain for the cluster")
-	flag.BoolVar(&globalOpts.UpgradeTestsEnabled, "e2e.upgrade-tests-enabled", false, "Enables upgrade tests")
-	flag.StringVar(&globalOpts.ControlPlaneOperatorImage, "e2e.control-plane-operator-image", "", "The image to use for the control plane operator. If none specified, the default is used.")
-	flag.Var(&globalOpts.AdditionalTags, "e2e.additional-tags", "Additional tags to set on AWS resources")
+	flag.StringVar(&globalOpts.defaultClusterOptions.BaseDomain, "e2e.base-domain", "", "The ingress base domain for the cluster")
+	flag.StringVar(&globalOpts.defaultClusterOptions.ControlPlaneOperatorImage, "e2e.control-plane-operator-image", "", "The image to use for the control plane operator. If none specified, the default is used.")
+	flag.Var(&globalOpts.additionalTags, "e2e.additional-tags", "Additional tags to set on AWS resources")
 
 	flag.Parse()
 
@@ -166,22 +165,16 @@ func dumpTestMetrics(log logr.Logger, artifactDir string) {
 
 // options are global test options applicable to all scenarios.
 type options struct {
-	AWSCredentialsFile        string
-	Region                    string
-	PullSecretFile            string
-	LatestReleaseImage        string
-	PreviousReleaseImage      string
-	IsRunningInCI             bool
-	UpgradeTestsEnabled       bool
-	ArtifactDir               string
-	BaseDomain                string
-	ControlPlaneOperatorImage string
-	AdditionalTags            stringSliceVar
+	LatestReleaseImage   string
+	PreviousReleaseImage string
+	IsRunningInCI        bool
+	ArtifactDir          string
 
 	defaultClusterOptions cmdcluster.Options
+	additionalTags        stringSliceVar
 }
 
-func (o options) DefaultClusterOptions() cmdcluster.Options {
+func (o *options) DefaultClusterOptions() cmdcluster.Options {
 	return o.defaultClusterOptions
 }
 
@@ -210,29 +203,21 @@ func (o *options) Complete() error {
 		if len(o.ArtifactDir) == 0 {
 			o.ArtifactDir = os.Getenv("ARTIFACT_DIR")
 		}
-		if len(o.BaseDomain) == 0 {
+		if len(o.defaultClusterOptions.BaseDomain) == 0 {
 			// TODO: make this an envvar with change to openshift/release, then change here
-			o.BaseDomain = "origin-ci-int-aws.dev.rhcloud.com"
+			o.defaultClusterOptions.BaseDomain = "origin-ci-int-aws.dev.rhcloud.com"
 		}
 	}
 
-	// TODO: Remove duplicate fields from options struct if the general approach is desirable
-	o.defaultClusterOptions = cmdcluster.Options{
-		ReleaseImage:              o.PreviousReleaseImage,
-		PullSecretFile:            o.PullSecretFile,
-		AWSCredentialsFile:        o.AWSCredentialsFile,
-		Region:                    o.Region,
-		GenerateSSH:               true,
-		SSHKeyFile:                "",
-		NodePoolReplicas:          2,
-		InstanceType:              "m4.large",
-		BaseDomain:                o.BaseDomain,
-		NetworkType:               string(hyperv1.OpenShiftSDN),
-		RootVolumeSize:            64,
-		RootVolumeType:            "gp2",
-		ControlPlaneOperatorImage: o.ControlPlaneOperatorImage,
-		AdditionalTags:            o.AdditionalTags,
-	}
+	o.defaultClusterOptions.ReleaseImage = o.PreviousReleaseImage
+	o.defaultClusterOptions.GenerateSSH = true
+	o.defaultClusterOptions.SSHKeyFile = ""
+	o.defaultClusterOptions.NodePoolReplicas = 2
+	o.defaultClusterOptions.InstanceType = "m4.large"
+	o.defaultClusterOptions.NetworkType = string(hyperv1.OpenShiftSDN)
+	o.defaultClusterOptions.RootVolumeSize = 64
+	o.defaultClusterOptions.RootVolumeType = "gp2"
+	o.defaultClusterOptions.AdditionalTags = o.additionalTags
 
 	return nil
 }
@@ -246,7 +231,7 @@ func (o *options) Validate() error {
 		errs = append(errs, fmt.Errorf("latest release image is required"))
 	}
 
-	if len(o.BaseDomain) == 0 {
+	if len(o.defaultClusterOptions.BaseDomain) == 0 {
 		errs = append(errs, fmt.Errorf("base domain is required"))
 	}
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -30,23 +30,6 @@ import (
 	"github.com/openshift/hypershift/support/upsert"
 )
 
-func GenerateNamespace(t *testing.T, ctx context.Context, client crclient.Client, prefix string) *corev1.Namespace {
-	g := NewWithT(t)
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: prefix,
-			Labels: map[string]string{
-				"hypershift-e2e-component": "hostedclusters-namespace",
-			},
-		},
-	}
-	err := client.Create(ctx, namespace)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
-	g.Expect(namespace.Name).ToNot(BeEmpty(), "generated namespace has no name")
-	t.Logf("Created test namespace: %s", namespace.Name)
-	return namespace
-}
-
 // CreateCluster creates a new namespace and a HostedCluster in that namespace using
 // the provided options.
 //
@@ -83,8 +66,6 @@ func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, op
 	// Define a standard teardown function
 	teardown := func(ctx context.Context) {
 		SaveMachineConsoleLogs(t, ctx, hc, opts.AWSCredentialsFile, artifactDir)
-		// TODO: Make this configurable somehow as chaos tests expect crashing
-		//EnsureNoCrashingPods(t, ctx, client, hc)
 		// TODO: Figure out why this is slow
 		//e2eutil.DumpGuestCluster(context.Background(), client, hostedCluster, globalOpts.ArtifactDir)
 		DumpAndDestroyHostedCluster(t, ctx, hc, opts.AWSCredentialsFile, opts.Region, opts.BaseDomain, artifactDir)


### PR DESCRIPTION
Refactor the e2e test cluster setup code to use a common setup and
teardown routine to remove error prone boilerplate.