### PR TITLE
Output machine journals on e2e runs

### DIFF
--- a/cmd/bastion/aws/create.go
+++ b/cmd/bastion/aws/create.go
@@ -25,7 +25,7 @@ import (
 	"github.com/openshift/hypershift/cmd/util"
 )
 
-type createBastionOpts struct {
+type CreateBastionOpts struct {
 	Namespace          string
 	Name               string
 	InfraID            string
@@ -36,7 +36,7 @@ type createBastionOpts struct {
 }
 
 func NewCreateCommand() *cobra.Command {
-	opts := &createBastionOpts{
+	opts := &CreateBastionOpts{
 		Namespace: "clusters",
 		Wait:      true,
 	}
@@ -83,7 +83,7 @@ func NewCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func (o *createBastionOpts) Validate() error {
+func (o *CreateBastionOpts) Validate() error {
 	if len(o.Name) > 0 {
 		if len(o.Namespace) == 0 {
 			return fmt.Errorf("a namespace must be specified if specifying a hosted cluster name")
@@ -102,7 +102,7 @@ func (o *createBastionOpts) Validate() error {
 	return nil
 }
 
-func (o *createBastionOpts) Run(ctx context.Context) (string, string, error) {
+func (o *CreateBastionOpts) Run(ctx context.Context) (string, string, error) {
 
 	var infraID, region string
 	var sshPublicKey []byte

--- a/cmd/bastion/aws/destroy.go
+++ b/cmd/bastion/aws/destroy.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/hypershift/cmd/util"
 )
 
-type destroyBastionOpts struct {
+type DestroyBastionOpts struct {
 	Namespace          string
 	Name               string
 	InfraID            string
@@ -28,7 +28,7 @@ type destroyBastionOpts struct {
 }
 
 func NewDestroyCommand() *cobra.Command {
-	opts := destroyBastionOpts{
+	opts := DestroyBastionOpts{
 		Namespace: "clusters",
 	}
 	cmd := &cobra.Command{
@@ -71,7 +71,7 @@ func NewDestroyCommand() *cobra.Command {
 	return cmd
 }
 
-func (o *destroyBastionOpts) Validate() error {
+func (o *DestroyBastionOpts) Validate() error {
 	if len(o.Name) > 0 {
 		if len(o.Namespace) == 0 {
 			return fmt.Errorf("a namespace must be specified if specifying a hosted cluster name")
@@ -87,7 +87,7 @@ func (o *destroyBastionOpts) Validate() error {
 	return nil
 }
 
-func (o *destroyBastionOpts) Run(ctx context.Context) error {
+func (o *DestroyBastionOpts) Run(ctx context.Context) error {
 
 	var infraID, region string
 

--- a/test/e2e/util/copy-machine-journals.sh
+++ b/test/e2e/util/copy-machine-journals.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEST_DIR="${1:-.}"
+
+# Script Variables
+# ----------------
+
+# INFRAID is only used if the BASTION_IP and INSTANCE_IPS are not provided. 
+# It is used to query AWS for those.
+INFRAID="${INFRAID:-}"
+
+# BASTION_IP is the external IP of the bastion machine. If not present, 
+BASTION_IP="${BASTION_IP:-}"
+
+# INSTANCE_IPS is a space-separated list of machine IPs from which to download 
+# the journal logs
+INSTANCE_IPS="${INSTANCE_IPS:-}"
+
+# SSH_PRIVATE_KEY is the path to a SSH private key to use for the ssh/scp commands.
+# If empty, it is assumed that any required private keys have been added to the ssh 
+# agent via ssh-add
+SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-}"
+
+if [[ -z "${BASTION_IP}" ]]; then
+  if [[ -z "${INFRAID}" ]]; then
+    echo "INFRAID must be set when BASTION_IP is not set."
+    exit 1
+  fi
+  BASTION_IP="$(aws ec2 describe-instances --filters "Name=tag:Name,Values=${INFRAID}-bastion" | jq -r '.Reservations[].Instances[].PublicIpAddress')"
+  if [[ -z "${BASTION_IP}" ]]; then
+    echo "Could not determine BASTION_IP. Ensure that a bastion has been created for your target cluster"
+    exit 1
+  fi
+fi
+
+if [[ -z "${INSTANCE_IPS}" ]]; then
+  if [[ -z "${INFRAID}" ]]; then
+    echo "INFRAID must be set when INSTANCE_IPS is not set."
+    exit 1
+  fi
+  INSTANCE_IPS="$(aws ec2 describe-instances --filters "Name=tag:kubernetes.io/cluster/${INFRAID},Values=owned" \
+    | jq -r "[ (.Reservations[].Instances[] | select(.Tags[] | select(.Key == \"Name\") | select(.Value != \"${INFRAID}-bastion\")) | .PrivateIpAddress) ] | join(\" \")")"
+  if [[ -z "${INSTANCE_IPS}" ]]; then
+    echo "Could not determine INSTANCE_IPS. Ensure that INFRAID is valid and that the cluster has worker nodes"
+  fi
+fi
+
+function copylog {
+  local machine_ip="${1}"
+  local config_file="$(mktemp)"
+  cat << EOF > "${config_file}"
+Host bastion
+    User                   ec2-user
+    ForwardAgent           yes
+    Hostname               ${BASTION_IP}
+    StrictHostKeyChecking  no
+    PasswordAuthentication no
+    UserKnownHostsFile     /dev/null
+Host machine
+    User                   core
+    Hostname               ${machine_ip}
+    StrictHostKeyChecking  no
+    PasswordAuthentication no
+    UserKnownHostsFile     /dev/null
+    ProxyJump              bastion
+EOF
+
+  ssh -F "${config_file}" -n machine "sudo journalctl > /tmp/journal.log && gzip -f /tmp/journal.log"
+  scp -F "${config_file}" machine:/tmp/journal.log.gz "${DEST_DIR}/journal_${machine_ip}.log.gz"
+}
+
+eval "$(ssh-agent)"
+if [[ -n "${SSH_PRIVATE_KEY}" ]]; then
+  ssh-add "${SSH_PRIVATE_KEY}"
+fi
+
+IFS=' ' read -a IP_ARRAY <<< "${INSTANCE_IPS}"
+mkdir -p "${DEST_DIR}"
+
+for ip in "${IP_ARRAY[@]}"; do 
+  copylog "${ip}"
+done

--- a/test/e2e/util/journals.go
+++ b/test/e2e/util/journals.go
@@ -1,0 +1,142 @@
+package util
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	bastionaws "github.com/openshift/hypershift/cmd/bastion/aws"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
+	cmdutil "github.com/openshift/hypershift/cmd/util"
+)
+
+//go:embed copy-machine-journals.sh
+var copyJournalsScript []byte
+
+func dumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, artifactDir, awsCreds string) error {
+
+	// Write out private ssh key
+	secretName := hc.Spec.SSHKey.Name
+	if len(secretName) == 0 {
+		return fmt.Errorf("No SSH secret specified for cluster, cannot dump journals")
+	}
+	sshKeySecret := &corev1.Secret{}
+	sshKeySecret.Name = secretName
+	sshKeySecret.Namespace = hc.Namespace
+	kubeClient := cmdutil.GetClientOrDie()
+	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(sshKeySecret), sshKeySecret); err != nil {
+		return err
+	}
+	privateKey, exists := sshKeySecret.Data["id_rsa"]
+	if !exists {
+		return fmt.Errorf("Cannot find SSH private key in SSH key secret %s/%s", sshKeySecret.Namespace, sshKeySecret.Name)
+	}
+	privateSSHKeyDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return fmt.Errorf("cannot create temp dir for ssh key: %w", err)
+	}
+	privateKeyFile := filepath.Join(privateSSHKeyDir, "id_rsa")
+	if err := ioutil.WriteFile(privateKeyFile, privateKey, 0600); err != nil {
+		return fmt.Errorf("error writing private ssh key file: %w", err)
+	}
+
+	// Write out dump script where we can find it and invoke it
+	copyJournalFile, err := ioutil.TempFile("", "copy-journal-")
+	if err != nil {
+		return err
+	}
+	if err := copyJournalFile.Close(); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(copyJournalFile.Name(), copyJournalsScript, 0644); err != nil {
+		return err
+	}
+	if err := os.Chmod(copyJournalFile.Name(), 0755); err != nil {
+		return err
+	}
+
+	// Create a bastion
+	createBastion := bastionaws.CreateBastionOpts{
+		Namespace:          hc.Namespace,
+		Name:               hc.Name,
+		AWSCredentialsFile: awsCreds,
+		Wait:               true,
+	}
+	_, bastionIP, err := createBastion.Run(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		destroyBastion := bastionaws.DestroyBastionOpts{
+			Namespace:          hc.Namespace,
+			Name:               hc.Name,
+			AWSCredentialsFile: awsCreds,
+		}
+		if err := destroyBastion.Run(ctx); err != nil {
+			t.Logf("error destroying bastion: %v", err)
+		}
+	}()
+
+	// Find worker machine IPs
+	awsSession := awsutil.NewSession("cli-destroy-bastion")
+	awsConfig := awsutil.NewConfig(awsCreds, hc.Spec.Platform.AWS.Region)
+	ec2Client := ec2.New(awsSession, awsConfig)
+
+	result, err := ec2Client.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:kubernetes.io/cluster/" + hc.Spec.InfraID),
+				Values: []*string{aws.String("owned")},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	var machineIPs []string
+	for _, reservation := range result.Reservations {
+		for _, instance := range reservation.Instances {
+			skip := false
+			for _, tag := range instance.Tags {
+				if aws.StringValue(tag.Key) == "Name" && aws.StringValue(tag.Value) == (hc.Spec.InfraID+"-bastion") {
+					skip = true
+					break
+				}
+			}
+			if skip {
+				continue
+			}
+			machineIPs = append(machineIPs, aws.StringValue(instance.PrivateIpAddress))
+		}
+	}
+
+	// Invoke script
+	outputDir := filepath.Join(artifactDir, "machine-journals")
+	scriptCmd := exec.Command(copyJournalFile.Name(), outputDir)
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("BASTION_IP=%s", bastionIP))
+	env = append(env, fmt.Sprintf("INSTANCE_IPS=%s", strings.Join(machineIPs, " ")))
+	env = append(env, fmt.Sprintf("SSH_PRIVATE_KEY=%s", privateKeyFile))
+	scriptCmd.Env = env
+	scriptCmd.Stdout = os.Stdout
+	scriptCmd.Stderr = os.Stderr
+	err = scriptCmd.Run()
+	if err != nil {
+		t.Logf("Error copying machine journals to artifacts directory: %v", err)
+	} else {
+		t.Logf("Successfully copied machine journals to %s", outputDir)
+	}
+	return err
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -93,7 +93,7 @@ func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, op
 
 // DumpHostedCluster tries to dump important resources related to the HostedCluster, and
 // logs any failures along the way.
-func DumpHostedCluster(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, artifactDir string) {
+func DumpHostedCluster(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, artifactDir, awsCredsFile string) {
 	if len(artifactDir) == 0 {
 		t.Logf("Skipping cluster dump because no artifact dir was provided")
 		return
@@ -112,12 +112,15 @@ func DumpHostedCluster(t *testing.T, ctx context.Context, hostedCluster *hyperv1
 	if err != nil {
 		t.Errorf("Failed to dump cluster: %v", err)
 	}
+	if err := dumpJournals(t, ctx, hostedCluster, artifactDir, awsCredsFile); err != nil {
+		t.Logf("Failed to dump machine journals: %v", err)
+	}
 }
 
 // DumpAndDestroyHostedCluster calls DumpHostedCluster and then destroys the HostedCluster,
 // logging any failures along the way.
 func DumpAndDestroyHostedCluster(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, awsCreds string, awsRegion string, baseDomain string, artifactDir string) {
-	DumpHostedCluster(t, ctx, hostedCluster, artifactDir)
+	DumpHostedCluster(t, ctx, hostedCluster, artifactDir, awsCreds)
 
 	opts := &cmdcluster.DestroyOptions{
 		Namespace:          hostedCluster.Namespace,


### PR DESCRIPTION
Makes create/destroy bastion commands public
Invokes bastion creation/destroy from e2e dump routine to copy journals from each of the cluster machines and places the gzipped journals in the artifacts directory.