### PR TITLE
Openshift API: Allow connecting to the registry

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1675,7 +1675,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.C
 
 	deployment := manifests.OpenShiftAPIServerDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, deployment, func() error {
-		return oapi.ReconcileDeployment(deployment, p.OwnerRef, p.OpenShiftAPIServerDeploymentConfig, p.OpenShiftAPIServerImage, p.HaproxyImage, p.EtcdURL, p.AvailabilityProberImage)
+		return oapi.ReconcileDeployment(deployment, p.OwnerRef, p.OpenShiftAPIServerDeploymentConfig, p.OpenShiftAPIServerImage, p.ProxyImage, p.EtcdURL, p.AvailabilityProberImage)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift apiserver deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/config.go
@@ -3,11 +3,10 @@ package oapi
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/konnectivity"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"path"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path"
 
 	configv1 "github.com/openshift/api/config/v1"
 	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
@@ -19,9 +18,7 @@ import (
 
 const (
 	openshiftAPIServerConfigKey     = "config.yaml"
-	oasKonnectivityProxyConfigKey   = "haproxy.cfg"
 	defaultInternalRegistryHostname = "image-registry.openshift-image-registry.svc:5000"
-	haproxyCombinedPemLocation      = "/tmp/tls.pem"
 )
 
 func ReconcileConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdURL, ingressDomain, minTLSVersion string, cipherSuites []string) error {
@@ -41,8 +38,6 @@ func ReconcileConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdURL, in
 		return fmt.Errorf("failed to serialize openshift apiserver config: %w", err)
 	}
 	cm.Data[openshiftAPIServerConfigKey] = string(serializedConfig)
-	oasKonnectivityProxyConfig := reconcileOASKonnectivityProxyConfig()
-	cm.Data[oasKonnectivityProxyConfigKey] = oasKonnectivityProxyConfig
 	return nil
 }
 
@@ -93,39 +88,4 @@ func reconcileConfigObject(cfg *openshiftcpv1.OpenShiftAPIServerConfig, etcdURL,
 			CA: cpath(oasVolumeEtcdClientCA().Name, pki.CASignerCertMapKey),
 		},
 	}
-}
-
-const haproxyTemplate = `
-global
-  maxconn 7000
-  log stdout local0
-  log stdout local1 notice
-
-defaults
-  mode http
-  log global
-  option log-health-checks
-  balance roundrobin
-  timeout client 10m
-  timeout server 10m
-  timeout connect 10s
-  timeout client-fin 5s
-  timeout server-fin 5s
-  timeout queue 5s
-  retries 3
-
-frontend http-in
-  bind *:%d
-  default_backend be
-backend be
-  mode http
-  server ks %s:%d ssl verify required ca-file %s crt %s
-`
-
-func reconcileOASKonnectivityProxyConfig() string {
-	cpath := func(volume, file string) string {
-		dir := volumeMounts.Path(oasKonnectivityProxyContainer().Name, volume)
-		return path.Join(dir, file)
-	}
-	return fmt.Sprintf(haproxyTemplate, konnectivity.KonnectivityServerLocalPort, manifests.KonnectivityServerLocalService("").Name, konnectivity.KonnectivityServerLocalPort, cpath(oasVolumeKonnectivityProxyCert().Name, "ca.crt"), haproxyCombinedPemLocation)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -22,7 +22,7 @@ type OpenShiftAPIServerParams struct {
 	config.OwnerRef                         `json:",inline"`
 	OpenShiftAPIServerImage                 string `json:"openshiftAPIServerImage"`
 	OAuthAPIServerImage                     string `json:"oauthAPIServerImage"`
-	HaproxyImage                            string `json:"haproxyImage"`
+	ProxyImage                              string `json:"haproxyImage"`
 	AvailabilityProberImage                 string `json:"availabilityProberImage"`
 }
 
@@ -40,7 +40,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 	params := &OpenShiftAPIServerParams{
 		OpenShiftAPIServerImage: images["openshift-apiserver"],
 		OAuthAPIServerImage:     images["oauth-apiserver"],
-		HaproxyImage:            images["haproxy-router"],
+		ProxyImage:              images["socks5-proxy"],
 		APIServer:               globalConfig.APIServer,
 		ServiceAccountIssuerURL: hcp.Spec.IssuerURL,
 		IngressSubDomain:        config.IngressSubdomain(hcp),


### PR DESCRIPTION
The openshift api wants to connect to the image registry by its service
dns name. This requires the proxy to resolve that name prior to
connecting. We already have this logic as a socks5 proxy, but
unfortunately golang does not support that for a http proxy. We work
around this by adding a http proxy shim that uses the socks5 proxy.

Note: The connection still doesn't work because certificate verification fails, adding this will be a follow-up.

Ref https://issues.redhat.com/browse/HOSTEDCP-239

/cc @csrwng 