### PR TITLE
update staticcheck target with new binary paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,10 @@ staticcheck: $(STATICCHECK)
 		./hosted-cluster-config-operator/... \
 		./cmd/... \
 		./support/certs/... \
-		./support/releaseinfo/...
+		./support/releaseinfo/... \
+		./support/upsert/... \
+		./konnectivity-socks5-proxy/... \
+		./availability-prober/...
 
 # Build the docker image with official golang image
 .PHONY: docker-build

--- a/support/upsert/upsert.go
+++ b/support/upsert/upsert.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -37,7 +36,7 @@ type createOrUpdateProvider struct {
 // avoids unnecessary updates when our code sets a whole struct that
 // has fields that get defaulted by the server.
 func (p *createOrUpdateProvider) CreateOrUpdate(ctx context.Context, c crclient.Client, obj crclient.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
-	key := client.ObjectKeyFromObject(obj)
+	key := crclient.ObjectKeyFromObject(obj)
 	if err := c.Get(ctx, key, obj); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return controllerutil.OperationResultNone, err

--- a/support/upsert/upsert_test.go
+++ b/support/upsert/upsert_test.go
@@ -13,13 +13,13 @@ import (
 var _ CreateOrUpdateProvider = &createOrUpdateProvider{}
 
 func TestCreateOrUpdate(t *testing.T) {
-	client := fake.NewFakeClient(&appsv1.Deployment{
+	client := fake.NewClientBuilder().WithRuntimeObjects(&appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{ServiceAccountName: "service-account"},
 			},
 		},
-	})
+	}).Build()
 
 	deployment := &appsv1.Deployment{}
 	result, err := (&createOrUpdateProvider{}).CreateOrUpdate(context.Background(), client, deployment, func() error { return nil })


### PR DESCRIPTION
`konnectivity-socks5-proxy` and `availability-prober` got added but didn't get included in the paths that staticcheck monitors