### PR TITLE
Fix controller when no etcd storage strategy details are supplied

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -51,6 +51,13 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *E
 		p.DeploymentConfig.Replicas = 1
 	}
 
+	if hcp.Spec.Etcd.Managed == nil {
+		hcp.Spec.Etcd.Managed = &hyperv1.ManagedEtcdSpec{
+			Storage: hyperv1.ManagedEtcdStorageSpec{
+				Type: hyperv1.PersistentVolumeEtcdStorage,
+			},
+		}
+	}
 	switch hcp.Spec.Etcd.Managed.Storage.Type {
 	case hyperv1.PersistentVolumeEtcdStorage:
 		p.StorageSpec.PersistentVolume = &hyperv1.PersistentVolumeEtcdStorageSpec{

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params_test.go
@@ -1,0 +1,35 @@
+package etcd
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+func TestNewEtcdParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		hcp    *hyperv1.HostedControlPlane
+		images map[string]string
+	}{
+		{
+			name: "default managed storage options if unset",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Etcd: hyperv1.EtcdSpec{
+						ManagementType: hyperv1.Managed,
+						Managed:        nil,
+					},
+				},
+			},
+			images: map[string]string{"etcd": "someimage"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			g.Expect(NewEtcdParams(tt.hcp, tt.images)).ToNot(BeNil())
+		})
+	}
+}


### PR DESCRIPTION
Fall back to the default PVC strategy instead of crashing.

Fixes issues like this when no storage strategy is specified:

```
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/etcd.NewEtcdParams(0xc000846380, 0xc0003b8330, 0x0)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go:54 +0x67b
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane.(*HostedControlPlaneReconciler).reconcileManagedEtcd(0xc000219980, 0x2930e08, 0xc0002dac30, 0xc000846380, 0xc0002d3790, 0x0, 0x0)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go:1350 +0x71
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane.(*HostedControlPlaneReconciler).update(0xc000219980, 0x2930e08, 0xc0002dac30, 0xc000846380, 0x0, 0x0)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go:584 +0x1cb0
github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane.(*HostedControlPlaneReconciler).Reconcile(0xc000219980, 0x2930e08, 0xc0002dac30, 0xc0005fed30, 0x10, 0xc0005fed20, 0x7, 0x23fc500, 0x0, 0x0, ...)
	/hypershift/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go:442 +0x1c71
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc0001590e0, 0x2930e08, 0xc0002dac30, 0xc0005fed30, 0x10, 0xc0005fed20, 0x7, 0x175eb09ee0c4900, 0x0, 0x0, ...)
	/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114 +0x319
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0001590e0, 0x2930e08, 0xc0002daba0, 0x24798e0, 0xc0007c8020)
	/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311 +0x3fc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0001590e0, 0x2930d60, 0xc000916680, 0xc00062f700)
	/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266 +0x35a
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2(0xc000803210, 0xc0001590e0, 0x2930d60, 0xc000916680)
	/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:223 +0x855
```

The issue seemed to be introduced with #580 