### PR TITLE
Infrastructure resource: Set controlPlaneTopology: External

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/cluster-infrastructure-02-config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/cluster-infrastructure-02-config.yaml
@@ -16,7 +16,7 @@ status:
   etcdDiscoveryDomain: {{ .BaseDomain }}
   infrastructureName: "{{ .InfraID }}"
   platform: {{ .PlatformType }}
-  controlPlaneTopology: HighlyAvailable
+  controlPlaneTopology: External
   infrastructureTopology: {{ .InfrastructureAvailabilityPolicy }}
   platformStatus:
     type: {{ .PlatformType }}


### PR DESCRIPTION
This allows to detect that a cluster is a hypershift cluster which is
for example needed for tests.

Related enhancement is in
https://github.com/openshift/enhancements/commit/46da245786e539722bb10a7964e15b7a8967bd41#diff-1f93c9be7f93ed45d04551f345307ebc6d5e8cd41d65afb97feb324b51bb3848

/assign @csrwng 

Ref https://issues.redhat.com/browse/HOSTEDCP-257