### PR TITLE
remove replica check (replicas allowed to be nil)

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -250,9 +250,6 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	}
 	if err := mgr.GetClient().Get(ctx, types.NamespacedName{Namespace: ic.Namespace, Name: ic.Name}, ic); err == nil {
 		if _, err := controllerutil.CreateOrUpdate(ctx, mgr.GetClient(), ic, func() error {
-			if ic.Spec.Replicas == nil {
-				return fmt.Errorf("default ingress controller not found")
-			}
 			if ic.Spec.RouteSelector == nil {
 				ic.Spec.RouteSelector = &metav1.LabelSelector{}
 			}


### PR DESCRIPTION
replicas are allowed to be nil per openshift docs and it will default to 2
```
https://github.com/openshift/api/blob/master/operator/v1/types_ingress.go#L78-L82

	// replicas is the desired number of ingress controller replicas. If unset,
	// defaults to 2.
	//
	// +optional
	Replicas *int32 `json:"replicas,omitempty"`
````