### PR TITLE
WIP: Use a serving cert trusted by the root ca for the OIDC route

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -16,7 +16,7 @@ const (
 	ServiceSignerPublicKey  = "service-account.pub"
 )
 
-func ReconcileKASServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalAPIAddress, serviceCIDR string) error {
+func ReconcileKASServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalAPIAddress, serviceCIDR, oidcISSuerURL string) error {
 	svc := manifests.KubeAPIServerService(secret.Namespace)
 	_, serviceIPNet, err := net.ParseCIDR(serviceCIDR)
 	if err != nil {
@@ -32,6 +32,7 @@ func ReconcileKASServerCertSecret(secret, ca *corev1.Secret, ownerRef config.Own
 		svc.Name,
 		fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace),
 		fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace),
+		oidcISSuerURL,
 	}
 	apiServerIPs := []string{
 		"127.0.0.1",


### PR DESCRIPTION
This is required for the `[sig-auth] ServiceAccounts ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer` conformance test.

Ref https://issues.redhat.com/browse/HOSTEDCP-257

Marking as WIP because this currently breaks the AWS OIDC provider. Not using the hosting clusters CA to verify the serving cert of the OIDC provider on AWS is a prereq for this.