### PR TITLE
Reduce API docs generation time by 97%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ cluster-api-provider-ibmcloud: $(CONTROLLER_GEN)
 
 .PHONY: api-docs
 api-docs: $(GENAPIDOCS)
-	$(GENAPIDOCS) --config $(DIR)/docs/api-doc-gen/config.json --template-dir $(DIR)/docs/api-doc-gen/templates --api-dir ./api/v1alpha1 --out-file $(DIR)/docs/content/reference/api.md
+	hack/gen-api-docs.sh $(GENAPIDOCS) $(DIR)
 
 # Run tests
 .PHONY: test

--- a/hack/gen-api-docs.sh
+++ b/hack/gen-api-docs.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This generation script sets up a fake GOPATH for docs generation
+# to work around performance issues in the upstream code generation
+# libraries. See:
+#
+#    https://github.com/kubernetes/gengo/issues/147
+#    https://github.com/kubernetes/code-generator/issues/69
+
+GEN_BIN="$1"
+REPO_ROOT_DIR="$2"
+
+FAKE_GOPATH="$(mktemp -d)"
+trap 'rm -rf ${FAKE_GOPATH}' EXIT
+
+FAKE_REPOPATH="${FAKE_GOPATH}/src/github.com/openshift/hypershift"
+mkdir -p "$(dirname "${FAKE_REPOPATH}")" && ln -s "${REPO_ROOT_DIR}" "${FAKE_REPOPATH}"
+
+cd "${FAKE_REPOPATH}"
+
+export GOPATH="${FAKE_GOPATH}"
+export GO111MODULE="off"
+
+${GEN_BIN} \
+--config "${FAKE_REPOPATH}/docs/api-doc-gen/config.json" \
+--template-dir "${FAKE_REPOPATH}/docs/api-doc-gen/templates" \
+--api-dir ./api/v1alpha1 \
+--out-file "${FAKE_REPOPATH}/docs/content/reference/api.md"


### PR DESCRIPTION
Optimize the API docs generation by disabling the use of Go modules
when running the generation tool. This is a workaround for performance
issues in the upstream libraries:

- https://github.com/kubernetes/gengo/issues/147
- https://github.com/kubernetes/code-generator/issues/69

Before this workaround:

    make api-docs  93.87s user 171.98s system 426% cpu 1:02.30 total

After the workaround:

    make api-docs  2.91s user 0.83s system 135% cpu 2.752 total

The hack seems worth the 97% improvement for iterating on docs.