### PR TITLE
Implement pod disruption budget for etcd

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -16,6 +16,8 @@ type EtcdParams struct {
 	DeploymentConfig config.DeploymentConfig
 
 	StorageSpec hyperv1.ManagedEtcdStorageSpec
+
+	Availability hyperv1.AvailabilityPolicy
 }
 
 func etcdPodSelector() map[string]string {
@@ -24,8 +26,9 @@ func etcdPodSelector() map[string]string {
 
 func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *EtcdParams {
 	p := &EtcdParams{
-		EtcdImage: images["etcd"],
-		OwnerRef:  config.OwnerRefFrom(hcp),
+		EtcdImage:    images["etcd"],
+		OwnerRef:     config.OwnerRefFrom(hcp),
+		Availability: hcp.Spec.ControllerAvailabilityPolicy,
 	}
 	p.DeploymentConfig.Resources = config.ResourcesSpec{
 		etcdContainer().Name: {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/etcd.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/etcd.go
@@ -4,6 +4,7 @@ import (
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,6 +37,15 @@ func EtcdClientService(ns string) *corev1.Service {
 
 func EtcdServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
 	return &prometheusoperatorv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: ns,
+		},
+	}
+}
+
+func EtcdPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "etcd",
 			Namespace: ns,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1930,6 +1930,11 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 			Resources: []string{"cronjobs", "jobs"},
 			Verbs:     []string{"*"},
 		},
+		{
+			APIGroups: []string{"policy"},
+			Resources: []string{"poddisruptionbudgets"},
+			Verbs:     []string{"*"},
+		},
 	}
 	return nil
 }


### PR DESCRIPTION
This commit introduces a pod disruption budget for etcd which behaves
as follows:

- For SingleReplica clusters, tolerate 100% disruption.
- For HighlyAvailable clusters, tolerate disruption of a minority of
  etcd members.

This ensures the HA invariant is preserved during potentially disruptive
management cluster scenarios, e.g.prohibiting a node upgrade that would
induce loss of quorum (and thus control plane API disruption).