### PR TITLE
Skip running journal dump script if there are no workers found

### DIFF
--- a/test/e2e/util/journals.go
+++ b/test/e2e/util/journals.go
@@ -122,6 +122,11 @@ func dumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 		}
 	}
 
+	if len(machineIPs) == 0 {
+		t.Logf("No machines associated with infra id %s were found. Skipping journal dump.", hc.Spec.InfraID)
+		return nil
+	}
+
 	// Invoke script
 	outputDir := filepath.Join(artifactDir, "machine-journals")
 	scriptCmd := exec.Command(copyJournalFile.Name(), outputDir)


### PR DESCRIPTION
The dumpJournals function should avoid calling the dump script when no
machines exist for the given hosted cluster.