### PR TITLE
Add pod disruption budget to kube apiserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1618,6 +1618,15 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 		return fmt.Errorf("failed to reconcile authentication token webhook config: %w", err)
 	}
 
+	pdb := manifests.KASPodDisruptionBudget(hcp.Namespace)
+	if result, err := r.CreateOrUpdate(ctx, r, pdb, func() error {
+		return kas.ReconcilePodDisruptionBudget(pdb, p)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile api server pdb: %w", err)
+	} else {
+		r.Log.Info("Reconciled api server pdb", "result", result)
+	}
+
 	kubeAPIServerDeployment := manifests.KASDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, kubeAPIServerDeployment, func() error {
 		return kas.ReconcileKubeAPIServerDeployment(kubeAPIServerDeployment,

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -50,6 +50,8 @@ type KubeAPIServerParams struct {
 	config.OwnerRef
 
 	Images KubeAPIServerImages `json:"images"`
+
+	Availability hyperv1.AvailabilityPolicy
 }
 
 type KubeAPIServerServiceParams struct {
@@ -71,6 +73,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		ServiceAccountIssuer: hcp.Spec.IssuerURL,
 		ServiceCIDR:          hcp.Spec.ServiceCIDR,
 		PodCIDR:              hcp.Spec.PodCIDR,
+		Availability:         hcp.Spec.ControllerAvailabilityPolicy,
 
 		Images: KubeAPIServerImages{
 			HyperKube:             images["hyperkube"],

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/pdb.go
@@ -1,0 +1,29 @@
+package kas
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *KubeAPIServerParams) error {
+	if pdb.CreationTimestamp.IsZero() {
+		pdb.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: kasLabels(),
+		}
+	}
+
+	p.OwnerRef.ApplyTo(pdb)
+
+	var minAvailable int
+	switch p.Availability {
+	case hyperv1.SingleReplica:
+		minAvailable = 0
+	case hyperv1.HighlyAvailable:
+		minAvailable = 1
+	}
+	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -5,6 +5,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
@@ -78,6 +79,15 @@ func KASBootstrapKubeconfigSecret(controlPlaneNamespace string) *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bootstrap-kubeconfig",
 			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
+func KASPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver",
+			Namespace: ns,
 		},
 	}
 }


### PR DESCRIPTION
This commit adds a pod disruption budget to the kube api server that
ensures a minimum of 1 replica when the control plane is running in
a highly available configuration.