### PR TITLE
Add openshift apiserver pod disruption budget

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1705,6 +1705,15 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.C
 		return fmt.Errorf("failed to reconcile openshift apiserver audit config: %w", err)
 	}
 
+	pdb := manifests.OpenShiftAPIServerPodDisruptionBudget(hcp.Namespace)
+	if result, err := r.CreateOrUpdate(ctx, r, pdb, func() error {
+		return oapi.ReconcilePodDisruptionBudget(pdb, p)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile openshift apiserver pdb: %w", err)
+	} else {
+		r.Log.Info("Reconciled openshift apiserver pdb", "result", result)
+	}
+
 	deployment := manifests.OpenShiftAPIServerDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, deployment, func() error {
 		return oapi.ReconcileDeployment(deployment, p.OwnerRef, p.OpenShiftAPIServerDeploymentConfig, p.OpenShiftAPIServerImage, p.ProxyImage, p.EtcdURL, p.AvailabilityProberImage, hcp.Spec.APIPort)

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_apiserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_apiserver.go
@@ -5,6 +5,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
@@ -22,6 +23,15 @@ func OpenShiftAPIServerAuditConfig(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openshift-apiserver-audit",
+			Namespace: ns,
+		},
+	}
+}
+
+func OpenShiftAPIServerPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-apiserver",
 			Namespace: ns,
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -46,11 +46,14 @@ var (
 			oasVolumeKonnectivityProxyCert().Name: "/etc/konnectivity-proxy-tls",
 		},
 	}
-	openShiftAPIServerLabels = map[string]string{
+)
+
+func openShiftAPIServerLabels() map[string]string {
+	return map[string]string{
 		"app":                         "openshift-apiserver",
 		hyperv1.ControlPlaneComponent: "openshift-apiserver",
 	}
-)
+}
 
 func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, socks5ProxyImage string, etcdURL string, availabilityProberImage string, apiPort *int32) error {
 	ownerRef.ApplyTo(deployment)
@@ -66,9 +69,9 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		},
 	}
 	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: openShiftAPIServerLabels,
+		MatchLabels: openShiftAPIServerLabels(),
 	}
-	deployment.Spec.Template.ObjectMeta.Labels = openShiftAPIServerLabels
+	deployment.Spec.Template.ObjectMeta.Labels = openShiftAPIServerLabels()
 	etcdUrlData, err := url.Parse(etcdURL)
 	if err != nil {
 		return fmt.Errorf("failed to parse etcd url: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -24,6 +24,7 @@ type OpenShiftAPIServerParams struct {
 	OAuthAPIServerImage                     string `json:"oauthAPIServerImage"`
 	ProxyImage                              string `json:"haproxyImage"`
 	AvailabilityProberImage                 string `json:"availabilityProberImage"`
+	Availability                            hyperv1.AvailabilityPolicy
 }
 
 type OAuthDeploymentParams struct {
@@ -45,6 +46,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 		ServiceAccountIssuerURL: hcp.Spec.IssuerURL,
 		IngressSubDomain:        config.IngressSubdomain(hcp),
 		AvailabilityProberImage: images[util.AvailabilityProberImageName],
+		Availability:            hcp.Spec.ControllerAvailabilityPolicy,
 	}
 	params.OpenShiftAPIServerDeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
@@ -153,7 +155,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 		params.OpenShiftAPIServerDeploymentConfig.Replicas = 3
 		params.OpenShiftOAuthAPIServerDeploymentConfig.Replicas = 3
 		params.OpenShiftOAuthAPIServerDeploymentConfig.SetMultizoneSpread(openShiftOAuthAPIServerLabels)
-		params.OpenShiftAPIServerDeploymentConfig.SetMultizoneSpread(openShiftAPIServerLabels)
+		params.OpenShiftAPIServerDeploymentConfig.SetMultizoneSpread(openShiftAPIServerLabels())
 	default:
 		params.OpenShiftAPIServerDeploymentConfig.Replicas = 1
 		params.OpenShiftOAuthAPIServerDeploymentConfig.Replicas = 1

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/pdb.go
@@ -1,0 +1,29 @@
+package oapi
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OpenShiftAPIServerParams) error {
+	if pdb.CreationTimestamp.IsZero() {
+		pdb.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: openShiftAPIServerLabels(),
+		}
+	}
+
+	p.OwnerRef.ApplyTo(pdb)
+
+	var minAvailable int
+	switch p.Availability {
+	case hyperv1.SingleReplica:
+		minAvailable = 0
+	case hyperv1.HighlyAvailable:
+		minAvailable = 1
+	}
+	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
+
+	return nil
+}


### PR DESCRIPTION
This commit adds a pod disruption budget to the openshift apiserver
so that a minimum of 1 replica is maintained when the control plane
is configured to be highly available.