### PR TITLE
Add openshift oauth apiserver pod disruption budget

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1769,6 +1769,15 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftOAuthAPIServer(ctx cont
 		return fmt.Errorf("failed to reconcile openshift oauth apiserver audit config: %w", err)
 	}
 
+	pdb := manifests.OpenShiftOAuthAPIServerDisruptionBudget(hcp.Namespace)
+	if result, err := r.CreateOrUpdate(ctx, r, pdb, func() error {
+		return oapi.ReconcileOpenShiftOAuthAPIServerPodDisruptionBudget(pdb, p.OAuthAPIServerDeploymentParams())
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile openshift oauth apiserver pdb: %w", err)
+	} else {
+		r.Log.Info("Reconciled openshift oauth apiserver pdb", "result", result)
+	}
+
 	deployment := manifests.OpenShiftOAuthAPIServerDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, deployment, func() error {
 		return oapi.ReconcileOAuthAPIServerDeployment(deployment, p.OwnerRef, p.OAuthAPIServerDeploymentParams(), hcp.Spec.APIPort)

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_oauth_apiserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_oauth_apiserver.go
@@ -5,6 +5,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
@@ -20,6 +21,15 @@ func OpenShiftOAuthAPIServerAuditConfig(ns string) *corev1.ConfigMap {
 
 func OpenShiftOAuthAPIServerDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-oauth-apiserver",
+			Namespace: ns,
+		},
+	}
+}
+
+func OpenShiftOAuthAPIServerDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openshift-oauth-apiserver",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -7,6 +7,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
@@ -31,11 +32,14 @@ var (
 			oauthVolumeEtcdClientCert().Name:     "/etc/kubernetes/certs/etcd-client",
 		},
 	}
-	openShiftOAuthAPIServerLabels = map[string]string{
+)
+
+func openShiftOAuthAPIServerLabels() map[string]string {
+	return map[string]string{
 		"app":                         "openshift-oauth-apiserver",
 		hyperv1.ControlPlaneComponent: "openshift-oauth-apiserver",
 	}
-)
+}
 
 func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, p *OAuthDeploymentParams, apiPort *int32) error {
 	ownerRef.ApplyTo(deployment)
@@ -51,9 +55,9 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 		},
 	}
 	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: openShiftOAuthAPIServerLabels,
+		MatchLabels: openShiftOAuthAPIServerLabels(),
 	}
-	deployment.Spec.Template.ObjectMeta.Labels = openShiftOAuthAPIServerLabels
+	deployment.Spec.Template.ObjectMeta.Labels = openShiftOAuthAPIServerLabels()
 	deployment.Spec.Template.Spec = corev1.PodSpec{
 		AutomountServiceAccountToken: pointer.BoolPtr(false),
 		Containers: []corev1.Container{
@@ -202,4 +206,25 @@ func oauthVolumeEtcdClientCert() *corev1.Volume {
 func buildOAuthVolumeEtcdClientCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.EtcdClientSecret("").Name
+}
+
+func ReconcileOpenShiftOAuthAPIServerPodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OAuthDeploymentParams) error {
+	if pdb.CreationTimestamp.IsZero() {
+		pdb.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: openShiftOAuthAPIServerLabels(),
+		}
+	}
+
+	p.OwnerRef.ApplyTo(pdb)
+
+	var minAvailable int
+	switch p.Availability {
+	case hyperv1.SingleReplica:
+		minAvailable = 0
+	case hyperv1.HighlyAvailable:
+		minAvailable = 1
+	}
+	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
+
+	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -35,6 +35,8 @@ type OAuthDeploymentParams struct {
 	ServiceAccountIssuerURL string
 	DeploymentConfig        config.DeploymentConfig
 	AvailabilityProberImage string
+	Availability            hyperv1.AvailabilityPolicy
+	OwnerRef                config.OwnerRef
 }
 
 func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig config.GlobalConfig, images map[string]string) *OpenShiftAPIServerParams {
@@ -154,7 +156,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig c
 	case hyperv1.HighlyAvailable:
 		params.OpenShiftAPIServerDeploymentConfig.Replicas = 3
 		params.OpenShiftOAuthAPIServerDeploymentConfig.Replicas = 3
-		params.OpenShiftOAuthAPIServerDeploymentConfig.SetMultizoneSpread(openShiftOAuthAPIServerLabels)
+		params.OpenShiftOAuthAPIServerDeploymentConfig.SetMultizoneSpread(openShiftOAuthAPIServerLabels())
 		params.OpenShiftAPIServerDeploymentConfig.SetMultizoneSpread(openShiftAPIServerLabels())
 	default:
 		params.OpenShiftAPIServerDeploymentConfig.Replicas = 1
@@ -191,6 +193,8 @@ func (p *OpenShiftAPIServerParams) OAuthAPIServerDeploymentParams() *OAuthDeploy
 		MinTLSVersion:           p.MinTLSVersion(),
 		CipherSuites:            p.CipherSuites(),
 		AvailabilityProberImage: p.AvailabilityProberImage,
+		Availability:            p.Availability,
+		OwnerRef:                p.OwnerRef,
 	}
 }
 


### PR DESCRIPTION
This commit adds a pod disruption budget to the openshift oauth apiserver
so that a minimum of 1 replica is maintained when the control plane
is configured to be highly available.