### PR TITLE
Add pod disruption budget to oauth server

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/oauth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/oauth.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -10,6 +11,15 @@ import (
 
 func OAuthServerConfig(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oauth-openshift",
+			Namespace: ns,
+		},
+	}
+}
+
+func OAuthServerPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-openshift",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -37,16 +37,19 @@ var (
 			oauthVolumeWorkLogs().Name:          "/var/run/kubernetes",
 		},
 	}
-	oauthLabels = map[string]string{
+)
+
+func oauthLabels() map[string]string {
+	return map[string]string{
 		"app":                         "oauth-openshift",
 		hyperv1.ControlPlaneComponent: "oauth-openshift",
 	}
-)
+}
 
 func ReconcileDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment, ownerRef config.OwnerRef, config *corev1.ConfigMap, image string, deploymentConfig config.DeploymentConfig, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, availabilityProberImage string, apiPort *int32) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: oauthLabels,
+		MatchLabels: oauthLabels(),
 	}
 	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 	maxSurge := intstr.FromInt(3)
@@ -58,7 +61,7 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 	if deployment.Spec.Template.ObjectMeta.Labels == nil {
 		deployment.Spec.Template.ObjectMeta.Labels = map[string]string{}
 	}
-	for k, v := range oauthLabels {
+	for k, v := range oauthLabels() {
 		deployment.Spec.Template.ObjectMeta.Labels[k] = v
 	}
 	if deployment.Spec.Template.ObjectMeta.Annotations == nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -1,12 +1,10 @@
 package oauth
 
 import (
-	"context"
-
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"encoding/json"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	osinv1 "github.com/openshift/api/osin/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -40,6 +38,7 @@ type OAuthServerParams struct {
 	// for this is IBMCloud Red Hat Openshift
 	LoginURLOverride        string
 	AvailabilityProberImage string `json:"availabilityProberImage"`
+	Availability            hyperv1.AvailabilityPolicy
 }
 
 type OAuthConfigParams struct {
@@ -70,7 +69,7 @@ type ConfigOverride struct {
 	Claims osinv1.OpenIDClaims `json:"claims,omitempty"`
 }
 
-func NewOAuthServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig config.GlobalConfig, images map[string]string, host string, port int32) *OAuthServerParams {
+func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, globalConfig config.GlobalConfig, images map[string]string, host string, port int32) *OAuthServerParams {
 	p := &OAuthServerParams{
 		OwnerRef:                config.OwnerRefFrom(hcp),
 		ExternalAPIHost:         hcp.Status.ControlPlaneEndpoint.Host,
@@ -81,6 +80,7 @@ func NewOAuthServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, 
 		OAuth:                   globalConfig.OAuth,
 		APIServer:               globalConfig.APIServer,
 		AvailabilityProberImage: images[util.AvailabilityProberImageName],
+		Availability:            hcp.Spec.ControllerAvailabilityPolicy,
 	}
 	p.Scheduling = config.Scheduling{
 		PriorityClass: config.APICriticalPriorityClass,

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/pdb.go
@@ -1,0 +1,29 @@
+package oauth
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OAuthServerParams) error {
+	if pdb.CreationTimestamp.IsZero() {
+		pdb.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: oauthLabels(),
+		}
+	}
+
+	p.OwnerRef.ApplyTo(pdb)
+
+	var minAvailable int
+	switch p.Availability {
+	case hyperv1.SingleReplica:
+		minAvailable = 0
+	case hyperv1.HighlyAvailable:
+		minAvailable = 1
+	}
+	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
+
+	return nil
+}


### PR DESCRIPTION
This commit adds a pod disruption budget to the oauth server
so that a minimum of 1 replica is maintained when the control plane
is configured to be highly available.