### PR TITLE
Add ci-install-hypershift Maketarget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,3 +186,7 @@ docker-push:
 .PHONY: run-local
 run-local:
 	bin/hypershift-operator run
+
+.PHONY: ci-install-hypershift
+ci-install-hypershift:
+	bin/hypershift install --hypershift-image $(HYPERSHIFT_RELEASE_LATEST)


### PR DESCRIPTION
This and a follow-up in o/release allows us to atomically change the
hypershift code and install command. This is needed to be able to add
mandatory flags, like the upcoming aws-oidc-in-bucket work will do.

Ref https://issues.redhat.com/browse/HOSTEDCP-257
/cc @csrwng 