### PR TITLE
AWS: Store the OIDC documents in a S3 bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,4 +193,7 @@ run-local:
 
 .PHONY: ci-install-hypershift
 ci-install-hypershift:
-	bin/hypershift install --hypershift-image $(HYPERSHIFT_RELEASE_LATEST)
+	bin/hypershift install --hypershift-image $(HYPERSHIFT_RELEASE_LATEST) \
+		--oidc-storage-provider-s3-credentials=/etc/hypershift-pool-aws-credentials/credentials \
+		--oidc-storage-provider-s3-bucket-name=hypershift-ci-oidc \
+		--oidc-storage-provider-s3-region=us-east-1

--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ HyperShift is deployed into an existing OpenShift cluster which will host the ma
 * Admin access to an OpenShift cluster (version 4.7+) specified by the `KUBECONFIG` environment variable
 * The OpenShift `oc` CLI tool
 * The `hypershift` CLI tool
-- An [AWS credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) with permissions to create infrastructure for the cluster
+* An [AWS credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) with permissions to create infrastructure for the cluster
+* An AWS S3 bucket into which the above credentials can write. The bucket must allow public objects.
 
 Install HyperShift into the management cluster:
 
 ```shell
-hypershift install
+hypershift install --oidc-storage-provider-s3-bucket-name="$name-of-bucket" --oidc-storage-provider-s3-region="$region-of-bucket" --oidc-storage-provider-s3-credentials="$path-to-aws-credentials-file"
 ```
 
 To uninstall HyperShift, run:

--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -202,7 +202,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 			{
 				Service: hyperv1.OIDC,
 				ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-					Type: hyperv1.Route,
+					Type: hyperv1.S3,
 				},
 			},
 			{

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -190,7 +190,7 @@ type ServicePublishingStrategyMapping struct {
 // ServicePublishingStrategy defines metadata around how a service is published
 type ServicePublishingStrategy struct {
 	// Type defines the publishing strategy used for the service.
-	// +kubebuilder:validation:Enum=LoadBalancer;NodePort;Route;None
+	// +kubebuilder:validation:Enum=LoadBalancer;NodePort;Route;None;S3
 	// +immutable
 	Type PublishingStrategyType `json:"type"`
 	// NodePort is used to define extra metadata for the NodePort publishing strategy.
@@ -207,6 +207,8 @@ var (
 	NodePort PublishingStrategyType = "NodePort"
 	// Route exposes services with a Route + ClusterIP kube service.
 	Route PublishingStrategyType = "Route"
+	// S3 exoses a service through an S3 bucket
+	S3 PublishingStrategyType = "S3"
 	// None disables exposing the service
 	None PublishingStrategyType = "None"
 )

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -3,34 +3,34 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/util/wait"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	configv1 "github.com/openshift/api/config/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
+	"github.com/openshift/hypershift/cmd/install/assets"
 	"github.com/openshift/hypershift/cmd/util"
 )
 
 type CreateIAMOptions struct {
-	Region             string
-	AWSCredentialsFile string
-	InfraID            string
-	IssuerURL          string
-	OutputFile         string
-	AdditionalTags     []string
+	Region                          string
+	AWSCredentialsFile              string
+	OIDCStorageProviderS3BucketName string
+	OIDCStorageProviderS3Region     string
+	InfraID                         string
+	IssuerURL                       string
+	OutputFile                      string
+	AdditionalTags                  []string
 
 	additionalIAMTags []*iam.Tag
 }
@@ -61,12 +61,16 @@ func NewCreateIAMCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.AWSCredentialsFile, "aws-creds", opts.AWSCredentialsFile, "Path to an AWS credentials file (required)")
 	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Infrastructure ID to use for AWS resources.")
+	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3BucketName, "oidc-storage-provider-s3-bucket-name", "", "The name of the bucket in which the OIDC discovery document is stored")
+	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3Region, "oidc-storage-provider-s3-region", "", "The region of the bucket in which the OIDC discovery document is stored")
 	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "Region where cluster infra should be created")
 	cmd.Flags().StringVar(&opts.OutputFile, "output-file", opts.OutputFile, "Path to file that will contain output information from infra resources (optional)")
 	cmd.Flags().StringSliceVar(&opts.AdditionalTags, "additional-tags", opts.AdditionalTags, "Additional tags to set on AWS resources")
 
 	cmd.MarkFlagRequired("aws-creds")
 	cmd.MarkFlagRequired("infra-id")
+	cmd.MarkFlagRequired("oidc-bucket-name")
+	cmd.MarkFlagRequired("oidc-bucket-region")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -117,25 +121,28 @@ func (o *CreateIAMOptions) CreateIAM(ctx context.Context, client crclient.Client
 	if err = o.parseAdditionalTags(); err != nil {
 		return nil, err
 	}
-
-	ingressConfig := &configv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster",
-		},
-	}
-
-	err = wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
-		if err = client.Get(ctx, crclient.ObjectKeyFromObject(ingressConfig), ingressConfig); err != nil {
-			log.Error(err, "failed to get ingress config")
-			return false, nil
+	if o.OIDCStorageProviderS3BucketName == "" || o.OIDCStorageProviderS3Region == "" {
+		cm := assets.OIDCStorageProviderS3ConfigMap("", "")
+		if err := client.Get(ctx, crclient.ObjectKeyFromObject(cm), cm); err != nil {
+			return nil, fmt.Errorf("failed to discover OIDC bucket configuration: failed to get the %s/%s configmap: %w", cm.Namespace, cm.Name, err)
 		}
-		return true, nil
-	}, ctx.Done())
-	if err != nil {
-		return nil, fmt.Errorf("failed to discover issuer URL: %w", err)
+		// Set both, doesn't make sense to only get one from the configmap
+		o.OIDCStorageProviderS3BucketName = cm.Data["name"]
+		o.OIDCStorageProviderS3Region = cm.Data["region"]
 	}
 
-	o.IssuerURL = fmt.Sprintf("https://oidc-%s.%s", o.InfraID, ingressConfig.Spec.Domain)
+	var errs []error
+	if o.OIDCStorageProviderS3BucketName == "" {
+		errs = append(errs, errors.New("mandatory --oidc-storage-provider-s3-bucket-name could not be discovered from cluster and wasn't excplicitly passed either"))
+	}
+	if o.OIDCStorageProviderS3Region == "" {
+		errs = append(errs, errors.New("mandatory --oidc-storage-provider-s3-region could not be discovered from cluster and wasn't explicitly passed either"))
+	}
+	if err := utilerrors.NewAggregate(errs); err != nil {
+		return nil, err
+	}
+
+	o.IssuerURL = oidcDiscoveryURL(o.OIDCStorageProviderS3BucketName, o.OIDCStorageProviderS3Region, o.InfraID)
 	log.Info("Detected Issuer URL", "issuer", o.IssuerURL)
 
 	awsSession := awsutil.NewSession("cli-create-iam")
@@ -169,4 +176,11 @@ func (o *CreateIAMOptions) parseAdditionalTags() error {
 		})
 	}
 	return nil
+}
+
+func oidcDiscoveryURL(bucketName, region, infraID string) string {
+	if bucketName == "" || region == "" || infraID == "" {
+		panic(fmt.Sprintf("bucket: %q, region: %q, infraID: %q", bucketName, region, infraID))
+	}
+	return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, infraID)
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -787,6 +787,7 @@ spec:
                           - NodePort
                           - Route
                           - None
+                          - S3
                           type: string
                       required:
                       - type

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -712,6 +712,7 @@ spec:
                           - NodePort
                           - Route
                           - None
+                          - S3
                           type: string
                       required:
                       - type

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
@@ -11,7 +11,6 @@ const (
 	KubeAPIServerPrivateServiceName = "kube-apiserver-private"
 	OauthServiceName                = "oauth-openshift"
 	oauthRouteName                  = "oauth"
-	oidcRouteName                   = "oidc"
 	konnectivityServerServiceName   = "konnectivity-server"
 	openshiftAPIServerServiceName   = "openshift-apiserver"
 	oauthAPIServerName              = "openshift-oauth-apiserver"
@@ -50,15 +49,6 @@ func OauthServerRoute(hostedClusterNamespace string) *routev1.Route {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedClusterNamespace,
 			Name:      oauthRouteName,
-		},
-	}
-}
-
-func OIDCRoute(hostedClusterNamespace string) *routev1.Route {
-	return &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: hostedClusterNamespace,
-			Name:      oidcRouteName,
 		},
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -17,15 +17,23 @@ limitations under the License.
 package hostedcluster
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	capiibmv1 "github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/api/v1alpha4"
@@ -61,6 +69,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"k8s.io/client-go/util/workqueue"
 	k8sutilspointer "k8s.io/utils/pointer"
 	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha4"
@@ -141,6 +153,9 @@ type HostedClusterReconciler struct {
 	EnableCIDebugOutput bool
 
 	PrivatePlatform hyperv1.PlatformType
+
+	OIDCStorageProviderS3BucketName string
+	S3Client                        s3iface.S3API
 }
 
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters,verbs=get;list;watch;create;update;patch;delete
@@ -1016,6 +1031,14 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if err = r.reconcileMachineApprover(ctx, hcluster, hcp); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile machine approver: %w", err)
+	}
+
+	// Reconcile the AWS OIDC discovery
+	switch hcluster.Spec.Platform.Type {
+	case hyperv1.AWSPlatform:
+		if err := r.reconcileAWSOIDCDocuments(ctx, hcluster, hcp); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile the AWS OIDC documents: %w", err)
+		}
 	}
 
 	r.Log.Info("successfully reconciled")
@@ -2924,6 +2947,10 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, req ctrl.Request, 
 	if err := r.Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
 		return false, fmt.Errorf("failed to delete namespace: %w", err)
 	}
+
+	if err := r.cleanupOIDCBucketData(ctx, hc); err != nil {
+		return false, err
+	}
 	return true, nil
 }
 
@@ -3255,5 +3282,144 @@ func reconcileMachineApproverDeployment(deployment *appsv1.Deployment, hc *hyper
 	hyperutil.SetRestartAnnotation(hc, deployment)
 	hyperutil.SetControlPlaneIsolation(hc, deployment)
 	hyperutil.SetDefaultPriorityClass(deployment)
+	return nil
+}
+
+const oidcDocumentsFinalizer = "hypershift.io/aws-oidc-discovery"
+
+func oidcPublicDocumentPaths() []string {
+	return []string{"/.well-known/openid-configuration", "/openid/v1/jwks"}
+}
+
+func (r *HostedClusterReconciler) reconcileAWSOIDCDocuments(ctx context.Context, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) error {
+	if hcp.Status.KubeConfig == nil {
+		return nil
+	}
+
+	// We use the presence of the finalizer to short-circuit the document upload to avoid
+	// constantly re-uploading it.
+	if controllerutil.ContainsFinalizer(hcluster, oidcDocumentsFinalizer) {
+		return nil
+	}
+
+	if r.OIDCStorageProviderS3BucketName == "" || r.S3Client == nil {
+		return errors.New("hypershift wasn't configured with a S3 bucket or credentials, this makes it unable to set up OIDC for AWS clusters. Please install hypershift with the --aws-oidc-bucket-name, --aws-oidc-bucket-region and --aws-oidc-bucket-creds-file flags set. The bucket must pre-exist and the credentials must be authorized to write into it")
+	}
+
+	if apiAvailableCondition := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.KubeAPIServerAvailable)); apiAvailableCondition == nil || apiAvailableCondition.Status != metav1.ConditionTrue {
+		return nil
+	}
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hcp.Namespace,
+			Name:      hcp.Status.KubeConfig.Name,
+		},
+	}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(src), src); err != nil {
+		return fmt.Errorf("failed to get controlplane kubeconfig secret %q: %w", client.ObjectKeyFromObject(src), err)
+	}
+	var kubeconfig clientcmdapiv1.Config
+	if err := yaml.Unmarshal(src.Data["kubeconfig"], &kubeconfig); err != nil {
+		return fmt.Errorf("failed to deserialize the kubeconfig: %w", err)
+	}
+
+	// The clientcmd helper that constructs a rest.Config expects a different format so we have to convert...
+	var apiKubeconfig clientcmdapi.Config
+	if err := clientcmdapiv1.Convert_v1_Config_To_api_Config(&kubeconfig, &apiKubeconfig, nil); err != nil {
+		return fmt.Errorf("failed to covert clientcmdapiv1 kubeconfig to clientcmdapi kubeconfig: %w", err)
+	}
+	cfg, err := clientcmd.NewDefaultClientConfig(apiKubeconfig, nil).ClientConfig()
+	if err != nil {
+		return fmt.Errorf("failed to construct rest config for cluster: %w", err)
+	}
+	tlsConfig, err := rest.TLSConfigFor(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to construct tls config for cluster: %w", err)
+	}
+
+	// We put the result of this request into a public location and expect the original
+	// to be public as well so make sure we fail if that is somehow not the case.
+	tlsConfig.GetClientCertificate = nil
+
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+
+	for _, path := range oidcPublicDocumentPaths() {
+		requestURL := "https://" + hcp.Status.ControlPlaneEndpoint.Host + ":" + strconv.Itoa(int(hcp.Status.ControlPlaneEndpoint.Port)) + path
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+		if err != nil {
+			return fmt.Errorf("failed to construct request for %s: %w", requestURL, err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to do request for %s: %w", requestURL, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("request to %s returned with unexpected status code %d", requestURL, resp.StatusCode)
+		}
+
+		// In theory we should be able to pass resp.Body
+		// as the Body argument to PutObject as that takes
+		// an io.Reader. In practice doing so results in
+		// `NotImplemented: A header you provided implies functionality that is not implemented`
+		// which apparently happens when there is no body:
+		// https://github.com/aws/aws-sdk-js/issues/15#issuecomment-11666580
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("faild to read body: %w", err)
+		}
+
+		_, err = r.S3Client.PutObject(&s3.PutObjectInput{
+			ACL:    aws.String("public-read"),
+			Body:   aws.ReadSeekCloser(bytes.NewReader(body)),
+			Bucket: aws.String(r.OIDCStorageProviderS3BucketName),
+			Key:    aws.String(hcluster.Spec.InfraID + path),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to upload %s to the %s s3 bucket: %w", path, r.OIDCStorageProviderS3BucketName, err)
+		}
+	}
+
+	hcluster.Finalizers = append(hcluster.Finalizers, oidcDocumentsFinalizer)
+	if err := r.Client.Update(ctx, hcluster); err != nil {
+		return fmt.Errorf("failed to update the hosted cluster after adding the %s finalizer: %w", oidcDocumentsFinalizer, err)
+	}
+
+	r.Log.Info("Successfully uploaded the OIDC documents to the S3 bucket")
+
+	return nil
+}
+
+func (r *HostedClusterReconciler) cleanupOIDCBucketData(ctx context.Context, hcluster *hyperv1.HostedCluster) error {
+	if !controllerutil.ContainsFinalizer(hcluster, oidcDocumentsFinalizer) {
+		return nil
+	}
+
+	if r.OIDCStorageProviderS3BucketName == "" || r.S3Client == nil {
+		return fmt.Errorf("hypershift wasn't configured with AWS credentials and a bucket, can not clean up OIDC documents from bucket. Please either set those up or clean up manually and then remove the %s finalizer from the hosted cluster", oidcDocumentsFinalizer)
+	}
+
+	var objectsToDelete []*s3.ObjectIdentifier
+	for _, path := range oidcPublicDocumentPaths() {
+		objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
+			Key: aws.String(hcluster.Spec.InfraID + path),
+		})
+	}
+
+	if _, err := r.S3Client.DeleteObjects(&s3.DeleteObjectsInput{
+		Bucket: aws.String(r.OIDCStorageProviderS3BucketName),
+		Delete: &s3.Delete{Objects: objectsToDelete},
+	}); err != nil {
+		return fmt.Errorf("failed to delete OIDC objects from %s S3 bucket: %w", r.OIDCStorageProviderS3BucketName, err)
+	}
+
+	controllerutil.RemoveFinalizer(hcluster, oidcDocumentsFinalizer)
+	if err := r.Client.Update(ctx, hcluster); err != nil {
+		return fmt.Errorf("failed to update hostedcluster after removing %s finalizer: %w", oidcDocumentsFinalizer, err)
+	}
+
+	r.Log.Info("Successfully deleted the OIDC documents from the S3 bucket")
 	return nil
 }

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/go-logr/logr"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperapi "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/platform/aws"
@@ -71,18 +73,21 @@ func main() {
 }
 
 type StartOptions struct {
-	Namespace                  string
-	DeploymentName             string
-	MetricsAddr                string
-	EnableLeaderElection       bool
-	IgnitionServerImage        string
-	OpenTelemetryEndpoint      string
-	EnableOCPClusterMonitoring bool
-	EnableCIDebugOutput        bool
-	ControlPlaneOperatorImage  string
-	AvailabilityProberImage    string
-	RegistryOverrides          map[string]string
-	PrivatePlatform            string
+	Namespace                        string
+	DeploymentName                   string
+	MetricsAddr                      string
+	EnableLeaderElection             bool
+	IgnitionServerImage              string
+	OpenTelemetryEndpoint            string
+	EnableOCPClusterMonitoring       bool
+	EnableCIDebugOutput              bool
+	ControlPlaneOperatorImage        string
+	AvailabilityProberImage          string
+	RegistryOverrides                map[string]string
+	PrivatePlatform                  string
+	OIDCStorageProviderS3BucketName  string
+	OIDCStorageProviderS3Region      string
+	OIDCStorageProviderS3Credentials string
 }
 
 func NewStartCommand() *cobra.Command {
@@ -94,15 +99,16 @@ func NewStartCommand() *cobra.Command {
 	}
 
 	opts := StartOptions{
-		Namespace:                 "hypershift",
-		DeploymentName:            "operator",
-		MetricsAddr:               "0",
-		EnableLeaderElection:      false,
-		ControlPlaneOperatorImage: "",
-		IgnitionServerImage:       "",
-		OpenTelemetryEndpoint:     "",
-		RegistryOverrides:         map[string]string{},
-		PrivatePlatform:           string(hyperv1.NonePlatform),
+		Namespace:                   "hypershift",
+		DeploymentName:              "operator",
+		MetricsAddr:                 "0",
+		EnableLeaderElection:        false,
+		ControlPlaneOperatorImage:   "",
+		IgnitionServerImage:         "",
+		OpenTelemetryEndpoint:       "",
+		RegistryOverrides:           map[string]string{},
+		PrivatePlatform:             string(hyperv1.NonePlatform),
+		OIDCStorageProviderS3Region: "us-east-1",
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace this operator lives in")
@@ -119,6 +125,9 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", false, "If extra CI debug output should be enabled")
 	cmd.Flags().StringToStringVar(&opts.RegistryOverrides, "registry-overrides", map[string]string{}, "registry-overrides contains the source registry string as a key and the destination registry string as value. Images before being applied are scanned for the source registry string and if found the string is replaced with the destination registry string. Format is: sr1=dr1,sr2=dr2")
 	cmd.Flags().StringVar(&opts.PrivatePlatform, "private-platform", opts.PrivatePlatform, "Platform on which private clusters are supported by this operator (supports \"AWS\" or \"None\")")
+	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3BucketName, "oidc-storage-provider-s3-bucket-name", "", "Name of the bucket in which to store the clusters OIDC discovery information. Required for AWS guest clusters")
+	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3Region, "oidc-storage-provider-s3-region", opts.OIDCStorageProviderS3Region, "Region in which the OIDC bucket is located. Required for AWS guest clusters")
+	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3Credentials, "oidc-storage-provider-s3-credentials", "", "Location of the credentials file for the OIDC bucket. Required for AWS guest clusters.")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
@@ -211,7 +220,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 
 	createOrUpdate := upsert.New(opts.EnableCIDebugOutput)
 
-	if err = (&hostedcluster.HostedClusterReconciler{
+	hostedClusterReconciler := &hostedcluster.HostedClusterReconciler{
 		Client:                        mgr.GetClient(),
 		ManagementClusterCapabilities: mgmtClusterCaps,
 		HypershiftOperatorImage:       operatorImage,
@@ -228,7 +237,15 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
 		CreateOrUpdateProvider:     createOrUpdate,
 		EnableCIDebugOutput:        opts.EnableCIDebugOutput,
-	}).SetupWithManager(mgr); err != nil {
+	}
+	if opts.OIDCStorageProviderS3Credentials != "" {
+		awsSession := awsutil.NewSession("hypershift-operator-oidc-bucket")
+		awsConfig := awsutil.NewConfig(opts.OIDCStorageProviderS3Credentials, opts.OIDCStorageProviderS3Region)
+		s3Client := s3.New(awsSession, awsConfig)
+		hostedClusterReconciler.S3Client = s3Client
+		hostedClusterReconciler.OIDCStorageProviderS3BucketName = opts.OIDCStorageProviderS3BucketName
+	}
+	if err := hostedClusterReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}
 


### PR DESCRIPTION
This change makes hypershift store the OIDC documents in a S3 bucket
rather than serving them from a dedicated ingress pointing to the
kube-apiserver. This is needed for two reasons:

1. Private clusters should not be publicly accessible
2. Tests (and probably more) assume that the serving cert of the
   endpoint serving these documents is either publicly trusted or signed
   by the guest clusters root ca

This implies that a hypershift setup that should manage AWS clusters
must be configured with a pre-existing S3 bucket and credentials to
write and delete objects in that bucket.

In detail, the following things were changed:
* Hypershift install got optional arguments for a OIDC bucket and region
* Hypershift install will always create a configmap with the data from
  these arguments in the kube-public namespace, although it might be
  empty if the flags were unset
* If the flags were set, the hypershift operator will be configured with
  flags for these settings
* AWS Create IAM got optional flags for the bucket region and name that
  will get defaulted to the values from the configmap in kube-public
* AWS Create IAM will set the Issuer URL of the AWS OIDC provider to the
  S3 Bucket url/$infra-id
* The hypershift operator will for AWS clusters download
  /.well-known/openid-configuration and /openid/v1/jwk from the
  kube-apiserver and place them in the S3 bucket below $infra_id
* Once it did that, it sets an additional finalizer on the hostedcluster
* On cleanup, it will remove the two documents again from the bucket and
  then remove the finalizer
* The controlplaneoperator will not create an OIDC route anymore as we
  don't need it

I've verified that this change both doesn't break the AWS OIDC provider
and fixes the `[sig-auth] ServiceAccounts ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer`
conformance testcase.

Ref https://issues.redhat.com/browse/HOSTEDCP-257
/cc @csrwng @sjenning 