### PR TITLE
add registry override support to support image mirroring translation in non-crio environments

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1300,7 +1300,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	}
 	controlPlaneOperatorDeployment := controlplaneoperator.OperatorDeployment(controlPlaneNamespace.Name)
 	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
-		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput)
+		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.(*releaseinfo.RegistryMirrorProviderDecorator).RegistryOverrides))
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator deployment: %w", err)
@@ -1331,6 +1331,18 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	}
 
 	return nil
+}
+
+func convertRegistryOverridesToCommandLineFlag(registryOverrides map[string]string) string {
+	commandLineFlagArray := []string{}
+	for registrySource, registryReplacement := range registryOverrides {
+		commandLineFlagArray = append(commandLineFlagArray, fmt.Sprintf("%s=%s", registrySource, registryReplacement))
+	}
+	if len(commandLineFlagArray) > 0 {
+		return strings.Join(commandLineFlagArray, ",")
+	}
+	// this is the equivalent of null on a StringToString command line variable.
+	return "="
 }
 
 func servicePublishingStrategyByType(hcp *hyperv1.HostedCluster, svcType hyperv1.ServiceType) *hyperv1.ServicePublishingStrategy {
@@ -1634,6 +1646,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 								"start",
 								"--cert-file", "/var/run/secrets/ignition/serving-cert/tls.crt",
 								"--key-file", "/var/run/secrets/ignition/serving-cert/tls.key",
+								"--registry-overrides", convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.(*releaseinfo.RegistryMirrorProviderDecorator).RegistryOverrides),
 							},
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
@@ -1801,7 +1814,7 @@ func getControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 	}
 }
 
-func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, image string, sa *corev1.ServiceAccount, enableCIDebugOutput bool) error {
+func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, image string, sa *corev1.ServiceAccount, enableCIDebugOutput bool, registryOverrideCommandLine string) error {
 	deployment.Spec = appsv1.DeploymentSpec{
 		Replicas: k8sutilspointer.Int32Ptr(1),
 		Selector: &metav1.LabelSelector{
@@ -1839,7 +1852,7 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 							RunAsUser: k8sutilspointer.Int64Ptr(1000),
 						},
 						Command: []string{"/usr/bin/control-plane-operator"},
-						Args:    []string{"run", "--namespace", "$(MY_NAMESPACE)", "--deployment-name", "control-plane-operator", "--metrics-addr", "0.0.0.0:8080", fmt.Sprintf("--enable-ci-debug-output=%t", enableCIDebugOutput)},
+						Args:    []string{"run", "--namespace", "$(MY_NAMESPACE)", "--deployment-name", "control-plane-operator", "--metrics-addr", "0.0.0.0:8080", fmt.Sprintf("--enable-ci-debug-output=%t", enableCIDebugOutput), fmt.Sprintf("--registry-overrides=%s", registryOverrideCommandLine)},
 						Ports:   []corev1.ContainerPort{{Name: "metrics", ContainerPort: 8080}},
 					},
 				},

--- a/support/releaseinfo/registry_mirror_provider.go
+++ b/support/releaseinfo/registry_mirror_provider.go
@@ -1,0 +1,40 @@
+package releaseinfo
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+var _ Provider = (*RegistryMirrorProviderDecorator)(nil)
+
+// RegistryMirrorProviderDecorator decorates another Provider to add user-specified
+// component name to image mappings. The Lookup implementation will first
+// delegate to the given Delegate, and will then add additional TagReferences
+// to the Delegate's results based on the ComponentImages.
+type RegistryMirrorProviderDecorator struct {
+	Delegate Provider
+	// RegistryOverrides contains the source registry string as a key and the destination registry string as value.
+	// images before being applied are scanned for the source registry string and if found the string is replaced with
+	// the destination registry string. This allows hypershift to run in non-crio environments where mirroring is not
+	// applicable.
+	RegistryOverrides map[string]string
+
+	lock sync.Mutex
+}
+
+func (p *RegistryMirrorProviderDecorator) Lookup(ctx context.Context, image string, pullSecret []byte) (*ReleaseImage, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	releaseImage, err := p.Delegate.Lookup(ctx, image, pullSecret)
+	if err != nil {
+		return nil, err
+	}
+	for i := range releaseImage.ImageStream.Spec.Tags {
+		for registrySource, registryDest := range p.RegistryOverrides {
+			releaseImage.ImageStream.Spec.Tags[i].From.Name = strings.Replace(releaseImage.ImageStream.Spec.Tags[i].From.Name, registrySource, registryDest, 1)
+		}
+	}
+	return releaseImage, nil
+}


### PR DESCRIPTION
This provides the ability for the hypershift components that schedule images into a cluster to do "image mirroring" without relying on cri-o's capabilities. This allows hypershift to run in non-crio environments (only supported use case of this so far is internal IBM ROKS offering). The registry override contains source registry strings as keys and destination registry strings as values. Before applying an image the image is scanned for source registry strings and if so they are replaced with the destination registry.

It is controlled through a command line flag in the hypershift-operator and rolls downstream to components from there.

Example with hypershift operator with parameter
```
  - apiVersion: apps/v1
    kind: Deployment
    metadata:
      creationTimestamp: null
      name: operator
      namespace: hypershift
    spec:
      replicas: 3
      selector:
        matchLabels:
          name: operator
      strategy:
        type: RollingUpdate
        rollingUpdate:
          maxSurge: 0
          maxUnavailable: 1
      minReadySeconds: 15
      template:
        metadata:
          creationTimestamp: null
          labels:
            name: operator
        spec:
          tolerations:
            - key: "hypershift.openshift.io/cluster"
              operator: Exists
          affinity:
            podAntiAffinity:
              requiredDuringSchedulingIgnoredDuringExecution:
                - labelSelector:
                    matchExpressions:
                      - key: name
                        operator: In
                        values: [ "operator" ]
                  topologyKey: "kubernetes.io/hostname"
                - labelSelector:
                    matchExpressions:
                      - key: name
                        operator: In
                        values: [ "operator" ]
                  topologyKey: "topology.kubernetes.io/zone"
          containers:
            - args:
                - run
                - --namespace=$(MY_NAMESPACE)
                - --deployment-name=operator
                - --enable-leader-election
                - --metrics-addr=:9000
                - --registry-overrides=quay.io/openshift-release-dev/ocp-v4.0-art-dev=us.icr.io/armada-master/ocp-release
              command:
                - /usr/bin/hypershift-operator
              env:
                - name: MY_NAMESPACE
                  valueFrom:
                    fieldRef:
                      fieldPath: metadata.namespace
              image: (( concat "{{ registry }}/armada-master/armada-hypershift-operator:" metadata.annotations.version ))
              imagePullPolicy: Always
              name: operator
              readinessProbe:
                httpGet:
                  path: /metrics
                  port: 9000
                  scheme: HTTP
                failureThreshold: 3
                periodSeconds: 60
                successThreshold: 1
                initialDelaySeconds: 15
                timeoutSeconds: 5
              livenessProbe:
                httpGet:
                  path: /metrics
                  port: 9000
                  scheme: HTTP
                initialDelaySeconds: 60
                failureThreshold: 5
                periodSeconds: 60
                successThreshold: 1
                timeoutSeconds: 5
              ports:
                - containerPort: 9000
                  name: metrics
                  protocol: TCP
              resources: {}
              securityContext:
                runAsUser: 1000
          serviceAccountName: operator
```

Specifically
```
                - --registry-overrides=quay.io/openshift-release-dev/ocp-v4.0-art-dev=us.icr.io/armada-master/ocp-release
```