### PR TITLE
Kube-apiserver: Reduce v level from five to two

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -276,7 +276,7 @@ func buildKASContainerMain(image string) func(c *corev1.Container) {
 		c.Args = []string{
 			"kube-apiserver",
 			fmt.Sprintf("--openshift-config=%s", path.Join(volumeMounts.Path(c.Name, kasVolumeConfig().Name), KubeAPIServerConfigKey)),
-			"-v5",
+			"-v2",
 		}
 		c.WorkingDir = volumeMounts.Path(c.Name, kasVolumeWorkLogs().Name)
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)


### PR DESCRIPTION
The logs are currently super spammy, reduce the log level to what is the
default in self-hosted OCP.