### PR TITLE
Fix clusterautoscaler command

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2547,7 +2547,7 @@ func reconcileAutoScalerDeployment(deployment *appsv1.Deployment, hc *hyperv1.Ho
 								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
-						Command: []string{"/cluster-autoscaler"},
+						Command: []string{"/usr/bin/cluster-autoscaler"},
 						Args:    args,
 					},
 				},


### PR DESCRIPTION
The binary location changed in the new image, the pod fails with
CreateContainerError: stat /cluster-autoscaler: no such file or directory