### PR TITLE
Fix the kubelet serving ca, its cluster signer not root

### DIFF
--- a/hosted-cluster-config-operator/controllers/kubeletservingca/setup.go
+++ b/hosted-cluster-config-operator/controllers/kubeletservingca/setup.go
@@ -18,9 +18,9 @@ func Setup(cfg *operator.HostedClusterConfigOperatorConfig) error {
 	configMaps := informerFactory.Core().V1().ConfigMaps()
 
 	reconciler := &KubeletServingCASyncer{
-		InitialCA:    cfg.InitialCA(),
-		TargetClient: cfg.TargetKubeClient(),
-		Log:          cfg.Logger().WithName("KubeletServingCA"),
+		ClusterSignerCA: cfg.ClusterSignerCA(),
+		TargetClient:    cfg.TargetKubeClient(),
+		Log:             cfg.Logger().WithName("KubeletServingCA"),
 	}
 	c, err := controller.New("kubelet-serving-ca", cfg.Manager(), controller.Options{Reconciler: reconciler})
 	if err != nil {

--- a/hosted-cluster-config-operator/controllers/kubeletservingca/syncer.go
+++ b/hosted-cluster-config-operator/controllers/kubeletservingca/syncer.go
@@ -17,9 +17,9 @@ import (
 var syncInterval = 20 * time.Minute
 
 type KubeletServingCASyncer struct {
-	TargetClient kubeclient.Interface
-	Log          logr.Logger
-	InitialCA    string
+	TargetClient    kubeclient.Interface
+	Log             logr.Logger
+	ClusterSignerCA string
 }
 
 func (s *KubeletServingCASyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -53,7 +53,7 @@ func (s *KubeletServingCASyncer) expectedConfigMap() *corev1.ConfigMap {
 	cm.Name = "kubelet-serving-ca"
 	cm.Namespace = "openshift-config-managed"
 	cm.Data = map[string]string{
-		"ca-bundle.crt": s.InitialCA,
+		"ca-bundle.crt": s.ClusterSignerCA,
 	}
 	return cm
 }

--- a/hosted-cluster-config-operator/operator/config.go
+++ b/hosted-cluster-config-operator/operator/config.go
@@ -26,12 +26,13 @@ import (
 
 type ControllerSetupFunc func(*HostedClusterConfigOperatorConfig) error
 
-func NewHostedClusterConfigOperatorConfig(targetKubeconfig, namespace string, initialCA []byte, versions map[string]string, controllers []string, controllerFuncs map[string]ControllerSetupFunc, enableCIDebugOutput bool, platformType hyperv1.PlatformType) *HostedClusterConfigOperatorConfig {
+func NewHostedClusterConfigOperatorConfig(targetKubeconfig, namespace string, initialCA []byte, versions map[string]string, controllers []string, controllerFuncs map[string]ControllerSetupFunc, enableCIDebugOutput bool, platformType hyperv1.PlatformType, clusterSignerCA []byte) *HostedClusterConfigOperatorConfig {
 	return &HostedClusterConfigOperatorConfig{
 		targetKubeconfig:             targetKubeconfig,
 		TargetCreateOrUpdateProvider: upsert.New(enableCIDebugOutput),
 		namespace:                    namespace,
 		initialCA:                    initialCA,
+		clusterSignerCA:              clusterSignerCA,
 		controllers:                  controllers,
 		controllerFuncs:              controllerFuncs,
 		versions:                     versions,
@@ -53,6 +54,7 @@ type HostedClusterConfigOperatorConfig struct {
 	targetKubeconfig    string
 	namespace           string
 	initialCA           []byte
+	clusterSignerCA     []byte
 	controllers         []string
 	PlatformType        hyperv1.PlatformType
 	controllerFuncs     map[string]ControllerSetupFunc
@@ -184,6 +186,10 @@ func (c *HostedClusterConfigOperatorConfig) Versions() map[string]string {
 
 func (c *HostedClusterConfigOperatorConfig) InitialCA() string {
 	return string(c.initialCA)
+}
+
+func (c *HostedClusterConfigOperatorConfig) ClusterSignerCA() string {
+	return string(c.clusterSignerCA)
 }
 
 func (c *HostedClusterConfigOperatorConfig) Fatal(err error, msg string) {


### PR DESCRIPTION
We currently put the root ca into the kubelet serving ca configmap which
is incorrect, as kubelet serving certs are signed by the KCM using the
cluster signer CA.

This fixes prometheus scraping of Kubelet endpoints which in turn means
we have data in the metrics api which fixes the HPA and the related
conformance test.

Ref https://issues.redhat.com/browse/HOSTEDCP-257

/cc @csrwng 