### PR TITLE
Add missing rbac for ingress-to-route controller

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/ingress-to-route-controller-clusterrole.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/ingress-to-route-controller-clusterrole.yaml
@@ -1,0 +1,56 @@
+# source: https://github.com/openshift/cluster-openshift-controller-manager-operator/blob/179b82ce93f645cacb003a51afedebf4cd2c3e80/bindata/v3.11.0/openshift-controller-manager/ingress-to-route-controller-clusterrole.yaml#L1
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingress
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update

--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/ingress-to-route-controller-clusterrolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/ingress-to-route-controller-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+# Source: https://github.com/openshift/cluster-openshift-controller-manager-operator/blob/179b82ce93f645cacb003a51afedebf4cd2c3e80/bindata/v3.11.0/openshift-controller-manager/ingress-to-route-controller-clusterrolebinding.yaml#L1
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-infra
+  name: ingress-to-route-controller


### PR DESCRIPTION
The controller wasn't allowed to create rotues, hence it didn't work.
This fixes the `The HAProxy router should serve routes that were created from an ingress`
conformance test.

Ref: https://issues.redhat.com/browse/HOSTEDCP-257

/cc @csrwng 