### PR TITLE
add detection and toggles for v1 cronjobs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2102,29 +2102,31 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 		return fmt.Errorf("failed to reconcile catalog rollout rolebinding: %w", err)
 	}
 
-	certifiedOperatorsCronJob := manifests.CertifiedOperatorsCronJob(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, certifiedOperatorsCronJob, func() error {
-		return olm.ReconcileCertifiedOperatorsCronJob(certifiedOperatorsCronJob, p.OwnerRef, p.CLIImage)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile certified operators cronjob: %w", err)
-	}
-	communityOperatorsCronJob := manifests.CommunityOperatorsCronJob(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, communityOperatorsCronJob, func() error {
-		return olm.ReconcileCommunityOperatorsCronJob(communityOperatorsCronJob, p.OwnerRef, p.CLIImage)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile community operators cronjob: %w", err)
-	}
-	marketplaceOperatorsCronJob := manifests.RedHatMarketplaceOperatorsCronJob(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, marketplaceOperatorsCronJob, func() error {
-		return olm.ReconcileRedHatMarketplaceOperatorsCronJob(marketplaceOperatorsCronJob, p.OwnerRef, p.CLIImage)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile marketplace operators cronjob: %w", err)
-	}
-	redHatOperatorsCronJob := manifests.RedHatOperatorsCronJob(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, redHatOperatorsCronJob, func() error {
-		return olm.ReconcileRedHatOperatorsCronJob(redHatOperatorsCronJob, p.OwnerRef, p.CLIImage)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile red hat operators cronjob: %w", err)
+	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityV1Cronjob) {
+		certifiedOperatorsCronJob := manifests.CertifiedOperatorsCronJob(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, certifiedOperatorsCronJob, func() error {
+			return olm.ReconcileCertifiedOperatorsCronJob(certifiedOperatorsCronJob, p.OwnerRef, p.CLIImage)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile certified operators cronjob: %w", err)
+		}
+		communityOperatorsCronJob := manifests.CommunityOperatorsCronJob(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, communityOperatorsCronJob, func() error {
+			return olm.ReconcileCommunityOperatorsCronJob(communityOperatorsCronJob, p.OwnerRef, p.CLIImage)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile community operators cronjob: %w", err)
+		}
+		marketplaceOperatorsCronJob := manifests.RedHatMarketplaceOperatorsCronJob(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, marketplaceOperatorsCronJob, func() error {
+			return olm.ReconcileRedHatMarketplaceOperatorsCronJob(marketplaceOperatorsCronJob, p.OwnerRef, p.CLIImage)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile marketplace operators cronjob: %w", err)
+		}
+		redHatOperatorsCronJob := manifests.RedHatOperatorsCronJob(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, redHatOperatorsCronJob, func() error {
+			return olm.ReconcileRedHatOperatorsCronJob(redHatOperatorsCronJob, p.OwnerRef, p.CLIImage)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile red hat operators cronjob: %w", err)
+		}
 	}
 
 	catalogOperatorMetricsService := manifests.CatalogOperatorMetricsService(hcp.Namespace)

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -1,9 +1,11 @@
 package capabilities
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sync"
 
 	routev1 "github.com/openshift/api/route/v1"
+	batchv1 "k8s.io/api/batch/v1"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -14,6 +16,7 @@ type CapabilityType int
 const (
 	// CapabilityRoute indicates if the management cluster supports routes
 	CapabilityRoute CapabilityType = iota
+	CapabilityV1Cronjob
 )
 
 // ManagementClusterCapabilities holds all information about optional capabilities of
@@ -64,6 +67,29 @@ func isGroupVersionRegistered(client discovery.ServerResourcesInterface, groupVe
 	return false, nil
 }
 
+// isObjectKindRegistered determines if a specified kube api-resource exists in the cluster
+func isObjectKindRegistered(client discovery.ServerResourcesInterface, object schema.ObjectKind) (bool, error) {
+	_, apis, err := client.ServerGroupsAndResources()
+	for _, api := range apis {
+		if api.GroupVersion == object.GroupVersionKind().GroupVersion().String() {
+			for _, apiResource := range api.APIResources {
+				if apiResource.Kind == object.GroupVersionKind().Kind {
+					return true, nil
+				}
+			}
+		}
+	}
+	if err != nil && discovery.IsGroupDiscoveryFailedError(err) {
+		e := err.(*discovery.ErrGroupDiscoveryFailed)
+		if _, exists := e.Groups[object.GroupVersionKind().GroupVersion()]; !exists {
+			//the group was fully discovered and we confirmed the resource does not exist
+			//can safely ignore error
+			return false, nil
+		}
+	}
+	return false, err
+}
+
 func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterface) (*ManagementClusterCapabilities, error) {
 	discoveredCapabilities := map[CapabilityType]struct{}{}
 	hasRoutesCap, err := isGroupVersionRegistered(client, routev1.GroupVersion)
@@ -72,6 +98,18 @@ func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterfa
 	}
 	if hasRoutesCap {
 		discoveredCapabilities[CapabilityRoute] = struct{}{}
+	}
+	hasV1CronjobCap, err := isObjectKindRegistered(client, &batchv1.CronJob{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "CronJob",
+			APIVersion: batchv1.SchemeGroupVersion.String(),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if hasV1CronjobCap {
+		discoveredCapabilities[CapabilityV1Cronjob] = struct{}{}
 	}
 	return &ManagementClusterCapabilities{capabilities: discoveredCapabilities}, nil
 }


### PR DESCRIPTION
Cronjobs did not GA till Kube 1.21. This adds detection for that version and if so applies the cronjobs to do the periodic refreshes. If not: they are skipped to allow full reconcilation of the other components.

It is the expectation if this is not available: the operator of the cluster must provide a replacement in the form of a out of band beta cronjob until the appropriate version can be reached.