### PR TITLE
move to using beta resources for pdb and cronjobs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -12,7 +12,8 @@ import (
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
@@ -296,7 +297,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	return nil
 }
 
-func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *EtcdParams) error {
+func ReconcilePodDisruptionBudget(pdb *policyv1beta1.PodDisruptionBudget, p *EtcdParams) error {
 	if pdb.CreationTimestamp.IsZero() {
 		pdb.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: etcdPodSelector(),

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -12,7 +12,8 @@ import (
 
 	"github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/hypershift/support/capabilities"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"sigs.k8s.io/cluster-api/util/annotations"
 
 	"github.com/go-logr/logr"
@@ -131,7 +132,7 @@ func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Watches(&source.Kind{Type: &corev1.ServiceAccount{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
-		Watches(&source.Kind{Type: &policyv1.PodDisruptionBudget{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
+		Watches(&source.Kind{Type: &policyv1beta1.PodDisruptionBudget{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Watches(&source.Channel{Source: r.HostedAPICache.Events()}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Build(r)
 	if err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/pdb.go
@@ -2,12 +2,13 @@ package kas
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *KubeAPIServerParams) error {
+func ReconcilePodDisruptionBudget(pdb *policyv1beta1.PodDisruptionBudget, p *KubeAPIServerParams) error {
 	if pdb.CreationTimestamp.IsZero() {
 		pdb.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: kasLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/etcd.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/etcd.go
@@ -4,7 +4,8 @@ import (
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -44,8 +45,8 @@ func EtcdServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
 	}
 }
 
-func EtcdPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
-	return &policyv1.PodDisruptionBudget{
+func EtcdPodDisruptionBudget(ns string) *policyv1beta1.PodDisruptionBudget {
+	return &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "etcd",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -5,7 +5,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
@@ -83,8 +84,8 @@ func KASBootstrapKubeconfigSecret(controlPlaneNamespace string) *corev1.Secret {
 	}
 }
 
-func KASPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
-	return &policyv1.PodDisruptionBudget{
+func KASPodDisruptionBudget(ns string) *policyv1beta1.PodDisruptionBudget {
+	return &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kube-apiserver",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/oauth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/oauth.go
@@ -3,7 +3,8 @@ package manifests
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -18,8 +19,8 @@ func OAuthServerConfig(ns string) *corev1.ConfigMap {
 	}
 }
 
-func OAuthServerPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
-	return &policyv1.PodDisruptionBudget{
+func OAuthServerPodDisruptionBudget(ns string) *policyv1beta1.PodDisruptionBudget {
+	return &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-openshift",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/olm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/olm.go
@@ -2,7 +2,8 @@ package manifests
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
+	//TODO: Switch to k8s.io/api/batch/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,8 +38,8 @@ func CertifiedOperatorsService(ns string) *corev1.Service {
 	}
 }
 
-func CertifiedOperatorsCronJob(ns string) *batchv1.CronJob {
-	return &batchv1.CronJob{
+func CertifiedOperatorsCronJob(ns string) *batchv1beta1.CronJob {
+	return &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "certified-operators-catalog-rollout",
 			Namespace: ns,
@@ -75,8 +76,8 @@ func CommunityOperatorsService(ns string) *corev1.Service {
 	}
 }
 
-func CommunityOperatorsCronJob(ns string) *batchv1.CronJob {
-	return &batchv1.CronJob{
+func CommunityOperatorsCronJob(ns string) *batchv1beta1.CronJob {
+	return &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "community-operators-catalog-rollout",
 			Namespace: ns,
@@ -113,8 +114,8 @@ func RedHatMarketplaceOperatorsService(ns string) *corev1.Service {
 	}
 }
 
-func RedHatMarketplaceOperatorsCronJob(ns string) *batchv1.CronJob {
-	return &batchv1.CronJob{
+func RedHatMarketplaceOperatorsCronJob(ns string) *batchv1beta1.CronJob {
+	return &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "redhat-marketplace-catalog-rollout",
 			Namespace: ns,
@@ -151,8 +152,8 @@ func RedHatOperatorsService(ns string) *corev1.Service {
 	}
 }
 
-func RedHatOperatorsCronJob(ns string) *batchv1.CronJob {
-	return &batchv1.CronJob{
+func RedHatOperatorsCronJob(ns string) *batchv1beta1.CronJob {
+	return &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "redhat-operators-catalog-rollout",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_apiserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_apiserver.go
@@ -5,7 +5,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
@@ -28,8 +29,8 @@ func OpenShiftAPIServerAuditConfig(ns string) *corev1.ConfigMap {
 	}
 }
 
-func OpenShiftAPIServerPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
-	return &policyv1.PodDisruptionBudget{
+func OpenShiftAPIServerPodDisruptionBudget(ns string) *policyv1beta1.PodDisruptionBudget {
+	return &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openshift-apiserver",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_oauth_apiserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_oauth_apiserver.go
@@ -5,7 +5,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
@@ -28,8 +29,8 @@ func OpenShiftOAuthAPIServerDeployment(ns string) *appsv1.Deployment {
 	}
 }
 
-func OpenShiftOAuthAPIServerDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
-	return &policyv1.PodDisruptionBudget{
+func OpenShiftOAuthAPIServerDisruptionBudget(ns string) *policyv1beta1.PodDisruptionBudget {
+	return &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openshift-oauth-apiserver",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -7,7 +7,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
@@ -208,7 +209,7 @@ func buildOAuthVolumeEtcdClientCert(v *corev1.Volume) {
 	v.Secret.SecretName = manifests.EtcdClientSecret("").Name
 }
 
-func ReconcileOpenShiftOAuthAPIServerPodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OAuthDeploymentParams) error {
+func ReconcileOpenShiftOAuthAPIServerPodDisruptionBudget(pdb *policyv1beta1.PodDisruptionBudget, p *OAuthDeploymentParams) error {
 	if pdb.CreationTimestamp.IsZero() {
 		pdb.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: openShiftOAuthAPIServerLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/pdb.go
@@ -2,12 +2,13 @@ package oapi
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OpenShiftAPIServerParams) error {
+func ReconcilePodDisruptionBudget(pdb *policyv1beta1.PodDisruptionBudget, p *OpenShiftAPIServerParams) error {
 	if pdb.CreationTimestamp.IsZero() {
 		pdb.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: openShiftAPIServerLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/pdb.go
@@ -2,12 +2,13 @@ package oauth
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	policyv1 "k8s.io/api/policy/v1"
+	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OAuthServerParams) error {
+func ReconcilePodDisruptionBudget(pdb *policyv1beta1.PodDisruptionBudget, p *OAuthServerParams) error {
 	if pdb.CreationTimestamp.IsZero() {
 		pdb.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: oauthLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
+	//TODO: Switch to k8s.io/api/batch/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,8 +50,8 @@ func MustDeployment(fileName string) *appsv1.Deployment {
 	return deployment
 }
 
-func MustCronJob(fileName string) *batchv1.CronJob {
-	cronJob := &batchv1.CronJob{}
+func MustCronJob(fileName string) *batchv1beta1.CronJob {
+	cronJob := &batchv1beta1.CronJob{}
 	deserializeResource(fileName, cronJob)
 	return cronJob
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified-rollout.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified-rollout.cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: certified-operators-catalog-rollout

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community-rollout.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community-rollout.cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: community-operators-catalog-rollout

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace-rollout.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace-rollout.cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: redhat-marketplace-catalog-rollout

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators-rollout.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators-rollout.cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: redhat-operators-catalog-rollout

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -5,7 +5,8 @@ import (
 	"math/big"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
+	//TODO: Switch to k8s.io/api/batch/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
@@ -115,20 +116,20 @@ var (
 	redHatOperatorsCatalogRolloutCronJob   = MustCronJob("assets/catalog-redhat-operators-rollout.cronjob.yaml")
 )
 
-func ReconcileCertifiedOperatorsCronJob(cronJob *batchv1.CronJob, ownerRef config.OwnerRef, cliImage string) error {
+func ReconcileCertifiedOperatorsCronJob(cronJob *batchv1beta1.CronJob, ownerRef config.OwnerRef, cliImage string) error {
 	return reconcileCatalogCronJob(cronJob, ownerRef, cliImage, certifiedCatalogRolloutCronJob)
 }
-func ReconcileCommunityOperatorsCronJob(cronJob *batchv1.CronJob, ownerRef config.OwnerRef, cliImage string) error {
+func ReconcileCommunityOperatorsCronJob(cronJob *batchv1beta1.CronJob, ownerRef config.OwnerRef, cliImage string) error {
 	return reconcileCatalogCronJob(cronJob, ownerRef, cliImage, communityCatalogRolloutCronJob)
 }
-func ReconcileRedHatMarketplaceOperatorsCronJob(cronJob *batchv1.CronJob, ownerRef config.OwnerRef, cliImage string) error {
+func ReconcileRedHatMarketplaceOperatorsCronJob(cronJob *batchv1beta1.CronJob, ownerRef config.OwnerRef, cliImage string) error {
 	return reconcileCatalogCronJob(cronJob, ownerRef, cliImage, redHatMarketplaceCatalogRolloutCronJob)
 }
-func ReconcileRedHatOperatorsCronJob(cronJob *batchv1.CronJob, ownerRef config.OwnerRef, cliImage string) error {
+func ReconcileRedHatOperatorsCronJob(cronJob *batchv1beta1.CronJob, ownerRef config.OwnerRef, cliImage string) error {
 	return reconcileCatalogCronJob(cronJob, ownerRef, cliImage, redHatOperatorsCatalogRolloutCronJob)
 }
 
-func reconcileCatalogCronJob(cronJob *batchv1.CronJob, ownerRef config.OwnerRef, cliImage string, sourceCronJob *batchv1.CronJob) error {
+func reconcileCatalogCronJob(cronJob *batchv1beta1.CronJob, ownerRef config.OwnerRef, cliImage string, sourceCronJob *batchv1beta1.CronJob) error {
 	ownerRef.ApplyTo(cronJob)
 	cronJob.Spec = sourceCronJob.DeepCopy().Spec
 	cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image = cliImage

--- a/support/upsert/upsert.go
+++ b/support/upsert/upsert.go
@@ -6,7 +6,8 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
+	//TODO: Switch to k8s.io/api/batch/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -60,8 +61,8 @@ func (p *createOrUpdateProvider) CreateOrUpdate(ctx context.Context, c crclient.
 		defaultDeploymentSpec(&existingTyped.Spec, &obj.(*appsv1.Deployment).Spec)
 	case *appsv1.StatefulSet:
 		defaultStatefulSetSpec(&existingTyped.Spec, &obj.(*appsv1.StatefulSet).Spec)
-	case *batchv1.CronJob:
-		defaultCronJobSpec(&existingTyped.Spec, &obj.(*batchv1.CronJob).Spec)
+	case *batchv1beta1.CronJob:
+		defaultCronJobSpec(&existingTyped.Spec, &obj.(*batchv1beta1.CronJob).Spec)
 	case *corev1.Service:
 		defaultServiceSpec(&existingTyped.Spec, &obj.(*corev1.Service).Spec)
 	case *routev1.Route:
@@ -140,7 +141,7 @@ func defaultServiceSpec(original, mutated *corev1.ServiceSpec) {
 	}
 }
 
-func defaultCronJobSpec(original, mutated *batchv1.CronJobSpec) {
+func defaultCronJobSpec(original, mutated *batchv1beta1.CronJobSpec) {
 	if mutated.ConcurrencyPolicy == "" {
 		mutated.ConcurrencyPolicy = original.ConcurrencyPolicy
 	}


### PR DESCRIPTION
This PR transitions to using beta versions of resources that GAed in kube 1.21+. The current plan is we will continue to use these versions until we can bring all management clusters to 1.21+ (currently at 1.20). Then, once all at 1.21+ we will switch from using the beta apis to using the GA apis. 

This allows hypershift to run in kube 1.20 clusters

We will switch to the GA version when all management clusters are at 1.21+ OR 4.8_openshift+. This is noted in the TODOs