### PR TITLE
Create apireqiestcounts CRD

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/apiserver.openshift.io_apirequestcount-crd.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/assets/cluster-bootstrap/apiserver.openshift.io_apirequestcount-crd.yaml
@@ -1,0 +1,255 @@
+# Copied from https://github.com/openshift/api/blob/be1be0e89115702f8b508d351c4f5c9a16e5ae95/apiserver/v1/apiserver.openshift.io_apirequestcount.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/897
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: apirequestcounts.apiserver.openshift.io
+spec:
+  group: apiserver.openshift.io
+  names:
+    kind: APIRequestCount
+    listKind: APIRequestCountList
+    plural: apirequestcounts
+    singular: apirequestcount
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: RemovedInRelease
+          type: string
+          description: Release in which an API will be removed.
+          jsonPath: .status.removedInRelease
+        - name: RequestsInCurrentHour
+          type: integer
+          description: Number of requests in the current hour.
+          jsonPath: .status.currentHour.requestCount
+        - name: RequestsInLast24h
+          type: integer
+          description: Number of requests in the last 24h.
+          jsonPath: .status.requestCount
+      "schema":
+        "openAPIV3Schema":
+          description: "APIRequestCount tracks requests made to an API. The instance name must be of the form `resource.version.group`, matching the resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec defines the characteristics of the resource.
+              type: object
+              properties:
+                numberOfUsersToReport:
+                  description: numberOfUsersToReport is the number of users to include in the report. If unspecified or zero, the default is ten.  This is default is subject to change.
+                  type: integer
+                  format: int64
+                  default: 10
+                  maximum: 100
+                  minimum: 0
+            status:
+              description: status contains the observed state of the resource.
+              type: object
+              properties:
+                conditions:
+                  description: conditions contains details of the current status of this API Resource.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                currentHour:
+                  description: currentHour contains request history for the current hour. This is porcelain to make the API easier to read by humans seeing if they addressed a problem. This field is reset on the hour.
+                  type: object
+                  properties:
+                    byNode:
+                      description: byNode contains logs of requests per node.
+                      type: array
+                      maxItems: 512
+                      items:
+                        description: PerNodeAPIRequestLog contains logs of requests to a certain node.
+                        type: object
+                        properties:
+                          byUser:
+                            description: byUser contains request details by top .spec.numberOfUsersToReport users. Note that because in the case of an apiserver, restart the list of top users is determined on a best-effort basis, the list might be imprecise. In addition, some system users may be explicitly included in the list.
+                            type: array
+                            maxItems: 500
+                            items:
+                              description: PerUserAPIRequestCount contains logs of a user's requests.
+                              type: object
+                              properties:
+                                byVerb:
+                                  description: byVerb details by verb.
+                                  type: array
+                                  maxItems: 10
+                                  items:
+                                    description: PerVerbAPIRequestCount requestCounts requests by API request verb.
+                                    type: object
+                                    properties:
+                                      requestCount:
+                                        description: requestCount of requests for verb.
+                                        type: integer
+                                        format: int64
+                                        minimum: 0
+                                      verb:
+                                        description: verb of API request (get, list, create, etc...)
+                                        type: string
+                                        maxLength: 20
+                                requestCount:
+                                  description: requestCount of requests by the user across all verbs.
+                                  type: integer
+                                  format: int64
+                                  minimum: 0
+                                userAgent:
+                                  description: userAgent that made the request. The same user often has multiple binaries which connect (pods with many containers).  The different binaries will have different userAgents, but the same user.  In addition, we have userAgents with version information embedded and the userName isn't likely to change.
+                                  type: string
+                                  maxLength: 1024
+                                username:
+                                  description: userName that made the request.
+                                  type: string
+                                  maxLength: 512
+                          nodeName:
+                            description: nodeName where the request are being handled.
+                            type: string
+                            maxLength: 512
+                            minLength: 1
+                          requestCount:
+                            description: requestCount is a sum of all requestCounts across all users, even those outside of the top 10 users.
+                            type: integer
+                            format: int64
+                            minimum: 0
+                    requestCount:
+                      description: requestCount is a sum of all requestCounts across nodes.
+                      type: integer
+                      format: int64
+                      minimum: 0
+                last24h:
+                  description: last24h contains request history for the last 24 hours, indexed by the hour, so 12:00AM-12:59 is in index 0, 6am-6:59am is index 6, etc. The index of the current hour is updated live and then duplicated into the requestsLastHour field.
+                  type: array
+                  maxItems: 24
+                  items:
+                    description: PerResourceAPIRequestLog logs request for various nodes.
+                    type: object
+                    properties:
+                      byNode:
+                        description: byNode contains logs of requests per node.
+                        type: array
+                        maxItems: 512
+                        items:
+                          description: PerNodeAPIRequestLog contains logs of requests to a certain node.
+                          type: object
+                          properties:
+                            byUser:
+                              description: byUser contains request details by top .spec.numberOfUsersToReport users. Note that because in the case of an apiserver, restart the list of top users is determined on a best-effort basis, the list might be imprecise. In addition, some system users may be explicitly included in the list.
+                              type: array
+                              maxItems: 500
+                              items:
+                                description: PerUserAPIRequestCount contains logs of a user's requests.
+                                type: object
+                                properties:
+                                  byVerb:
+                                    description: byVerb details by verb.
+                                    type: array
+                                    maxItems: 10
+                                    items:
+                                      description: PerVerbAPIRequestCount requestCounts requests by API request verb.
+                                      type: object
+                                      properties:
+                                        requestCount:
+                                          description: requestCount of requests for verb.
+                                          type: integer
+                                          format: int64
+                                          minimum: 0
+                                        verb:
+                                          description: verb of API request (get, list, create, etc...)
+                                          type: string
+                                          maxLength: 20
+                                  requestCount:
+                                    description: requestCount of requests by the user across all verbs.
+                                    type: integer
+                                    format: int64
+                                    minimum: 0
+                                  userAgent:
+                                    description: userAgent that made the request. The same user often has multiple binaries which connect (pods with many containers).  The different binaries will have different userAgents, but the same user.  In addition, we have userAgents with version information embedded and the userName isn't likely to change.
+                                    type: string
+                                    maxLength: 1024
+                                  username:
+                                    description: userName that made the request.
+                                    type: string
+                                    maxLength: 512
+                            nodeName:
+                              description: nodeName where the request are being handled.
+                              type: string
+                              maxLength: 512
+                              minLength: 1
+                            requestCount:
+                              description: requestCount is a sum of all requestCounts across all users, even those outside of the top 10 users.
+                              type: integer
+                              format: int64
+                              minimum: 0
+                      requestCount:
+                        description: requestCount is a sum of all requestCounts across nodes.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                removedInRelease:
+                  description: removedInRelease is when the API will be removed.
+                  type: string
+                  maxLength: 64
+                  minLength: 0
+                  pattern: ^[0-9][0-9]*\.[0-9][0-9]*$
+                requestCount:
+                  description: requestCount is a sum of all requestCounts across all current hours, nodes, and users.
+                  type: integer
+                  format: int64
+                  minimum: 0


### PR DESCRIPTION
We didn't create the apirequestcounts CRD, which made the corresponding
controller in the kube-apiserver error and the
`[sig-arch][Late] clients should not use APIs that are removed in upcoming releases [Suite:openshift/conformance/parallel]"`
conformance test fail.

https://issues.redhat.com/browse/HOSTEDCP-257

/cc @csrwng 