### PR TITLE
Add SupportedHostedCluster condition HostedCluster

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -740,6 +740,13 @@ const (
 	// ValidHostedClusterConfiguration indicates (if status is true) that the
 	// ClusterConfiguration specified for the HostedCluster is valid.
 	ValidHostedClusterConfiguration ConditionType = "ValidConfiguration"
+
+	// SupportedHostedCluster indicates whether a HostedCluster is supported by
+	// the current configuration of the hypershift-operator.
+	// e.g. If HostedCluster requests endpointAcess Private but the hypershift-operator
+	// is running on a management cluster outside AWS or is not configured with AWS
+	// credentials, the HostedCluster is not supported.
+	SupportedHostedCluster ConditionType = "SupportedHostedCluster"
 )
 
 const (
@@ -751,6 +758,8 @@ const (
 	HostedClusterAsExpectedReason          = "HostedClusterAsExpected"
 	HostedClusterUnhealthyComponentsReason = "UnhealthyControlPlaneComponents"
 	InvalidConfigurationReason             = "InvalidConfiguration"
+
+	UnsupportedHostedClusterReason = "UnsupportedHostedCluster"
 
 	UnmanagedEtcdStatusUnknownReason = "UnmanagedEtcdStatusUnknown"
 	UnmanagedEtcdMisconfiguredReason = "UnmanagedEtcdMisconfigured"

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	hyperapi "github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/install/assets"
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/cmd/version"
@@ -46,8 +47,22 @@ type Options struct {
 	ExcludeEtcdManifests       bool
 	EnableOCPClusterMonitoring bool
 	EnableCIDebugOutput        bool
-	AWSCreds                   string
-	AWSRegion                  string
+	PrivatePlatform            string
+	AWSPrivateCreds            string
+	AWSPrivateRegion           string
+}
+
+func (o *Options) Validate() error {
+	switch hyperv1.PlatformType(o.PrivatePlatform) {
+	case hyperv1.AWSPlatform:
+		if o.AWSPrivateCreds == "" || o.AWSPrivateRegion == "" {
+			return fmt.Errorf("--aws-private-region and --aws-private-creds are required with --private-platform=%s", hyperv1.AWSPlatform)
+		}
+	case hyperv1.NonePlatform:
+	default:
+		return fmt.Errorf("--private-platform must be either %s or %s", hyperv1.AWSPlatform, hyperv1.NonePlatform)
+	}
+	return nil
 }
 
 func NewCommand() *cobra.Command {
@@ -62,7 +77,7 @@ func NewCommand() *cobra.Command {
 		opts.EnableOCPClusterMonitoring = true
 		opts.EnableCIDebugOutput = true
 	}
-	opts.AWSRegion = "us-east-1"
+	opts.PrivatePlatform = string(hyperv1.NonePlatform)
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", "hypershift", "The namespace in which to install HyperShift")
 	cmd.Flags().StringVar(&opts.HyperShiftImage, "hypershift-image", version.HyperShiftImage, "The HyperShift image to deploy")
@@ -71,10 +86,15 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.ExcludeEtcdManifests, "exclude-etcd", false, "Leave out etcd manifests")
 	cmd.Flags().BoolVar(&opts.EnableOCPClusterMonitoring, "enable-ocp-cluster-monitoring", opts.EnableOCPClusterMonitoring, "Development-only option that will make your OCP cluster unsupported: If the cluster Prometheus should be configured to scrape metrics")
 	cmd.Flags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", opts.EnableCIDebugOutput, "If extra CI debug output should be enabled")
-	cmd.Flags().StringVar(&opts.AWSCreds, "aws-creds", opts.AWSCreds, "Path to an AWS credentials file")
-	cmd.Flags().StringVar(&opts.AWSRegion, "aws-region", opts.AWSRegion, "AWS region in which the operator will create resources")
+	cmd.Flags().StringVar(&opts.PrivatePlatform, "private-platform", opts.PrivatePlatform, "Platform on which private clusters are supported by this operator (supports \"AWS\" or \"None\")")
+	cmd.Flags().StringVar(&opts.AWSPrivateCreds, "aws-private-creds", opts.AWSPrivateCreds, "Path to an AWS credentials file with privileges sufficient to manage private cluster resources")
+	cmd.Flags().StringVar(&opts.AWSPrivateRegion, "aws-private-region", opts.AWSPrivateRegion, "AWS region where private clusters are supported by this operator")
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := opts.Validate(); err != nil {
+			return err
+		}
+
 		ctx, cancel := context.WithCancel(context.Background())
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT)
@@ -90,7 +110,10 @@ func NewCommand() *cobra.Command {
 			opts.HyperShiftOperatorReplicas = 1
 		}
 
-		objects := hyperShiftOperatorManifests(opts)
+		objects, err := hyperShiftOperatorManifests(opts)
+		if err != nil {
+			return err
+		}
 
 		switch {
 		case opts.Render:
@@ -98,9 +121,10 @@ func NewCommand() *cobra.Command {
 		default:
 			err := apply(ctx, objects)
 			if err != nil {
-				panic(err)
+				return err
 			}
 		}
+		return nil
 	}
 
 	return cmd
@@ -145,7 +169,7 @@ func apply(ctx context.Context, objects []crclient.Object) error {
 	return nil
 }
 
-func hyperShiftOperatorManifests(opts Options) []crclient.Object {
+func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	controlPlanePriorityClass := assets.HyperShiftControlPlanePriorityClass{}.Build()
 	etcdPriorityClass := assets.HyperShiftEtcdPriorityClass{}.Build()
 	apiCriticalPriorityClass := assets.HyperShiftAPICriticalPriorityClass{}.Build()
@@ -168,18 +192,6 @@ func hyperShiftOperatorManifests(opts Options) []crclient.Object {
 		ServiceAccount: operatorServiceAccount,
 		Role:           operatorRole,
 	}.Build()
-	var awsCredBytes []byte
-	if len(opts.AWSCreds) != 0 {
-		var err error
-		awsCredBytes, err = ioutil.ReadFile(opts.AWSCreds)
-		if err != nil {
-			panic(err)
-		}
-	}
-	operatorAWSCredentialsSecret := assets.HyperShiftOperatorAWSCredentialsSecret{
-		Namespace:     operatorNamespace,
-		AWSCredsBytes: awsCredBytes,
-	}.Build()
 	operatorDeployment := assets.HyperShiftOperatorDeployment{
 		Namespace:                  operatorNamespace,
 		OperatorImage:              opts.HyperShiftImage,
@@ -187,7 +199,9 @@ func hyperShiftOperatorManifests(opts Options) []crclient.Object {
 		Replicas:                   opts.HyperShiftOperatorReplicas,
 		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
 		EnableCIDebugOutput:        opts.EnableCIDebugOutput,
-		AWSRegion:                  opts.AWSRegion,
+		PrivatePlatform:            opts.PrivatePlatform,
+		AWSPrivateRegion:           opts.AWSPrivateRegion,
+		AWSPrivateCreds:            opts.AWSPrivateCreds,
 	}.Build()
 	operatorService := assets.HyperShiftOperatorService{
 		Namespace: operatorNamespace,
@@ -209,6 +223,20 @@ func hyperShiftOperatorManifests(opts Options) []crclient.Object {
 
 	var objects []crclient.Object
 
+	var credBytes []byte
+	switch hyperv1.PlatformType(opts.PrivatePlatform) {
+	case hyperv1.AWSPlatform:
+		var err error
+		credBytes, err = ioutil.ReadFile(opts.AWSPrivateCreds)
+		if err != nil {
+			return objects, err
+		}
+	}
+	operatorCredentialsSecret := assets.HyperShiftOperatorCredentialsSecret{
+		Namespace:  operatorNamespace,
+		CredsBytes: credBytes,
+	}.Build()
+
 	objects = append(objects, assets.CustomResourceDefinitions(func(path string) bool {
 		if strings.Contains(path, "etcd") && opts.ExcludeEtcdManifests {
 			return false
@@ -225,7 +253,7 @@ func hyperShiftOperatorManifests(opts Options) []crclient.Object {
 	objects = append(objects, operatorClusterRoleBinding)
 	objects = append(objects, operatorRole)
 	objects = append(objects, operatorRoleBinding)
-	objects = append(objects, operatorAWSCredentialsSecret)
+	objects = append(objects, operatorCredentialsSecret)
 	objects = append(objects, operatorDeployment)
 	objects = append(objects, operatorService)
 	objects = append(objects, prometheusRole)
@@ -233,5 +261,5 @@ func hyperShiftOperatorManifests(opts Options) []crclient.Object {
 	objects = append(objects, serviceMonitor)
 	objects = append(objects, recordingRule)
 
-	return objects
+	return objects, nil
 }


### PR DESCRIPTION
This PR does a number of things in service to validating the `HostedCluster` spec is compatible with with the `hypershift-operator` configuration.

There is a new condition `SupportedHostedCluster` that reflects the result of this validation.

There are new/renamed flags on `hypershift install`: `private-platform` new, `aws-private-creds` renamed from `aws-creds`, `aws-private-region` renamed from `aws-region`.  Hopefully this makes it more clear that the information provided is used for private cluster support.  `private-platform` can be `None` (default) or `AWS`.  If `AWS` is set, `aws-private-creds` and `aws-creds` are required.

`aws-region` flag is removed from `hypershift-operator` and `private-platform` flag is added.  AWS region is now set via an env var.  This allows the AWS SDK to Just Work and requires no explicit plumbing from us.

Currently untested but wanted to get it in front of the team.