### PR TITLE
Properly override AWS infraID if not specified on cluster create

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -71,6 +71,7 @@ func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
 
 func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
 	client := util.GetClientOrDie()
+	infraID := opts.InfraID
 
 	// Load or create infrastructure for the cluster
 	var infra *awsinfra.CreateInfraOutput
@@ -92,7 +93,6 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		}
 	}
 	if infra == nil {
-		infraID := opts.InfraID
 		if len(infraID) == 0 {
 			infraID = fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
 		}
@@ -148,6 +148,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	exampleOptions.IssuerURL = iamInfo.IssuerURL
 	exampleOptions.PrivateZoneID = infra.PrivateZoneID
 	exampleOptions.PublicZoneID = infra.PublicZoneID
+	exampleOptions.InfraID = infraID
 
 	exampleOptions.AWS = &apifixtures.ExampleAWSOptions{
 		Region:                                 infra.Region,

--- a/cmd/cluster/none/create.go
+++ b/cmd/cluster/none/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	kubeclient "k8s.io/client-go/kubernetes"
 )
 
@@ -85,7 +86,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 
 	infraID := opts.InfraID
 	if len(infraID) == 0 {
-		infraID = opts.Name
+		infraID = fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
 	}
 	exampleOptions.InfraID = infraID
 	exampleOptions.BaseDomain = "example.com"


### PR DESCRIPTION
Set the generated infraID properly on AWS cluster create in the
hostedcluster resource.

Further avoid infraID collisions for the none provider by also appending a random string there.

Fixes an issue which I introduced in #630. As a consequence destroying an AWS cluster fails via the hypershift commandline.