### PR TITLE
Mark infraID as required

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -118,7 +118,7 @@ type HostedClusterSpec struct {
 
 	// InfraID is used to identify the cluster in cloud platforms
 	// +immutable
-	InfraID string `json:"infraID,omitempty"`
+	InfraID string `json:"infraID"`
 
 	// DNS configuration for the cluster
 	// +immutable

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -803,6 +803,7 @@ spec:
                     type: string
                 type: object
             required:
+            - infraID
             - issuerURL
             - networking
             - platform


### PR DESCRIPTION
infraID is assumed to be required by AWS and a core primitive which the code takes as a source of truth.
Seems fair to make it required for consistency and UX even though some platforms might not make that heavy use of it.