### PR TITLE
Add bz component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,3 +11,4 @@ reviewers:
 - ironcladlou
 - sjenning
 - alvaroaleman
+component: ibm-roks-toolkit


### PR DESCRIPTION
Add a placeholder component to OWNERS so that release processes can
work immediately while we work on getting a more appropriate BugZilla
component.