### PR TITLE
Improve API reference docs

### DIFF
--- a/api/v1alpha1/doc.go
+++ b/api/v1alpha1/doc.go
@@ -1,4 +1,14 @@
-// Package v1alpha1 contains API Schema definitions for the hypershift.openshift.io v1alpha1 API group
+/*
+Package v1alpha1 contains the HyperShift API.
+
+The HyperShift API enables creating and managing lightweight, flexible, heterogeneous
+OpenShift clusters at scale.
+
+HyperShift clusters are deployed in a topology which isolates the "control plane"
+(e.g. etcd, the API server, controller manager, etc.) from the "data plane" (e.g.
+worker nodes and their kubelets, and the infrastructure on which they run). This
+enables "hosted control plane as a service" use cases.
+*/
 // +kubebuilder:object:generate=true
 // +groupName=hypershift.openshift.io
 package v1alpha1

--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -97,11 +97,21 @@ type HostedControlPlaneSpec struct {
 	SecretEncryption *SecretEncryptionSpec `json:"secretEncryption,omitempty"`
 }
 
+// AvailabilityPolicy specifies a high level availability policy for components.
 type AvailabilityPolicy string
 
 const (
+	// HighlyAvailable means components should be resilient to problems across fault
+	// boundaries as defined by the component to which the policy is attached. This
+	// usually means running critical workloads with 3 replicas and with little or
+	// no toleration of disruption of the component.
 	HighlyAvailable AvailabilityPolicy = "HighlyAvailable"
-	SingleReplica   AvailabilityPolicy = "SingleReplica"
+
+	// SingleReplica means components are not expected to be resilient to problems
+	// across most fault boundaries associated with high availability. This usually
+	// means running critical workloads with just 1 replica and with toleration of
+	// full disruption of the component.
+	SingleReplica AvailabilityPolicy = "SingleReplica"
 )
 
 type KubeconfigSecretRef struct {

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -129,7 +129,8 @@ type HostedClusterSpec struct {
 	// TODO (alberto): include Ignition endpoint here.
 	Services []ServicePublishingStrategyMapping `json:"services"`
 
-	// ControllerAvailabilityPolicy specifies whether to run control plane controllers in HA mode
+	// ControllerAvailabilityPolicy specifies an availability policy to apply
+	// to critical control plane components.
 	// Defaults to SingleReplica when not set.
 	// +optional
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
@@ -841,6 +842,14 @@ type ClusterConfiguration struct {
 	Items []runtime.RawExtension `json:"items,omitempty"`
 }
 
+// +genclient
+
+// HostedCluster is the primary representation of a HyperShift cluster and encapsulates
+// the control plane and common data plane configuration. Creating a HostedCluster
+// results in a fully functional OpenShift control plane with no attached nodes.
+// To support workloads (e.g. pods), a HostedCluster may have one or more associated
+// NodePool resources.
+//
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=hostedclusters,shortName=hc;hcs,scope=Namespaced
 // +kubebuilder:storageversion
@@ -850,12 +859,14 @@ type ClusterConfiguration struct {
 // +kubebuilder:printcolumn:name="Progress",type="string",JSONPath=".status.version.history[?(@.state!=\"\")].state",description="Progress"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].status",description="Available"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].reason",description="Reason"
-// HostedCluster is the Schema for the hostedclusters API
 type HostedCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   HostedClusterSpec   `json:"spec,omitempty"`
+	// Spec is the desired behavior of the HostedCluster.
+	Spec HostedClusterSpec `json:"spec,omitempty"`
+
+	// Status is the latest observed status of the HostedCluster.
 	Status HostedClusterStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -30,7 +30,12 @@ func init() {
 	SchemeBuilder.Register(&NodePoolList{})
 }
 
-// NodePool defines the desired state of NodePool
+// +genclient
+
+// NodePool is a scalable set of worker nodes attached to a HostedCluster. NodePool
+// machine architectures are uniform within a given pool, and are independent of
+// the control plane’s underlying machine architecture.
+//
 // +kubebuilder:resource:path=nodepools,shortName=np;nps,scope=Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
@@ -47,7 +52,10 @@ type NodePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   NodePoolSpec   `json:"spec,omitempty"`
+	// Spec is the desired behavior of the NodePool.
+	Spec NodePoolSpec `json:"spec,omitempty"`
+
+	// Status is the most recently observed status of the NodePool.
 	Status NodePoolStatus `json:"status,omitempty"`
 }
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -43,7 +43,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: HostedCluster is the Schema for the hostedclusters API
+        description: HostedCluster is the primary representation of a HyperShift cluster
+          and encapsulates the control plane and common data plane configuration.
+          Creating a HostedCluster results in a fully functional OpenShift control
+          plane with no attached nodes. To support workloads (e.g. pods), a HostedCluster
+          may have one or more associated NodePool resources.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -58,7 +62,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: HostedClusterSpec defines the desired state of HostedCluster
+            description: Spec is the desired behavior of the HostedCluster.
             properties:
               auditWebhook:
                 description: AuditWebhook contains metadata for configuring an audit
@@ -144,9 +148,9 @@ spec:
                     type: array
                 type: object
               controllerAvailabilityPolicy:
-                description: ControllerAvailabilityPolicy specifies whether to run
-                  control plane controllers in HA mode Defaults to SingleReplica when
-                  not set.
+                description: ControllerAvailabilityPolicy specifies an availability
+                  policy to apply to critical control plane components. Defaults to
+                  SingleReplica when not set.
                 type: string
               dns:
                 description: DNS configuration for the cluster
@@ -813,7 +817,7 @@ spec:
             - sshKey
             type: object
           status:
-            description: HostedClusterStatus defines the observed state of HostedCluster
+            description: Status is the latest observed status of the HostedCluster.
             properties:
               conditions:
                 items:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -51,7 +51,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NodePool defines the desired state of NodePool
+        description: NodePool is a scalable set of worker nodes attached to a HostedCluster.
+          NodePool machine architectures are uniform within a given pool, and are
+          independent of the control plane’s underlying machine architecture.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -66,7 +68,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: NodePoolSpec defines the desired state of NodePool
+            description: Spec is the desired behavior of the NodePool.
             properties:
               autoScaling:
                 properties:
@@ -325,7 +327,7 @@ spec:
             - release
             type: object
           status:
-            description: NodePoolStatus defines the observed state of NodePool
+            description: Status is the most recently observed status of the NodePool.
             properties:
               conditions:
                 items:

--- a/docs/api-doc-gen/config.json
+++ b/docs/api-doc-gen/config.json
@@ -1,25 +1,29 @@
 {
   "hideMemberFields": [
-      "TypeMeta"
+    "TypeMeta"
   ],
   "hideTypePatterns": [
-      "ParseError$",
-      "List$"
+    "ParseError$",
+    "List$",
+    "HostedControlPlane*$",
+    "KubeconfigSecretRef",
+    "APIEndpoint",
+    "AWSEndpointService*"
   ],
   "externalPackages": [
-      {
-          "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/apis/meta/v1\\.Duration$",
-          "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
-      },
-      {
-          "typeMatchPrefix": "^k8s\\.io/(api|apimachinery|apiextensions-apiserver/pkg/apis)/",
-          "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
-      }
+    {
+      "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/apis/meta/v1\\.Duration$",
+      "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
+    },
+    {
+      "typeMatchPrefix": "^k8s\\.io/(api|apimachinery|apiextensions-apiserver/pkg/apis)/",
+      "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+    }
   ],
   "typeDisplayNamePrefixOverrides": {
-      "k8s.io/api/": "Kubernetes ",
-      "k8s.io/apimachinery/pkg/apis/": "Kubernetes ",
-      "k8s.io/apiextensions-apiserver/pkg/apis/": "Kubernetes "
+    "k8s.io/api/": "Kubernetes ",
+    "k8s.io/apimachinery/pkg/apis/": "Kubernetes ",
+    "k8s.io/apiextensions-apiserver/pkg/apis/": "Kubernetes "
   },
   "markdownDisabled": false
 }

--- a/docs/api-doc-gen/templates/pkg.tpl
+++ b/docs/api-doc-gen/templates/pkg.tpl
@@ -29,17 +29,6 @@ title: API Reference
         {{ end }}
     {{ end }}
 
-    Resource Types:
-    <ul>
-    {{- range (visibleTypes (sortedTypes .Types)) -}}
-        {{ if isExportedType . -}}
-        <li>
-            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
-        </li>
-        {{- end }}
-    {{- end -}}
-    </ul>
-
     {{ range (visibleTypes (sortedTypes .Types))}}
         {{ template "type" .  }}
     {{ end }}

--- a/docs/api-doc-gen/templates/type.tpl
+++ b/docs/api-doc-gen/templates/type.tpl
@@ -1,9 +1,11 @@
 {{ define "type" }}
 
-<h3 id="{{ anchorIDForType . }}">
-    {{- .Name.Name }}
-    {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias)</p>{{ end -}}
-</h3>
+{{ if isExportedType . -}}
+## {{- .Name.Name }} { #{{ anchorIDForType . }} }
+{{ else -}}
+### {{- .Name.Name }} { #{{ anchorIDForType . }} }
+{{ end -}}
+
 {{ with (typeReferences .) }}
     <p>
         (<em>Appears on:</em>
@@ -21,6 +23,30 @@
 <p>
     {{ safe (renderComments .CommentLines) }}
 </p>
+
+{{ with (constantsOfType .) }}
+<table>
+    <thead>
+        <tr>
+            <th>Value</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+      {{- range . -}}
+      <tr>
+        {{- /*
+            renderComments implicitly creates a <p> element, so we
+            add one to the display name as well to make the contents
+            of the two cells align evenly.
+        */ -}}
+        <td><p>{{ typeDisplayName . }}</p></td>
+        <td>{{ safe (renderComments .CommentLines) }}</td>
+      </tr>
+      {{- end -}}
+    </tbody>
+</table>
+{{ end }}
 
 {{ if .Members }}
 <table>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -10,18 +10,21 @@ title: API Reference
 </ul>
 <h2 id="hypershift.openshift.io/v1alpha1">hypershift.openshift.io/v1alpha1</h2>
 <p>
-<p>Package v1alpha1 contains API Schema definitions for the hypershift.openshift.io v1alpha1 API group</p>
+<p>Package v1alpha1 contains the HyperShift API.</p>
+<p>The HyperShift API enables creating and managing lightweight, flexible, heterogeneous
+OpenShift clusters at scale.</p>
+<p>HyperShift clusters are deployed in a topology which isolates the &ldquo;control plane&rdquo;
+(e.g. etcd, the API server, controller manager, etc.) from the &ldquo;data plane&rdquo; (e.g.
+worker nodes and their kubelets, and the infrastructure on which they run). This
+enables &ldquo;hosted control plane as a service&rdquo; use cases.</p>
 </p>
-Resource Types:
-<ul></ul>
-<h3 id="hypershift.openshift.io/v1alpha1.AESCBCSpec">AESCBCSpec
-</h3>
+##HostedCluster { #hypershift.openshift.io/v1alpha1.HostedCluster }
 <p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
-</p>
-<p>
-<p>AESCBCSpec defines metadata about the AESCBC secret encryption strategy</p>
+<p>HostedCluster is the primary representation of a HyperShift cluster and encapsulates
+the control plane and common data plane configuration. Creating a HostedCluster
+results in a fully functional OpenShift control plane with no attached nodes.
+To support workloads (e.g. pods), a HostedCluster may have one or more associated
+NodePool resources.</p>
 </p>
 <table>
 <thead>
@@ -33,1421 +36,21 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>activeKey</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
+<code>apiVersion</code></br>
+string</td>
 <td>
-<p>ActiveKey defines the active key used to encrypt new secrets</p>
+<code>
+hypershift.openshift.io/v1alpha1
+</code>
 </td>
 </tr>
 <tr>
 <td>
-<code>backupKey</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackupKey defines the old key during the rotation process so previously created
-secrets can continue to be decrypted until they are all re-encrypted with the active key.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.APIEndpoint">APIEndpoint
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>host</code></br>
-<em>
+<code>kind</code></br>
 string
-</em>
 </td>
-<td>
-<p>Host is the hostname on which the API server is serving.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>port</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Port is the port on which the API server is serving.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.APIServerNetworking">APIServerNetworking
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">ClusterNetworking</a>)
-</p>
-<p>
-<p>APIServerNetworking specifies how the APIServer is exposed inside a worker node.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>advertiseAddress</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>AdvertiseAddress is the address that workers will use to talk to the
-API server. This is an address associated with the loopback adapter of
-each worker. If not specified, 172.20.0.1 is used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>port</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Port is the port at which the APIServer is exposed inside a worker node
-Other pods using host networking cannot listen on this port. If not
-specified, 6443 is used.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSCloudProviderConfig">AWSCloudProviderConfig
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subnet</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">
-AWSResourceReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Subnet is the subnet to use for instances</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>zone</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Zone is the availability zone where the instances are created</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>vpc</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>VPC specifies the VPC used for the cluster</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSEndpointAccessType">AWSEndpointAccessType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
-</p>
-<p>
-</p>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSEndpointService">AWSEndpointService
-</h3>
-<p>
-<p>AWSEndpointService specifies a request for an Endpoint Service in AWS</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSEndpointServiceSpec">
-AWSEndpointServiceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>networkLoadBalancerName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the NLB for which an Endpoint Service should be configured</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSEndpointServiceStatus">
-AWSEndpointServiceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSEndpointServiceSpec">AWSEndpointServiceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSEndpointService">AWSEndpointService</a>)
-</p>
-<p>
-<p>AWSEndpointServiceSpec defines the desired state of AWSEndpointService</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>networkLoadBalancerName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the NLB for which an Endpoint Service should be configured</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSEndpointServiceStatus">AWSEndpointServiceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSEndpointService">AWSEndpointService</a>)
-</p>
-<p>
-<p>AWSEndpointServiceStatus defines the observed state of AWSEndpointService</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>endpointServiceName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The endpoint service name created in AWS in response to the request</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>conditions</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#condition-v1-meta">
-[]Kubernetes meta/v1.Condition
-</a>
-</em>
-</td>
-<td>
-<p>Condition contains details for the current state of the Endpoint Service
-request If there is an error processing the request e.g. the NLB doesn&rsquo;t
-exist, then the Available condition will be false, reason AWSErrorReason,
-and the error reported in the message.</p>
-<p>Current condition types are: &ldquo;Available&rdquo;</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSKMSAuthSpec">AWSKMSAuthSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSSpec">AWSKMSSpec</a>)
-</p>
-<p>
-<p>AWSKMSAuthSpec defines metadata about the management of credentials used to interact with AWS KMS</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>credentials</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Credentials contains the name of the secret that holds the aws credentials that can be used
-to make the necessary KMS calls. It should at key AWSCredentialsFileSecretKey contain the
-aws credentials file that can be used to configure AWS SDKs</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSKMSKeyEntry">AWSKMSKeyEntry
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSSpec">AWSKMSSpec</a>)
-</p>
-<p>
-<p>AWSKMSKeyEntry defines metadata to locate the encryption key in AWS</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>arn</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ARN is the Amazon Resource Name for the encryption key</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSKMSSpec">AWSKMSSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KMSSpec">KMSSpec</a>)
-</p>
-<p>
-<p>AWSKMSSpec defines metadata about the configuration of the AWS KMS Secret Encryption provider</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>region</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Region contains the AWS region</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>activeKey</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSKeyEntry">
-AWSKMSKeyEntry
-</a>
-</em>
-</td>
-<td>
-<p>ActiveKey defines the active key used to encrypt new secrets</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>backupKey</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSKeyEntry">
-AWSKMSKeyEntry
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackupKey defines the old key during the rotation process so previously created
-secrets can continue to be decrypted until they are all re-encrypted with the active key.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>auth</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSAuthSpec">
-AWSKMSAuthSpec
-</a>
-</em>
-</td>
-<td>
-<p>Auth defines metadata about the management of credentials used to interact with AWS KMS</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">AWSNodePoolPlatform
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>)
-</p>
-<p>
-<p>AWSNodePoolPlatform stores the configuration for a node pool
-installed on AWS.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>instanceType</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>InstanceType defines the ec2 instance type.
-eg. m4-large</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>instanceProfile</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>subnet</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">
-AWSResourceReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Subnet is the subnet to use for instances</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ami</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>AMI is the image id to use</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityGroups</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">
-[]AWSResourceReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityGroups is the set of security groups to associate with nodepool machines</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>rootVolume</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.Volume">
-Volume
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RootVolume specifies the root volume of the platform.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resourceTags</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceTag">
-[]AWSResourceTag
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>resourceTags is a list of additional tags to apply to AWS nodes.
-These will be merged with Cluster-level tags and Cluster-level tags take precedence in case of conflicts.
-See <a href="https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html">https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html</a> for information on tagging AWS resources.
-AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags
-available for the user.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>region</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Region is the AWS region for the cluster.
-This is used by CRs that are consumed by OCP Operators.
-E.g cluster-infrastructure-02-config.yaml and install-config.yaml
-This is also used by nodePools to fetch the default boot AMI in a given payload.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>cloudProviderConfig</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSCloudProviderConfig">
-AWSCloudProviderConfig
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CloudProviderConfig is used to generate the ConfigMap with the cloud config consumed
-by the Control Plane components.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceEndpoints</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSServiceEndpoint">
-[]AWSServiceEndpoint
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceEndpoints list contains custom endpoints which will override default
-service endpoint of AWS Services.
-There must be only one ServiceEndpoint for a service.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>roles</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSRoleCredentials">
-[]AWSRoleCredentials
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>kubeCloudControllerCreds</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>KubeCloudControllerCreds is a reference to a secret containing cloud
-credentials with permissions matching the Kube cloud controller policy.
-The secret should have exactly one key, <code>credentials</code>, whose value is
-an AWS credentials file.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodePoolManagementCreds</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>NodePoolManagementCreds is a reference to a secret containing cloud
-credentials with permissions matching the noe pool management policy.
-The secret should have exactly one key, <code>credentials</code>, whose value is
-an AWS credentials file.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resourceTags</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceTag">
-[]AWSResourceTag
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>resourceTags is a list of additional tags to apply to AWS resources created for the cluster.
-See <a href="https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html">https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html</a> for information on tagging AWS resources.
-AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags
-available for the user.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>endpointAccess</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSEndpointAccessType">
-AWSEndpointAccessType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>EndpointAccess determines if cluster endpoints are public and/or private</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSResourceReference">AWSResourceReference
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)
-</p>
-<p>
-<p>AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
-Only one of ID, ARN or Filters may be specified. Specifying more than one will result in
-a validation error.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>id</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ID of resource</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>arn</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ARN of resource</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>filters</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.Filter">
-[]Filter
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Filters is a set of key/value pairs used to identify a resource
-They are applied according to the rules defined by the AWS API:
-<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSResourceTag">AWSResourceTag
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
-</p>
-<p>
-<p>AWSResourceTag is a tag to apply to AWS resources created for the cluster.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>key</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>key is the key of the tag</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>value is the value of the tag.
-Some AWS service do not support empty values. Since tags are added to resources in many services, the
-length of the tag value must meet the requirements of all services.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSRoleCredentials">AWSRoleCredentials
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>arn</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>namespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AWSServiceEndpoint">AWSServiceEndpoint
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
-</p>
-<p>
-<p>AWSServiceEndpoint stores the configuration for services to
-override existing defaults of AWS Services.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the AWS service.
-This must be provided and cannot be empty.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>url</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>URL is fully qualified URI with scheme https, that overrides the default generated
-endpoint for a client.
-This must be provided and cannot be empty.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.AvailabilityPolicy">AvailabilityPolicy
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
-</p>
-<p>
-</p>
-<h3 id="hypershift.openshift.io/v1alpha1.ClusterAutoscaling">ClusterAutoscaling
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>)
-</p>
-<p>
-<p>TODO maybe we have profiles for scaling behaviors</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>maxNodesTotal</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Maximum number of nodes in all node groups.
-Cluster autoscaler will not grow the cluster beyond this number.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxPodGracePeriod</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Gives pods graceful termination time before scaling down
-default: 600 seconds</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxNodeProvisionTime</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Maximum time CA waits for node to be provisioned
-default: 15 minutes</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>podPriorityThreshold</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>To allow users to schedule &ldquo;best-effort&rdquo; pods, which shouldn&rsquo;t trigger
-Cluster Autoscaler actions, but only run when there are spare resources available,
-default: -10
-More info: <a href="https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption">https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.ClusterConfiguration">ClusterConfiguration
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
-</p>
-<p>
-<p>ClusterConfiguration contains global configuration for a HostedCluster.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretRefs</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-[]Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecretRefs holds references to secrets used in configuration entries
-so that they can be properly synced by the hypershift operator.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>configMapRefs</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-[]Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ConfigMapRefs holds references to configmaps used in configuration entries
-so that they can be properly synced by the hypershift operator.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>items</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#rawextension-runtime-pkg">
-[]k8s.io/apimachinery/pkg/runtime.RawExtension
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Items embeds the configuration resource</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.ClusterNetworking">ClusterNetworking
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>serviceCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>podCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>machineCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>networkType</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.NetworkType">
-NetworkType
-</a>
-</em>
-</td>
-<td>
-<p>NetworkType specifies the SDN provider used for cluster networking.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiServer</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.APIServerNetworking">
-APIServerNetworking
-</a>
-</em>
-</td>
-<td>
-<p>APIServer contains advanced network settings for the API server that affect
-how the APIServer is exposed inside a worker node.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.ClusterVersionStatus">ClusterVersionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterStatus">HostedClusterStatus</a>)
-</p>
-<p>
-<p>ClusterVersionStatus reports the status of the cluster versioning,
-including any upgrades that are in progress. The current field will
-be set to whichever version the cluster is reconciling to, and the
-conditions array will report whether the update succeeded, is in
-progress, or is failing.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>desired</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.Release">
-Release
-</a>
-</em>
-</td>
-<td>
-<p>desired is the version that the cluster is reconciling towards.
-If the cluster is not yet fully initialized desired will be set
-with the information available, which may be an image or a tag.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>history</code></br>
-<em>
-[]github.com/openshift/api/config/v1.UpdateHistory
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>history contains a list of the most recent versions applied to the cluster.
-This value may be empty during cluster startup, and then will be updated
-when a new update is being applied. The newest update is first in the
-list and it is ordered by recency. Updates in the history have state
-Completed if the rollout completed - if an update was failing or halfway
-applied the state will be Partial. Only a limited amount of update history
-is preserved.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>observedGeneration</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>observedGeneration reports which version of the spec is being synced.
-If this value is not equal to metadata.generation, then the desired
-and conditions fields may represent a previous version.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.ConditionType">ConditionType
-(<code>string</code> alias)</p></h3>
-<p>
-</p>
-<h3 id="hypershift.openshift.io/v1alpha1.DNSSpec">DNSSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
-</p>
-<p>
-<p>DNSSpec specifies the DNS configuration in the cluster</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>baseDomain</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>BaseDomain is the base domain of the cluster.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>publicZoneID</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PublicZoneID is the Hosted Zone ID where all the DNS records that are publicly accessible to
-the internet exist.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>privateZoneID</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PrivateZoneID is the Hosted Zone ID where all the DNS records that are only available internally
-to the cluster exist.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.EtcdManagementType">EtcdManagementType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">EtcdSpec</a>)
-</p>
-<p>
-<p>EtcdManagementType is a enum specifying the strategy for managing the cluster&rsquo;s etcd instance</p>
-</p>
-<h3 id="hypershift.openshift.io/v1alpha1.EtcdSpec">EtcdSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>managementType</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdManagementType">
-EtcdManagementType
-</a>
-</em>
-</td>
-<td>
-<p>ManagementType defines how the etcd cluster is managed. Unmanaged means
-the etcd cluster is managed by a system outside the hypershift controllers.
-Managed means the hypershift controllers manage the provisioning of the etcd cluster
-and the operations around it</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>managed</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdSpec">
-ManagedEtcdSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Managed provides metadata that defines how the hypershift controllers manage the etcd cluster</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>unmanaged</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.UnmanagedEtcdSpec">
-UnmanagedEtcdSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Unmanaged provides metadata that enables the Openshift controllers to connect to the external etcd cluster</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.EtcdTLSConfig">EtcdTLSConfig
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.UnmanagedEtcdSpec">UnmanagedEtcdSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>clientSecret</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>ClientSecret refers to a secret for client MTLS authentication with the etcd cluster
-The CA must be stored at secret key etcd-client-ca.crt.
-The client cert must be stored at secret key etcd-client.crt.
-The client key must be stored at secret key etcd-client.key.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.Filter">Filter
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">AWSResourceReference</a>)
-</p>
-<p>
-<p>Filter is a filter used to identify an AWS resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the filter. Filter names are case-sensitive.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>values</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Values includes one or more filter values. Filter values are case-sensitive.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.HostedCluster">HostedCluster
-</h3>
-<p>
-<p>HostedCluster is the Schema for the hostedclusters API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
+<td><code>HostedCluster</code></td>
 </tr>
-</thead>
-<tbody>
 <tr>
 <td>
 <code>metadata</code></br>
@@ -1472,6 +75,7 @@ HostedClusterSpec
 </em>
 </td>
 <td>
+<p>Spec is the desired behavior of the HostedCluster.</p>
 <br/>
 <br/>
 <table>
@@ -1646,7 +250,8 @@ AvailabilityPolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>ControllerAvailabilityPolicy specifies whether to run control plane controllers in HA mode
+<p>ControllerAvailabilityPolicy specifies an availability policy to apply
+to critical control plane components.
 Defaults to SingleReplica when not set.</p>
 </td>
 </tr>
@@ -1737,12 +342,1496 @@ HostedClusterStatus
 </em>
 </td>
 <td>
+<p>Status is the latest observed status of the HostedCluster.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec
-</h3>
+##NodePool { #hypershift.openshift.io/v1alpha1.NodePool }
+<p>
+<p>NodePool is a scalable set of worker nodes attached to a HostedCluster. NodePool
+machine architectures are uniform within a given pool, and are independent of
+the control plane’s underlying machine architecture.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+hypershift.openshift.io/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>NodePool</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">
+NodePoolSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the desired behavior of the NodePool.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>clusterName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ClusterName is the name of the Cluster this object belongs to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeCount</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>config</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+[]Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>TODO (alberto): this ConfigMaps are meant to contain
+MachineConfig, KubeletConfig and ContainerRuntimeConfig but
+MCO only supports MachineConfig in bootstrap mode atm
+<a href="https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119">https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119</a>
+By contractual convention the ConfigMap structure is as follow:
+type: ConfigMap
+data:
+config: |-</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodePoolManagement</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">
+NodePoolManagement
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>autoScaling</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.NodePoolAutoScaling">
+NodePoolAutoScaling
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>platform</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">
+NodePoolPlatform
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>release</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.Release">
+Release
+</a>
+</em>
+</td>
+<td>
+<p>Release specifies the release image to use for this NodePool
+For a nodePool a given version dictates the ignition config and
+an image artifact e.g an AMI in AWS.
+Release specifies the release image to use for this HostedCluster</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.NodePoolStatus">
+NodePoolStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status is the most recently observed status of the NodePool.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AESCBCSpec { #hypershift.openshift.io/v1alpha1.AESCBCSpec }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
+</p>
+<p>
+<p>AESCBCSpec defines metadata about the AESCBC secret encryption strategy</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>activeKey</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ActiveKey defines the active key used to encrypt new secrets</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backupKey</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackupKey defines the old key during the rotation process so previously created
+secrets can continue to be decrypted until they are all re-encrypted with the active key.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###APIServerNetworking { #hypershift.openshift.io/v1alpha1.APIServerNetworking }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">ClusterNetworking</a>)
+</p>
+<p>
+<p>APIServerNetworking specifies how the APIServer is exposed inside a worker node.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>advertiseAddress</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>AdvertiseAddress is the address that workers will use to talk to the
+API server. This is an address associated with the loopback adapter of
+each worker. If not specified, 172.20.0.1 is used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>port</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Port is the port at which the APIServer is exposed inside a worker node
+Other pods using host networking cannot listen on this port. If not
+specified, 6443 is used.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSCloudProviderConfig { #hypershift.openshift.io/v1alpha1.AWSCloudProviderConfig }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subnet</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">
+AWSResourceReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subnet is the subnet to use for instances</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>zone</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Zone is the availability zone where the instances are created</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vpc</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>VPC specifies the VPC used for the cluster</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSEndpointAccessType { #hypershift.openshift.io/v1alpha1.AWSEndpointAccessType }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Private&#34;</p></td>
+<td><p>Private endpoint access allows only private kube-apiserver access and private node communication with the control plane</p>
+</td>
+</tr><tr><td><p>&#34;Public&#34;</p></td>
+<td><p>Public endpoint access allows public kube-apiserver access and public node communication with the control plane</p>
+</td>
+</tr><tr><td><p>&#34;PublicAndPrivate&#34;</p></td>
+<td><p>PublicAndPrivate endpoint access allows public kube-apiserver access and private node communication with the control plane</p>
+</td>
+</tr></tbody>
+</table>
+###AWSKMSAuthSpec { #hypershift.openshift.io/v1alpha1.AWSKMSAuthSpec }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSKMSSpec">AWSKMSSpec</a>)
+</p>
+<p>
+<p>AWSKMSAuthSpec defines metadata about the management of credentials used to interact with AWS KMS</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>credentials</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Credentials contains the name of the secret that holds the aws credentials that can be used
+to make the necessary KMS calls. It should at key AWSCredentialsFileSecretKey contain the
+aws credentials file that can be used to configure AWS SDKs</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSKMSKeyEntry { #hypershift.openshift.io/v1alpha1.AWSKMSKeyEntry }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSKMSSpec">AWSKMSSpec</a>)
+</p>
+<p>
+<p>AWSKMSKeyEntry defines metadata to locate the encryption key in AWS</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>arn</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ARN is the Amazon Resource Name for the encryption key</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSKMSSpec { #hypershift.openshift.io/v1alpha1.AWSKMSSpec }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.KMSSpec">KMSSpec</a>)
+</p>
+<p>
+<p>AWSKMSSpec defines metadata about the configuration of the AWS KMS Secret Encryption provider</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>region</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Region contains the AWS region</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>activeKey</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSKMSKeyEntry">
+AWSKMSKeyEntry
+</a>
+</em>
+</td>
+<td>
+<p>ActiveKey defines the active key used to encrypt new secrets</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backupKey</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSKMSKeyEntry">
+AWSKMSKeyEntry
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackupKey defines the old key during the rotation process so previously created
+secrets can continue to be decrypted until they are all re-encrypted with the active key.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>auth</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSKMSAuthSpec">
+AWSKMSAuthSpec
+</a>
+</em>
+</td>
+<td>
+<p>Auth defines metadata about the management of credentials used to interact with AWS KMS</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSNodePoolPlatform { #hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>)
+</p>
+<p>
+<p>AWSNodePoolPlatform stores the configuration for a node pool
+installed on AWS.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>instanceType</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>InstanceType defines the ec2 instance type.
+eg. m4-large</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>instanceProfile</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>subnet</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">
+AWSResourceReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subnet is the subnet to use for instances</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ami</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AMI is the image id to use</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityGroups</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">
+[]AWSResourceReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityGroups is the set of security groups to associate with nodepool machines</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>rootVolume</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.Volume">
+Volume
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RootVolume specifies the root volume of the platform.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourceTags</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSResourceTag">
+[]AWSResourceTag
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>resourceTags is a list of additional tags to apply to AWS nodes.
+These will be merged with Cluster-level tags and Cluster-level tags take precedence in case of conflicts.
+See <a href="https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html">https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html</a> for information on tagging AWS resources.
+AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags
+available for the user.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSPlatformSpec { #hypershift.openshift.io/v1alpha1.AWSPlatformSpec }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>region</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Region is the AWS region for the cluster.
+This is used by CRs that are consumed by OCP Operators.
+E.g cluster-infrastructure-02-config.yaml and install-config.yaml
+This is also used by nodePools to fetch the default boot AMI in a given payload.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cloudProviderConfig</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSCloudProviderConfig">
+AWSCloudProviderConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CloudProviderConfig is used to generate the ConfigMap with the cloud config consumed
+by the Control Plane components.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceEndpoints</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSServiceEndpoint">
+[]AWSServiceEndpoint
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceEndpoints list contains custom endpoints which will override default
+service endpoint of AWS Services.
+There must be only one ServiceEndpoint for a service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>roles</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSRoleCredentials">
+[]AWSRoleCredentials
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>kubeCloudControllerCreds</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>KubeCloudControllerCreds is a reference to a secret containing cloud
+credentials with permissions matching the Kube cloud controller policy.
+The secret should have exactly one key, <code>credentials</code>, whose value is
+an AWS credentials file.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodePoolManagementCreds</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>NodePoolManagementCreds is a reference to a secret containing cloud
+credentials with permissions matching the noe pool management policy.
+The secret should have exactly one key, <code>credentials</code>, whose value is
+an AWS credentials file.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourceTags</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSResourceTag">
+[]AWSResourceTag
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>resourceTags is a list of additional tags to apply to AWS resources created for the cluster.
+See <a href="https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html">https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html</a> for information on tagging AWS resources.
+AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags
+available for the user.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>endpointAccess</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSEndpointAccessType">
+AWSEndpointAccessType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EndpointAccess determines if cluster endpoints are public and/or private</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSResourceReference { #hypershift.openshift.io/v1alpha1.AWSResourceReference }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>, 
+<a href="#hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)
+</p>
+<p>
+<p>AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.
+Only one of ID, ARN or Filters may be specified. Specifying more than one will result in
+a validation error.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ID of resource</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>arn</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ARN of resource</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>filters</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.Filter">
+[]Filter
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Filters is a set of key/value pairs used to identify a resource
+They are applied according to the rules defined by the AWS API:
+<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSResourceTag { #hypershift.openshift.io/v1alpha1.AWSResourceTag }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+</p>
+<p>
+<p>AWSResourceTag is a tag to apply to AWS resources created for the cluster.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>key</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>key is the key of the tag</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>value is the value of the tag.
+Some AWS service do not support empty values. Since tags are added to resources in many services, the
+length of the tag value must meet the requirements of all services.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSRoleCredentials { #hypershift.openshift.io/v1alpha1.AWSRoleCredentials }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>arn</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+###AWSServiceEndpoint { #hypershift.openshift.io/v1alpha1.AWSServiceEndpoint }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+</p>
+<p>
+<p>AWSServiceEndpoint stores the configuration for services to
+override existing defaults of AWS Services.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the AWS service.
+This must be provided and cannot be empty.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>url</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>URL is fully qualified URI with scheme https, that overrides the default generated
+endpoint for a client.
+This must be provided and cannot be empty.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###AvailabilityPolicy { #hypershift.openshift.io/v1alpha1.AvailabilityPolicy }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+</p>
+<p>
+<p>AvailabilityPolicy specifies a high level availability policy for components.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;HighlyAvailable&#34;</p></td>
+<td><p>HighlyAvailable means components should be resilient to problems across fault
+boundaries as defined by the component to which the policy is attached. This
+usually means running critical workloads with 3 replicas and with little or
+no toleration of disruption of the component.</p>
+</td>
+</tr><tr><td><p>&#34;SingleReplica&#34;</p></td>
+<td><p>SingleReplica means components are not expected to be resilient to problems
+across most fault boundaries associated with high availability. This usually
+means running critical workloads with just 1 replica and with toleration of
+full disruption of the component.</p>
+</td>
+</tr></tbody>
+</table>
+###ClusterAutoscaling { #hypershift.openshift.io/v1alpha1.ClusterAutoscaling }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>)
+</p>
+<p>
+<p>TODO maybe we have profiles for scaling behaviors</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>maxNodesTotal</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Maximum number of nodes in all node groups.
+Cluster autoscaler will not grow the cluster beyond this number.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxPodGracePeriod</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Gives pods graceful termination time before scaling down
+default: 600 seconds</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxNodeProvisionTime</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Maximum time CA waits for node to be provisioned
+default: 15 minutes</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podPriorityThreshold</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>To allow users to schedule &ldquo;best-effort&rdquo; pods, which shouldn&rsquo;t trigger
+Cluster Autoscaler actions, but only run when there are spare resources available,
+default: -10
+More info: <a href="https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption">https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+###ClusterConfiguration { #hypershift.openshift.io/v1alpha1.ClusterConfiguration }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+</p>
+<p>
+<p>ClusterConfiguration contains global configuration for a HostedCluster.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretRefs</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+[]Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecretRefs holds references to secrets used in configuration entries
+so that they can be properly synced by the hypershift operator.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>configMapRefs</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+[]Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConfigMapRefs holds references to configmaps used in configuration entries
+so that they can be properly synced by the hypershift operator.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>items</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#rawextension-runtime-pkg">
+[]k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Items embeds the configuration resource</p>
+</td>
+</tr>
+</tbody>
+</table>
+###ClusterNetworking { #hypershift.openshift.io/v1alpha1.ClusterNetworking }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>serviceCIDR</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>podCIDR</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>machineCIDR</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>networkType</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.NetworkType">
+NetworkType
+</a>
+</em>
+</td>
+<td>
+<p>NetworkType specifies the SDN provider used for cluster networking.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>apiServer</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.APIServerNetworking">
+APIServerNetworking
+</a>
+</em>
+</td>
+<td>
+<p>APIServer contains advanced network settings for the API server that affect
+how the APIServer is exposed inside a worker node.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###ClusterVersionStatus { #hypershift.openshift.io/v1alpha1.ClusterVersionStatus }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.HostedClusterStatus">HostedClusterStatus</a>)
+</p>
+<p>
+<p>ClusterVersionStatus reports the status of the cluster versioning,
+including any upgrades that are in progress. The current field will
+be set to whichever version the cluster is reconciling to, and the
+conditions array will report whether the update succeeded, is in
+progress, or is failing.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>desired</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.Release">
+Release
+</a>
+</em>
+</td>
+<td>
+<p>desired is the version that the cluster is reconciling towards.
+If the cluster is not yet fully initialized desired will be set
+with the information available, which may be an image or a tag.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>history</code></br>
+<em>
+[]github.com/openshift/api/config/v1.UpdateHistory
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>history contains a list of the most recent versions applied to the cluster.
+This value may be empty during cluster startup, and then will be updated
+when a new update is being applied. The newest update is first in the
+list and it is ordered by recency. Updates in the history have state
+Completed if the rollout completed - if an update was failing or halfway
+applied the state will be Partial. Only a limited amount of update history
+is preserved.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>observedGeneration reports which version of the spec is being synced.
+If this value is not equal to metadata.generation, then the desired
+and conditions fields may represent a previous version.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###ConditionType { #hypershift.openshift.io/v1alpha1.ConditionType }
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Available&#34;</p></td>
+<td><p>AWSEndpointServiceAvailable indicates whether the AWS Endpoint Service
+has been created for the specified NLB</p>
+</td>
+</tr><tr><td><p>&#34;ClusterVersionFailing&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;Available&#34;</p></td>
+<td><p>HostedClusterAvailable indicates whether the HostedCluster has a healthy
+control plane.</p>
+</td>
+</tr><tr><td><p>&#34;Available&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;IgnitionEndpointAvailable&#34;</p></td>
+<td><p>IgnitionEndpointAvailable indicates whether the ignition server for the
+HostedCluster is available to handle ignition requests.</p>
+</td>
+</tr><tr><td><p>&#34;InfrastructureReady&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;KubeAPIServerAvailable&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;SupportedHostedCluster&#34;</p></td>
+<td><p>SupportedHostedCluster indicates whether a HostedCluster is supported by
+the current configuration of the hypershift-operator.
+e.g. If HostedCluster requests endpointAcess Private but the hypershift-operator
+is running on a management cluster outside AWS or is not configured with AWS
+credentials, the HostedCluster is not supported.</p>
+</td>
+</tr><tr><td><p>&#34;UnmanagedEtcdAvailable&#34;</p></td>
+<td><p>UnmanagedEtcdAvailable indicates whether a user-managed etcd cluster is
+healthy.</p>
+</td>
+</tr><tr><td><p>&#34;ValidConfiguration&#34;</p></td>
+<td><p>ValidHostedClusterConfiguration indicates (if status is true) that the
+ClusterConfiguration specified for the HostedCluster is valid.</p>
+</td>
+</tr><tr><td><p>&#34;ValidHostedControlPlaneConfiguration&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+###DNSSpec { #hypershift.openshift.io/v1alpha1.DNSSpec }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+</p>
+<p>
+<p>DNSSpec specifies the DNS configuration in the cluster</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>baseDomain</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>BaseDomain is the base domain of the cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>publicZoneID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PublicZoneID is the Hosted Zone ID where all the DNS records that are publicly accessible to
+the internet exist.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>privateZoneID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PrivateZoneID is the Hosted Zone ID where all the DNS records that are only available internally
+to the cluster exist.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###EtcdManagementType { #hypershift.openshift.io/v1alpha1.EtcdManagementType }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">EtcdSpec</a>)
+</p>
+<p>
+<p>EtcdManagementType is a enum specifying the strategy for managing the cluster&rsquo;s etcd instance</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Managed&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;Unmanaged&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+###EtcdSpec { #hypershift.openshift.io/v1alpha1.EtcdSpec }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>managementType</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.EtcdManagementType">
+EtcdManagementType
+</a>
+</em>
+</td>
+<td>
+<p>ManagementType defines how the etcd cluster is managed. Unmanaged means
+the etcd cluster is managed by a system outside the hypershift controllers.
+Managed means the hypershift controllers manage the provisioning of the etcd cluster
+and the operations around it</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managed</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdSpec">
+ManagedEtcdSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Managed provides metadata that defines how the hypershift controllers manage the etcd cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>unmanaged</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.UnmanagedEtcdSpec">
+UnmanagedEtcdSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Unmanaged provides metadata that enables the Openshift controllers to connect to the external etcd cluster</p>
+</td>
+</tr>
+</tbody>
+</table>
+###EtcdTLSConfig { #hypershift.openshift.io/v1alpha1.EtcdTLSConfig }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.UnmanagedEtcdSpec">UnmanagedEtcdSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>clientSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ClientSecret refers to a secret for client MTLS authentication with the etcd cluster
+The CA must be stored at secret key etcd-client-ca.crt.
+The client cert must be stored at secret key etcd-client.crt.
+The client key must be stored at secret key etcd-client.key.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###Filter { #hypershift.openshift.io/v1alpha1.Filter }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">AWSResourceReference</a>)
+</p>
+<p>
+<p>Filter is a filter used to identify an AWS resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the filter. Filter names are case-sensitive.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>values</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Values includes one or more filter values. Filter values are case-sensitive.</p>
+</td>
+</tr>
+</tbody>
+</table>
+###HostedClusterSpec { #hypershift.openshift.io/v1alpha1.HostedClusterSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.HostedCluster">HostedCluster</a>)
@@ -1929,7 +2018,8 @@ AvailabilityPolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>ControllerAvailabilityPolicy specifies whether to run control plane controllers in HA mode
+<p>ControllerAvailabilityPolicy specifies an availability policy to apply
+to critical control plane components.
 Defaults to SingleReplica when not set.</p>
 </td>
 </tr>
@@ -2009,8 +2099,7 @@ cluster when applicable.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.HostedClusterStatus">HostedClusterStatus
-</h3>
+###HostedClusterStatus { #hypershift.openshift.io/v1alpha1.HostedClusterStatus }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.HostedCluster">HostedCluster</a>)
@@ -2083,362 +2172,7 @@ It exposes the config for instances to become kubernetes nodes.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.HostedControlPlane">HostedControlPlane
-</h3>
-<p>
-<p>HostedControlPlane defines the desired state of HostedControlPlane</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">
-HostedControlPlaneSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>releaseImage</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>pullSecret</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>issuerURL</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>podCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>machineCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>networkType</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.NetworkType">
-NetworkType
-</a>
-</em>
-</td>
-<td>
-<p>NetworkType specifies the SDN provider used for cluster networking.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sshKey</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>infraID</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>platform</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">
-PlatformSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>dns</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.DNSSpec">
-DNSSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiPort</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>APIPort is the port at which the APIServer listens inside a worker</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiAdvertiseAddress</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>APIAdvertiseAddress is the address at which the APIServer listens
-inside a worker.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>controllerAvailabilityPolicy</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AvailabilityPolicy">
-AvailabilityPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ControllerAvailabilityPolicy specifies whether to run control plane controllers in HA mode
-Defaults to SingleReplica when not set</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>infrastructureAvailabilityPolicy</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AvailabilityPolicy">
-AvailabilityPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>InfrastructureAvailabilityPolicy specifies whether to run infrastructure services that
-run on the guest cluster nodes in HA mode
-Defaults to HighlyAvailable when not set</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>fips</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>FIPS specifies if the nodes for the cluster will be running in FIPS mode</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kubeconfig</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.KubeconfigSecretRef">
-KubeconfigSecretRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>KubeConfig specifies the name and key for the kubeconfig secret</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>services</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping">
-[]ServicePublishingStrategyMapping
-</a>
-</em>
-</td>
-<td>
-<p>Services defines metadata about how control plane services are published
-in the management cluster.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>auditWebhook</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>AuditWebhook contains metadata for configuring an audit webhook
-endpoint for a cluster to process cluster audit events. It references
-a secret that contains the webhook information for the audit webhook endpoint.
-It is a secret because if the endpoint has MTLS the kubeconfig will contain client
-keys. This is currently only supported in IBM Cloud. The kubeconfig needs to be stored
-in the secret with a secret key name that corresponds to the constant AuditWebhookKubeconfigKey.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>etcd</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">
-EtcdSpec
-</a>
-</em>
-</td>
-<td>
-<p>Etcd contains metadata about the etcd cluster the hypershift managed Openshift control plane components
-use to store data.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>configuration</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterConfiguration">
-ClusterConfiguration
-</a>
-</em>
-</td>
-<td>
-<p>Configuration embeds resources that correspond to the openshift configuration API:
-<a href="https://docs.openshift.com/container-platform/4.7/rest_api/config_apis/config-apis-index.html">https://docs.openshift.com/container-platform/4.7/rest_api/config_apis/config-apis-index.html</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>imageContentSources</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.ImageContentSource">
-[]ImageContentSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ImageContentSources lists sources/repositories for the release-image content.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretEncryption</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">
-SecretEncryptionSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecretEncryption contains metadata about the kubernetes secret encryption strategy being used for the
-cluster when applicable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneStatus">
-HostedControlPlaneStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlane">HostedControlPlane</a>)
-</p>
+###HostedControlPlaneSpec { #hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec }
 <p>
 <p>HostedControlPlaneSpec defines the desired state of HostedControlPlane</p>
 </p>
@@ -2745,12 +2479,7 @@ cluster when applicable.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.HostedControlPlaneStatus">HostedControlPlaneStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlane">HostedControlPlane</a>)
-</p>
+###HostedControlPlaneStatus { #hypershift.openshift.io/v1alpha1.HostedControlPlaneStatus }
 <p>
 <p>HostedControlPlaneStatus defines the observed state of HostedControlPlane</p>
 </p>
@@ -2885,8 +2614,7 @@ Current condition types are: &ldquo;Available&rdquo;</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec
-</h3>
+###IBMCloudKMSAuthSpec { #hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSSpec">IBMCloudKMSSpec</a>)
@@ -2946,8 +2674,7 @@ KMS system (all provider managed).</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthType">IBMCloudKMSAuthType
-(<code>string</code> alias)</p></h3>
+###IBMCloudKMSAuthType { #hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthType }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec</a>)
@@ -2955,8 +2682,24 @@ KMS system (all provider managed).</p>
 <p>
 <p>IBMCloudKMSAuthType defines the IBM Cloud KMS authentication strategy</p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.IBMCloudKMSKeyEntry">IBMCloudKMSKeyEntry
-</h3>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Managed&#34;</p></td>
+<td><p>IBMCloudKMSManagedAuth defines the KMS authentication strategy where the IKS/ROKS platform uses
+service to service auth to call IBM Cloud KMS APIs (no customer credentials requried)</p>
+</td>
+</tr><tr><td><p>&#34;Unmanaged&#34;</p></td>
+<td><p>IBMCloudKMSUnmanagedAuth defines the KMS authentication strategy where a customer supplies IBM Cloud
+authentication to interact with IBM Cloud KMS APIs</p>
+</td>
+</tr></tbody>
+</table>
+###IBMCloudKMSKeyEntry { #hypershift.openshift.io/v1alpha1.IBMCloudKMSKeyEntry }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSSpec">IBMCloudKMSSpec</a>)
@@ -3030,8 +2773,7 @@ key is enabled for data encryption.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.IBMCloudKMSManagedAuthSpec">IBMCloudKMSManagedAuthSpec
-</h3>
+###IBMCloudKMSManagedAuthSpec { #hypershift.openshift.io/v1alpha1.IBMCloudKMSManagedAuthSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec</a>)
@@ -3040,8 +2782,7 @@ key is enabled for data encryption.</p>
 <p>IBMCloudKMSManagedAuthSpec defines metadata around the service to service authentication strategy for the IBM Cloud
 KMS system (all provider managed).</p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.IBMCloudKMSSpec">IBMCloudKMSSpec
-</h3>
+###IBMCloudKMSSpec { #hypershift.openshift.io/v1alpha1.IBMCloudKMSSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.KMSSpec">KMSSpec</a>)
@@ -3096,8 +2837,7 @@ IBMCloudKMSAuthSpec
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.IBMCloudKMSUnmanagedAuthSpec">IBMCloudKMSUnmanagedAuthSpec
-</h3>
+###IBMCloudKMSUnmanagedAuthSpec { #hypershift.openshift.io/v1alpha1.IBMCloudKMSUnmanagedAuthSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec</a>)
@@ -3129,8 +2869,7 @@ call IBM Cloud KMS APIs</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.ImageContentSource">ImageContentSource
-</h3>
+###ImageContentSource { #hypershift.openshift.io/v1alpha1.ImageContentSource }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
@@ -3172,16 +2911,14 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.InPlaceUpgrade">InPlaceUpgrade
-</h3>
+###InPlaceUpgrade { #hypershift.openshift.io/v1alpha1.InPlaceUpgrade }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">NodePoolManagement</a>)
 </p>
 <p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.KMSProvider">KMSProvider
-(<code>string</code> alias)</p></h3>
+###KMSProvider { #hypershift.openshift.io/v1alpha1.KMSProvider }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.KMSSpec">KMSSpec</a>)
@@ -3189,8 +2926,20 @@ string
 <p>
 <p>KMSProvider defines the supported KMS providers</p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.KMSSpec">KMSSpec
-</h3>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;AWS&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;IBMCloud&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+###KMSSpec { #hypershift.openshift.io/v1alpha1.KMSSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
@@ -3249,47 +2998,7 @@ AWSKMSSpec
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.KubeconfigSecretRef">KubeconfigSecretRef
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>key</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.ManagedEtcdSpec">ManagedEtcdSpec
-</h3>
+###ManagedEtcdSpec { #hypershift.openshift.io/v1alpha1.ManagedEtcdSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">EtcdSpec</a>)
@@ -3319,8 +3028,7 @@ ManagedEtcdStorageSpec
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.ManagedEtcdStorageSpec">ManagedEtcdStorageSpec
-</h3>
+###ManagedEtcdStorageSpec { #hypershift.openshift.io/v1alpha1.ManagedEtcdStorageSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdSpec">ManagedEtcdSpec</a>)
@@ -3368,16 +3076,26 @@ availability configuration).</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.ManagedEtcdStorageType">ManagedEtcdStorageType
-(<code>string</code> alias)</p></h3>
+###ManagedEtcdStorageType { #hypershift.openshift.io/v1alpha1.ManagedEtcdStorageType }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdStorageSpec">ManagedEtcdStorageSpec</a>)
 </p>
 <p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.NetworkType">NetworkType
-(<code>string</code> alias)</p></h3>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;PersistentVolume&#34;</p></td>
+<td><p>PersistentVolumeEtcdStorage uses PersistentVolumes for etcd storage.</p>
+</td>
+</tr></tbody>
+</table>
+###NetworkType { #hypershift.openshift.io/v1alpha1.NetworkType }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">ClusterNetworking</a>, 
@@ -3386,160 +3104,22 @@ availability configuration).</p>
 <p>
 <p>NetworkType specifies the SDN provider used for cluster networking.</p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.NodePool">NodePool
-</h3>
-<p>
-<p>NodePool defines the desired state of NodePool</p>
-</p>
 <table>
 <thead>
 <tr>
-<th>Field</th>
+<th>Value</th>
 <th>Description</th>
 </tr>
 </thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
+<tbody><tr><td><p>&#34;Calico&#34;</p></td>
+<td><p>Calico specifies Calico as the SDN provider</p>
 </td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
+</tr><tr><td><p>&#34;OpenShiftSDN&#34;</p></td>
+<td><p>OpenShiftSDN specifies OpenshiftSDN as the SDN provider</p>
 </td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">
-NodePoolSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>clusterName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ClusterName is the name of the Cluster this object belongs to.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodeCount</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>config</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-[]Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>TODO (alberto): this ConfigMaps are meant to contain
-MachineConfig, KubeletConfig and ContainerRuntimeConfig but
-MCO only supports MachineConfig in bootstrap mode atm
-<a href="https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119">https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119</a>
-By contractual convention the ConfigMap structure is as follow:
-type: ConfigMap
-data:
-config: |-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodePoolManagement</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">
-NodePoolManagement
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>autoScaling</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolAutoScaling">
-NodePoolAutoScaling
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>platform</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">
-NodePoolPlatform
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>release</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.Release">
-Release
-</a>
-</em>
-</td>
-<td>
-<p>Release specifies the release image to use for this NodePool
-For a nodePool a given version dictates the ignition config and
-an image artifact e.g an AMI in AWS.
-Release specifies the release image to use for this HostedCluster</p>
-</td>
-</tr>
+</tr></tbody>
 </table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolStatus">
-NodePoolStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="hypershift.openshift.io/v1alpha1.NodePoolAutoScaling">NodePoolAutoScaling
-</h3>
+###NodePoolAutoScaling { #hypershift.openshift.io/v1alpha1.NodePoolAutoScaling }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">NodePoolSpec</a>)
@@ -3576,8 +3156,7 @@ int32
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.NodePoolManagement">NodePoolManagement
-</h3>
+###NodePoolManagement { #hypershift.openshift.io/v1alpha1.NodePoolManagement }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">NodePoolSpec</a>)
@@ -3641,8 +3220,7 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform
-</h3>
+###NodePoolPlatform { #hypershift.openshift.io/v1alpha1.NodePoolPlatform }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">NodePoolSpec</a>)
@@ -3686,8 +3264,7 @@ AWSNodePoolPlatform
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.NodePoolSpec">NodePoolSpec
-</h3>
+###NodePoolSpec { #hypershift.openshift.io/v1alpha1.NodePoolSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePool">NodePool</a>)
@@ -3800,8 +3377,7 @@ Release specifies the release image to use for this HostedCluster</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.NodePoolStatus">NodePoolStatus
-</h3>
+###NodePoolStatus { #hypershift.openshift.io/v1alpha1.NodePoolStatus }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePool">NodePool</a>)
@@ -3857,8 +3433,7 @@ an image artifact e.g an AMI in AWS.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.NodePortPublishingStrategy">NodePortPublishingStrategy
-</h3>
+###NodePortPublishingStrategy { #hypershift.openshift.io/v1alpha1.NodePortPublishingStrategy }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
@@ -3898,8 +3473,7 @@ int32
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.PersistentVolumeEtcdStorageSpec">PersistentVolumeEtcdStorageSpec
-</h3>
+###PersistentVolumeEtcdStorageSpec { #hypershift.openshift.io/v1alpha1.PersistentVolumeEtcdStorageSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdStorageSpec">ManagedEtcdStorageSpec</a>)
@@ -3945,8 +3519,7 @@ k8s.io/apimachinery/pkg/api/resource.Quantity
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec
-</h3>
+###PlatformSpec { #hypershift.openshift.io/v1alpha1.PlatformSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
@@ -3991,8 +3564,7 @@ AWSPlatformSpec
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.PlatformType">PlatformType
-(<code>string</code> alias)</p></h3>
+###PlatformType { #hypershift.openshift.io/v1alpha1.PlatformType }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>, 
@@ -4001,8 +3573,23 @@ AWSPlatformSpec
 <p>
 <p>PlatformType is a specific supported infrastructure provider.</p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.PublishingStrategyType">PublishingStrategyType
-(<code>string</code> alias)</p></h3>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;AWS&#34;</p></td>
+<td><p>AWSPlatformType represents Amazon Web Services infrastructure.</p>
+</td>
+</tr><tr><td><p>&#34;IBMCloud&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+###PublishingStrategyType { #hypershift.openshift.io/v1alpha1.PublishingStrategyType }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
@@ -4010,8 +3597,7 @@ AWSPlatformSpec
 <p>
 <p>PublishingStrategyType defines publishing strategies for services.</p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.Release">Release
-</h3>
+###Release { #hypershift.openshift.io/v1alpha1.Release }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ClusterVersionStatus">ClusterVersionStatus</a>, 
@@ -4041,8 +3627,7 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.ReplaceUpgrade">ReplaceUpgrade
-</h3>
+###ReplaceUpgrade { #hypershift.openshift.io/v1alpha1.ReplaceUpgrade }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">NodePoolManagement</a>)
@@ -4083,8 +3668,7 @@ RollingUpdate
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.RollingUpdate">RollingUpdate
-</h3>
+###RollingUpdate { #hypershift.openshift.io/v1alpha1.RollingUpdate }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ReplaceUpgrade">ReplaceUpgrade</a>)
@@ -4125,8 +3709,7 @@ k8s.io/apimachinery/pkg/util/intstr.IntOrString
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">SecretEncryptionSpec
-</h3>
+###SecretEncryptionSpec { #hypershift.openshift.io/v1alpha1.SecretEncryptionSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
@@ -4187,8 +3770,7 @@ AESCBCSpec
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.SecretEncryptionType">SecretEncryptionType
-(<code>string</code> alias)</p></h3>
+###SecretEncryptionType { #hypershift.openshift.io/v1alpha1.SecretEncryptionType }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
@@ -4196,8 +3778,22 @@ AESCBCSpec
 <p>
 <p>SecretEncryptionType defines the type of kube secret encryption being used.</p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.ServicePublishingStrategy">ServicePublishingStrategy
-</h3>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;aescbc&#34;</p></td>
+<td><p>AESCBC uses AES-CBC with PKCS#7 padding to do secret encryption</p>
+</td>
+</tr><tr><td><p>&#34;kms&#34;</p></td>
+<td><p>KMS integrates with a cloud provider&rsquo;s key management service to do secret encryption</p>
+</td>
+</tr></tbody>
+</table>
+###ServicePublishingStrategy { #hypershift.openshift.io/v1alpha1.ServicePublishingStrategy }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping">ServicePublishingStrategyMapping</a>)
@@ -4241,8 +3837,7 @@ NodePortPublishingStrategy
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping">ServicePublishingStrategyMapping
-</h3>
+###ServicePublishingStrategyMapping { #hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
@@ -4286,8 +3881,7 @@ ServicePublishingStrategy
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.ServiceType">ServiceType
-(<code>string</code> alias)</p></h3>
+###ServiceType { #hypershift.openshift.io/v1alpha1.ServiceType }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping">ServicePublishingStrategyMapping</a>)
@@ -4295,8 +3889,7 @@ ServicePublishingStrategy
 <p>
 <p>ServiceType defines what control plane services can be exposed from the management control plane</p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.UnmanagedEtcdSpec">UnmanagedEtcdSpec
-</h3>
+###UnmanagedEtcdSpec { #hypershift.openshift.io/v1alpha1.UnmanagedEtcdSpec }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">EtcdSpec</a>)
@@ -4340,24 +3933,47 @@ the etcd cluster</p>
 </tr>
 </tbody>
 </table>
-<h3 id="hypershift.openshift.io/v1alpha1.UpgradeStrategy">UpgradeStrategy
-(<code>string</code> alias)</p></h3>
+###UpgradeStrategy { #hypershift.openshift.io/v1alpha1.UpgradeStrategy }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.ReplaceUpgrade">ReplaceUpgrade</a>)
 </p>
 <p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.UpgradeType">UpgradeType
-(<code>string</code> alias)</p></h3>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;OnDelete&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;RollingUpdate&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+###UpgradeType { #hypershift.openshift.io/v1alpha1.UpgradeType }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">NodePoolManagement</a>)
 </p>
 <p>
 </p>
-<h3 id="hypershift.openshift.io/v1alpha1.Volume">Volume
-</h3>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;InPlace&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;Replace&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+###Volume { #hypershift.openshift.io/v1alpha1.Volume }
 <p>
 (<em>Appears on:</em>
 <a href="#hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,3 +9,7 @@ plugins:
 docs_dir: content
 repo_url: https://github.com/openshift/hypershift
 repo_name: openshift/hypershift
+markdown_extensions:
+- toc:
+    toc_depth: "2-2"
+- attr_list:


### PR DESCRIPTION
This commit updates API documentation on the Go types and also improves
the generated API documentation to include only the public types, as well
as other minor small fixes for readability.

Note that the `+gencopy` comments added to the API types are to work around
an issue[1] in the upstream docs generation code which doesn't yet understand
the `+kubebuilder:object:root` tag. This is necessary to make the generator
understand which types are "public" (e.g. HostedCluster and NodePool).

[1] https://github.com/ahmetb/gen-crd-api-reference-docs/pull/26