### PR TITLE
cleanup GetCluster

### DIFF
--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -45,12 +45,11 @@ func GetCluster(ctx context.Context, o *DestroyOptions) (*hyperv1.HostedCluster,
 		if apierrors.IsNotFound(err) {
 			log.Info("Hosted cluster not found, destroying infrastructure from user input", "namespace", o.Namespace, "name", o.Name, "infraID", o.InfraID)
 			return nil, nil
-		} else {
-			return nil, fmt.Errorf("failed to get hostedcluster: %w", err)
 		}
-	} else {
-		log.Info("Found hosted cluster", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name)
+		return nil, fmt.Errorf("failed to get hostedcluster: %w", err)
 	}
+
+	log.Info("Found hosted cluster", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name)
 	return &hostedCluster, nil
 }
 


### PR DESCRIPTION
Removing unneeded elses in `GetCluster` as follow up to https://github.com/openshift/hypershift/pull/666#discussion_r746944554