### PR TITLE
Replace default ingress controller bootstrap manifests

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -79,6 +79,17 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
 				"update",
 			},
 		},
+		{
+			APIGroups: []string{corev1.SchemeGroupVersion.Group},
+			Resources: []string{
+				"secrets",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
 	}
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/ingresscontroller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/ingresscontroller.go
@@ -3,95 +3,15 @@ package ingress
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
-	"github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/util"
 )
 
 const (
 	HypershiftRouteLabel = "hypershift.openshift.io/hosted-control-plane"
 )
-
-func ReconcileDefaultIngressControllerWorkerManifest(cm *corev1.ConfigMap, ownerRef config.OwnerRef, ingressSubdomain string, platformType hyperv1.PlatformType, replicas int32) error {
-	ownerRef.ApplyTo(cm)
-	ingressController := manifests.IngressDefaultIngressController()
-	if err := reconcileDefaultIngressController(ingressController, ingressSubdomain, platformType, replicas); err != nil {
-		return err
-	}
-	return util.ReconcileWorkerManifest(cm, ingressController)
-}
-
-func ReconcileDefaultIngressControllerCertWorkerManifest(cm *corev1.ConfigMap, ownerRef config.OwnerRef, ingressCert *corev1.Secret) error {
-	ownerRef.ApplyTo(cm)
-	certSecret := manifests.IngressDefaultIngressControllerCert()
-	if err := reconcileDefaultIngressControllerCertSecret(certSecret, ingressCert); err != nil {
-		return err
-	}
-	return util.ReconcileWorkerManifest(cm, certSecret)
-}
-
-func reconcileDefaultIngressController(ingressController *operatorv1.IngressController, ingressSubdomain string, platformType hyperv1.PlatformType, replicas int32) error {
-	ingressController.Spec.Domain = ingressSubdomain
-	ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
-		Type: operatorv1.LoadBalancerServiceStrategyType,
-	}
-	if replicas > 0 {
-		ingressController.Spec.Replicas = &(replicas)
-	}
-	switch platformType {
-	case hyperv1.NonePlatform:
-		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
-			Type: operatorv1.HostNetworkStrategyType,
-		}
-		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
-			Name: manifests.IngressDefaultIngressControllerCert().Name,
-		}
-	case hyperv1.IBMCloudPlatform:
-		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
-			Type: operatorv1.LoadBalancerServiceStrategyType,
-			LoadBalancer: &operatorv1.LoadBalancerStrategy{
-				Scope: operatorv1.ExternalLoadBalancer,
-			},
-		}
-		ingressController.Spec.NodePlacement = &operatorv1.NodePlacement{
-			Tolerations: []corev1.Toleration{
-				{
-					Key:   "dedicated",
-					Value: "edge",
-				},
-			},
-		}
-	default:
-		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
-			Type: operatorv1.LoadBalancerServiceStrategyType,
-		}
-		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
-			Name: manifests.IngressDefaultIngressControllerCert().Name,
-		}
-	}
-	return nil
-}
-
-func reconcileDefaultIngressControllerCertSecret(certSecret *corev1.Secret, sourceSecret *corev1.Secret) error {
-	if _, hasCertKey := sourceSecret.Data[corev1.TLSCertKey]; !hasCertKey {
-		return fmt.Errorf("source secret %s/%s does not have a cert key", sourceSecret.Namespace, sourceSecret.Name)
-	}
-	if _, hasKeyKey := sourceSecret.Data[corev1.TLSPrivateKeyKey]; !hasKeyKey {
-		return fmt.Errorf("source secret %s/%s does not have a key key", sourceSecret.Namespace, sourceSecret.Name)
-	}
-
-	if certSecret.Data == nil {
-		certSecret.Data = map[string][]byte{}
-	}
-	certSecret.Data[corev1.TLSCertKey] = sourceSecret.Data[corev1.TLSCertKey]
-	certSecret.Data[corev1.TLSPrivateKeyKey] = sourceSecret.Data[corev1.TLSPrivateKeyKey]
-	return nil
-}
 
 func ReconcilePrivateIngressController(ingressController *operatorv1.IngressController, name, domain string, platformType hyperv1.PlatformType) error {
 	ingressController.Spec.Domain = domain

--- a/hosted-cluster-config-operator/controllers/resources/ingress/params.go
+++ b/hosted-cluster-config-operator/controllers/resources/ingress/params.go
@@ -1,0 +1,24 @@
+package ingress
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/globalconfig"
+)
+
+type IngressParams struct {
+	IngressSubdomain string
+	Replicas         int32
+	PlatformType     hyperv1.PlatformType
+}
+
+func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
+	var replicas int32 = 2
+	if hcp.Spec.InfrastructureAvailabilityPolicy == hyperv1.SingleReplica {
+		replicas = 1
+	}
+	return &IngressParams{
+		IngressSubdomain: globalconfig.IngressDomain(hcp),
+		Replicas:         replicas,
+		PlatformType:     hcp.Spec.Platform.Type,
+	}
+}

--- a/hosted-cluster-config-operator/controllers/resources/ingress/reconcile.go
+++ b/hosted-cluster-config-operator/controllers/resources/ingress/reconcile.go
@@ -1,0 +1,67 @@
+package ingress
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/hosted-cluster-config-operator/controllers/resources/manifests"
+)
+
+func ReconcileDefaultIngressController(ingressController *operatorv1.IngressController, ingressSubdomain string, platformType hyperv1.PlatformType, replicas int32) error {
+	ingressController.Spec.Domain = ingressSubdomain
+	ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+		Type: operatorv1.LoadBalancerServiceStrategyType,
+	}
+	if replicas > 0 {
+		ingressController.Spec.Replicas = &(replicas)
+	}
+	switch platformType {
+	case hyperv1.NonePlatform:
+		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+			Type: operatorv1.HostNetworkStrategyType,
+		}
+		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
+			Name: manifests.IngressDefaultIngressControllerCert().Name,
+		}
+	case hyperv1.IBMCloudPlatform:
+		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+			Type: operatorv1.LoadBalancerServiceStrategyType,
+			LoadBalancer: &operatorv1.LoadBalancerStrategy{
+				Scope: operatorv1.ExternalLoadBalancer,
+			},
+		}
+		ingressController.Spec.NodePlacement = &operatorv1.NodePlacement{
+			Tolerations: []corev1.Toleration{
+				{
+					Key:   "dedicated",
+					Value: "edge",
+				},
+			},
+		}
+	default:
+		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+			Type: operatorv1.LoadBalancerServiceStrategyType,
+		}
+		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
+			Name: manifests.IngressDefaultIngressControllerCert().Name,
+		}
+	}
+	return nil
+}
+
+func ReconcileDefaultIngressControllerCertSecret(certSecret *corev1.Secret, sourceSecret *corev1.Secret) error {
+	if _, hasCertKey := sourceSecret.Data[corev1.TLSCertKey]; !hasCertKey {
+		return fmt.Errorf("source secret %s/%s does not have a cert key", sourceSecret.Namespace, sourceSecret.Name)
+	}
+	if _, hasKeyKey := sourceSecret.Data[corev1.TLSPrivateKeyKey]; !hasKeyKey {
+		return fmt.Errorf("source secret %s/%s does not have a key key", sourceSecret.Namespace, sourceSecret.Name)
+	}
+
+	certSecret.Data = map[string][]byte{}
+	certSecret.Data[corev1.TLSCertKey] = sourceSecret.Data[corev1.TLSCertKey]
+	certSecret.Data[corev1.TLSPrivateKeyKey] = sourceSecret.Data[corev1.TLSPrivateKeyKey]
+	return nil
+}

--- a/hosted-cluster-config-operator/controllers/resources/manifests/ingress.go
+++ b/hosted-cluster-config-operator/controllers/resources/manifests/ingress.go
@@ -1,0 +1,35 @@
+package manifests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+func IngressDefaultIngressController() *operatorv1.IngressController {
+	return &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "openshift-ingress-operator",
+		},
+	}
+}
+
+func IngressDefaultIngressControllerCert() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-ingress-cert",
+			Namespace: "openshift-ingress",
+		},
+	}
+}
+
+func IngressCert(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-crt",
+			Namespace: ns,
+		},
+	}
+}

--- a/hosted-cluster-config-operator/controllers/resources/resources.go
+++ b/hosted-cluster-config-operator/controllers/resources/resources.go
@@ -20,6 +20,7 @@ import (
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/hosted-cluster-config-operator/controllers/resources/crd"
+	"github.com/openshift/hypershift/hosted-cluster-config-operator/controllers/resources/ingress"
 	"github.com/openshift/hypershift/hosted-cluster-config-operator/controllers/resources/manifests"
 	"github.com/openshift/hypershift/hosted-cluster-config-operator/controllers/resources/monitoring"
 	"github.com/openshift/hypershift/hosted-cluster-config-operator/controllers/resources/namespaces"
@@ -138,6 +139,11 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		return nil
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile imageregistry config: %w", err))
+	}
+
+	log.Info("reconciling ingress controller")
+	if err := r.reconcileIngressController(ctx, hcp); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile ingress controller: %w", err))
 	}
 
 	log.Info("reconciling kube control plane signer secret")
@@ -344,5 +350,29 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 		}
 	}
 
+	return errors.NewAggregate(errs)
+}
+
+func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	var errs []error
+	p := ingress.NewIngressParams(hcp)
+	ingressController := manifests.IngressDefaultIngressController()
+	if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
+		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas)
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
+	}
+
+	sourceCert := manifests.IngressCert(hcp.Namespace)
+	if err := r.cpClient.Get(ctx, crclient.ObjectKeyFromObject(sourceCert), sourceCert); err != nil {
+		errs = append(errs, fmt.Errorf("failed to get ingress cert (%s/%s) from control plane: %w", sourceCert.Namespace, sourceCert.Name, err))
+	} else {
+		ingressControllerCert := manifests.IngressDefaultIngressControllerCert()
+		if _, err := r.CreateOrUpdate(ctx, r.client, ingressControllerCert, func() error {
+			return ingress.ReconcileDefaultIngressControllerCertSecret(ingressControllerCert, sourceCert)
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller cert: %w", err))
+		}
+	}
 	return errors.NewAggregate(errs)
 }

--- a/support/globalconfig/dns.go
+++ b/support/globalconfig/dns.go
@@ -18,7 +18,7 @@ func DNSConfig() *configv1.DNS {
 }
 
 func ReconcileDNSConfig(dns *configv1.DNS, hcp *hyperv1.HostedControlPlane) {
-	dns.Spec.BaseDomain = baseDomain(hcp)
+	dns.Spec.BaseDomain = BaseDomain(hcp)
 	if len(hcp.Spec.DNS.PublicZoneID) > 0 {
 		dns.Spec.PublicZone = &configv1.DNSZone{
 			ID: hcp.Spec.DNS.PublicZoneID,
@@ -31,6 +31,6 @@ func ReconcileDNSConfig(dns *configv1.DNS, hcp *hyperv1.HostedControlPlane) {
 	}
 }
 
-func baseDomain(hcp *hyperv1.HostedControlPlane) string {
+func BaseDomain(hcp *hyperv1.HostedControlPlane) string {
 	return fmt.Sprintf("%s.%s", hcp.Name, hcp.Spec.DNS.BaseDomain)
 }

--- a/support/globalconfig/infrastructure.go
+++ b/support/globalconfig/infrastructure.go
@@ -26,7 +26,7 @@ func ReconcileInfrastructure(infra *configv1.Infrastructure, hcp *hyperv1.Hosted
 	infra.Spec.PlatformSpec.Type = configv1.PlatformType(hcp.Spec.Platform.Type)
 	infra.Status.APIServerInternalURL = fmt.Sprintf("https://%s:%d", apiServerAddress, apiServerPort)
 	infra.Status.APIServerURL = fmt.Sprintf("https://%s:%d", apiServerAddress, apiServerPort)
-	infra.Status.EtcdDiscoveryDomain = baseDomain(hcp)
+	infra.Status.EtcdDiscoveryDomain = BaseDomain(hcp)
 	infra.Status.InfrastructureName = hcp.Spec.InfraID
 	infra.Status.Platform = configv1.PlatformType(hcp.Spec.Platform.Type)
 	infra.Status.ControlPlaneTopology = configv1.ExternalTopologyMode

--- a/support/globalconfig/ingress.go
+++ b/support/globalconfig/ingress.go
@@ -18,7 +18,7 @@ func IngressConfig() *configv1.Ingress {
 }
 
 func ReconcileIngressConfig(cfg *configv1.Ingress, hcp *hyperv1.HostedControlPlane, globalConfig GlobalConfig) {
-	cfg.Spec.Domain = ingressDomain(hcp)
+	cfg.Spec.Domain = IngressDomain(hcp)
 	if globalConfig.Ingress != nil {
 		// For now only the AppsDomain is configurable through the HCP configuration
 		// field. As needed, we can enable other parts of the spec.
@@ -26,6 +26,6 @@ func ReconcileIngressConfig(cfg *configv1.Ingress, hcp *hyperv1.HostedControlPla
 	}
 }
 
-func ingressDomain(hcp *hyperv1.HostedControlPlane) string {
-	return fmt.Sprintf("apps.%s", baseDomain(hcp))
+func IngressDomain(hcp *hyperv1.HostedControlPlane) string {
+	return fmt.Sprintf("apps.%s", BaseDomain(hcp))
 }


### PR DESCRIPTION
Removes code that creates user-manifest configmaps for the default
ingress controller and adds code to the hosted cluster config
operator to reconcile the resources directly with the guest cluster.