### PR TITLE
remove need for hostnetwork from konnectivity agent daemonset

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -278,7 +278,6 @@ func reconcileWorkerAgentDaemonSet(daemonset *appsv1.DaemonSet, deploymentConfig
 				SecurityContext: &corev1.PodSecurityContext{
 					RunAsUser: pointer.Int64Ptr(1000),
 				},
-				HostNetwork: true,
 				Containers: []corev1.Container{
 					util.BuildContainer(konnectivityAgentContainer(), buildKonnectivityWorkerAgentContainer(image, host, port)),
 				},


### PR DESCRIPTION
Previously: when debugging konnectivity I believed this was necessary with the redumentary haproxy solution we were using. Now that we have moved to the SOCKS proxy I no longer think host network is necessary for the daemonset. This is a more secure solution since the ports aren't exposed on the node and helps prevent network conflicts with other host network pods