### PR TITLE
AWS: Fix volumes by passing cloud provider creds to KAS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	Provider          = "aws"
+	Provider          = util.AWSCloudProviderName
 	ProviderConfigKey = "aws.conf"
 )
 

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/util"
@@ -57,11 +56,6 @@ var (
 	cloudProviderConfigVolumeMount = util.PodVolumeMounts{
 		kasContainerMain().Name: {
 			kasVolumeCloudConfig().Name: "/etc/kubernetes/cloud",
-		},
-	}
-	cloudProviderCredsVolumeMount = util.PodVolumeMounts{
-		kasContainerMain().Name: {
-			kasVolumeCloudProviderCreds().Name: "/etc/kubernetes/secrets/cloud-provider",
 		},
 	}
 
@@ -171,6 +165,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 				util.BuildVolume(kasVolumeKubeletClientCA(), buildKASVolumeKubeletClientCA),
 				util.BuildVolume(kasVolumeKonnectivityClientCert(), buildKASVolumeKonnectivityClientCert),
 				util.BuildVolume(kasVolumeEgressSelectorConfig(), buildKASVolumeEgressSelectorConfig),
+				util.BuildVolume(kasVolumeKubeconfig(), buildKASVolumeKubeconfig),
 			},
 		},
 	}
@@ -179,7 +174,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	}
 	applyNamedCertificateMounts(namedCertificates, &deployment.Spec.Template.Spec)
 	applyCloudConfigVolumeMount(cloudProviderConfigRef, &deployment.Spec.Template.Spec)
-	applyCloudProviderCreds(&deployment.Spec.Template.Spec, cloudProviderName, cloudProviderCreds)
+	util.ApplyCloudProviderCreds(&deployment.Spec.Template.Spec, cloudProviderName, cloudProviderCreds, images.TokenMinterImage, kasContainerMain().Name)
 
 	if auditWebhookRef != nil {
 		applyKASAuditWebhookConfigFileVolume(&deployment.Spec.Template.Spec, auditWebhookRef)
@@ -459,12 +454,6 @@ func kasVolumeEgressSelectorConfig() *corev1.Volume {
 	}
 }
 
-func kasVolumeCloudProviderCreds() *corev1.Volume {
-	return &corev1.Volume{
-		Name: "cloud-creds",
-	}
-
-}
 func buildKASVolumeEgressSelectorConfig(v *corev1.Volume) {
 	if v.ConfigMap == nil {
 		v.ConfigMap = &corev1.ConfigMapVolumeSource{}
@@ -695,46 +684,14 @@ func applyGenericSecretEncryptionConfig(podSpec *corev1.PodSpec) {
 		genericSecretEncryptionConfigFileVolumeMount.ContainerMounts(kasContainerMain().Name)...)
 }
 
-func applyCloudProviderCreds(podSpec *corev1.PodSpec, cloudProvider string, cloudProviderCreds *corev1.LocalObjectReference) {
-	if cloudProviderCreds == nil || cloudProviderCreds.Name == "" {
-		return
-	}
-	podSpec.Volumes = append(podSpec.Volumes, util.BuildVolume(kasVolumeCloudProviderCreds(), buildKASVolumeCloudProviderCreds(cloudProviderCreds.Name)))
-	container := mustContainer(podSpec, kasContainerMain().Name)
-	container.VolumeMounts = append(container.VolumeMounts, cloudProviderCredsVolumeMount.ContainerMounts(kasContainerMain().Name)...)
-
-	switch cloudProvider {
-	case aws.Provider:
-		credsPath := path.Join(cloudProviderCredsVolumeMount.Path(kasContainerMain().Name, kasVolumeCloudProviderCreds().Name), awsCloudProviderCredsKey)
-		container.Env = append(container.Env,
-			corev1.EnvVar{
-				Name:  "AWS_SHARED_CREDENTIALS_FILE",
-				Value: credsPath,
-			},
-			corev1.EnvVar{
-				Name:  "AWS_EC2_METADATA_DISABLED",
-				Value: "true",
-			})
+func kasVolumeKubeconfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "kubeconfig",
 	}
 }
 
-func buildKASVolumeCloudProviderCreds(cloudProviderCredsName string) func(v *corev1.Volume) {
-	return func(v *corev1.Volume) {
-		v.Secret = &corev1.SecretVolumeSource{}
-		v.Secret.SecretName = cloudProviderCredsName
+func buildKASVolumeKubeconfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
 	}
-}
-
-func mustContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
-	var container *corev1.Container
-	for i, c := range podSpec.Containers {
-		if c.Name == name {
-			container = &podSpec.Containers[i]
-			break
-		}
-	}
-	if container == nil {
-		panic(fmt.Sprintf("expected container %s not found pod spec", name))
-	}
-	return container
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -10,10 +10,11 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/config"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/util"
 )
 
 const (
-	KubeconfigKey = "kubeconfig"
+	KubeconfigKey = util.KubeconfigKey
 )
 
 func ReconcileServiceKubeconfigSecret(secret, cert, ca *corev1.Secret, ownerRef config.OwnerRef, apiServerPort int32) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -23,6 +23,7 @@ type KubeAPIServerImages struct {
 	IBMCloudKMS           string `json:"ibmcloudKMS"`
 	AWSKMS                string `json:"awsKMS"`
 	Portieris             string `json:"portieris"`
+	TokenMinterImage      string
 }
 
 type KubeAPIServerParams struct {
@@ -80,6 +81,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			HyperKube:             images["hyperkube"],
 			CLI:                   images["cli"],
 			ClusterConfigOperator: images["cluster-config-operator"],
+			TokenMinterImage:      images["hosted-cluster-config-operator"],
 		},
 	}
 	if hcp.Spec.APIAdvertiseAddress != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
@@ -44,20 +43,6 @@ var (
 	cloudProviderConfigVolumeMount = util.PodVolumeMounts{
 		kcmContainerMain().Name: {
 			kcmVolumeCloudConfig().Name: "/etc/kubernetes/cloud",
-		},
-	}
-	cloudProviderCredsVolumeMount = util.PodVolumeMounts{
-		kcmContainerMain().Name: {
-			kcmVolumeCloudProviderCreds().Name: "/etc/kubernetes/secrets/cloud-provider",
-		},
-	}
-	cloudProviderTokenVolumeMount = util.PodVolumeMounts{
-		kcmContainerMain().Name: {
-			kcmVolumeCloudProviderToken().Name: "/var/run/secrets/openshift/serviceaccount",
-		},
-		kcmInitContainerTokenMinter().Name: {
-			kcmVolumeCloudProviderToken().Name: "/var/run/secrets/openshift/serviceaccount",
-			kcmVolumeKubeconfig().Name:         "/etc/kubernetes",
 		},
 	}
 	kcmLabels = map[string]string{
@@ -114,26 +99,10 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev
 		applyServingCAVolume(&deployment.Spec.Template.Spec, servingCA)
 	}
 	applyCloudConfigVolumeMount(&deployment.Spec.Template.Spec, p.CloudProviderConfig)
-	applyCloudProviderCreds(&deployment.Spec.Template.Spec, p.CloudProvider, p.CloudProviderCreds, p.TokenMinterImage)
+	util.ApplyCloudProviderCreds(&deployment.Spec.Template.Spec, p.CloudProvider, p.CloudProviderCreds, p.TokenMinterImage, kcmContainerMain().Name)
 
 	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), p.AvailabilityProberImage, &deployment.Spec.Template.Spec)
 	return nil
-}
-
-func kcmInitContainerTokenMinter() *corev1.Container {
-	return &corev1.Container{
-		Name: "token-minter",
-	}
-}
-
-func buildKCMInitContainerTokenMinter(image string, args []string) func(c *corev1.Container) {
-	return func(c *corev1.Container) {
-		c.Image = image
-		c.ImagePullPolicy = corev1.PullAlways
-		c.Command = []string{"/usr/bin/token-minter"}
-		c.Args = args
-		c.VolumeMounts = cloudProviderTokenVolumeMount.ContainerMounts(c.Name)
-	}
 }
 
 func kcmContainerMain() *corev1.Container {
@@ -255,31 +224,6 @@ func buildKCMVolumeCloudConfig(cloudProviderConfigName string) func(v *corev1.Vo
 	}
 }
 
-func kcmVolumeCloudProviderCreds() *corev1.Volume {
-	return &corev1.Volume{
-		Name: "cloud-creds",
-	}
-}
-
-func buildKCMVolumeCloudProviderCreds(cloudProviderCredsName string) func(v *corev1.Volume) {
-	return func(v *corev1.Volume) {
-		v.Secret = &corev1.SecretVolumeSource{}
-		v.Secret.SecretName = cloudProviderCredsName
-	}
-}
-
-func kcmVolumeCloudProviderToken() *corev1.Volume {
-	return &corev1.Volume{
-		Name: "cloud-token",
-	}
-}
-
-func buildKCMVolumeCloudProviderToken() func(v *corev1.Volume) {
-	return func(v *corev1.Volume) {
-		v.EmptyDir = &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}
-	}
-}
-
 type serviceCAVolumeBuilder string
 
 func (name serviceCAVolumeBuilder) buildKCMVolumeServiceServingCA(v *corev1.Volume) {
@@ -352,19 +296,6 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 	return args
 }
 
-func tokenMinterArgs() []string {
-	cpath := func(vol, file string) string {
-		return path.Join(cloudProviderTokenVolumeMount.Path(kcmInitContainerTokenMinter().Name, vol), file)
-	}
-	return []string{
-		"-service-account-namespace=kube-system",
-		"-service-account-name=kube-controller-manager",
-		"-token-audience=openshift",
-		fmt.Sprintf("-token-file=%s", cpath(kcmVolumeCloudProviderToken().Name, "token")),
-		fmt.Sprintf("-kubeconfig=%s", cpath(kcmVolumeKubeconfig().Name, kas.KubeconfigKey)),
-	}
-}
-
 func cloudProviderConfig(cloudProvider string, configRef *corev1.LocalObjectReference) string {
 	if configRef != nil && configRef.Name != "" {
 		cfgDir := cloudProviderConfigVolumeMount.Path(kcmContainerMain().Name, kcmVolumeCloudConfig().Name)
@@ -381,39 +312,6 @@ func applyCloudConfigVolumeMount(podSpec *corev1.PodSpec, cloudProviderConfigRef
 	container := mustContainer(podSpec, kcmContainerMain().Name)
 	container.VolumeMounts = append(container.VolumeMounts,
 		cloudProviderConfigVolumeMount.ContainerMounts(kcmContainerMain().Name)...)
-}
-
-func applyCloudProviderCreds(podSpec *corev1.PodSpec, cloudProvider string, cloudProviderCreds *corev1.LocalObjectReference, tokenMinterImage string) {
-	if cloudProviderCreds == nil || cloudProviderCreds.Name == "" {
-		return
-	}
-	podSpec.Volumes = append(podSpec.Volumes, util.BuildVolume(kcmVolumeCloudProviderCreds(), buildKCMVolumeCloudProviderCreds(cloudProviderCreds.Name)))
-	container := mustContainer(podSpec, kcmContainerMain().Name)
-	container.VolumeMounts = append(container.VolumeMounts,
-		cloudProviderCredsVolumeMount.ContainerMounts(kcmContainerMain().Name)...)
-
-	switch cloudProvider {
-	case aws.Provider:
-		credsPath := path.Join(cloudProviderCredsVolumeMount.Path(kcmContainerMain().Name, kcmVolumeCloudProviderCreds().Name), AWSCloudProviderCredsKey)
-		container.Env = append(container.Env,
-			corev1.EnvVar{
-				Name:  "AWS_SHARED_CREDENTIALS_FILE",
-				Value: credsPath,
-			},
-			corev1.EnvVar{
-				Name:  "AWS_SDK_LOAD_CONFIG",
-				Value: "true",
-			},
-			corev1.EnvVar{
-				Name:  "AWS_EC2_METADATA_DISABLED",
-				Value: "true",
-			})
-		podSpec.Volumes = append(podSpec.Volumes, util.BuildVolume(kcmVolumeCloudProviderToken(), buildKCMVolumeCloudProviderToken()))
-		container.VolumeMounts = append(container.VolumeMounts,
-			cloudProviderTokenVolumeMount.ContainerMounts(kcmContainerMain().Name)...)
-		tokenMinterInitContainer := util.BuildContainer(kcmInitContainerTokenMinter(), buildKCMInitContainerTokenMinter(tokenMinterImage, tokenMinterArgs()))
-		podSpec.InitContainers = append(podSpec.InitContainers, tokenMinterInitContainer)
-	}
 }
 
 func mustContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {

--- a/control-plane-operator/controllers/hostedcontrolplane/util/cloudprovidercreds.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/util/cloudprovidercreds.go
@@ -1,0 +1,146 @@
+package util
+
+import (
+	"fmt"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	awsCloudProviderCredsKey = "credentials"
+	KubeconfigKey            = "kubeconfig"
+	AWSCloudProviderName     = "aws"
+)
+
+func cloudProviderCredsVolumeMount(containerName string) PodVolumeMounts {
+	return PodVolumeMounts{
+		containerName: {
+			cloudProviderCredsVolume().Name: "/etc/kubernetes/secrets/cloud-provider",
+		},
+	}
+}
+func cloudProviderTokenVolumeMount(containerName string) PodVolumeMounts {
+	return PodVolumeMounts{
+		containerName: {
+			cloudProviderTokenVolume().Name: "/var/run/secrets/openshift/serviceaccount",
+		},
+		cloudProviderInitContainerTokenMinter().Name: {
+			cloudProviderTokenVolume().Name:           "/var/run/secrets/openshift/serviceaccount",
+			cloudProviderTokenKubeconfigVolume().Name: "/etc/kubernetes",
+		},
+	}
+}
+
+func ApplyCloudProviderCreds(
+	podSpec *corev1.PodSpec,
+	cloudProvider string,
+	cloudProviderCreds *corev1.LocalObjectReference,
+	tokenMinterImage string,
+	containerName string,
+) {
+	if cloudProviderCreds == nil || cloudProviderCreds.Name == "" {
+		return
+	}
+	podSpec.Volumes = append(podSpec.Volumes, BuildVolume(cloudProviderCredsVolume(), buildCloudProviderCreds(cloudProviderCreds.Name)))
+	container := mustContainer(podSpec, containerName)
+	container.VolumeMounts = append(container.VolumeMounts, cloudProviderCredsVolumeMount(containerName).ContainerMounts(containerName)...)
+
+	switch cloudProvider {
+	case AWSCloudProviderName:
+		credsPath := path.Join(cloudProviderCredsVolumeMount(containerName).Path(containerName, cloudProviderCredsVolume().Name), awsCloudProviderCredsKey)
+		container.Env = append(container.Env,
+			corev1.EnvVar{
+				Name:  "AWS_SHARED_CREDENTIALS_FILE",
+				Value: credsPath,
+			},
+			corev1.EnvVar{
+				Name:  "AWS_SDK_LOAD_CONFIG",
+				Value: "true",
+			},
+			corev1.EnvVar{
+				Name:  "AWS_EC2_METADATA_DISABLED",
+				Value: "true",
+			})
+		podSpec.Volumes = append(podSpec.Volumes, BuildVolume(cloudProviderTokenVolume(), buildCloudProviderTokenVolume()))
+		container.VolumeMounts = append(container.VolumeMounts,
+			cloudProviderTokenVolumeMount(containerName).ContainerMounts(containerName)...)
+		tokenMinterContainer := BuildContainer(cloudProviderInitContainerTokenMinter(), buildCloudProviderTokenMinterContainer(tokenMinterImage, tokenMinterArgs()))
+		podSpec.Containers = append(podSpec.Containers, tokenMinterContainer)
+	}
+}
+
+func cloudProviderCredsVolume() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cloud-creds",
+	}
+}
+
+func buildCloudProviderCreds(cloudProviderCredsName string) func(v *corev1.Volume) {
+	return func(v *corev1.Volume) {
+		v.Secret = &corev1.SecretVolumeSource{}
+		v.Secret.SecretName = cloudProviderCredsName
+	}
+}
+
+func cloudProviderTokenVolume() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cloud-token",
+	}
+}
+
+func buildCloudProviderTokenVolume() func(v *corev1.Volume) {
+	return func(v *corev1.Volume) {
+		v.EmptyDir = &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}
+	}
+}
+
+func cloudProviderInitContainerTokenMinter() *corev1.Container {
+	return &corev1.Container{
+		Name: "token-minter",
+	}
+}
+
+func cloudProviderTokenKubeconfigVolume() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "kubeconfig",
+	}
+}
+
+func buildCloudProviderTokenMinterContainer(image string, args []string) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.ImagePullPolicy = corev1.PullAlways
+		c.Command = []string{"/usr/bin/token-minter"}
+		c.Args = args
+		c.VolumeMounts = cloudProviderTokenVolumeMount(c.Name).ContainerMounts(c.Name)
+	}
+}
+
+func tokenMinterArgs() []string {
+	cpath := func(vol, file string) string {
+		return path.Join(cloudProviderTokenVolumeMount("").Path(cloudProviderInitContainerTokenMinter().Name, vol), file)
+	}
+	return []string{
+		"-service-account-namespace=kube-system",
+		"-service-account-name=kube-controller-manager",
+		"-token-audience=openshift",
+		fmt.Sprintf("-token-file=%s", cpath(cloudProviderTokenVolume().Name, "token")),
+		fmt.Sprintf("-kubeconfig=%s", cpath(cloudProviderTokenKubeconfigVolume().Name, KubeconfigKey)),
+		"--sleep=true",
+	}
+}
+
+func mustContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
+	var container *corev1.Container
+	for i, c := range podSpec.Containers {
+		if c.Name == name {
+			container = &podSpec.Containers[i]
+			break
+		}
+	}
+	if container == nil {
+		panic(fmt.Sprintf("expected container %s not found pod spec", name))
+	}
+	return container
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2381,31 +2381,6 @@ func reconcileCAPIAWSProviderDeployment(deployment *appsv1.Deployment, hc *hyper
 						},
 					},
 				},
-				InitContainers: []corev1.Container{
-					{
-						Name:            "token-minter",
-						Image:           tokenMinterImage,
-						ImagePullPolicy: corev1.PullAlways,
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "token",
-								MountPath: "/var/run/secrets/openshift/serviceaccount",
-							},
-							{
-								Name:      "svc-kubeconfig",
-								MountPath: "/etc/kubernetes",
-							},
-						},
-						Command: []string{"/usr/bin/token-minter"},
-						Args: []string{
-							"-service-account-namespace=kube-system",
-							"-service-account-name=capa-controller-manager",
-							"-token-audience=openshift",
-							"-token-file=/var/run/secrets/openshift/serviceaccount/token",
-							"-kubeconfig=/etc/kubernetes/kubeconfig",
-						},
-					},
-				},
 				Containers: []corev1.Container{
 					{
 						Name:            "manager",
@@ -2473,6 +2448,30 @@ func reconcileCAPIAWSProviderDeployment(deployment *appsv1.Deployment, hc *hyper
 									Port: intstr.FromString("healthz"),
 								},
 							},
+						},
+					},
+					{
+						Name:            "token-minter",
+						Image:           tokenMinterImage,
+						ImagePullPolicy: corev1.PullAlways,
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "token",
+								MountPath: "/var/run/secrets/openshift/serviceaccount",
+							},
+							{
+								Name:      "svc-kubeconfig",
+								MountPath: "/etc/kubernetes",
+							},
+						},
+						Command: []string{"/usr/bin/token-minter"},
+						Args: []string{
+							"-service-account-namespace=kube-system",
+							"-service-account-name=capa-controller-manager",
+							"-token-audience=openshift",
+							"-token-file=/var/run/secrets/openshift/serviceaccount/token",
+							"-kubeconfig=/etc/kubernetes/kubeconfig",
+							"-sleep=true",
 						},
 					},
 				},

--- a/token-minter/main.go
+++ b/token-minter/main.go
@@ -26,12 +26,14 @@ func main() {
 	var tokenAudience string
 	var tokenFile string
 	var kubeconfigPath string
+	var sleep bool
 
 	flag.StringVar(&serviceAccountNamespace, "service-account-namespace", "kube-system", "namespace of the service account for which to mint a token")
 	flag.StringVar(&serviceAccountName, "service-account-name", "", "name of the service account for which to mint a token")
 	flag.StringVar(&tokenAudience, "token-audience", "openshift", "audience for the token")
 	flag.StringVar(&tokenFile, "token-file", "/var/run/secrets/openshift/serviceaccount/token", "path to the file where the token will be written")
 	flag.StringVar(&kubeconfigPath, "kubeconfig", "/etc/kubernetes/kubeconfig", "path to the kubeconfig file")
+	flag.BoolVar(&sleep, "sleep", false, "If the binary should sleep after finishing. Required when running as a sidecar, as otherwise the container will be considered crashing.")
 	flag.Parse()
 
 	if serviceAccountNamespace == "" ||
@@ -139,4 +141,8 @@ func main() {
 	f.WriteString(token.Status.Token)
 
 	fmt.Println("Successfully wrote token to", tokenFile)
+	if sleep {
+		fmt.Println("Done, starting to sleep")
+		<-ctx.Done()
+	}
 }


### PR DESCRIPTION
The KAS needs to cloud provider creds as it communicates with the cloud
provider for admitting them. Updating the KAS was forgotten when
refactoring the code to use STS. As cluster creation will fail if the
KAS has an initcontainer that requires the KAS to be running, the
token-minter was changed to be a sidecar instead of an initcontainer.

Also, the corresponding code was refactored to be shared between the KAS
and the KCM to avoid this kind of mistake in the future and de-duplicate
it.

Ref https://issues.redhat.com/browse/HOSTEDCP-257