### PR TITLE
reduce keepalive timeouts to ensure it is lower than oses tcp_keepalive timeout value

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -117,6 +117,10 @@ func buildKonnectivityServerContainer(image string) func(c *corev1.Container) {
 			"--admin-port=8093",
 			"--mode=http-connect",
 			"--proxy-strategies=destHost,defaultRoute",
+			"--keepalive-time",
+			"30s",
+			"--frontend-keepalive-time",
+			"30s",
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}
@@ -334,6 +338,14 @@ func buildKonnectivityWorkerAgentContainer(image, host string, port int32) func(
 			"--health-server-port",
 			fmt.Sprint(healthPort),
 			"--agent-identifiers=default-route=true",
+			"--keepalive-time",
+			"30s",
+			"--probe-interval",
+			"30s",
+			"--sync-interval",
+			"1m",
+			"--sync-interval-cap",
+			"5m",
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}
@@ -398,6 +410,14 @@ func buildKonnectivityAgentContainer(image string, ips []string) func(c *corev1.
 			fmt.Sprint(healthPort),
 			"--agent-identifiers",
 			agentIDs.String(),
+			"--keepalive-time",
+			"30s",
+			"--probe-interval",
+			"30s",
+			"--sync-interval",
+			"1m",
+			"--sync-interval-cap",
+			"5m",
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}


### PR DESCRIPTION
pr showing the changes with a konnectivity image that has the latest sync of master is here
https://github.com/openshift/hypershift/pull/680

Depends on this konnectivity community sync PR:
https://github.com/openshift/apiserver-network-proxy/pull/7


Details:

Once community is synced: grpc connection health checking and keepalived parameters are exposed for configuration in konnectivity. By default these are extremely high values (for example keepalive time is an hour and it takes two probes before determining a connection is dead meaning it can take up to 2 hours to determine a HTTP2 connection is dead.)This can lead to failures like we have been seeing in our environment 

This pr sets those parameters to run the checks every 30 seconds both server and client side (which should be in sync)

There are also important connection management fixes that went into the konnectivity upstream to help prevent connection locks that we should pickup

