### PR TITLE
do not proxy well known registries for samples operator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -192,7 +192,7 @@ func buildOASContainerMain(image string, etcdHostname string) func(c *corev1.Con
 			},
 			{
 				Name:  "NO_PROXY",
-				Value: fmt.Sprintf("%s,%s", manifests.KubeAPIServerService("").Name, etcdHostname),
+				Value: fmt.Sprintf("%s,%s,registry.access.redhat.com,quay.io,registry.redhat.io", manifests.KubeAPIServerService("").Name, etcdHostname),
 			},
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)


### PR DESCRIPTION
this will fix:
https://github.com/openshift/hypershift/issues/681

Currently: most sample operator image imports fail because there is a race condition between konnectivity starting up and the samples operator rolling out the samples. Once the samples fail: it takes multiple days to rereconcile all of the tags across the failures and during that time oc new-app is not available for use.

By not proxying well known registries: this allows the openshift-apiserver to process well known registry imports without having to proxy through konnectivity. This removes the race condition