### PR TITLE
Add make to the promoted hypershift image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,14 @@ COPY . .
 RUN make build
 
 FROM quay.io/openshift/origin-base:4.9
+
+# This is pretty gross, we need `make` for CI because we install hypershift
+# through a maketarget in this image for the 4.8 release branch.
+# We can not yum install make, because this would break building it locally
+# as all repo URLs in the image are kube service URLs that only work in the
+# CI build clusters.
+COPY --from=builder /usr/bin/make /usr/bin/make
+
 COPY --from=builder /hypershift/bin/ignition-server /usr/bin/ignition-server
 COPY --from=builder /hypershift/bin/hypershift /usr/bin/hypershift
 COPY --from=builder /hypershift/bin/hypershift-operator /usr/bin/hypershift-operator


### PR DESCRIPTION
Needed for the 4.8 CI that runs `hypershift install` in this image and
indirects it from o/release to o/hypershift through a maketarget.