### PR TITLE
Add AWSEndpointService controller to CPO

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -22,8 +22,9 @@ type ExampleResources struct {
 }
 
 type ExampleAWSResources struct {
-	KubeCloudControllerAWSCreds *corev1.Secret
-	NodePoolManagementAWSCreds  *corev1.Secret
+	KubeCloudControllerAWSCreds  *corev1.Secret
+	NodePoolManagementAWSCreds   *corev1.Secret
+	ControlPlaneOperatorAWSCreds *corev1.Secret
 }
 
 func (o *ExampleResources) AsObjects() []crclient.Object {
@@ -35,6 +36,7 @@ func (o *ExampleResources) AsObjects() []crclient.Object {
 	if o.AWSResources != nil {
 		objects = append(objects, o.AWSResources.KubeCloudControllerAWSCreds)
 		objects = append(objects, o.AWSResources.NodePoolManagementAWSCreds)
+		objects = append(objects, o.AWSResources.ControlPlaneOperatorAWSCreds)
 	}
 	if o.SSHKey != nil {
 		objects = append(objects, o.SSHKey)
@@ -75,20 +77,21 @@ type ExampleNoneOptions struct {
 }
 
 type ExampleAWSOptions struct {
-	Region                     string
-	Zone                       string
-	VPCID                      string
-	SubnetID                   string
-	SecurityGroupID            string
-	InstanceProfile            string
-	InstanceType               string
-	Roles                      []hyperv1.AWSRoleCredentials
-	KubeCloudControllerRoleARN string
-	NodePoolManagementRoleARN  string
-	RootVolumeSize             int64
-	RootVolumeType             string
-	RootVolumeIOPS             int64
-	ResourceTags               []hyperv1.AWSResourceTag
+	Region                      string
+	Zone                        string
+	VPCID                       string
+	SubnetID                    string
+	SecurityGroupID             string
+	InstanceProfile             string
+	InstanceType                string
+	Roles                       []hyperv1.AWSRoleCredentials
+	KubeCloudControllerRoleARN  string
+	NodePoolManagementRoleARN   string
+	ControlPlaneOperatorRoleARN string
+	RootVolumeSize              int64
+	RootVolumeType              string
+	RootVolumeIOPS              int64
+	ResourceTags                []hyperv1.AWSResourceTag
 }
 
 func (o ExampleOptions) Resources() *ExampleResources {
@@ -169,6 +172,9 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 		exampleAWSResources.NodePoolManagementAWSCreds = buildAWSCreds(
 			o.Name+"-node-mgmt-creds",
 			o.AWS.NodePoolManagementRoleARN)
+		exampleAWSResources.ControlPlaneOperatorAWSCreds = buildAWSCreds(
+			o.Name+"-cpo-creds",
+			o.AWS.ControlPlaneOperatorRoleARN)
 		platformSpec = hyperv1.PlatformSpec{
 			Type: hyperv1.AWSPlatform,
 			AWS: &hyperv1.AWSPlatformSpec{
@@ -181,9 +187,10 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 					},
 					Zone: o.AWS.Zone,
 				},
-				KubeCloudControllerCreds: corev1.LocalObjectReference{Name: exampleAWSResources.KubeCloudControllerAWSCreds.Name},
-				NodePoolManagementCreds:  corev1.LocalObjectReference{Name: exampleAWSResources.NodePoolManagementAWSCreds.Name},
-				ResourceTags:             o.AWS.ResourceTags,
+				KubeCloudControllerCreds:  corev1.LocalObjectReference{Name: exampleAWSResources.KubeCloudControllerAWSCreds.Name},
+				NodePoolManagementCreds:   corev1.LocalObjectReference{Name: exampleAWSResources.NodePoolManagementAWSCreds.Name},
+				ControlPlaneOperatorCreds: corev1.LocalObjectReference{Name: exampleAWSResources.ControlPlaneOperatorAWSCreds.Name},
+				ResourceTags:              o.AWS.ResourceTags,
 			},
 		}
 		services = []hyperv1.ServicePublishingStrategyMapping{

--- a/api/v1alpha1/endpointservice_types.go
+++ b/api/v1alpha1/endpointservice_types.go
@@ -11,11 +11,15 @@ func init() {
 // The following are reasons for the IgnitionEndpointAvailable condition.
 const (
 	// AWSEndpointServiceAvailable indicates whether the AWS Endpoint Service
-	// has been created for the specified NLB
-	AWSEndpointServiceAvailable ConditionType = "Available"
+	// has been created for the specified NLB in the management VPC
+	AWSEndpointServiceAvailable ConditionType = "EndpointServiceAvailable"
 
-	AWSSuccessReason string = "AWSSuccessReason"
-	AWSErrorReason   string = "AWSErrorReason"
+	// AWSEndpointServiceAvailable indicates whether the AWS Endpoint has been
+	// created in the guest VPC
+	AWSEndpointAvailable ConditionType = "EndpointAvailable"
+
+	AWSSuccessReason string = "AWSSuccess"
+	AWSErrorReason   string = "AWSError"
 )
 
 // AWSEndpointServiceSpec defines the desired state of AWSEndpointService
@@ -26,9 +30,13 @@ type AWSEndpointServiceSpec struct {
 
 // AWSEndpointServiceStatus defines the observed state of AWSEndpointService
 type AWSEndpointServiceStatus struct {
-	// The endpoint service name created in AWS in response to the request
+	// The endpoint service name created in the management VPC in response to the request
 	// +optional
 	EndpointServiceName string `json:"endpointServiceName,omitempty"`
+
+	// The endpoint ID created in the guest VPC in response to the request
+	// +optional
+	EndpointID string `json:"endpointID,omitempty"`
 
 	// Condition contains details for the current state of the Endpoint Service
 	// request If there is an error processing the request e.g. the NLB doesn't

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -509,6 +509,16 @@ type AWSPlatformSpec struct {
 	// +immutable
 	NodePoolManagementCreds corev1.LocalObjectReference `json:"nodePoolManagementCreds"`
 
+	// ControlPlaneOperatorCreds is a reference to a secret containing cloud
+	// credentials with permissions matching the control-plane-operator policy.
+	// The secret should have exactly one key, `credentials`, whose value is
+	// an AWS credentials file.
+	//
+	// TODO(dan): document the "node pool management policy"
+	//
+	// +immutable
+	ControlPlaneOperatorCreds corev1.LocalObjectReference `json:"controlPlaneOperatorCreds"`
+
 	// ResourceTags is a list of additional tags to apply to AWS resources created
 	// for the cluster. See
 	// https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -315,6 +315,7 @@ func (in *AWSPlatformSpec) DeepCopyInto(out *AWSPlatformSpec) {
 	}
 	out.KubeCloudControllerCreds = in.KubeCloudControllerCreds
 	out.NodePoolManagementCreds = in.NodePoolManagementCreds
+	out.ControlPlaneOperatorCreds = in.ControlPlaneOperatorCreds
 	if in.ResourceTags != nil {
 		in, out := &in.ResourceTags, &out.ResourceTags
 		*out = make([]AWSResourceTag, len(*in))

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -151,20 +151,21 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	exampleOptions.InfraID = infraID
 
 	exampleOptions.AWS = &apifixtures.ExampleAWSOptions{
-		Region:                     infra.Region,
-		Zone:                       infra.Zone,
-		VPCID:                      infra.VPCID,
-		SubnetID:                   infra.PrivateSubnetID,
-		SecurityGroupID:            infra.SecurityGroupID,
-		InstanceProfile:            iamInfo.ProfileName,
-		InstanceType:               opts.AWSPlatform.InstanceType,
-		Roles:                      iamInfo.Roles,
-		KubeCloudControllerRoleARN: iamInfo.KubeCloudControllerRoleARN,
-		NodePoolManagementRoleARN:  iamInfo.NodePoolManagementRoleARN,
-		RootVolumeSize:             opts.AWSPlatform.RootVolumeSize,
-		RootVolumeType:             opts.AWSPlatform.RootVolumeType,
-		RootVolumeIOPS:             opts.AWSPlatform.RootVolumeIOPS,
-		ResourceTags:               tags,
+		Region:                      infra.Region,
+		Zone:                        infra.Zone,
+		VPCID:                       infra.VPCID,
+		SubnetID:                    infra.PrivateSubnetID,
+		SecurityGroupID:             infra.SecurityGroupID,
+		InstanceProfile:             iamInfo.ProfileName,
+		InstanceType:                opts.AWSPlatform.InstanceType,
+		Roles:                       iamInfo.Roles,
+		KubeCloudControllerRoleARN:  iamInfo.KubeCloudControllerRoleARN,
+		NodePoolManagementRoleARN:   iamInfo.NodePoolManagementRoleARN,
+		ControlPlaneOperatorRoleARN: iamInfo.ControlPlaneOperatorRoleARN,
+		RootVolumeSize:              opts.AWSPlatform.RootVolumeSize,
+		RootVolumeType:              opts.AWSPlatform.RootVolumeType,
+		RootVolumeIOPS:              opts.AWSPlatform.RootVolumeIOPS,
+		ResourceTags:                tags,
 	}
 	return nil
 }

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/cmd/util"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,7 +43,7 @@ func GetCluster(ctx context.Context, o *DestroyOptions) (*hyperv1.HostedCluster,
 
 	var hostedCluster hyperv1.HostedCluster
 	if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			log.Info("Hosted cluster not found, destroying infrastructure from user input", "namespace", o.Namespace, "name", o.Name, "infraID", o.InfraID)
 			return nil, nil
 		}

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -42,8 +42,9 @@ type CreateIAMOutput struct {
 	IssuerURL   string                       `json:"issuerURL"`
 	Roles       []hyperv1.AWSRoleCredentials `json:"roles"`
 
-	KubeCloudControllerRoleARN string `json:"kubeCloudControllerRoleARN"`
-	NodePoolManagementRoleARN  string `json:"nodePoolManagementRoleARN"`
+	KubeCloudControllerRoleARN  string `json:"kubeCloudControllerRoleARN"`
+	NodePoolManagementRoleARN   string `json:"nodePoolManagementRoleARN"`
+	ControlPlaneOperatorRoleARN string `json:"controlPlaneOperatorRoleARN"`
 }
 
 func NewCreateIAMCommand() *cobra.Command {

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -137,6 +137,9 @@ func (o *DestroyIAMOptions) DestroyOIDCResources(ctx context.Context, iamClient 
 	if err = o.DestroyOIDCRole(iamClient, "node-pool"); err != nil {
 		return err
 	}
+	if err = o.DestroyOIDCRole(iamClient, "control-plane-operator"); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -239,6 +239,21 @@ const (
     }
   ]
 }`
+
+	controlPlaneOperatorPolicy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"ec2:CreateVpcEndpoint",
+				"ec2:DescribeVpcEndpoints",
+				"ec2:DeleteVpcEndpoints"
+			],
+			"Resource": "*"
+		}
+	]
+}`
 )
 
 type KeyResponse struct {
@@ -348,6 +363,13 @@ func (o *CreateIAMOptions) CreateOIDCResources(iamClient iamiface.IAMAPI) (*Crea
 		return nil, err
 	}
 	output.NodePoolManagementRoleARN = arn
+
+	controlPlaneOperatorTrustPolicy := oidcTrustPolicy(providerARN, providerName, "system:serviceaccount:kube-system:control-plane-operator")
+	arn, err = o.CreateOIDCRole(iamClient, "control-plane-operator", controlPlaneOperatorTrustPolicy, controlPlaneOperatorPolicy)
+	if err != nil {
+		return nil, err
+	}
+	output.ControlPlaneOperatorRoleARN = arn
 
 	return output, nil
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_awsendpointservices.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_awsendpointservices.yaml
@@ -119,9 +119,13 @@ spec:
                   - type
                   type: object
                 type: array
-              endpointServiceName:
-                description: The endpoint service name created in AWS in response
+              endpointID:
+                description: The endpoint ID created in the guest VPC in response
                   to the request
+                type: string
+              endpointServiceName:
+                description: The endpoint service name created in the management VPC
+                  in response to the request
                 type: string
             required:
             - conditions

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -417,6 +417,19 @@ spec:
                         required:
                         - vpc
                         type: object
+                      controlPlaneOperatorCreds:
+                        description: "ControlPlaneOperatorCreds is a reference to
+                          a secret containing cloud credentials with permissions matching
+                          the control-plane-operator policy. The secret should have
+                          exactly one key, `credentials`, whose value is an AWS credentials
+                          file. \n TODO(dan): document the \"node pool management
+                          policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
                       endpointAccess:
                         default: Public
                         description: EndpointAccess specifies the publishing scope
@@ -537,6 +550,7 @@ spec:
                           type: object
                         type: array
                     required:
+                    - controlPlaneOperatorCreds
                     - kubeCloudControllerCreds
                     - nodePoolManagementCreds
                     - region

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -333,6 +333,19 @@ spec:
                         required:
                         - vpc
                         type: object
+                      controlPlaneOperatorCreds:
+                        description: "ControlPlaneOperatorCreds is a reference to
+                          a secret containing cloud credentials with permissions matching
+                          the control-plane-operator policy. The secret should have
+                          exactly one key, `credentials`, whose value is an AWS credentials
+                          file. \n TODO(dan): document the \"node pool management
+                          policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
                       endpointAccess:
                         default: Public
                         description: EndpointAccess specifies the publishing scope
@@ -453,6 +466,7 @@ spec:
                           type: object
                         type: array
                     required:
+                    - controlPlaneOperatorCreds
                     - kubeCloudControllerCreds
                     - nodePoolManagementCreds
                     - region

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -109,6 +109,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 		"--metrics-addr=:9000",
 		fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", o.EnableOCPClusterMonitoring),
 		fmt.Sprintf("--enable-ci-debug-output=%t", o.EnableCIDebugOutput),
+		fmt.Sprintf("--private-platform=%s", o.PrivatePlatform),
 	}
 	if o.OIDCStorageProviderS3BucketName != "" {
 		args = append(args,
@@ -162,10 +163,6 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 										},
 									},
 								},
-								{
-									Name:  "AWS_SHARED_CREDENTIALS_FILE",
-									Value: "/etc/aws/" + awsCredsSecretKey,
-								},
 							},
 							Command: []string{"/usr/bin/hypershift-operator"},
 							Args:    args,
@@ -206,10 +203,6 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "credentials",
-									MountPath: "/etc/aws",
-								},
-								{
 									Name:      "oidc-storage-provider-s3-creds",
 									MountPath: "/etc/oidc-storage-provider-s3-creds",
 								},
@@ -217,14 +210,6 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 						},
 					},
 					Volumes: []corev1.Volume{
-						{
-							Name: "credentials",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: awsCredsSecretName,
-								},
-							},
-						},
 						{
 							Name: "oidc-storage-provider-s3-creds",
 							VolumeSource: corev1.VolumeSource{
@@ -249,7 +234,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 		Name: "credentials",
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: "hypershift-operator-creds",
+				SecretName: awsCredsSecretName,
 			},
 		},
 	})

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -7,7 +7,14 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -17,12 +24,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/support/upsert"
 )
 
@@ -31,8 +40,8 @@ const (
 )
 
 type PrivateServiceObserver struct {
-	client client.Client
-	log    logr.Logger
+	client.Client
+	log logr.Logger
 
 	ControllerName   string
 	ServiceNamespace string
@@ -68,7 +77,6 @@ func ControllerName(name string) string {
 
 func (r *PrivateServiceObserver) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	r.log = ctrl.Log.WithName(r.ControllerName).WithValues("name", r.ServiceName, "namespace", r.ServiceNamespace)
-	r.client = mgr.GetClient()
 	var err error
 	kubeClient, err := kubeclient.NewForConfig(mgr.GetConfig())
 	if err != nil {
@@ -91,16 +99,34 @@ func (r *PrivateServiceObserver) SetupWithManager(ctx context.Context, mgr ctrl.
 }
 
 func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.log.Info("reconcile start", "request", req)
+	r.log.Info("reconciling")
+
+	// Fetch the Service
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Name,
 			Namespace: req.Namespace,
 		},
 	}
-	if err := r.client.Get(ctx, client.ObjectKeyFromObject(svc), svc); err != nil {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(svc), svc); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Fetch the HostedControlPlane
+	hcpList := &hyperv1.HostedControlPlaneList{}
+	if err := r.List(ctx, hcpList, &client.ListOptions{Namespace: r.HCPNamespace}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get resource: %w", err)
+	}
+	if len(hcpList.Items) != 1 {
+		return ctrl.Result{}, fmt.Errorf("unexpected number of HostedControlPlanes in namespace, expected: 1, actual: %d", len(hcpList.Items))
+	}
+	hcp := hcpList.Items[0]
+
+	// Return early if HostedControlPlane is deleted
+	if !hcp.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	if len(svc.Status.LoadBalancer.Ingress) == 0 {
 		r.log.Info("load balancer not provisioned yet")
 		return ctrl.Result{}, nil
@@ -112,16 +138,201 @@ func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request
 		},
 	}
 	lbName := strings.Split(strings.Split(svc.Status.LoadBalancer.Ingress[0].Hostname, ".")[0], "-")[0]
-	if _, err := r.CreateOrUpdate(ctx, r.client, awsEndpointService, func() error {
-		return reconcileAWSEndpointService(awsEndpointService, lbName)
+	if _, err := r.CreateOrUpdate(ctx, r, awsEndpointService, func() error {
+		awsEndpointService.Spec.NetworkLoadBalancerName = lbName
+		return nil
 	}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reconcile AWS Endpoint Service: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile AWSEndpointService: %w", err)
 	}
 	r.log.Info("reconcile complete", "request", req)
 	return ctrl.Result{}, nil
 }
 
-func reconcileAWSEndpointService(awsEndpointService *hyperv1.AWSEndpointService, lbName string) error {
-	awsEndpointService.Spec.NetworkLoadBalancerName = lbName
+const (
+	finalizer                              = "hypershift.openshift.io/control-plane-operator-finalizer"
+	endpointServiceDeletionRequeueDuration = time.Duration(5 * time.Second)
+)
+
+type AWSEndpointServiceReconciler struct {
+	client.Client
+	ec2Client ec2iface.EC2API
+}
+
+func (r *AWSEndpointServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	_, err := ctrl.NewControllerManagedBy(mgr).
+		For(&hyperv1.AWSEndpointService{}).
+		Build(r)
+	if err != nil {
+		return fmt.Errorf("failed setting up with a controller manager: %w", err)
+	}
+
+	r.Client = mgr.GetClient()
+
+	// AWS_SHARED_CREDENTIALS_FILE and AWS_REGION envvar should be set in operator deployment
+	awsSession := awsutil.NewSession("control-plane-operator")
+	awsConfig := aws.NewConfig()
+	r.ec2Client = ec2.New(awsSession, awsConfig)
+
 	return nil
+}
+
+func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logr.FromContext(ctx)
+	log.Info("reconciling")
+
+	// Fetch the AWSEndpointService
+	obj := &hyperv1.AWSEndpointService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Name,
+			Namespace: req.Namespace,
+		},
+	}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get resource: %w", err)
+	}
+
+	// Don't change the cached object
+	awsEndpointService := obj.DeepCopy()
+
+	// fetch the HostedControlPlane
+	hcpList := &hyperv1.HostedControlPlaneList{}
+	if err := r.List(ctx, hcpList, &client.ListOptions{Namespace: req.Namespace}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get resource: %w", err)
+	}
+	if len(hcpList.Items) != 1 {
+		return ctrl.Result{}, fmt.Errorf("unexpected number of HostedControlPlanes in namespace, expected: 1, actual: %d", len(hcpList.Items))
+	}
+	hcp := hcpList.Items[0]
+
+	// Return early if deleted
+	if !awsEndpointService.DeletionTimestamp.IsZero() {
+		completed, err := r.delete(ctx, awsEndpointService, r.ec2Client)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete resource: %w", err)
+		}
+		if !completed {
+			return ctrl.Result{RequeueAfter: endpointServiceDeletionRequeueDuration}, nil
+		}
+		if controllerutil.ContainsFinalizer(awsEndpointService, finalizer) {
+			controllerutil.RemoveFinalizer(awsEndpointService, finalizer)
+			if err := r.Update(ctx, awsEndpointService); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure the awsEndpointService has a finalizer for cleanup
+	if !controllerutil.ContainsFinalizer(awsEndpointService, finalizer) {
+		controllerutil.AddFinalizer(awsEndpointService, finalizer)
+		if err := r.Update(ctx, awsEndpointService); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+	}
+
+	serviceName := awsEndpointService.Status.EndpointServiceName
+	if serviceName == "" {
+		// Service Endpoint is not yet set, wait for hypershift-operator to populate
+		// Likely observing our own Create
+		return ctrl.Result{}, nil
+	}
+
+	// Reconcile the AWSEndpointService
+	if err := reconcileAWSEndpointService(ctx, awsEndpointService, r.ec2Client, hcp); err != nil {
+		meta.SetStatusCondition(&awsEndpointService.Status.Conditions, metav1.Condition{
+			Type:    string(hyperv1.AWSEndpointAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  hyperv1.AWSErrorReason,
+			Message: err.Error(),
+		})
+		if err := r.Status().Update(ctx, awsEndpointService); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, err
+	}
+
+	meta.SetStatusCondition(&awsEndpointService.Status.Conditions, metav1.Condition{
+		Type:    string(hyperv1.AWSEndpointAvailable),
+		Status:  metav1.ConditionTrue,
+		Reason:  hyperv1.AWSSuccessReason,
+		Message: "",
+	})
+
+	if err := r.Status().Update(ctx, awsEndpointService); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.Info("reconcilation complete")
+	return ctrl.Result{}, nil
+}
+
+func reconcileAWSEndpointService(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, ec2Client ec2iface.EC2API, hcp hyperv1.HostedControlPlane) error {
+	log := logr.FromContext(ctx)
+	serviceName := awsEndpointService.Status.EndpointServiceName
+
+	endpointID := awsEndpointService.Status.EndpointID
+	if endpointID != "" {
+		// check if Endpoint exists in AWS
+		output, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{
+			VpcEndpointIds: []*string{aws.String(endpointID)},
+		})
+		if err != nil {
+			return err
+		}
+		if len(output.VpcEndpoints) == 0 {
+			// clear the EndpointID so a new Endpoint is created on the requeue
+			awsEndpointService.Status.EndpointID = ""
+			return fmt.Errorf("endpoint %s not found, resetting status", serviceName)
+		}
+		log.Info("endpoint exists", "endpointID", endpointID)
+		return nil
+
+	}
+
+	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform || hcp.Spec.Platform.AWS == nil || hcp.Spec.Platform.AWS.CloudProviderConfig == nil {
+		return fmt.Errorf("AWS platform information not provided in HostedControlPlane")
+	}
+	input := &ec2.CreateVpcEndpointInput{
+		ServiceName:     aws.String(serviceName),
+		VpcId:           aws.String(hcp.Spec.Platform.AWS.CloudProviderConfig.VPC),
+		VpcEndpointType: aws.String(ec2.VpcEndpointTypeInterface),
+	}
+	if hcp.Spec.Platform.AWS.CloudProviderConfig.Subnet != nil && hcp.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {
+		input.SubnetIds = []*string{hcp.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID}
+	}
+	output, err := ec2Client.CreateVpcEndpointWithContext(ctx, input)
+	if err != nil {
+		return err
+	}
+
+	endpointID = *output.VpcEndpoint.VpcEndpointId
+	log.Info("endpoint created", "endpointID", endpointID)
+	awsEndpointService.Status.EndpointID = endpointID
+
+	return nil
+}
+
+func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, ec2Client ec2iface.EC2API) (bool, error) {
+	log := logr.FromContext(ctx)
+
+	endpointID := awsEndpointService.Status.EndpointID
+	if endpointID == "" {
+		// nothing to clean up
+		return true, nil
+	}
+
+	if _, err := ec2Client.DeleteVpcEndpointsWithContext(ctx, &ec2.DeleteVpcEndpointsInput{
+		VpcEndpointIds: []*string{aws.String(endpointID)},
+	}); err != nil {
+		return false, err
+	}
+
+	log.Info("endpoint deleted", "endpointID", endpointID)
+	return true, nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -96,5 +96,6 @@ func ReconcilePrivateService(svc *corev1.Service, owner *metav1.OwnerReference) 
 }
 
 func ReconcilePrivateServiceStatus(svc *corev1.Service, mgmtBaseDomain string) (host string, port int32, err error) {
-	return fmt.Sprintf("api-%s.%s", svc.GetNamespace(), mgmtBaseDomain), 6443, nil
+	//return fmt.Sprintf("api-%s.%s", svc.GetNamespace(), mgmtBaseDomain), 6443, nil
+	return fmt.Sprintf("kube-apiserver.%s.svc", svc.Namespace), 6443, nil
 }

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -223,6 +223,7 @@ func NewStartCommand() *cobra.Command {
 
 		controllerName := "PrivateKubeAPIServerServiceObserver"
 		if err := (&awsprivatelink.PrivateServiceObserver{
+			Client:                 mgr.GetClient(),
 			ControllerName:         controllerName,
 			ServiceNamespace:       namespace,
 			ServiceName:            manifests.KubeAPIServerPrivateServiceName,
@@ -236,6 +237,7 @@ func NewStartCommand() *cobra.Command {
 
 		controllerName = "PrivateIngressServiceObserver"
 		if err := (&awsprivatelink.PrivateServiceObserver{
+			Client:                 mgr.GetClient(),
 			ControllerName:         controllerName,
 			ServiceNamespace:       "openshift-ingress",
 			ServiceName:            fmt.Sprintf("router-%s", namespace),
@@ -244,6 +246,11 @@ func NewStartCommand() *cobra.Command {
 		}).SetupWithManager(ctx, mgr); err != nil {
 			controllerName := awsprivatelink.ControllerName(fmt.Sprintf("router-%s", namespace))
 			setupLog.Error(err, "unable to create controller", "controller", controllerName)
+			os.Exit(1)
+		}
+
+		if err := (&awsprivatelink.AWSEndpointServiceReconciler{}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "aws-endpoint-service")
 			os.Exit(1)
 		}
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1103,6 +1103,23 @@ credentials file.</p>
 </tr>
 <tr>
 <td>
+<code>controlPlaneOperatorCreds</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ControlPlaneOperatorCreds is a reference to a secret containing cloud
+credentials with permissions matching the control-plane-operator policy.
+The secret should have exactly one key, <code>credentials</code>, whose value is
+an AWS credentials file.</p>
+<p>TODO(dan): document the &ldquo;node pool management policy&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>resourceTags</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1alpha1.AWSResourceTag">
@@ -1674,9 +1691,13 @@ and conditions fields may represent a previous version.</p>
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;Available&#34;</p></td>
+<tbody><tr><td><p>&#34;EndpointAvailable&#34;</p></td>
+<td><p>AWSEndpointServiceAvailable indicates whether the AWS Endpoint has been
+created in the guest VPC</p>
+</td>
+</tr><tr><td><p>&#34;EndpointServiceAvailable&#34;</p></td>
 <td><p>AWSEndpointServiceAvailable indicates whether the AWS Endpoint Service
-has been created for the specified NLB</p>
+has been created for the specified NLB in the management VPC</p>
 </td>
 </tr><tr><td><p>&#34;ClusterVersionFailing&#34;</p></td>
 <td></td>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -575,6 +575,34 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	// Reconcile the platform provider node pool management credentials secret by
+	// resolving  the reference from the HostedCluster and syncing the secret in
+	// the control plane namespace.
+	switch hcluster.Spec.Platform.Type {
+	case hyperv1.AWSPlatform:
+		var src corev1.Secret
+		err = r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.Platform.AWS.ControlPlaneOperatorCreds.Name}, &src)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get control plane operator provider creds %s: %w", hcluster.Spec.Platform.AWS.ControlPlaneOperatorCreds.Name, err)
+		}
+		dest := manifests.AWSControlPlaneOperatorCreds(controlPlaneNamespace.Name)
+		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
+			srcData, srcHasData := src.Data["credentials"]
+			if !srcHasData {
+				return fmt.Errorf("control plane operator provider credentials secret %q is missing credentials key", src.Name)
+			}
+			dest.Type = corev1.SecretTypeOpaque
+			if dest.Data == nil {
+				dest.Data = map[string][]byte{}
+			}
+			dest.Data["credentials"] = srcData
+			return nil
+		})
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile control plane operator provider creds: %w", err)
+		}
+	}
+
 	// Reconcile the HostedControlPlane pull secret by resolving the source secret
 	// reference from the HostedCluster and syncing the secret in the control plane namespace.
 	{
@@ -1117,9 +1145,11 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hcp.Spec.Platform.AWS.KubeCloudControllerCreds = corev1.LocalObjectReference{
 			Name: manifests.AWSKubeCloudControllerCreds(hcp.Namespace).Name,
 		}
-		// TODO: Not actually used by the control plane operator...
 		hcp.Spec.Platform.AWS.NodePoolManagementCreds = corev1.LocalObjectReference{
 			Name: manifests.AWSNodePoolManagementCreds(hcp.Namespace).Name,
+		}
+		hcp.Spec.Platform.AWS.ControlPlaneOperatorCreds = corev1.LocalObjectReference{
+			Name: manifests.AWSControlPlaneOperatorCreds(hcp.Namespace).Name,
 		}
 	case hyperv1.NonePlatform:
 		hcp.Spec.Platform.Type = hyperv1.NonePlatform
@@ -1911,6 +1941,72 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 			},
 		},
 	}
+
+	// Add platform specific settings
+	switch hc.Spec.Platform.Type {
+	case hyperv1.AWSPlatform:
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes,
+			corev1.Volume{
+				Name: "cloud-token",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{
+						Medium: corev1.StorageMediumMemory,
+					},
+				},
+			},
+			corev1.Volume{
+				Name: "provider-creds",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: manifests.AWSControlPlaneOperatorCreds(deployment.Namespace).Name,
+					},
+				},
+			})
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  "AWS_SHARED_CREDENTIALS_FILE",
+				Value: "/etc/provider/credentials",
+			},
+			corev1.EnvVar{
+				Name:  "AWS_REGION",
+				Value: hc.Spec.Platform.AWS.Region,
+			},
+			corev1.EnvVar{
+				Name:  "AWS_SDK_LOAD_CONFIG",
+				Value: "true",
+			})
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "cloud-token",
+				MountPath: "/var/run/secrets/openshift/serviceaccount",
+			},
+			corev1.VolumeMount{
+				Name:      "provider-creds",
+				MountPath: "/etc/provider",
+			})
+		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, corev1.Container{
+			Name:            "token-minter",
+			Image:           image,
+			ImagePullPolicy: corev1.PullAlways,
+			Command:         []string{"/usr/bin/token-minter"},
+			Args: []string{
+				"-service-account-namespace=kube-system",
+				"-service-account-name=control-plane-operator",
+				"-token-audience=openshift",
+				"-token-file=/var/run/secrets/openshift/serviceaccount/token",
+				fmt.Sprintf("-kubeconfig-secret-namespace=%s", deployment.Namespace),
+				"-kubeconfig-secret-name=service-network-admin-kubeconfig",
+				"--sleep=true",
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "cloud-token",
+					MountPath: "/var/run/secrets/openshift/serviceaccount",
+				},
+			},
+		})
+	}
+
 	hyperutil.SetColocation(hc, deployment)
 	hyperutil.SetRestartAnnotation(hc, deployment)
 	hyperutil.SetControlPlaneIsolation(hc, deployment)
@@ -2916,6 +3012,16 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, req ctrl.Request, 
 	for key := range nodePools {
 		if err := r.Delete(ctx, &nodePools[key]); err != nil && !apierrors.IsNotFound(err) {
 			return false, fmt.Errorf("failed to delete nodePool %q for cluster %q: %w", nodePools[key].GetName(), req.Name, err)
+		}
+	}
+
+	var awsEndpointServiceList hyperv1.AWSEndpointServiceList
+	if err := r.List(ctx, &awsEndpointServiceList); err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to list AWSEndpointServices for cluster %q: %w", req.Name, err)
+	}
+	for _, ep := range awsEndpointServiceList.Items {
+		if err := r.Delete(ctx, &ep); err != nil && !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to delete AWSEndpointService %q for cluster %q: %w", ep.Name, req.Name, err)
 		}
 	}
 

--- a/hypershift-operator/controllers/manifests/manifests.go
+++ b/hypershift-operator/controllers/manifests/manifests.go
@@ -41,3 +41,12 @@ func AWSNodePoolManagementCreds(controlPlaneNamespace string) *corev1.Secret {
 		},
 	}
 }
+
+func AWSControlPlaneOperatorCreds(controlPlaneNamespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      "cpo-provider-creds",
+		},
+	}
+}

--- a/token-minter/main.go
+++ b/token-minter/main.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -26,6 +27,8 @@ func main() {
 	var tokenAudience string
 	var tokenFile string
 	var kubeconfigPath string
+	var kubeconfigSecretName string
+	var kubeconfigSecretNamespace string
 	var sleep bool
 
 	flag.StringVar(&serviceAccountNamespace, "service-account-namespace", "kube-system", "namespace of the service account for which to mint a token")
@@ -33,6 +36,8 @@ func main() {
 	flag.StringVar(&tokenAudience, "token-audience", "openshift", "audience for the token")
 	flag.StringVar(&tokenFile, "token-file", "/var/run/secrets/openshift/serviceaccount/token", "path to the file where the token will be written")
 	flag.StringVar(&kubeconfigPath, "kubeconfig", "/etc/kubernetes/kubeconfig", "path to the kubeconfig file")
+	flag.StringVar(&kubeconfigSecretName, "kubeconfig-secret-name", "", "name of a secret containing a kubeconfig key")
+	flag.StringVar(&kubeconfigSecretNamespace, "kubeconfig-secret-namespace", "", "namespace of a secret containing a kubeconfig key")
 	flag.BoolVar(&sleep, "sleep", false, "If the binary should sleep after finishing. Required when running as a sidecar, as otherwise the container will be considered crashing.")
 	flag.Parse()
 
@@ -56,11 +61,39 @@ func main() {
 		os.Exit(1) // second signal. Exit directly.
 	}()
 
-	loadingRules := clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath}
-	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, &clientcmd.ConfigOverrides{})
-	restConfig, err := clientConfig.ClientConfig()
-	if err != nil {
-		panic(err)
+	var restConfig *rest.Config
+	if kubeconfigSecretName != "" && kubeconfigSecretNamespace != "" {
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			panic(err)
+		}
+		kubeClient := kubernetes.NewForConfigOrDie(config)
+		if err := wait.PollImmediate(time.Second*5, time.Minute*2, func() (done bool, err error) {
+			secret, err := kubeClient.CoreV1().Secrets(kubeconfigSecretNamespace).Get(ctx, kubeconfigSecretName, metav1.GetOptions{})
+			if err != nil {
+				fmt.Println("Unable to get kubeconfig secret, retrying in 5s:", err)
+				return false, nil
+			}
+			kubeconfigBytes, ok := secret.Data["kubeconfig"]
+			if !ok {
+				return false, fmt.Errorf("kubeconfig secret does not have a kubeconfig key")
+			}
+			restConfig, err = clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
+			if err != nil {
+				return false, fmt.Errorf("invalid kubeconfig: %w", err)
+			}
+			return true, nil
+		}); err != nil {
+			panic(err)
+		}
+	} else {
+		loadingRules := clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath}
+		clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, &clientcmd.ConfigOverrides{})
+		var err error
+		restConfig, err = clientConfig.ClientConfig()
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	clientset, err := kubernetes.NewForConfig(restConfig)
@@ -78,7 +111,7 @@ func main() {
 		if apierrors.IsNotFound(err) {
 			return true, err
 		}
-		fmt.Println("Unable to get service account, retry in 10s:", err)
+		fmt.Println("Unable to get service account, retrying in 5s:", err)
 		return false, nil
 	})
 


### PR DESCRIPTION
Included in this PR:
* Controller that creates AWS Endpoint once the AWS Endpoint Service is created by the `hypershift-operator`
* `create aws iam` phase now creates a Role for the CPO
* `token-minter` sidecar added the CPO to create a serviceaccount token the CPO can use to create AWS Endpoints
* `token-minter` now allows the secret name and namespace to be passed and will wait up to 2m (5s check interval) for the secret to exist and read the kubeconfig from it

**API IMPACT**
New `ControlPlaneOperatorCreds` to plumb through the created Role for CPO

**DEPLOY TIME IMPACT**
The NLBs must be in `Active` state before the Endpoint Service can be created.  This takes about 2m30s.  The subsequent `CreateVpcEndpoint` creation call is synchronous and takes about 30s to return.  Total time to establish the private link component set is ~3m.  The nodes will not be able to join the cluster before this is configured.