### PR TITLE
Revert "Add make to the promoted hypershift image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,6 @@ COPY . .
 RUN make build
 
 FROM quay.io/openshift/origin-base:4.9
-
-# This is pretty gross, we need `make` for CI because we install hypershift
-# through a maketarget in this image for the 4.8 release branch.
-# We can not yum install make, because this would break building it locally
-# as all repo URLs in the image are kube service URLs that only work in the
-# CI build clusters.
-COPY --from=builder /usr/bin/make /usr/bin/make
-
 COPY --from=builder /hypershift/bin/ignition-server /usr/bin/ignition-server
 COPY --from=builder /hypershift/bin/hypershift /usr/bin/hypershift
 COPY --from=builder /hypershift/bin/hypershift-operator /usr/bin/hypershift-operator


### PR DESCRIPTION
We actually need the source code to get the Maketarget so we are using
the e2e image instead, which mans the hypershift image doesn't need
make.

This reverts commit f3c7bf45e40c60d7f4faf7882b6daeac8161b535.

/hold
So this doesn't merge before https://github.com/openshift/release/pull/23669