### PR TITLE
Use a cache-backed client to reduce number of api requests

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -939,7 +939,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		awsCluster := controlplaneoperator.AWSCluster(controlPlaneNamespace.Name, hcluster.Name)
-		_, err = controllerutil.CreateOrPatch(ctx, r.Client, awsCluster, func() error {
+		_, err = createOrUpdate(ctx, r.Client, awsCluster, func() error {
 			return reconcileAWSCluster(awsCluster, hcluster, hcp.Status.ControlPlaneEndpoint)
 		})
 		if err != nil {

--- a/support/upsert/upsert.go
+++ b/support/upsert/upsert.go
@@ -6,11 +6,14 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
+
 	//TODO: Switch to k8s.io/api/batch/v1 when all management clusters at 1.21+ OR 4.8_openshift+
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	capiawsv1beta1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -19,6 +22,12 @@ type CreateOrUpdateFN = func(ctx context.Context, c crclient.Client, obj crclien
 
 type CreateOrUpdateProvider interface {
 	CreateOrUpdate(ctx context.Context, c crclient.Client, obj crclient.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error)
+}
+
+var withStatusSubresource = sets.NewString(fmt.Sprintf("%T", &capiawsv1beta1.AWSCluster{}))
+
+func hasStatusSubResource(o crclient.Object) bool {
+	return withStatusSubresource.Has(fmt.Sprintf("%T", o))
 }
 
 func New(enableUpdateLoopDetector bool) CreateOrUpdateProvider {
@@ -49,6 +58,14 @@ func (p *createOrUpdateProvider) CreateOrUpdate(ctx context.Context, c crclient.
 		}
 		if err := c.Create(ctx, obj); err != nil {
 			return controllerutil.OperationResultNone, err
+		}
+		if hasStatusSubResource(obj) {
+			if err := mutate(f, key, obj); err != nil {
+				return controllerutil.OperationResultNone, err
+			}
+			if err := c.Status().Update(ctx, obj); err != nil {
+				return controllerutil.OperationResultNone, err
+			}
 		}
 		return controllerutil.OperationResultCreated, nil
 	}
@@ -83,6 +100,14 @@ func (p *createOrUpdateProvider) CreateOrUpdate(ctx context.Context, c crclient.
 
 	if err := c.Update(ctx, obj); err != nil {
 		return controllerutil.OperationResultNone, err
+	}
+	if hasStatusSubResource(obj) {
+		if err := mutate(f, key, obj); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		if err := c.Status().Update(ctx, obj); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
 	}
 	return controllerutil.OperationResultUpdated, nil
 }


### PR DESCRIPTION
We currently use an api reader which results in an actual api request
whenwever we need to get an object. This change makes us use the
default cache-backed client again. There are now a couple of conflict
errors in the log, but as that results in a retry it is not a
correctness issue.

Ref https://issues.redhat.com/browse/HOSTEDCP-154