### PR TITLE
Read PowerVS images from the release stream

### DIFF
--- a/support/releaseinfo/deserialize_test.go
+++ b/support/releaseinfo/deserialize_test.go
@@ -7,13 +7,17 @@ import (
 )
 
 func TestDeserializeImageStream(t *testing.T) {
-	if _, err := DeserializeImageStream(fixtures.ImageReferencesJSON_4_8); err != nil {
-		t.Fatal(err)
+	for _, imageStream := range [][]byte{fixtures.ImageReferencesJSON_4_8, fixtures.ImageReferencesJSON_4_10} {
+		if _, err := DeserializeImageStream(imageStream); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
 func TestDeserializeImageMetadata(t *testing.T) {
-	if _, err := DeserializeImageMetadata(fixtures.CoreOSBootImagesYAML_4_8); err != nil {
-		t.Fatal(err)
+	for _, imageMetadata := range [][]byte{fixtures.CoreOSBootImagesYAML_4_8, fixtures.CoreOSBootImagesYAML_4_10} {
+		if _, err := DeserializeImageMetadata(imageMetadata); err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/support/releaseinfo/fixtures/4.10-image-references.json
+++ b/support/releaseinfo/fixtures/4.10-image-references.json
@@ -1,0 +1,2507 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "image.openshift.io/v1",
+  "metadata": {
+    "name": "4.10.0-0.nightly-2021-11-14-184249",
+    "creationTimestamp": "2021-11-14T18:51:28Z",
+    "annotations": {
+      "release.openshift.io/from-image-stream": "ocp/4.10-art-latest-2021-11-14-184249"
+    }
+  },
+  "spec": {
+    "lookupPolicy": {
+      "local": false
+    },
+    "tags": [
+      {
+        "name": "aws-cloud-controller-manager",
+        "annotations": {
+          "io.openshift.build.commit.id": "1f666fd6a58bbb6a6e57d02cb4c1e2d029eb0f20",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cloud-provider-aws"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ad3510986668d0dadbbd1381ab9f9f668629ca5b679d7c355060eaef1cacb653"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "aws-ebs-csi-driver",
+        "annotations": {
+          "io.openshift.build.commit.id": "8741c5f4c53d527996fa876e5744c7f409fc63e8",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/aws-ebs-csi-driver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:92767cec192f906f4be1110fdf03102e453488d332e3cf0017f76c1126522ecd"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "aws-ebs-csi-driver-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "a7bcbe3d9560c50996c134e570055a9bdd1f3af1",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/aws-ebs-csi-driver-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:73872fb599fd027a24996438fca316827976190d73c98df3a8d9c1bd80e66b07"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "aws-machine-controllers",
+        "annotations": {
+          "io.openshift.build.commit.id": "b045e9da245d4b1f3ba5275d6cdec10d17b14bc8",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-api-provider-aws"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:86b16549de5f3e12a891e1781d7b01ade6b81773addbaa2b48bdc58c9a199239"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "aws-pod-identity-webhook",
+        "annotations": {
+          "io.openshift.build.commit.id": "0c22344fd967c86024131ed887d104d0b9827ec1",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/aws-pod-identity-webhook"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:503efaf58aaca8263560786648cdaffb252b90de85cfe44c10beef31c17bb6c2"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "azure-cloud-controller-manager",
+        "annotations": {
+          "io.openshift.build.commit.id": "f16606e024f0f2c03cc112aa626dc1160844afcb",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cloud-provider-azure"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:808fda14bc36cfa92ed9a609fe8a65b6c16c2763fec646bcb8eb5f920a3b292a"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "azure-cloud-node-manager",
+        "annotations": {
+          "io.openshift.build.commit.id": "f16606e024f0f2c03cc112aa626dc1160844afcb",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cloud-provider-azure"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6483c567290c03beb2c434b817944a87d465a9bcc0fdb54d6667cdbee8fe3fd3"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "azure-disk-csi-driver",
+        "annotations": {
+          "io.openshift.build.commit.id": "7b2a62058dea176dd058e333eed6ee18772a8de9",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/azure-disk-csi-driver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b004a53b6b2390e31b67f973beb68fa8d761ca15236ac332b0a44cd9f50eef7f"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "azure-disk-csi-driver-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "de0689f2ec2ea456996dc832e7127ae766d4ae7a",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/azure-disk-csi-driver-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1cda035aeb56e495e8348e2842a6c80675b7a1eda1c6cb8dd43afed0dfe3f834"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "azure-file-csi-driver",
+        "annotations": {
+          "io.openshift.build.commit.id": "19be5d3de0ef9702a19ad3f73093c76dd893287d",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/azure-file-csi-driver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aefb76d1c3f3d3bdda97a77aafcec43ea236dc082cde87d5e834b508d174e013"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "azure-file-csi-driver-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "a54bce297aa84ae0f919de4cc84978e12121bb49",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/azure-file-csi-driver-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1315877369f55badcbad7e226cb6331cd006bc98e1a06797df456cee64aa35c9"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "azure-machine-controllers",
+        "annotations": {
+          "io.openshift.build.commit.id": "2040aeac3a8ff8ecf19ae13e9076a5c30e5e96df",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-api-provider-azure"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b9355e8f85dc74802bc2816fb38d7955775d88956a2e6d0ae4345a68d54508a3"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "baremetal-installer",
+        "annotations": {
+          "io.openshift.build.commit.id": "8fc863d833b1b361efc61c81998890e1305bcf9b",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/installer"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a09b26284085adfaa3f1f609a20d0aece9ec48789bfe3ac4aa0a55b5bac768dd"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "baremetal-machine-controllers",
+        "annotations": {
+          "io.openshift.build.commit.id": "c2d3ece4da387258a748d16f046fb11566fbacc8",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-api-provider-baremetal"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8db1bba4234e16c25ff5d3e021f20ae1f88b7a239fdf227ce046f98d4cd2a80c"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "baremetal-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "469cc9bf7fee287079e63043152aa08b50c3175e",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/baremetal-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3d7ec79e86f917991222d8408a944091e7953c72973ba5f0beefbbd6e275e993"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "baremetal-runtimecfg",
+        "annotations": {
+          "io.openshift.build.commit.id": "a6fb15f5c3d71d251ea8bd633aa6e28c98da6b4f",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/baremetal-runtimecfg"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fea19ede3767ba708de3349eb4998f0baee780ef1c46b91453d7a39bb04b6b14"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cli",
+        "annotations": {
+          "io.openshift.build.commit.id": "a253d9d0e65e012be8c6211a988a90d9148992d4",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/oc"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b752e77bdc93fbdbcc091daf5686a42ad42fb25943e0816481e03d36a68eeca9"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cli-artifacts",
+        "annotations": {
+          "io.openshift.build.commit.id": "a253d9d0e65e012be8c6211a988a90d9148992d4",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/oc"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6b60396e987becbc8325044960b84f5aec69a0b50b6b024419ad29616ab4746f"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cloud-credential-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "b1ddda444c74fc62a5cf0bef80c890ecb4908d4c",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cloud-credential-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10f03f2085b7aaa14ed9febf7a6f4f0891486c4ebae95e684efa5bb8392b1dff"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-authentication-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "7f9ca91a1c60069beb60e73645c99115bdfcb3e9",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-authentication-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:56c3ecdb5327330afe208f5ffff99ec10a6f779f116289cdb101c32175d955e2"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-autoscaler",
+        "annotations": {
+          "io.openshift.build.commit.id": "ce263e9722044ba35f8ac453c6603f27dce98fab",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/kubernetes-autoscaler"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6e2d863bae7946d936c5bf83f73ecebb0a4f2ce7b96ae4178b8906b61ff2eac3"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-autoscaler-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "96ef5bc65ed09e81e80ac268dd00e9801c139bba",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-autoscaler-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3876be0d7a36868f3be2cb13f55b721d84cd69d3f4d04f6fc35a5fd1cf53ddf3"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-baremetal-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "beef41d34b9f8713692234bdf95e740ff6d49cfd",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-baremetal-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1e9161851cf7bd1dd5b16a3794646c745baff91edbf67dbf73c652356bd82d8c"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-bootstrap",
+        "annotations": {
+          "io.openshift.build.commit.id": "f22d1c60c188a4b5ce1731a8b1db7c20067dc7e9",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-bootstrap"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ba344131d41fb8d6a5681a0eb460c57ab8327abe7478b272be561b88bb822b52"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-cloud-controller-manager-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "8afd434bbda645cb6d1e90c3f115520f37f05841",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-cloud-controller-manager-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ab2c2334e13ade1e001b2c90df76c17ea6bcf4c5693b12ea38f6f5d7167d27d7"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-config-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "3d9297ed0eff1fd54674f5adad05a2248ddd2502",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-config-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f3534aa8ae6ef2bc3b83d17b9d5c638a41379df7015405e352cc67faeeec898c"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-csi-snapshot-controller-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "fe3b0e8e7ef6232584bc4041a9669a242f5d99ca",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-csi-snapshot-controller-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:007c0351b49b80a8d178ff9a86ddd1b918ea0dfdf79d8f9660b01b3abe22c221"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-dns-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "4d323b95a7bc9aef39bdbea53b9cda6607a24e34",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-dns-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9839f0d560e5b0de5c76265ace627197f78f58d924fb2547cd52f465edd95b67"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-etcd-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "a60ced6e2c5f494081d80eb821e413a58314b1c3",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-etcd-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:44a3163e6efe5fdf350ff168b1aa5e46cc16f8bb96294404a6f47f9d7d68a876"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-image-registry-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "4e615c17ea3417d8ab2be2e063f71d774bf17cce",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-image-registry-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b2c83eb6fc8c43bd062f475de90293937bf324fffab7af0a63a8e9cd375909ee"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-ingress-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "417ec3596282a6ba23f8a9660f28fae96b82c84e",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-ingress-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b18fcd437c34c73d2ac817bf86b958f491523a7303905ba06da6b1c564e2f518"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-kube-apiserver-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "3fb33804538b00c9311a83e934c1346eff179ee8",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-kube-apiserver-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8ae90e4513e3db61a01ae4acabb2a3e51f06dba5526fa4fcfa95f2161cd04709"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-kube-controller-manager-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "3327b3cb7c6a91cde03876ac8741dfdb7a12fcd6",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-kube-controller-manager-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e8cb7049f700446938779160d58d426d1b4339223582d9d58a98dfaca3f27fef"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-kube-scheduler-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "ff34e67a8348789bdfa2bfffb1bd115458a49473",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-kube-scheduler-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8b9fb32bddcb5342f9070511700750be5bb9c942198f7539badb14e7786a1920"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-kube-storage-version-migrator-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "44ef4153820ffbbc0c3241b7ce471ad6ec50794b",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-kube-storage-version-migrator-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0a501a5315b6e4ca9ef30b39d42d9dfcb1af2975b27c6298b2921f1d92b63ed7"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-machine-approver",
+        "annotations": {
+          "io.openshift.build.commit.id": "0a64d91c6d5cc3bc7dbf9940c7b57f12ac3a8a75",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-machine-approver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1373f728ad99ab2af2887ad2944c3c658d29808cc9976d936d3e868dc15ceaab"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-monitoring-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "0ac1e0614f9dba6b49c708e82d9ed2abcfd77b9d",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-monitoring-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a429f60ddf33c1df84951bd6cbcdcaf92f7ca308010b5822bf33c4e37ec1981e"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-network-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "b3e4d570846450240c32393b12cc049732fa4018",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-network-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:38ff9411588c88768e074a216e1b38ab2bcd18d11aa116f6ed2b4571188fdf14"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-node-tuning-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "7c05b4a9008426b5b652925b80ea580a4a6c0d1f",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-node-tuning-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1943baf944b02fc436c08cf0b98ca0b5a5ade12bf713304e0603e8bb1469de45"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-openshift-apiserver-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "e27552529de7e60dbcfad1825dd2e8a77f609e72",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-openshift-apiserver-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5699b56374b90bcd42e3ce9331820a986fd723d4ea03ceb4e8bb31f7a0cbc20b"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-openshift-controller-manager-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "179b82ce93f645cacb003a51afedebf4cd2c3e80",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-openshift-controller-manager-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:329c45539814bfdf7f78ce42921a8f4597f118d8e8e7574c33b07750dd652893"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-policy-controller",
+        "annotations": {
+          "io.openshift.build.commit.id": "ef97a191cfad8a151c138e9d22360e77d3f2237b",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-policy-controller"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6ebab8f63aa479e9891d66753e9472c07c0c2b3701d56bc424e075c377cb4200"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-samples-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "6cb10ac8721f4efddcb56bebcb60d25f14f8ec27",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-samples-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e04c1a6db7157e1a8ff2aa8ee71463cb19bfe02fa30c6c1a718ce444cfe6f09c"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-storage-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "eec1c2166a2d1f208a653e0339a246457e9baa9c",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-storage-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9100102e964aba4670f62d9a8ee45522e41f59a918db32fd270e7cce93d77d50"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-update-keys",
+        "annotations": {
+          "io.openshift.build.commit.id": "342eb8e2631f3218ea386479102784d5e288d868",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-update-keys"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9102c2c1accd606bf20edf021fe4c3413a26d43819430fd28bfdbafd578a7f74"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "cluster-version-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "a3ca316544752768fb6b01d5496b04e644a8d1b7",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-version-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:baa7ae946c341db4808db570ad4d2931bd3235ae5e0df43983bb5237c70c1de1"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "configmap-reloader",
+        "annotations": {
+          "io.openshift.build.commit.id": "22a40ce77a1c3d4842b80de89f4df449672e5f5e",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/configmap-reload"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:daff3634f4295d5a7b1f58611b0d2fddfc09cd377d1f0f3d85f5cea694a85224"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "console",
+        "annotations": {
+          "io.openshift.build.commit.id": "66a8ce5d4fab8c64deb537332820c8bc7e478f23",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/console"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6c18a117f613893a492626b0c5163fe6c4e5a134bb170d2fab5f9f41e2a71682"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "console-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "d68cd6c651463e33355f11c47217ebb7e2a3e768",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/console-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2cd1cb59fa3ddd96d9161598c5472e40d60ce6b724a4747a43b99f6584c126b3"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "container-networking-plugins",
+        "annotations": {
+          "io.openshift.build.commit.id": "693f1c1f6e0f8f01cbfed546ce99a3faf3161564",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/containernetworking-plugins"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e01c499b9e222b811a0df0769a35050ee90caa0faf097ba649d2be7ee9fb5dfb"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "coredns",
+        "annotations": {
+          "io.openshift.build.commit.id": "ebeb0b2e6315e05e1daf50202aed307949b7e4c1",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/coredns"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f0c1b89092c1966baa30586089f8698f2768b346717194f925cd80dfd84ed040"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-driver-manila",
+        "annotations": {
+          "io.openshift.build.commit.id": "eb15f08c0ba479077c18cf0d00bac22a02dbcd85",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cloud-provider-openstack"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a12e1028c2e12919772b308919ce5ef106a44cb8c57aa59ba465d62861e1d250"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-driver-manila-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "3dad9e120170861b7fbd10ce6db202eb197112c9",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-driver-manila-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:606c9a5741e2a525029b63bb443b6a1b427fca19429c1c2f534c725d5328da0d"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-driver-nfs",
+        "annotations": {
+          "io.openshift.build.commit.id": "d7ed37d3fc3d6d072b4b1323a1b5e52740d178c7",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-driver-nfs"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0f36c3ef2dcf8ce04309f267756e6082ffe578037601533c6429ecfdcb929eba"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-driver-shared-resource",
+        "annotations": {
+          "io.openshift.build.commit.id": "32fffa0df52e9be11b8f8646fadbc4f48a11c08b",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-driver-shared-resource"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8c7c4a1d5635988ccef20deea5596a9cc80ecdd79cc069013b6e909b7c38c082"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-driver-shared-resource-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "1d69d219558fef95a108915fe5f04d3b0bd20b41",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-driver-shared-resource-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6abb48cd325ef2a213cc77988fa2e88a7123f99e65fcad63141b9b5581978a3e"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-external-attacher",
+        "annotations": {
+          "io.openshift.build.commit.id": "9445dfaeba21fe4789026f124b7f7d30b9f9effd",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-external-attacher"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c1d63ce40a2108555709cff7f4376b09eed634fd086bca53aba01966ff1f2e72"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-external-provisioner",
+        "annotations": {
+          "io.openshift.build.commit.id": "d4252078a86d03586841c69355596f172ba0382e",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-external-provisioner"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d18664d07d2601ae8aa27791e558b5e69e7ba5cffaa29a9800aae755a83c149c"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-external-resizer",
+        "annotations": {
+          "io.openshift.build.commit.id": "2bc34ab636dff1667705223491e4e685359c661b",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-external-resizer"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c9c28f627887a8cb8674c7a9f66a5df8abcfc8589b9b15a85d1ac50afc936fe2"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-external-snapshotter",
+        "annotations": {
+          "io.openshift.build.commit.id": "4f6dbaaf350baa44c69dbe38555a4c6cb793e9a2",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-external-snapshotter"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7c75303dc271f2926dd95ee2b5fecb51c94821691f93661704c00f314a91cdc2"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-livenessprobe",
+        "annotations": {
+          "io.openshift.build.commit.id": "8c1a5bcac1675711b51fffe88b40bb46f0e22db9",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-livenessprobe"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b2987bfb4bff5b8c087f120466dc90186323c4ea7f1d0bdebb24d705f882f2db"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-node-driver-registrar",
+        "annotations": {
+          "io.openshift.build.commit.id": "bb0bd823c2212c6657e5835eb0015aab4e93839d",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-node-driver-registrar"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3075d5aeeed104f9780c40309e023fac8f2772b289eca654f0536a9b46cc97fd"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-snapshot-controller",
+        "annotations": {
+          "io.openshift.build.commit.id": "4f6dbaaf350baa44c69dbe38555a4c6cb793e9a2",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-external-snapshotter"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:29722e17fc4c0bb596dfb4d7801d412fbf541074f21d6b4cb56ce47ad0e3680e"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "csi-snapshot-validation-webhook",
+        "annotations": {
+          "io.openshift.build.commit.id": "4f6dbaaf350baa44c69dbe38555a4c6cb793e9a2",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/csi-external-snapshotter"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6357f0ddb3146b24becd886fe244eeaf23e76d4a65fa5c570e3edea028f14a0a"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "deployer",
+        "annotations": {
+          "io.openshift.build.commit.id": "a253d9d0e65e012be8c6211a988a90d9148992d4",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/oc"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f5a0d3650c67d0c6a48d82c592bfff34227ac10e612d34dc3e60bc18b3585736"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "docker-builder",
+        "annotations": {
+          "io.openshift.build.commit.id": "756e38429c07207c842e3ade17e2a7904c92ea89",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/builder"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bbe0555e45fb074602f1637c4011a01702ab7e668a4e818251ec5e34910c9a72"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "docker-registry",
+        "annotations": {
+          "io.openshift.build.commit.id": "663f8633307b2e36fa04748961a399b65e597029",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/image-registry"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bba9400125a54c27b337f81dae2b80d1fe31f729be81c8d7f1c1648e0efcac2e"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "driver-toolkit",
+        "annotations": {
+          "io.openshift.build.commit.id": "ca1565983d444cb29174bbb7e113c1796f5435d8",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/driver-toolkit"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7f0c83c52a9ba19e2bae258b0ecd2660152d52e47d061c30dd632a0e2537a9f6"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "egress-router-cni",
+        "annotations": {
+          "io.openshift.build.commit.id": "7a4cd82c35345828685b6a4553877d7317fe1ea7",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/egress-router-cni"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a6f9b10f626a31231e0121dd643e5c9cf79222b4014eb8590a841459bfed3887"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "etcd",
+        "annotations": {
+          "io.openshift.build.commit.id": "383d146869b96abaf76a0e2ffe95bda4967f79c4",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/etcd"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6a00f745905f7f2c0dc1dab7e4cae7d9be969c0d9b69a3b6122c3613244f1259"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "gcp-machine-controllers",
+        "annotations": {
+          "io.openshift.build.commit.id": "48057fcd3cf06b40134fa4e450a2c651e305de05",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-api-provider-gcp"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:03ba42253d5980789c8f4f7dc195e525662376e24bc3d659abd2eb7d9179b0a4"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "gcp-pd-csi-driver",
+        "annotations": {
+          "io.openshift.build.commit.id": "7405b5bb9e3357f84394fc421d6df4d640799266",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/gcp-pd-csi-driver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d0e41e323d2c99a9692f4cfa2bb09547d778c04f66f04f23c6b2d4947df3eafd"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "gcp-pd-csi-driver-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "095483aadecae96a1c66937fd9a052f38feb6c59",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/gcp-pd-csi-driver-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2fbd5e76add87a2135be95623387dcf7f499a726555cc078d50c3132bcf5e53b"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "grafana",
+        "annotations": {
+          "io.openshift.build.commit.id": "725ba0a7b182a212296c468cf1094fda872cddb4",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/grafana"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb676ca24c28d226e6c1c394718745d431a10afd3a2469a11c4a3bb0da926fde"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "haproxy-router",
+        "annotations": {
+          "io.openshift.build.commit.id": "9a90b013cee67c6e5b225d78319e215c1ea178df",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/router"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a05ad126b31a6b274514de150f34e7531772756d32caa55777e9caac492be6e8"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "hyperkube",
+        "annotations": {
+          "io.openshift.build.commit.id": "f773b8b2b47b6f908236a76f4cafcb04bb2a43fe",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/kubernetes",
+          "io.openshift.build.version-display-names": "",
+          "io.openshift.build.versions": "kubernetes=1.22.1"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c19f2a3691d46728b9c7949f4a4845522da056343ab087f1f894e2896ed22c3b"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ibm-cloud-controller-manager",
+        "annotations": {
+          "io.openshift.build.commit.id": "2a68d5e604aee1c4a28813295554ef38f0f9159c",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cloud-provider-ibm"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b619e8c62a46269235019ff2073f91dc9195066476821f19536a647a3d679627"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ibmcloud-machine-controllers",
+        "annotations": {
+          "io.openshift.build.commit.id": "4d7907adbd6bb6fe8a4581c7e3530162e6e014a8",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-api-provider-ibmcloud"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:078fb75c0f0974aa64f1cacebd06c18c16464a546d4ad9a258960c1023f0e05a"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "insights-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "018938fe4ddb62381b9cf2d32ed9a41d8e3bd074",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/insights-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d9b68d55246341ddb13b54761fb590b0bef0a03504644133a1c6a54f593b15d"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "installer",
+        "annotations": {
+          "io.openshift.build.commit.id": "8fc863d833b1b361efc61c81998890e1305bcf9b",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/installer"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:20aebc9c2c431d5d7d9a38e8bbca7d4e12dd589ffc90b1d2afb163fde21bf2a7"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "installer-artifacts",
+        "annotations": {
+          "io.openshift.build.commit.id": "8fc863d833b1b361efc61c81998890e1305bcf9b",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/installer"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b9ba7a6d0f01009b73aea7e34ce16205e6727afe7458791c639dc24db5194956"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ironic",
+        "annotations": {
+          "io.openshift.build.commit.id": "0e7e9b2c94f36cdff36a062c07da1c3c4dce5a13",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/ironic-image"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9845256331954fe28858a702d2266112f3a27664764e5df4173575d26ded33a5"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ironic-agent",
+        "annotations": {
+          "io.openshift.build.commit.id": "ee0a7791606b6a7b0d7f997b70432ff7fc391a75",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/ironic-agent-image"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:408fee9762c1bc56dce0a9464c87223a7bda2fc231999e299135544235ce5eda"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ironic-hardware-inventory-recorder",
+        "annotations": {
+          "io.openshift.build.commit.id": "6246922338bc8aa21276c7e679bdd082307cbd45",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/ironic-hardware-inventory-recorder-image"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b6626baa5a6e74d0e49d67c3d0bb166191c1f065a3b007de0feadbf35af75cb2"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ironic-ipa-downloader",
+        "annotations": {
+          "io.openshift.build.commit.id": "8702c2b5591198bfecea7ab3ad3705309c5a962f",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/ironic-ipa-downloader"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8af155a7376c0829b1e93a7180ab9156fe75e9d99692c9fe611b2adc8025efd7"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ironic-machine-os-downloader",
+        "annotations": {
+          "io.openshift.build.commit.id": "2901c28c27a9ed9ac697071cdea87b85cfe6adbb",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/ironic-rhcos-downloader"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:90c36f2c5bfbb2ed5201328dd5dde5a7b0cef2a0ab21b1a424cca91f2b0e4c6f"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ironic-static-ip-manager",
+        "annotations": {
+          "io.openshift.build.commit.id": "cee63ad8d7c5c92a7d6c7ee71828ad447fc2dabe",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/ironic-static-ip-manager"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d9369b75b1c991e27ea7be1a691b2d0d89141b041aa6178bfb1c3aa3481fe367"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "jenkins",
+        "annotations": {
+          "io.openshift.build.commit.id": "402dc9f905bab0bc6123fda9b6df0464076ea035",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/jenkins"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4edef305bd90e32b631d7e53503e5dd3e098d696d75b73532a85f7261cbae751"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "jenkins-agent-base",
+        "annotations": {
+          "io.openshift.build.commit.id": "402dc9f905bab0bc6123fda9b6df0464076ea035",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/jenkins"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:578816f86a1b236a1313a8fe2a662fb71566debfa7a412f2c88e572699675389"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "jenkins-agent-maven",
+        "annotations": {
+          "io.openshift.build.commit.id": "402dc9f905bab0bc6123fda9b6df0464076ea035",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/jenkins"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:25ffa5ba3fe68dda1fa2de7a49d1e85b40a6f3a15099d7ceb08ba87f701315e9"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "jenkins-agent-nodejs",
+        "annotations": {
+          "io.openshift.build.commit.id": "402dc9f905bab0bc6123fda9b6df0464076ea035",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/jenkins"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:70a8caba6e1b0c97754d7dcbb0316dd7aeed5d74f805a862498f76520718e462"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "k8s-prometheus-adapter",
+        "annotations": {
+          "io.openshift.build.commit.id": "8229025dd5301f3181d4c58b1a81e30e83019d76",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/k8s-prometheus-adapter"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4521db386a8b9928877213da1c41ade5ce8d492ed8684f6fcc556589c243c2bc"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "keepalived-ipfailover",
+        "annotations": {
+          "io.openshift.build.commit.id": "544601e82413bc549bfe2eb8b54a7ff9f8c7c42e",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/images"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3e96c1755163ecb2827bf4b4d1dfdabf2a125e6aeef620a0b8ba52d0c450432c"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "kube-proxy",
+        "annotations": {
+          "io.openshift.build.commit.id": "a22d08c57013651a72ff018513f076afae3cbba8",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/sdn"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb7a55350c5f9428abd70bc6e65ec2e68e68ca2ecf1d7d47348fd5d5b78d5c29"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "kube-rbac-proxy",
+        "annotations": {
+          "io.openshift.build.commit.id": "58e09297223ca912cba8b369bfad150b0fc04a9f",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/kube-rbac-proxy"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:da2149a0469fb553d83418d6ff5f4430fafab71c594deaf789376167cfeed9cc"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "kube-state-metrics",
+        "annotations": {
+          "io.openshift.build.commit.id": "9cb8c674cd2c1266699514ef95d464428f80d161",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/kube-state-metrics"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:801fe6b701908b92955cc2daed13891806e881a6aa031bacc09021c06d68a4eb"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "kube-storage-version-migrator",
+        "annotations": {
+          "io.openshift.build.commit.id": "901a6d221d1cf79b4b6ba859bb43521e0ee635b3",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/kubernetes-kube-storage-version-migrator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:be037688cb86e3cb9a3ba107b034d431e60f26de487f5d9861335e4cd8f4bad4"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "kuryr-cni",
+        "annotations": {
+          "io.openshift.build.commit.id": "dca77077c405f971544e7497a5fdd27e6c3d0eae",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/kuryr-kubernetes"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e24fa0d76428600ce0719d3f838fbf2796cd9aab476daebd94f604f8df51e621"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "kuryr-controller",
+        "annotations": {
+          "io.openshift.build.commit.id": "dca77077c405f971544e7497a5fdd27e6c3d0eae",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/kuryr-kubernetes"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0e3f8a0213f3dbf7fda8a04fdaab49a87a8b3a54c60e2ef11709f7aa04180e9b"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "libvirt-machine-controllers",
+        "annotations": {
+          "io.openshift.build.commit.id": "d2c8cbf9925615e09e77c3800fb00e3068601d73",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-api-provider-libvirt"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:49161d893ee673abc4443ca92f8c94b325546617fd7a6d90e235a25d837f96cf"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "machine-api-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "c8bba3e643104a745506283caa8aa329b83663b9",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/machine-api-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f3b9f5d1b4da64722919eb66c22c445986fef803fb0a19f2ea22cdf25a368411"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "machine-config-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "0abf68a0c3206df0be0e13980da645d2c0ac9aa7",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/machine-config-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c948704f6f5c3f704eb9bd51612cefc0447d1f8f08651d273e2940692f81ca31"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "machine-os-content",
+        "annotations": {
+          "io.openshift.build.commit.id": "",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "",
+          "io.openshift.build.version-display-names": "machine-os=Red Hat Enterprise Linux CoreOS",
+          "io.openshift.build.versions": "machine-os=410.84.202111112202-0"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ef70e09018d97db72271780acbafa3adf7e3872d6b2a2fb0313efa0d4504cd59"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "multus-admission-controller",
+        "annotations": {
+          "io.openshift.build.commit.id": "3c28a57a831d11380e612a616820bf8a42261d9d",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/multus-admission-controller"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:03b5aee0afbe27298fcfec7a1e5585655106401f7bb9cc4a8234ed42fb80614a"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "multus-cni",
+        "annotations": {
+          "io.openshift.build.commit.id": "5e081d5de3ba3bbb48d0904eabce050f636140e4",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/multus-cni"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ebd776482cd2e052ea4023f918d2a454cbcf18e517c036a3b82de14ecd6ac5d3"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "multus-networkpolicy",
+        "annotations": {
+          "io.openshift.build.commit.id": "bfcc6c85b5ad1c47fc1d50ddec0acd108d270fe1",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/multus-networkpolicy"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b319fd2cd36914883984d1797c1256ed4aeeca134ed92550d47f2002ac3fde78"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "multus-route-override-cni",
+        "annotations": {
+          "io.openshift.build.commit.id": "707dd38046554810f601f2fae4a69bc4b907d7d3",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/route-override-cni"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a2f0497271eaada92dee35375853480a0da114f327c6d7d73c21eb4c5f8e351f"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "multus-whereabouts-ipam-cni",
+        "annotations": {
+          "io.openshift.build.commit.id": "a2460bebb70c1435e28a7e48a4fc053acbf59942",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/whereabouts-cni"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c047559565f3030b98428a9fc1f550ec51e7368509b45def6dd4b41c940fea76"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "must-gather",
+        "annotations": {
+          "io.openshift.build.commit.id": "ebcb99511457c8e66c3adf10d07270d92e004a48",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/must-gather"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a3e0643d86b1c6f3a2e098f21da2f3e1f50e1cb8d6a1dabb888e95f4cd8bcab"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "network-metrics-daemon",
+        "annotations": {
+          "io.openshift.build.commit.id": "9fd6103057d648a153cba0b8f06db92eff6d62f9",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/network-metrics-daemon"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7f6e3f6c766b86603a7192dee58d663f9514dfed3bc3fe2ee4aec8a688744730"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "network-tools",
+        "annotations": {
+          "io.openshift.build.commit.id": "ed0b846c056056848f0ab7741bd3f1254e1862d6",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/network-tools"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:55f8d4956880ee1d4ffd1a345156145f1ad93ec21abcb149d021b2dace41a007"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "oauth-apiserver",
+        "annotations": {
+          "io.openshift.build.commit.id": "1d6c975fade7240754cc35ac44460d490c166071",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/oauth-apiserver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:45dc7b269c4795a446f3148b42eadc52bb06e11dd1fbd92a1f7ee8f5bc27c2a4"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "oauth-proxy",
+        "annotations": {
+          "io.openshift.build.commit.id": "9ea1ebc89f721d3cd929f58c7ab9ed4273d3c493",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/oauth-proxy"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8739c4f4b3397da121346117178a4f4cfa7d43efd72e87346b3c428648410077"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "oauth-server",
+        "annotations": {
+          "io.openshift.build.commit.id": "2f374a66b260c2e7f9d6b9cce85f3138ee85f31e",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/oauth-server"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:825797dc771d88fc0e784d7461fbca1f4ba4184855c1ac93b7ce83f4547ac286"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "openshift-apiserver",
+        "annotations": {
+          "io.openshift.build.commit.id": "309c8e8b1d447bee0435cc812c4f53e2e09b5050",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/openshift-apiserver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cedaadc4fecb1fde420633ba78acf00c6dbd59cfd850d76c3f9a8809db3eee34"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "openshift-controller-manager",
+        "annotations": {
+          "io.openshift.build.commit.id": "4b96187495df95b35b3728d4966ca0720b57541c",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/openshift-controller-manager"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:74cc12fa81a47a93925a32cf0a633dc5dc107215d95246373c2f15dfc8f466c0"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "openshift-state-metrics",
+        "annotations": {
+          "io.openshift.build.commit.id": "2dcf523061502a5fff2b13829c74b3f266e1776c",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/openshift-state-metrics"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e949a7298aab2af0c857c83b99bee38b6b45dca2e8f18576cc1713bfd23525df"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "openstack-cinder-csi-driver",
+        "annotations": {
+          "io.openshift.build.commit.id": "eb15f08c0ba479077c18cf0d00bac22a02dbcd85",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cloud-provider-openstack"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c012d7fd2a5b6fcb592370224a91e9b996f36ad7520833f50ce7806a9bf68ee4"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "openstack-cinder-csi-driver-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "f9bad0d283b0d0f9957bc3e1a6afacc98309e158",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/openstack-cinder-csi-driver-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c46e102b9e051e3e9ba6a132ba1606bed30cdcc4be42f3315ff51eea01daa468"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "openstack-cloud-controller-manager",
+        "annotations": {
+          "io.openshift.build.commit.id": "eb15f08c0ba479077c18cf0d00bac22a02dbcd85",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cloud-provider-openstack"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1e50a6d96e223be64dd7c3fbb49096aff06c20d0c3fdc6a2ecc4e47edd555cf2"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "openstack-machine-controllers",
+        "annotations": {
+          "io.openshift.build.commit.id": "611d320170af674eca8b68f2be2ebb5be8ad829b",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-api-provider-openstack"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8e0470f0a623a703d6c8b9ead6d7569da99d41531d5842dc106996cc6b3dd93d"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "operator-lifecycle-manager",
+        "annotations": {
+          "io.openshift.build.commit.id": "8970fc081f9c411112446d29ebaeb82d00ba7331",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/operator-framework-olm"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a74c1a8fc82498a6d731d36c7a29ba3dcd58211cc37d8abd657a8643472d25db"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "operator-marketplace",
+        "annotations": {
+          "io.openshift.build.commit.id": "fd858de8ebc117d0ea102127aad689ede84d87e0",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/operator-framework/operator-marketplace"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1e416e66cb410611c9954a27b439b3e11c5df962977cbb30aa9b376353106e61"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "operator-registry",
+        "annotations": {
+          "io.openshift.build.commit.id": "8970fc081f9c411112446d29ebaeb82d00ba7331",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/operator-framework-olm"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cbd71ac02affb069f924ba11fb3e0a30904f41dcf7ed20b43d41accce52cd1ed"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ovirt-csi-driver",
+        "annotations": {
+          "io.openshift.build.commit.id": "75d5266e29e2d8f5c27822a238cd3c3f381f8fa8",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/ovirt-csi-driver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6538671ba4c021576dc804105d7e481c7167636824438722feb115ecab4b067d"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ovirt-csi-driver-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "33e4580a4629672160d5a7cec0da8c3e871d8d84",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/ovirt-csi-driver-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3f5d7e529542879475a113bdb5da0aceca92424bf4d3a8aba37e125dd1d5e670"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ovirt-machine-controllers",
+        "annotations": {
+          "io.openshift.build.commit.id": "d7fe4b39d6d57c3d4ac59a70fc3278e3c19c114d",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-api-provider-ovirt"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cac0e7c9cd4abe23fde6aa4d81b8873fe6607a0a27a7c7edbcc16f39f0a0c1d6"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "ovn-kubernetes",
+        "annotations": {
+          "io.openshift.build.commit.id": "f182e9fd406037ea146481bbbf51589a4b33bff7",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/ovn-kubernetes"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7a39e136e432c5ae0da7664d776bb5b50146a59d6a13f466a1fd11e1daedf494"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "pod",
+        "annotations": {
+          "io.openshift.build.commit.id": "f773b8b2b47b6f908236a76f4cafcb04bb2a43fe",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/kubernetes"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:46f936d6e51589bbb79466258b7db9a9af797fd8c704b2248e27661cbfb0a8c7"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "powervs-machine-controllers",
+        "annotations": {
+          "io.openshift.build.commit.id": "58f8170c027926a16d6d13401febfdb51b1b426c",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/cluster-api-provider-powervs"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:381ab2a75c89b540fbb86f0960daf08f1e4ce516441322a5ae2ab167387eaf96"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "prom-label-proxy",
+        "annotations": {
+          "io.openshift.build.commit.id": "41588a73f200e2df0a6ddbecbb23b9b59e1a89b2",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/prom-label-proxy"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4989b6a5911bf7460bd24788708c0e250aaa58182224b4d0c75cbd39350ff446"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "prometheus",
+        "annotations": {
+          "io.openshift.build.commit.id": "8f3f08e784340babe6618f11aa87d22d2daa354d",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/prometheus"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:79cadd266fbfb1766029f4ff60f4a944e756a36df6edd4c047864fba361170da"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "prometheus-alertmanager",
+        "annotations": {
+          "io.openshift.build.commit.id": "9f3a23a00830cf07a03b0bf74115f9854a3a3be3",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/prometheus-alertmanager"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ae55162b24c1e5bf7f0d1fa0e9348f642959112df37784d0f91b6b1d865c79d8"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "prometheus-config-reloader",
+        "annotations": {
+          "io.openshift.build.commit.id": "e2f1f5ddee62b2d69690faab8ad0ec5f68cc538f",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/prometheus-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:500053bdc97bc4014fe59c1159af276a04a923813afd1e73474507411dbcfde8"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "prometheus-node-exporter",
+        "annotations": {
+          "io.openshift.build.commit.id": "48647cc40c4f7b09d07231b1effeed6d5106f44f",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/node_exporter"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:976c799b6cabf4acdb9e5559f2001a7c72747186f28b2bb0153c626a6ab6724d"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "prometheus-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "e2f1f5ddee62b2d69690faab8ad0ec5f68cc538f",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/prometheus-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:991479b116b7d430f922667698fbb689ce61a08a082cc0cacd7067f3845d9f78"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "sdn",
+        "annotations": {
+          "io.openshift.build.commit.id": "a22d08c57013651a72ff018513f076afae3cbba8",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/sdn"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3895503537fb735f7ba12512eb66ac4464b032962c5839850a3b9f2a354e52d7"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "service-ca-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "76f048a60891c425f2b83a666c231ea6c44ae8d1",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/service-ca-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d2044295db3458f93cc1ccf7babfb01f23e3fe15c255702eee1df330b537434b"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "telemeter",
+        "annotations": {
+          "io.openshift.build.commit.id": "91bff806c60507a1f806b9dc48bd64b83c2d9cb6",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/telemeter"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6edf2d8b64552c6735f2b1163c9a5f4ae480c825fb7172666fe85fddb8c464bd"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "tests",
+        "annotations": {
+          "io.openshift.build.commit.id": "aa1ee49a4b2392c70c586717b071e2867c258b02",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/origin"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:53199f08da4e393b1cc63061016fba738379fe8829e42f34a59273239b3bb8f0"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "thanos",
+        "annotations": {
+          "io.openshift.build.commit.id": "2aee8b19cfeb196e873fc8bc314fe4617cd7c5cc",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/thanos"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bdd58580409a422e38d6b2c27f0afba1604419fee6b30086b83b033f46e33f9b"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "tools",
+        "annotations": {
+          "io.openshift.build.commit.id": "a253d9d0e65e012be8c6211a988a90d9148992d4",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/oc"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:51ccbe294e7fff49650a674fe42904b0aa6035d059ab3e57428b7956acf8ea05"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "vsphere-csi-driver",
+        "annotations": {
+          "io.openshift.build.commit.id": "6fa85bdbeda05caed3bf09a712d463a71f9d9a69",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/vmware-vsphere-csi-driver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:089b8a5b41c24b792011f95dda176121a36d71a64898861cee670a77385e0214"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "vsphere-csi-driver-operator",
+        "annotations": {
+          "io.openshift.build.commit.id": "bb7eaac1f3afc9d094aa10a19bcdc48ad84d18ca",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/vmware-vsphere-csi-driver-operator"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:447406f10b0a71bd571b5c27bd393a96e7aa394f75e4697cfd7b8a1501c00770"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "vsphere-csi-driver-syncer",
+        "annotations": {
+          "io.openshift.build.commit.id": "6fa85bdbeda05caed3bf09a712d463a71f9d9a69",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/vmware-vsphere-csi-driver"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e4879ae40706c23ffac4dd315af17476201c28f214e4d963e46d4507eeeeb071"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      },
+      {
+        "name": "vsphere-problem-detector",
+        "annotations": {
+          "io.openshift.build.commit.id": "f9b4a42b943c3d66cebaddc1ac1c6f63eca90127",
+          "io.openshift.build.commit.ref": "",
+          "io.openshift.build.source-location": "https://github.com/openshift/vsphere-problem-detector"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e691e266cdceaaaff496a2f68e5ef706e9df6d9307864473c31b8e1d0020c460"
+        },
+        "generation": null,
+        "importPolicy": {},
+        "referencePolicy": {
+          "type": ""
+        }
+      }
+    ]
+  },
+  "status": {
+    "dockerImageRepository": ""
+  }
+}

--- a/support/releaseinfo/fixtures/4.10-installer-coreos-bootimages.yaml
+++ b/support/releaseinfo/fixtures/4.10-installer-coreos-bootimages.yaml
@@ -1,0 +1,629 @@
+apiVersion: v1
+data:
+  releaseVersion: 0.0.1-snapshot
+  stream: |
+    {
+      "stream": "rhcos-4.10",
+      "metadata": {
+        "last-modified": "2021-11-11T19:40:38Z",
+        "generator": "plume cosa2stream 0.11.0+454-g226dbc8e9"
+      },
+      "architectures": {
+        "aarch64": {
+          "artifacts": {
+            "aws": {
+              "release": "410.84.202111111403-0",
+              "formats": {
+                "vmdk.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-aws.aarch64.vmdk.gz",
+                    "sha256": "b355cb94d0e5e640f729419eea34f0a5fbd2dcb181bb00b229fcef2892bef660",
+                    "uncompressed-sha256": "cd33b106831eec1dbb2914bec9df6b84b5e821ef639a35195e2681512530ddca"
+                  }
+                }
+              }
+            },
+            "metal": {
+              "release": "410.84.202111111403-0",
+              "formats": {
+                "4k.raw.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-metal4k.aarch64.raw.gz",
+                    "sha256": "19379c5e3796c30923c61bebefed3e286835d4d7d16fa4793f732700ade1d5cd",
+                    "uncompressed-sha256": "c2b3bfe292f1fdd15068e0a24a757eca7d2069b4077488aa32a687bd3fbc47b3"
+                  }
+                },
+                "iso": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-live.aarch64.iso",
+                    "sha256": "0c7797b5325ab0f71e0786e1249ad62c9319799145721bedf99e1ff8622cd138"
+                  }
+                },
+                "pxe": {
+                  "kernel": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-live-kernel-aarch64",
+                    "sha256": "210ad7e3cf24d0a5388600bad437cd3a0ac211605decf869498dd9ffb32d7ccb"
+                  },
+                  "initramfs": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-live-initramfs.aarch64.img",
+                    "sha256": "9e9e5ffcac9b3c6968d48dae9e0793626f7bf43e80ce77a58bab574206b7335c"
+                  },
+                  "rootfs": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-live-rootfs.aarch64.img",
+                    "sha256": "9bcf2a82d8aa7ebcadbdeb56d408f43fe6729cbc141a0e37e4e4218c47b59e81"
+                  }
+                },
+                "raw.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-metal.aarch64.raw.gz",
+                    "sha256": "4e901e4024631b211244bcc92a97e6e911c07bc677c7e6e777aecdf05cb4b2af",
+                    "uncompressed-sha256": "b721f664926ce85906dc289a17189485f80fc6f0c62a8bd46aeaba17c9df1da8"
+                  }
+                }
+              }
+            },
+            "openstack": {
+              "release": "410.84.202111111403-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-openstack.aarch64.qcow2.gz",
+                    "sha256": "2f1aaeff835adcdb63af923c852b903686c9c0496f4fe8fbf0699de076f7f63d",
+                    "uncompressed-sha256": "636760c3a974faa1ce8698ab4ab7fab72d0cfeca21f3c40081993159382e3608"
+                  }
+                }
+              }
+            },
+            "qemu": {
+              "release": "410.84.202111111403-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-qemu.aarch64.qcow2.gz",
+                    "sha256": "291b806387b630d020f1158984eff9e764e292ace3abfc31bd854ffcaab3d5b2",
+                    "uncompressed-sha256": "0e463b9bd462dcac8270d9dc5ae0c4910630032a8878ae92e4a58d34504e1e0f"
+                  }
+                }
+              }
+            }
+          },
+          "images": {
+            "aws": {
+              "regions": {
+                "ap-east-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-0a5d702a40d99411c"
+                },
+                "ap-northeast-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-0874b6143e5a90dd8"
+                },
+                "ap-northeast-2": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-09aef6d4c011743f5"
+                },
+                "ap-south-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-078e98cd05e71e714"
+                },
+                "ap-southeast-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-07e5fc52189352c74"
+                },
+                "ap-southeast-2": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-0d5d934b9f6516fa2"
+                },
+                "ca-central-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-0a03806dd3fc25850"
+                },
+                "eu-central-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-048cc5892569bef7f"
+                },
+                "eu-north-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-0945a4f116ee187ac"
+                },
+                "eu-south-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-011f6f9ef172db09c"
+                },
+                "eu-west-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-0131e0ac452aba369"
+                },
+                "eu-west-2": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-01e3e0bc9d26c320f"
+                },
+                "eu-west-3": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-0d224e2702a94b211"
+                },
+                "me-south-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-041b0da04cdbb81e2"
+                },
+                "sa-east-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-036851f96b8898f44"
+                },
+                "us-east-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-0022ae02b40256546"
+                },
+                "us-east-2": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-0b511d5d32d354b67"
+                },
+                "us-west-1": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-06135896c507a0fb5"
+                },
+                "us-west-2": {
+                  "release": "410.84.202111111403-0",
+                  "image": "ami-02ae1fa58542aeb5d"
+                }
+              }
+            }
+          }
+        },
+        "ppc64le": {
+          "artifacts": {
+            "metal": {
+              "release": "410.84.202111111404-0",
+              "formats": {
+                "4k.raw.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-metal4k.ppc64le.raw.gz",
+                    "sha256": "4cb13dcc7f90cccd84be9b7410477abd446d18d85b444dd93c2b250a65b54917",
+                    "uncompressed-sha256": "a87af1c769936ad66cc4a9ef3959f9d85232898208b24464716d65e5293e5af1"
+                  }
+                },
+                "iso": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-live.ppc64le.iso",
+                    "sha256": "a72b48a9595c9d8ab13b84724ea8ab2ba96dd05b4a80b299743667c1eccd7d22"
+                  }
+                },
+                "pxe": {
+                  "kernel": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-live-kernel-ppc64le",
+                    "sha256": "d14366b7f5ffdbe7360ba40a0060356268947976bf09201792f3fd3ea014dd90"
+                  },
+                  "initramfs": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-live-initramfs.ppc64le.img",
+                    "sha256": "5e3147c81ebe2b421a9985e61d3bac89d2bda3bdbc1ea362bb4103eeeab6847c"
+                  },
+                  "rootfs": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-live-rootfs.ppc64le.img",
+                    "sha256": "ae2e3c7df2c981a1f249ee1741cb295a806878182769fa2d80e676b2d7af11cd"
+                  }
+                },
+                "raw.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-metal.ppc64le.raw.gz",
+                    "sha256": "987878dc024c97782287416141986751a3c29f2f471df4fecc96f6c998e28e4a",
+                    "uncompressed-sha256": "8feadeb935e2d0da33fe3dd6052efcc5b95e59d58d96049c5bdd139258c9912c"
+                  }
+                }
+              }
+            },
+            "openstack": {
+              "release": "410.84.202111111404-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-openstack.ppc64le.qcow2.gz",
+                    "sha256": "0b8c19a30f4ca6b5a20a43a46f6dcc2c80fd9597e6c4f740688954566454f5f3",
+                    "uncompressed-sha256": "6aff5a372dbefd422e18d6241fc942e27bd80e616c00a689df081a266c68e0a5"
+                  }
+                }
+              }
+            },
+            "powervs": {
+              "release": "410.84.202111111404-0",
+              "formats": {
+                "ova.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-powervs.ppc64le.ova.gz",
+                    "sha256": "b339aa8e2b8d91b5f86c8c863d12143c7dd62f3d70802093f05abb8949a59baf",
+                    "uncompressed-sha256": "f3d5e18f48a413de582f60cde755e0d0dbbc9f5d83ee6b06f0d2145baea89c13"
+                  }
+                }
+              }
+            },
+            "qemu": {
+              "release": "410.84.202111111404-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-qemu.ppc64le.qcow2.gz",
+                    "sha256": "055f5e8a39f72ead4fb157e09e49909d6477e1aa3badb9c836cc26f5af165a56",
+                    "uncompressed-sha256": "9903f017ba80bdb4141a3edbfc42a46f09ac04d7cd73ebd0194382b9a3c42565"
+                  }
+                }
+              }
+            }
+          },
+          "images": {
+            "powervs": {
+              "regions": {
+                "au-syd": {
+                  "release": "410.84.202111111404-0",
+                  "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-au-syd",
+                  "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+                },
+                "br-sao": {
+                  "release": "410.84.202111111404-0",
+                  "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-br-sao",
+                  "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+                },
+                "ca-tor": {
+                  "release": "410.84.202111111404-0",
+                  "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-ca-tor",
+                  "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+                },
+                "eu-de": {
+                  "release": "410.84.202111111404-0",
+                  "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-eu-de",
+                  "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+                },
+                "eu-gb": {
+                  "release": "410.84.202111111404-0",
+                  "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-eu-gb",
+                  "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+                },
+                "jp-osa": {
+                  "release": "410.84.202111111404-0",
+                  "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-jp-osa",
+                  "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+                },
+                "jp-tok": {
+                  "release": "410.84.202111111404-0",
+                  "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-jp-tok",
+                  "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+                },
+                "us-east": {
+                  "release": "410.84.202111111404-0",
+                  "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-us-east",
+                  "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+                },
+                "us-south": {
+                  "release": "410.84.202111111404-0",
+                  "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-us-south",
+                  "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+                }
+              }
+            }
+          }
+        },
+        "s390x": {
+          "artifacts": {
+            "metal": {
+              "release": "410.84.202111111403-0",
+              "formats": {
+                "4k.raw.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-metal4k.s390x.raw.gz",
+                    "sha256": "0b15622504531b9fb9f6228b3fdb089c1588fba1fb34913019a9be607ffaf9de",
+                    "uncompressed-sha256": "33cb5d74cecfa61d3228bcd68d4f09f48f96c523f2be130603ac1557fdbba6d4"
+                  }
+                },
+                "iso": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-live.s390x.iso",
+                    "sha256": "595b1131a243698c9eb6f499c617e13f85e271041eef5c9424c6a10660c59d6b"
+                  }
+                },
+                "pxe": {
+                  "kernel": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-live-kernel-s390x",
+                    "sha256": "56568da41178d4ace5f3f7ff3ffda4ca6c4f3ae156ff4e2769457ef64078c475"
+                  },
+                  "initramfs": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-live-initramfs.s390x.img",
+                    "sha256": "0f76f39026d0b767b9c58ed2d6baf09d842467679095e6b654f7fccc77338320"
+                  },
+                  "rootfs": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-live-rootfs.s390x.img",
+                    "sha256": "c717d8d0f7fe79bcc2dfd6206705254e59e5551336bd3873604849980215d313"
+                  }
+                },
+                "raw.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-metal.s390x.raw.gz",
+                    "sha256": "7e370a6d5c35138e6c84843e6ecaf0fb2bdbcb4965f3350c1c43e0cf1f1703a8",
+                    "uncompressed-sha256": "811e9392e7ff370975dc6cffa4815700416ee94b9799ec007b67d936fbde9fc0"
+                  }
+                }
+              }
+            },
+            "openstack": {
+              "release": "410.84.202111111403-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-openstack.s390x.qcow2.gz",
+                    "sha256": "19d7d557a0f9777d8d1a6b876ac4d18120e27c8b43e10dc3f416020963c5d248",
+                    "uncompressed-sha256": "8c968b3e079c02a2a1a51336117cd7e23ad6dc9311642a6b36d166fe3dd14fc5"
+                  }
+                }
+              }
+            },
+            "qemu": {
+              "release": "410.84.202111111403-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-qemu.s390x.qcow2.gz",
+                    "sha256": "e24346ff4d8c229d500476eaeb4573394ed5a36be3f28c65d40b775ff06244d9",
+                    "uncompressed-sha256": "a7c422c1032f609020007771ee7cdc40f30979294c3962d20792762498b613e8"
+                  }
+                }
+              }
+            }
+          },
+          "images": {}
+        },
+        "x86_64": {
+          "artifacts": {
+            "aws": {
+              "release": "410.84.202111111322-0",
+              "formats": {
+                "vmdk.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-aws.x86_64.vmdk.gz",
+                    "sha256": "94e4e6f17e1dd2ee32a03420267691b2c2f1e382ea0a113cc61cc52ebf42e803",
+                    "uncompressed-sha256": "a9090e48e2607f5e1103198735f5182f4b89a102ec754e45d4b949b2aa70bb54"
+                  }
+                }
+              }
+            },
+            "azure": {
+              "release": "410.84.202111111322-0",
+              "formats": {
+                "vhd.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-azure.x86_64.vhd.gz",
+                    "sha256": "49ff633f3488c9e033845891e167209b8f9734d2709274b6f59325c895131ab7",
+                    "uncompressed-sha256": "12d28c89287da8d2b86700435edd386f3a21b62415b9c0958b548b9c26c4e7cb"
+                  }
+                }
+              }
+            },
+            "azurestack": {
+              "release": "410.84.202111111322-0",
+              "formats": {
+                "vhd.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-azurestack.x86_64.vhd.gz",
+                    "sha256": "6ecf18746d9404f237323971cb7d5b3565a033024a7a0c810f6d131b8a546575",
+                    "uncompressed-sha256": "17b85a4eba773acec16bb05f61f1d4b2bc8f79ef59acc1804de9f58e2322b964"
+                  }
+                }
+              }
+            },
+            "gcp": {
+              "release": "410.84.202111111322-0",
+              "formats": {
+                "tar.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-gcp.x86_64.tar.gz",
+                    "sha256": "9df28d47e414e6c5de2e5ccbe4a05d6e9e0cd6d1986589708fe2403fde6ed872",
+                    "uncompressed-sha256": "ec9794015b977d53ee319119479d47c1f5d27f2044cd6206d457dff333dd8227"
+                  }
+                }
+              }
+            },
+            "ibmcloud": {
+              "release": "410.84.202111111322-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-ibmcloud.x86_64.qcow2.gz",
+                    "sha256": "00e11f45277933ffc668248170e2a587fdf1a1ff72a712353002b1f72cc56c57",
+                    "uncompressed-sha256": "309051de984fe63f81c5f4996377b2f7c5df8bdf7b903fe832c26fe9a09e7739"
+                  }
+                }
+              }
+            },
+            "metal": {
+              "release": "410.84.202111111322-0",
+              "formats": {
+                "4k.raw.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-metal4k.x86_64.raw.gz",
+                    "sha256": "2972f10c2db39c750c20b50edcd540ea894604aed24826029d706876ce2e5f7c",
+                    "uncompressed-sha256": "311bb716f5940a2f847df845f83c864a6a1c332bd5f25120ca509347a5cf6e31"
+                  }
+                },
+                "iso": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-live.x86_64.iso",
+                    "sha256": "2349028216f129e914c43a4f83dab902640332122afd0c4f36f8f5acc9320527"
+                  }
+                },
+                "pxe": {
+                  "kernel": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-live-kernel-x86_64",
+                    "sha256": "a752fbc6b291520df85a2012c6bfc297a468de67f745b0da3fca734fef709164"
+                  },
+                  "initramfs": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-live-initramfs.x86_64.img",
+                    "sha256": "cee41269a34fa0f7466ad3d82a3f4f6ae28c3f4601470080185b203d5961e276"
+                  },
+                  "rootfs": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-live-rootfs.x86_64.img",
+                    "sha256": "b31cca1e9a5098ba360f18214e29799e4ddc336a26a28974ac73b11c1c119207"
+                  }
+                },
+                "raw.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-metal.x86_64.raw.gz",
+                    "sha256": "543c4dad51954657727be66e7084c17287864ee2351aa68f2adae8d893b94552",
+                    "uncompressed-sha256": "836550fbda2cd51232b22dbde405a727f455bf3dc0f6996c395ce5f72ae46f20"
+                  }
+                }
+              }
+            },
+            "openstack": {
+              "release": "410.84.202111111322-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-openstack.x86_64.qcow2.gz",
+                    "sha256": "415f2219b9960829f6c463d1b5f429a09e99d6f7fd458f95cc5b06db1505281b",
+                    "uncompressed-sha256": "ee6492e572469c80b940ed38a740e84440c289922382442e365b9eb3b6fda04d"
+                  }
+                }
+              }
+            },
+            "qemu": {
+              "release": "410.84.202111111322-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-qemu.x86_64.qcow2.gz",
+                    "sha256": "f0d8f502e1107bd282f57ccb7126898f69d177e65a1e8194d31fb4a9c985ad0d",
+                    "uncompressed-sha256": "a692ed81c089981a58fdce843136bf6ef2c111585de255a5b874db8a26665706"
+                  }
+                }
+              }
+            },
+            "vmware": {
+              "release": "410.84.202111111322-0",
+              "formats": {
+                "ova": {
+                  "disk": {
+                    "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-vmware.x86_64.ova",
+                    "sha256": "bff9e3793708a14e7c7c7fc3f4cc6bcdac8e76bb48754d94c696be3c753e37e0"
+                  }
+                }
+              }
+            }
+          },
+          "images": {
+            "aws": {
+              "regions": {
+                "af-south-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0aa991762109bd955"
+                },
+                "ap-east-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0f279d4784a72d40c"
+                },
+                "ap-northeast-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0b9a082a4dc3c89cd"
+                },
+                "ap-northeast-2": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0ce4b303db099f99f"
+                },
+                "ap-northeast-3": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0b04fcda674dd372c"
+                },
+                "ap-south-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-05c6342dd03d27b2b"
+                },
+                "ap-southeast-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-051a71b23d871b011"
+                },
+                "ap-southeast-2": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0171e63e24d2880b2"
+                },
+                "ca-central-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-06631ddbe660842b5"
+                },
+                "eu-central-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-02303ca361d9181bc"
+                },
+                "eu-north-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-08ba59b0ad16e7d3e"
+                },
+                "eu-south-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0b76a89747f4c3bdc"
+                },
+                "eu-west-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-027fc9e8211a23fc8"
+                },
+                "eu-west-2": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0ef9f9dce1b9a3dbd"
+                },
+                "eu-west-3": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-045e1a370fb01a509"
+                },
+                "me-south-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-018903dd2c601602e"
+                },
+                "sa-east-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0d56ea3e1e05062bc"
+                },
+                "us-east-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0713d9bcf78401cd1"
+                },
+                "us-east-2": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0c2dbd95931008b1a"
+                },
+                "us-west-1": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0483451d19cd3f521"
+                },
+                "us-west-2": {
+                  "release": "410.84.202111111322-0",
+                  "image": "ami-0fa07c6be7f16a985"
+                }
+              }
+            },
+            "gcp": {
+              "release": "410.84.202111111322-0",
+              "project": "rhcos-cloud",
+              "name": "rhcos-410-84-202111111322-0-gcp-x86-64"
+            }
+          },
+          "rhel-coreos-extensions": {
+            "azure-disk": {
+              "release": "410.84.202111111322-0",
+              "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-410.84.202111111322-0-azure.x86_64.vhd"
+            }
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  creationTimestamp: null
+  name: coreos-bootimages
+  namespace: openshift-machine-config-operator

--- a/support/releaseinfo/fixtures/fixtures.go
+++ b/support/releaseinfo/fixtures/fixtures.go
@@ -9,3 +9,9 @@ var ImageReferencesJSON_4_8 []byte
 
 //go:embed 4.8-installer-coreos-bootimages.yaml
 var CoreOSBootImagesYAML_4_8 []byte
+
+//go:embed 4.10-image-references.json
+var ImageReferencesJSON_4_10 []byte
+
+//go:embed 4.10-installer-coreos-bootimages.yaml
+var CoreOSBootImagesYAML_4_10 []byte

--- a/support/releaseinfo/releaseinfo.go
+++ b/support/releaseinfo/releaseinfo.go
@@ -51,7 +51,8 @@ type CoreOSFormat struct {
 }
 
 type CoreOSImages struct {
-	AWS CoreOSAWSImages `json:"aws"`
+	AWS     CoreOSAWSImages     `json:"aws"`
+	PowerVS CoreOSPowerVSImages `json:"powervs"`
 }
 
 type CoreOSAWSImages struct {
@@ -61,6 +62,17 @@ type CoreOSAWSImages struct {
 type CoreOSAWSImage struct {
 	Release string `json:"release"`
 	Image   string `json:"image"`
+}
+
+type CoreOSPowerVSImages struct {
+	Regions map[string]CoreOSPowerVSImage `json:"regions"`
+}
+
+type CoreOSPowerVSImage struct {
+	Release string `json:"release"`
+	Object  string `json:"object"`
+	Bucket  string `json:"bucket"`
+	URL     string `json:"url"`
 }
 
 func (i *ReleaseImage) Version() string {

--- a/support/releaseinfo/releaseinfo_test.go
+++ b/support/releaseinfo/releaseinfo_test.go
@@ -1,0 +1,27 @@
+package releaseinfo
+
+import (
+	"testing"
+
+	"github.com/openshift/hypershift/support/releaseinfo/fixtures"
+)
+
+// TestReleaseInfoPowerVS test validates the presence of the powervs images in the 4.10 release
+func TestReleaseInfoPowerVS(t *testing.T) {
+	metadata, err := DeserializeImageMetadata(fixtures.CoreOSBootImagesYAML_4_10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	arch, ok := metadata.Architectures["ppc64le"]
+	if !ok {
+		t.Fatal("metadata does not contain the ppc64le architecture")
+	}
+	if len(arch.Images.PowerVS.Regions) == 0 {
+		t.Fatal("metadata does not contain any powervs regions")
+	}
+	for _, region := range arch.Images.PowerVS.Regions {
+		if region.Release == "" || region.Object == "" || region.Bucket == "" || region.URL == "" {
+			t.Fatalf("none of the fields in the image can be empty: %+v", region)
+		}
+	}
+}


### PR DESCRIPTION
With recent PR into the installer included the [PowerVS](https://www.ibm.com/in-en/products/power-virtual-server) images into the rhcos.json file, this enhancement will allow us to use the powervs image in the IBM Cloud ppc64le support

Installer PR: https://github.com/openshift/installer/pull/5377