### PR TITLE
Allow the KAS to finish its graceful shutdown

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -133,10 +133,13 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 			},
 		},
 		Spec: corev1.PodSpec{
-			DNSPolicy:                     corev1.DNSClusterFirst,
-			RestartPolicy:                 corev1.RestartPolicyAlways,
-			SecurityContext:               &corev1.PodSecurityContext{},
-			TerminationGracePeriodSeconds: pointer.Int64Ptr(30),
+			DNSPolicy:       corev1.DNSClusterFirst,
+			RestartPolicy:   corev1.RestartPolicyAlways,
+			SecurityContext: &corev1.PodSecurityContext{},
+			// The KAS takes 90 seconds to finish its graceful shutdown, give it enough
+			// time to do that + 5 seconds margin. The shutdown sequence is described
+			// in detail here: https://github.com/openshift/installer/blob/master/docs/dev/kube-apiserver-health-check.md
+			TerminationGracePeriodSeconds: pointer.Int64Ptr(95),
 			SchedulerName:                 corev1.DefaultSchedulerName,
 			AutomountServiceAccountToken:  pointer.BoolPtr(false),
 			InitContainers: []corev1.Container{


### PR DESCRIPTION
Currently, the KAS has a 30 seconds TerminationGracePeriodSeconds but
its shutdown sequence takes 90 seconds, where it still takes requests
for the first 30 seconds and finishes responding to them for the next 60
seconds. This is to ensure that client requests created during a rollout
still get a response.

The current setting means that the kubelet just kills the KAS after 30
seconds, interrupting this sequence. Bump TerminationGracePeriodSeconds
to 95 seconds to allow the shutdown sequence to finish. This is visible
in the KAS log where we now see `[graceful-termination] apiserver is
exiting` in the very end after deleting a pod.

The shutdown sequence of the KAS is described in more detail here:
https://github.com/openshift/installer/blob/master/docs/dev/kube-apiserver-health-check.md