### PR TITLE
Get rid of the anonymous auth rule for the OIDC

### DIFF
--- a/hosted-cluster-config-operator/controllers/resources/manifests/rbac.go
+++ b/hosted-cluster-config-operator/controllers/resources/manifests/rbac.go
@@ -68,11 +68,3 @@ func CSRRenewalClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		},
 	}
 }
-
-func ServiceAccountIssuerDiscoveryClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "system:service-account-issuer-discovery-unauthenticated",
-		},
-	}
-}

--- a/hosted-cluster-config-operator/controllers/resources/rbac/reconcile.go
+++ b/hosted-cluster-config-operator/controllers/resources/rbac/reconcile.go
@@ -226,19 +226,3 @@ func ReconcileCSRRenewalClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
 	}
 	return nil
 }
-
-func ReconcileServiceAccountIssuerDiscoveryClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
-	r.RoleRef = rbacv1.RoleRef{
-		APIGroup: rbacv1.SchemeGroupVersion.Group,
-		Kind:     "ClusterRole",
-		Name:     "system:service-account-issuer-discovery",
-	}
-	r.Subjects = []rbacv1.Subject{
-		{
-			APIGroup: rbacv1.SchemeGroupVersion.Group,
-			Kind:     "Group",
-			Name:     "system:unauthenticated",
-		},
-	}
-	return nil
-}

--- a/hosted-cluster-config-operator/controllers/resources/resources.go
+++ b/hosted-cluster-config-operator/controllers/resources/resources.go
@@ -315,7 +315,6 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 		{manifest: manifests.NamespaceSecurityAllocationControllerClusterRoleBinding, reconcile: rbac.ReconcileNamespaceSecurityAllocationControllerClusterRoleBinding},
 		{manifest: manifests.NodeBootstrapperClusterRoleBinding, reconcile: rbac.ReconcileNodeBootstrapperClusterRoleBinding},
 		{manifest: manifests.CSRRenewalClusterRoleBinding, reconcile: rbac.ReconcileCSRRenewalClusterRoleBinding},
-		{manifest: manifests.ServiceAccountIssuerDiscoveryClusterRoleBinding, reconcile: rbac.ReconcileServiceAccountIssuerDiscoveryClusterRoleBinding},
 	}
 
 	var errs []error


### PR DESCRIPTION
We don't need it anymore as we publish these to S3. This fixes the
`[sig-auth][Feature:OpenShiftAuthorization] The default cluster RBAC policy should have correct RBAC rules`
conformance test.

Ref https://issues.redhat.com/browse/HOSTEDCP-257

/cc @csrwng 