### PR TITLE
Add a control plane operator Dockerfile

### DIFF
--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -4,16 +4,14 @@ WORKDIR /hypershift
 
 COPY . .
 
-RUN make build
+RUN make control-plane-operator ignition-server hosted-cluster-config-operator konnectivity-socks5-proxy availability-prober token-minter
 
 FROM quay.io/openshift/origin-base:4.10
-COPY --from=builder /hypershift/bin/ignition-server /usr/bin/ignition-server
-COPY --from=builder /hypershift/bin/hypershift /usr/bin/hypershift
-COPY --from=builder /hypershift/bin/hypershift-operator /usr/bin/hypershift-operator
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
+COPY --from=builder /hypershift/bin/ignition-server /usr/bin/ignition-server
 COPY --from=builder /hypershift/bin/hosted-cluster-config-operator /usr/bin/hosted-cluster-config-operator
 COPY --from=builder /hypershift/bin/konnectivity-socks5-proxy /usr/bin/konnectivity-socks5-proxy
 COPY --from=builder /hypershift/bin/availability-prober /usr/bin/availability-prober
 COPY --from=builder /hypershift/bin/token-minter /usr/bin/token-minter
 
-ENTRYPOINT /usr/bin/hypershift
+ENTRYPOINT /usr/bin/control-plane-operator


### PR DESCRIPTION
Add a discrete Dockerfile for a control plane image containing only
those binaries which should be incorporated into the OCP payload.