### PR TITLE
Enable metrics integration in CI installation Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,4 +196,5 @@ ci-install-hypershift:
 	bin/hypershift install --hypershift-image $(HYPERSHIFT_RELEASE_LATEST) \
 		--oidc-storage-provider-s3-credentials=/etc/hypershift-pool-aws-credentials/credentials \
 		--oidc-storage-provider-s3-bucket-name=hypershift-ci-oidc \
-		--oidc-storage-provider-s3-region=us-east-1
+		--oidc-storage-provider-s3-region=us-east-1 \
+		--enable-ocp-cluster-monitoring


### PR DESCRIPTION
For CI hypershift installation, metrics integration should always be
enabled by default so that the jobs can choose to export them.