### PR TITLE
operator-lifecycle-manager-packageserver: Add namespace to related objects

### DIFF
--- a/hosted-cluster-config-operator/controllers/clusteroperator/reconcile.go
+++ b/hosted-cluster-config-operator/controllers/clusteroperator/reconcile.go
@@ -238,7 +238,12 @@ var clusterOperators = []ClusterOperatorInfo{
 		VersionMapping: map[string]string{
 			"operator": "release",
 		},
-		RelatedObjects: []configv1.ObjectReference{},
+		RelatedObjects: []configv1.ObjectReference{
+			{
+				Resource: "namespaces",
+				Name:     "openshift-operator-lifecycle-manager",
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
Fixes the 'ClusterOperators should define at least one namespace in their
lists of related objects' conformance test.

Ref https://issues.redhat.com/browse/HOSTEDCP-257

/cc @csrwng 