### PR TITLE
Default MachineDeployment replicas to 0 if they are nil

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -610,6 +610,58 @@ func TestSetMachineDeploymentReplicas(t *testing.T) {
 				autoscalerMaxAnnotation: "5",
 			},
 		},
+		{
+			name: "it sets current replicas to 1 and set annotations when autoscaling is enabled" +
+				" and the MachineDeployment has 0 replicas",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: hyperv1.NodePoolSpec{
+					AutoScaling: &hyperv1.NodePoolAutoScaling{
+						Min: 1,
+						Max: 5,
+					},
+				},
+			},
+			machineDeployment: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: capiv1.MachineDeploymentSpec{
+					Replicas: pointer.Int32Ptr(0),
+				},
+			},
+			expectReplicas: 1,
+			expectAutoscalerAnnotations: map[string]string{
+				autoscalerMinAnnotation: "1",
+				autoscalerMaxAnnotation: "5",
+			},
+		},
+		{
+			name: "it sets current replicas to 1 and set annotations when autoscaling is enabled" +
+				" and the MachineDeployment has nil replicas",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: hyperv1.NodePoolSpec{
+					AutoScaling: &hyperv1.NodePoolAutoScaling{
+						Min: 1,
+						Max: 5,
+					},
+				},
+			},
+			machineDeployment: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: capiv1.MachineDeploymentSpec{
+					Replicas: nil,
+				},
+			},
+			expectReplicas: 1,
+			expectAutoscalerAnnotations: map[string]string{
+				autoscalerMinAnnotation: "1",
+				autoscalerMaxAnnotation: "5",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Before this PR MachineDeployments with nil replicas i.e brand new MachineDeployments were temporary defaulted to 1 when a brand new NodePool replicas was nil. The immediate next call to setMachineDeploymentReplicas was reconciling to the right MachineDeployments replicas in this scenario i.e 0.
This PR ensures the MachineDeployment replicas remains 0 all the time in the scenario above.