### PR TITLE
Hypershift operator: Ensure created objects are annotated to trigger reconciliation

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer.go
+++ b/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer.go
@@ -1,0 +1,33 @@
+package hostedcluster
+
+import (
+	"context"
+
+	"github.com/openshift/hypershift/support/upsert"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func createOrUpdateWithAnnotationFactory(upstream upsert.CreateOrUpdateProvider) func(reconcile.Request) upsert.CreateOrUpdateFN {
+	return func(req reconcile.Request) upsert.CreateOrUpdateFN {
+		return func(ctx context.Context, c crclient.Client, obj crclient.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+
+			// Wrap f() to add the annotation at the end
+			mutateFN := func() error {
+				if err := f(); err != nil {
+					return err
+				}
+				annotations := obj.GetAnnotations()
+				if annotations == nil {
+					annotations = map[string]string{}
+				}
+				annotations[hostedClusterAnnotation] = req.String()
+				obj.SetAnnotations(annotations)
+				return nil
+			}
+
+			return upstream.CreateOrUpdate(ctx, c, obj, mutateFN)
+		}
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer_test.go
+++ b/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer_test.go
@@ -1,0 +1,88 @@
+package hostedcluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/hypershift/support/upsert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestCreateOrUpdateWithAnnotationFactory(t *testing.T) {
+
+	testCases := []struct {
+		name     string
+		mutateFN func(m *metav1.ObjectMeta) controllerutil.MutateFn
+		verify   func(*testing.T, *corev1.ConfigMap)
+	}{
+		{
+			name: "No annotations",
+			mutateFN: func(m *metav1.ObjectMeta) controllerutil.MutateFn {
+				return func() error { return nil }
+			},
+		},
+		{
+			name: "Existing annotations are kept",
+			mutateFN: func(m *metav1.ObjectMeta) controllerutil.MutateFn {
+				return func() error {
+					m.Annotations = map[string]string{
+						"foo": "bar",
+					}
+					return nil
+				}
+			},
+			verify: func(t *testing.T, cm *corev1.ConfigMap) {
+				if cm.Annotations["foo"] != "bar" {
+					t.Errorf("expected 'foo' annotation to be kept, but it's gone. Annotations: %+v", cm.Annotations)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			}
+
+			// expectedObj is the original object + mutateFN + the annotation
+			expectedObj := obj.DeepCopy()
+			tc.mutateFN(&expectedObj.ObjectMeta)()
+			if expectedObj.Annotations == nil {
+				expectedObj.Annotations = map[string]string{}
+			}
+			expectedObj.Annotations[hostedClusterAnnotation] = "/foo"
+
+			client := fake.NewClientBuilder().WithObjects(obj).Build()
+			providerFactory := createOrUpdateWithAnnotationFactory(upsert.New(false))
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}}
+
+			if _, err := providerFactory(req)(context.Background(), client, obj, tc.mutateFN(&obj.ObjectMeta)); err != nil {
+				t.Fatalf("CreateOrUpdate failed: %v", err)
+			}
+
+			actual := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+			if err := client.Get(context.Background(), crclient.ObjectKeyFromObject(actual), actual); err != nil {
+				t.Fatalf("failed to get object from client after running CreateOrUpdate: %v", err)
+			}
+			actual.ResourceVersion = ""
+			actual.TypeMeta = metav1.TypeMeta{}
+			if diff := cmp.Diff(actual, expectedObj); diff != "" {
+				t.Errorf("actual differs from expected: %v", diff)
+			}
+
+			if tc.verify != nil {
+				tc.verify(t, actual)
+			}
+		})
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -146,7 +146,7 @@ type HostedClusterReconciler struct {
 
 	EnableOCPClusterMonitoring bool
 
-	upsert.CreateOrUpdateProvider
+	createOrUpdate func(reconcile.Request) upsert.CreateOrUpdateFN
 
 	EnableCIDebugOutput bool
 
@@ -159,10 +159,11 @@ type HostedClusterReconciler struct {
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters/status,verbs=get;update;patch
 
-func (r *HostedClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *HostedClusterReconciler) SetupWithManager(mgr ctrl.Manager, createOrUpdate upsert.CreateOrUpdateProvider) error {
 	if r.Clock == nil {
 		r.Clock = clock.RealClock{}
 	}
+	r.createOrUpdate = createOrUpdateWithAnnotationFactory(createOrUpdate)
 	r.tracer = otel.Tracer("hostedcluster-controller")
 	// Set up watches for resource types the controller manages. The list basically
 	// tracks types of the resources in the clusterapi, controlplaneoperator, and
@@ -501,9 +502,11 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	createOrUpdate := r.createOrUpdate(req)
+
 	// Reconcile the hosted cluster namespace
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, controlPlaneNamespace, func() error {
+	_, err = createOrUpdate(ctx, r.Client, controlPlaneNamespace, func() error {
 		if controlPlaneNamespace.Labels == nil {
 			controlPlaneNamespace.Labels = make(map[string]string)
 		}
@@ -528,7 +531,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get cloud controller provider creds %s: %w", hcluster.Spec.Platform.AWS.KubeCloudControllerCreds.Name, err)
 		}
 		dest := manifests.AWSKubeCloudControllerCreds(controlPlaneNamespace.Name)
-		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
+		_, err = createOrUpdate(ctx, r.Client, dest, func() error {
 			srcData, srcHasData := src.Data["credentials"]
 			if !srcHasData {
 				return fmt.Errorf("hostedcluster cloud controller provider credentials secret %q must have a credentials key", src.Name)
@@ -556,7 +559,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get node pool provider creds %s: %w", hcluster.Spec.Platform.AWS.NodePoolManagementCreds.Name, err)
 		}
 		dest := manifests.AWSNodePoolManagementCreds(controlPlaneNamespace.Name)
-		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
+		_, err = createOrUpdate(ctx, r.Client, dest, func() error {
 			srcData, srcHasData := src.Data["credentials"]
 			if !srcHasData {
 				return fmt.Errorf("node pool provider credentials secret %q is missing credentials key", src.Name)
@@ -584,7 +587,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get control plane operator provider creds %s: %w", hcluster.Spec.Platform.AWS.ControlPlaneOperatorCreds.Name, err)
 		}
 		dest := manifests.AWSControlPlaneOperatorCreds(controlPlaneNamespace.Name)
-		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
+		_, err = createOrUpdate(ctx, r.Client, dest, func() error {
 			srcData, srcHasData := src.Data["credentials"]
 			if !srcHasData {
 				return fmt.Errorf("control plane operator provider credentials secret %q is missing credentials key", src.Name)
@@ -609,7 +612,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get pull secret %s: %w", hcluster.Spec.PullSecret.Name, err)
 		}
 		dst := controlplaneoperator.PullSecret(controlPlaneNamespace.Name)
-		_, err = r.CreateOrUpdate(ctx, r.Client, dst, func() error {
+		_, err = createOrUpdate(ctx, r.Client, dst, func() error {
 			srcData, srcHasData := src.Data[".dockerconfigjson"]
 			if !srcHasData {
 				return fmt.Errorf("hostedcluster pull secret %q must have a .dockerconfigjson key", src.Name)
@@ -651,7 +654,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					Name:      src.Name,
 				},
 			}
-			_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneActiveKeySecret, func() error {
+			_, err = createOrUpdate(ctx, r.Client, hostedControlPlaneActiveKeySecret, func() error {
 				if hostedControlPlaneActiveKeySecret.Data == nil {
 					hostedControlPlaneActiveKeySecret.Data = map[string][]byte{}
 				}
@@ -678,7 +681,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 						Name:      src.Name,
 					},
 				}
-				_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneBackupKeySecret, func() error {
+				_, err = createOrUpdate(ctx, r.Client, hostedControlPlaneBackupKeySecret, func() error {
 					if hostedControlPlaneBackupKeySecret.Data == nil {
 						hostedControlPlaneBackupKeySecret.Data = map[string][]byte{}
 					}
@@ -724,7 +727,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 							Name:      src.Name,
 						},
 					}
-					_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneIBMCloudKMSAuthSecret, func() error {
+					_, err = createOrUpdate(ctx, r.Client, hostedControlPlaneIBMCloudKMSAuthSecret, func() error {
 						if hostedControlPlaneIBMCloudKMSAuthSecret.Data == nil {
 							hostedControlPlaneIBMCloudKMSAuthSecret.Data = map[string][]byte{}
 						}
@@ -757,7 +760,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 						Name:      src.Name,
 					},
 				}
-				_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneAWSKMSAuthSecret, func() error {
+				_, err = createOrUpdate(ctx, r.Client, hostedControlPlaneAWSKMSAuthSecret, func() error {
 					if hostedControlPlaneAWSKMSAuthSecret.Data == nil {
 						hostedControlPlaneAWSKMSAuthSecret.Data = map[string][]byte{}
 					}
@@ -799,7 +802,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					Name:      src.Name,
 				},
 			}
-			_, err = r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneAuditWebhookSecret, func() error {
+			_, err = createOrUpdate(ctx, r.Client, hostedControlPlaneAuditWebhookSecret, func() error {
 				if hostedControlPlaneAuditWebhookSecret.Data == nil {
 					hostedControlPlaneAuditWebhookSecret.Data = map[string][]byte{}
 				}
@@ -822,7 +825,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get hostedcluster SSH key secret %s: %w", hcluster.Spec.SSHKey.Name, err)
 		}
 		dest := controlplaneoperator.SSHKey(controlPlaneNamespace.Name)
-		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
+		_, err = createOrUpdate(ctx, r.Client, dest, func() error {
 			srcData, srcHasData := src.Data["id_rsa.pub"]
 			if !srcHasData {
 				return fmt.Errorf("hostedcluster ssh key secret %q must have a id_rsa.pub key", src.Name)
@@ -856,7 +859,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				Name:      hcluster.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name,
 			},
 		}
-		if result, err := r.CreateOrUpdate(ctx, r.Client, hostedControlPlaneEtcdClientSecret, func() error {
+		if result, err := createOrUpdate(ctx, r.Client, hostedControlPlaneEtcdClientSecret, func() error {
 			if hostedControlPlaneEtcdClientSecret.Data == nil {
 				hostedControlPlaneEtcdClientSecret.Data = map[string][]byte{}
 			}
@@ -881,7 +884,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				destCM := &corev1.ConfigMap{}
 				destCM.Name = sourceCM.Name
 				destCM.Namespace = controlPlaneNamespace.Name
-				if _, err := r.CreateOrUpdate(ctx, r.Client, destCM, func() error {
+				if _, err := createOrUpdate(ctx, r.Client, destCM, func() error {
 					destCM.Annotations = sourceCM.Annotations
 					destCM.Labels = sourceCM.Labels
 					destCM.Data = sourceCM.Data
@@ -901,7 +904,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				destSecret := &corev1.Secret{}
 				destSecret.Name = sourceSecret.Name
 				destSecret.Namespace = controlPlaneNamespace.Name
-				if _, err := r.CreateOrUpdate(ctx, r.Client, destSecret, func() error {
+				if _, err := createOrUpdate(ctx, r.Client, destSecret, func() error {
 					destSecret.Annotations = sourceSecret.Annotations
 					destSecret.Labels = sourceSecret.Labels
 					destSecret.Data = sourceSecret.Data
@@ -917,7 +920,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Reconcile the HostedControlPlane
 	hcp := controlplaneoperator.HostedControlPlane(controlPlaneNamespace.Name, hcluster.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, hcp, func() error {
+	_, err = createOrUpdate(ctx, r.Client, hcp, func() error {
 		return reconcileHostedControlPlane(hcp, hcluster)
 	})
 	if err != nil {
@@ -951,7 +954,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		ibmCluster := controlplaneoperator.IBMCloudCluster(controlPlaneNamespace.Name, hcluster.Name)
-		_, err = r.CreateOrUpdate(ctx, r.Client, ibmCluster, func() error {
+		_, err = createOrUpdate(ctx, r.Client, ibmCluster, func() error {
 			return reconcileIBMCloudCluster(ibmCluster, hcluster, hcp.Status.ControlPlaneEndpoint)
 		})
 		if err != nil {
@@ -964,14 +967,14 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Reconcile cluster prometheus RBAC resources if enabled
 	if r.EnableOCPClusterMonitoring {
-		if err := reconcileClusterPrometheusRBAC(ctx, r.Client, hcp.Namespace); err != nil {
+		if err := r.reconcileClusterPrometheusRBAC(ctx, createOrUpdate, hcp.Namespace); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile RBAC for OCP cluster prometheus: %w", err)
 		}
 	}
 
 	// Reconcile the CAPI Cluster resource
 	capiCluster := controlplaneoperator.CAPICluster(controlPlaneNamespace.Name, hcluster.Spec.InfraID)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiCluster, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiCluster, func() error {
 		return reconcileCAPICluster(capiCluster, hcluster, hcp, infraCR)
 	})
 	if err != nil {
@@ -991,7 +994,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to get controlplane kubeconfig secret %q: %w", client.ObjectKeyFromObject(src), err)
 		}
 		dest := manifests.KubeConfigSecret(hcluster.Namespace, hcluster.Name)
-		_, err = r.CreateOrUpdate(ctx, r.Client, dest, func() error {
+		_, err = createOrUpdate(ctx, r.Client, dest, func() error {
 			key := hcp.Status.KubeConfig.Key
 			srcData, srcHasData := src.Data[key]
 			if !srcHasData {
@@ -1016,7 +1019,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile the CAPI manager components
-	err = r.reconcileCAPIManager(ctx, hcluster)
+	err = r.reconcileCAPIManager(ctx, createOrUpdate, hcluster)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile capi manager: %w", err)
 	}
@@ -1024,7 +1027,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	switch hcluster.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		// Reconcile the CAPI AWS provider components
-		err = r.reconcileCAPIAWSProvider(ctx, hcluster)
+		err = r.reconcileCAPIAWSProvider(ctx, createOrUpdate, hcluster)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile capi aws provider: %w", err)
 		}
@@ -1034,28 +1037,28 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile the autoscaler
-	err = r.reconcileAutoscaler(ctx, hcluster, hcp)
+	err = r.reconcileAutoscaler(ctx, createOrUpdate, hcluster, hcp)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile autoscaler: %w", err)
 	}
 
 	// Reconcile the control plane operator
-	err = r.reconcileControlPlaneOperator(ctx, hcluster, hcp)
+	err = r.reconcileControlPlaneOperator(ctx, createOrUpdate, hcluster, hcp)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile control plane operator: %w", err)
 	}
 
 	// Reconcile the Ignition server
-	if err = r.reconcileIgnitionServer(ctx, hcluster, hcp); err != nil {
+	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, hcp); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile ignition server: %w", err)
 	}
 
 	// Reconcile the machine config server
-	if err = r.reconcileMachineConfigServer(ctx, hcluster); err != nil {
+	if err = r.reconcileMachineConfigServer(ctx, createOrUpdate, hcluster); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile machine config server: %w", err)
 	}
 
-	if err = r.reconcileMachineApprover(ctx, hcluster, hcp); err != nil {
+	if err = r.reconcileMachineApprover(ctx, createOrUpdate, hcluster, hcp); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile machine approver: %w", err)
 	}
 
@@ -1163,7 +1166,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 }
 
 // reconcileCAPIManager orchestrates orchestrates of  all CAPI manager components.
-func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hcluster *hyperv1.HostedCluster) error {
+func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster) error {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
@@ -1172,7 +1175,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI webhooks TLS secret
 	capiWebhooksTLSSecret := clusterapi.CAPIWebhooksTLSSecret(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiWebhooksTLSSecret, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiWebhooksTLSSecret, func() error {
 		_, hasTLSPrivateKeyKey := capiWebhooksTLSSecret.Data[corev1.TLSPrivateKeyKey]
 		_, hasTLSCertKey := capiWebhooksTLSSecret.Data[corev1.TLSCertKey]
 		if hasTLSPrivateKeyKey && hasTLSCertKey {
@@ -1206,14 +1209,14 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI manager service account
 	capiManagerServiceAccount := clusterapi.CAPIManagerServiceAccount(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerServiceAccount, NoopReconcile)
+	_, err = createOrUpdate(ctx, r.Client, capiManagerServiceAccount, NoopReconcile)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile capi manager service account: %w", err)
 	}
 
 	// Reconcile CAPI manager cluster role
 	capiManagerClusterRole := clusterapi.CAPIManagerClusterRole(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerClusterRole, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiManagerClusterRole, func() error {
 		return reconcileCAPIManagerClusterRole(capiManagerClusterRole)
 	})
 	if err != nil {
@@ -1222,7 +1225,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI manager cluster role binding
 	capiManagerClusterRoleBinding := clusterapi.CAPIManagerClusterRoleBinding(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerClusterRoleBinding, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiManagerClusterRoleBinding, func() error {
 		return reconcileCAPIManagerClusterRoleBinding(capiManagerClusterRoleBinding, capiManagerClusterRole, capiManagerServiceAccount)
 	})
 	if err != nil {
@@ -1231,7 +1234,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI manager role
 	capiManagerRole := clusterapi.CAPIManagerRole(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerRole, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiManagerRole, func() error {
 		return reconcileCAPIManagerRole(capiManagerRole)
 	})
 	if err != nil {
@@ -1240,7 +1243,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 	// Reconcile CAPI manager role binding
 	capiManagerRoleBinding := clusterapi.CAPIManagerRoleBinding(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerRoleBinding, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiManagerRoleBinding, func() error {
 		return reconcileCAPIManagerRoleBinding(capiManagerRoleBinding, capiManagerRole, capiManagerServiceAccount)
 	})
 	if err != nil {
@@ -1253,7 +1256,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 		capiImage = hcluster.Annotations[hyperv1.ClusterAPIManagerImage]
 	}
 	capiManagerDeployment := clusterapi.ClusterAPIManagerDeployment(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiManagerDeployment, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiManagerDeployment, func() error {
 		// TODO (alberto): This image builds from https://github.com/kubernetes-sigs/cluster-api/pull/4709
 		// We need to build from main branch and push to quay.io/hypershift once this is merged or otherwise enable webhooks.
 		return reconcileCAPIManagerDeployment(capiManagerDeployment, hcluster, capiManagerServiceAccount, capiImage)
@@ -1267,7 +1270,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, hclu
 
 // reconcileCAPIAWSProvider orchestrates reconciliation of the CAPI AWS provider
 // components.
-func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, hcluster *hyperv1.HostedCluster) error {
+func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster) error {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
@@ -1276,7 +1279,7 @@ func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, 
 
 	// Reconcile CAPI AWS provider role
 	capiAwsProviderRole := clusterapi.CAPIAWSProviderRole(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiAwsProviderRole, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiAwsProviderRole, func() error {
 		return reconcileCAPIAWSProviderRole(capiAwsProviderRole)
 	})
 	if err != nil {
@@ -1285,14 +1288,14 @@ func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, 
 
 	// Reconcile CAPI AWS provider service account
 	capiAwsProviderServiceAccount := clusterapi.CAPIAWSProviderServiceAccount(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiAwsProviderServiceAccount, NoopReconcile)
+	_, err = createOrUpdate(ctx, r.Client, capiAwsProviderServiceAccount, NoopReconcile)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile capi aws provider service account: %w", err)
 	}
 
 	// Reconcile CAPI AWS provider role binding
 	capiAwsProviderRoleBinding := clusterapi.CAPIAWSProviderRoleBinding(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiAwsProviderRoleBinding, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiAwsProviderRoleBinding, func() error {
 		return reconcileCAPIAWSProviderRoleBinding(capiAwsProviderRoleBinding, capiAwsProviderRole, capiAwsProviderServiceAccount)
 	})
 	if err != nil {
@@ -1301,7 +1304,7 @@ func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, 
 
 	// Reconcile CAPI AWS provider deployment
 	capiAwsProviderDeployment := clusterapi.CAPIAWSProviderDeployment(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, capiAwsProviderDeployment, func() error {
+	_, err = createOrUpdate(ctx, r.Client, capiAwsProviderDeployment, func() error {
 		// TODO (alberto): This image builds from https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2453
 		// We need to build from main branch and push to quay.io/hypershift once this is merged or otherwise enable webhooks.
 		return reconcileCAPIAWSProviderDeployment(capiAwsProviderDeployment, hcluster, capiAwsProviderServiceAccount, r.TokenMinterImage)
@@ -1315,7 +1318,7 @@ func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, 
 
 // reconcileControlPlaneOperator orchestrates reconciliation of the control plane
 // operator components.
-func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane) error {
+func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane) error {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
@@ -1324,14 +1327,14 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 
 	// Reconcile operator service account
 	controlPlaneOperatorServiceAccount := controlplaneoperator.OperatorServiceAccount(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorServiceAccount, NoopReconcile)
+	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorServiceAccount, NoopReconcile)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator service account: %w", err)
 	}
 
 	// Reconcile operator cluster role
 	controlPlaneOperatorClusterRole := controlplaneoperator.OperatorClusterRole()
-	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRole, func() error {
+	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRole, func() error {
 		return reconcileControlPlaneOperatorClusterRole(controlPlaneOperatorClusterRole)
 	})
 	if err != nil {
@@ -1340,7 +1343,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 
 	// Reconcile operator cluster role binding
 	controlPlaneOperatorClusterRoleBinding := controlplaneoperator.OperatorClusterRoleBinding(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRoleBinding, func() error {
+	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRoleBinding, func() error {
 		return reconcileControlPlaneOperatorClusterRoleBinding(controlPlaneOperatorClusterRoleBinding, controlPlaneOperatorClusterRole, controlPlaneOperatorServiceAccount)
 	})
 	if err != nil {
@@ -1349,7 +1352,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 
 	// Reconcile operator role
 	controlPlaneOperatorRole := controlplaneoperator.OperatorRole(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorRole, func() error {
+	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorRole, func() error {
 		return reconcileControlPlaneOperatorRole(controlPlaneOperatorRole)
 	})
 	if err != nil {
@@ -1358,7 +1361,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 
 	// Reconcile operator role binding
 	controlPlaneOperatorRoleBinding := controlplaneoperator.OperatorRoleBinding(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorRoleBinding, func() error {
+	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorRoleBinding, func() error {
 		return reconcileControlPlaneOperatorRoleBinding(controlPlaneOperatorRoleBinding, controlPlaneOperatorRole, controlPlaneOperatorServiceAccount)
 	})
 	if err != nil {
@@ -1379,7 +1382,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 		return err
 	}
 	controlPlaneOperatorDeployment := controlplaneoperator.OperatorDeployment(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
+	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
 		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.(*releaseinfo.RegistryMirrorProviderDecorator).RegistryOverrides))
 	})
 	if err != nil {
@@ -1388,7 +1391,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 
 	// Reconcile operator PodMonitor
 	podMonitor := controlplaneoperator.PodMonitor(controlPlaneNamespace.Name, hcluster.Name)
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, podMonitor, func() error {
+	if _, err := createOrUpdate(ctx, r.Client, podMonitor, func() error {
 		podMonitor.Spec.Selector = *controlPlaneOperatorDeployment.Spec.Selector
 		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
 			Interval: "15s",
@@ -1463,7 +1466,7 @@ func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.Servi
 	return nil
 }
 
-func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) error {
+func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) error {
 	var span trace.Span
 	ctx, span = r.tracer.Start(ctx, "reconcile-ignition-server")
 	defer span.End()
@@ -1480,7 +1483,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	}
 	// Reconcile service
 	ignitionServerService := ignitionserver.Service(controlPlaneNamespace.Name)
-	if result, err := r.CreateOrUpdate(ctx, r.Client, ignitionServerService, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, ignitionServerService, func() error {
 		return reconcileIgnitionServerService(ignitionServerService, serviceStrategy)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition service: %w", err)
@@ -1492,7 +1495,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	case hyperv1.Route:
 		// Reconcile route
 		ignitionServerRoute := ignitionserver.Route(controlPlaneNamespace.Name)
-		if result, err := r.CreateOrUpdate(ctx, r.Client, ignitionServerRoute, func() error {
+		if result, err := createOrUpdate(ctx, r.Client, ignitionServerRoute, func() error {
 			if ignitionServerRoute.Annotations == nil {
 				ignitionServerRoute.Annotations = map[string]string{}
 			}
@@ -1538,7 +1541,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	// Reconcile a root CA for ignition serving certificates. We only create this
 	// and don't update it for now.
 	caCertSecret := ignitionserver.IgnitionCACertSecret(controlPlaneNamespace.Name)
-	if result, err := r.CreateOrUpdate(ctx, r.Client, caCertSecret, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, caCertSecret, func() error {
 		if caCertSecret.CreationTimestamp.IsZero() {
 			cfg := &certs.CertCfg{
 				Subject:   pkix.Name{CommonName: "ignition-root-ca", OrganizationalUnit: []string{"openshift"}},
@@ -1567,7 +1570,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	// Reconcile a ignition serving certificate issued by the generated root CA. We
 	// only create this and don't update it for now.
 	servingCertSecret := ignitionserver.IgnitionServingCertSecret(controlPlaneNamespace.Name)
-	if result, err := r.CreateOrUpdate(ctx, r.Client, servingCertSecret, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, servingCertSecret, func() error {
 		if servingCertSecret.CreationTimestamp.IsZero() {
 			caCert, err := certs.PemToCertificate(caCertSecret.Data[corev1.TLSCertKey])
 			if err != nil {
@@ -1607,7 +1610,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	}
 
 	role := ignitionserver.Role(controlPlaneNamespace.Name)
-	if result, err := r.CreateOrUpdate(ctx, r.Client, role, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, role, func() error {
 		role.Rules = []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
@@ -1639,14 +1642,14 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 	}
 
 	sa := ignitionserver.ServiceAccount(controlPlaneNamespace.Name)
-	if result, err := r.CreateOrUpdate(ctx, r.Client, sa, NoopReconcile); err != nil {
+	if result, err := createOrUpdate(ctx, r.Client, sa, NoopReconcile); err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator service account: %w", err)
 	} else {
 		span.AddEvent("reconciled ignition ServiceAccount", trace.WithAttributes(attribute.String("result", string(result))))
 	}
 
 	roleBinding := ignitionserver.RoleBinding(controlPlaneNamespace.Name)
-	if result, err := r.CreateOrUpdate(ctx, r.Client, roleBinding, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, roleBinding, func() error {
 		roleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
@@ -1669,7 +1672,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 
 	// Reconcile deployment
 	ignitionServerDeployment := ignitionserver.Deployment(controlPlaneNamespace.Name)
-	if result, err := r.CreateOrUpdate(ctx, r.Client, ignitionServerDeployment, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, ignitionServerDeployment, func() error {
 		if ignitionServerDeployment.Annotations == nil {
 			ignitionServerDeployment.Annotations = map[string]string{}
 		}
@@ -1806,7 +1809,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, h
 // reconcileAutoscaler orchestrates reconciliation of autoscaler components using
 // both the HostedCluster and the HostedControlPlane which the autoscaler takes
 // inputs from.
-func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) error {
+func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) error {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
@@ -1815,7 +1818,7 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, hclus
 
 	// Reconcile autoscaler role
 	autoScalerRole := autoscaler.AutoScalerRole(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, autoScalerRole, func() error {
+	_, err = createOrUpdate(ctx, r.Client, autoScalerRole, func() error {
 		return reconcileAutoScalerRole(autoScalerRole)
 	})
 	if err != nil {
@@ -1824,14 +1827,14 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, hclus
 
 	// Reconcile autoscaler service account
 	autoScalerServiceAccount := autoscaler.AutoScalerServiceAccount(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, autoScalerServiceAccount, NoopReconcile)
+	_, err = createOrUpdate(ctx, r.Client, autoScalerServiceAccount, NoopReconcile)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile autoscaler service account: %w", err)
 	}
 
 	// Reconcile autoscaler role binding
 	autoScalerRoleBinding := autoscaler.AutoScalerRoleBinding(controlPlaneNamespace.Name)
-	_, err = r.CreateOrUpdate(ctx, r.Client, autoScalerRoleBinding, func() error {
+	_, err = createOrUpdate(ctx, r.Client, autoScalerRoleBinding, func() error {
 		return reconcileAutoScalerRoleBinding(autoScalerRoleBinding, autoScalerRole, autoScalerServiceAccount)
 	})
 	if err != nil {
@@ -1859,7 +1862,7 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, hclus
 			clusterAutoScalerImage = hcluster.Annotations[hyperv1.ClusterAutoscalerImage]
 		}
 		autoScalerDeployment := autoscaler.AutoScalerDeployment(controlPlaneNamespace.Name)
-		_, err = r.CreateOrUpdate(ctx, r.Client, autoScalerDeployment, func() error {
+		_, err = createOrUpdate(ctx, r.Client, autoScalerDeployment, func() error {
 			return reconcileAutoScalerDeployment(autoScalerDeployment, hcluster, autoScalerServiceAccount, capiKubeConfigSecret, hcluster.Spec.Autoscaling, clusterAutoScalerImage, r.AvailabilityProberImage)
 		})
 		if err != nil {
@@ -3084,7 +3087,7 @@ func enqueueParentHostedCluster(obj client.Object) []reconcile.Request {
 	}
 }
 
-func (r *HostedClusterReconciler) reconcileMachineConfigServer(ctx context.Context, hcluster *hyperv1.HostedCluster) error {
+func (r *HostedClusterReconciler) reconcileMachineConfigServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster) error {
 	var span trace.Span
 	ctx, span = r.tracer.Start(ctx, "reconcile-machine-config-server")
 	defer span.End()
@@ -3096,7 +3099,7 @@ func (r *HostedClusterReconciler) reconcileMachineConfigServer(ctx context.Conte
 
 	// Reconcile service
 	mcsService := ignitionserver.MCSService(controlPlaneNamespace.Name)
-	if result, err := r.CreateOrUpdate(ctx, r.Client, mcsService, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, mcsService, func() error {
 		return reconcileMachineConfigServerService(mcsService)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile machine config server service: %w", err)
@@ -3127,9 +3130,9 @@ func reconcileMachineConfigServerService(svc *corev1.Service) error {
 	return nil
 }
 
-func reconcileClusterPrometheusRBAC(ctx context.Context, c client.Client, namespace string) error {
+func (r *HostedClusterReconciler) reconcileClusterPrometheusRBAC(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, namespace string) error {
 	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "openshift-prometheus"}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, c, role, func() error {
+	if _, err := createOrUpdate(ctx, r.Client, role, func() error {
 		role.Rules = []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
 			Resources: []string{
@@ -3149,7 +3152,7 @@ func reconcileClusterPrometheusRBAC(ctx context.Context, c client.Client, namesp
 	}
 
 	binding := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "openshift-prometheus"}}
-	if _, err := controllerutil.CreateOrUpdate(ctx, c, binding, func() error {
+	if _, err := createOrUpdate(ctx, r.Client, binding, func() error {
 		binding.RoleRef.APIGroup = "rbac.authorization.k8s.io"
 		binding.RoleRef.Kind = "Role"
 		binding.RoleRef.Name = role.Name
@@ -3166,12 +3169,12 @@ func reconcileClusterPrometheusRBAC(ctx context.Context, c client.Client, namesp
 	return nil
 }
 
-func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) error {
+func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) error {
 	controlPlaneNamespaceName := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
 
 	// Reconcile machine-approver role
 	role := machineapprover.Role(controlPlaneNamespaceName)
-	if _, err := r.CreateOrUpdate(ctx, r.Client, role, func() error {
+	if _, err := createOrUpdate(ctx, r.Client, role, func() error {
 		return reconcileMachineApproverRole(role)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile machine-approver role: %w", err)
@@ -3179,19 +3182,19 @@ func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, 
 
 	// Reconcile machine-approver service account
 	sa := machineapprover.ServiceAccount(controlPlaneNamespaceName)
-	if _, err := r.CreateOrUpdate(ctx, r.Client, sa, NoopReconcile); err != nil {
+	if _, err := createOrUpdate(ctx, r.Client, sa, NoopReconcile); err != nil {
 		return fmt.Errorf("failed to reconcile machine-approver service account: %w", err)
 	}
 
 	// Reconcile machine-approver role binding
 	rolebinding := machineapprover.RoleBinding(controlPlaneNamespaceName)
-	if _, err := r.CreateOrUpdate(ctx, r.Client, rolebinding, func() error {
+	if _, err := createOrUpdate(ctx, r.Client, rolebinding, func() error {
 		return reconcileMachineApproverRoleBinding(rolebinding, role, sa)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile machine-approver role binding: %w", err)
 	}
 	config := machineapprover.ConfigMap(controlPlaneNamespaceName)
-	if _, err := r.CreateOrUpdate(ctx, r.Client, config, func() error {
+	if _, err := createOrUpdate(ctx, r.Client, config, func() error {
 		return reconcileMachineApproverConfig(config)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile machine-approver config: %w", err)
@@ -3208,7 +3211,7 @@ func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, 
 			image = hcluster.Annotations[hyperv1.MachineApproverImage]
 		}
 		deployment := machineapprover.Deployment(controlPlaneNamespaceName)
-		if _, err := r.CreateOrUpdate(ctx, r.Client, deployment, func() error {
+		if _, err := createOrUpdate(ctx, r.Client, deployment, func() error {
 			return reconcileMachineApproverDeployment(deployment, hcluster, sa, kubeconfigSecretName, config, image, r.AvailabilityProberImage)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile machine-approver deployment: %w", err)

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -235,7 +235,6 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 			RegistryOverrides: opts.RegistryOverrides,
 		},
 		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
-		CreateOrUpdateProvider:     createOrUpdate,
 		EnableCIDebugOutput:        opts.EnableCIDebugOutput,
 	}
 	if opts.OIDCStorageProviderS3Credentials != "" {
@@ -245,7 +244,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		hostedClusterReconciler.S3Client = s3Client
 		hostedClusterReconciler.OIDCStorageProviderS3BucketName = opts.OIDCStorageProviderS3BucketName
 	}
-	if err := hostedClusterReconciler.SetupWithManager(mgr); err != nil {
+	if err := hostedClusterReconciler.SetupWithManager(mgr, createOrUpdate); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}
 

--- a/support/upsert/upsert.go
+++ b/support/upsert/upsert.go
@@ -15,6 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+type CreateOrUpdateFN = func(ctx context.Context, c crclient.Client, obj crclient.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error)
+
 type CreateOrUpdateProvider interface {
 	CreateOrUpdate(ctx context.Context, c crclient.Client, obj crclient.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error)
 }


### PR DESCRIPTION
The hypershift operator creates a number of resources per hostedcluster
and changes to these trigger a reconciliation of the corresponding
hostedcluster. The mapping is done through an annotation.

Unfortunately, we do not set the annotation in many cases which means
that external changes do not get corrected by the Hypershift operator.

This change makes us automically insert the annotation. It went through
several rounds before I was happy with the result:
1. Wrap the client and just check and error: This works but requires to
   update a massive amount of code to insert the annotation everywhere
   and plug the required info through
2. Wrap the client to automatically insert the annotation: This mostly
   works, but if someone ever removes the annotaiton, we will not re-add
   it because CreateOrUpdate doesn't see the diff, as it happens on a
   layer below
3. Add a CreateOrUpdate wrapper that gets constructed with the
   reconcile.Request and wraps the mutateFN: This makes CreateOrUpdate
   automatically insert the annotation and see the diff created by this,
   if any. The wrapper is tiny so this seems pretty elegant to me.

/cc @csrwng 