### PR TITLE
Add private DNS zone and CPO record management for AWS private clusters

### DIFF
--- a/api/v1alpha1/endpointservice_types.go
+++ b/api/v1alpha1/endpointservice_types.go
@@ -30,15 +30,24 @@ type AWSEndpointServiceSpec struct {
 
 // AWSEndpointServiceStatus defines the observed state of AWSEndpointService
 type AWSEndpointServiceStatus struct {
-	// The endpoint service name created in the management VPC in response to the request
+	// EndpointServiceName is the name of the Endpoint Service created in the
+	// management VPC
 	// +optional
 	EndpointServiceName string `json:"endpointServiceName,omitempty"`
 
-	// The endpoint ID created in the guest VPC in response to the request
+	// EndpointID is the ID of the Endpoint created in the guest VPC
 	// +optional
 	EndpointID string `json:"endpointID,omitempty"`
 
-	// Condition contains details for the current state of the Endpoint Service
+	// DNSName is the name for the record created in the hypershift private zone
+	// +optional
+	DNSName string `json:"dnsName,omitempty"`
+
+	// DNSZoneID is ID for the hypershift private zone
+	// +optional
+	DNSZoneID string `json:"dnsZoneID,omitempty"`
+
+	// Conditions contains details for the current state of the Endpoint Service
 	// request If there is an error processing the request e.g. the NLB doesn't
 	// exist, then the Available condition will be false, reason AWSErrorReason,
 	// and the error reported in the message.

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -514,7 +514,7 @@ type AWSPlatformSpec struct {
 	// The secret should have exactly one key, `credentials`, whose value is
 	// an AWS credentials file.
 	//
-	// TODO(dan): document the "node pool management policy"
+	// TODO(dan): document the "control plane operator policy"
 	//
 	// +immutable
 	ControlPlaneOperatorCreds corev1.LocalObjectReference `json:"controlPlaneOperatorCreds"`

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -47,7 +47,8 @@ const (
 	PrivateSubnetCIDR = "10.0.128.0/20"
 	PublicSubnetCIDR  = "10.0.0.0/20"
 
-	clusterTagValue = "owned"
+	clusterTagValue         = "owned"
+	hypershiftLocalZoneName = "hypershift.local"
 )
 
 func NewCreateCommand() *cobra.Command {
@@ -184,7 +185,11 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 	if err != nil {
 		return nil, err
 	}
-	result.PrivateZoneID, err = o.CreatePrivateZone(ctx, route53Client, result.VPCID)
+	result.PrivateZoneID, err = o.CreatePrivateZone(ctx, route53Client, fmt.Sprintf("%s.%s", o.Name, o.BaseDomain), result.VPCID)
+	if err != nil {
+		return nil, err
+	}
+	_, err = o.CreatePrivateZone(ctx, route53Client, fmt.Sprintf("%s.%s", o.Name, hypershiftLocalZoneName), result.VPCID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -248,7 +248,10 @@ const (
 			"Action": [
 				"ec2:CreateVpcEndpoint",
 				"ec2:DescribeVpcEndpoints",
-				"ec2:DeleteVpcEndpoints"
+				"ec2:DeleteVpcEndpoints",
+				"route53:ListHostedZones",
+				"route53:ChangeResourceRecordSets",
+				"route53:ListResourceRecordSets"
 			],
 			"Resource": "*"
 		}

--- a/cmd/infra/aws/route53.go
+++ b/cmd/infra/aws/route53.go
@@ -51,8 +51,7 @@ func lookupZone(ctx context.Context, client route53iface.Route53API, name string
 	return cleanZoneID(*res.Id), nil
 }
 
-func (o *CreateInfraOptions) CreatePrivateZone(ctx context.Context, client route53iface.Route53API, vpcID string) (string, error) {
-	name := fmt.Sprintf("%s.%s", o.Name, o.BaseDomain)
+func (o *CreateInfraOptions) CreatePrivateZone(ctx context.Context, client route53iface.Route53API, name, vpcID string) (string, error) {
 	id, err := lookupZone(ctx, client, name, true)
 	if err == nil {
 		log.Info("Found existing private zone", "name", name, "id", id)
@@ -91,13 +90,13 @@ func (o *CreateInfraOptions) CreatePrivateZone(ctx context.Context, client route
 
 func (o *DestroyInfraOptions) DestroyDNS(ctx context.Context, client route53iface.Route53API) []error {
 	var errs []error
-	errs = append(errs, o.DestroyPrivateZone(ctx, client))
+	errs = append(errs, o.DestroyPrivateZone(ctx, client, fmt.Sprintf("%s.%s", o.Name, o.BaseDomain)))
+	errs = append(errs, o.DestroyPrivateZone(ctx, client, fmt.Sprintf("%s.%s", o.Name, hypershiftLocalZoneName)))
 	errs = append(errs, o.CleanupPublicZone(ctx, client))
 	return errs
 }
 
-func (o *DestroyInfraOptions) DestroyPrivateZone(ctx context.Context, client route53iface.Route53API) error {
-	name := fmt.Sprintf("%s.%s", o.Name, o.BaseDomain)
+func (o *DestroyInfraOptions) DestroyPrivateZone(ctx context.Context, client route53iface.Route53API, name string) error {
 	id, err := lookupZone(ctx, client, name, true)
 	if err != nil {
 		return nil

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_awsendpointservices.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_awsendpointservices.yaml
@@ -46,7 +46,7 @@ spec:
             description: AWSEndpointServiceStatus defines the observed state of AWSEndpointService
             properties:
               conditions:
-                description: "Condition contains details for the current state of
+                description: "Conditions contains details for the current state of
                   the Endpoint Service request If there is an error processing the
                   request e.g. the NLB doesn't exist, then the Available condition
                   will be false, reason AWSErrorReason, and the error reported in
@@ -119,13 +119,20 @@ spec:
                   - type
                   type: object
                 type: array
+              dnsName:
+                description: DNSName is the name for the record created in the hypershift
+                  private zone
+                type: string
+              dnsZoneID:
+                description: DNSZoneID is ID for the hypershift private zone
+                type: string
               endpointID:
-                description: The endpoint ID created in the guest VPC in response
-                  to the request
+                description: EndpointID is the ID of the Endpoint created in the guest
+                  VPC
                 type: string
               endpointServiceName:
-                description: The endpoint service name created in the management VPC
-                  in response to the request
+                description: EndpointServiceName is the name of the Endpoint Service
+                  created in the management VPC
                 type: string
             required:
             - conditions

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -422,7 +422,7 @@ spec:
                           a secret containing cloud credentials with permissions matching
                           the control-plane-operator policy. The secret should have
                           exactly one key, `credentials`, whose value is an AWS credentials
-                          file. \n TODO(dan): document the \"node pool management
+                          file. \n TODO(dan): document the \"control plane operator
                           policy\""
                         properties:
                           name:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -338,7 +338,7 @@ spec:
                           a secret containing cloud credentials with permissions matching
                           the control-plane-operator policy. The secret should have
                           exactly one key, `credentials`, whose value is an AWS credentials
-                          file. \n TODO(dan): document the \"node pool management
+                          file. \n TODO(dan): document the \"control plane operator
                           policy\""
                         properties:
                           name:

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -20,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/workqueue"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -117,9 +120,14 @@ func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.List(ctx, hcpList, &client.ListOptions{Namespace: r.HCPNamespace}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get resource: %w", err)
 	}
-	if len(hcpList.Items) != 1 {
+	if len(hcpList.Items) == 0 {
+		// Return early if HostedControlPlane is deleted
+		return ctrl.Result{}, nil
+	}
+	if len(hcpList.Items) > 1 {
 		return ctrl.Result{}, fmt.Errorf("unexpected number of HostedControlPlanes in namespace, expected: 1, actual: %d", len(hcpList.Items))
 	}
+
 	hcp := hcpList.Items[0]
 
 	// Return early if HostedControlPlane is deleted
@@ -151,16 +159,21 @@ func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request
 const (
 	finalizer                              = "hypershift.openshift.io/control-plane-operator-finalizer"
 	endpointServiceDeletionRequeueDuration = time.Duration(5 * time.Second)
+	hypershiftLocalZone                    = "hypershift.local"
 )
 
 type AWSEndpointServiceReconciler struct {
 	client.Client
-	ec2Client ec2iface.EC2API
+	ec2Client     ec2iface.EC2API
+	route53Client route53iface.Route53API
 }
 
 func (r *AWSEndpointServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	_, err := ctrl.NewControllerManagedBy(mgr).
 		For(&hyperv1.AWSEndpointService{}).
+		WithOptions(controller.Options{
+			RateLimiter: workqueue.NewItemExponentialFailureRateLimiter(3*time.Second, 30*time.Second),
+		}).
 		Build(r)
 	if err != nil {
 		return fmt.Errorf("failed setting up with a controller manager: %w", err)
@@ -172,6 +185,10 @@ func (r *AWSEndpointServiceReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	awsSession := awsutil.NewSession("control-plane-operator")
 	awsConfig := aws.NewConfig()
 	r.ec2Client = ec2.New(awsSession, awsConfig)
+	route53Config := aws.NewConfig()
+	// Hardcode region for route53 config
+	route53Config.Region = aws.String("us-east-1")
+	r.route53Client = route53.New(awsSession, route53Config)
 
 	return nil
 }
@@ -201,19 +218,13 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Don't change the cached object
 	awsEndpointService := obj.DeepCopy()
 
-	// fetch the HostedControlPlane
-	hcpList := &hyperv1.HostedControlPlaneList{}
-	if err := r.List(ctx, hcpList, &client.ListOptions{Namespace: req.Namespace}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get resource: %w", err)
-	}
-	if len(hcpList.Items) != 1 {
-		return ctrl.Result{}, fmt.Errorf("unexpected number of HostedControlPlanes in namespace, expected: 1, actual: %d", len(hcpList.Items))
-	}
-	hcp := hcpList.Items[0]
-
 	// Return early if deleted
 	if !awsEndpointService.DeletionTimestamp.IsZero() {
-		completed, err := r.delete(ctx, awsEndpointService, r.ec2Client)
+		if !controllerutil.ContainsFinalizer(awsEndpointService, finalizer) {
+			// If we previously removed our finalizer, don't delete again and return early
+			return ctrl.Result{}, nil
+		}
+		completed, err := r.delete(ctx, awsEndpointService, r.ec2Client, r.route53Client)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to delete resource: %w", err)
 		}
@@ -247,8 +258,22 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	// Fetch the HostedControlPlane
+	hcpList := &hyperv1.HostedControlPlaneList{}
+	if err := r.List(ctx, hcpList, &client.ListOptions{Namespace: req.Namespace}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get resource: %w", err)
+	}
+	if len(hcpList.Items) == 0 {
+		// Return early if HostedControlPlane is deleted
+		return ctrl.Result{}, nil
+	}
+	if len(hcpList.Items) > 1 {
+		return ctrl.Result{}, fmt.Errorf("unexpected number of HostedControlPlanes in namespace, expected: 1, actual: %d", len(hcpList.Items))
+	}
+	hcp := &hcpList.Items[0]
+
 	// Reconcile the AWSEndpointService
-	if err := reconcileAWSEndpointService(ctx, awsEndpointService, r.ec2Client, hcp); err != nil {
+	if err := reconcileAWSEndpointService(ctx, awsEndpointService, hcp, r.ec2Client, r.route53Client); err != nil {
 		meta.SetStatusCondition(&awsEndpointService.Status.Conditions, metav1.Condition{
 			Type:    string(hyperv1.AWSEndpointAvailable),
 			Status:  metav1.ConditionFalse,
@@ -276,15 +301,20 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{}, nil
 }
 
-func reconcileAWSEndpointService(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, ec2Client ec2iface.EC2API, hcp hyperv1.HostedControlPlane) error {
+func hasAWSConfig(platform *hyperv1.PlatformSpec) bool {
+	return platform.Type == hyperv1.AWSPlatform && platform.AWS != nil && platform.AWS.CloudProviderConfig != nil &&
+		platform.AWS.CloudProviderConfig.Subnet != nil && platform.AWS.CloudProviderConfig.Subnet.ID != nil
+}
+
+func reconcileAWSEndpointService(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, hcp *hyperv1.HostedControlPlane, ec2Client ec2iface.EC2API, route53Client route53iface.Route53API) error {
 	log, err := logr.FromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("logger not found: %w", err)
 	}
-
 	serviceName := awsEndpointService.Status.EndpointServiceName
 
 	endpointID := awsEndpointService.Status.EndpointID
+	var endpointDNSEntries []*ec2.DnsEntry
 	if endpointID != "" {
 		// check if Endpoint exists in AWS
 		output, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{
@@ -299,51 +329,102 @@ func reconcileAWSEndpointService(ctx context.Context, awsEndpointService *hyperv
 			return fmt.Errorf("endpoint %s not found, resetting status", serviceName)
 		}
 		log.Info("endpoint exists", "endpointID", endpointID)
+		endpointDNSEntries = output.VpcEndpoints[0].DnsEntries
+	} else {
+		if !hasAWSConfig(&hcp.Spec.Platform) {
+			return fmt.Errorf("AWS platform information not provided in HostedControlPlane")
+		}
+		input := &ec2.CreateVpcEndpointInput{
+			ServiceName:     aws.String(serviceName),
+			VpcId:           aws.String(hcp.Spec.Platform.AWS.CloudProviderConfig.VPC),
+			VpcEndpointType: aws.String(ec2.VpcEndpointTypeInterface),
+			SubnetIds:       []*string{hcp.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID},
+		}
+		output, err := ec2Client.CreateVpcEndpointWithContext(ctx, input)
+		if err != nil {
+			return err
+		}
+		if output == nil || output.VpcEndpoint == nil {
+			return fmt.Errorf("CreateVpcEndpointWithContext output is nil")
+		}
+
+		endpointID = *output.VpcEndpoint.VpcEndpointId
+		log.Info("endpoint created", "endpointID", endpointID)
+		awsEndpointService.Status.EndpointID = endpointID
+		endpointDNSEntries = output.VpcEndpoint.DnsEntries
+	}
+
+	if len(endpointDNSEntries) == 0 {
+		log.Info("endpoint has no DNS entries, skipping DNS record creation", "endpointID", endpointID)
 		return nil
-
 	}
 
-	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform || hcp.Spec.Platform.AWS == nil || hcp.Spec.Platform.AWS.CloudProviderConfig == nil {
-		return fmt.Errorf("AWS platform information not provided in HostedControlPlane")
+	var recordName string
+	if awsEndpointService.Name == "kube-apiserver-private" {
+		recordName = "api"
+	} else if strings.HasPrefix(awsEndpointService.Name, "router-") {
+		recordName = "*.apps"
+	} else {
+		return fmt.Errorf("no mapping from AWSEndpointService to DNS")
 	}
-	input := &ec2.CreateVpcEndpointInput{
-		ServiceName:     aws.String(serviceName),
-		VpcId:           aws.String(hcp.Spec.Platform.AWS.CloudProviderConfig.VPC),
-		VpcEndpointType: aws.String(ec2.VpcEndpointTypeInterface),
-	}
-	if hcp.Spec.Platform.AWS.CloudProviderConfig.Subnet != nil && hcp.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {
-		input.SubnetIds = []*string{hcp.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID}
-	}
-	output, err := ec2Client.CreateVpcEndpointWithContext(ctx, input)
+
+	zoneName := fmt.Sprintf("%s.%s", hcp.Name, hypershiftLocalZone)
+	zoneID, err := lookupZoneID(ctx, route53Client, zoneName)
 	if err != nil {
 		return err
 	}
 
-	endpointID = *output.VpcEndpoint.VpcEndpointId
-	log.Info("endpoint created", "endpointID", endpointID)
-	awsEndpointService.Status.EndpointID = endpointID
+	fqdn := fmt.Sprintf("%s.%s", recordName, zoneName)
+	err = createRecord(ctx, route53Client, zoneID, fqdn, *(endpointDNSEntries[0].DnsName))
+	if err != nil {
+		return err
+	}
+	log.Info("DNS record created", "fqdn", fqdn)
+
+	awsEndpointService.Status.DNSName = fqdn
+	awsEndpointService.Status.DNSZoneID = zoneID
 
 	return nil
 }
 
-func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, ec2Client ec2iface.EC2API) (bool, error) {
+func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, ec2Client ec2iface.EC2API, route53Client route53iface.Route53API) (bool, error) {
 	log, err := logr.FromContext(ctx)
 	if err != nil {
 		return false, fmt.Errorf("logger not found: %w", err)
 	}
 
 	endpointID := awsEndpointService.Status.EndpointID
-	if endpointID == "" {
-		// nothing to clean up
-		return true, nil
+	if endpointID != "" {
+		if _, err := ec2Client.DeleteVpcEndpointsWithContext(ctx, &ec2.DeleteVpcEndpointsInput{
+			VpcEndpointIds: []*string{aws.String(endpointID)},
+		}); err != nil {
+			return false, err
+		}
+		log.Info("endpoint deleted", "endpointID", endpointID)
 	}
 
-	if _, err := ec2Client.DeleteVpcEndpointsWithContext(ctx, &ec2.DeleteVpcEndpointsInput{
-		VpcEndpointIds: []*string{aws.String(endpointID)},
-	}); err != nil {
+	fqdn := awsEndpointService.Status.DNSName
+	zoneID := awsEndpointService.Status.DNSZoneID
+	if err != nil {
 		return false, err
 	}
+	if fqdn != "" && zoneID != "" {
+		record, err := findRecord(ctx, route53Client, zoneID, fqdn)
+		if err != nil {
+			return false, err
+		}
+		if record != nil {
+			err = deleteRecord(ctx, route53Client, zoneID, record)
+			if err != nil {
+				return false, err
+			}
+			log.Info("DNS record deleted", "fqdn", fqdn)
+		} else {
+			log.Info("no DNS record found", "fqdn", fqdn)
+		}
+	} else {
+		log.Info("no DNS status set in AWSEndpointService", "name", awsEndpointService.Name)
+	}
 
-	log.Info("endpoint deleted", "endpointID", endpointID)
 	return true, nil
 }

--- a/control-plane-operator/controllers/awsprivatelink/route53.go
+++ b/control-plane-operator/controllers/awsprivatelink/route53.go
@@ -1,0 +1,140 @@
+package awsprivatelink
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+)
+
+func lookupZoneID(ctx context.Context, client route53iface.Route53API, name string) (string, error) {
+	var res *route53.HostedZone
+	f := func(resp *route53.ListHostedZonesOutput, lastPage bool) (shouldContinue bool) {
+		for idx, zone := range resp.HostedZones {
+			if zone.Config != nil && aws.BoolValue(zone.Config.PrivateZone) && strings.TrimSuffix(aws.StringValue(zone.Name), ".") == strings.TrimSuffix(name, ".") {
+				res = resp.HostedZones[idx]
+				return false
+			}
+		}
+		return !lastPage
+	}
+	if err := client.ListHostedZonesPagesWithContext(ctx, &route53.ListHostedZonesInput{}, f); err != nil {
+		return "", err
+	}
+	if res == nil {
+		return "", fmt.Errorf("hosted zone %s not found", name)
+	}
+	return cleanZoneID(*res.Id), nil
+}
+
+func createRecord(ctx context.Context, client route53iface.Route53API, zondID, name, value string) error {
+	record := &route53.ResourceRecordSet{
+		Name: aws.String(name),
+		Type: aws.String("CNAME"),
+		TTL:  aws.Int64(300),
+		ResourceRecords: []*route53.ResourceRecord{
+			{
+				Value: aws.String(value),
+			},
+		},
+	}
+
+	changeBatch := &route53.ChangeBatch{
+		Changes: []*route53.Change{
+			{
+				Action:            aws.String("UPSERT"),
+				ResourceRecordSet: record,
+			},
+		},
+	}
+
+	input := &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zondID),
+		ChangeBatch:  changeBatch,
+	}
+
+	_, err := client.ChangeResourceRecordSetsWithContext(ctx, input)
+	return err
+}
+
+func cleanZoneID(ID string) string {
+	return strings.TrimPrefix(ID, "/hostedzone/")
+}
+
+func cleanRecordName(name string) string {
+	str := name
+	s, err := strconv.Unquote(`"` + str + `"`)
+	if err != nil {
+		return str
+	}
+	return s
+}
+
+func fqdn(name string) string {
+	n := len(name)
+	if n == 0 || name[n-1] == '.' {
+		return name
+	} else {
+		return name + "."
+	}
+}
+
+func findRecord(ctx context.Context, client route53iface.Route53API, id, name string) (*route53.ResourceRecordSet, error) {
+	recordName := fqdn(strings.ToLower(name))
+	recordType := "CNAME"
+	input := &route53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(id),
+		StartRecordName: aws.String(recordName),
+		StartRecordType: aws.String(recordType),
+		MaxItems:        aws.String("1"),
+	}
+
+	var record *route53.ResourceRecordSet
+	err := client.ListResourceRecordSetsPagesWithContext(ctx, input, func(resp *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
+		if len(resp.ResourceRecordSets) == 0 {
+			return false
+		}
+
+		recordSet := resp.ResourceRecordSets[0]
+		responseName := strings.ToLower(cleanRecordName(*recordSet.Name))
+		responseType := strings.ToUpper(*recordSet.Type)
+
+		if recordName != responseName {
+			return false
+		}
+		if recordType != responseType {
+			return false
+		}
+
+		record = recordSet
+		return false
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+func deleteRecord(ctx context.Context, client route53iface.Route53API, id string, record *route53.ResourceRecordSet) error {
+	changeBatch := &route53.ChangeBatch{
+		Changes: []*route53.Change{
+			{
+				Action:            aws.String("DELETE"),
+				ResourceRecordSet: record,
+			},
+		},
+	}
+
+	input := &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(id),
+		ChangeBatch:  changeBatch,
+	}
+
+	_, err := client.ChangeResourceRecordSetsWithContext(ctx, input)
+	return err
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -907,12 +907,7 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerServiceStatus(ctx conte
 	if cpoutil.IsPrivateHCP(hcp) {
 		// If private: true, assume nodes will be connecting over the private connection
 		// This DNS record is created out-of-band and points to the Endpoint within the guest VPC
-		dnsConfig := manifests.DNSConfig()
-		err = r.Get(ctx, client.ObjectKeyFromObject(dnsConfig), dnsConfig)
-		if err != nil {
-			return
-		}
-		return kas.ReconcilePrivateServiceStatus(svc, dnsConfig.Spec.BaseDomain)
+		return kas.ReconcilePrivateServiceStatus(svc)
 	}
 
 	if err = r.Get(ctx, client.ObjectKeyFromObject(svc), svc); err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -95,7 +95,7 @@ func ReconcilePrivateService(svc *corev1.Service, owner *metav1.OwnerReference) 
 	return nil
 }
 
-func ReconcilePrivateServiceStatus(svc *corev1.Service, mgmtBaseDomain string) (host string, port int32, err error) {
-	//return fmt.Sprintf("api-%s.%s", svc.GetNamespace(), mgmtBaseDomain), 6443, nil
-	return fmt.Sprintf("kube-apiserver.%s.svc", svc.Namespace), 6443, nil
+func ReconcilePrivateServiceStatus(svc *corev1.Service) (host string, port int32, err error) {
+	// TODO: will be change to api.$hcpName.hypershift.local once OIDC controller is switch the service network
+	return fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace), 6443, nil
 }

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1115,7 +1115,7 @@ Kubernetes core/v1.LocalObjectReference
 credentials with permissions matching the control-plane-operator policy.
 The secret should have exactly one key, <code>credentials</code>, whose value is
 an AWS credentials file.</p>
-<p>TODO(dan): document the &ldquo;node pool management policy&rdquo;</p>
+<p>TODO(dan): document the &ldquo;control plane operator policy&rdquo;</p>
 </td>
 </tr>
 <tr>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -577,7 +577,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Reconcile the platform provider node pool management credentials secret by
+	// Reconcile the platform provider control plane operator credentials secret by
 	// resolving  the reference from the HostedCluster and syncing the secret in
 	// the control plane namespace.
 	switch hcluster.Spec.Platform.Type {
@@ -3031,16 +3031,6 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, req ctrl.Request, 
 		}
 	}
 
-	var awsEndpointServiceList hyperv1.AWSEndpointServiceList
-	if err := r.List(ctx, &awsEndpointServiceList); err != nil && !apierrors.IsNotFound(err) {
-		return false, fmt.Errorf("failed to list AWSEndpointServices for cluster %q: %w", req.Name, err)
-	}
-	for _, ep := range awsEndpointServiceList.Items {
-		if err := r.Delete(ctx, &ep); err != nil && !apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("failed to delete AWSEndpointService %q for cluster %q: %w", ep.Name, req.Name, err)
-		}
-	}
-
 	if hc != nil && len(hc.Spec.InfraID) > 0 {
 		r.Log.Info("Deleting Cluster", "clusterName", hc.Spec.InfraID, "clusterNamespace", controlPlaneNamespace)
 		cluster := &capiv1.Cluster{
@@ -3059,6 +3049,21 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, req ctrl.Request, 
 			r.Log.Info("Waiting for Cluster deletion", "clusterName", hc.Spec.InfraID, "clusterNamespace", controlPlaneNamespace)
 			return false, nil
 		}
+	}
+
+	var awsEndpointServiceList hyperv1.AWSEndpointServiceList
+	if err := r.List(ctx, &awsEndpointServiceList, &client.ListOptions{Namespace: controlPlaneNamespace}); err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to list AWSEndpointServices for cluster %q: %w", req.Name, err)
+	}
+	for _, ep := range awsEndpointServiceList.Items {
+		if err := r.Delete(ctx, &ep); err != nil && !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to delete AWSEndpointService %q for cluster %q: %w", ep.Name, req.Name, err)
+		}
+	}
+	if len(awsEndpointServiceList.Items) != 0 {
+		// The CPO puts a finalizer on AWSEndpointService resources and should
+		// not be terminated until the resources are removed from the API server
+		return false, nil
 	}
 
 	r.Log.Info("Deleting controlplane namespace", "namespace", controlPlaneNamespace)


### PR DESCRIPTION
`create infra aws` creates a `$name.hypershift.local` private DNS zone attached to the guest VPC.

CPO creates records in this zone for `api.$name.hypershift.local` and `*.apps.$name.hypershift.local` that point to the apiserver and ingress Endpoints respectively.

`destroy infra aws` removes the DNS zone

`AWSEndpointService` type changed to include new `status` fields: `DNSName` and `DNSZoneID` primarily for tracking for removal because the HCP might already be deleted by then.  Also nice from a UX/debuggability standpoint.