### PR TITLE
Refactor hosted cluster config operator start code

### DIFF
--- a/hosted-cluster-config-operator/controllers/clusteroperator/setup.go
+++ b/hosted-cluster-config-operator/controllers/clusteroperator/setup.go
@@ -1,22 +1,37 @@
 package clusteroperator
 
 import (
+	"context"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/hypershift/hosted-cluster-config-operator/controllers"
 	"github.com/openshift/hypershift/hosted-cluster-config-operator/operator"
 )
 
 func Setup(cfg *operator.HostedClusterConfigOperatorConfig) error {
-	clusterOperators := cfg.TargetConfigInformers().Config().V1().ClusterOperators()
-	reconciler := &ControlPlaneClusterOperatorSyncer{
-		Versions: cfg.Versions(),
-		Client:   cfg.TargetConfigClient(),
-		Lister:   clusterOperators.Lister(),
-		Log:      cfg.Logger().WithName("HostedClusterConfigOperatorSyncer"),
+	configClient, err := configclient.NewForConfig(cfg.TargetConfig)
+	if err != nil {
+		return err
 	}
-	c, err := controller.New("hosted-cluster-config-operator-syncer", cfg.Manager(), controller.Options{Reconciler: reconciler})
+	informerFactory := configinformers.NewSharedInformerFactory(configClient, controllers.DefaultResync)
+	cfg.Manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		informerFactory.Start(ctx.Done())
+		return nil
+	}))
+	clusterOperators := informerFactory.Config().V1().ClusterOperators()
+	reconciler := &ControlPlaneClusterOperatorSyncer{
+		Versions: cfg.Versions,
+		Client:   configClient,
+		Lister:   clusterOperators.Lister(),
+		Log:      cfg.Logger.WithName("HostedClusterConfigOperatorSyncer"),
+	}
+	c, err := controller.New("hosted-cluster-config-operator-syncer", cfg.Manager, controller.Options{Reconciler: reconciler})
 	if err != nil {
 		return err
 	}

--- a/hosted-cluster-config-operator/controllers/clusterversion/setup.go
+++ b/hosted-cluster-config-operator/controllers/clusterversion/setup.go
@@ -16,12 +16,12 @@ import (
 )
 
 func Setup(cfg *operator.HostedClusterConfigOperatorConfig) error {
-	openshiftClient, err := configclient.NewForConfig(cfg.TargetConfig())
+	openshiftClient, err := configclient.NewForConfig(cfg.TargetConfig)
 	if err != nil {
 		return err
 	}
 	informerFactory := configinformers.NewSharedInformerFactory(openshiftClient, controllers.DefaultResync)
-	cfg.Manager().Add(manager.RunnableFunc(func(ctx context.Context) error {
+	cfg.Manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		informerFactory.Start(ctx.Done())
 		return nil
 	}))
@@ -29,9 +29,9 @@ func Setup(cfg *operator.HostedClusterConfigOperatorConfig) error {
 	reconciler := &ClusterVersionReconciler{
 		Client: openshiftClient,
 		Lister: clusterVersions.Lister(),
-		Log:    cfg.Logger().WithName("ClusterVersion"),
+		Log:    cfg.Logger.WithName("ClusterVersion"),
 	}
-	c, err := controller.New("cluster-version", cfg.Manager(), controller.Options{Reconciler: reconciler})
+	c, err := controller.New("cluster-version", cfg.Manager, controller.Options{Reconciler: reconciler})
 	if err != nil {
 		return err
 	}

--- a/hosted-cluster-config-operator/controllers/openshiftapiservermonitor/setup.go
+++ b/hosted-cluster-config-operator/controllers/openshiftapiservermonitor/setup.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Setup(cfg *operator.HostedClusterConfigOperatorConfig) error {
-	apiextClient, err := apiextensionsclient.NewForConfig(cfg.TargetConfig())
+	apiextClient, err := apiextensionsclient.NewForConfig(cfg.TargetConfig)
 	if err != nil {
 		return err
 	}
@@ -37,16 +37,16 @@ func Setup(cfg *operator.HostedClusterConfigOperatorConfig) error {
 		controllers.DefaultResync,
 		cache.Indexers{},
 	)
-	cfg.Manager().Add(manager.RunnableFunc(func(ctx context.Context) error {
+	cfg.Manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		crdInformer.Run(ctx.Done())
 		return nil
 	}))
 	reconciler := &OpenshiftAPIServerMonitor{
 		KubeClient: cfg.KubeClient(),
-		Namespace:  cfg.Namespace(),
-		Log:        cfg.Logger().WithName("OpenshiftAPIServerMonitor"),
+		Namespace:  cfg.Namespace,
+		Log:        cfg.Logger.WithName("OpenshiftAPIServerMonitor"),
 	}
-	c, err := controller.New("openshift-apiserver-monitor", cfg.Manager(), controller.Options{Reconciler: reconciler})
+	c, err := controller.New("openshift-apiserver-monitor", cfg.Manager, controller.Options{Reconciler: reconciler})
 	if err != nil {
 		return err
 	}

--- a/hosted-cluster-config-operator/controllers/resources/resources.go
+++ b/hosted-cluster-config-operator/controllers/resources/resources.go
@@ -53,17 +53,17 @@ func eventHandler() handler.EventHandler {
 }
 
 func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
-	if err := imageregistryv1.AddToScheme(opts.Manager().GetScheme()); err != nil {
+	if err := imageregistryv1.AddToScheme(opts.Manager.GetScheme()); err != nil {
 		return fmt.Errorf("failed to add to scheme: %w", err)
 	}
-	c, err := controller.New(ControllerName, opts.Manager(), controller.Options{Reconciler: &reconciler{
-		client:                 opts.Manager().GetClient(),
+	c, err := controller.New(ControllerName, opts.Manager, controller.Options{Reconciler: &reconciler{
+		client:                 opts.Manager.GetClient(),
 		CreateOrUpdateProvider: opts.TargetCreateOrUpdateProvider,
 		platformType:           opts.PlatformType,
-		clusterSignerCA:        opts.ClusterSignerCA(),
+		clusterSignerCA:        opts.ClusterSignerCA,
 		cpClient:               opts.CPCluster.GetClient(),
-		hcpName:                opts.HCPName(),
-		hcpNamespace:           opts.Namespace(),
+		hcpName:                opts.HCPName,
+		hcpNamespace:           opts.Namespace,
 	}})
 	if err != nil {
 		return fmt.Errorf("failed to construct controller: %w", err)

--- a/hosted-cluster-config-operator/operator/config.go
+++ b/hosted-cluster-config-operator/operator/config.go
@@ -10,8 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -19,15 +17,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	configv1 "github.com/openshift/api/config/v1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
-	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/hosted-cluster-config-operator/api"
-	common "github.com/openshift/hypershift/hosted-cluster-config-operator/controllers"
 	"github.com/openshift/hypershift/support/upsert"
 )
 
@@ -46,67 +40,26 @@ func cacheLabelSelector() labels.Selector {
 
 type ControllerSetupFunc func(*HostedClusterConfigOperatorConfig) error
 
-func NewHostedClusterConfigOperatorConfig(targetKubeconfig, namespace, hcpName string, initialCA []byte, versions map[string]string, controllers []string, controllerFuncs map[string]ControllerSetupFunc, enableCIDebugOutput bool, platformType hyperv1.PlatformType, clusterSignerCA []byte) *HostedClusterConfigOperatorConfig {
-	cfg := cfgFromFile(targetKubeconfig)
-	cpConfig := ctrl.GetConfigOrDie()
-	mgr := mgr(cfg, cpConfig, namespace)
-	cpCluster, err := cluster.New(cpConfig, withScheme(api.Scheme), withNamespace(namespace))
-	if err != nil {
-		panic(fmt.Sprintf("Cannot create control plane cluster: %v", err))
-	}
-	if err := mgr.Add(cpCluster); err != nil {
-		panic(fmt.Sprintf("Cannot add CPCluster to manager: %v", err))
-	}
-	return &HostedClusterConfigOperatorConfig{
-		TargetCreateOrUpdateProvider: &labelEnforcingUpsertProvider{
-			upstream:  upsert.New(enableCIDebugOutput),
-			apiReader: mgr.GetAPIReader(),
-		},
-		config:          cpConfig,
-		targetConfig:    cfg,
-		manager:         mgr,
-		namespace:       namespace,
-		hcpName:         hcpName,
-		initialCA:       initialCA,
-		clusterSignerCA: clusterSignerCA,
-		controllers:     controllers,
-		controllerFuncs: controllerFuncs,
-		versions:        versions,
-		PlatformType:    platformType,
-		CPCluster:       cpCluster,
-	}
-}
-
 type HostedClusterConfigOperatorConfig struct {
-	manager                      ctrl.Manager
-	config                       *rest.Config
-	targetConfig                 *rest.Config
-	targetKubeClient             kubeclient.Interface
+	Manager                      ctrl.Manager
+	Config                       *rest.Config
+	TargetConfig                 *rest.Config
 	TargetCreateOrUpdateProvider upsert.CreateOrUpdateProvider
-	kubeClient                   kubeclient.Interface
 	CPCluster                    cluster.Cluster
-	logger                       logr.Logger
+	Logger                       logr.Logger
+	Versions                     map[string]string
+	HCPName                      string
+	Namespace                    string
+	InitialCA                    string
+	ClusterSignerCA              string
+	Controllers                  []string
+	PlatformType                 hyperv1.PlatformType
+	ControllerFuncs              map[string]ControllerSetupFunc
 
-	versions            map[string]string
-	hcpName             string
-	namespace           string
-	initialCA           []byte
-	clusterSignerCA     []byte
-	controllers         []string
-	PlatformType        hyperv1.PlatformType
-	controllerFuncs     map[string]ControllerSetupFunc
-	namespacedInformers map[string]informers.SharedInformerFactory
+	kubeClient kubeclient.Interface
 }
 
-func (c *HostedClusterConfigOperatorConfig) Scheme() *runtime.Scheme {
-	return c.manager.GetScheme()
-}
-
-func (c *HostedClusterConfigOperatorConfig) Manager() ctrl.Manager {
-	return c.manager
-}
-
-func mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
+func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 	cfg.UserAgent = "hosted-cluster-config-operator-manager"
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             true,
@@ -150,31 +103,7 @@ func mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 	return mgr
 }
 
-func (c *HostedClusterConfigOperatorConfig) Namespace() string {
-	return c.namespace
-}
-
-func (c *HostedClusterConfigOperatorConfig) HCPName() string {
-	return c.hcpName
-}
-
-func (c *HostedClusterConfigOperatorConfig) Config() *rest.Config {
-	if c.config == nil {
-		c.config = ctrl.GetConfigOrDie()
-	}
-	return c.config
-}
-
-func (c *HostedClusterConfigOperatorConfig) Logger() logr.Logger {
-	c.logger = ctrl.Log.WithName("hypershift-operator")
-	return c.logger
-}
-
-func (c *HostedClusterConfigOperatorConfig) TargetConfig() *rest.Config {
-	return c.targetConfig
-}
-
-func cfgFromFile(path string) *rest.Config {
+func CfgFromFile(path string) *rest.Config {
 	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
 		&clientcmd.ConfigOverrides{}).ClientConfig()
@@ -184,68 +113,10 @@ func cfgFromFile(path string) *rest.Config {
 	return cfg
 }
 
-func (c *HostedClusterConfigOperatorConfig) TargetKubeClient() kubeclient.Interface {
-	if c.targetKubeClient == nil {
-		var err error
-		c.targetKubeClient, err = kubeclient.NewForConfig(c.TargetConfig())
-		if err != nil {
-			c.Fatal(err, "cannot get target kube client")
-		}
-	}
-	return c.targetKubeClient
-}
-
-func (c *HostedClusterConfigOperatorConfig) TargetConfigClient() configclient.Interface {
-	client, err := configclient.NewForConfig(c.TargetConfig())
-	if err != nil {
-		c.Fatal(err, "cannot get target config client")
-	}
-	return client
-}
-
-func (c *HostedClusterConfigOperatorConfig) TargetConfigInformers() configinformers.SharedInformerFactory {
-	informerFactory := configinformers.NewSharedInformerFactory(c.TargetConfigClient(), common.DefaultResync)
-	c.Manager().Add(manager.RunnableFunc(func(ctx context.Context) error {
-		informerFactory.Start(ctx.Done())
-		return nil
-	}))
-	return informerFactory
-}
-
-func (c *HostedClusterConfigOperatorConfig) TargetKubeInformersForNamespace(namespace string) informers.SharedInformerFactory {
-	informer, exists := c.namespacedInformers[namespace]
-	if !exists {
-		informer = informers.NewSharedInformerFactoryWithOptions(c.TargetKubeClient(), common.DefaultResync, informers.WithNamespace(namespace))
-		if c.namespacedInformers == nil {
-			c.namespacedInformers = map[string]informers.SharedInformerFactory{}
-		}
-		c.namespacedInformers[namespace] = informer
-		c.Manager().Add(manager.RunnableFunc(func(ctx context.Context) error {
-			informer.Start(ctx.Done())
-			return nil
-		}))
-	}
-	return informer
-}
-
-func withScheme(scheme *runtime.Scheme) func(*cluster.Options) {
-	return func(o *cluster.Options) {
-		o.Scheme = scheme
-	}
-}
-
-func withNamespace(ns string) func(*cluster.Options) {
-	return func(o *cluster.Options) {
-		o.Namespace = ns
-	}
-}
-
 func (c *HostedClusterConfigOperatorConfig) KubeClient() kubeclient.Interface {
 	if c.kubeClient == nil {
 		var err error
-		config := c.Config()
-		config.UserAgent = "hosted-cluster-config-operator-kubeclient"
-		c.kubeClient, err = kubeclient.NewForConfig(config)
+		c.kubeClient, err = kubeclient.NewForConfig(c.Config)
 		if err != nil {
 			c.Fatal(err, "cannot get management kube client")
 		}
@@ -253,26 +124,14 @@ func (c *HostedClusterConfigOperatorConfig) KubeClient() kubeclient.Interface {
 	return c.kubeClient
 }
 
-func (c *HostedClusterConfigOperatorConfig) Versions() map[string]string {
-	return c.versions
-}
-
-func (c *HostedClusterConfigOperatorConfig) InitialCA() string {
-	return string(c.initialCA)
-}
-
-func (c *HostedClusterConfigOperatorConfig) ClusterSignerCA() string {
-	return string(c.clusterSignerCA)
-}
-
 func (c *HostedClusterConfigOperatorConfig) Fatal(err error, msg string) {
-	c.Logger().Error(err, msg)
+	c.Logger.Error(err, msg)
 	os.Exit(1)
 }
 
 func (c *HostedClusterConfigOperatorConfig) Start(ctx context.Context) error {
-	for _, controllerName := range c.controllers {
-		setupFunc, ok := c.controllerFuncs[controllerName]
+	for _, controllerName := range c.Controllers {
+		setupFunc, ok := c.ControllerFuncs[controllerName]
 		if !ok {
 			return fmt.Errorf("unknown controller specified: %s", controllerName)
 		}
@@ -280,6 +139,5 @@ func (c *HostedClusterConfigOperatorConfig) Start(ctx context.Context) error {
 			return fmt.Errorf("cannot setup controller %s: %v", controllerName, err)
 		}
 	}
-	// TODO: receive a context from the caller
-	return c.Manager().Start(ctx)
+	return c.Manager.Start(ctx)
 }

--- a/hosted-cluster-config-operator/operator/labelenforcer_test.go
+++ b/hosted-cluster-config-operator/operator/labelenforcer_test.go
@@ -107,9 +107,9 @@ func TestLabelEnforcingUpsertProvider(t *testing.T) {
 	// we want to test, so clear it.
 	obj.ResourceVersion = ""
 
-	provider := &labelEnforcingUpsertProvider{
-		upstream:  upsert.New(false),
-		apiReader: client,
+	provider := &LabelEnforcingUpsertProvider{
+		Upstream:  upsert.New(false),
+		APIReader: client,
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
What:
This PR refactors the configuration code of the
hosted-cluster-config-operator to make it easier to access configuration
parameters from controllers.

Why:
As we move more code to be handled by the resources controller, we will
need additional parameters passed to the hosted-cluster-config-operator.
Before this PR, this required the same field to be added in multiple
places.