### PR TITLE
set ibmcloud capi components to proper v1alpha4 version and properly reconcile infrastructure resource for ibmcloud

### DIFF
--- a/cmd/install/assets/assets.go
+++ b/cmd/install/assets/assets.go
@@ -31,7 +31,7 @@ var capiResources = map[string]string{
 	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclusters.yaml":         "v1beta1",
 	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachines.yaml":         "v1beta1",
 	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml": "v1beta1",
-	"cluster-api-provider-ibmcloud/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml": "v1beta1",
+	"cluster-api-provider-ibmcloud/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml": "v1alpha4",
 	"hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml":              "v1alpha1",
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1,6 +1,10 @@
 package hostedcluster
 
 import (
+	"github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/api/v1alpha4"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 	"time"
 
@@ -794,6 +798,145 @@ func TestReconcileAWSCluster(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.initialAWSCluster, tc.expectedAWSCluster); diff != "" {
 				t.Errorf("reconciled AWS cluster differs from expcted AWS cluster: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReconcileCAPICluster(t *testing.T) {
+	testCases := []struct {
+		name               string
+		capiCluster        *v1beta1.Cluster
+		hostedCluster      *hyperv1.HostedCluster
+		hostedControlPlane *hyperv1.HostedControlPlane
+		infraCR            client.Object
+
+		expectedCAPICluster *v1beta1.Cluster
+	}{
+		{
+			name:        "IBM Cloud cluster",
+			capiCluster: controlplaneoperator.CAPICluster("master-cluster1", "cluster1"),
+			hostedCluster: &hyperv1.HostedCluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HostedCluster",
+					APIVersion: hyperv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "master",
+					Name:      "cluster1",
+				},
+			},
+			hostedControlPlane: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HostedControlPlane",
+					APIVersion: hyperv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "master-cluster1",
+					Name:      "cluster1",
+				},
+			},
+			infraCR: &v1alpha4.IBMVPCCluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "IBMVPCCluster",
+					APIVersion: v1alpha4.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster1",
+					Namespace: "master-cluster1",
+				},
+			},
+			expectedCAPICluster: &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						hostedClusterAnnotation: "master/cluster1",
+					},
+					Namespace: "master-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: v1beta1.ClusterSpec{
+					ControlPlaneEndpoint: v1beta1.APIEndpoint{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						APIVersion: "hypershift.openshift.io/v1alpha1",
+						Kind:       "HostedControlPlane",
+						Namespace:  "master-cluster1",
+						Name:       "cluster1",
+					},
+					InfrastructureRef: &corev1.ObjectReference{
+						APIVersion: v1alpha4.GroupVersion.String(),
+						Kind:       "IBMVPCCluster",
+						Namespace:  "master-cluster1",
+						Name:       "cluster1",
+					},
+				},
+			},
+		},
+		{
+			name:        "AWS cluster",
+			capiCluster: controlplaneoperator.CAPICluster("master-cluster1", "cluster1"),
+			hostedCluster: &hyperv1.HostedCluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HostedCluster",
+					APIVersion: hyperv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "master",
+					Name:      "cluster1",
+				},
+			},
+			hostedControlPlane: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HostedControlPlane",
+					APIVersion: hyperv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "master-cluster1",
+					Name:      "cluster1",
+				},
+			},
+			infraCR: &capiawsv1.AWSCluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AWSCluster",
+					APIVersion: capiawsv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster1",
+					Namespace: "master-cluster1",
+				},
+			},
+			expectedCAPICluster: &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						hostedClusterAnnotation: "master/cluster1",
+					},
+					Namespace: "master-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: v1beta1.ClusterSpec{
+					ControlPlaneEndpoint: v1beta1.APIEndpoint{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						APIVersion: "hypershift.openshift.io/v1alpha1",
+						Kind:       "HostedControlPlane",
+						Namespace:  "master-cluster1",
+						Name:       "cluster1",
+					},
+					InfrastructureRef: &corev1.ObjectReference{
+						APIVersion: capiawsv1.GroupVersion.String(),
+						Kind:       "AWSCluster",
+						Namespace:  "master-cluster1",
+						Name:       "cluster1",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := reconcileCAPICluster(tc.capiCluster, tc.hostedCluster, tc.hostedControlPlane, tc.infraCR); err != nil {
+				t.Fatalf("reconcileCAPICluster failed: %v", err)
+			}
+			if diff := cmp.Diff(tc.capiCluster, tc.expectedCAPICluster); diff != "" {
+				t.Errorf("reconciled CAPI cluster differs from expcted CAPI cluster: %s", diff)
 			}
 		})
 	}

--- a/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
@@ -111,6 +111,10 @@ func SSHKey(controlPlaneNamespace string) *corev1.Secret {
 
 func IBMCloudCluster(controlPlaneNamespace string, hostedClusterName string) *capiibmv1.IBMVPCCluster {
 	return &capiibmv1.IBMVPCCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "IBMVPCCluster",
+			APIVersion: capiibmv1.GroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
 			Name:      hostedClusterName,
@@ -129,6 +133,10 @@ func PodMonitor(controlPlaneNamespace string, hostedClusterName string) *prometh
 
 func AWSCluster(controlPlaneNamespace string, hostedClusterName string) *capiawsv1.AWSCluster {
 	return &capiawsv1.AWSCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AWSCluster",
+			APIVersion: capiawsv1.GroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
 			Name:      hostedClusterName,

--- a/support/globalconfig/infrastructure.go
+++ b/support/globalconfig/infrastructure.go
@@ -54,5 +54,9 @@ func ReconcileInfrastructure(infra *configv1.Infrastructure, hcp *hyperv1.Hosted
 			})
 		}
 		infra.Status.PlatformStatus.AWS.ResourceTags = tags
+	case hyperv1.IBMCloudPlatform:
+		infra.Status.Platform = configv1.PlatformType(hcp.Spec.Platform.Type)
+		infra.Status.PlatformStatus = &configv1.PlatformStatus{}
+		infra.Status.PlatformStatus.Type = configv1.IBMCloudPlatformType
 	}
 }


### PR DESCRIPTION
the repo does not yet have a v1beta1 version. We need to keep it v1alpha4 for now

Fixes:
- Properly sets the infrastructureRef for IBM Cloud clusters. Previously it was inaccurately getting set to v1beta1
- Properly reconciles the IBMCloud infrastructure references so all downstream components roll out in the cluster appropriately
