### PR TITLE
Create platform interface for HostedCluster controller.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,10 @@
 
 Thanks for your interest in contributing to Hypershift. Here are some guidelines that help making the process more straight-forward for everyone:
 
-* For small changes, you can just do the change and submit a pull request with it
-* For bigger changes (more than 200 lines of code diff), do not just do the change but ask for feedback on the idea and direction of the change
-  first (Either in a GitHub issue or the #project-hypershift channel in the CoreOS slack). This avoids situations where big changes are submitted
-  that are then declined or never reviewed, which is frustrating for everyone
-* Regardless of the size of the change, always explain how the change will improve the project
-* Make sure the "Why" and "How" are included in the message of each commit
-* Always keep refactorings (how we do something) seperate from logic changes (what we do)
-* Keep changes scoped to one thing and as minimal as possible. If you find additional things along the way that you feel should be improved,
-  do that in a seperate pull request. This helps ensure that you will get a timely review of your change, as a series of a small pull requests
-  is a lot easier to review than one big pull request that changes 10 independent things for independent reasons
-* Before submitting the pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer. Try to find the aspects
-  that might not immediately make sense for someone else and explain them in the pull request description. Also ensure that the previous point
-  (scoped to one thing and as minimal as possible) was followed
+* For small changes, you can just do the change and submit a pull request with it.
+* For bigger changes (more than 200 lines of code diff), do not just do the change but ask for feedback on the idea and direction of the change first (Either in a GitHub issue or the #project-hypershift channel in the CoreOS slack). This avoids situations where big changes are submitted that are then declined or never reviewed, which is frustrating for everyone.
+* Regardless of the size of the change, always explain how the change will improve the project.
+* Make sure the "Why" and "How" are included in the message of each commit.
+* Always keep refactorings (how we do something) separate from logic changes (what we do).
+* Keep changes scoped to one thing and as minimal as possible. If you find additional things along the way that you feel should be improved, do that in a separate pull request. This helps ensure that you will get a timely review of your change, as a series of a small pull requests is a lot easier to review than one big pull request that changes 10 independent things for independent reasons.
+* Before submitting the pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer. Try to find the aspects that might not immediately make sense for someone else and explain them in the pull request description. Also ensure that the previous point (scoped to one thing and as minimal as possible) was followed.

--- a/docs/content/developers/how-to/contributing.md
+++ b/docs/content/developers/how-to/contributing.md
@@ -1,0 +1,1 @@
+../../../../CONTRIBUTING.md

--- a/docs/content/developers/how-to/onboard-a-platform.md
+++ b/docs/content/developers/how-to/onboard-a-platform.md
@@ -1,0 +1,24 @@
+---
+title: Onboard a platform
+---
+
+# How to extend HyperShift to support a new platform
+
+A Platform represents a series of assumptions and choices that Hyperhift makes about the environment where it's running, e.g AWS, IBMCloud, Kubevirt.
+The implementation of a new platform crosses multiple controllers.
+
+The HostedCluster controller requires an implementation of the [Platform interface](hypershift-operator/controllers/hostedcluster/internal/platform) to shim a particular CAPI implementation and manage required cloud credentials.
+
+The NodePool controller requires an implementation of the [machine template reconciliation](https://github.com/openshift/hypershift/blob/58cabbac00c541b55c7e7925fe7e46f0a55b5ceb/hypershift-operator/controllers/nodepool/nodepool_controller.go#L496).
+
+The ControlPlane Operator requires the following:
+
+- [Implement cloud credentials](https://github.com/openshift/hypershift/blob/58cabbac00c541b55c7e7925fe7e46f0a55b5ceb/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go#L1039-L1049)
+
+- [Reconcile Kubernetes cloud provider config](https://github.com/openshift/hypershift/blob/58cabbac00c541b55c7e7925fe7e46f0a55b5ceb/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go#L1329)
+
+- [Reconcile the OCP Infrastructure CR](https://github.com/openshift/hypershift/blob/58cabbac00c541b55c7e7925fe7e46f0a55b5ceb/support/globalconfig/infrastructure.go#L21)
+
+## Supported platforms
+
+- AWS.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1,12 +1,8 @@
 /*
-
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,12 +31,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
-	capiibmv1 "github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/api/v1alpha4"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/autoscaler"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/clusterapi"
@@ -72,8 +68,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 	k8sutilspointer "k8s.io/utils/pointer"
-	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
-	capiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4" // Need this dep atm to satisfy IBM provider dep.
+	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1" // Need this dep atm to satisfy IBM provider dep.
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -102,11 +97,6 @@ const (
 	// Upstream canonical image comes from https://console.cloud.google.com/gcr/images/k8s-staging-cluster-api/global/
 	// us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v1.0.0
 	imageCAPI = "registry.ci.openshift.org/hypershift/cluster-api:v1.0.0"
-
-	// Image built from https://github.com/openshift/cluster-api-provider-aws/tree/release-1.1
-	// Upstream canonical image comes from  https://console.cloud.google.com/gcr/images/k8s-artifacts-prod
-	// us.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller:v1.1.0
-	imageCAPA = "registry.ci.openshift.org/hypershift/cluster-api-aws-controller:v1.1.0"
 )
 
 // NoopReconcile is just a default mutation function that does nothing.
@@ -520,88 +510,16 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile namespace: %w", err)
 	}
 
-	// Reconcile the platform provider cloud controller credentials secret by resolving
-	// the reference from the HostedCluster and syncing the secret in the control
-	// plane namespace.
-	switch hcluster.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		var src corev1.Secret
-		err = r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.Platform.AWS.KubeCloudControllerCreds.Name}, &src)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get cloud controller provider creds %s: %w", hcluster.Spec.Platform.AWS.KubeCloudControllerCreds.Name, err)
-		}
-		dest := manifests.AWSKubeCloudControllerCreds(controlPlaneNamespace.Name)
-		_, err = createOrUpdate(ctx, r.Client, dest, func() error {
-			srcData, srcHasData := src.Data["credentials"]
-			if !srcHasData {
-				return fmt.Errorf("hostedcluster cloud controller provider credentials secret %q must have a credentials key", src.Name)
-			}
-			dest.Type = corev1.SecretTypeOpaque
-			if dest.Data == nil {
-				dest.Data = map[string][]byte{}
-			}
-			dest.Data["credentials"] = srcData
-			return nil
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile cloud controller provider creds: %w", err)
-		}
+	// Reconcile Platform specifics.
+	p, err := platform.GetPlatform(hcluster)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
-	// Reconcile the platform provider node pool management credentials secret by
-	// resolving  the reference from the HostedCluster and syncing the secret in
-	// the control plane namespace.
-	switch hcluster.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		var src corev1.Secret
-		err = r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.Platform.AWS.NodePoolManagementCreds.Name}, &src)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get node pool provider creds %s: %w", hcluster.Spec.Platform.AWS.NodePoolManagementCreds.Name, err)
-		}
-		dest := manifests.AWSNodePoolManagementCreds(controlPlaneNamespace.Name)
-		_, err = createOrUpdate(ctx, r.Client, dest, func() error {
-			srcData, srcHasData := src.Data["credentials"]
-			if !srcHasData {
-				return fmt.Errorf("node pool provider credentials secret %q is missing credentials key", src.Name)
-			}
-			dest.Type = corev1.SecretTypeOpaque
-			if dest.Data == nil {
-				dest.Data = map[string][]byte{}
-			}
-			dest.Data["credentials"] = srcData
-			return nil
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile node pool provider creds: %w", err)
-		}
-	}
-
-	// Reconcile the platform provider control plane operator credentials secret by
-	// resolving  the reference from the HostedCluster and syncing the secret in
-	// the control plane namespace.
-	switch hcluster.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		var src corev1.Secret
-		err = r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.Platform.AWS.ControlPlaneOperatorCreds.Name}, &src)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get control plane operator provider creds %s: %w", hcluster.Spec.Platform.AWS.ControlPlaneOperatorCreds.Name, err)
-		}
-		dest := manifests.AWSControlPlaneOperatorCreds(controlPlaneNamespace.Name)
-		_, err = createOrUpdate(ctx, r.Client, dest, func() error {
-			srcData, srcHasData := src.Data["credentials"]
-			if !srcHasData {
-				return fmt.Errorf("control plane operator provider credentials secret %q is missing credentials key", src.Name)
-			}
-			dest.Type = corev1.SecretTypeOpaque
-			if dest.Data == nil {
-				dest.Data = map[string][]byte{}
-			}
-			dest.Data["credentials"] = srcData
-			return nil
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile control plane operator provider creds: %w", err)
-		}
+	if err := p.ReconcileCredentials(r.Client, ctx, createOrUpdate,
+		hcluster,
+		controlPlaneNamespace.Name); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Reconcile the HostedControlPlane pull secret by resolving the source secret
@@ -699,82 +617,9 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				// don't return error here as reconciling won't fix input error
 				return ctrl.Result{}, nil
 			}
-			switch hcluster.Spec.SecretEncryption.KMS.Provider {
-			case hyperv1.IBMCloud:
-				if hcluster.Spec.SecretEncryption.KMS.IBMCloud == nil {
-					r.Log.Error(fmt.Errorf("ibm kms metadata nil"), "")
-					// don't return error here as reconciling won't fix input error
-					return ctrl.Result{}, nil
-				}
-				if hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Type == hyperv1.IBMCloudKMSUnmanagedAuth {
-					if hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged == nil || len(hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged.Credentials.Name) == 0 {
-						r.Log.Error(fmt.Errorf("ibm unmanaged auth credential nil"), "")
-						// don't return error here as reconciling won't fix input error
-						return ctrl.Result{}, nil
-					}
-					var src corev1.Secret
-					if err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged.Credentials.Name}, &src); err != nil {
-						return ctrl.Result{}, fmt.Errorf("failed to get ibmcloud kms credentials %s: %w", hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged.Credentials.Name, err)
-					}
-					if _, ok := src.Data[hyperv1.IBMCloudIAMAPIKeySecretKey]; !ok {
-						r.Log.Error(fmt.Errorf("no ibmcloud iam apikey field %s specified in auth secret", hyperv1.IBMCloudIAMAPIKeySecretKey), "")
-						// don't return error here as reconciling won't fix input error
-						return ctrl.Result{}, nil
-					}
-					hostedControlPlaneIBMCloudKMSAuthSecret := &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: controlPlaneNamespace.Name,
-							Name:      src.Name,
-						},
-					}
-					_, err = createOrUpdate(ctx, r.Client, hostedControlPlaneIBMCloudKMSAuthSecret, func() error {
-						if hostedControlPlaneIBMCloudKMSAuthSecret.Data == nil {
-							hostedControlPlaneIBMCloudKMSAuthSecret.Data = map[string][]byte{}
-						}
-						hostedControlPlaneIBMCloudKMSAuthSecret.Data[hyperv1.IBMCloudIAMAPIKeySecretKey] = src.Data[hyperv1.IBMCloudIAMAPIKeySecretKey]
-						hostedControlPlaneIBMCloudKMSAuthSecret.Type = corev1.SecretTypeOpaque
-						return nil
-					})
-					if err != nil {
-						return ctrl.Result{}, fmt.Errorf("failed reconciling aescbc backup key: %w", err)
-					}
-				}
-			case hyperv1.AWS:
-				if hcluster.Spec.SecretEncryption.KMS.AWS == nil || len(hcluster.Spec.SecretEncryption.KMS.AWS.Auth.Credentials.Name) == 0 {
-					r.Log.Error(fmt.Errorf("aws kms metadata nil"), "")
-					// don't return error here as reconciling won't fix input error
-					return ctrl.Result{}, nil
-				}
-				var src corev1.Secret
-				if err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.SecretEncryption.KMS.AWS.Auth.Credentials.Name}, &src); err != nil {
-					return ctrl.Result{}, fmt.Errorf("failed to get ibmcloud kms credentials %s: %w", hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged.Credentials.Name, err)
-				}
-				if _, ok := src.Data[hyperv1.AWSCredentialsFileSecretKey]; !ok {
-					r.Log.Error(fmt.Errorf("aws credential key %s not present in auth secret", hyperv1.AWSCredentialsFileSecretKey), "")
-					// don't return error here as reconciling won't fix input error
-					return ctrl.Result{}, nil
-				}
-				hostedControlPlaneAWSKMSAuthSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: controlPlaneNamespace.Name,
-						Name:      src.Name,
-					},
-				}
-				_, err = createOrUpdate(ctx, r.Client, hostedControlPlaneAWSKMSAuthSecret, func() error {
-					if hostedControlPlaneAWSKMSAuthSecret.Data == nil {
-						hostedControlPlaneAWSKMSAuthSecret.Data = map[string][]byte{}
-					}
-					hostedControlPlaneAWSKMSAuthSecret.Data[hyperv1.AWSCredentialsFileSecretKey] = src.Data[hyperv1.AWSCredentialsFileSecretKey]
-					hostedControlPlaneAWSKMSAuthSecret.Type = corev1.SecretTypeOpaque
-					return nil
-				})
-				if err != nil {
-					return ctrl.Result{}, fmt.Errorf("failed reconciling aws kms backup key: %w", err)
-				}
-			default:
-				r.Log.Error(fmt.Errorf("unsupported kms provider %s", hcluster.Spec.SecretEncryption.KMS.Provider), "")
-				// don't return error here as reconciling won't fix input error
-				return ctrl.Result{}, nil
+			if err := p.ReconcileSecretEncryption(hcluster, controlPlaneNamespace.Name, ctx, r.Client,
+				createOrUpdate); err != nil {
+				return ctrl.Result{}, err
 			}
 		default:
 			r.Log.Error(fmt.Errorf("unsupported encryption type %s", hcluster.Spec.SecretEncryption.Type), "")
@@ -927,42 +772,16 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile hostedcontrolplane: %w", err)
 	}
 
-	var infraCR client.Object
-	switch hcluster.Spec.Platform.Type {
-	// We run the AWS controller for NonePlatform for now
-	// So nodePools can be created to expose ign endpoints that can be used for byo machines to join.
-	case hyperv1.AWSPlatform, hyperv1.NonePlatform:
-		// Reconcile external AWSCluster
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(hcp), hcp); err != nil {
-			r.Log.Error(err, "failed to get control plane ref")
-			return reconcile.Result{}, err
-		}
+	// Reconcile CAPI Infra CR.
+	infraCR, err := p.ReconcileCAPIInfraCR(hcluster, controlPlaneNamespace.Name, hcp.Status.ControlPlaneEndpoint, r.Client, ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
-		awsCluster := controlplaneoperator.AWSCluster(controlPlaneNamespace.Name, hcluster.Name)
-		_, err = createOrUpdate(ctx, r.Client, awsCluster, func() error {
-			return reconcileAWSCluster(awsCluster, hcluster, hcp.Status.ControlPlaneEndpoint)
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile AWSCluster: %w", err)
-		}
-		infraCR = awsCluster
-	case hyperv1.IBMCloudPlatform:
-		// Reconcile external IBM Cloud Cluster
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(hcp), hcp); err != nil {
-			r.Log.Error(err, "failed to get control plane ref")
-			return reconcile.Result{}, err
-		}
-
-		ibmCluster := controlplaneoperator.IBMCloudCluster(controlPlaneNamespace.Name, hcluster.Name)
-		_, err = createOrUpdate(ctx, r.Client, ibmCluster, func() error {
-			return reconcileIBMCloudCluster(ibmCluster, hcluster, hcp.Status.ControlPlaneEndpoint)
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile IBMCluster: %w", err)
-		}
-		infraCR = ibmCluster
-	default:
-		// TODO(alberto): for platform None implement back a "pass through" infra CR similar to externalInfraCluster.
+	// Reconcile CAPI Provider Deployment.
+	capiProviderDeploymentSpec, err := p.CAPIProviderDeploymentSpec(hcluster, r.TokenMinterImage)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Reconcile cluster prometheus RBAC resources if enabled
@@ -1024,16 +843,9 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile capi manager: %w", err)
 	}
 
-	switch hcluster.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		// Reconcile the CAPI AWS provider components
-		err = r.reconcileCAPIAWSProvider(ctx, createOrUpdate, hcluster)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile capi aws provider: %w", err)
-		}
-	default:
-		//TODO: add other providers
-		r.Log.Info("provider specific cluster api components not specified", "provider", hcluster.Spec.Platform.Type)
+	// Reconcile the CAPI provider components
+	if err = r.reconcileCAPIProvider(ctx, createOrUpdate, hcluster, capiProviderDeploymentSpec); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile capi provider: %w", err)
 	}
 
 	// Reconcile the autoscaler
@@ -1139,24 +951,9 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	if hcluster.Spec.SecretEncryption != nil {
 		hcp.Spec.SecretEncryption = hcluster.Spec.SecretEncryption.DeepCopy()
 	}
-	switch hcluster.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		hcp.Spec.Platform.Type = hyperv1.AWSPlatform
-		hcp.Spec.Platform.AWS = hcluster.Spec.Platform.AWS.DeepCopy()
-		hcp.Spec.Platform.AWS.KubeCloudControllerCreds = corev1.LocalObjectReference{
-			Name: manifests.AWSKubeCloudControllerCreds(hcp.Namespace).Name,
-		}
-		hcp.Spec.Platform.AWS.NodePoolManagementCreds = corev1.LocalObjectReference{
-			Name: manifests.AWSNodePoolManagementCreds(hcp.Namespace).Name,
-		}
-		hcp.Spec.Platform.AWS.ControlPlaneOperatorCreds = corev1.LocalObjectReference{
-			Name: manifests.AWSControlPlaneOperatorCreds(hcp.Namespace).Name,
-		}
-	case hyperv1.NonePlatform:
-		hcp.Spec.Platform.Type = hyperv1.NonePlatform
-	case hyperv1.IBMCloudPlatform:
-		hcp.Spec.Platform.Type = hyperv1.IBMCloudPlatform
-	}
+
+	// Pass through Platform spec.
+	hcp.Spec.Platform = *hcluster.Spec.Platform.DeepCopy()
 
 	// always reconcile the release image (facilitates rolling forward)
 	hcp.Spec.ReleaseImage = hcluster.Spec.Release.Image
@@ -1268,49 +1065,90 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, crea
 	return nil
 }
 
-// reconcileCAPIAWSProvider orchestrates reconciliation of the CAPI AWS provider
-// components.
-func (r *HostedClusterReconciler) reconcileCAPIAWSProvider(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster) error {
+// reconcileCAPIProvider orchestrates reconciliation of the CAPI provider
+// components for a given platform.
+func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster,
+	capiProviderDeploymentSpec *appsv1.DeploymentSpec) error {
+	if capiProviderDeploymentSpec == nil {
+		// If there's no capiProviderDeploymentSpec implementation return early.
+		return nil
+	}
+
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get control plane namespace: %w", err)
 	}
 
-	// Reconcile CAPI AWS provider role
-	capiAwsProviderRole := clusterapi.CAPIAWSProviderRole(controlPlaneNamespace.Name)
-	_, err = createOrUpdate(ctx, r.Client, capiAwsProviderRole, func() error {
-		return reconcileCAPIAWSProviderRole(capiAwsProviderRole)
+	// Reconcile CAPI provider role
+	capiProviderRole := clusterapi.CAPIProviderRole(controlPlaneNamespace.Name)
+	_, err = createOrUpdate(ctx, r.Client, capiProviderRole, func() error {
+		return reconcileCAPIProviderRole(capiProviderRole)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to reconcile capi aws provider role: %w", err)
+		return fmt.Errorf("failed to reconcile capi provider role: %w", err)
 	}
 
-	// Reconcile CAPI AWS provider service account
-	capiAwsProviderServiceAccount := clusterapi.CAPIAWSProviderServiceAccount(controlPlaneNamespace.Name)
-	_, err = createOrUpdate(ctx, r.Client, capiAwsProviderServiceAccount, NoopReconcile)
+	// Reconcile CAPI provider service account
+	capiProviderServiceAccount := clusterapi.CAPIProviderServiceAccount(controlPlaneNamespace.Name)
+	_, err = createOrUpdate(ctx, r.Client, capiProviderServiceAccount, NoopReconcile)
 	if err != nil {
-		return fmt.Errorf("failed to reconcile capi aws provider service account: %w", err)
+		return fmt.Errorf("failed to reconcile capi provider service account: %w", err)
 	}
 
-	// Reconcile CAPI AWS provider role binding
-	capiAwsProviderRoleBinding := clusterapi.CAPIAWSProviderRoleBinding(controlPlaneNamespace.Name)
-	_, err = createOrUpdate(ctx, r.Client, capiAwsProviderRoleBinding, func() error {
-		return reconcileCAPIAWSProviderRoleBinding(capiAwsProviderRoleBinding, capiAwsProviderRole, capiAwsProviderServiceAccount)
+	// Reconcile CAPI provider role binding
+	capiProviderRoleBinding := clusterapi.CAPIProviderRoleBinding(controlPlaneNamespace.Name)
+	_, err = createOrUpdate(ctx, r.Client, capiProviderRoleBinding, func() error {
+		return reconcileCAPIProviderRoleBinding(capiProviderRoleBinding, capiProviderRole, capiProviderServiceAccount)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to reconcile capi aws provider role binding: %w", err)
+		return fmt.Errorf("failed to reconcile capi provider role binding: %w", err)
 	}
 
-	// Reconcile CAPI AWS provider deployment
-	capiAwsProviderDeployment := clusterapi.CAPIAWSProviderDeployment(controlPlaneNamespace.Name)
-	_, err = createOrUpdate(ctx, r.Client, capiAwsProviderDeployment, func() error {
-		// TODO (alberto): This image builds from https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2453
-		// We need to build from main branch and push to quay.io/hypershift once this is merged or otherwise enable webhooks.
-		return reconcileCAPIAWSProviderDeployment(capiAwsProviderDeployment, hcluster, capiAwsProviderServiceAccount, r.TokenMinterImage)
+	// Reconcile CAPI provider deployment
+	deployment := clusterapi.CAPIProviderDeployment(controlPlaneNamespace.Name)
+	labels := map[string]string{
+		"control-plane":               "capi-provider-controller-manager",
+		"app":                         "capi-provider-controller-manager",
+		hyperv1.ControlPlaneComponent: "capi-provider-controller-manager",
+	}
+	_, err = createOrUpdate(ctx, r.Client, deployment, func() error {
+		// Enforce provider specifics.
+		deployment.Spec = *capiProviderDeploymentSpec
+
+		// Enforce labels.
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: labels,
+		}
+		deployment.Spec.Template.Labels = labels
+
+		// Enforce ServiceAccount.
+		deployment.Spec.Template.Spec.ServiceAccountName = capiProviderServiceAccount.Name
+
+		hyperutil.SetColocation(hcluster, deployment)
+		// TODO (alberto): Reconsider enable this back when we face a real need
+		// with no better solution.
+		// hyperutil.SetRestartAnnotation(hc, deployment)
+		hyperutil.SetControlPlaneIsolation(hcluster, deployment)
+		hyperutil.SetDefaultPriorityClass(deployment)
+		switch hcluster.Spec.ControllerAvailabilityPolicy {
+		case hyperv1.HighlyAvailable:
+			maxSurge := intstr.FromInt(1)
+			maxUnavailable := intstr.FromInt(1)
+			deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
+			deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge:       &maxSurge,
+				MaxUnavailable: &maxUnavailable,
+			}
+			deployment.Spec.Replicas = k8sutilspointer.Int32Ptr(3)
+			hyperutil.SetMultizoneSpread(labels, deployment)
+		default:
+			deployment.Spec.Replicas = k8sutilspointer.Int32Ptr(1)
+		}
+		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to reconcile capi aws provider deployment: %w", err)
+		return fmt.Errorf("failed to reconcile capi provider deployment: %w", err)
 	}
 
 	return nil
@@ -1960,7 +1798,7 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 				Name: "provider-creds",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: manifests.AWSControlPlaneOperatorCreds(deployment.Namespace).Name,
+						SecretName: hc.Spec.Platform.AWS.ControlPlaneOperatorCreds.Name,
 					},
 				},
 			})
@@ -2153,67 +1991,6 @@ func reconcileControlPlaneOperatorRoleBinding(binding *rbacv1.RoleBinding, role 
 		},
 	}
 
-	return nil
-}
-
-func reconcileAWSCluster(awsCluster *capiawsv1.AWSCluster, hcluster *hyperv1.HostedCluster, apiEndpoint hyperv1.APIEndpoint) error {
-	// We only create this resource once and then let CAPI own it
-	awsCluster.Annotations = map[string]string{
-		hostedClusterAnnotation:    client.ObjectKeyFromObject(hcluster).String(),
-		capiv1.ManagedByAnnotation: "external",
-	}
-
-	awsCluster.Spec.AdditionalTags = nil
-	if hcluster.Spec.Platform.AWS != nil {
-		awsCluster.Spec.Region = hcluster.Spec.Platform.AWS.Region
-
-		if hcluster.Spec.Platform.AWS.CloudProviderConfig != nil {
-			awsCluster.Spec.NetworkSpec.VPC.ID = hcluster.Spec.Platform.AWS.CloudProviderConfig.VPC
-
-			// TODO: This https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2728
-			// broke our assumption in CAPA 0.7 for externally managed infrastructure.
-			// This effectively limit our ability to span NodePools across multiple subnets.
-			// In a follow up we need to either enable upstream back to support arbitrary subnets IDs
-			// in the awsMachine CR or possibly expose a slice of available subnets for NodePools in hcluster.Spec.Platform.AWS.
-			if hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet != nil &&
-				hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {
-				awsCluster.Spec.NetworkSpec.Subnets = []capiawsv1.SubnetSpec{
-					{
-						ID: *hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID,
-					},
-				}
-			}
-		}
-
-		if len(hcluster.Spec.Platform.AWS.ResourceTags) > 0 {
-			awsCluster.Spec.AdditionalTags = capiawsv1.Tags{}
-		}
-		for _, entry := range hcluster.Spec.Platform.AWS.ResourceTags {
-			awsCluster.Spec.AdditionalTags[entry.Key] = entry.Value
-		}
-	}
-
-	// Set the values for upper level controller
-	awsCluster.Status.Ready = true
-	awsCluster.Spec.ControlPlaneEndpoint = capiv1.APIEndpoint{
-		Host: apiEndpoint.Host,
-		Port: apiEndpoint.Port,
-	}
-	return nil
-}
-
-func reconcileIBMCloudCluster(ibmCluster *capiibmv1.IBMVPCCluster, hcluster *hyperv1.HostedCluster, apiEndpoint hyperv1.APIEndpoint) error {
-	ibmCluster.Annotations = map[string]string{
-		hostedClusterAnnotation:    client.ObjectKeyFromObject(hcluster).String(),
-		capiv1.ManagedByAnnotation: "external",
-	}
-
-	// Set the values for upper level controller
-	ibmCluster.Status.Ready = true
-	ibmCluster.Spec.ControlPlaneEndpoint = capiv1alpha4.APIEndpoint{
-		Host: apiEndpoint.Host,
-		Port: apiEndpoint.Port,
-	}
 	return nil
 }
 
@@ -2432,189 +2209,7 @@ func reconcileCAPIManagerRoleBinding(binding *rbacv1.RoleBinding, role *rbacv1.R
 	return nil
 }
 
-func reconcileCAPIAWSProviderDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, sa *corev1.ServiceAccount, tokenMinterImage string) error {
-	defaultMode := int32(420)
-	capaLabels := map[string]string{
-		"control-plane":               "capa-controller-manager",
-		"app":                         "capa-controller-manager",
-		hyperv1.ControlPlaneComponent: "capa-controller-manager",
-	}
-	deployment.Spec = appsv1.DeploymentSpec{
-		Replicas: k8sutilspointer.Int32Ptr(1),
-		Selector: &metav1.LabelSelector{
-			MatchLabels: capaLabels,
-		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: capaLabels,
-			},
-			Spec: corev1.PodSpec{
-				ServiceAccountName:            sa.Name,
-				TerminationGracePeriodSeconds: k8sutilspointer.Int64Ptr(10),
-				Tolerations: []corev1.Toleration{
-					{
-						Key:    "node-role.kubernetes.io/master",
-						Effect: corev1.TaintEffectNoSchedule,
-					},
-				},
-				Volumes: []corev1.Volume{
-					{
-						Name: "capi-webhooks-tls",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								DefaultMode: &defaultMode,
-								SecretName:  "capi-webhooks-tls",
-							},
-						},
-					},
-					{
-						Name: "credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: manifests.AWSNodePoolManagementCreds(deployment.Namespace).Name,
-							},
-						},
-					},
-					{
-						Name: "svc-kubeconfig",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								DefaultMode: &defaultMode,
-								SecretName:  "service-network-admin-kubeconfig",
-							},
-						},
-					},
-					{
-						Name: "token",
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{
-								Medium: corev1.StorageMediumMemory,
-							},
-						},
-					},
-				},
-				Containers: []corev1.Container{
-					{
-						Name:            "manager",
-						Image:           imageCAPA,
-						ImagePullPolicy: corev1.PullAlways,
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "credentials",
-								MountPath: "/home/.aws",
-							},
-							{
-								Name:      "capi-webhooks-tls",
-								ReadOnly:  true,
-								MountPath: "/tmp/k8s-webhook-server/serving-certs",
-							},
-							{
-								Name:      "token",
-								MountPath: "/var/run/secrets/openshift/serviceaccount",
-							},
-						},
-						Env: []corev1.EnvVar{
-							{
-								Name: "MY_NAMESPACE",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "metadata.namespace",
-									},
-								},
-							},
-							{
-								Name:  "AWS_SHARED_CREDENTIALS_FILE",
-								Value: "/home/.aws/credentials",
-							},
-							{
-								Name:  "AWS_SDK_LOAD_CONFIG",
-								Value: "true",
-							},
-						},
-						Command: []string{"/manager"},
-						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--alsologtostderr",
-							"--v=4",
-							"--leader-elect=true",
-							"--feature-gates=EKS=false",
-						},
-						Ports: []corev1.ContainerPort{
-							{
-								Name:          "healthz",
-								ContainerPort: 9440,
-								Protocol:      corev1.ProtocolTCP,
-							},
-						},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/healthz",
-									Port: intstr.FromString("healthz"),
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/readyz",
-									Port: intstr.FromString("healthz"),
-								},
-							},
-						},
-					},
-					{
-						Name:            "token-minter",
-						Image:           tokenMinterImage,
-						ImagePullPolicy: corev1.PullAlways,
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "token",
-								MountPath: "/var/run/secrets/openshift/serviceaccount",
-							},
-							{
-								Name:      "svc-kubeconfig",
-								MountPath: "/etc/kubernetes",
-							},
-						},
-						Command: []string{"/usr/bin/token-minter"},
-						Args: []string{
-							"-service-account-namespace=kube-system",
-							"-service-account-name=capa-controller-manager",
-							"-token-audience=openshift",
-							"-token-file=/var/run/secrets/openshift/serviceaccount/token",
-							"-kubeconfig=/etc/kubernetes/kubeconfig",
-							"-sleep=true",
-						},
-					},
-				},
-			},
-		},
-	}
-	hyperutil.SetColocation(hc, deployment)
-	// TODO (alberto): Reconsider enable this back when we face a real need
-	// with no better solution.
-	// hyperutil.SetRestartAnnotation(hc, deployment)
-	hyperutil.SetControlPlaneIsolation(hc, deployment)
-	hyperutil.SetDefaultPriorityClass(deployment)
-	switch hc.Spec.ControllerAvailabilityPolicy {
-	case hyperv1.HighlyAvailable:
-		maxSurge := intstr.FromInt(1)
-		maxUnavailable := intstr.FromInt(1)
-		deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
-		deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge:       &maxSurge,
-			MaxUnavailable: &maxUnavailable,
-		}
-		deployment.Spec.Replicas = k8sutilspointer.Int32Ptr(3)
-		hyperutil.SetMultizoneSpread(capaLabels, deployment)
-	default:
-		deployment.Spec.Replicas = k8sutilspointer.Int32Ptr(1)
-	}
-
-	return nil
-}
-
-func reconcileCAPIAWSProviderRole(role *rbacv1.Role) error {
+func reconcileCAPIProviderRole(role *rbacv1.Role) error {
 	role.Rules = []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
@@ -2655,7 +2250,7 @@ func reconcileCAPIAWSProviderRole(role *rbacv1.Role) error {
 	return nil
 }
 
-func reconcileCAPIAWSProviderRoleBinding(binding *rbacv1.RoleBinding, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
+func reconcileCAPIProviderRoleBinding(binding *rbacv1.RoleBinding, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
 	binding.RoleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "Role",

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
-	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 )
 
 var Now = metav1.NewTime(time.Now())
@@ -710,91 +709,6 @@ func TestReconcileIgnitionServerServiceRoute(t *testing.T) {
 			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Port).To(Equal(int32(443)))
 			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Name).To(Equal("https"))
 			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
-		})
-	}
-}
-
-func TestReconcileAWSCluster(t *testing.T) {
-	testCases := []struct {
-		name              string
-		initialAWSCluster *capiawsv1.AWSCluster
-		hostedCluster     *hyperv1.HostedCluster
-
-		expectedAWSCluster *capiawsv1.AWSCluster
-	}{
-		{
-			name:              "Tags get copied over",
-			initialAWSCluster: &capiawsv1.AWSCluster{},
-			hostedCluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{AWS: &hyperv1.AWSPlatformSpec{
-				ResourceTags: []hyperv1.AWSResourceTag{
-					{Key: "foo", Value: "bar"},
-				},
-			}}}},
-
-			expectedAWSCluster: &capiawsv1.AWSCluster{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					"cluster.x-k8s.io/managed-by":     "external",
-					"hypershift.openshift.io/cluster": "/",
-				}},
-				Spec: capiawsv1.AWSClusterSpec{
-					AdditionalTags: capiawsv1.Tags{"foo": "bar"},
-				},
-				Status: capiawsv1.AWSClusterStatus{
-					Ready: true,
-				},
-			},
-		},
-		{
-			name: "Existing tags get removed",
-			initialAWSCluster: &capiawsv1.AWSCluster{Spec: capiawsv1.AWSClusterSpec{AdditionalTags: capiawsv1.Tags{
-				"to-be-removed": "value",
-			}}},
-			hostedCluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{AWS: &hyperv1.AWSPlatformSpec{
-				ResourceTags: []hyperv1.AWSResourceTag{
-					{Key: "foo", Value: "bar"},
-				},
-			}}}},
-
-			expectedAWSCluster: &capiawsv1.AWSCluster{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					"cluster.x-k8s.io/managed-by":     "external",
-					"hypershift.openshift.io/cluster": "/",
-				}},
-				Spec: capiawsv1.AWSClusterSpec{
-					AdditionalTags: capiawsv1.Tags{"foo": "bar"},
-				},
-				Status: capiawsv1.AWSClusterStatus{
-					Ready: true,
-				},
-			},
-		},
-		{
-			name: "No tags on hostedcluster clears existing awscluster tags",
-			initialAWSCluster: &capiawsv1.AWSCluster{Spec: capiawsv1.AWSClusterSpec{AdditionalTags: capiawsv1.Tags{
-				"to-be-removed": "value",
-			}}},
-			hostedCluster: &hyperv1.HostedCluster{},
-
-			expectedAWSCluster: &capiawsv1.AWSCluster{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					"cluster.x-k8s.io/managed-by":     "external",
-					"hypershift.openshift.io/cluster": "/",
-				}},
-				Status: capiawsv1.AWSClusterStatus{
-					Ready: true,
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := reconcileAWSCluster(tc.initialAWSCluster, tc.hostedCluster, hyperv1.APIEndpoint{}); err != nil {
-				t.Fatalf("reconcileAWSCluster failed: %v", err)
-			}
-			if diff := cmp.Diff(tc.initialAWSCluster, tc.expectedAWSCluster); diff != "" {
-				t.Errorf("reconciled AWS cluster differs from expcted AWS cluster: %s", diff)
-			}
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -1,0 +1,366 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/upsert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sutilspointer "k8s.io/utils/pointer"
+	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// Image built from https://github.com/openshift/cluster-api-provider-aws/tree/release-1.1
+	// Upstream canonical image comes from  https://console.cloud.google.com/gcr/images/k8s-artifacts-prod
+	// us.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller:v1.1.0
+	imageCAPA = "registry.ci.openshift.org/hypershift/cluster-api-aws-controller:v1.1.0"
+
+	hostedClusterAnnotation = "hypershift.openshift.io/cluster"
+)
+
+type AWS struct{}
+
+func (p AWS) ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, apiEndpoint hyperv1.APIEndpoint,
+	c client.Client, ctx context.Context) (client.Object, error) {
+	awsCluster := &capiawsv1.AWSCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      hcluster.Name,
+		},
+	}
+
+	_, err := controllerutil.CreateOrPatch(ctx, c, awsCluster, func() error {
+		return reconcileAWSCluster(awsCluster, hcluster, apiEndpoint)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return awsCluster, nil
+}
+
+func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+	defaultMode := int32(420)
+	deploymentSpec := &appsv1.DeploymentSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				TerminationGracePeriodSeconds: k8sutilspointer.Int64Ptr(10),
+				Tolerations: []corev1.Toleration{
+					{
+						Key:    "node-role.kubernetes.io/master",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "capi-webhooks-tls",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								DefaultMode: &defaultMode,
+								SecretName:  "capi-webhooks-tls",
+							},
+						},
+					},
+					{
+						Name: "credentials",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: hcluster.Spec.Platform.AWS.NodePoolManagementCreds.Name,
+							},
+						},
+					},
+					{
+						Name: "svc-kubeconfig",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								DefaultMode: &defaultMode,
+								SecretName:  "service-network-admin-kubeconfig",
+							},
+						},
+					},
+					{
+						Name: "token",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{
+								Medium: corev1.StorageMediumMemory,
+							},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:            "manager",
+						Image:           imageCAPA,
+						ImagePullPolicy: corev1.PullAlways,
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "credentials",
+								MountPath: "/home/.aws",
+							},
+							{
+								Name:      "capi-webhooks-tls",
+								ReadOnly:  true,
+								MountPath: "/tmp/k8s-webhook-server/serving-certs",
+							},
+							{
+								Name:      "token",
+								MountPath: "/var/run/secrets/openshift/serviceaccount",
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name: "MY_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
+							},
+							{
+								Name:  "AWS_SHARED_CREDENTIALS_FILE",
+								Value: "/home/.aws/credentials",
+							},
+							{
+								Name:  "AWS_SDK_LOAD_CONFIG",
+								Value: "true",
+							},
+						},
+						Command: []string{"/manager"},
+						Args: []string{"--namespace", "$(MY_NAMESPACE)",
+							"--alsologtostderr",
+							"--v=4",
+							"--leader-elect=true",
+							"--feature-gates=EKS=false",
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "healthz",
+								ContainerPort: 9440,
+								Protocol:      corev1.ProtocolTCP,
+							},
+						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/healthz",
+									Port: intstr.FromString("healthz"),
+								},
+							},
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/readyz",
+									Port: intstr.FromString("healthz"),
+								},
+							},
+						},
+					},
+					{
+						Name:            "token-minter",
+						Image:           tokenMinterImage,
+						ImagePullPolicy: corev1.PullAlways,
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "token",
+								MountPath: "/var/run/secrets/openshift/serviceaccount",
+							},
+							{
+								Name:      "svc-kubeconfig",
+								MountPath: "/etc/kubernetes",
+							},
+						},
+						Command: []string{"/usr/bin/token-minter"},
+						Args: []string{
+							"-service-account-namespace=kube-system",
+							"-service-account-name=capa-controller-manager",
+							"-token-audience=openshift",
+							"-token-file=/var/run/secrets/openshift/serviceaccount/token",
+							"-kubeconfig=/etc/kubernetes/kubeconfig",
+							"-sleep=true",
+						},
+					},
+				},
+			},
+		},
+	}
+	return deploymentSpec, nil
+}
+
+func (p AWS) ReconcileCredentials(c client.Client, ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string) error {
+	// Reconcile the platform provider cloud controller credentials secret by resolving
+	// the reference from the HostedCluster and syncing the secret in the control
+	// plane namespace.
+	var src corev1.Secret
+	if err := c.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.Platform.AWS.KubeCloudControllerCreds.Name}, &src); err != nil {
+		return fmt.Errorf("failed to get cloud controller provider creds %s: %w", hcluster.Spec.Platform.AWS.KubeCloudControllerCreds.Name, err)
+	}
+	dest := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      src.Name,
+		},
+	}
+	_, err := createOrUpdate(ctx, c, dest, func() error {
+		srcData, srcHasData := src.Data["credentials"]
+		if !srcHasData {
+			return fmt.Errorf("hostedcluster cloud controller provider credentials secret %q must have a credentials key", src.Name)
+		}
+		dest.Type = corev1.SecretTypeOpaque
+		if dest.Data == nil {
+			dest.Data = map[string][]byte{}
+		}
+		dest.Data["credentials"] = srcData
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile cloud controller provider creds: %w", err)
+	}
+
+	// Reconcile the platform provider node pool management credentials secret by
+	// resolving  the reference from the HostedCluster and syncing the secret in
+	// the control plane namespace.
+	err = c.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.Platform.AWS.NodePoolManagementCreds.Name}, &src)
+	if err != nil {
+		return fmt.Errorf("failed to get node pool provider creds %s: %w", hcluster.Spec.Platform.AWS.NodePoolManagementCreds.Name, err)
+	}
+	dest = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      src.Name,
+		},
+	}
+	_, err = createOrUpdate(ctx, c, dest, func() error {
+		srcData, srcHasData := src.Data["credentials"]
+		if !srcHasData {
+			return fmt.Errorf("node pool provider credentials secret %q is missing credentials key", src.Name)
+		}
+		dest.Type = corev1.SecretTypeOpaque
+		if dest.Data == nil {
+			dest.Data = map[string][]byte{}
+		}
+		dest.Data["credentials"] = srcData
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile node pool provider creds: %w", err)
+	}
+
+	// Reconcile the platform provider node pool management credentials secret by
+	// resolving  the reference from the HostedCluster and syncing the secret in
+	// the control plane namespace.
+	err = c.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.Platform.AWS.ControlPlaneOperatorCreds.Name}, &src)
+	if err != nil {
+		return fmt.Errorf("failed to get control plane operator provider creds %s: %w", hcluster.Spec.Platform.AWS.ControlPlaneOperatorCreds.Name, err)
+	}
+	dest = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      src.Name,
+		},
+	}
+	_, err = createOrUpdate(ctx, c, dest, func() error {
+		srcData, srcHasData := src.Data["credentials"]
+		if !srcHasData {
+			return fmt.Errorf("control plane operator provider credentials secret %q is missing credentials key", src.Name)
+		}
+		dest.Type = corev1.SecretTypeOpaque
+		if dest.Data == nil {
+			dest.Data = map[string][]byte{}
+		}
+		dest.Data["credentials"] = srcData
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile control plane operator provider creds: %w", err)
+	}
+	return nil
+}
+
+func (AWS) ReconcileSecretEncryption(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, ctx context.Context, c client.Client,
+	createOrUpdate upsert.CreateOrUpdateFN) error {
+	if hcluster.Spec.SecretEncryption.KMS.AWS == nil || len(hcluster.Spec.SecretEncryption.KMS.AWS.Auth.Credentials.Name) == 0 {
+		return fmt.Errorf("aws kms metadata nil")
+	}
+	var src corev1.Secret
+	if err := c.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.SecretEncryption.KMS.AWS.Auth.Credentials.Name}, &src); err != nil {
+		return fmt.Errorf("failed to get ibmcloud kms credentials %s: %w", hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged.Credentials.Name, err)
+	}
+	if _, ok := src.Data[hyperv1.AWSCredentialsFileSecretKey]; !ok {
+		return fmt.Errorf("aws credential key %s not present in auth secret", hyperv1.AWSCredentialsFileSecretKey)
+	}
+	hostedControlPlaneAWSKMSAuthSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      src.Name,
+		},
+	}
+	_, err := createOrUpdate(ctx, c, hostedControlPlaneAWSKMSAuthSecret, func() error {
+		if hostedControlPlaneAWSKMSAuthSecret.Data == nil {
+			hostedControlPlaneAWSKMSAuthSecret.Data = map[string][]byte{}
+		}
+		hostedControlPlaneAWSKMSAuthSecret.Data[hyperv1.AWSCredentialsFileSecretKey] = src.Data[hyperv1.AWSCredentialsFileSecretKey]
+		hostedControlPlaneAWSKMSAuthSecret.Type = corev1.SecretTypeOpaque
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed reconciling aws kms backup key: %w", err)
+	}
+	return nil
+}
+
+func reconcileAWSCluster(awsCluster *capiawsv1.AWSCluster, hcluster *hyperv1.HostedCluster, apiEndpoint hyperv1.APIEndpoint) error {
+	// We only create this resource once and then let CAPI own it
+	awsCluster.Annotations = map[string]string{
+		// TODO (alberto): let this annotation be set by our createOrUpdate construct.
+		hostedClusterAnnotation:    client.ObjectKeyFromObject(hcluster).String(),
+		capiv1.ManagedByAnnotation: "external",
+	}
+
+	awsCluster.Spec.AdditionalTags = nil
+	if hcluster.Spec.Platform.AWS != nil {
+		awsCluster.Spec.Region = hcluster.Spec.Platform.AWS.Region
+
+		if hcluster.Spec.Platform.AWS.CloudProviderConfig != nil {
+			awsCluster.Spec.NetworkSpec.VPC.ID = hcluster.Spec.Platform.AWS.CloudProviderConfig.VPC
+
+			// TODO: This https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2728
+			// broke our assumption in CAPA 0.7 for externally managed infrastructure.
+			// This effectively limit our ability to span NodePools across multiple subnets.
+			// In a follow up we need to either enable upstream back to support arbitrary subnets IDs
+			// in the awsMachine CR or possibly expose a slice of available subnets for NodePools in hcluster.Spec.Platform.AWS.
+			if hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet != nil &&
+				hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {
+				awsCluster.Spec.NetworkSpec.Subnets = []capiawsv1.SubnetSpec{
+					{
+						ID: *hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID,
+					},
+				}
+			}
+		}
+
+		if len(hcluster.Spec.Platform.AWS.ResourceTags) > 0 {
+			awsCluster.Spec.AdditionalTags = capiawsv1.Tags{}
+		}
+		for _, entry := range hcluster.Spec.Platform.AWS.ResourceTags {
+			awsCluster.Spec.AdditionalTags[entry.Key] = entry.Value
+		}
+	}
+
+	// Set the values for upper level controller
+	awsCluster.Status.Ready = true
+	awsCluster.Spec.ControlPlaneEndpoint = capiv1.APIEndpoint{
+		Host: apiEndpoint.Host,
+		Port: apiEndpoint.Port,
+	}
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws_test.go
@@ -1,0 +1,95 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+)
+
+func TestReconcileAWSCluster(t *testing.T) {
+	testCases := []struct {
+		name              string
+		initialAWSCluster *capiawsv1.AWSCluster
+		hostedCluster     *hyperv1.HostedCluster
+
+		expectedAWSCluster *capiawsv1.AWSCluster
+	}{
+		{
+			name:              "Tags get copied over",
+			initialAWSCluster: &capiawsv1.AWSCluster{},
+			hostedCluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{AWS: &hyperv1.AWSPlatformSpec{
+				ResourceTags: []hyperv1.AWSResourceTag{
+					{Key: "foo", Value: "bar"},
+				},
+			}}}},
+
+			expectedAWSCluster: &capiawsv1.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					"cluster.x-k8s.io/managed-by":     "external",
+					"hypershift.openshift.io/cluster": "/",
+				}},
+				Spec: capiawsv1.AWSClusterSpec{
+					AdditionalTags: capiawsv1.Tags{"foo": "bar"},
+				},
+				Status: capiawsv1.AWSClusterStatus{
+					Ready: true,
+				},
+			},
+		},
+		{
+			name: "Existing tags get removed",
+			initialAWSCluster: &capiawsv1.AWSCluster{Spec: capiawsv1.AWSClusterSpec{AdditionalTags: capiawsv1.Tags{
+				"to-be-removed": "value",
+			}}},
+			hostedCluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{AWS: &hyperv1.AWSPlatformSpec{
+				ResourceTags: []hyperv1.AWSResourceTag{
+					{Key: "foo", Value: "bar"},
+				},
+			}}}},
+
+			expectedAWSCluster: &capiawsv1.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					"cluster.x-k8s.io/managed-by":     "external",
+					"hypershift.openshift.io/cluster": "/",
+				}},
+				Spec: capiawsv1.AWSClusterSpec{
+					AdditionalTags: capiawsv1.Tags{"foo": "bar"},
+				},
+				Status: capiawsv1.AWSClusterStatus{
+					Ready: true,
+				},
+			},
+		},
+		{
+			name: "No tags on hostedcluster clears existing awscluster tags",
+			initialAWSCluster: &capiawsv1.AWSCluster{Spec: capiawsv1.AWSClusterSpec{AdditionalTags: capiawsv1.Tags{
+				"to-be-removed": "value",
+			}}},
+			hostedCluster: &hyperv1.HostedCluster{},
+
+			expectedAWSCluster: &capiawsv1.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					"cluster.x-k8s.io/managed-by":     "external",
+					"hypershift.openshift.io/cluster": "/",
+				}},
+				Status: capiawsv1.AWSClusterStatus{
+					Ready: true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := reconcileAWSCluster(tc.initialAWSCluster, tc.hostedCluster, hyperv1.APIEndpoint{}); err != nil {
+				t.Fatalf("reconcileAWSCluster failed: %v", err)
+			}
+			if diff := cmp.Diff(tc.initialAWSCluster, tc.expectedAWSCluster); diff != "" {
+				t.Errorf("reconciled AWS cluster differs from expcted AWS cluster: %s", diff)
+			}
+		})
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
@@ -1,0 +1,101 @@
+package ibmcloud
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	capiibmv1 "github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/api/v1alpha4"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/upsert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4" // Need this dep atm to satisfy IBM provider dep.
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	hostedClusterAnnotation = "hypershift.openshift.io/cluster"
+)
+
+type IBMCloud struct{}
+
+func (p IBMCloud) ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, apiEndpoint hyperv1.APIEndpoint,
+	c client.Client, ctx context.Context) (client.Object, error) {
+
+	ibmCluster := &capiibmv1.IBMVPCCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      hcluster.Name,
+		},
+	}
+
+	_, err := controllerutil.CreateOrPatch(ctx, c, ibmCluster, func() error {
+		ibmCluster.Annotations = map[string]string{
+			hostedClusterAnnotation:    client.ObjectKeyFromObject(hcluster).String(),
+			capiv1.ManagedByAnnotation: "external",
+		}
+
+		// Set the values for upper level controller
+		ibmCluster.Status.Ready = true
+		ibmCluster.Spec.ControlPlaneEndpoint = capiv1alpha4.APIEndpoint{
+			Host: apiEndpoint.Host,
+			Port: apiEndpoint.Port,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (p IBMCloud) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+	return nil, nil
+}
+
+func (p IBMCloud) ReconcileCredentials(c client.Client, ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string) error {
+	return nil
+}
+
+func (IBMCloud) ReconcileSecretEncryption(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, ctx context.Context, c client.Client,
+	createOrUpdate upsert.CreateOrUpdateFN) error {
+	if hcluster.Spec.SecretEncryption.KMS.IBMCloud == nil {
+		return fmt.Errorf("ibm kms metadata nil")
+	}
+	if hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Type == hyperv1.IBMCloudKMSUnmanagedAuth {
+		if hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged == nil || len(hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged.Credentials.Name) == 0 {
+			return fmt.Errorf("ibm unmanaged auth credential nil")
+		}
+		var src corev1.Secret
+		if err := c.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged.Credentials.Name}, &src); err != nil {
+			return fmt.Errorf("failed to get ibmcloud kms credentials %s: %w", hcluster.Spec.SecretEncryption.KMS.IBMCloud.Auth.Unmanaged.Credentials.Name, err)
+		}
+		if _, ok := src.Data[hyperv1.IBMCloudIAMAPIKeySecretKey]; !ok {
+			return fmt.Errorf("no ibmcloud iam apikey field %s specified in auth secret", hyperv1.IBMCloudIAMAPIKeySecretKey)
+		}
+		hostedControlPlaneIBMCloudKMSAuthSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: controlPlaneNamespace,
+				Name:      src.Name,
+			},
+		}
+		_, err := createOrUpdate(ctx, c, hostedControlPlaneIBMCloudKMSAuthSecret, func() error {
+			if hostedControlPlaneIBMCloudKMSAuthSecret.Data == nil {
+				hostedControlPlaneIBMCloudKMSAuthSecret.Data = map[string][]byte{}
+			}
+			hostedControlPlaneIBMCloudKMSAuthSecret.Data[hyperv1.IBMCloudIAMAPIKeySecretKey] = src.Data[hyperv1.IBMCloudIAMAPIKeySecretKey]
+			hostedControlPlaneIBMCloudKMSAuthSecret.Type = corev1.SecretTypeOpaque
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed reconciling aescbc backup key: %w", err)
+		}
+	}
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/none/none.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/none/none.go
@@ -1,0 +1,32 @@
+package none
+
+import (
+	"context"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/upsert"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type None struct{}
+
+func (p None) ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, apiEndpoint hyperv1.APIEndpoint,
+	c client.Client, ctx context.Context) (client.Object, error) {
+
+	return nil, nil
+}
+
+func (p None) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+	return nil, nil
+}
+
+func (p None) ReconcileCredentials(c client.Client, ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string) error {
+	return nil
+}
+
+func (None) ReconcileSecretEncryption(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, ctx context.Context, c client.Client,
+	createOrUpdate upsert.CreateOrUpdateFN) error {
+	return nil
+}

--- a/hypershift-operator/controllers/manifests/clusterapi/manifests.go
+++ b/hypershift-operator/controllers/manifests/clusterapi/manifests.go
@@ -59,38 +59,38 @@ func CAPIManagerRoleBinding(controlPlaneNamespace string) *rbacv1.RoleBinding {
 	}
 }
 
-func CAPIAWSProviderDeployment(controlPlaneNamespace string) *appsv1.Deployment {
+func CAPIProviderDeployment(controlPlaneNamespace string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
-			Name:      "capa-controller-manager",
+			Name:      "capi-provider",
 		},
 	}
 }
 
-func CAPIAWSProviderServiceAccount(controlPlaneNamespace string) *corev1.ServiceAccount {
+func CAPIProviderServiceAccount(controlPlaneNamespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
-			Name:      "capa-controller-manager",
+			Name:      "capi-provider",
 		},
 	}
 }
 
-func CAPIAWSProviderRole(controlPlaneNamespace string) *rbacv1.Role {
+func CAPIProviderRole(controlPlaneNamespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
-			Name:      "capa-manager",
+			Name:      "capi-provider",
 		},
 	}
 }
 
-func CAPIAWSProviderRoleBinding(controlPlaneNamespace string) *rbacv1.RoleBinding {
+func CAPIProviderRoleBinding(controlPlaneNamespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
-			Name:      "capa-manager",
+			Name:      "capi-provider",
 		},
 	}
 }

--- a/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
@@ -1,14 +1,12 @@
 package controlplaneoperator
 
 import (
-	capiibmv1 "github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/api/v1alpha4"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -91,15 +89,6 @@ func PullSecret(controlPlaneNamespace string) *corev1.Secret {
 	}
 }
 
-func SigningKey(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      "signing-key",
-		},
-	}
-}
-
 func SSHKey(controlPlaneNamespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -109,26 +98,8 @@ func SSHKey(controlPlaneNamespace string) *corev1.Secret {
 	}
 }
 
-func IBMCloudCluster(controlPlaneNamespace string, hostedClusterName string) *capiibmv1.IBMVPCCluster {
-	return &capiibmv1.IBMVPCCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      hostedClusterName,
-		},
-	}
-}
-
 func PodMonitor(controlPlaneNamespace string, hostedClusterName string) *prometheusoperatorv1.PodMonitor {
 	return &prometheusoperatorv1.PodMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      hostedClusterName,
-		},
-	}
-}
-
-func AWSCluster(controlPlaneNamespace string, hostedClusterName string) *capiawsv1.AWSCluster {
-	return &capiawsv1.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
 			Name:      hostedClusterName,

--- a/hypershift-operator/controllers/manifests/manifests.go
+++ b/hypershift-operator/controllers/manifests/manifests.go
@@ -23,30 +23,3 @@ func KubeConfigSecret(hostedClusterNamespace string, hostedClusterName string) *
 		},
 	}
 }
-
-func AWSKubeCloudControllerCreds(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      "provider-creds",
-		},
-	}
-}
-
-func AWSNodePoolManagementCreds(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      "node-provider-creds",
-		},
-	}
-}
-
-func AWSControlPlaneOperatorCreds(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      "cpo-provider-creds",
-		},
-	}
-}


### PR DESCRIPTION
This is a first step towards a more sustainable model for the code base to extend to multiple platforms.
It creates an interface to be implemented for each platform to handle the HostedController needs.
It add docs for extend support to other platforms.
As a follow up if this model proves to be satisfactory we can extend the interface to support the NodePool controller and handle infra machines lifecycle. Furthermore, we could at some point consider this to be an adhoc platform controller which communicates with the core one through conditions there fore enabling out of tree platform implementations.