### PR TITLE
Hypershift CLI: Dont use json-encoding for logs

### DIFF
--- a/cmd/bastion/aws/logging.go
+++ b/cmd/bastion/aws/logging.go
@@ -1,5 +1,5 @@
 package aws
 
-import "sigs.k8s.io/controller-runtime/pkg/log/zap"
+import "github.com/openshift/hypershift/cmd/util"
 
-var log = zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+var log = util.Log

--- a/cmd/cluster/aws/log.go
+++ b/cmd/cluster/aws/log.go
@@ -1,5 +1,5 @@
 package aws
 
-import "sigs.k8s.io/controller-runtime/pkg/log/zap"
+import "github.com/openshift/hypershift/cmd/util"
 
-var log = zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+var log = util.Log

--- a/cmd/cluster/core/log.go
+++ b/cmd/cluster/core/log.go
@@ -1,7 +1,5 @@
 package core
 
-import (
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-)
+import "github.com/openshift/hypershift/cmd/util"
 
-var log = zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+var log = util.Log

--- a/cmd/cluster/none/log.go
+++ b/cmd/cluster/none/log.go
@@ -1,7 +1,7 @@
 package none
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"github.com/openshift/hypershift/cmd/util"
 )
 
-var log = zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+var log = util.Log

--- a/cmd/consolelogs/aws/logging.go
+++ b/cmd/consolelogs/aws/logging.go
@@ -1,5 +1,5 @@
 package aws
 
-import "sigs.k8s.io/controller-runtime/pkg/log/zap"
+import "github.com/openshift/hypershift/cmd/util"
 
-var log = zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+var log = util.Log

--- a/cmd/infra/aws/logging.go
+++ b/cmd/infra/aws/logging.go
@@ -1,5 +1,5 @@
 package aws
 
-import "sigs.k8s.io/controller-runtime/pkg/log/zap"
+import "github.com/openshift/hypershift/cmd/util"
 
-var log = zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+var log = util.Log

--- a/cmd/util/log.go
+++ b/cmd/util/log.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var Log = zap.New(zap.UseDevMode(true), func(o *zap.Options) {
+	o.TimeEncoder = zapcore.RFC3339TimeEncoder
+})


### PR DESCRIPTION
JSON-Encoding makes sense for long-running components but not for a CLI
that is only ever invoked by a human. Also changes the time encoding to
be RFC3339 instead of unix epoch.

/cc @csrwng 