### PR TITLE
Use VPC endpoint for controlPlaneEndpoint with private clusters

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -95,7 +95,6 @@ func ReconcilePrivateService(svc *corev1.Service, owner *metav1.OwnerReference) 
 	return nil
 }
 
-func ReconcilePrivateServiceStatus(svc *corev1.Service) (host string, port int32, err error) {
-	// TODO: will be change to api.$hcpName.hypershift.local once OIDC controller is switch the service network
-	return fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace), 6443, nil
+func ReconcilePrivateServiceStatus(hcpName string) (host string, port int32, err error) {
+	return fmt.Sprintf("api.%s.hypershift.local", hcpName), 6443, nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -208,6 +208,7 @@ func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, private bool
 			route.Labels = map[string]string{}
 		}
 		route.Labels[ingress.HypershiftRouteLabel] = route.GetNamespace()
+		route.Spec.Host = fmt.Sprintf("%s.apps.%s.hypershift.local", route.Name, ownerRef.Reference.Name)
 	}
 	route.Spec.To = routev1.RouteTargetReference{
 		Kind: "Service",

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -1,6 +1,8 @@
 package oauth
 
 import (
+	"fmt"
+
 	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ingress"
@@ -15,6 +17,7 @@ func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, private bool
 			route.Labels = map[string]string{}
 		}
 		route.Labels[ingress.HypershiftRouteLabel] = route.GetNamespace()
+		route.Spec.Host = fmt.Sprintf("%s.apps.%s.hypershift.local", route.Name, ownerRef.Reference.Name)
 	}
 	route.Spec.To = routev1.RouteTargetReference{
 		Kind: "Service",

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1506,6 +1506,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 					ignitionServerRoute.Labels = map[string]string{}
 				}
 				ignitionServerRoute.Labels[hyperutil.HypershiftRouteLabel] = controlPlaneNamespace.Name
+				ignitionServerRoute.Spec.Host = fmt.Sprintf("%s.apps.%s.hypershift.local", ignitionServerRoute.Name, hcluster.Name)
 			}
 			ignitionServerRoute.Annotations[hostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
 			ignitionServerRoute.Spec.TLS = &routev1.TLSConfig{


### PR DESCRIPTION
Needs https://github.com/openshift/hypershift/pull/710 and https://github.com/openshift/hypershift/pull/720 first, but this PR is the endgame; full private cluster support

/hold