### PR TITLE
Replace Konnectivity Agent user manifests

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -124,7 +124,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, config *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, config *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
@@ -139,7 +139,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
-					util.BuildContainer(hccContainerMain(), buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion, enableCIDebugOutput, platformType)),
+					util.BuildContainer(hccContainerMain(), buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion, enableCIDebugOutput, platformType, konnectivityAddress, konnectivityPort)),
 				},
 				Volumes: []corev1.Volume{
 					util.BuildVolume(hccVolumeKubeconfig(), buildHCCVolumeKubeconfig),
@@ -179,7 +179,7 @@ func hccVolumeClusterSignerCA() *corev1.Volume {
 	}
 }
 
-func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string, enableCIDebugOutput bool, platformType hyperv1.PlatformType) func(c *corev1.Container) {
+func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, konnectivityAddress string, konnectivityPort int32) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.ImagePullPolicy = corev1.PullAlways
@@ -192,6 +192,8 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 			"--platform-type", string(platformType),
 			fmt.Sprintf("--enable-ci-debug-output=%t", enableCIDebugOutput),
 			fmt.Sprintf("--hosted-control-plane=%s", hcpName),
+			fmt.Sprintf("--konnectivity-address=%s", konnectivityAddress),
+			fmt.Sprintf("--konnectivity-port=%d", konnectivityPort),
 		}
 		c.Env = []corev1.EnvVar{
 			{

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -259,42 +259,6 @@ func ReconcileServerServiceStatus(svc *corev1.Service, route *routev1.Route, str
 	return
 }
 
-func ReconcileWorkerAgentDaemonSet(cm *corev1.ConfigMap, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, image string, host string, port int32) error {
-	ownerRef.ApplyTo(cm)
-	agentDaemonSet := manifests.KonnectivityAgentDaemonSet()
-	if err := reconcileWorkerAgentDaemonSet(agentDaemonSet, deploymentConfig, image, host, port); err != nil {
-		return err
-	}
-	return util.ReconcileWorkerManifest(cm, agentDaemonSet)
-}
-
-func reconcileWorkerAgentDaemonSet(daemonset *appsv1.DaemonSet, deploymentConfig config.DeploymentConfig, image string, host string, port int32) error {
-	daemonset.Spec = appsv1.DaemonSetSpec{
-		Selector: &metav1.LabelSelector{
-			MatchLabels: konnectivityAgentLabels(),
-		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: konnectivityAgentLabels(),
-			},
-			Spec: corev1.PodSpec{
-				AutomountServiceAccountToken: pointer.BoolPtr(false),
-				SecurityContext: &corev1.PodSecurityContext{
-					RunAsUser: pointer.Int64Ptr(1000),
-				},
-				Containers: []corev1.Container{
-					util.BuildContainer(konnectivityAgentContainer(), buildKonnectivityWorkerAgentContainer(image, host, port)),
-				},
-				Volumes: []corev1.Volume{
-					util.BuildVolume(konnectivityVolumeAgentCerts(), buildKonnectivityVolumeWorkerAgentCerts),
-				},
-			},
-		},
-	}
-	deploymentConfig.ApplyToDaemonSet(daemonset)
-	return nil
-}
-
 func konnectivityAgentContainer() *corev1.Container {
 	return &corev1.Container{
 		Name: "konnectivity-agent",
@@ -307,47 +271,9 @@ func konnectivityVolumeAgentCerts() *corev1.Volume {
 	}
 }
 
-func buildKonnectivityVolumeWorkerAgentCerts(v *corev1.Volume) {
+func buildKonnectivityVolumeAgentCerts(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
 		SecretName: manifests.KonnectivityAgentSecret("").Name,
-	}
-}
-
-func buildKonnectivityWorkerAgentContainer(image, host string, port int32) func(c *corev1.Container) {
-	cpath := func(volume, file string) string {
-		return path.Join(volumeMounts.Path(konnectivityAgentContainer().Name, volume), file)
-	}
-	return func(c *corev1.Container) {
-		c.Image = image
-		c.ImagePullPolicy = corev1.PullAlways
-		c.Command = []string{
-			"/usr/bin/proxy-agent",
-		}
-		c.Args = []string{
-			"--logtostderr=true",
-			"--ca-cert",
-			cpath(konnectivityVolumeAgentCerts().Name, pki.CASignerCertMapKey),
-			"--agent-cert",
-			cpath(konnectivityVolumeAgentCerts().Name, corev1.TLSCertKey),
-			"--agent-key",
-			cpath(konnectivityVolumeAgentCerts().Name, corev1.TLSPrivateKeyKey),
-			"--proxy-server-host",
-			host,
-			"--proxy-server-port",
-			fmt.Sprint(port),
-			"--health-server-port",
-			fmt.Sprint(healthPort),
-			"--agent-identifiers=default-route=true",
-			"--keepalive-time",
-			"30s",
-			"--probe-interval",
-			"30s",
-			"--sync-interval",
-			"1m",
-			"--sync-interval-cap",
-			"5m",
-		}
-		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}
 }
 
@@ -367,7 +293,7 @@ func ReconcileAgentDeployment(deployment *appsv1.Deployment, ownerRef config.Own
 					util.BuildContainer(konnectivityAgentContainer(), buildKonnectivityAgentContainer(image, ips)),
 				},
 				Volumes: []corev1.Volume{
-					util.BuildVolume(konnectivityVolumeAgentCerts(), buildKonnectivityVolumeWorkerAgentCerts),
+					util.BuildVolume(konnectivityVolumeAgentCerts(), buildKonnectivityVolumeAgentCerts),
 				},
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/konnectivity.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/konnectivity.go
@@ -32,21 +32,3 @@ func KonnectivityAgentDeployment(ns string) *appsv1.Deployment {
 		},
 	}
 }
-
-func KonnectivityAgentDaemonSet() *appsv1.DaemonSet {
-	return &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "konnectivity-agent",
-			Namespace: "kube-system",
-		},
-	}
-}
-
-func KonnectivityWorkerAgentDaemonSet(ns string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-manifest-konnectivity-agent-daemonset",
-			Namespace: ns,
-		},
-	}
-}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -194,15 +194,6 @@ func KonnectivityAgentSecret(ns string) *corev1.Secret {
 	}
 }
 
-func KonnectivityWorkerAgentSecret(ns string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-manifest-konnectivity-agent-secret",
-			Namespace: ns,
-		},
-	}
-}
-
 func IngressCert(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/konnectivity.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/konnectivity.go
@@ -3,11 +3,8 @@ package pki
 import (
 	"fmt"
 
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/yaml"
 )
 
 func ReconcileKonnectivityServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
@@ -40,15 +37,4 @@ func ReconcileKonnectivityClientSecret(secret, ca *corev1.Secret, ownerRef confi
 
 func ReconcileKonnectivityAgentSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
 	return reconcileSignedCert(secret, ca, ownerRef, "konnectivity-agent", []string{"kubernetes"}, X509DefaultUsage, X509UsageClientAuth)
-}
-
-func ReconcileKonnectivityWorkerAgentSecret(cm *corev1.ConfigMap, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	ownerRef.ApplyTo(cm)
-	secret := manifests.KonnectivityAgentSecret("kube-system")
-	// Ignore errors here, the configmap might be empty initially
-	yaml.Unmarshal([]byte(cm.Data[util.UserDataKey]), secret)
-	if err := ReconcileKonnectivityAgentSecret(secret, ca, config.OwnerRef{}); err != nil {
-		return err
-	}
-	return util.ReconcileWorkerManifest(cm, secret)
 }

--- a/hosted-cluster-config-operator/controllers/resources/konnectivity/params.go
+++ b/hosted-cluster-config-operator/controllers/resources/konnectivity/params.go
@@ -1,0 +1,61 @@
+package konnectivity
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/config"
+)
+
+const (
+	systemNodeCriticalPriorityClass = "system-node-critical"
+)
+
+type KonnectivityParams struct {
+	Image           string
+	ExternalAddress string
+	ExternalPort    int32
+	config.DeploymentConfig
+}
+
+func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]string, externalAddress string, externalPort int32) *KonnectivityParams {
+	p := &KonnectivityParams{
+		Image:           images["konnectivity-agent"],
+		ExternalAddress: externalAddress,
+		ExternalPort:    externalPort,
+	}
+
+	p.DeploymentConfig.Resources = config.ResourcesSpec{
+		konnectivityAgentContainer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("40m"),
+			},
+		},
+	}
+	p.DeploymentConfig.Scheduling = config.Scheduling{
+		PriorityClass: systemNodeCriticalPriorityClass,
+	}
+	p.DeploymentConfig.LivenessProbes = config.LivenessProbes{
+		konnectivityAgentContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			InitialDelaySeconds: 120,
+			TimeoutSeconds:      30,
+			PeriodSeconds:       60,
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+		},
+	}
+	if _, ok := hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]; ok {
+		p.Image = hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]
+	}
+	return p
+}

--- a/hosted-cluster-config-operator/controllers/resources/konnectivity/reconcile.go
+++ b/hosted-cluster-config-operator/controllers/resources/konnectivity/reconcile.go
@@ -1,0 +1,125 @@
+package konnectivity
+
+import (
+	"fmt"
+	"path"
+
+	"k8s.io/utils/pointer"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+)
+
+const (
+	healthPort = 2041
+)
+
+var (
+	volumeMounts = util.PodVolumeMounts{
+		konnectivityAgentContainer().Name: util.ContainerVolumeMounts{
+			konnectivityVolumeAgentCerts().Name: "/etc/konnectivity/agent",
+		},
+	}
+)
+
+func konnectivityAgentLabels() map[string]string {
+	return map[string]string{
+		"app":                         "konnectivity-agent",
+		hyperv1.ControlPlaneComponent: "konnectivity-agent",
+	}
+}
+
+func ReconcileAgentDaemonSet(daemonset *appsv1.DaemonSet, deploymentConfig config.DeploymentConfig, image string, host string, port int32) {
+	daemonset.Spec = appsv1.DaemonSetSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: konnectivityAgentLabels(),
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: konnectivityAgentLabels(),
+			},
+			Spec: corev1.PodSpec{
+				AutomountServiceAccountToken: pointer.BoolPtr(false),
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser: pointer.Int64Ptr(1000),
+				},
+				Containers: []corev1.Container{
+					util.BuildContainer(konnectivityAgentContainer(), buildKonnectivityWorkerAgentContainer(image, host, port)),
+				},
+				Volumes: []corev1.Volume{
+					util.BuildVolume(konnectivityVolumeAgentCerts(), buildKonnectivityVolumeWorkerAgentCerts),
+				},
+			},
+		},
+	}
+	deploymentConfig.ApplyToDaemonSet(daemonset)
+}
+
+func konnectivityAgentContainer() *corev1.Container {
+	return &corev1.Container{
+		Name: "konnectivity-agent",
+	}
+}
+
+func konnectivityVolumeAgentCerts() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "agent-certs",
+	}
+}
+
+func buildKonnectivityWorkerAgentContainer(image, host string, port int32) func(c *corev1.Container) {
+	cpath := func(volume, file string) string {
+		return path.Join(volumeMounts.Path(konnectivityAgentContainer().Name, volume), file)
+	}
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.ImagePullPolicy = corev1.PullAlways
+		c.Command = []string{
+			"/usr/bin/proxy-agent",
+		}
+		c.Args = []string{
+			"--logtostderr=true",
+			"--ca-cert",
+			cpath(konnectivityVolumeAgentCerts().Name, "ca.crt"),
+			"--agent-cert",
+			cpath(konnectivityVolumeAgentCerts().Name, corev1.TLSCertKey),
+			"--agent-key",
+			cpath(konnectivityVolumeAgentCerts().Name, corev1.TLSPrivateKeyKey),
+			"--proxy-server-host",
+			host,
+			"--proxy-server-port",
+			fmt.Sprint(port),
+			"--health-server-port",
+			fmt.Sprint(healthPort),
+			"--agent-identifiers=default-route=true",
+			"--keepalive-time",
+			"30s",
+			"--probe-interval",
+			"30s",
+			"--sync-interval",
+			"1m",
+			"--sync-interval-cap",
+			"5m",
+		}
+		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+	}
+}
+
+func buildKonnectivityVolumeWorkerAgentCerts(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.KonnectivityAgentSecret("").Name,
+	}
+}
+
+func ReconcileKonnectivityAgentSecret(secret, source *corev1.Secret) {
+	secret.Data = map[string][]byte{}
+	for k, v := range source.Data {
+		secret.Data[k] = v
+	}
+}

--- a/hosted-cluster-config-operator/controllers/resources/manifests/konnectivity.go
+++ b/hosted-cluster-config-operator/controllers/resources/manifests/konnectivity.go
@@ -1,0 +1,34 @@
+package manifests
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func KonnectivityAgentDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "konnectivity-agent",
+			Namespace: "kube-system",
+		},
+	}
+}
+
+func KonnectivityAgentSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "konnectivity-agent",
+			Namespace: "kube-system",
+		},
+	}
+}
+
+func KonnectivityControlPlaneAgentSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "konnectivity-agent",
+			Namespace: ns,
+		},
+	}
+}

--- a/hosted-cluster-config-operator/controllers/resources/manifests/pullsecret.go
+++ b/hosted-cluster-config-operator/controllers/resources/manifests/pullsecret.go
@@ -1,0 +1,15 @@
+package manifests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func PullSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pull-secret",
+			Namespace: ns,
+		},
+	}
+}

--- a/hosted-cluster-config-operator/operator/config.go
+++ b/hosted-cluster-config-operator/operator/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -22,6 +23,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/hosted-cluster-config-operator/api"
+	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 )
 
@@ -55,6 +57,9 @@ type HostedClusterConfigOperatorConfig struct {
 	Controllers                  []string
 	PlatformType                 hyperv1.PlatformType
 	ControllerFuncs              map[string]ControllerSetupFunc
+	ReleaseProvider              releaseinfo.Provider
+	KonnectivityAddress          string
+	KonnectivityPort             int32
 
 	kubeClient kubeclient.Interface
 }
@@ -93,6 +98,7 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 				&configv1.Ingress{}:          {Label: cacheLabelSelector()},
 				&configv1.Network{}:          {Label: cacheLabelSelector()},
 				&configv1.Proxy{}:            {Label: cacheLabelSelector()},
+				&appsv1.DaemonSet{}:          {Label: cacheLabelSelector()},
 			},
 		}),
 		Scheme: api.Scheme,


### PR DESCRIPTION
This commit replaces the user manifests for the Konnectivity agent
applied by the manifest bootstrapper pod with reconciliation code in
the hosted cluster config operator. This enables continuous
reconciliation of the agent and is part of the effort to remove the
manifest bootstrapper pod.