### PR TITLE
Avoid talking to kubernetes cluster if --render specified

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -152,8 +152,6 @@ func generateSSHKeys() ([]byte, []byte, error) {
 
 func apply(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, render bool) error {
 
-	client := util.GetClientOrDie()
-
 	exampleObjects := exampleOptions.Resources().AsObjects()
 	switch {
 	case render:
@@ -165,6 +163,7 @@ func apply(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, rend
 			fmt.Println("---")
 		}
 	default:
+		client := util.GetClientOrDie()
 		for _, object := range exampleObjects {
 			key := crclient.ObjectKeyFromObject(object)
 			object.SetLabels(map[string]string{util.AutoInfraLabelName: exampleOptions.InfraID})


### PR DESCRIPTION
Below code is talking to kubernetes cluster even if `--render` option is specified, it's not really required if `--render` is present, hence reducing the scope for client creation within the block where it is making the apply calls.