### PR TITLE
set ibmcloud capi components to proper v1alpha4 version and properly reconcile infrastructure resource for ibmcloud

### DIFF
--- a/cmd/install/assets/assets.go
+++ b/cmd/install/assets/assets.go
@@ -31,7 +31,7 @@ var capiResources = map[string]string{
 	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclusters.yaml":         "v1beta1",
 	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachines.yaml":         "v1beta1",
 	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml": "v1beta1",
-	"cluster-api-provider-ibmcloud/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml": "v1beta1",
+	"cluster-api-provider-ibmcloud/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml": "v1alpha4",
 	"hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml":              "v1alpha1",
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -33,7 +33,6 @@ import (
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	"github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform"
@@ -72,7 +71,6 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -2003,10 +2001,6 @@ func reconcileCAPICluster(cluster *capiv1.Cluster, hcluster *hyperv1.HostedClust
 	cluster.Annotations = map[string]string{
 		hostedClusterAnnotation: client.ObjectKeyFromObject(hcluster).String(),
 	}
-	gvk, err := apiutil.GVKForObject(infraCR, api.Scheme)
-	if err != nil {
-		return err
-	}
 	cluster.Spec = capiv1.ClusterSpec{
 		ControlPlaneEndpoint: capiv1.APIEndpoint{},
 		ControlPlaneRef: &corev1.ObjectReference{
@@ -2016,8 +2010,8 @@ func reconcileCAPICluster(cluster *capiv1.Cluster, hcluster *hyperv1.HostedClust
 			Name:       hcp.Name,
 		},
 		InfrastructureRef: &corev1.ObjectReference{
-			APIVersion: gvk.GroupVersion().String(),
-			Kind:       gvk.Kind,
+			APIVersion: infraCR.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+			Kind:       infraCR.GetObjectKind().GroupVersionKind().Kind,
 			Namespace:  infraCR.GetNamespace(),
 			Name:       infraCR.GetName(),
 		},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1,6 +1,11 @@
 package hostedcluster
 
 import (
+	"github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/api/v1alpha4"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
+	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 	"time"
 
@@ -709,6 +714,145 @@ func TestReconcileIgnitionServerServiceRoute(t *testing.T) {
 			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Port).To(Equal(int32(443)))
 			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Name).To(Equal("https"))
 			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+		})
+	}
+}
+
+func TestReconcileCAPICluster(t *testing.T) {
+	testCases := []struct {
+		name               string
+		capiCluster        *v1beta1.Cluster
+		hostedCluster      *hyperv1.HostedCluster
+		hostedControlPlane *hyperv1.HostedControlPlane
+		infraCR            client.Object
+
+		expectedCAPICluster *v1beta1.Cluster
+	}{
+		{
+			name:        "IBM Cloud cluster",
+			capiCluster: controlplaneoperator.CAPICluster("master-cluster1", "cluster1"),
+			hostedCluster: &hyperv1.HostedCluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HostedCluster",
+					APIVersion: hyperv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "master",
+					Name:      "cluster1",
+				},
+			},
+			hostedControlPlane: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HostedControlPlane",
+					APIVersion: hyperv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "master-cluster1",
+					Name:      "cluster1",
+				},
+			},
+			infraCR: &v1alpha4.IBMVPCCluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "IBMVPCCluster",
+					APIVersion: v1alpha4.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster1",
+					Namespace: "master-cluster1",
+				},
+			},
+			expectedCAPICluster: &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						hostedClusterAnnotation: "master/cluster1",
+					},
+					Namespace: "master-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: v1beta1.ClusterSpec{
+					ControlPlaneEndpoint: v1beta1.APIEndpoint{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						APIVersion: "hypershift.openshift.io/v1alpha1",
+						Kind:       "HostedControlPlane",
+						Namespace:  "master-cluster1",
+						Name:       "cluster1",
+					},
+					InfrastructureRef: &corev1.ObjectReference{
+						APIVersion: v1alpha4.GroupVersion.String(),
+						Kind:       "IBMVPCCluster",
+						Namespace:  "master-cluster1",
+						Name:       "cluster1",
+					},
+				},
+			},
+		},
+		{
+			name:        "AWS cluster",
+			capiCluster: controlplaneoperator.CAPICluster("master-cluster1", "cluster1"),
+			hostedCluster: &hyperv1.HostedCluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HostedCluster",
+					APIVersion: hyperv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "master",
+					Name:      "cluster1",
+				},
+			},
+			hostedControlPlane: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HostedControlPlane",
+					APIVersion: hyperv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "master-cluster1",
+					Name:      "cluster1",
+				},
+			},
+			infraCR: &capiawsv1.AWSCluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AWSCluster",
+					APIVersion: capiawsv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster1",
+					Namespace: "master-cluster1",
+				},
+			},
+			expectedCAPICluster: &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						hostedClusterAnnotation: "master/cluster1",
+					},
+					Namespace: "master-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: v1beta1.ClusterSpec{
+					ControlPlaneEndpoint: v1beta1.APIEndpoint{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						APIVersion: "hypershift.openshift.io/v1alpha1",
+						Kind:       "HostedControlPlane",
+						Namespace:  "master-cluster1",
+						Name:       "cluster1",
+					},
+					InfrastructureRef: &corev1.ObjectReference{
+						APIVersion: capiawsv1.GroupVersion.String(),
+						Kind:       "AWSCluster",
+						Namespace:  "master-cluster1",
+						Name:       "cluster1",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := reconcileCAPICluster(tc.capiCluster, tc.hostedCluster, tc.hostedControlPlane, tc.infraCR); err != nil {
+				t.Fatalf("reconcileCAPICluster failed: %v", err)
+			}
+			if diff := cmp.Diff(tc.capiCluster, tc.expectedCAPICluster); diff != "" {
+				t.Errorf("reconciled CAPI cluster differs from expcted CAPI cluster: %s", diff)
+			}
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -43,7 +43,12 @@ func (p AWS) ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlPlaneN
 	if err != nil {
 		return nil, err
 	}
-
+	// reconciliation strips TypeMeta. We repopulate the static values since they are necessary for
+	// downstream reconciliation of the CAPI Cluster resource.
+	awsCluster.TypeMeta = metav1.TypeMeta{
+		Kind:       "AWSCluster",
+		APIVersion: capiawsv1.GroupVersion.String(),
+	}
 	return awsCluster, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
@@ -50,7 +50,12 @@ func (p IBMCloud) ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlP
 	if err != nil {
 		return nil, err
 	}
-
+	// reconciliation strips TypeMeta. We repopulate the static values since they are necessary for
+	// downstream reconciliation of the CAPI Cluster resource.
+	ibmCluster.TypeMeta = metav1.TypeMeta{
+		Kind:       "IBMVPCCluster",
+		APIVersion: capiibmv1.GroupVersion.String(),
+	}
 	return nil, nil
 }
 

--- a/support/globalconfig/infrastructure.go
+++ b/support/globalconfig/infrastructure.go
@@ -54,5 +54,8 @@ func ReconcileInfrastructure(infra *configv1.Infrastructure, hcp *hyperv1.Hosted
 			})
 		}
 		infra.Status.PlatformStatus.AWS.ResourceTags = tags
+	case hyperv1.IBMCloudPlatform:
+		infra.Status.PlatformStatus = &configv1.PlatformStatus{}
+		infra.Status.PlatformStatus.Type = configv1.IBMCloudPlatformType
 	}
 }


### PR DESCRIPTION
the repo does not yet have a v1beta1 version. We need to keep it v1alpha4 for now

Fixes:
- Properly sets the infrastructureRef for IBM Cloud clusters. Previously it was inaccurately getting set to v1beta1
- Properly reconciles the IBMCloud infrastructure references so all downstream components roll out in the cluster appropriately
