### PR TITLE
Add projected token to hypershift-operator for Role based access

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -255,6 +255,27 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 				Name:  "AWS_REGION",
 				Value: o.AWSPrivateRegion,
 			})
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "token",
+				MountPath: "/var/run/secrets/openshift/serviceaccount",
+			})
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes,
+			corev1.Volume{
+				Name: "token",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{
+								ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+									Audience: "openshift",
+									Path:     "token",
+								},
+							},
+						},
+					},
+				},
+			})
 	}
 	return deployment
 }


### PR DESCRIPTION
Currently, the `aws-private-creds` passed to hypershift-operator must be IAM user creds because there is no token projected into the hypershift-operator pod.

This PR adds that token.

This isn't the best from UX because the `aws-private-creds` will need to specify the `web_identity_token_file` to be the bespoke path of the projected token at `/var/run/secrets/openshift/serviceaccount/token`.  But it does allow for Role-based creds for AWS private cluster functions i.e. creating the Endpoint Services.