### PR TITLE
token-minter renews token before expiration

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1836,7 +1836,6 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 				"-token-file=/var/run/secrets/openshift/serviceaccount/token",
 				fmt.Sprintf("-kubeconfig-secret-namespace=%s", deployment.Namespace),
 				"-kubeconfig-secret-name=service-network-admin-kubeconfig",
-				"--sleep=true",
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -185,7 +185,6 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMi
 							"-token-audience=openshift",
 							"-token-file=/var/run/secrets/openshift/serviceaccount/token",
 							"-kubeconfig=/etc/kubernetes/kubeconfig",
-							"-sleep=true",
 						},
 					},
 				},

--- a/support/util/cloudprovidercreds.go
+++ b/support/util/cloudprovidercreds.go
@@ -127,7 +127,6 @@ func tokenMinterArgs() []string {
 		"-token-audience=openshift",
 		fmt.Sprintf("-token-file=%s", cpath(cloudProviderTokenVolume().Name, "token")),
 		fmt.Sprintf("-kubeconfig=%s", cpath(cloudProviderTokenKubeconfigVolume().Name, KubeconfigKey)),
-		"--sleep=true",
 	}
 }
 


### PR DESCRIPTION
I think this should fix the observed `ExpiredTokenException` issue.  The default expiration set by the KAS when `ExpirationSeconds` isn't explicitly set on the request is 3600 seconds, which aligns with the expiration of the underlying STS token.

This is what is done elsewhere in OCP
https://github.com/openshift/cluster-ingress-operator/blob/3f35d0c05831e465d314ef75bd102967a5369545/manifests/02-deployment.yaml#L109-L116

Results
```
# oc get deployment -n openshift-ingress-operator ingress-operator -oyaml | grep -A6 projected:
        projected:
          defaultMode: 420
          sources:
          - serviceAccountToken:
              audience: openshift
              expirationSeconds: 3600
              path: token
```

With the added code to renew the token, this should work.