### PR TITLE
Expose kubeadmin password in HostedCluster status

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -177,6 +177,11 @@ type HostedControlPlaneStatus struct {
 	// for this control plane.
 	KubeConfig *KubeconfigSecretRef `json:"kubeConfig,omitempty"`
 
+	// KubeadminPassword is a reference to the secret containing the initial kubeadmin password
+	// for the guest cluster.
+	// +optional
+	KubeadminPassword *corev1.LocalObjectReference `json:"kubeadminPassword,omitempty"`
+
 	// Condition contains details for one aspect of the current state of the HostedControlPlane.
 	// Current condition types are: "Available"
 	// +kubebuilder:validation:Required

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -950,6 +950,11 @@ type HostedClusterStatus struct {
 	// +optional
 	KubeConfig *corev1.LocalObjectReference `json:"kubeconfig,omitempty"`
 
+	// KubeadminPassword is a reference to the secret that contains the initial
+	// kubeadmin user password for the guest cluster.
+	// +optional
+	KubeadminPassword *corev1.LocalObjectReference `json:"kubeadminPassword,omitempty"`
+
 	// IgnitionEndpoint is the endpoint injected in the ign config userdata.
 	// It exposes the config for instances to become kubernetes nodes.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -716,6 +716,11 @@ func (in *HostedClusterStatus) DeepCopyInto(out *HostedClusterStatus) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.KubeadminPassword != nil {
+		in, out := &in.KubeadminPassword, &out.KubeadminPassword
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))
@@ -874,6 +879,11 @@ func (in *HostedControlPlaneStatus) DeepCopyInto(out *HostedControlPlaneStatus) 
 	if in.KubeConfig != nil {
 		in, out := &in.KubeConfig, &out.KubeConfig
 		*out = new(KubeconfigSecretRef)
+		**out = **in
+	}
+	if in.KubeadminPassword != nil {
+		in, out := &in.KubeadminPassword, &out.KubeadminPassword
+		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
 	if in.Conditions != nil {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -948,6 +948,15 @@ spec:
                   config userdata. It exposes the config for instances to become kubernetes
                   nodes.
                 type: string
+              kubeadminPassword:
+                description: KubeadminPassword is a reference to the secret that contains
+                  the initial kubeadmin user password for the guest cluster.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
               kubeconfig:
                 description: KubeConfig is a reference to the secret containing the
                   default kubeconfig for the cluster.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -893,6 +893,15 @@ spec:
                 - key
                 - name
                 type: object
+              kubeadminPassword:
+                description: KubeadminPassword is a reference to the secret containing
+                  the initial kubeadmin password for the guest cluster.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
               lastReleaseImageTransitionTime:
                 description: lastReleaseImageTransitionTime is the time of the last
                   update to the current releaseImage property.

--- a/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
@@ -22,3 +22,12 @@ func DefaultServiceAccount(ns string) *corev1.ServiceAccount {
 		},
 	}
 }
+
+func KubeadminPasswordSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubeadmin-password",
+			Namespace: ns,
+		},
+	}
+}

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2306,6 +2306,21 @@ for the cluster.</p>
 </tr>
 <tr>
 <td>
+<code>kubeadminPassword</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KubeadminPassword is a reference to the secret that contains the initial
+kubeadmin user password for the guest cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ignitionEndpoint</code></br>
 <em>
 string
@@ -2772,6 +2787,21 @@ KubeconfigSecretRef
 <td>
 <p>KubeConfig is a reference to the secret containing the default kubeconfig
 for this control plane.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kubeadminPassword</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KubeadminPassword is a reference to the secret containing the initial kubeadmin password
+for the guest cluster.</p>
 </td>
 </tr>
 <tr>

--- a/hypershift-operator/controllers/manifests/manifests.go
+++ b/hypershift-operator/controllers/manifests/manifests.go
@@ -23,3 +23,12 @@ func KubeConfigSecret(hostedClusterNamespace string, hostedClusterName string) *
 		},
 	}
 }
+
+func KubeadminPasswordSecret(hostedClusterNamespace string, hostedClusterName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hostedClusterNamespace,
+			Name:      hostedClusterName + "-kubeadmin-password",
+		},
+	}
+}


### PR DESCRIPTION
Before this PR, end users of Hypershift had no way to find the kubeadmin
password for their HostedCluster apart from looking inside the control
plane namespace.

This PR adds code to copy the kubeadmin password secret from the control
plane namespace to the HostedCluster's namespace and adds a field in the
status of the HostedCluster that references the password secret.