### PR TITLE
Return a valid ibmcluster object

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
@@ -56,7 +56,7 @@ func (p IBMCloud) ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlP
 		Kind:       "IBMVPCCluster",
 		APIVersion: capiibmv1.GroupVersion.String(),
 	}
-	return nil, nil
+	return ibmCluster, nil
 }
 
 func (p IBMCloud) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {


### PR DESCRIPTION
This is return a valid ibmcluster object instead of nil