### PR TITLE
Use createOrUpdate in ReconcileCAPIInfraCR

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -527,7 +527,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	if err := p.ReconcileCredentials(r.Client, ctx, createOrUpdate,
+	if err := p.ReconcileCredentials(ctx, r.Client, createOrUpdate,
 		hcluster,
 		controlPlaneNamespace.Name); err != nil {
 		return ctrl.Result{}, err
@@ -628,8 +628,9 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				// don't return error here as reconciling won't fix input error
 				return ctrl.Result{}, nil
 			}
-			if err := p.ReconcileSecretEncryption(hcluster, controlPlaneNamespace.Name, ctx, r.Client,
-				createOrUpdate); err != nil {
+			if err := p.ReconcileSecretEncryption(ctx, r.Client, createOrUpdate,
+				hcluster,
+				controlPlaneNamespace.Name); err != nil {
 				return ctrl.Result{}, err
 			}
 		default:
@@ -784,7 +785,10 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile CAPI Infra CR.
-	infraCR, err := p.ReconcileCAPIInfraCR(hcluster, controlPlaneNamespace.Name, hcp.Status.ControlPlaneEndpoint, r.Client, ctx)
+	infraCR, err := p.ReconcileCAPIInfraCR(ctx, r.Client, createOrUpdate,
+		hcluster,
+		controlPlaneNamespace.Name,
+		hcp.Status.ControlPlaneEndpoint)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws_test.go
@@ -28,8 +28,7 @@ func TestReconcileAWSCluster(t *testing.T) {
 
 			expectedAWSCluster: &capiawsv1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					"cluster.x-k8s.io/managed-by":     "external",
-					"hypershift.openshift.io/cluster": "/",
+					"cluster.x-k8s.io/managed-by": "external",
 				}},
 				Spec: capiawsv1.AWSClusterSpec{
 					AdditionalTags: capiawsv1.Tags{"foo": "bar"},
@@ -52,8 +51,7 @@ func TestReconcileAWSCluster(t *testing.T) {
 
 			expectedAWSCluster: &capiawsv1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					"cluster.x-k8s.io/managed-by":     "external",
-					"hypershift.openshift.io/cluster": "/",
+					"cluster.x-k8s.io/managed-by": "external",
 				}},
 				Spec: capiawsv1.AWSClusterSpec{
 					AdditionalTags: capiawsv1.Tags{"foo": "bar"},
@@ -72,8 +70,7 @@ func TestReconcileAWSCluster(t *testing.T) {
 
 			expectedAWSCluster: &capiawsv1.AWSCluster{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					"cluster.x-k8s.io/managed-by":     "external",
-					"hypershift.openshift.io/cluster": "/",
+					"cluster.x-k8s.io/managed-by": "external",
 				}},
 				Status: capiawsv1.AWSClusterStatus{
 					Ready: true,

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
@@ -14,17 +14,14 @@ import (
 	capiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4" // Need this dep atm to satisfy IBM provider dep.
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-)
-
-const (
-	hostedClusterAnnotation = "hypershift.openshift.io/cluster"
 )
 
 type IBMCloud struct{}
 
-func (p IBMCloud) ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, apiEndpoint hyperv1.APIEndpoint,
-	c client.Client, ctx context.Context) (client.Object, error) {
+func (p IBMCloud) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string,
+	apiEndpoint hyperv1.APIEndpoint) (client.Object, error) {
 
 	ibmCluster := &capiibmv1.IBMVPCCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -33,9 +30,8 @@ func (p IBMCloud) ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlP
 		},
 	}
 
-	_, err := controllerutil.CreateOrPatch(ctx, c, ibmCluster, func() error {
+	_, err := createOrUpdate(ctx, c, ibmCluster, func() error {
 		ibmCluster.Annotations = map[string]string{
-			hostedClusterAnnotation:    client.ObjectKeyFromObject(hcluster).String(),
 			capiv1.ManagedByAnnotation: "external",
 		}
 
@@ -63,13 +59,15 @@ func (p IBMCloud) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, to
 	return nil, nil
 }
 
-func (p IBMCloud) ReconcileCredentials(c client.Client, ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster,
+func (p IBMCloud) ReconcileCredentials(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
 	controlPlaneNamespace string) error {
 	return nil
 }
 
-func (IBMCloud) ReconcileSecretEncryption(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, ctx context.Context, c client.Client,
-	createOrUpdate upsert.CreateOrUpdateFN) error {
+func (IBMCloud) ReconcileSecretEncryption(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string) error {
 	if hcluster.Spec.SecretEncryption.KMS.IBMCloud == nil {
 		return fmt.Errorf("ibm kms metadata nil")
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/none/none.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/none/none.go
@@ -11,8 +11,9 @@ import (
 
 type None struct{}
 
-func (p None) ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, apiEndpoint hyperv1.APIEndpoint,
-	c client.Client, ctx context.Context) (client.Object, error) {
+func (p None) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string, apiEndpoint hyperv1.APIEndpoint) (client.Object, error) {
 
 	return nil, nil
 }
@@ -21,12 +22,14 @@ func (p None) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenM
 	return nil, nil
 }
 
-func (p None) ReconcileCredentials(c client.Client, ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster,
+func (p None) ReconcileCredentials(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
 	controlPlaneNamespace string) error {
 	return nil
 }
 
-func (None) ReconcileSecretEncryption(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, ctx context.Context, c client.Client,
-	createOrUpdate upsert.CreateOrUpdateFN) error {
+func (None) ReconcileSecretEncryption(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string) error {
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -22,8 +22,11 @@ type Platform interface {
 	// Implementations should use the given input and client to create and update the desired state of the
 	// platform infrastructure CAPI CR, which will then be referenced by the CAPI Cluster CR.
 	// TODO (alberto): Pass createOrUpdate construct instead of client.
-	ReconcileCAPIInfraCR(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, apiEndpoint hyperv1.APIEndpoint,
-		c client.Client, ctx context.Context) (client.Object, error)
+	ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+		hcluster *hyperv1.HostedCluster,
+		controlPlaneNamespace string,
+		apiEndpoint hyperv1.APIEndpoint,
+	) (client.Object, error)
 
 	// CAPIProviderDeploymentSpec is called during HostedCluster reconciliation prior to reconciling
 	// the CAPI provider Deployment.
@@ -34,15 +37,16 @@ type Platform interface {
 	// ReconcileCredentials is responsible for reconciling resources related to cloud credentials
 	// from the HostedCluster namespace into to the HostedControlPlaneNamespace. So they can be used by
 	// the Control Plane Operator.
-	ReconcileCredentials(c client.Client, ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN,
+	ReconcileCredentials(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
 		hcluster *hyperv1.HostedCluster,
 		controlPlaneNamespace string) error
 
 	// ReconcileSecretEncryption is responsible for reconciling resources related to secret encryption
 	// from the HostedCluster namespace into to the HostedControlPlaneNamespace. So they can be used by
 	// the Control Plane Operator if your platform supports KMS.
-	ReconcileSecretEncryption(hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, ctx context.Context, c client.Client,
-		createOrUpdate upsert.CreateOrUpdateFN) error
+	ReconcileSecretEncryption(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+		hcluster *hyperv1.HostedCluster,
+		controlPlaneNamespace string) error
 }
 
 func GetPlatform(hcluster *hyperv1.HostedCluster) (Platform, error) {


### PR DESCRIPTION
Update ReconcileCAPIInfraCR to receive createOrUpdate as a parameter.
Reorganise interface funcs signature parameters consistently.