### PR TITLE
Add endpoint-access flag for create cluster aws

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -89,6 +89,7 @@ type ExampleAWSOptions struct {
 	RootVolumeType              string
 	RootVolumeIOPS              int64
 	ResourceTags                []hyperv1.AWSResourceTag
+	EndpointAccess              string
 }
 
 func (o ExampleOptions) Resources() *ExampleResources {
@@ -183,6 +184,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 				NodePoolManagementCreds:   corev1.LocalObjectReference{Name: resources.(*ExampleAWSResources).NodePoolManagementAWSCreds.Name},
 				ControlPlaneOperatorCreds: corev1.LocalObjectReference{Name: resources.(*ExampleAWSResources).ControlPlaneOperatorAWSCreds.Name},
 				ResourceTags:              o.AWS.ResourceTags,
+				EndpointAccess:            hyperv1.AWSEndpointAccessType(o.AWS.EndpointAccess),
 			},
 		}
 		services = []hyperv1.ServicePublishingStrategyMapping{

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -32,6 +32,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		RootVolumeType:     "gp2",
 		RootVolumeSize:     16,
 		RootVolumeIOPS:     0,
+		EndpointAccess:     string(hyperv1.Public),
 	}
 
 	cmd.Flags().StringVar(&opts.AWSPlatform.AWSCredentialsFile, "aws-creds", opts.AWSPlatform.AWSCredentialsFile, "Path to an AWS credentials file (required)")
@@ -43,6 +44,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().Int64Var(&opts.AWSPlatform.RootVolumeIOPS, "root-volume-iops", opts.AWSPlatform.RootVolumeIOPS, "The iops of the root volume when specifying type:io1 for machines in the NodePool")
 	cmd.Flags().Int64Var(&opts.AWSPlatform.RootVolumeSize, "root-volume-size", opts.AWSPlatform.RootVolumeSize, "The size of the root volume (default: 16, min: 8) for machines in the NodePool")
 	cmd.Flags().StringSliceVar(&opts.AWSPlatform.AdditionalTags, "additional-tags", opts.AWSPlatform.AdditionalTags, "Additional tags to set on AWS resources")
+	cmd.Flags().StringVar(&opts.AWSPlatform.EndpointAccess, "endpoint-access", opts.AWSPlatform.EndpointAccess, "Access for control plane endpoints (Public, PublicAndPrivate, Private)")
 
 	cmd.MarkFlagRequired("aws-creds")
 
@@ -165,6 +167,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		RootVolumeType:              opts.AWSPlatform.RootVolumeType,
 		RootVolumeIOPS:              opts.AWSPlatform.RootVolumeIOPS,
 		ResourceTags:                tags,
+		EndpointAccess:              opts.AWSPlatform.EndpointAccess,
 	}
 	return nil
 }

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -63,6 +63,7 @@ type AWSPlatformOptions struct {
 	RootVolumeIOPS     int64
 	RootVolumeSize     int64
 	RootVolumeType     string
+	EndpointAccess     string
 }
 
 func createCommonFixture(opts *CreateOptions) (*apifixtures.ExampleOptions, error) {


### PR DESCRIPTION
Help UX for private clusters when using `create cluster aws`.  Current procedure is to use `--render` and edit the yaml manually.