### PR TITLE
Avoid "core ingition config has not been created yet" error during startup

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -390,7 +390,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		// additional core config resource created when image content source specified.
 		expectedCoreConfigResources += 1
 	}
-	config, err := r.getConfig(ctx, nodePool, expectedCoreConfigResources, controlPlaneNamespace)
+	config, missingConfigs, err := r.getConfig(ctx, nodePool, expectedCoreConfigResources, controlPlaneNamespace)
 	if err != nil {
 		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
 			Type:               hyperv1.NodePoolConfigValidConfigConditionType,
@@ -400,6 +400,17 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			ObservedGeneration: nodePool.Generation,
 		})
 		return ctrl.Result{}, fmt.Errorf("failed to get config: %w", err)
+	}
+	if missingConfigs {
+		meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
+			Type:               hyperv1.NodePoolConfigValidConfigConditionType,
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.NodePoolValidationFailedConditionReason,
+			Message:            "Core ignition config has not been created yet",
+			ObservedGeneration: nodePool.Generation,
+		})
+		// We watch configmaps so we will get an event when these get created
+		return ctrl.Result{}, nil
 	}
 	meta.SetStatusCondition(&nodePool.Status.Conditions, metav1.Condition{
 		Type:               hyperv1.NodePoolConfigValidConfigConditionType,
@@ -876,7 +887,7 @@ func ignConfig(encodedCACert, encodedToken, endpoint string) ignitionapi.Config 
 	}
 }
 
-func (r *NodePoolReconciler) getConfig(ctx context.Context, nodePool *hyperv1.NodePool, expectedCoreConfigResources int, controlPlaneResource string) (string, error) {
+func (r *NodePoolReconciler) getConfig(ctx context.Context, nodePool *hyperv1.NodePool, expectedCoreConfigResources int, controlPlaneResource string) (configsRaw string, missingConfigs bool, err error) {
 	var configs []corev1.ConfigMap
 	allConfigPlainText := ""
 	var errors []error
@@ -889,7 +900,7 @@ func (r *NodePoolReconciler) getConfig(ctx context.Context, nodePool *hyperv1.No
 	}
 
 	if len(coreConfigMapList.Items) != expectedCoreConfigResources {
-		errors = append(errors, fmt.Errorf("core ingition config has not been created yet"))
+		missingConfigs = true
 	}
 
 	configs = coreConfigMapList.Items
@@ -917,7 +928,7 @@ func (r *NodePoolReconciler) getConfig(ctx context.Context, nodePool *hyperv1.No
 		allConfigPlainText = allConfigPlainText + "\n---\n" + manifest
 	}
 
-	return allConfigPlainText, utilerrors.NewAggregate(errors)
+	return allConfigPlainText, missingConfigs, utilerrors.NewAggregate(errors)
 }
 
 // validateManagement does additional backend validation. API validation/default should


### PR DESCRIPTION
This error is currently always emitted, even though it is not an actual
error but just means that we are blocked by waiting for those configs
which are expected to take some time. Use a retryAfter to avoid logging
error messages.

/cc @enxebre 