### PR TITLE
Create DNS zones from infra ID instead of cluster name

### DIFF
--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -185,11 +185,11 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 	if err != nil {
 		return nil, err
 	}
-	result.PrivateZoneID, err = o.CreatePrivateZone(ctx, route53Client, fmt.Sprintf("%s.%s", o.Name, o.BaseDomain), result.VPCID)
+	result.PrivateZoneID, err = o.CreatePrivateZone(ctx, route53Client, fmt.Sprintf("%s.%s", o.InfraID, o.BaseDomain), result.VPCID)
 	if err != nil {
 		return nil, err
 	}
-	_, err = o.CreatePrivateZone(ctx, route53Client, fmt.Sprintf("%s.%s", o.Name, hypershiftLocalZoneName), result.VPCID)
+	_, err = o.CreatePrivateZone(ctx, route53Client, fmt.Sprintf("%s.%s", o.InfraID, hypershiftLocalZoneName), result.VPCID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/infra/aws/route53.go
+++ b/cmd/infra/aws/route53.go
@@ -90,8 +90,8 @@ func (o *CreateInfraOptions) CreatePrivateZone(ctx context.Context, client route
 
 func (o *DestroyInfraOptions) DestroyDNS(ctx context.Context, client route53iface.Route53API) []error {
 	var errs []error
-	errs = append(errs, o.DestroyPrivateZone(ctx, client, fmt.Sprintf("%s.%s", o.Name, o.BaseDomain)))
-	errs = append(errs, o.DestroyPrivateZone(ctx, client, fmt.Sprintf("%s.%s", o.Name, hypershiftLocalZoneName)))
+	errs = append(errs, o.DestroyPrivateZone(ctx, client, fmt.Sprintf("%s.%s", o.InfraID, o.BaseDomain)))
+	errs = append(errs, o.DestroyPrivateZone(ctx, client, fmt.Sprintf("%s.%s", o.InfraID, hypershiftLocalZoneName)))
 	errs = append(errs, o.CleanupPublicZone(ctx, client))
 	return errs
 }


### PR DESCRIPTION
Before this change, private DNS zones were generated for hosted clusters
using a naming strategy like `$name.$basedomain` which is almost certain
to cause conflicts and misidentification across similarly named clusters
in shared AWS accounts, resulting in multiple CLI users destroying and
manipulating zones of other users.

This commit tries to make these conflicts less likely by instead generating
zones using `$infraID.basedomain`, given that `.spec.infraID` is documented
as having a globally unique requirement.