### PR TITLE
Simplify and clarify development workflows with better defaulting

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -74,9 +74,9 @@ func NewStartCommand() *cobra.Command {
 		registryOverrides                map[string]string
 	)
 
-	cmd.Flags().StringVar(&namespace, "namespace", "", "The namespace this operator lives in (required)")
-	cmd.Flags().StringVar(&deploymentName, "deployment-name", "", "The name of the deployment of this operator")
-	cmd.Flags().StringVar(&metricsAddr, "metrics-addr", "0", "The address the metric endpoint binds to.")
+	cmd.Flags().StringVar(&namespace, "namespace", os.Getenv("MY_NAMESPACE"), "The namespace this operator lives in (required)")
+	cmd.Flags().StringVar(&deploymentName, "deployment-name", "control-plane-operator", "The name of the deployment of this operator")
+	cmd.Flags().StringVar(&metricsAddr, "metrics-addr", "0.0.0.0:8080", "The address the metric endpoint binds to.")
 	cmd.Flags().BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -88,7 +88,6 @@ func NewStartCommand() *cobra.Command {
 		"to avoid assuming access to the service network)")
 	cmd.Flags().BoolVar(&enableCIDebugOutput, "enable-ci-debug-output", false, "If extra CI debug output should be enabled")
 	cmd.Flags().StringToStringVar(&registryOverrides, "registry-overrides", map[string]string{}, "registry-overrides contains the source registry string as a key and the destination registry string as value. Images before being applied are scanned for the source registry string and if found the string is replaced with the destination registry string. Format is: sr1=dr1,sr2=dr2")
-	cmd.MarkFlagRequired("namespace")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder()))

--- a/docs/content/developers/how-to/develop-in-cluster.md
+++ b/docs/content/developers/how-to/develop-in-cluster.md
@@ -111,7 +111,7 @@ flag which sets up the deployment with zero replicas:
 
 ```shell
 go run . install \
-  --oidc-storage-provider-s3-bucket-name=$BUCKET \
+  --oidc-storage-provider-s3-bucket-name=$BUCKET_NAME \
   --oidc-storage-provider-s3-region=$BUCKET_REGION \
   --oidc-storage-provider-s3-credentials=$AWS_CREDS \ 
   --development
@@ -120,17 +120,20 @@ go run . install \
 Now, you can build and publish the `hypershift-operator` image and run it interactively
 in a single shot using `publish-ocp.sh` together with the `oc debug` command:
 
-```shell
-oc debug --namespace hypershift deployments/operator --image $(hack/publish-ocp.sh ./hypershift-operator) -- /ko-app/hypershift-operator run
+```shell hl_lines="3 4"
+oc debug --namespace hypershift deployments/operator --image $(hack/publish-ocp.sh ./hypershift-operator) -- \
+  /ko-app/hypershift-operator run \
+  --oidc-storage-provider-s3-region $BUCKET_NAME \
+  --oidc-storage-provider-s3-bucket-name $BUCKET_REGION
 ```
-
-Your latest code should be deployed and logs should soon begin streaming. Just
-press `ctrl-c` to terminate and delete the pod.
 
 !!! note
 
-    The default arguments to `hypershift-operator run` should be sufficient to
-    get started.
+    Make sure to replace `$BUCKET_NAME` and `$BUCKET_REGION` with the same values used to
+    install HyperShift.
+
+Your latest code should be deployed and logs should soon begin streaming. Just
+press `ctrl-c` to terminate and delete the pod.
 
 ## Configure a HostedCluster for iterative control plane development
 
@@ -181,13 +184,16 @@ sure to replace `$NAMESPACE` with the namespace of the control plane that was de
 for the `HostedCluster`.
 
 ```shell
-oc debug --namespace $NAMESPACE deployments/control-plane-operator \
-  --image $(hack/publish-ocp.sh ./control-plane-operator) -- \
-  /ko-app/control-plane-operator run --namespace $NAMESPACE --deployment-name control-plane-operator
+oc debug --namespace $NAMESPACE deployments/control-plane-operator --image $(hack/publish-ocp.sh ./control-plane-operator) -- /ko-app/control-plane-operator run
 ```
 
 Your latest code should be deployed and logs should soon begin streaming. Just
 press `ctrl-c` to terminate and delete the pod.
+
+!!! note
+
+    The default arguments to `control-plane-operator run` should be sufficient to
+    get started.
 
 ## Launch a custom `ignition-server` image interactively
 
@@ -201,11 +207,13 @@ sure to replace `$NAMESPACE` with the namespace of the control plane that was de
 for the `HostedCluster`.
 
 ```shell
-oc debug --namespace $NAMESPACE deployments/ignition-server \
-  --image $(hack/publish-ocp.sh ./ignition-server) -- \
-  /ko-app/ignition-server start --cert-file /var/run/secrets/ignition/serving-cert/tls.crt \
-  --key-file /var/run/secrets/ignition/serving-cert/tls.key
+oc debug --namespace $NAMESPACE deployments/ignition-server --image $(hack/publish-ocp.sh ./ignition-server) -- /ko-app/ignition-server start
 ```
 
 Your latest code should be deployed and logs should soon begin streaming. Just
 press `ctrl-c` to terminate and delete the pod.
+
+!!! note
+
+    The default arguments to `ignition-server start` should be sufficient to
+    get started.

--- a/hack/publish-ocp.sh
+++ b/hack/publish-ocp.sh
@@ -13,7 +13,7 @@ INTERNAL_REPO="image-registry.openshift-image-registry.svc:5000"
 
 PROJECT="$1"
 
-export KO_DOCKER_REPO="$(oc registry info)/hypershift"
+export KO_DOCKER_REPO="$(oc registry info --public)/hypershift"
 EXTERNAL_PULLSPEC=$(ko publish --insecure-registry "$PROJECT")
 
 INTERNAL_PULLSPEC="$INTERNAL_REPO/$(echo $EXTERNAL_PULLSPEC | cut -d'/' -f2 -f3)"

--- a/hypershift-operator/controllers/util/deployment.go
+++ b/hypershift-operator/controllers/util/deployment.go
@@ -19,7 +19,7 @@ const (
 	// debugDeploymentsAnnotation is applied to a HostedCluster and contains a
 	// comma separated list of deployment names which should always be scaled to 0
 	// for development.
-	debugDeploymentsAnnotation = "hypershift.openshift.io/debug-deployments"
+	DebugDeploymentsAnnotation = "hypershift.openshift.io/debug-deployments"
 )
 
 func SetDefaultPriorityClass(deployment *appsv1.Deployment) {
@@ -160,7 +160,7 @@ func SetControlPlaneIsolation(hc *hyperv1.HostedCluster, deployment *appsv1.Depl
 // debugDeploymentsAnnotation value that contains the Deployment name,
 // indicating the deployment should be considered to be in development mode.
 func IsDeploymentDebugEnabled(hc *hyperv1.HostedCluster, deployment *appsv1.Deployment) bool {
-	val, exists := hc.Annotations[debugDeploymentsAnnotation]
+	val, exists := hc.Annotations[DebugDeploymentsAnnotation]
 	if !exists {
 		return false
 	}

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -96,16 +96,17 @@ func NewStartCommand() *cobra.Command {
 	}
 
 	opts := StartOptions{
-		Namespace:                   "hypershift",
-		DeploymentName:              "operator",
-		MetricsAddr:                 "0",
-		EnableLeaderElection:        false,
-		ControlPlaneOperatorImage:   "",
-		IgnitionServerImage:         "",
-		OpenTelemetryEndpoint:       "",
-		RegistryOverrides:           map[string]string{},
-		PrivatePlatform:             string(hyperv1.NonePlatform),
-		OIDCStorageProviderS3Region: "us-east-1",
+		Namespace:                        "hypershift",
+		DeploymentName:                   "operator",
+		MetricsAddr:                      "0",
+		EnableLeaderElection:             false,
+		ControlPlaneOperatorImage:        "",
+		IgnitionServerImage:              "",
+		OpenTelemetryEndpoint:            "",
+		RegistryOverrides:                map[string]string{},
+		PrivatePlatform:                  string(hyperv1.NonePlatform),
+		OIDCStorageProviderS3Region:      "us-east-1",
+		OIDCStorageProviderS3Credentials: "/etc/oidc-storage-provider-s3-creds/credentials",
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace this operator lives in")
@@ -124,7 +125,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.PrivatePlatform, "private-platform", opts.PrivatePlatform, "Platform on which private clusters are supported by this operator (supports \"AWS\" or \"None\")")
 	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3BucketName, "oidc-storage-provider-s3-bucket-name", "", "Name of the bucket in which to store the clusters OIDC discovery information. Required for AWS guest clusters")
 	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3Region, "oidc-storage-provider-s3-region", opts.OIDCStorageProviderS3Region, "Region in which the OIDC bucket is located. Required for AWS guest clusters")
-	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3Credentials, "oidc-storage-provider-s3-credentials", "", "Location of the credentials file for the OIDC bucket. Required for AWS guest clusters.")
+	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3Credentials, "oidc-storage-provider-s3-credentials", opts.OIDCStorageProviderS3Credentials, "Location of the credentials file for the OIDC bucket. Required for AWS guest clusters.")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())

--- a/ignition-server/main.go
+++ b/ignition-server/main.go
@@ -66,8 +66,8 @@ func NewStartCommand() *cobra.Command {
 
 	opts := Options{
 		Addr:              "0.0.0.0:9090",
-		CertFile:          "/var/run/secrets/ignition/tls.crt",
-		KeyFile:           "/var/run/secrets/ignition/tls.key",
+		CertFile:          "/var/run/secrets/ignition/serving-cert/tls.crt",
+		KeyFile:           "/var/run/secrets/ignition/serving-cert/tls.key",
 		RegistryOverrides: map[string]string{},
 	}
 


### PR DESCRIPTION
This commit adds some development workflow improvements:

- Simplify development workflows by introducing better defaults to the
hypershift-operator, control-plane-operator, and ignition-server which eliminate
the need to document or use many flags which are relevant only in rare debugging
contexts. The documentation has been updated to reflect these changes.

- Tweak the `public-ocp.sh` script to always use the public registry endpoint,
fixing a flake where sometimes the script would erroneously produce the internal
registry name as output.

- Update the in-cluster developer workflow docs to describe required OIDC
hypershift-operator flags which weren't documented before.

- Mirror the `hypershift.openshift.io/debug-deployments` annotation to
HostedControlPlane resources for future use (e.g. to enable developing against
the hosted-cluster-config-operator).