### PR TITLE
Fix openshift/tools:latest imagestream import

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -192,7 +192,7 @@ func buildOASContainerMain(image string, etcdHostname string) func(c *corev1.Con
 			},
 			{
 				Name:  "NO_PROXY",
-				Value: fmt.Sprintf("%s,%s,registry.access.redhat.com,quay.io,registry.redhat.io", manifests.KubeAPIServerService("").Name, etcdHostname),
+				Value: fmt.Sprintf("%s,%s,registry.access.redhat.com,quay.io,registry.redhat.io,amazonaws.com", manifests.KubeAPIServerService("").Name, etcdHostname),
 			},
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)


### PR DESCRIPTION
Without this, the import fails with an error like
```
Internal error occurred: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e44074f21e0cca6464e50cb6ff934747e0bd11162ea01d522433a1a1ae116103:
        Get "https://quayio-production-s3.s3.amazonaws.com/sha256/b0/b0e2957fede15fffb1b12987d8f6068953739aac8775983c45f6ecfaecb91473?Signature=GF5mIHG057nJUTbxy%2FfHhE4TF%2FM%3D&Expires=1638555529&AWSAccessKeyId=AKIAI5LUAQGPZRPNKSJA":
        EOF'
```

as it tries to route that over the socks5 proxy which does DNS resolving
but can only do that for kubernetes services. And even if was able to
resolve, it wouldn't be able to route.

TBH I am not sure why this now started to happen, maybe quay started to
return direct download links to S3 rather than proxying requests?

We allowlist all of aws in the no_proxy env var, because it never makes
sense to proxy aws requests.

The failing import breaks a large number of conformance tests.