### PR TITLE
Log: Use RFC3339 timestamps rather than unix epoch

### DIFF
--- a/availability-prober/main.go
+++ b/availability-prober/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
+	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -21,7 +22,9 @@ func main() {
 	flag.StringVar(&opts.target, "target", "", "A http url to probe. The program will continue until it gets a http 2XX back.")
 	flag.Parse()
 
-	log := zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+	log := zap.New(zap.UseDevMode(true), zap.JSONEncoder(), func(o *zap.Options) {
+		o.TimeEncoder = zapcore.RFC3339TimeEncoder
+	})
 
 	url, err := url.Parse(opts.target)
 	if err != nil {

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/util"
+	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -91,7 +92,9 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringToStringVar(&registryOverrides, "registry-overrides", map[string]string{}, "registry-overrides contains the source registry string as a key and the destination registry string as value. Images before being applied are scanned for the source registry string and if found the string is replaced with the destination registry string. Format is: sr1=dr1,sr2=dr2")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder()))
+		ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(), func(o *zap.Options) {
+			o.TimeEncoder = zapcore.RFC3339TimeEncoder
+		}))
 		ctx := ctrl.SetupSignalHandler()
 
 		restConfig := ctrl.GetConfigOrDie()

--- a/hosted-cluster-config-operator/main.go
+++ b/hosted-cluster-config-operator/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -34,7 +35,9 @@ const (
 )
 
 func main() {
-	log.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder()))
+	log.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(), func(o *zap.Options) {
+		o.TimeEncoder = zapcore.RFC3339TimeEncoder
+	}))
 	setupLog := ctrl.Log.WithName("setup")
 	if err := newHostedClusterConfigOperatorCommand().Execute(); err != nil {
 		setupLog.Error(err, "Operator failed")

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -42,6 +42,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"
+	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
@@ -88,7 +89,9 @@ type StartOptions struct {
 }
 
 func NewStartCommand() *cobra.Command {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder()))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(), func(o *zap.Options) {
+		o.TimeEncoder = zapcore.RFC3339TimeEncoder
+	}))
 
 	cmd := &cobra.Command{
 		Use:   "run",

--- a/ignition-server/main.go
+++ b/ignition-server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hypershift/ignition-server/controllers"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -102,7 +103,9 @@ func setUpPayloadStoreReconciler(ctx context.Context, registryOverrides map[stri
 		return nil, fmt.Errorf("environment variable %s is empty, this is not supported", namespaceEnvVariableName)
 	}
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder()))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(), func(o *zap.Options) {
+		o.TimeEncoder = zapcore.RFC3339TimeEncoder
+	}))
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.UserAgent = "ignition-server-manager"
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{

--- a/support/upsert/loopdetector.go
+++ b/support/upsert/loopdetector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/go-logr/logr"
@@ -18,7 +19,9 @@ func newUpdateLoopDetector() *updateLoopDetector {
 	return &updateLoopDetector{
 		hasNoOpUpdate:    sets.String{},
 		updateEventCount: map[string]int{},
-		log:              zap.New(zap.UseDevMode(true), zap.JSONEncoder()),
+		log: zap.New(zap.UseDevMode(true), zap.JSONEncoder(), func(o *zap.Options) {
+			o.TimeEncoder = zapcore.RFC3339TimeEncoder
+		}),
 	}
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/hypershift/test/e2e/podtimingcontroller"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -39,7 +40,9 @@ var (
 	// be cancelled if a SIGINT or SIGTERM is received. It's set up in TestMain.
 	testContext context.Context
 
-	log = zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+	log = zap.New(zap.UseDevMode(true), zap.JSONEncoder(), func(o *zap.Options) {
+		o.TimeEncoder = zapcore.RFC3339TimeEncoder
+	})
 )
 
 func init() {


### PR DESCRIPTION
As the latter is extremely hard to parse by humans.