### PR TITLE
Fix konnektivity-socks5-proxy

### DIFF
--- a/konnectivity-socks5-proxy/main.go
+++ b/konnectivity-socks5-proxy/main.go
@@ -112,7 +112,6 @@ func dialKonnectivityFunc(caCertPath string, clientCertPath string, clientKeyPat
 			return nil, fmt.Errorf("reading HTTP response from CONNECT to %s via proxy %s failed: %v",
 				requestAddress, proxyAddress, err)
 		}
-		defer res.Body.Close()
 		if res.StatusCode != 200 {
 			return nil, fmt.Errorf("proxy error from %s while dialing %s: %v", proxyAddress, requestAddress, res.Status)
 		}


### PR DESCRIPTION
In 868bb057c4119b76ec3b4100ea88d55664c92715 I made the proxy close the
bodies it receives. This broke the proxy entirely, as closing the body
effectively discards any remaining data in there, but the data is the
response for the actual client which gets read by the proxy and then
forwarded.

This changes makes the openshift-apiserver again able to talk to the registry which in turn fixes a bunch of e2e tests.