### PR TITLE
Prevent flapping of nodepool config

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -331,7 +331,7 @@ spec:
 					BinaryData: nil,
 				},
 			},
-			expect: "\n---\n" + machineConfig1,
+			expect: machineConfig1,
 			error:  false,
 		},
 		{
@@ -372,7 +372,7 @@ spec:
 					},
 				},
 			},
-			expect: "\n---\n" + machineConfig1 + "\n---\n" + machineConfig2,
+			expect: machineConfig1 + "\n---\n" + machineConfig2,
 			error:  false,
 		},
 		{
@@ -462,7 +462,7 @@ spec:
 				},
 			},
 			expectedCoreConfigResources: 1,
-			expect:                      "\n---\n" + coreMachineConfig1 + "\n---\n" + machineConfig1,
+			expect:                      coreMachineConfig1 + "\n---\n" + machineConfig1,
 			error:                       false,
 		},
 		{
@@ -517,7 +517,7 @@ spec:
 				},
 			},
 			expectedCoreConfigResources: 1,
-			expect:                      "\n---\n" + coreMachineConfig1 + "\n---\n" + machineConfig1,
+			expect:                      coreMachineConfig1 + "\n---\n" + machineConfig1,
 			error:                       false,
 		},
 		{


### PR DESCRIPTION
Currently, we flap back and forth between different nodepool configs
that differ only in the user-data secret name. This happens because that
secret has a suffix that is the hash of it's configs. Those configs in
turn are assembled from a list of configmaps, but that list wasn't
sorted. Sort the list, be happy.