### PR TITLE
docs: Update private cluster howto

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,6 +26,8 @@ markdown_extensions:
 - pymdownx.snippets
 - admonition
 - pymdownx.details
+- pymdownx.tabbed:
+    alternate_style: true
 nav:
 - Home: index.md
 - 'Getting started': getting-started.md


### PR DESCRIPTION
This commit cleans up and revises the private cluster howto guide. The
architectural content has been removed and will be placed elsewhere
(perhaps in the reference section).