### PR TITLE
Added None platform to ReconcileInfrastructure

### DIFF
--- a/support/globalconfig/infrastructure.go
+++ b/support/globalconfig/infrastructure.go
@@ -57,5 +57,8 @@ func ReconcileInfrastructure(infra *configv1.Infrastructure, hcp *hyperv1.Hosted
 	case hyperv1.IBMCloudPlatform:
 		infra.Status.PlatformStatus = &configv1.PlatformStatus{}
 		infra.Status.PlatformStatus.Type = configv1.IBMCloudPlatformType
+	case hyperv1.NonePlatform:
+		infra.Status.PlatformStatus = &configv1.PlatformStatus{}
+		infra.Status.PlatformStatus.Type = configv1.NonePlatformType
 	}
 }


### PR DESCRIPTION
kube-controller-manager keeps logging this error when HyperShift HostedCluster platform is none:
```
I1207 11:59:01.295504       1 event.go:291] "Event occurred" object="openshift-monitoring/cluster-monitoring-operator-97cd798c5" kind="ReplicaSet" apiVersion="apps/v1" type="Warning" reason="FailedCreate" message="Error creating: pods \"cluster-monitoring-operator-97cd798c5-\" is forbidden: infrastructure.config.openshift.io \"cluster\" not found"
```
This error leads to worker nodes not getting any pods scheduled (not even SDN) and resulting worker nodes stuck with NotREady status.