### PR TITLE
Use correct apiserver host for kubeconfigs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -43,6 +43,8 @@ type KubeAPIServerParams struct {
 	AdvertiseAddress     string                       `json:"advertiseAddress"`
 	ExternalAddress      string                       `json:"externalAddress"`
 	ExternalPort         int32                        `json:"externalPort"`
+	InternalAddress      string                       `json:"internalAddress"`
+	InternalPort         int32                        `json:"internalPort"`
 	ExternalOAuthAddress string                       `json:"externalOAuthAddress"`
 	ExternalOAuthPort    int32                        `json:"externalOAuthPort"`
 	EtcdURL              string                       `json:"etcdAddress"`
@@ -71,6 +73,8 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		Scheduler:            globalConfig.Scheduler,
 		ExternalAddress:      hcp.Status.ControlPlaneEndpoint.Host,
 		ExternalPort:         hcp.Status.ControlPlaneEndpoint.Port,
+		InternalAddress:      fmt.Sprintf("api.%s.hypershift.local", hcp.Name),
+		InternalPort:         6443,
 		ExternalOAuthAddress: externalOAuthAddress,
 		ExternalOAuthPort:    externalOAuthPort,
 		ServiceAccountIssuer: hcp.Spec.IssuerURL,
@@ -314,6 +318,10 @@ func (p *KubeAPIServerParams) AuditPolicyProfile() configv1.AuditProfileType {
 
 func (p *KubeAPIServerParams) ExternalURL() string {
 	return fmt.Sprintf("https://%s:%d", p.ExternalAddress, p.ExternalPort)
+}
+
+func (p *KubeAPIServerParams) InternalURL() string {
+	return fmt.Sprintf("https://%s:%d", p.InternalAddress, p.InternalPort)
 }
 
 func (p *KubeAPIServerParams) ExternalKubeconfigKey() string {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -16,7 +16,7 @@ const (
 	ServiceSignerPublicKey  = "service-account.pub"
 )
 
-func ReconcileKASServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalAPIAddress, serviceCIDR string) error {
+func ReconcileKASServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalAPIAddress, internalAPIAddress, serviceCIDR string) error {
 	svc := manifests.KubeAPIServerService(secret.Namespace)
 	_, serviceIPNet, err := net.ParseCIDR(serviceCIDR)
 	if err != nil {
@@ -41,6 +41,11 @@ func ReconcileKASServerCertSecret(secret, ca *corev1.Secret, ownerRef config.Own
 		apiServerIPs = append(apiServerIPs, externalAPIAddress)
 	} else {
 		dnsNames = append(dnsNames, externalAPIAddress)
+	}
+	if isNumericIP(internalAPIAddress) {
+		apiServerIPs = append(apiServerIPs, internalAPIAddress)
+	} else {
+		dnsNames = append(dnsNames, internalAPIAddress)
 	}
 	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "kubernetes", []string{"kubernetes"}, X509UsageServerAuth, dnsNames, apiServerIPs)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
@@ -1,6 +1,8 @@
 package pki
 
 import (
+	"fmt"
+
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 
 	"github.com/openshift/hypershift/support/config"
@@ -18,6 +20,10 @@ type PKIParams struct {
 	// ExternalAPIAddress
 	// An externally accessible DNS name or IP for the API server. Currently obtained from the load balancer DNS name.
 	ExternalAPIAddress string `json:"externalAPIAddress"`
+
+	// InternalAPIAddress
+	// An internally accessible DNS name or IP for the API server.
+	InternalAPIAddress string `json:"internalAPIAddress"`
 
 	// ExternalKconnectivityAddress
 	// An externally accessible DNS name or IP for the Konnectivity proxy. Currently obtained from the load balancer DNS name.
@@ -51,6 +57,7 @@ func NewPKIParams(hcp *hyperv1.HostedControlPlane,
 		PodCIDR:                      hcp.Spec.PodCIDR,
 		Namespace:                    hcp.Namespace,
 		ExternalAPIAddress:           apiExternalAddress,
+		InternalAPIAddress:           fmt.Sprintf("api.%s.hypershift.local", hcp.Name),
 		ExternalKconnectivityAddress: konnectivityExternalAddress,
 		ExternalOauthAddress:         oauthExternalAddress,
 		IngressSubdomain:             config.IngressSubdomain(hcp),


### PR DESCRIPTION
EndpointAccess `PublicAndPrivate` currently does not work as the HC kubeconfig contains the internal API address and the KAS cert is not configured with both the internal and external addresses.

This PR fixes it.

Also, the proliferation of private `hypershift.local` name generation logic is not escaping me.  I will fix it up in a follow on.