### PR TITLE
Fix kube-apiserver servicemonitor

### DIFF
--- a/hosted-cluster-config-operator/controllers/resources/monitoring/servicemonitor.go
+++ b/hosted-cluster-config-operator/controllers/resources/monitoring/servicemonitor.go
@@ -17,11 +17,17 @@ func ReconcileKubeAPIServerServiceMonitor(serviceMonitor *prometheusoperatorv1.S
 	}
 	serviceMonitor.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-			Interval:        "30s",
-			Scheme:          "https",
-			Port:            "https",
-			Path:            "/metrics",
+			BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+			TLSConfig: &prometheusoperatorv1.TLSConfig{
+				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
+					ServerName: "kubernetes.default.svc",
+				},
+				CAFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+			},
+			Interval: "30s",
+			Scheme:   "https",
+			Port:     "https",
+			Path:     "/metrics",
 			MetricRelabelConfigs: []*prometheusoperatorv1.RelabelConfig{
 				{
 					Action: "keep",


### PR DESCRIPTION
This broken in
https://github.com/openshift/hypershift/commit/abe306569744055a2bb4bd8192d7309725a72514,
as the CA file was omitted and the token file was pointing to the CA
file which obviously doesn't work.

This fixes the last conformance test which currently fails because
scraping fails due to the invalid config:
```
[sig-instrumentation] Prometheus when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured
```