### PR TITLE
Create cluster: Add flags for service and pod CIDR

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -55,6 +55,8 @@ type ExampleOptions struct {
 	NodePoolReplicas                 int32
 	InfraID                          string
 	ComputeCIDR                      string
+	ServiceCIDR                      string
+	PodCIDR                          string
 	BaseDomain                       string
 	PublicZoneID                     string
 	PrivateZoneID                    string
@@ -270,8 +272,8 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 				},
 			},
 			Networking: hyperv1.ClusterNetworking{
-				ServiceCIDR: "172.31.0.0/16",
-				PodCIDR:     "10.132.0.0/14",
+				ServiceCIDR: o.ServiceCIDR,
+				PodCIDR:     o.PodCIDR,
 				MachineCIDR: o.ComputeCIDR,
 				NetworkType: o.NetworkType,
 			},

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -22,6 +22,8 @@ func NewCreateCommands() *cobra.Command {
 		NetworkType:                    string(hyperv1.OpenShiftSDN),
 		InfrastructureJSON:             "",
 		InfraID:                        "",
+		ServiceCIDR:                    "172.31.0.0/16",
+		PodCIDR:                        "10.132.0.0/14",
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -46,6 +48,8 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.EtcdStorageClass, "etcd-storage-class", opts.EtcdStorageClass, "The persistent volume storage class for etcd data volumes")
 	cmd.PersistentFlags().StringVar(&opts.InfrastructureJSON, "infra-json", opts.InfrastructureJSON, "Path to file containing infrastructure information for the cluster. If not specified, infrastructure will be created")
 	cmd.PersistentFlags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Infrastructure ID to use for hosted cluster resources.")
+	cmd.PersistentFlags().StringVar(&opts.ServiceCIDR, "service-cidr", opts.ServiceCIDR, "The CIDR of the service network")
+	cmd.PersistentFlags().StringVar(&opts.PodCIDR, "pod-cidr", opts.PodCIDR, "The CIDR of the pod network")
 
 	cmd.MarkPersistentFlagRequired("pull-secret")
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -45,6 +45,8 @@ type CreateOptions struct {
 	ReleaseImage                     string
 	Render                           bool
 	SSHKeyFile                       string
+	ServiceCIDR                      string
+	PodCIDR                          string
 	NonePlatform                     NonePlatformCreateOptions
 	AWSPlatform                      AWSPlatformOptions
 	AgentPlatform                    AgentPlatformCreateOptions
@@ -134,6 +136,8 @@ func createCommonFixture(opts *CreateOptions) (*apifixtures.ExampleOptions, erro
 		SSHPrivateKey:                    sshPrivateKey,
 		SSHPublicKey:                     sshKey,
 		EtcdStorageClass:                 opts.EtcdStorageClass,
+		ServiceCIDR:                      opts.ServiceCIDR,
+		PodCIDR:                          opts.PodCIDR,
 	}, nil
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -203,6 +203,8 @@ func (o *options) DefaultClusterOptions() core.CreateOptions {
 			Region:             o.configurableClusterOptions.Region,
 			EndpointAccess:     o.configurableClusterOptions.AWSEndpointAccess,
 		},
+		ServiceCIDR: "172.31.0.0/16",
+		PodCIDR:     "10.132.0.0/14",
 	}
 	createOption.AWSPlatform.AdditionalTags = append(createOption.AWSPlatform.AdditionalTags, o.additionalTags...)
 


### PR DESCRIPTION
This is needed for nested Hypershift, as the service cidr of the guest
cluster must not overlap with the one of the management cluster,
otherwise the KAS can not reach the services that run in the management
cluster.

Needed for https://github.com/openshift/release/pull/24556