### PR TITLE
Introduce support to propagate labels from NodePools to Nodes

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -85,6 +85,11 @@ type NodePoolSpec struct {
 	// +optional
 	NodeCount *int32 `json:"nodeCount"`
 
+	// Labels specifies labels that are applied in an additive fashion to the
+	// Nodes resulting from this NodePool.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// Management specifies behavior for managing nodes in the pool, such as
 	// upgrade strategies and auto-repair behaviors.
 	Management NodePoolManagement `json:"management"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1262,6 +1262,13 @@ func (in *NodePoolSpec) DeepCopyInto(out *NodePoolSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Management.DeepCopyInto(&out.Management)
 	if in.AutoScaling != nil {
 		in, out := &in.AutoScaling, &out.AutoScaling

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -113,6 +113,12 @@ spec:
                       type: string
                   type: object
                 type: array
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels specifies labels that are applied in an additive
+                  fashion to the Nodes resulting from this NodePool.
+                type: object
               management:
                 description: Management specifies behavior for managing nodes in the
                   pool, such as upgrade strategies and auto-repair behaviors.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -496,6 +496,19 @@ unset, the default value is 0.</p>
 </tr>
 <tr>
 <td>
+<code>labels</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels specifies labels that are applied in an additive fashion to the
+Nodes resulting from this NodePool.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>management</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">
@@ -3631,6 +3644,19 @@ int32
 <em>(Optional)</em>
 <p>NodeCount is the desired number of nodes the pool should maintain. If
 unset, the default value is 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>labels</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels specifies labels that are applied in an additive fashion to the
+Nodes resulting from this NodePool.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
First iteration to support reconciling labels from NodePools to Nodes.
Labels are additive i.e they don't step on labels not owned by NodePool.spec.labels.
Last labels applied are stored as an annotation so dropped labels can be identified and removed from Nodes.

Ideally we can rely on CAPI implementation eventually to handle this https://docs.google.com/document/d/17QA2E0GcbWNYb160qs8ArHOW0uMfL-NTYivefPGtn-c/edit#heading=h.ww3hv1e0mpnl
