### PR TITLE
AWS: Create role for cloud-network-config-controller

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -487,12 +487,13 @@ type AWSPlatformSpec struct {
 	// +immutable
 	ServiceEndpoints []AWSServiceEndpoint `json:"serviceEndpoints,omitempty"`
 
-	// Roles must contain exactly 3 entries representing the locators for roles
+	// Roles must contain exactly 4 entries representing the locators for roles
 	// supporting the following OCP services:
 	//
 	// - openshift-ingress-operator/cloud-credentials
 	// - openshift-image-registry/installer-cloud-credentials
-	//  -openshift-cluster-csi-drivers/ebs-cloud-credentials
+	// - openshift-cluster-csi-drivers/ebs-cloud-credentials
+	// - cloud-network-config-controller/cloud-credentials
 	//
 	// Each role has unique permission requirements whose documentation is TBD.
 	//

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -140,6 +140,9 @@ func (o *DestroyIAMOptions) DestroyOIDCResources(ctx context.Context, iamClient 
 	if err = o.DestroyOIDCRole(iamClient, "control-plane-operator"); err != nil {
 		return err
 	}
+	if err := o.DestroyOIDCRole(iamClient, "cloud-network-config-controller"); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -257,6 +257,26 @@ const (
 		}
 	]
 }`
+	cloudNetworkConfigControllerPolicy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstanceTypes",
+        "ec2:UnassignPrivateIpAddresses",
+        "ec2:AssignPrivateIpAddresses",
+        "ec2:UnassignIpv6Addresses",
+        "ec2:AssignIpv6Addresses",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeNetworkInterfaces"
+			],
+			"Resource": "*"
+		}
+	]
+}`
 )
 
 type KeyResponse struct {
@@ -373,6 +393,17 @@ func (o *CreateIAMOptions) CreateOIDCResources(iamClient iamiface.IAMAPI) (*Crea
 		return nil, err
 	}
 	output.ControlPlaneOperatorRoleARN = arn
+
+	cloudNetworkConfigControllerTrustPolicy := oidcTrustPolicy(providerARN, providerName, "system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller")
+	arn, err = o.CreateOIDCRole(iamClient, "cloud-network-config-controller", cloudNetworkConfigControllerTrustPolicy, cloudNetworkConfigControllerPolicy)
+	if err != nil {
+		return nil, err
+	}
+	output.Roles = append(output.Roles, hyperv1.AWSRoleCredentials{
+		ARN:       arn,
+		Namespace: "openshift-cloud-network-config-controller",
+		Name:      "cloud-credentials",
+	})
 
 	return output, nil
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -503,11 +503,12 @@ spec:
                         maxItems: 25
                         type: array
                       roles:
-                        description: "Roles must contain exactly 3 entries representing
+                        description: "Roles must contain exactly 4 entries representing
                           the locators for roles supporting the following OCP services:
                           \n - openshift-ingress-operator/cloud-credentials - openshift-image-registry/installer-cloud-credentials
-                          \ -openshift-cluster-csi-drivers/ebs-cloud-credentials \n
-                          Each role has unique permission requirements whose documentation
+                          - openshift-cluster-csi-drivers/ebs-cloud-credentials -
+                          cloud-network-config-controller/cloud-credentials \n Each
+                          role has unique permission requirements whose documentation
                           is TBD. \n TODO(dan): revisit this field; it's really 3
                           required fields with specific content requirements"
                         items:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -419,11 +419,12 @@ spec:
                         maxItems: 25
                         type: array
                       roles:
-                        description: "Roles must contain exactly 3 entries representing
+                        description: "Roles must contain exactly 4 entries representing
                           the locators for roles supporting the following OCP services:
                           \n - openshift-ingress-operator/cloud-credentials - openshift-image-registry/installer-cloud-credentials
-                          \ -openshift-cluster-csi-drivers/ebs-cloud-credentials \n
-                          Each role has unique permission requirements whose documentation
+                          - openshift-cluster-csi-drivers/ebs-cloud-credentials -
+                          cloud-network-config-controller/cloud-credentials \n Each
+                          role has unique permission requirements whose documentation
                           is TBD. \n TODO(dan): revisit this field; it's really 3
                           required fields with specific content requirements"
                         items:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1059,12 +1059,13 @@ the default service endpoint of specific AWS Services.</p>
 </em>
 </td>
 <td>
-<p>Roles must contain exactly 3 entries representing the locators for roles
+<p>Roles must contain exactly 4 entries representing the locators for roles
 supporting the following OCP services:</p>
 <ul>
 <li>openshift-ingress-operator/cloud-credentials</li>
-<li>openshift-image-registry/installer-cloud-credentials
--openshift-cluster-csi-drivers/ebs-cloud-credentials</li>
+<li>openshift-image-registry/installer-cloud-credentials</li>
+<li>openshift-cluster-csi-drivers/ebs-cloud-credentials</li>
+<li>cloud-network-config-controller/cloud-credentials</li>
 </ul>
 <p>Each role has unique permission requirements whose documentation is TBD.</p>
 <p>TODO(dan): revisit this field; it&rsquo;s really 3 required fields with specific content requirements</p>


### PR DESCRIPTION
This is a new component that was added in the 4.10 cycle.
Ref: https://github.com/openshift/cloud-network-config-controller/pull/6