### PR TITLE
Docs: Link to instructions for infrastructure operator

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -57,6 +57,8 @@ you should adjust to your own environment.
           --region $REGION
         ```
 
+* HyperShift supports the Agent platform via [cluster-api-provider-agent](https://github.com/openshift/cluster-api-provider-agent). It requires the Infrastructure Operator to be installed. See instructions [here](https://github.com/openshift/assisted-service/blob/master/docs/user-guide/infrastructure-operator-olm.md).
+
 ## Before you begin
 
 Install HyperShift into the management cluster, specifying the OIDC bucket,


### PR DESCRIPTION
The cluster-api-provider-agent requires the Infrastructure Operator to be installed.
This PR add a link to instructions on how to install it on OCP.