### PR TITLE
add distributed cronjob schedule to olm-collect-metrics cronjob

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: olm-collect-profiles
 spec:
-  schedule: "*/15 * * * *"
+  schedule: CRON_SCHEDULE
   jobTemplate:
     spec:
       template:

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/olm-collect-profiles.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/olm-collect-profiles.go
@@ -24,6 +24,7 @@ func ReconcileCollectProfilesCronJob(cronJob *batchv1beta1.CronJob, ownerRef con
 			cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args[i] = namespace
 		}
 	}
+	cronJob.Spec.Schedule = generateModularDailyCronSchedule([]byte(cronJob.Namespace))
 }
 
 func ReconcileCollectProfilesConfigMap(configMap *corev1.ConfigMap, ownerRef config.OwnerRef) {


### PR DESCRIPTION
add distributed cronjob schedule to olm-collect-metrics cronjob to prevent management cluster scheduling overload at specific intervals.

Uses same scheduling algorithm used for other cronjobs