### PR TITLE
update cert duration to match maximum time allowed by fs cloud controls (2 years)

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -288,7 +288,7 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 		fmt.Sprintf("--service-account-private-key-file=%s", cpath(kcmVolumeServiceSigner().Name, pki.ServiceSignerPrivateKey)),
 		fmt.Sprintf("--service-cluster-ip-range=%s", p.ServiceCIDR),
 		"--use-service-account-credentials=true",
-		"--experimental-cluster-signing-duration=26280h",
+		"--experimental-cluster-signing-duration=17520h",
 	}...)
 	for _, f := range p.FeatureGates() {
 		args = append(args, fmt.Sprintf("--feature-gates=%s", f))


### PR DESCRIPTION
This will ensure issued worker certs for kubelet have a duration that is compliant with fs cloud controls. The maximum allowed time is 2 years which is 17520 hours.