### PR TITLE
allow kubelet configs and container runtime configs to be specified now that mco bootstrapping supports it

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -998,11 +998,8 @@ func validateConfigManifest(manifest []byte) error {
 	switch obj := cr.(type) {
 	case *mcfgv1.MachineConfig:
 	case *v1alpha1.ImageContentSourcePolicy:
-	//	TODO (alberto): enable this kinds when they are supported in mcs bootstrap mode
-	// since our mcsIgnitionProvider implementation uses bootstrap mode to render the ignition payload out of an input.
-	// https://github.com/openshift/machine-config-operator/pull/2547
-	//case *mcfgv1.KubeletConfig:
-	//case *mcfgv1.ContainerRuntimeConfig:
+	case *mcfgv1.KubeletConfig:
+	case *mcfgv1.ContainerRuntimeConfig:
 	default:
 		return fmt.Errorf("unsupported config type: %T", obj)
 	}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -419,8 +419,8 @@ spec:
 					},
 				},
 			},
-			expect: "",
-			error:  true,
+			expect: kubeletConfig1,
+			error:  false,
 		},
 		{
 			name: "gets a single valid MachineConfig with a core MachineConfig",


### PR DESCRIPTION
This support appears to be added in the following commits for 4.10:
https://github.com/openshift/machine-config-operator/commit/eb0afb8374b097d4971021b1b00c0f471a8a5892
https://github.com/openshift/machine-config-operator/commit/a282006d2d3b245c2f5cdf444a4dea45d1b27585#diff-ee4889f36bd8b3bb13f51dd15721cbc3f0eae1cf4d6bb8635dec6de843e78c4d


It would as of now though fail in release-4.9 and release-4.8 (meaning the user would have to be aware that it is only allowed starting in release 4.10. Or the commits could be backported. 
