### PR TITLE
Update hypershift image references to new location

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -9,7 +9,7 @@ import (
 var (
 	// TODO: This goes away when control-plane-operator becomes another component
 	// in the OCP payload.
-	HyperShiftImage = "registry.ci.openshift.org/hypershift/hypershift:latest"
+	HyperShiftImage = "quay.io/hypershift/hypershift:latest"
 )
 
 // https://docs.ci.openshift.org/docs/getting-started/useful-links/#services


### PR DESCRIPTION
As of https://github.com/openshift/release/pull/24928, hypershift images
are promoted into the `ocp` registry namespace (which is private) and mirrored
to quay (which is public). This commit updates old references to point at the
new location.