### PR TITLE
kubevirt provider e2e create cluster test

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -5,10 +5,96 @@ package e2e
 
 import (
 	"context"
+	"os"
 	"testing"
+	"time"
 
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// TestKubeVirtCreateCluster implements a test that mimics the operation described in the
+// HyperShift quick start (creating a basic guest cluster).
+//
+// This test is meant to provide a first, fast signal to detect regression; it
+// is recommended to use it as a PR blocker test.
+func TestKubeVirtCreateCluster(t *testing.T) {
+	// TODO remove this env-var once the Openshift CI lanes
+	// move to explicitly opting into the exact tests that should run
+	// with the -test.run cli arg.
+	if os.Getenv("KUBEVIRT_PLATFORM_ENABLED") != "true" {
+		t.Skip("Skipping testing because environment doesn't support KubeVirt")
+	}
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	t.Parallel()
+	g := NewWithT(t)
+	client := e2eutil.GetClientOrDie()
+
+	clusterOpts := globalOpts.DefaultClusterOptions()
+	hostedCluster := e2eutil.CreateKubeVirtCluster(t, ctx, client, clusterOpts, globalOpts.ArtifactDir)
+
+	waitForHostedClusterAvailable := func() {
+		start := time.Now()
+
+		localCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+		t.Logf("Waiting for hosted cluster to become available")
+		err := wait.PollUntil(5*time.Second, func() (done bool, err error) {
+			latest := hostedCluster.DeepCopy()
+			err = client.Get(ctx, crclient.ObjectKeyFromObject(latest), latest)
+			if err != nil {
+				t.Errorf("Failed to get hostedcluster: %v", err)
+				return false, nil
+			}
+
+			isAvailable := meta.IsStatusConditionTrue(latest.Status.Conditions, string(hyperv1.HostedClusterAvailable))
+			if isAvailable {
+				return true, nil
+			}
+			return false, nil
+		}, localCtx.Done())
+		g.Expect(err).NotTo(HaveOccurred(), "timeout waiting for hosted cluster to become available")
+
+		t.Logf("Hosted cluster is available in %s", time.Since(start).Round(time.Second))
+	}
+
+	// Get the newly created nodepool
+	nodepool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hostedCluster.Namespace,
+			Name:      hostedCluster.Name,
+		},
+	}
+	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
+	t.Logf("Created nodepool. Namespace: %s, name: %s", nodepool.Namespace, nodepool.Name)
+
+	// Wait for hosted cluster to become ready
+	// TODO: replace this with WaitForImageRollout once we can achieve a full
+	// image roll out out consistently
+	waitForHostedClusterAvailable()
+
+	// Wait for kubevirt machines to come online
+	// TODO: Replace this with the generic WaitForNReadyNodes() function
+	// once we get better ingress support for KubeVirt platform
+	// that allows us to use the guest cluster's client to view
+	// node status.
+	e2eutil.WaitForKubeVirtMachines(t, testContext, client, hostedCluster, *nodepool.Spec.NodeCount)
+
+	// Wait for kubevirt cluster to be marked as available
+	e2eutil.WaitForKubeVirtCluster(t, testContext, client, hostedCluster)
+
+	// TODO verify introspecting guest cluster once ingress is sorted out.
+}
 
 func TestNoneCreateCluster(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -56,6 +56,8 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.Region, "e2e.aws-region", "us-east-1", "AWS region for clusters")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PullSecretFile, "e2e.pull-secret-file", "", "path to pull secret")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AWSEndpointAccess, "e2e.aws-endpoint-access", "", "endpoint access profile for the cluster")
+	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "container disk image to use for kubevirt nodes")
+	flag.IntVar(&globalOpts.configurableClusterOptions.NodePoolReplicas, "e2e.node-pool-replicas", 2, "the number of replicas in the cluster's node pool")
 	flag.StringVar(&globalOpts.LatestReleaseImage, "e2e.latest-release-image", "", "The latest OCP release image for use by tests")
 	flag.StringVar(&globalOpts.PreviousReleaseImage, "e2e.previous-release-image", "", "The previous OCP release image relative to the latest")
 	flag.StringVar(&globalOpts.ArtifactDir, "e2e.artifact-dir", "", "The directory where cluster resources and logs should be dumped. If empty, nothing is dumped")
@@ -177,12 +179,14 @@ type options struct {
 }
 
 type configurableClusterOptions struct {
-	AWSCredentialsFile        string
-	Region                    string
-	PullSecretFile            string
-	BaseDomain                string
-	ControlPlaneOperatorImage string
-	AWSEndpointAccess         string
+	AWSCredentialsFile         string
+	Region                     string
+	PullSecretFile             string
+	BaseDomain                 string
+	ControlPlaneOperatorImage  string
+	AWSEndpointAccess          string
+	KubeVirtContainerDiskImage string
+	NodePoolReplicas           int
 }
 
 func (o *options) DefaultClusterOptions() core.CreateOptions {
@@ -190,7 +194,7 @@ func (o *options) DefaultClusterOptions() core.CreateOptions {
 		ReleaseImage:              o.LatestReleaseImage,
 		GenerateSSH:               true,
 		SSHKeyFile:                "",
-		NodePoolReplicas:          2,
+		NodePoolReplicas:          int32(o.configurableClusterOptions.NodePoolReplicas),
 		NetworkType:               string(hyperv1.OpenShiftSDN),
 		BaseDomain:                o.configurableClusterOptions.BaseDomain,
 		PullSecretFile:            o.configurableClusterOptions.PullSecretFile,
@@ -202,6 +206,11 @@ func (o *options) DefaultClusterOptions() core.CreateOptions {
 			AWSCredentialsFile: o.configurableClusterOptions.AWSCredentialsFile,
 			Region:             o.configurableClusterOptions.Region,
 			EndpointAccess:     o.configurableClusterOptions.AWSEndpointAccess,
+		},
+		KubevirtPlatform: core.KubevirtPlatformCreateOptions{
+			ContainerDiskImage: o.configurableClusterOptions.KubeVirtContainerDiskImage,
+			Cores:              2,
+			Memory:             "4Gi",
 		},
 		ServiceCIDR: "172.31.0.0/16",
 		PodCIDR:     "10.132.0.0/14",

--- a/test/e2e/util/cluster/kubevirt/cluster.go
+++ b/test/e2e/util/cluster/kubevirt/cluster.go
@@ -1,0 +1,45 @@
+package kubevirt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
+	"github.com/openshift/hypershift/cmd/cluster/none"
+	"github.com/openshift/hypershift/test/e2e/util/cluster/aws"
+)
+
+type KubeVirt struct {
+	t    *testing.T
+	opts core.CreateOptions
+}
+
+func (k *KubeVirt) Describe() interface{} {
+	return k.opts
+}
+
+func (k *KubeVirt) CreateCluster(ctx context.Context, hc *hyperv1.HostedCluster) error {
+	k.opts.Namespace = hc.Namespace
+	k.opts.Name = hc.Name
+	return kubevirt.CreateCluster(ctx, &k.opts)
+}
+
+func (k *KubeVirt) DumpCluster(ctx context.Context, hc *hyperv1.HostedCluster, artifactsDir string) {
+	aws.DumpHostedCluster(k.t, ctx, hc, artifactsDir)
+}
+
+func (k *KubeVirt) DestroyCluster(ctx context.Context, hc *hyperv1.HostedCluster) error {
+	opts := &core.DestroyOptions{
+		Namespace:          hc.Namespace,
+		Name:               hc.Name,
+		ClusterGracePeriod: 15 * time.Minute,
+	}
+	return none.DestroyCluster(ctx, opts)
+}
+
+func New(t *testing.T, opts core.CreateOptions) *KubeVirt {
+	return &KubeVirt{opts: opts, t: t}
+}

--- a/test/e2e/util/kubevirt.go
+++ b/test/e2e/util/kubevirt.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+)
+
+func WaitForKubeVirtMachines(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, count int32) {
+	g := NewWithT(t)
+	start := time.Now()
+
+	localCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	t.Logf("Waiting for %d kubevirt machines to come online", count)
+
+	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+
+	err := wait.PollUntil(5*time.Second, func() (done bool, err error) {
+		var kvMachineList capikubevirt.KubevirtMachineList
+
+		err = client.List(ctx, &kvMachineList, crclient.InNamespace(namespace))
+		if err != nil {
+			t.Errorf("Failed to list KubeVirtMachines: %v", err)
+			return false, nil
+		}
+
+		readyCount := 0
+		for _, machine := range kvMachineList.Items {
+			if machine.Status.Ready {
+				readyCount++
+			}
+		}
+		if int32(readyCount) < count {
+			return false, nil
+		}
+
+		return true, nil
+	}, localCtx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), "timeout waiting for kubevirt machines to become ready")
+
+	t.Logf("KubeVirtMachines are ready in %s", time.Since(start).Round(time.Second))
+}
+
+func WaitForKubeVirtCluster(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+	start := time.Now()
+
+	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+
+	localCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	t.Logf("Waiting for kubevirt cluster to come online")
+	err := wait.PollUntil(5*time.Second, func() (done bool, err error) {
+		var kvClusterList capikubevirt.KubevirtClusterList
+
+		err = client.List(ctx, &kvClusterList, crclient.InNamespace(namespace))
+		if err != nil {
+			t.Errorf("Failed to list KubeVirtClusters: %v", err)
+			return false, nil
+		}
+
+		if len(kvClusterList.Items) == 0 {
+			// waiting on kubevirt cluster to be posted
+			return false, nil
+		}
+
+		return kvClusterList.Items[0].Status.Ready, nil
+	}, localCtx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), "timeout waiting for kubevirt cluster to become ready")
+
+	t.Logf("KubeVirtCluster is ready in %s", time.Since(start).Round(time.Second))
+}

--- a/test/e2e/util/scheme.go
+++ b/test/e2e/util/scheme.go
@@ -4,6 +4,7 @@ import (
 	hyperapi "github.com/openshift/hypershift/support/api"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 )
 
 var (
@@ -17,4 +18,5 @@ var (
 func init() {
 	operatorsv1.AddToScheme(scheme)
 	operatorsv1alpha1.AddToScheme(scheme)
+	capikubevirt.AddToScheme(scheme)
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/test/e2e/util/cluster"
 	awscluster "github.com/openshift/hypershift/test/e2e/util/cluster/aws"
+	kubevirtcluster "github.com/openshift/hypershift/test/e2e/util/cluster/kubevirt"
 	nonecluster "github.com/openshift/hypershift/test/e2e/util/cluster/none"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -39,6 +40,10 @@ import (
 // is required.
 func CreateAWSCluster(t *testing.T, ctx context.Context, client crclient.Client, opts core.CreateOptions, artifactDir string) *hyperv1.HostedCluster {
 	return createCluster(t, ctx, client, awscluster.New(t, opts), artifactDir)
+}
+
+func CreateKubeVirtCluster(t *testing.T, ctx context.Context, client crclient.Client, opts core.CreateOptions, artifactDir string) *hyperv1.HostedCluster {
+	return createCluster(t, ctx, client, kubevirtcluster.New(t, opts), artifactDir)
 }
 
 func CreateNoneCluster(t *testing.T, ctx context.Context, client crclient.Client, opts core.CreateOptions, artifactDir string) *hyperv1.HostedCluster {


### PR DESCRIPTION
This functional e2e test is very basic and is primarily meant as an entrypoint for us to begin fleshing out more advanced validation in the future. At the moment, we simply need a test case that we can wire up to Openshift CI to validate that a hosted cluster actually boots KubeVirt VMs successfully.

At the moment this test does the following.
- Posts a HostedCluster using the kubevirt provider
- Verifies the NodePool gets created as expected
- Verifies the KubeVirt Machines come online (meaning that the VMs boot, that's it)
- Verifies the KubeVirtCluster is ready

Unlike the AWS create cluster test, access to the guest cluster is not being exercised yet, and we aren't even verifying that the HostCluster reaches a completed state. This verification for the KubeVirt provider will come in time.
