### PR TITLE
Add support for control plane operator deployed from an OCP payload

### DIFF
--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -4,13 +4,9 @@ WORKDIR /hypershift
 
 COPY . .
 
-RUN make control-plane-operator ignition-server hosted-cluster-config-operator konnectivity-socks5-proxy availability-prober token-minter
+RUN make control-plane-operator
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
-COPY --from=builder /hypershift/bin/ignition-server /usr/bin/ignition-server
-COPY --from=builder /hypershift/bin/konnectivity-socks5-proxy /usr/bin/konnectivity-socks5-proxy
-COPY --from=builder /hypershift/bin/availability-prober /usr/bin/availability-prober
-COPY --from=builder /hypershift/bin/token-minter /usr/bin/token-minter
 
 ENTRYPOINT /usr/bin/control-plane-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -86,7 +86,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			HyperKube:             images["hyperkube"],
 			CLI:                   images["cli"],
 			ClusterConfigOperator: images["cluster-config-operator"],
-			TokenMinterImage:      images["hosted-cluster-config-operator"],
+			TokenMinterImage:      images["token-minter"],
 		},
 	}
 	if hcp.Spec.APIAdvertiseAddress != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -42,9 +42,8 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 		FeatureGate: globalConfig.FeatureGate,
 		// TODO: Come up with sane defaults for scheduling APIServer pods
 		// Expose configuration
-		HyperkubeImage: images["hyperkube"],
-		// TODO: HCCO is the Hypershift image which contains the token-minter binary.  Messy though.
-		TokenMinterImage:        images["hosted-cluster-config-operator"],
+		HyperkubeImage:          images["hyperkube"],
+		TokenMinterImage:        images["token-minter"],
 		Port:                    DefaultPort,
 		ServiceCIDR:             hcp.Spec.ServiceCIDR,
 		PodCIDR:                 hcp.Spec.PodCIDR,


### PR DESCRIPTION
This commit adds support for deploying the control-plane-operator from an OCP
payload. To enable this, the hypershift-operator has been updated to inspect the
release specified by a HostedCluster and, if a `hypershift` image is present in
the release metadata, that image will be used for the control-plane-operator.
Otherwise all the prior lookup behavior remains the same, so the code should be
compatible with all existing use cases and should work transparently when an OCP
payload containing hypershift is specified.

This commit also fixes the token minter, availability prober, and the socks
proxy deployments to ensure the are deployed by default from the hypershift
image instead of the control-plane-operator's image, as those components are
versioned independently of the control plane. A new control-plane-operator
`--token-minter-image` flag was added to support this.

Finally, this commit reduces the control plane image to include only the
control-plane-operator, which is the single component which will be shipped in
the OCP payload.