### PR TITLE
Fix update loops in hosted cluster config operator

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -28,8 +28,10 @@ import (
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const (
@@ -183,6 +185,9 @@ func (o *HostedClusterConfigOperator) Complete() error {
 }
 
 func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(), func(o *zap.Options) {
+		o.TimeEncoder = zapcore.RFC3339TimeEncoder
+	}))
 	versions := map[string]string{
 		"release":    o.ReleaseVersion,
 		"kubernetes": o.KubernetesVersion,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/clusteroperators.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/clusteroperators.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -255,7 +256,13 @@ func (r *reconciler) reconcileClusterOperators(ctx context.Context) error {
 
 func (r *reconciler) clusterOperatorStatus(coInfo ClusterOperatorInfo, currentStatus configv1.ClusterOperatorStatus) configv1.ClusterOperatorStatus {
 	status := configv1.ClusterOperatorStatus{}
-	for key, target := range coInfo.VersionMapping {
+	versionMappingKeys := make([]string, 0, len(coInfo.VersionMapping))
+	for key := range coInfo.VersionMapping {
+		versionMappingKeys = append(versionMappingKeys, key)
+	}
+	sort.Strings(versionMappingKeys)
+	for _, key := range versionMappingKeys {
+		target := coInfo.VersionMapping[key]
 		v, hasVersion := r.versions[target]
 		if !hasVersion {
 			continue

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/oapi/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/oapi/reconcile.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -22,6 +23,7 @@ func ReconcileAPIService(apiService *apiregistrationv1.APIService, svc *corev1.S
 		Service: &apiregistrationv1.ServiceReference{
 			Name:      svc.Name,
 			Namespace: svc.Namespace,
+			Port:      pointer.Int32(443),
 		},
 		VersionPriority: 15,
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -83,6 +84,9 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 			}, nil
 		},
 		NewCache: cache.BuilderWithOptions(cache.Options{
+			SelectorsByObject: cache.SelectorsByObject{
+				&corev1.Namespace{}: cache.ObjectSelector{Label: labels.Everything()},
+			},
 			DefaultSelector: cache.ObjectSelector{Label: cacheLabelSelector()},
 		}),
 		Scheme: api.Scheme,

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -223,6 +223,7 @@ func NewStartCommand() *cobra.Command {
 			ReleaseProvider:               releaseProvider,
 			HostedAPICache:                apiCacheController.GetCache(),
 			CreateOrUpdateProvider:        upsert.New(enableCIDebugOutput),
+			EnableCIDebugOutput:           enableCIDebugOutput,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")
 			os.Exit(1)

--- a/support/globalconfig/imagecontentsource.go
+++ b/support/globalconfig/imagecontentsource.go
@@ -20,9 +20,10 @@ func ImageContentSourcePolicy() *operatorv1alpha1.ImageContentSourcePolicy {
 }
 
 func ReconcileImageContentSourcePolicy(icsp *operatorv1alpha1.ImageContentSourcePolicy, hcp *hyperv1.HostedControlPlane) error {
-	icsp.Labels = map[string]string{
-		"machineconfiguration.openshift.io/role": "worker",
+	if icsp.Labels == nil {
+		icsp.Labels = map[string]string{}
 	}
+	icsp.Labels["machineconfiguration.openshift.io/role"] = "worker"
 	icsp.Spec.RepositoryDigestMirrors = []operatorv1alpha1.RepositoryDigestMirrors{}
 	for _, imageContentSourceEntry := range hcp.Spec.ImageContentSources {
 		icsp.Spec.RepositoryDigestMirrors = append(icsp.Spec.RepositoryDigestMirrors, operatorv1alpha1.RepositoryDigestMirrors{


### PR DESCRIPTION
Before this commit, the CPO was not passing the enable-ci-debug-output
flag to the hosted cluster config operator, so we were not detecting
update loops in CI. There were a few items causing update loops.

This PR enables loop dection for the hosted cluster config operator and
fixes resources that were causing update loops.