### PR TITLE
Change NodePool CLI to have platform sub command

### DIFF
--- a/cmd/log/log.go
+++ b/cmd/log/log.go
@@ -1,0 +1,9 @@
+package log
+
+import "github.com/openshift/hypershift/cmd/util"
+
+var log = util.Log
+
+func Error(err error, msg string, keysAndValues ...interface{}) {
+	log.Error(err, msg, keysAndValues)
+}

--- a/cmd/nodepool/aws/create.go
+++ b/cmd/nodepool/aws/create.go
@@ -1,0 +1,111 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/log"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type AWSPlatformCreateOptions struct {
+	InstanceProfile string
+	SubnetID        string
+	SecurityGroupID string
+	InstanceType    string
+	RootVolumeType  string
+	RootVolumeIOPS  int64
+	RootVolumeSize  int64
+}
+
+func NewCreateCommand(coreOpts core.CreateNodePoolOptions) *cobra.Command {
+	platformOpts := AWSPlatformCreateOptions{
+		InstanceType:   "m5.large",
+		RootVolumeType: "gp3",
+		RootVolumeSize: 120,
+		RootVolumeIOPS: 0,
+	}
+	cmd := &cobra.Command{
+		Use:          "aws",
+		Short:        "Creates basic functional NodePool resources for AWS platform",
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVar(&platformOpts.InstanceType, "instance-type", platformOpts.InstanceType, "The AWS instance type of the NodePool")
+	cmd.Flags().StringVar(&platformOpts.SubnetID, "subnet-id", platformOpts.SubnetID, "The AWS subnet ID in which to create the NodePool")
+	cmd.Flags().StringVar(&platformOpts.SecurityGroupID, "securitygroup-id", platformOpts.SecurityGroupID, "The AWS security group in which to create the NodePool")
+	cmd.Flags().StringVar(&platformOpts.InstanceProfile, "instance-profile", platformOpts.InstanceProfile, "The AWS instance profile for the NodePool")
+	cmd.Flags().StringVar(&platformOpts.RootVolumeType, "root-volume-type", platformOpts.RootVolumeType, "The type of the root volume (e.g. gp3, io2) for machines in the NodePool")
+	cmd.Flags().Int64Var(&platformOpts.RootVolumeIOPS, "root-volume-iops", platformOpts.RootVolumeIOPS, "The iops of the root volume for machines in the NodePool")
+	cmd.Flags().Int64Var(&platformOpts.RootVolumeSize, "root-volume-size", platformOpts.RootVolumeSize, "The size of the root volume (min: 8) for machines in the NodePool")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		if err := coreOpts.CreateNodePool(ctx, platformOpts); err != nil {
+			log.Error(err, "Failed to create nodepool")
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}
+
+func (o AWSPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
+	if len(o.InstanceProfile) == 0 {
+		o.InstanceProfile = fmt.Sprintf("%s-worker", hcluster.Spec.InfraID)
+	}
+	if len(o.SubnetID) == 0 {
+		if hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {
+			o.SubnetID = *hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID
+		} else {
+			return fmt.Errorf("subnet ID was not specified and cannot be determined from HostedCluster")
+		}
+	}
+	if len(o.SecurityGroupID) == 0 {
+		defaultNodePool := &hyperv1.NodePool{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: hcluster.Namespace, Name: hcluster.Name}, defaultNodePool); err != nil {
+			return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool: %v", err)
+		}
+		if defaultNodePool.Spec.Platform.AWS == nil || len(defaultNodePool.Spec.Platform.AWS.SecurityGroups) == 0 ||
+			defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID == nil {
+			return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool")
+		}
+		o.SecurityGroupID = *defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID
+	}
+	nodePool.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
+		InstanceType:    o.InstanceType,
+		InstanceProfile: o.InstanceProfile,
+		Subnet: &hyperv1.AWSResourceReference{
+			ID: &o.SubnetID,
+		},
+		SecurityGroups: []hyperv1.AWSResourceReference{
+			{
+				ID: &o.SecurityGroupID,
+			},
+		},
+		RootVolume: &hyperv1.Volume{
+			Type: o.RootVolumeType,
+			Size: o.RootVolumeSize,
+			IOPS: o.RootVolumeIOPS,
+		},
+	}
+	return nil
+}
+
+func (o AWSPlatformCreateOptions) Type() hyperv1.PlatformType {
+	return hyperv1.AWSPlatform
+}

--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -1,0 +1,102 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/util"
+	hyperapi "github.com/openshift/hypershift/support/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CreateNodePoolOptions struct {
+	Name         string
+	Namespace    string
+	ClusterName  string
+	NodeCount    int32
+	ReleaseImage string
+	Render       bool
+}
+
+type PlatformOptions interface {
+	// UpdateNodePool is used to update the platform specific values in the NodePool
+	UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error
+	// Type returns the platform type
+	Type() hyperv1.PlatformType
+}
+
+func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts PlatformOptions) error {
+	client := util.GetClientOrDie()
+
+	hcluster := &hyperv1.HostedCluster{}
+	err := client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.ClusterName}, hcluster)
+	if err != nil {
+		return fmt.Errorf("failed to get HostedCluster %s/%s: %w", o.Namespace, o.Name, err)
+	}
+
+	if platformOpts.Type() != hcluster.Spec.Platform.Type {
+		return fmt.Errorf("NodePool platform type %s must be HostedCluster type %s", platformOpts.Type(), hcluster.Spec.Platform.Type)
+	}
+
+	nodePool := &hyperv1.NodePool{}
+	err = client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, nodePool)
+	if err == nil && !o.Render {
+		return fmt.Errorf("NodePool %s/%s already exists", o.Namespace, o.Name)
+	}
+
+	var releaseImage string
+	if len(o.ReleaseImage) > 0 {
+		releaseImage = o.ReleaseImage
+	} else {
+		releaseImage = hcluster.Spec.Release.Image
+	}
+
+	nodePool = &hyperv1.NodePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NodePool",
+			APIVersion: hyperv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace,
+			Name:      o.Name,
+		},
+		Spec: hyperv1.NodePoolSpec{
+			Management: hyperv1.NodePoolManagement{
+				UpgradeType: hyperv1.UpgradeTypeReplace,
+			},
+			ClusterName: o.ClusterName,
+			NodeCount:   &o.NodeCount,
+			Release: hyperv1.Release{
+				Image: releaseImage,
+			},
+			Platform: hyperv1.NodePoolPlatform{
+				Type: hcluster.Spec.Platform.Type,
+			},
+		},
+	}
+
+	if err := platformOpts.UpdateNodePool(ctx, nodePool, hcluster, client); err != nil {
+		return err
+	}
+
+	if o.Render {
+		err := hyperapi.YamlSerializer.Encode(nodePool, os.Stdout)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("NodePool %s was rendered to yaml output file\n", o.Name)
+		return nil
+	}
+
+	err = client.Create(ctx, nodePool)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("NodePool %s created\n", o.Name)
+	return nil
+}

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -1,45 +1,16 @@
 package nodepool
 
 import (
-	"bytes"
-	"context"
-	"errors"
-	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-
 	"github.com/spf13/cobra"
 
-	hyperapi "github.com/openshift/hypershift/api"
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/cmd/util"
-
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	kubevirtv1 "kubevirt.io/api/core/v1"
-	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/nodepool/aws"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/openshift/hypershift/cmd/nodepool/kubevirt"
 )
 
-type CreateNodePoolOptions struct {
-	Name            string
-	Namespace       string
-	ClusterName     string
-	NodeCount       int32
-	ReleaseImage    string
-	InstanceType    string
-	SubnetID        string
-	SecurityGroupID string
-	InstanceProfile string
-	Render          bool
-	RootVolumeType  string
-	RootVolumeIOPS  int64
-	RootVolumeSize  int64
-	KubevirtMemory  string
-	KubevirtCPU     uint32
-	KubevirtImage   string
-}
+// The following lines are needed in order to validate that any platform implementing PlatformOptions satisfy the interface
+var _ core.PlatformOptions = aws.AWSPlatformCreateOptions{}
+var _ core.PlatformOptions = kubevirt.KubevirtPlatformCreateOptions{}
 
 func NewCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -48,20 +19,12 @@ func NewCreateCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	opts := CreateNodePoolOptions{
-		Name:           "example",
-		Namespace:      "clusters",
-		ClusterName:    "example",
-		NodeCount:      2,
-		ReleaseImage:   "",
-		InstanceType:   "m5.large",
-		RootVolumeType: "gp3",
-		RootVolumeSize: 120,
-		RootVolumeIOPS: 0,
-		// TODO (nargaman): Move kubevirt values into platform specific create file
-		KubevirtMemory: "4Gi",
-		KubevirtCPU:    2,
-		KubevirtImage:  "",
+	opts := core.CreateNodePoolOptions{
+		Name:         "example",
+		Namespace:    "clusters",
+		ClusterName:  "example",
+		NodeCount:    2,
+		ReleaseImage: "",
 	}
 
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "The name of the NodePool")
@@ -69,193 +32,11 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().Int32Var(&opts.NodeCount, "node-count", opts.NodeCount, "The number of nodes to create in the NodePool")
 	cmd.Flags().StringVar(&opts.ClusterName, "cluster-name", opts.ClusterName, "The name of the HostedCluster nodes in this pool will join")
 	cmd.Flags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes. If empty, defaults to the same release image as the HostedCluster.")
-	cmd.Flags().StringVar(&opts.InstanceType, "instance-type", opts.InstanceType, "The AWS instance type of the NodePool")
-	cmd.Flags().StringVar(&opts.SubnetID, "subnet-id", opts.SubnetID, "The AWS subnet ID in which to create the NodePool")
-	cmd.Flags().StringVar(&opts.SecurityGroupID, "securitygroup-id", opts.SecurityGroupID, "The AWS security group in which to create the NodePool")
-	cmd.Flags().StringVar(&opts.InstanceProfile, "instance-profile", opts.InstanceProfile, "The AWS instance profile for the NodePool")
 
 	cmd.Flags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying")
 
-	cmd.Flags().StringVar(&opts.RootVolumeType, "root-volume-type", opts.RootVolumeType, "The type of the root volume (e.g. gp3, io2) for machines in the NodePool")
-	cmd.Flags().Int64Var(&opts.RootVolumeIOPS, "root-volume-iops", opts.RootVolumeIOPS, "The iops of the root volume for machines in the NodePool")
-	cmd.Flags().Int64Var(&opts.RootVolumeSize, "root-volume-size", opts.RootVolumeSize, "The size of the root volume (min: 8) for machines in the NodePool")
-	cmd.Flags().StringVar(&opts.KubevirtMemory, "kubevirt-memory", opts.KubevirtMemory, "In KubeVirt platform - the amount of memory which is visible inside the Guest OS (type BinarySI, e.g. 5Gi, 100Mi)")
-	cmd.Flags().Uint32Var(&opts.KubevirtCPU, "kubevirt-cpu", opts.KubevirtCPU, "In KubeVirt platform - Cores specifies the number of cores inside the vmi, Must be a value greater or equal 1")
-	cmd.Flags().StringVar(&opts.KubevirtImage, "kubevirt-image", opts.KubevirtImage, "In KubeVirt platform - Image is a reference to docker image with the embedded disk to be used to create the machines")
-
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-		return opts.Run(ctx)
-	}
+	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
+	cmd.AddCommand(aws.NewCreateCommand(opts))
 
 	return cmd
-}
-
-func (o *CreateNodePoolOptions) Run(ctx context.Context) error {
-	client := util.GetClientOrDie()
-
-	hcluster := &hyperv1.HostedCluster{}
-	err := client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.ClusterName}, hcluster)
-	if err != nil {
-		return fmt.Errorf("failed to get HostedCluster %s/%s: %w", o.Namespace, o.Name, err)
-	}
-
-	nodePool := &hyperv1.NodePool{}
-	err = client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, nodePool)
-	if err == nil && !o.Render {
-		return fmt.Errorf("NodePool %s/%s already exists", o.Namespace, o.Name)
-	}
-
-	var releaseImage string
-	if len(o.ReleaseImage) > 0 {
-		releaseImage = o.ReleaseImage
-	} else {
-		releaseImage = hcluster.Spec.Release.Image
-	}
-
-	nodePool = &hyperv1.NodePool{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "NodePool",
-			APIVersion: hyperv1.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: o.Namespace,
-			Name:      o.Name,
-		},
-		Spec: hyperv1.NodePoolSpec{
-			Management: hyperv1.NodePoolManagement{
-				UpgradeType: hyperv1.UpgradeTypeReplace,
-			},
-			ClusterName: o.ClusterName,
-			NodeCount:   &o.NodeCount,
-			Release: hyperv1.Release{
-				Image: releaseImage,
-			},
-			Platform: hyperv1.NodePoolPlatform{
-				Type: hcluster.Spec.Platform.Type,
-			},
-		},
-	}
-
-	switch nodePool.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		if len(o.InstanceProfile) == 0 {
-			o.InstanceProfile = fmt.Sprintf("%s-worker", hcluster.Spec.InfraID)
-		}
-		if len(o.SubnetID) == 0 {
-			if hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {
-				o.SubnetID = *hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID
-			} else {
-				return fmt.Errorf("subnet ID was not specified and cannot be determined from HostedCluster")
-			}
-		}
-		if len(o.SecurityGroupID) == 0 {
-			defaultNodePool := &hyperv1.NodePool{}
-			if err := client.Get(ctx, types.NamespacedName{Namespace: hcluster.Namespace, Name: hcluster.Name}, defaultNodePool); err != nil {
-				return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool: %v", err)
-			}
-			if defaultNodePool.Spec.Platform.AWS == nil || len(defaultNodePool.Spec.Platform.AWS.SecurityGroups) == 0 ||
-				defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID == nil {
-				return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool")
-			}
-			o.SecurityGroupID = *defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID
-		}
-		nodePool.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
-			InstanceType:    o.InstanceType,
-			InstanceProfile: o.InstanceProfile,
-			Subnet: &hyperv1.AWSResourceReference{
-				ID: &o.SubnetID,
-			},
-			SecurityGroups: []hyperv1.AWSResourceReference{
-				{
-					ID: &o.SecurityGroupID,
-				},
-			},
-			RootVolume: &hyperv1.Volume{
-				Type: o.RootVolumeType,
-				Size: o.RootVolumeSize,
-				IOPS: o.RootVolumeIOPS,
-			},
-		}
-	case hyperv1.KubevirtPlatform:
-		// TODO (nargaman): replace with official container image, after RFE-2501 is completed
-		// As long as there is no official container image
-		// The image must be provided by user
-		// Otherwise it must fail
-		if o.KubevirtImage == "" {
-			return errors.New("the image for the Kubevirt machine must be provided by user (\"--kubevirt-image\" flag")
-		}
-		runAlways := kubevirtv1.RunStrategyAlways
-		guestQuantity := apiresource.MustParse(o.KubevirtMemory)
-		nodePool.Spec.Platform.Kubevirt = &hyperv1.KubevirtNodePoolPlatform{
-			NodeTemplate: &capikubevirt.VirtualMachineTemplateSpec{
-				Spec: kubevirtv1.VirtualMachineSpec{
-					RunStrategy: &runAlways,
-					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-						Spec: kubevirtv1.VirtualMachineInstanceSpec{
-							Domain: kubevirtv1.DomainSpec{
-								CPU:    &kubevirtv1.CPU{Cores: o.KubevirtCPU},
-								Memory: &kubevirtv1.Memory{Guest: &guestQuantity},
-								Devices: kubevirtv1.Devices{
-									Disks: []kubevirtv1.Disk{
-										{
-											Name: "containervolume",
-											DiskDevice: kubevirtv1.DiskDevice{
-												Disk: &kubevirtv1.DiskTarget{
-													Bus: "virtio",
-												},
-											},
-										},
-									},
-								},
-							},
-							Volumes: []kubevirtv1.Volume{
-								{
-									Name: "containervolume",
-									VolumeSource: kubevirtv1.VolumeSource{
-										ContainerDisk: &kubevirtv1.ContainerDiskSource{
-											Image: o.KubevirtImage,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-
-	if o.Render {
-		err := hyperapi.YamlSerializer.Encode(nodePool, os.Stdout)
-		if err != nil {
-			panic(err)
-		}
-		return nil
-	}
-
-	var nodePoolBytes bytes.Buffer
-	err = hyperapi.YamlSerializer.Encode(nodePool, &nodePoolBytes)
-	if err != nil {
-		return err
-	}
-
-	if o.Render {
-		_, err = nodePoolBytes.WriteTo(os.Stdout)
-		return err
-	}
-
-	err = client.Create(ctx, nodePool)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("NodePool %s created\n", o.Name)
-	return nil
 }

--- a/cmd/nodepool/kubevirt/create.go
+++ b/cmd/nodepool/kubevirt/create.go
@@ -1,0 +1,110 @@
+package kubevirt
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/log"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/spf13/cobra"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type KubevirtPlatformCreateOptions struct {
+	Memory             string
+	Cores              uint32
+	ContainerDiskImage string
+}
+
+func NewCreateCommand(coreOpts core.CreateNodePoolOptions) *cobra.Command {
+	platformOpts := KubevirtPlatformCreateOptions{
+		Memory:             "4Gi",
+		Cores:              2,
+		ContainerDiskImage: "",
+	}
+	cmd := &cobra.Command{
+		Use:          "kubevirt",
+		Short:        "Creates basic functional NodePool resources for KubeVirt platform",
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVar(&platformOpts.Memory, "memory", platformOpts.Memory, "The amount of memory which is visible inside the Guest OS (type BinarySI, e.g. 5Gi, 100Mi)")
+	cmd.Flags().Uint32Var(&platformOpts.Cores, "cores", platformOpts.Cores, "The number of cores inside the vmi, Must be a value greater or equal 1")
+	cmd.Flags().StringVar(&platformOpts.ContainerDiskImage, "containerdisk", platformOpts.ContainerDiskImage, "A reference to docker image with the embedded disk to be used to create the machines")
+
+	// TODO (nargaman): replace with official container image, after RFE-2501 is completed
+	// As long as there is no official container image
+	// The image must be provided by user
+	// Otherwise it must fail
+	cmd.MarkFlagRequired("containerdisk")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		if err := coreOpts.CreateNodePool(ctx, platformOpts); err != nil {
+			log.Error(err, "Failed to create nodepool")
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}
+
+func (o KubevirtPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
+	runAlways := kubevirtv1.RunStrategyAlways
+	guestQuantity := apiresource.MustParse(o.Memory)
+	nodePool.Spec.Platform.Kubevirt = &hyperv1.KubevirtNodePoolPlatform{
+		NodeTemplate: &capikubevirt.VirtualMachineTemplateSpec{
+			Spec: kubevirtv1.VirtualMachineSpec{
+				RunStrategy: &runAlways,
+				Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							CPU:    &kubevirtv1.CPU{Cores: o.Cores},
+							Memory: &kubevirtv1.Memory{Guest: &guestQuantity},
+							Devices: kubevirtv1.Devices{
+								Disks: []kubevirtv1.Disk{
+									{
+										Name: "containervolume",
+										DiskDevice: kubevirtv1.DiskDevice{
+											Disk: &kubevirtv1.DiskTarget{
+												Bus: "virtio",
+											},
+										},
+									},
+								},
+							},
+						},
+						Volumes: []kubevirtv1.Volume{
+							{
+								Name: "containervolume",
+								VolumeSource: kubevirtv1.VolumeSource{
+									ContainerDisk: &kubevirtv1.ContainerDiskSource{
+										Image: o.ContainerDiskImage,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return nil
+}
+
+func (o KubevirtPlatformCreateOptions) Type() hyperv1.PlatformType {
+	return hyperv1.KubevirtPlatform
+}

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -132,7 +132,8 @@ NODEPOOL_NAME=${CLUSTER_NAME}-work
 INSTANCE_TYPE=m5.2xlarge
 NODEPOOL_REPLICAS=2
 
-hypershift create nodepool --cluster-name $CLUSTER_NAME \
+hypershift create nodepool aws \
+  --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
   --node-count $NODEPOOL_REPLICAS \
   --instance-type $INSTANCE_TYPE


### PR DESCRIPTION
Change the NodePool CLI to be platform aware
This change is done as part of the multy platform support,
to allow the CLI to provide platform specific UX where needed