### PR TITLE
Refactor code to reconcile Machine templates

### DIFF
--- a/hypershift-operator/controllers/nodepool/agent.go
+++ b/hypershift-operator/controllers/nodepool/agent.go
@@ -1,31 +1,13 @@
 package nodepool
 
 import (
-	"fmt"
-
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func AgentMachineTemplate(nodePool *hyperv1.NodePool, controlPlaneNamespace string) *agentv1.AgentMachineTemplate {
-	agentMachineTemplate := &agentv1.AgentMachineTemplate{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				nodePoolAnnotation: ctrlclient.ObjectKeyFromObject(nodePool).String(),
-			},
-			Namespace: controlPlaneNamespace,
-		},
-		Spec: agentv1.AgentMachineTemplateSpec{
-			Template: agentv1.AgentMachineTemplateResource{
-				Spec: agentv1.AgentMachineSpec{},
-			},
+func agentMachineTemplateSpec() *agentv1.AgentMachineTemplateSpec {
+	return &agentv1.AgentMachineTemplateSpec{
+		Template: agentv1.AgentMachineTemplateResource{
+			Spec: agentv1.AgentMachineSpec{},
 		},
 	}
-	specHash := hashStruct(agentMachineTemplate.Spec.Template.Spec)
-	agentMachineTemplate.SetName(fmt.Sprintf("%s-%s", nodePool.GetName(), specHash))
-
-	return agentMachineTemplate
 }

--- a/hypershift-operator/controllers/nodepool/aws.go
+++ b/hypershift-operator/controllers/nodepool/aws.go
@@ -1,0 +1,94 @@
+package nodepool
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	k8sutilspointer "k8s.io/utils/pointer"
+	capiaws "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+)
+
+func awsMachineTemplateSpec(infraName, ami string, hostedCluster *hyperv1.HostedCluster, nodePool *hyperv1.NodePool) *capiaws.AWSMachineTemplateSpec {
+	subnet := &capiaws.AWSResourceReference{}
+	if nodePool.Spec.Platform.AWS.Subnet != nil {
+		subnet.ID = nodePool.Spec.Platform.AWS.Subnet.ID
+		subnet.ARN = nodePool.Spec.Platform.AWS.Subnet.ARN
+		for k := range nodePool.Spec.Platform.AWS.Subnet.Filters {
+			filter := capiaws.Filter{
+				Name:   nodePool.Spec.Platform.AWS.Subnet.Filters[k].Name,
+				Values: nodePool.Spec.Platform.AWS.Subnet.Filters[k].Values,
+			}
+			subnet.Filters = append(subnet.Filters, filter)
+		}
+	}
+	rootVolume := &capiaws.Volume{
+		Size: EC2VolumeDefaultSize,
+	}
+	if nodePool.Spec.Platform.AWS.RootVolume != nil {
+		if nodePool.Spec.Platform.AWS.RootVolume.Type != "" {
+			rootVolume.Type = capiaws.VolumeType(nodePool.Spec.Platform.AWS.RootVolume.Type)
+		} else {
+			rootVolume.Type = capiaws.VolumeType(EC2VolumeDefaultType)
+		}
+		if nodePool.Spec.Platform.AWS.RootVolume.Size > 0 {
+			rootVolume.Size = nodePool.Spec.Platform.AWS.RootVolume.Size
+		}
+		if nodePool.Spec.Platform.AWS.RootVolume.IOPS > 0 {
+			rootVolume.IOPS = nodePool.Spec.Platform.AWS.RootVolume.IOPS
+		}
+	}
+
+	securityGroups := []capiaws.AWSResourceReference{}
+	for _, sg := range nodePool.Spec.Platform.AWS.SecurityGroups {
+		filters := []capiaws.Filter{}
+		for _, f := range sg.Filters {
+			filters = append(filters, capiaws.Filter{
+				Name:   f.Name,
+				Values: f.Values,
+			})
+		}
+		securityGroups = append(securityGroups, capiaws.AWSResourceReference{
+			ARN:     sg.ARN,
+			ID:      sg.ID,
+			Filters: filters,
+		})
+	}
+
+	instanceProfile := fmt.Sprintf("%s-worker-profile", infraName)
+	if nodePool.Spec.Platform.AWS.InstanceProfile != "" {
+		instanceProfile = nodePool.Spec.Platform.AWS.InstanceProfile
+	}
+
+	instanceType := nodePool.Spec.Platform.AWS.InstanceType
+
+	var tags capiaws.Tags
+	for _, tag := range append(nodePool.Spec.Platform.AWS.ResourceTags, hostedCluster.Spec.Platform.AWS.ResourceTags...) {
+		if tags == nil {
+			tags = capiaws.Tags{}
+		}
+		tags[tag.Key] = tag.Value
+	}
+
+	awsMachineTemplateSpec := &capiaws.AWSMachineTemplateSpec{
+		Template: capiaws.AWSMachineTemplateResource{
+			Spec: capiaws.AWSMachineSpec{
+				UncompressedUserData: k8sutilspointer.BoolPtr(true),
+				CloudInit: capiaws.CloudInit{
+					InsecureSkipSecretsManager: true,
+					SecureSecretsBackend:       "secrets-manager",
+				},
+				IAMInstanceProfile: instanceProfile,
+				InstanceType:       instanceType,
+				AMI: capiaws.AMIReference{
+					ID: k8sutilspointer.StringPtr(ami),
+				},
+				AdditionalSecurityGroups: securityGroups,
+				Subnet:                   subnet,
+				RootVolume:               rootVolume,
+				AdditionalTags:           tags,
+			},
+		},
+	}
+
+	return awsMachineTemplateSpec
+}

--- a/hypershift-operator/controllers/nodepool/aws_test.go
+++ b/hypershift-operator/controllers/nodepool/aws_test.go
@@ -100,9 +100,9 @@ func TestAWSMachineTemplate(t *testing.T) {
 			if tc.nodePool.Platform.AWS == nil {
 				tc.nodePool.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
 			}
-			result, _ := AWSMachineTemplate("testi", amiName, &hyperv1.HostedCluster{Spec: tc.cluster}, &hyperv1.NodePool{Spec: tc.nodePool}, "test")
-			if !equality.Semantic.DeepEqual(tc.expected.Spec, result.Spec) {
-				t.Errorf(cmp.Diff(tc.expected.Spec, result.Spec))
+			result := awsMachineTemplateSpec("testi", amiName, &hyperv1.HostedCluster{Spec: tc.cluster}, &hyperv1.NodePool{Spec: tc.nodePool})
+			if !equality.Semantic.DeepEqual(&tc.expected.Spec, result) {
+				t.Errorf(cmp.Diff(tc.expected.Spec, result))
 			}
 		})
 	}

--- a/hypershift-operator/controllers/nodepool/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt.go
@@ -1,78 +1,16 @@
 package nodepool
 
 import (
-	"context"
-	"fmt"
-
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	ctrl "sigs.k8s.io/controller-runtime"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r NodePoolReconciler) reconcileKubevirtMachineTemplate(ctx context.Context,
-	nodePool *hyperv1.NodePool,
-	controlPlaneNamespace string,
-) (*capikubevirt.KubevirtMachineTemplate, error) {
-
-	log := ctrl.LoggerFrom(ctx)
-	// Get target template and hash.
-	targetKubevirtMachineTemplate, targetTemplateHash := kubevirtMachineTemplate(nodePool, controlPlaneNamespace)
-
-	// Get current template and hash.
-	currentTemplateHash := nodePool.GetAnnotations()[nodePoolAnnotationCurrentProviderConfig]
-	currentKubevirtMachineTemplate := &capikubevirt.KubevirtMachineTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", nodePool.GetName(), currentTemplateHash),
-			Namespace: controlPlaneNamespace,
-		},
-	}
-	if err := r.Get(ctx, ctrlclient.ObjectKeyFromObject(currentKubevirtMachineTemplate), currentKubevirtMachineTemplate); err != nil && !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("error getting existing KubevirtMachineTemplate: %w", err)
-	}
-
-	if equality.Semantic.DeepEqual(currentKubevirtMachineTemplate.Spec.Template.Spec, targetKubevirtMachineTemplate.Spec.Template.Spec) {
-		return currentKubevirtMachineTemplate, nil
-	}
-
-	// Otherwise create new template.
-	log.Info("The KubevirtMachineTemplate referenced by this NodePool has changed. Creating a new one")
-	if err := r.Create(ctx, targetKubevirtMachineTemplate); err != nil {
-		return nil, fmt.Errorf("error creating new KubevirtMachineTemplate: %w", err)
-	}
-
-	// Store new template hash.
-	if nodePool.Annotations == nil {
-		nodePool.Annotations = make(map[string]string)
-	}
-	nodePool.Annotations[nodePoolAnnotationCurrentProviderConfig] = targetTemplateHash
-
-	return targetKubevirtMachineTemplate, nil
-}
-
-func kubevirtMachineTemplate(nodePool *hyperv1.NodePool, controlPlaneNamespace string) (*capikubevirt.KubevirtMachineTemplate, string) {
-	kubevirtPlatform := nodePool.Spec.Platform.Kubevirt
-	kubevirtMachineTemplate := &capikubevirt.KubevirtMachineTemplate{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				nodePoolAnnotation: ctrlclient.ObjectKeyFromObject(nodePool).String(),
-			},
-			Namespace: controlPlaneNamespace,
-		},
-		Spec: capikubevirt.KubevirtMachineTemplateSpec{
-			Template: capikubevirt.KubevirtMachineTemplateResource{
-				Spec: capikubevirt.KubevirtMachineSpec{
-					VirtualMachineTemplate: *kubevirtPlatform.NodeTemplate,
-				},
+func kubevirtMachineTemplateSpec(nodePool *hyperv1.NodePool) *capikubevirt.KubevirtMachineTemplateSpec {
+	return &capikubevirt.KubevirtMachineTemplateSpec{
+		Template: capikubevirt.KubevirtMachineTemplateResource{
+			Spec: capikubevirt.KubevirtMachineSpec{
+				VirtualMachineTemplate: *nodePool.Spec.Platform.Kubevirt.NodeTemplate,
 			},
 		},
 	}
-	specHash := hashStruct(kubevirtMachineTemplate.Spec.Template.Spec)
-	kubevirtMachineTemplate.SetName(fmt.Sprintf("%s-%s", nodePool.GetName(), specHash))
-
-	return kubevirtMachineTemplate, specHash
 }

--- a/hypershift-operator/controllers/nodepool/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt_test.go
@@ -15,7 +15,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 	testCases := []struct {
 		name     string
 		nodePool *hyperv1.NodePool
-		expected capikubevirt.KubevirtMachineTemplateSpec
+		expected *capikubevirt.KubevirtMachineTemplateSpec
 	}{
 		{
 			name: "happy flow",
@@ -36,7 +36,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 				},
 			},
 
-			expected: capikubevirt.KubevirtMachineTemplateSpec{
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
 				Template: capikubevirt.KubevirtMachineTemplateResource{
 					Spec: capikubevirt.KubevirtMachineSpec{
 						VirtualMachineTemplate: *generateNodeTemplate("5Gi", 4, "testimage"),
@@ -47,9 +47,9 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, _ := kubevirtMachineTemplate(tc.nodePool, "testNamespace")
-			if !equality.Semantic.DeepEqual(tc.expected, result.Spec) {
-				t.Errorf(cmp.Diff(tc.expected, result.Spec))
+			result := kubevirtMachineTemplateSpec(tc.nodePool)
+			if !equality.Semantic.DeepEqual(tc.expected, result) {
+				t.Errorf(cmp.Diff(tc.expected, result))
 			}
 		})
 	}

--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -6,10 +6,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sutilspointer "k8s.io/utils/pointer"
-	capiaws "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -35,102 +32,6 @@ func machineHealthCheck(nodePool *hyperv1.NodePool, controlPlaneNamespace string
 			Namespace: controlPlaneNamespace,
 		},
 	}
-}
-
-func AWSMachineTemplate(infraName, ami string, hostedCluster *hyperv1.HostedCluster, nodePool *hyperv1.NodePool, controlPlaneNamespace string) (*capiaws.AWSMachineTemplate, string) {
-	subnet := &capiaws.AWSResourceReference{}
-	if nodePool.Spec.Platform.AWS.Subnet != nil {
-		subnet.ID = nodePool.Spec.Platform.AWS.Subnet.ID
-		subnet.ARN = nodePool.Spec.Platform.AWS.Subnet.ARN
-		for k := range nodePool.Spec.Platform.AWS.Subnet.Filters {
-			filter := capiaws.Filter{
-				Name:   nodePool.Spec.Platform.AWS.Subnet.Filters[k].Name,
-				Values: nodePool.Spec.Platform.AWS.Subnet.Filters[k].Values,
-			}
-			subnet.Filters = append(subnet.Filters, filter)
-		}
-	}
-	rootVolume := &capiaws.Volume{
-		Size: EC2VolumeDefaultSize,
-	}
-	if nodePool.Spec.Platform.AWS.RootVolume != nil {
-		if nodePool.Spec.Platform.AWS.RootVolume.Type != "" {
-			rootVolume.Type = capiaws.VolumeType(nodePool.Spec.Platform.AWS.RootVolume.Type)
-		} else {
-			rootVolume.Type = capiaws.VolumeType(EC2VolumeDefaultType)
-		}
-		if nodePool.Spec.Platform.AWS.RootVolume.Size > 0 {
-			rootVolume.Size = nodePool.Spec.Platform.AWS.RootVolume.Size
-		}
-		if nodePool.Spec.Platform.AWS.RootVolume.IOPS > 0 {
-			rootVolume.IOPS = nodePool.Spec.Platform.AWS.RootVolume.IOPS
-		}
-	}
-
-	securityGroups := []capiaws.AWSResourceReference{}
-	for _, sg := range nodePool.Spec.Platform.AWS.SecurityGroups {
-		filters := []capiaws.Filter{}
-		for _, f := range sg.Filters {
-			filters = append(filters, capiaws.Filter{
-				Name:   f.Name,
-				Values: f.Values,
-			})
-		}
-		securityGroups = append(securityGroups, capiaws.AWSResourceReference{
-			ARN:     sg.ARN,
-			ID:      sg.ID,
-			Filters: filters,
-		})
-	}
-
-	instanceProfile := fmt.Sprintf("%s-worker-profile", infraName)
-	if nodePool.Spec.Platform.AWS.InstanceProfile != "" {
-		instanceProfile = nodePool.Spec.Platform.AWS.InstanceProfile
-	}
-
-	instanceType := nodePool.Spec.Platform.AWS.InstanceType
-
-	var tags capiaws.Tags
-	for _, tag := range append(nodePool.Spec.Platform.AWS.ResourceTags, hostedCluster.Spec.Platform.AWS.ResourceTags...) {
-		if tags == nil {
-			tags = capiaws.Tags{}
-		}
-		tags[tag.Key] = tag.Value
-	}
-
-	awsMachineTemplate := &capiaws.AWSMachineTemplate{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				nodePoolAnnotation: ctrlclient.ObjectKeyFromObject(nodePool).String(),
-			},
-			Namespace: controlPlaneNamespace,
-		},
-		Spec: capiaws.AWSMachineTemplateSpec{
-			Template: capiaws.AWSMachineTemplateResource{
-				Spec: capiaws.AWSMachineSpec{
-					UncompressedUserData: k8sutilspointer.BoolPtr(true),
-					CloudInit: capiaws.CloudInit{
-						InsecureSkipSecretsManager: true,
-						SecureSecretsBackend:       "secrets-manager",
-					},
-					IAMInstanceProfile: instanceProfile,
-					InstanceType:       instanceType,
-					AMI: capiaws.AMIReference{
-						ID: k8sutilspointer.StringPtr(ami),
-					},
-					AdditionalSecurityGroups: securityGroups,
-					Subnet:                   subnet,
-					RootVolume:               rootVolume,
-					AdditionalTags:           tags,
-				},
-			},
-		},
-	}
-	specHash := hashStruct(awsMachineTemplate.Spec.Template.Spec)
-	awsMachineTemplate.SetName(fmt.Sprintf("%s-%s", nodePool.GetName(), specHash))
-
-	return awsMachineTemplate, specHash
 }
 
 func IgnitionUserDataSecret(namespace, name, payloadInputHash string) *corev1.Secret {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
-
 	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/operator/v1alpha1"
+	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
 	api "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -33,7 +33,6 @@ import (
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,6 +44,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	k8sutilspointer "k8s.io/utils/pointer"
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -59,18 +59,18 @@ import (
 )
 
 const (
-	finalizer                               = "hypershift.openshift.io/finalizer"
-	autoscalerMaxAnnotation                 = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
-	autoscalerMinAnnotation                 = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
-	nodePoolAnnotation                      = "hypershift.openshift.io/nodePool"
-	nodePoolAnnotationCurrentConfig         = "hypershift.openshift.io/nodePoolCurrentConfig"
-	nodePoolAnnotationCurrentConfigVersion  = "hypershift.openshift.io/nodePoolCurrentConfigVersion"
-	nodePoolAnnotationCurrentProviderConfig = "hypershift.openshift.io/nodePoolCurrentProviderConfig"
-	nodePoolCoreIgnitionConfigLabel         = "hypershift.openshift.io/core-ignition-config"
-	TokenSecretReleaseKey                   = "release"
-	TokenSecretTokenKey                     = "token"
-	TokenSecretConfigKey                    = "config"
-	TokenSecretAnnotation                   = "hypershift.openshift.io/ignition-config"
+	finalizer                                 = "hypershift.openshift.io/finalizer"
+	autoscalerMaxAnnotation                   = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
+	autoscalerMinAnnotation                   = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
+	nodePoolAnnotation                        = "hypershift.openshift.io/nodePool"
+	nodePoolAnnotationCurrentConfig           = "hypershift.openshift.io/nodePoolCurrentConfig"
+	nodePoolAnnotationCurrentConfigVersion    = "hypershift.openshift.io/nodePoolCurrentConfigVersion"
+	nodePoolAnnotationPlatformMachineTemplate = "hypershift.openshift.io/nodePoolPlatformMachineTemplate"
+	nodePoolCoreIgnitionConfigLabel           = "hypershift.openshift.io/core-ignition-config"
+	TokenSecretReleaseKey                     = "release"
+	TokenSecretTokenKey                       = "token"
+	TokenSecretConfigKey                      = "config"
+	TokenSecretAnnotation                     = "hypershift.openshift.io/ignition-config"
 )
 
 type NodePoolReconciler struct {
@@ -510,33 +510,6 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		nodePool.Annotations = make(map[string]string)
 	}
 
-	var machineTemplate client.Object
-	switch nodePool.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		machineTemplate, err = r.reconcileAWSMachineTemplate(ctx, hcluster, nodePool, infraID, ami, controlPlaneNamespace)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile AWSMachineTemplate: %w", err)
-		}
-		span.AddEvent("reconciled awsmachinetemplate", trace.WithAttributes(attribute.String("name", machineTemplate.GetName())))
-	case hyperv1.AgentPlatform:
-		machineTemplate = AgentMachineTemplate(nodePool, controlPlaneNamespace)
-		if err := r.Get(ctx, client.ObjectKeyFromObject(machineTemplate), machineTemplate); err != nil {
-			if apierrors.IsNotFound(err) {
-				if createErr := r.Create(ctx, machineTemplate); createErr != nil {
-					return ctrl.Result{}, fmt.Errorf("failed to create AgentMachineTemplate: %w", err)
-				}
-			} else {
-				return ctrl.Result{}, fmt.Errorf("failed to get AgentMachineTemplate: %w", err)
-			}
-		}
-	case hyperv1.KubevirtPlatform:
-		machineTemplate, err = r.reconcileKubevirtMachineTemplate(ctx, nodePool, controlPlaneNamespace)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile KubevirtMachineTemplate: %w", err)
-		}
-		span.AddEvent("reconciled kubevirtmachinetemplate", trace.WithAttributes(attribute.String("name", machineTemplate.GetName())))
-	}
-
 	// non automated infrastructure should not have any machine level cluster-api components
 	if !isAutomatedMachineManagement(nodePool) {
 		nodePool.Status.Version = targetVersion
@@ -551,15 +524,30 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion] = targetConfigVersionHash
 		return ctrl.Result{}, nil
 	}
+
+	// Reconcile (Platform)MachineTemplate.
+	template, mutateTemplate, machineTemplateSpecJSON, err := machineTemplateBuilders(hcluster, nodePool, infraID, ami)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if result, err := r.CreateOrUpdate(ctx, r.Client, template, func() error {
+		return mutateTemplate(template)
+	}); err != nil {
+		return ctrl.Result{}, err
+	} else {
+		log.Info("Reconciled Machine template", "result", result)
+		span.AddEvent("reconciled machinetemplate", trace.WithAttributes(attribute.String("result", string(result))))
+	}
+
 	md := machineDeployment(nodePool, infraID, controlPlaneNamespace)
 	if result, err := controllerutil.CreateOrPatch(ctx, r.Client, md, func() error {
 		return r.reconcileMachineDeployment(
 			log,
 			md, nodePool,
 			userDataSecret,
-			machineTemplate,
+			template,
 			infraID,
-			targetVersion, targetConfigHash, targetConfigVersionHash)
+			targetVersion, targetConfigHash, targetConfigVersionHash, machineTemplateSpecJSON)
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile MachineDeployment %q: %w",
 			client.ObjectKeyFromObject(md).String(), err)
@@ -567,6 +555,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		log.Info("Reconciled MachineDeployment", "result", result)
 		span.AddEvent("reconciled machinedeployment", trace.WithAttributes(attribute.String("result", string(result))))
 	}
+
 	mhc := machineHealthCheck(nodePool, controlPlaneNamespace)
 	if nodePool.Spec.Management.AutoRepair {
 		if result, err := ctrl.CreateOrUpdate(ctx, r.Client, mhc, func() error {
@@ -598,54 +587,6 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		})
 	}
 	return ctrl.Result{}, nil
-}
-
-func (r NodePoolReconciler) reconcileAWSMachineTemplate(ctx context.Context,
-	hostedCluster *hyperv1.HostedCluster,
-	nodePool *hyperv1.NodePool,
-	infraID string,
-	ami string,
-	controlPlaneNamespace string,
-) (*capiaws.AWSMachineTemplate, error) {
-
-	log := ctrl.LoggerFrom(ctx)
-	// Get target template and hash.
-	targetAWSMachineTemplate, targetTemplateHash := AWSMachineTemplate(infraID, ami, hostedCluster, nodePool, controlPlaneNamespace)
-
-	// Get current template and hash.
-	currentTemplateHash := nodePool.GetAnnotations()[nodePoolAnnotationCurrentProviderConfig]
-	currentAWSMachineTemplate := &capiaws.AWSMachineTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", nodePool.GetName(), currentTemplateHash),
-			Namespace: controlPlaneNamespace,
-		},
-	}
-	if err := r.Get(ctx, client.ObjectKeyFromObject(currentAWSMachineTemplate), currentAWSMachineTemplate); err != nil && !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("error getting existing AWSMachineTemplate: %w", err)
-	}
-
-	// Template has not changed, return early.
-	// TODO(alberto): can we hash in a deterministic way so we could just compare hashes?
-	if equality.Semantic.DeepEqual(currentAWSMachineTemplate.Spec.Template.Spec, targetAWSMachineTemplate.Spec.Template.Spec) {
-		return currentAWSMachineTemplate, nil
-	}
-
-	// Otherwise create new template.
-	log.Info("The AWSMachineTemplate referenced by this NodePool has changed. Creating a new one")
-	if err := r.Create(ctx, targetAWSMachineTemplate); err != nil {
-		return nil, fmt.Errorf("error creating new AWSMachineTemplate: %w", err)
-	}
-
-	// TODO (alberto): Create a mechanism to cleanup old machineTemplates.
-	// We can't just delete the old AWSMachineTemplate because
-	// this would break the rolling upgrade process since the MachineSet
-	// being scaled down is still referencing the old AWSMachineTemplate.
-	// May be consider one single template the whole NodePool lifecycle. Modify it in place
-	// and trigger rolling update by e.g annotating the machineDeployment.
-
-	nodePool.Annotations[nodePoolAnnotationCurrentProviderConfig] = targetTemplateHash
-
-	return targetAWSMachineTemplate, nil
 }
 
 func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.NodePool, CA, token []byte, ignEndpoint string) error {
@@ -699,7 +640,7 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 	machineTemplateCR client.Object,
 	CAPIClusterName string,
 	targetVersion,
-	targetConfigHash, targetConfigVersionHash string) error {
+	targetConfigHash, targetConfigVersionHash, machineTemplateSpecJSON string) error {
 
 	// Set annotations and labels
 	if machineDeployment.GetAnnotations() == nil {
@@ -730,6 +671,11 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 			Labels: map[string]string{
 				resourcesName:           resourcesName,
 				capiv1.ClusterLabelName: CAPIClusterName,
+			},
+			Annotations: map[string]string{
+				// TODO (alberto): Use conditions to signal an in progress rolling upgrade
+				// similar to what we do with nodePoolAnnotationCurrentConfig
+				nodePoolAnnotationPlatformMachineTemplate: machineTemplateSpecJSON, // This will trigger a deployment rolling upgrade when its value changes.
 			},
 		},
 
@@ -1325,4 +1271,54 @@ func isIBMUPI(nodePool *hyperv1.NodePool) bool {
 
 func isPlatformNone(nodePool *hyperv1.NodePool) bool {
 	return nodePool.Spec.Platform.Type == hyperv1.NonePlatform
+}
+
+// machineTemplateBuilders returns a client.Object with a particular (platform)MachineTemplate type.
+// a func to mutate the (platform)MachineTemplate.spec, a json string representation for (platform)MachineTemplate.spec
+// and an error.
+func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.NodePool,
+	infraID, ami string) (client.Object, func(object client.Object) error, string, error) {
+	var mutateTemplate func(object client.Object) error
+	var template client.Object
+	var machineTemplateSpec interface{}
+
+	switch nodePool.Spec.Platform.Type {
+	// Define the desired template type and mutateTemplate function.
+	case hyperv1.AWSPlatform:
+		template = &capiaws.AWSMachineTemplate{}
+		machineTemplateSpec = awsMachineTemplateSpec(infraID, ami, hcluster, nodePool)
+		mutateTemplate = func(object client.Object) error {
+			o, _ := object.(*capiaws.AWSMachineTemplate)
+			o.Spec = *machineTemplateSpec.(*capiaws.AWSMachineTemplateSpec)
+			return nil
+		}
+	case hyperv1.AgentPlatform:
+		template = &agentv1.AgentMachineTemplate{}
+		machineTemplateSpec = agentMachineTemplateSpec()
+		mutateTemplate = func(object client.Object) error {
+			o, _ := object.(*agentv1.AgentMachineTemplate)
+			o.Spec = *machineTemplateSpec.(*agentv1.AgentMachineTemplateSpec)
+			return nil
+		}
+	case hyperv1.KubevirtPlatform:
+		template = &capikubevirt.KubevirtMachineTemplate{}
+		machineTemplateSpec = kubevirtMachineTemplateSpec(nodePool)
+		mutateTemplate = func(object client.Object) error {
+			o, _ := object.(*capikubevirt.KubevirtMachineTemplate)
+			o.Spec = *machineTemplateSpec.(*capikubevirt.KubevirtMachineTemplateSpec)
+			return nil
+		}
+	default:
+		// TODO(alberto): Consider signal in a condition.
+		return nil, nil, "", fmt.Errorf("unsupported platform type: %s", nodePool.Spec.Platform.Type)
+	}
+	template.SetNamespace(manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name)
+	template.SetName(nodePool.GetName())
+
+	machineTemplateSpecJSON, err := json.Marshal(machineTemplateSpec)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return template, mutateTemplate, string(machineTemplateSpecJSON), nil
 }


### PR DESCRIPTION
This unifies the code to reconcile platform machine templates.
Move AWS code into its own file.
Additionally this changes existing behaviour to update existing templates in-place rather than creating a new one and rotate.
Initially rotation was used to not preclude us from leveraging MachineDeployments rollback ability. This seems unlikey so this PR drops that behaviour which also solves the problem of having to clean up old Machine templates.