### PR TITLE
Move Ingress Operator into management cluster to speed up creation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -66,6 +66,7 @@ var (
 		"0000_50_operator-marketplace_09_operator.yaml",
 		"0000_50_operator-marketplace_10_clusteroperator.yaml",
 		"0000_50_operator-marketplace_11_service_monitor.yaml",
+		"0000_50_cluster-ingress-operator_02-deployment-ibm-cloud-managed.yaml",
 
 		// TODO: Remove these when cluster profiles annotations are fixed
 		// for cco and auth  operators

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -1,0 +1,128 @@
+package ingressoperator
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+type Params struct {
+	IngressOperatorImage    string
+	HAProxyRouterImage      string
+	KubeRBACProxyImage      string
+	ReleaseVersion          string
+	TokenMinterImage        string
+	AvailabilityProberImage string
+	DeploymentConfig        config.DeploymentConfig
+}
+
+func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[string]string, setDefaultSecurityContext bool) Params {
+	p := Params{
+		IngressOperatorImage:    images["cluster-ingress-operator"],
+		HAProxyRouterImage:      images["haproxy-router"],
+		ReleaseVersion:          version,
+		TokenMinterImage:        images["token-minter"],
+		AvailabilityProberImage: images[util.AvailabilityProberImageName],
+	}
+	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.SetColocation(hcp)
+	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
+	p.DeploymentConfig.Replicas = 1
+	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+
+	return p
+}
+
+func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) {
+	dep.Spec.Replicas = utilpointer.Int32(1)
+	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": "ingress-operator"}}
+	dep.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = map[string]string{}
+	}
+	dep.Spec.Template.Annotations["target.workload.openshift.io/management"] = `{"effect": "PreferredDuringScheduling"}`
+	if dep.Spec.Template.Labels == nil {
+		dep.Spec.Template.Labels = map[string]string{}
+	}
+	dep.Spec.Template.Labels["name"] = "ingress-operator"
+	dep.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)
+	dep.Spec.Template.Spec.Containers = []corev1.Container{
+		{
+			Command: []string{
+				"ingress-operator",
+				"start",
+				"--namespace",
+				"openshift-ingress-operator",
+				"--image",
+				"$(IMAGE)",
+				"--canary-image",
+				"$(CANARY_IMAGE)",
+				"--release-version",
+				"$(RELEASE_VERSION)",
+			},
+			Env: []corev1.EnvVar{
+				{Name: "RELEASE_VERSION", Value: params.ReleaseVersion},
+				{Name: "IMAGE", Value: params.HAProxyRouterImage},
+				{Name: "CANARY_IMAGE", Value: params.IngressOperatorImage},
+				{Name: "KUBECONFIG", Value: "/etc/kubernetes/kubeconfig"},
+			},
+			Name:            "ingress-operator",
+			Image:           params.IngressOperatorImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("56Mi"),
+			}},
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "ingress-operator-kubeconfig", MountPath: "/etc/kubernetes"},
+				{Name: "serviceaccount-token", MountPath: "/var/run/secrets/openshift/serviceaccount"},
+			},
+		},
+		{
+			Name:    "token-minter",
+			Command: []string{"/usr/bin/token-minter"},
+			Args: []string{
+				"-service-account-namespace=openshift-ingress-operator",
+				"-service-account-name=ingress-operator",
+				"-token-file=/var/run/secrets/openshift/serviceaccount/token",
+				"-kubeconfig=/etc/kubernetes/kubeconfig",
+			},
+			Image: params.TokenMinterImage,
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "serviceaccount-token", MountPath: "/var/run/secrets/openshift/serviceaccount"},
+				{Name: "admin-kubeconfig", MountPath: "/etc/kubernetes"},
+			},
+		},
+	}
+
+	dep.Spec.Template.Spec.Volumes = []corev1.Volume{
+		{Name: "serviceaccount-token", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig"}}},
+		{Name: "ingress-operator-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.IngressOperatorKubeconfig("").Name}}},
+	}
+
+	util.AvailabilityProber(
+		kas.InClusterKASReadyURL(dep.Namespace, apiPort),
+		params.AvailabilityProberImage,
+		&dep.Spec.Template.Spec,
+		func(o *util.AvailabilityProberOpts) {
+			o.KubeconfigVolumeName = "ingress-operator-kubeconfig"
+			o.RequiredAPIs = []schema.GroupVersionKind{
+				{Group: "route.openshift.io", Version: "v1", Kind: "Route"},
+			}
+		},
+	)
+
+	params.DeploymentConfig.ApplyTo(dep)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -29,6 +29,12 @@ func ReconcileServiceCAPIKubeconfigSecret(secret, cert, ca *corev1.Secret, owner
 	return reconcileKubeconfig(secret, cert, ca, svcURL, "value", "capi", ownerRef)
 }
 
+func ReconcileIngressOperatorKubeconfigSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, apiServerPort int32) error {
+	svcURL := InClusterKASURL(secret.Namespace, apiServerPort)
+	// The secret that holds the kubeconfig and the one that holds the certs are the same
+	return reconcileKubeconfig(secret, secret, ca, svcURL, "", "ingress-operator", ownerRef)
+}
+
 func InClusterKASURL(namespace string, apiServerPort int32) string {
 	return fmt.Sprintf("https://%s:%d", manifests.KASService(namespace).Name, apiServerPort)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/ingressoperator.go
@@ -1,0 +1,25 @@
+package manifests
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func IngressOperatorKubeconfig(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-operator-kubeconfig",
+			Namespace: ns,
+		},
+	}
+}
+
+func IngressOperatorDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-operator",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -66,6 +66,10 @@ func ReconcileKASAdminClientCertSecret(secret, ca *corev1.Secret, ownerRef confi
 	return reconcileSignedCert(secret, ca, ownerRef, "system:admin", []string{"system:masters"}, X509UsageClientServerAuth)
 }
 
+func ReconcileIngressOperatorClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSignedCert(secret, ca, ownerRef, "system:serviceaccount:openshift-ingress-operator:ingress-operator", []string{"system:serviceaccounts"}, X509UsageClientServerAuth)
+}
+
 func nextIP(ip net.IP) net.IP {
 	nextIP := net.IP(make([]byte, len(ip)))
 	copy(nextIP, ip)


### PR DESCRIPTION
This change moves the Ingress Operator into the management cluster in
order to speed up cluster creation. I did two testruns with this, in the
first it took 698 seconds, in the second 642 seconds to create a
cluster. This is about two minutes faster than the fastest run we
currently have from CI (14.2 minutes/852 seconds).

POC because while this works, it would need some more polishing before we can merge it if that is what we want.

Pro arguments:
* Quicker startup

Con arguments:
* Slightly increased resource consumption (The operator requests 10m CPU and 56Mi memory and uses 3m CPU and 64Mi memory in my test)
* The added complexity of the code in this PR