### PR TITLE
:warning: Move InfraID under AWS platform spec

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -204,6 +204,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 				ControlPlaneOperatorCreds: corev1.LocalObjectReference{Name: resources.(*ExampleAWSResources).ControlPlaneOperatorAWSCreds.Name},
 				ResourceTags:              o.AWS.ResourceTags,
 				EndpointAccess:            hyperv1.AWSEndpointAccessType(o.AWS.EndpointAccess),
+				InfraID:                   o.InfraID,
 			},
 		}
 		services = []hyperv1.ServicePublishingStrategyMapping{
@@ -298,7 +299,6 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 				NetworkType: o.NetworkType,
 			},
 			Services:   services,
-			InfraID:    o.InfraID,
 			PullSecret: corev1.LocalObjectReference{Name: pullSecret.Name},
 			IssuerURL:  o.IssuerURL,
 			SSHKey:     sshKeyReference,

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -79,15 +79,6 @@ type HostedClusterSpec struct {
 	// and InfrastructureAvailabilityPolicy.
 	Release Release `json:"release"`
 
-	// InfraID is a globally unique identifier for the cluster. This identifier
-	// will be used to associate various cloud resources with the HostedCluster
-	// and its associated NodePools.
-	//
-	// TODO(dan): consider moving this to .platform.aws.infraID
-	//
-	// +immutable
-	InfraID string `json:"infraID"`
-
 	// Platform specifies the underlying infrastructure provider for the cluster
 	// and is used to configure platform specific behavior.
 	//
@@ -565,6 +556,13 @@ type AWSPlatformSpec struct {
 	// +kubebuilder:default=Public
 	// +optional
 	EndpointAccess AWSEndpointAccessType `json:"endpointAccess,omitempty"`
+
+	// InfraID is a globally unique identifier for the cluster. This identifier
+	// will be used to associate various cloud resources with the HostedCluster
+	// and its associated NodePools.
+	//
+	// +immutable
+	InfraID string `json:"infraID"`
 }
 
 // AWSResourceTag is a tag to apply to AWS resources created for the cluster.

--- a/cmd/bastion/aws/create.go
+++ b/cmd/bastion/aws/create.go
@@ -119,7 +119,7 @@ func (o *CreateBastionOpts) Run(ctx context.Context) (string, string, error) {
 			return "", "", fmt.Errorf("hosted cluster's platform is not AWS")
 		}
 
-		infraID = hostedCluster.Spec.InfraID
+		infraID = hostedCluster.Spec.Platform.AWS.InfraID
 		region = hostedCluster.Spec.Platform.AWS.Region
 		log.Info("Found hosted cluster", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name, "infraID", infraID, "region", region)
 

--- a/cmd/bastion/aws/destroy.go
+++ b/cmd/bastion/aws/destroy.go
@@ -103,7 +103,7 @@ func (o *DestroyBastionOpts) Run(ctx context.Context) error {
 			return fmt.Errorf("hosted cluster's platform is not AWS")
 		}
 
-		infraID = hostedCluster.Spec.InfraID
+		infraID = hostedCluster.Spec.Platform.AWS.InfraID
 		region = hostedCluster.Spec.Platform.AWS.Region
 		log.Info("Found hosted cluster", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name, "infraID", infraID, "region", region)
 	} else {

--- a/cmd/cluster/aws/destroy.go
+++ b/cmd/cluster/aws/destroy.go
@@ -89,7 +89,7 @@ func DestroyCluster(ctx context.Context, o *core.DestroyOptions) error {
 		return err
 	}
 	if hostedCluster != nil {
-		o.InfraID = hostedCluster.Spec.InfraID
+		o.InfraID = hostedCluster.Spec.Platform.AWS.InfraID
 		o.AWSPlatform.Region = hostedCluster.Spec.Platform.AWS.Region
 		o.AWSPlatform.BaseDomain = hostedCluster.Spec.DNS.BaseDomain
 	}

--- a/cmd/cluster/none/destroy.go
+++ b/cmd/cluster/none/destroy.go
@@ -42,9 +42,6 @@ func DestroyCluster(ctx context.Context, o *core.DestroyOptions) error {
 	if err != nil {
 		return err
 	}
-	if hostedCluster != nil {
-		o.InfraID = hostedCluster.Spec.InfraID
-	}
 	var inputErrors []error
 	if len(o.InfraID) == 0 {
 		inputErrors = append(inputErrors, fmt.Errorf("infrastructure ID is required"))

--- a/cmd/consolelogs/aws/getlogs.go
+++ b/cmd/consolelogs/aws/getlogs.go
@@ -76,7 +76,7 @@ func (o *ConsoleLogOpts) Run(ctx context.Context) error {
 	if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {
 		return fmt.Errorf("failed to get hostedcluster: %w", err)
 	}
-	infraID := hostedCluster.Spec.InfraID
+	infraID := hostedCluster.Spec.Platform.AWS.InfraID
 	region := hostedCluster.Spec.Platform.AWS.Region
 	awsSession := awsutil.NewSession("cli-console-logs")
 	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, region)

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -297,12 +297,6 @@ spec:
                   - source
                   type: object
                 type: array
-              infraID:
-                description: "InfraID is a globally unique identifier for the cluster.
-                  This identifier will be used to associate various cloud resources
-                  with the HostedCluster and its associated NodePools. \n TODO(dan):
-                  consider moving this to .platform.aws.infraID"
-                type: string
               infrastructureAvailabilityPolicy:
                 description: InfrastructureAvailabilityPolicy specifies the availability
                   policy applied to infrastructure services which run on cluster nodes.
@@ -449,6 +443,12 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      infraID:
+                        description: InfraID is a globally unique identifier for the
+                          cluster. This identifier will be used to associate various
+                          cloud resources with the HostedCluster and its associated
+                          NodePools.
+                        type: string
                       kubeCloudControllerCreds:
                         description: "KubeCloudControllerCreds is a reference to a
                           secret containing cloud credentials with permissions matching
@@ -562,6 +562,7 @@ spec:
                         type: array
                     required:
                     - controlPlaneOperatorCreds
+                    - infraID
                     - kubeCloudControllerCreds
                     - nodePoolManagementCreds
                     - region
@@ -881,7 +882,6 @@ spec:
                     type: string
                 type: object
             required:
-            - infraID
             - issuerURL
             - networking
             - platform

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -365,6 +365,12 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      infraID:
+                        description: InfraID is a globally unique identifier for the
+                          cluster. This identifier will be used to associate various
+                          cloud resources with the HostedCluster and its associated
+                          NodePools.
+                        type: string
                       kubeCloudControllerCreds:
                         description: "KubeCloudControllerCreds is a reference to a
                           secret containing cloud credentials with permissions matching
@@ -478,6 +484,7 @@ spec:
                         type: array
                     required:
                     - controlPlaneOperatorCreds
+                    - infraID
                     - kubeCloudControllerCreds
                     - nodePoolManagementCreds
                     - region

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -146,7 +146,7 @@ func (o *CreateNodePoolOptions) Run(ctx context.Context) error {
 	switch nodePool.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		if len(o.InstanceProfile) == 0 {
-			o.InstanceProfile = fmt.Sprintf("%s-worker", hcluster.Spec.InfraID)
+			o.InstanceProfile = fmt.Sprintf("%s-worker", hcluster.Spec.Platform.AWS.InfraID)
 		}
 		if len(o.SubnetID) == 0 {
 			if hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -100,20 +100,6 @@ and InfrastructureAvailabilityPolicy.</p>
 </tr>
 <tr>
 <td>
-<code>infraID</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>InfraID is a globally unique identifier for the cluster. This identifier
-will be used to associate various cloud resources with the HostedCluster
-and its associated NodePools.</p>
-<p>TODO(dan): consider moving this to .platform.aws.infraID</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>platform</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">
@@ -1162,6 +1148,19 @@ Value must be one of:
 </p>
 </td>
 </tr>
+<tr>
+<td>
+<code>infraID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>InfraID is a globally unique identifier for the cluster. This identifier
+will be used to associate various cloud resources with the HostedCluster
+and its associated NodePools.</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###AWSResourceReference { #hypershift.openshift.io/v1alpha1.AWSResourceReference }
@@ -2022,20 +2021,6 @@ Release
 <p>Updating this field will trigger a rollout of the control plane. The
 behavior of the rollout will be driven by the ControllerAvailabilityPolicy
 and InfrastructureAvailabilityPolicy.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>infraID</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>InfraID is a globally unique identifier for the cluster. This identifier
-will be used to associate various cloud resources with the HostedCluster
-and its associated NodePools.</p>
-<p>TODO(dan): consider moving this to .platform.aws.infraID</p>
 </td>
 </tr>
 <tr>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -875,15 +875,14 @@ func TestReconcileAWSResourceTags(t *testing.T) {
 		{
 			name: "Tag is added",
 			in: hyperv1.HostedClusterSpec{
-				InfraID: "123",
 				Platform: hyperv1.PlatformSpec{
-					AWS: &hyperv1.AWSPlatformSpec{},
+					AWS: &hyperv1.AWSPlatformSpec{InfraID: "123"},
 				},
 			},
 			expected: hyperv1.HostedClusterSpec{
-				InfraID: "123",
 				Platform: hyperv1.PlatformSpec{
 					AWS: &hyperv1.AWSPlatformSpec{
+						InfraID: "123",
 						ResourceTags: []hyperv1.AWSResourceTag{{
 							Key:   "kubernetes.io/cluster/123",
 							Value: "owned",
@@ -895,9 +894,9 @@ func TestReconcileAWSResourceTags(t *testing.T) {
 		{
 			name: "Tag already exists, nothing to do",
 			in: hyperv1.HostedClusterSpec{
-				InfraID: "123",
 				Platform: hyperv1.PlatformSpec{
 					AWS: &hyperv1.AWSPlatformSpec{
+						InfraID: "123",
 						ResourceTags: []hyperv1.AWSResourceTag{{
 							Key:   "kubernetes.io/cluster/123",
 							Value: "owned",
@@ -906,9 +905,9 @@ func TestReconcileAWSResourceTags(t *testing.T) {
 				},
 			},
 			expected: hyperv1.HostedClusterSpec{
-				InfraID: "123",
 				Platform: hyperv1.PlatformSpec{
 					AWS: &hyperv1.AWSPlatformSpec{
+						InfraID: "123",
 						ResourceTags: []hyperv1.AWSResourceTag{{
 							Key:   "kubernetes.io/cluster/123",
 							Value: "owned",
@@ -920,9 +919,9 @@ func TestReconcileAWSResourceTags(t *testing.T) {
 		{
 			name: "Tag already exists with wrong value",
 			in: hyperv1.HostedClusterSpec{
-				InfraID: "123",
 				Platform: hyperv1.PlatformSpec{
 					AWS: &hyperv1.AWSPlatformSpec{
+						InfraID: "123",
 						ResourceTags: []hyperv1.AWSResourceTag{{
 							Key:   "kubernetes.io/cluster/123",
 							Value: "borked",
@@ -931,9 +930,9 @@ func TestReconcileAWSResourceTags(t *testing.T) {
 				},
 			},
 			expected: hyperv1.HostedClusterSpec{
-				InfraID: "123",
 				Platform: hyperv1.PlatformSpec{
 					AWS: &hyperv1.AWSPlatformSpec{
+						InfraID: "123",
 						ResourceTags: []hyperv1.AWSResourceTag{{
 							Key:   "kubernetes.io/cluster/123",
 							Value: "owned",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -29,7 +29,7 @@ func (p Kubevirt) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, cre
 	kubevirtCluster := &capikubevirt.KubevirtCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
-			Name:      hcluster.Spec.InfraID,
+			Name:      hcluster.Name,
 		},
 	}
 	if _, err := createOrUpdate(ctx, c, kubevirtCluster, func() error {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt_test.go
@@ -20,15 +20,11 @@ func TestReconcileCAPIInfraCR(t *testing.T) {
 	kubevirt := Kubevirt{}
 	fakeClient := fake.NewClientBuilder().Build()
 	testNamespace := "testNamespace"
-	hcluster := &hyperv1.HostedCluster{
-		Spec: hyperv1.HostedClusterSpec{
-			InfraID: "testInfraID",
-		},
-	}
+	hcluster := &hyperv1.HostedCluster{}
 	expectedResult := &capikubevirt.KubevirtCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
-			Name:      hcluster.Spec.InfraID,
+			Name:      hcluster.Name,
 			Annotations: map[string]string{
 				hostedClusterAnnotation:    client.ObjectKeyFromObject(hcluster).String(),
 				capiv1.ManagedByAnnotation: "external",

--- a/test/e2e/util/cluster/aws/journals.go
+++ b/test/e2e/util/cluster/aws/journals.go
@@ -97,7 +97,7 @@ func dumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 	result, err := ec2Client.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("tag:kubernetes.io/cluster/" + hc.Spec.InfraID),
+				Name:   aws.String("tag:kubernetes.io/cluster/" + hc.Spec.Platform.AWS.InfraID),
 				Values: []*string{aws.String("owned")},
 			},
 		},
@@ -110,7 +110,7 @@ func dumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 		for _, instance := range reservation.Instances {
 			skip := false
 			for _, tag := range instance.Tags {
-				if aws.StringValue(tag.Key) == "Name" && aws.StringValue(tag.Value) == (hc.Spec.InfraID+"-bastion") {
+				if aws.StringValue(tag.Key) == "Name" && aws.StringValue(tag.Value) == (hc.Spec.Platform.AWS.InfraID+"-bastion") {
 					skip = true
 					break
 				}
@@ -123,7 +123,7 @@ func dumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 	}
 
 	if len(machineIPs) == 0 {
-		t.Logf("No machines associated with infra id %s were found. Skipping journal dump.", hc.Spec.InfraID)
+		t.Logf("No machines associated with infra id %s were found. Skipping journal dump.", hc.Spec.Platform.AWS.InfraID)
 		return nil
 	}
 


### PR DESCRIPTION
This change moves the infra ID under the AWS platform spec, as it is an
AWS-specific concept. The InfraID was also used to name the CAPI
cluster, this was changed to instead name it like the hosted
controlplane as there will only be ever one capi cluster per HCP
namespace.

Ref https://issues.redhat.com/browse/HOSTEDCP-280

/cc @enxebre 