### PR TITLE
Fix control plane teardown race with token secret finalization

### DIFF
--- a/ignition-server/main.go
+++ b/ignition-server/main.go
@@ -175,14 +175,14 @@ func run(ctx context.Context, opts Options) error {
 			return
 		}
 
-		payload, ok := payloadStore.Get(string(decodedToken))
+		value, ok := payloadStore.Get(string(decodedToken))
 		if !ok {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(payload)
+		w.Write(value.Payload)
 	})
 
 	server := http.Server{


### PR DESCRIPTION
Before this commit, the token controller used finalizers on ignition payload
secrets to ensure the token controller's internal cache could be purged upon
deleting the underlying secret for the token/payload. This causes the ignition
server process to race with namespace termination to clean up the finalizer.
When the ignition server process loses the race, the ignition secrets can remain
orphaned in the control plane namespace with finalizers that will never be
removed, resulting in HostedClusters being stuck deleting.

This commit eliminates the race by removing the use of finalizers entirely on
the ignition payload secrets. Instead of relying on a finalizer to do internal
cleanup, the token cache now internally tracks the secret name from which a
given token is derived. With that additional context, the token controller can
now reconcile its internal cache when secrets are deleted by simply purging any
tokens associated with the a secret which no longer exists.

In addition to the above, any additional potential gaps (e.g. a missed delete
event, etc.) should eventually resolve as all cache entries have a TTL. Given
the extremely small amount of information being stored to begin with (maybe a
couple of ignition payloads per NodePool per control plane), this seems like a
reasonable best-effort approach.