### PR TITLE
Fix route53 wildcard entry cleanup

### DIFF
--- a/cmd/infra/aws/route53.go
+++ b/cmd/infra/aws/route53.go
@@ -106,7 +106,7 @@ func (o *DestroyInfraOptions) DestroyPrivateZones(ctx context.Context, client ro
 
 	var errs []error
 	for _, zone := range output.HostedZoneSummaries {
-		recordName := o.wildcardRecordName(*zone.Name)
+		recordName := "*.apps." + strings.TrimSuffix(*zone.Name, ".")
 		id := cleanZoneID(*zone.HostedZoneId)
 		log.Info("deleting wildcard record from private zone", "id", id, "name", recordName)
 		err := deleteRecord(ctx, client, id, recordName)
@@ -140,22 +140,18 @@ func (o *DestroyInfraOptions) CleanupPublicZone(ctx context.Context, client rout
 	if err != nil {
 		return nil
 	}
-	recordName := o.wildcardRecordName(name)
+	recordName := fmt.Sprintf("*.apps.%s.%s", o.Name, o.BaseDomain)
 	err = deleteRecord(ctx, client, id, recordName)
 	if err != nil {
 		if !isRoute53RecordNotFoundErr(err) {
-			return fmt.Errorf("failed to delete willdcard record from public zone %s: %w", id, err)
+			return fmt.Errorf("failed to delete wildcard record from public zone %s: %w", id, err)
 		}
-		log.Info("Wildcard record not found in private zone")
+		log.Info("Wildcard record not found in public zone")
 
 	} else {
 		log.Info("Deleted wildcard record from public zone", "id", id, "name", recordName)
 	}
 	return nil
-}
-
-func (o *DestroyInfraOptions) wildcardRecordName(zoneName string) string {
-	return fmt.Sprintf("*.apps.%s.%s", strings.Split(zoneName, ".")[0], o.BaseDomain)
 }
 
 func deleteRecord(ctx context.Context, client route53iface.Route53API, id, recordName string) error {


### PR DESCRIPTION
For public zones, the wildcard entry name was wrong, it has the cluster
name as a component and that can not be derived from the zone name.

For private zones, it was needlessly complicated, the wildcard entry is
simply '*.apps.' + zoneNameWithTrailingDotStripped.
zoneNameWithTrailingDotStripped is the same as clusterName + "." +
baseDomain, but by directly using the zone name it will work even if the
basedomain argument is incorrect.