### PR TITLE
Add control plane image to the OCP payload

### DIFF
--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -10,3 +10,5 @@ FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 
 ENTRYPOINT /usr/bin/control-plane-operator
+
+LABEL io.openshift.release.operator=true


### PR DESCRIPTION
This commit labels the control plane image for inclusion into the official
OCP payload image. As of this commit, the control plane image will be shipped
with OCP 4.10+ as an OpenShift component.