### PR TITLE
Add missing CAPI provider image overrides

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -38,7 +38,7 @@ const (
 	ClusterAPIManagerImage = "hypershift.openshift.io/capi-manager-image"
 	// ClusterAutoscalerImage is an annotation that allows the specification of the cluster autoscaler image.
 	// This is a temporary workaround necessary for compliance reasons on the IBM Cloud side:
-	//no images can be pulled from registries outside of IBM Cloud's official regional registries
+	// no images can be pulled from registries outside of IBM Cloud's official regional registries
 	ClusterAutoscalerImage = "hypershift.openshift.io/cluster-autoscaler-image"
 	// AWSKMSProviderImage is an annotation that allows the specification of the AWS kms provider image.
 	// Upstream code located at: https://github.com/kubernetes-sigs/aws-encryption-provider
@@ -48,6 +48,18 @@ const (
 	// PortierisImageAnnotation is an annotation that allows the specification of the portieries component
 	// (performs container image verification).
 	PortierisImageAnnotation = "hypershift.openshift.io/portieris-image"
+
+	// ClusterAPIProviderAWSImage overrides the CAPI AWS provider image to use for
+	// a HostedControlPlane.
+	ClusterAPIProviderAWSImage = "hypershift.openshift.io/capi-provider-aws-image"
+
+	// ClusterAPIKubeVirtProviderImage overrides the CAPI KubeVirt provider image to use for
+	// a HostedControlPlane.
+	ClusterAPIKubeVirtProviderImage = "hypershift.openshift.io/capi-provider-kubevirt-image"
+
+	// ClusterAPIAgentProviderImage overrides the CAPI Agent provider image to use for
+	// a HostedControlPlane.
+	ClusterAPIAgentProviderImage = "hypershift.openshift.io/capi-provider-agent-image"
 
 	// AESCBCKeySecretKey defines the Kubernetes secret key name that contains the aescbc encryption key
 	// in the AESCBC secret encryption strategy

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	//TODO Pin to specific release
+	// TODO Pin to specific release
 	imageCAPAgent = "quay.io/edge-infrastructure/cluster-api-provider-agent:latest"
 )
 
@@ -54,6 +54,10 @@ func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, create
 }
 
 func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+	providerImage := imageCAPAgent
+	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIAgentProviderImage]; ok {
+		providerImage = override
+	}
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Replicas: k8sutilspointer.Int32Ptr(1),
 		Template: corev1.PodTemplateSpec{
@@ -62,7 +66,7 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, token
 				Containers: []corev1.Container{
 					{
 						Name:  "manager",
-						Image: imageCAPAgent,
+						Image: providerImage,
 						Env: []corev1.EnvVar{
 							{
 								Name: "MY_NAMESPACE",
@@ -119,7 +123,7 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, token
 	return deploymentSpec, nil
 }
 
-//TODO add a new method to Platform interface?
+// TODO add a new method to Platform interface?
 func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
 	hcluster *hyperv1.HostedCluster,
 	controlPlaneNamespace string) error {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -54,6 +54,10 @@ func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOr
 }
 
 func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+	providerImage := imageCAPA
+	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIProviderAWSImage]; ok {
+		providerImage = override
+	}
 	defaultMode := int32(420)
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Template: corev1.PodTemplateSpec{
@@ -104,7 +108,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMi
 				Containers: []corev1.Container{
 					{
 						Name:            "manager",
-						Image:           imageCAPA,
+						Image:           providerImage,
 						ImagePullPolicy: corev1.PullAlways,
 						VolumeMounts: []corev1.VolumeMount{
 							{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -57,6 +57,10 @@ func reconcileKubevirtCluster(kubevirtCluster *capikubevirt.KubevirtCluster, hcl
 }
 
 func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+	providerImage := imageCAPK
+	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIKubeVirtProviderImage]; ok {
+		providerImage = override
+	}
 	defaultMode := int32(420)
 	return &appsv1.DeploymentSpec{
 		Replicas: k8sutilspointer.Int32Ptr(1),
@@ -83,7 +87,7 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, to
 				Containers: []corev1.Container{
 					{
 						Name:            "manager",
-						Image:           imageCAPK,
+						Image:           providerImage,
 						ImagePullPolicy: corev1.PullAlways,
 						VolumeMounts: []corev1.VolumeMount{
 							{


### PR DESCRIPTION
This commit adds support for overriding CAPI provider images per
HostedCluster via annotations for consistency with the other components
which already support overrides. Adds overrides for kubevirt, agent, and AWS.