### PR TITLE
feat: Set default security context user for vanilla kube

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -20,7 +20,7 @@ type ClusterPolicyControllerParams struct {
 	config.OwnerRef  `json:",inline"`
 }
 
-func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string) *ClusterPolicyControllerParams {
+func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string, setDefaultSecurityContext bool) *ClusterPolicyControllerParams {
 	params := &ClusterPolicyControllerParams{
 		Image:                   images["cluster-policy-controller"],
 		APIServer:               globalConfig.APIServer,
@@ -50,6 +50,9 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalCon
 		params.DeploymentConfig.Replicas = 1
 	}
 	params.OwnerRef = config.OwnerRefFrom(hcp)
+
+	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	return params
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
@@ -22,7 +22,7 @@ type HostedClusterConfigOperatorParams struct {
 	AvailabilityProberImage string
 }
 
-func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, images map[string]string, openShiftVersion, kubernetesVersion string) *HostedClusterConfigOperatorParams {
+func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, images map[string]string, openShiftVersion, kubernetesVersion string, setDefaultSecurityContext bool) *HostedClusterConfigOperatorParams {
 	params := &HostedClusterConfigOperatorParams{
 		Image:                   images["hosted-cluster-config-operator"],
 		ReleaseImage:            hcp.Spec.ReleaseImage,
@@ -43,6 +43,7 @@ func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.Host
 			},
 		},
 	}
+
 	params.LivenessProbes = config.LivenessProbes{
 		hccContainerMain().Name: {
 			ProbeHandler: corev1.ProbeHandler{
@@ -78,5 +79,7 @@ func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.Host
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
+	params.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	return params
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -16,7 +16,7 @@ type CVOParams struct {
 	DeploymentConfig config.DeploymentConfig
 }
 
-func NewCVOParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *CVOParams {
+func NewCVOParams(hcp *hyperv1.HostedControlPlane, images map[string]string, setDefaultSecurityContext bool) *CVOParams {
 	p := &CVOParams{
 		CLIImage: images["cli"],
 		Image:    hcp.Spec.ReleaseImage,
@@ -41,5 +41,7 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *CV
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	p.DeploymentConfig.Replicas = 1
+	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	return p
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -90,6 +90,9 @@ type HostedControlPlaneReconciler struct {
 	// ManagementClusterCapabilities can be asked for support of optional management cluster capabilities
 	ManagementClusterCapabilities *capabilities.ManagementClusterCapabilities
 
+	// SetDefaultSecurityContext is used to configure Security Context for containers
+	SetDefaultSecurityContext bool
+
 	Log             logr.Logger
 	ReleaseProvider releaseinfo.Provider
 	HostedAPICache  hostedapicache.HostedAPICache
@@ -115,6 +118,11 @@ func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	if err != nil {
 		return fmt.Errorf("failed setting up with a controller manager %w", err)
 	}
+
+	// Set based on SCC capability
+	// When SCC is available (OpenShift), the container's security context and UID range is automatically set
+	// When SCC is not available (Kubernetes), we want to explicitly set a default (non-root) security context
+	r.SetDefaultSecurityContext = !r.ManagementClusterCapabilities.Has(capabilities.CapabilitySecurityContextConstraint)
 
 	return nil
 }
@@ -1273,7 +1281,7 @@ func (r *HostedControlPlaneReconciler) reconcileUnmanagedEtcd(ctx context.Contex
 
 func (r *HostedControlPlaneReconciler) reconcileKonnectivity(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage, infraStatus InfrastructureStatus) error {
 	r.Log.Info("Reconciling Konnectivity")
-	p := konnectivity.NewKonnectivityParams(hcp, releaseImage.ComponentImages(), infraStatus.KonnectivityHost, infraStatus.KonnectivityPort)
+	p := konnectivity.NewKonnectivityParams(hcp, releaseImage.ComponentImages(), infraStatus.KonnectivityHost, infraStatus.KonnectivityPort, r.SetDefaultSecurityContext)
 	serverDeployment := manifests.KonnectivityServerDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, serverDeployment, func() error {
 		return konnectivity.ReconcileServerDeployment(serverDeployment, p.OwnerRef, p.ServerDeploymentConfig, p.KonnectivityServerImage)
@@ -1301,7 +1309,7 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivity(ctx context.Context
 }
 
 func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, releaseImage *releaseinfo.ReleaseImage, oauthAddress string, oauthPort int32) error {
-	p := kas.NewKubeAPIServerParams(ctx, hcp, globalConfig, releaseImage.ComponentImages(), oauthAddress, oauthPort)
+	p := kas.NewKubeAPIServerParams(ctx, hcp, globalConfig, releaseImage.ComponentImages(), oauthAddress, oauthPort, r.SetDefaultSecurityContext)
 
 	rootCA := manifests.RootCASecret(hcp.Namespace)
 	if err := r.Get(ctx, client.ObjectKeyFromObject(rootCA), rootCA); err != nil {
@@ -1490,7 +1498,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 }
 
 func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, releaseImage *releaseinfo.ReleaseImage) error {
-	p := kcm.NewKubeControllerManagerParams(ctx, hcp, globalConfig, releaseImage.ComponentImages())
+	p := kcm.NewKubeControllerManagerParams(ctx, hcp, globalConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 
 	combinedCA := manifests.CombinedCAConfigMap(hcp.Namespace)
 	if err := r.Get(ctx, client.ObjectKeyFromObject(combinedCA), combinedCA); err != nil {
@@ -1521,7 +1529,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 }
 
 func (r *HostedControlPlaneReconciler) reconcileKubeScheduler(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, releaseImage *releaseinfo.ReleaseImage) error {
-	p := scheduler.NewKubeSchedulerParams(ctx, hcp, releaseImage.ComponentImages(), globalConfig)
+	p := scheduler.NewKubeSchedulerParams(ctx, hcp, releaseImage.ComponentImages(), globalConfig, r.SetDefaultSecurityContext)
 
 	schedulerConfig := manifests.SchedulerConfig(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, schedulerConfig, func() error {
@@ -1540,7 +1548,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeScheduler(ctx context.Contex
 }
 
 func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, releaseImage *releaseinfo.ReleaseImage, serviceClusterIP string) error {
-	p := oapi.NewOpenShiftAPIServerParams(hcp, globalConfig, releaseImage.ComponentImages())
+	p := oapi.NewOpenShiftAPIServerParams(hcp, globalConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 
 	oapicfg := manifests.OpenShiftAPIServerConfig(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, oapicfg, func() error {
@@ -1575,7 +1583,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.C
 }
 
 func (r *HostedControlPlaneReconciler) reconcileOpenShiftOAuthAPIServer(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, releaseImage *releaseinfo.ReleaseImage, serviceClusterIP string) error {
-	p := oapi.NewOpenShiftAPIServerParams(hcp, globalConfig, releaseImage.ComponentImages())
+	p := oapi.NewOpenShiftAPIServerParams(hcp, globalConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 
 	auditCfg := manifests.OpenShiftOAuthAPIServerAuditConfig(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, auditCfg, func() error {
@@ -1603,7 +1611,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftOAuthAPIServer(ctx cont
 }
 
 func (r *HostedControlPlaneReconciler) reconcileOAuthServer(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, releaseImage *releaseinfo.ReleaseImage, oauthHost string, oauthPort int32) error {
-	p := oauth.NewOAuthServerParams(hcp, globalConfig, releaseImage.ComponentImages(), oauthHost, oauthPort)
+	p := oauth.NewOAuthServerParams(hcp, globalConfig, releaseImage.ComponentImages(), oauthHost, oauthPort, r.SetDefaultSecurityContext)
 
 	sessionSecret := manifests.OAuthServerServiceSessionSecret(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, sessionSecret, func() error {
@@ -1664,7 +1672,7 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServer(ctx context.Context,
 }
 
 func (r *HostedControlPlaneReconciler) reconcileOpenShiftControllerManager(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, releaseImage *releaseinfo.ReleaseImage) error {
-	p := ocm.NewOpenShiftControllerManagerParams(hcp, globalConfig, releaseImage.ComponentImages())
+	p := ocm.NewOpenShiftControllerManagerParams(hcp, globalConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 
 	config := manifests.OpenShiftControllerManagerConfig(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, config, func() error {
@@ -1683,7 +1691,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftControllerManager(ctx c
 }
 
 func (r *HostedControlPlaneReconciler) reconcileClusterPolicyController(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, releaseImage *releaseinfo.ReleaseImage) error {
-	p := clusterpolicy.NewClusterPolicyControllerParams(hcp, globalConfig, releaseImage.ComponentImages())
+	p := clusterpolicy.NewClusterPolicyControllerParams(hcp, globalConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 
 	config := manifests.ClusterPolicyControllerConfig(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, config, func() error {
@@ -1702,7 +1710,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterPolicyController(ctx cont
 }
 
 func (r *HostedControlPlaneReconciler) reconcileClusterVersionOperator(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage) error {
-	p := cvo.NewCVOParams(hcp, releaseImage.ComponentImages())
+	p := cvo.NewCVOParams(hcp, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 
 	deployment := manifests.ClusterVersionOperatorDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, deployment, func() error {
@@ -1714,7 +1722,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterVersionOperator(ctx conte
 }
 
 func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage, packageServerAddress string) error {
-	p := olm.NewOperatorLifecycleManagerParams(hcp, releaseImage.ComponentImages(), releaseImage.Version())
+	p := olm.NewOperatorLifecycleManagerParams(hcp, releaseImage.ComponentImages(), releaseImage.Version(), r.SetDefaultSecurityContext)
 
 	certifiedOperatorsService := manifests.CertifiedOperatorsService(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, certifiedOperatorsService, func() error {
@@ -2005,7 +2013,7 @@ func (r *HostedControlPlaneReconciler) reconcileHostedClusterConfigOperator(ctx 
 	if err != nil {
 		return fmt.Errorf("failed to get component versions: %w", err)
 	}
-	p := configoperator.NewHostedClusterConfigOperatorParams(ctx, hcp, releaseInfo.ComponentImages(), releaseInfo.Version(), versions["kubernetes"])
+	p := configoperator.NewHostedClusterConfigOperatorParams(ctx, hcp, releaseInfo.ComponentImages(), releaseInfo.Version(), versions["kubernetes"], r.SetDefaultSecurityContext)
 
 	sa := manifests.ConfigOperatorServiceAccount(hcp.Namespace)
 	if _, err = r.CreateOrUpdate(ctx, r.Client, sa, func() error {

--- a/control-plane-operator/controllers/hostedcontrolplane/ignition/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignition/reconcile.go
@@ -203,7 +203,7 @@ func generateHAProxyStaticPod(image, internalAPIAddress string, internalAPIPort 
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser: pointer.Int64Ptr(1001),
+					RunAsUser: pointer.Int64Ptr(config.DefaultSecurityContextUser),
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -64,7 +64,7 @@ type KubeAPIServerServiceParams struct {
 	OwnerReference *metav1.OwnerReference
 }
 
-func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string, externalOAuthAddress string, externalOAuthPort int32) *KubeAPIServerParams {
+func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {
 	params := &KubeAPIServerParams{
 		APIServer:            globalConfig.APIServer,
 		FeatureGate:          globalConfig.FeatureGate,
@@ -297,6 +297,9 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 	params.KubeConfigRef = hcp.Spec.KubeConfig
 	params.OwnerRef = config.OwnerRefFrom(hcp)
+
+	params.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	return params
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
@@ -46,7 +46,7 @@ func TestNewAPIServerParamsAPIAdvertiseAddressAndPort(t *testing.T) {
 			hcp := &hyperv1.HostedControlPlane{}
 			hcp.Spec.APIAdvertiseAddress = test.advertiseAddress
 			hcp.Spec.APIPort = test.port
-			p := NewKubeAPIServerParams(context.Background(), hcp, globalconfig.GlobalConfig{}, map[string]string{}, "", 0)
+			p := NewKubeAPIServerParams(context.Background(), hcp, globalconfig.GlobalConfig{}, map[string]string{}, "", 0, false)
 			g := NewGomegaWithT(t)
 			g.Expect(p.AdvertiseAddress).To(Equal(test.expectedAddress))
 			g.Expect(p.APIServerPort).To(Equal(test.expectedPort))

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -37,7 +37,7 @@ const (
 	DefaultPort = 10257
 )
 
-func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string) *KubeControllerManagerParams {
+func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string, setDefaultSecurityContext bool) *KubeControllerManagerParams {
 	params := &KubeControllerManagerParams{
 		FeatureGate: globalConfig.FeatureGate,
 		// TODO: Come up with sane defaults for scheduling APIServer pods
@@ -109,6 +109,9 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	default:
 		params.Replicas = 1
 	}
+
+	params.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	params.OwnerRef = config.OwnerRefFrom(hcp)
 	return params
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -25,7 +25,7 @@ type KonnectivityParams struct {
 	AgentDeamonSetConfig    config.DeploymentConfig
 }
 
-func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]string, externalAddress string, externalPort int32) *KonnectivityParams {
+func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]string, externalAddress string, externalPort int32, setDefaultSecurityContext bool) *KonnectivityParams {
 	p := &KonnectivityParams{
 		KonnectivityServerImage: images["konnectivity-server"],
 		KonnectivityAgentImage:  images["konnectivity-agent"],
@@ -124,6 +124,12 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 			SuccessThreshold:    1,
 		},
 	}
+
+	// non root security context if scc capability is missing
+	p.AgentDeamonSetConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+	p.AgentDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+	p.ServerDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	if hcp.Annotations != nil {
 		if _, ok := hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]; ok {
 			p.KonnectivityServerImage = hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -40,7 +40,7 @@ type OAuthDeploymentParams struct {
 	OwnerRef                config.OwnerRef
 }
 
-func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string) *OpenShiftAPIServerParams {
+func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string, setDefaultSecurityContext bool) *OpenShiftAPIServerParams {
 	params := &OpenShiftAPIServerParams{
 		OpenShiftAPIServerImage: images["openshift-apiserver"],
 		OAuthAPIServerImage:     images["oauth-apiserver"],
@@ -142,6 +142,10 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig g
 			},
 		},
 	}
+
+	params.OpenShiftAPIServerDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+	params.OpenShiftOAuthAPIServerDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetColocation(hcp)
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetControlPlaneIsolation(hcp)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -70,7 +70,7 @@ type ConfigOverride struct {
 	Claims osinv1.OpenIDClaims `json:"claims,omitempty"`
 }
 
-func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string, host string, port int32) *OAuthServerParams {
+func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string, host string, port int32, setDefaultSecurityContext bool) *OAuthServerParams {
 	p := &OAuthServerParams{
 		OwnerRef:                config.OwnerRefFrom(hcp),
 		ExternalAPIHost:         hcp.Status.ControlPlaneEndpoint.Host,
@@ -152,6 +152,9 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalco
 			p.LoginURLOverride = annotationValue
 		}
 	}
+
+	p.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	return p
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -20,7 +20,7 @@ type OpenShiftControllerManagerParams struct {
 	config.OwnerRef  `json:",inline"`
 }
 
-func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string) *OpenShiftControllerManagerParams {
+func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string, setDefaultSecurityContext bool) *OpenShiftControllerManagerParams {
 	params := &OpenShiftControllerManagerParams{
 		OpenShiftControllerManagerImage: images["openshift-controller-manager"],
 		DockerBuilderImage:              images["docker-builder"],
@@ -50,6 +50,9 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, global
 	default:
 		params.DeploymentConfig.Replicas = 1
 	}
+
+	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	params.OwnerRef = config.OwnerRefFrom(hcp)
 	return params
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
@@ -23,7 +23,7 @@ type OperatorLifecycleManagerParams struct {
 	config.OwnerRef
 }
 
-func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images map[string]string, releaseVersion string) *OperatorLifecycleManagerParams {
+func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images map[string]string, releaseVersion string, setDefaultSecurityContext bool) *OperatorLifecycleManagerParams {
 	params := &OperatorLifecycleManagerParams{
 		CLIImage:                images["cli"],
 		OLMImage:                images["operator-lifecycle-manager"],
@@ -58,6 +58,9 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images m
 	default:
 		params.PackageServerConfig.Replicas = 1
 	}
+
+	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+	params.PackageServerConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return params
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -23,7 +23,7 @@ type KubeSchedulerParams struct {
 	config.DeploymentConfig `json:",inline"`
 }
 
-func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, images map[string]string, globalConfig globalconfig.GlobalConfig) *KubeSchedulerParams {
+func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, images map[string]string, globalConfig globalconfig.GlobalConfig, setDefaultSecurityContext bool) *KubeSchedulerParams {
 	params := &KubeSchedulerParams{
 		FeatureGate:             globalConfig.FeatureGate,
 		Scheduler:               globalConfig.Scheduler,
@@ -83,6 +83,9 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	default:
 		params.Replicas = 1
 	}
+
+	params.SetDefaultSecurityContext = setDefaultSecurityContext
+
 	params.OwnerRef = config.OwnerRefFrom(hcp)
 	return params
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -395,7 +395,7 @@ func TestClusterAutoscalerArgs(t *testing.T) {
 			hc := &hyperv1.HostedCluster{}
 			hc.Name = "name"
 			hc.Namespace = "namespace"
-			err := reconcileAutoScalerDeployment(deployment, hc, sa, secret, test.AutoscalerOptions, imageClusterAutoscaler, "availability-prober:latest")
+			err := reconcileAutoScalerDeployment(deployment, hc, sa, secret, test.AutoscalerOptions, imageClusterAutoscaler, "availability-prober:latest", false)
 			if err != nil {
 				t.Error(err)
 			}

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	routev1 "github.com/openshift/api/route/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -14,6 +15,10 @@ type CapabilityType int
 const (
 	// CapabilityRoute indicates if the management cluster supports routes
 	CapabilityRoute CapabilityType = iota
+
+	// CapabilitySecurityContextConstraint indicates if the management cluster
+	// supports security context constraints
+	CapabilitySecurityContextConstraint
 )
 
 // ManagementClusterCapabilities holds all information about optional capabilities of
@@ -66,6 +71,8 @@ func isGroupVersionRegistered(client discovery.ServerResourcesInterface, groupVe
 
 func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterface) (*ManagementClusterCapabilities, error) {
 	discoveredCapabilities := map[CapabilityType]struct{}{}
+
+	// check for route capability
 	hasRoutesCap, err := isGroupVersionRegistered(client, routev1.GroupVersion)
 	if err != nil {
 		return nil, err
@@ -73,5 +80,15 @@ func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterfa
 	if hasRoutesCap {
 		discoveredCapabilities[CapabilityRoute] = struct{}{}
 	}
+
+	// check for scc capability
+	hasSccCap, err := isGroupVersionRegistered(client, securityv1.GroupVersion)
+	if err != nil {
+		return nil, err
+	}
+	if hasSccCap {
+		discoveredCapabilities[CapabilitySecurityContextConstraint] = struct{}{}
+	}
+
 	return &ManagementClusterCapabilities{capabilities: discoveredCapabilities}, nil
 }

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -20,4 +20,5 @@ const (
 	DefaultAPIServerPort         = 6443
 	DefaultEtcdClusterVersion    = "3.4.9"
 	DefaultServiceNodePortRange  = "30000-32767"
+	DefaultSecurityContextUser   = 1001
 )

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -5,19 +5,21 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 )
 
 type DeploymentConfig struct {
-	Replicas              int                   `json:"replicas"`
-	Scheduling            Scheduling            `json:"scheduling"`
-	AdditionalLabels      AdditionalLabels      `json:"additionalLabels"`
-	AdditionalAnnotations AdditionalAnnotations `json:"additionalAnnotations"`
-	SecurityContexts      SecurityContextSpec   `json:"securityContexts"`
-	LivenessProbes        LivenessProbes        `json:"livenessProbes"`
-	ReadinessProbes       ReadinessProbes       `json:"readinessProbes"`
-	Resources             ResourcesSpec         `json:"resources"`
+	Replicas                  int                   `json:"replicas"`
+	Scheduling                Scheduling            `json:"scheduling"`
+	AdditionalLabels          AdditionalLabels      `json:"additionalLabels"`
+	AdditionalAnnotations     AdditionalAnnotations `json:"additionalAnnotations"`
+	SecurityContexts          SecurityContextSpec   `json:"securityContexts"`
+	SetDefaultSecurityContext bool                  `json:"setDefaultSecurityContext"`
+	LivenessProbes            LivenessProbes        `json:"livenessProbes"`
+	ReadinessProbes           ReadinessProbes       `json:"readinessProbes"`
+	Resources                 ResourcesSpec         `json:"resources"`
 }
 
 func (c *DeploymentConfig) SetRestartAnnotation(objectMetadata metav1.ObjectMeta) {
@@ -174,6 +176,14 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 		deployment.Spec.Strategy.RollingUpdate.MaxSurge = &maxSurge
 		deployment.Spec.Strategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 	}
+
+	// set default security context for pod
+	if c.SetDefaultSecurityContext {
+		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsUser: pointer.Int64(DefaultSecurityContextUser),
+		}
+	}
+
 	c.Scheduling.ApplyTo(&deployment.Spec.Template.Spec)
 	c.AdditionalLabels.ApplyTo(&deployment.Spec.Template.ObjectMeta)
 	c.SecurityContexts.ApplyTo(&deployment.Spec.Template.Spec)


### PR DESCRIPTION
Supersedes: #777 
Issue: #566 

Addresses PR comments:
- https://github.com/openshift/hypershift/pull/777#discussion_r782495269
- https://github.com/openshift/hypershift/pull/777#discussion_r782495803
- https://github.com/openshift/hypershift/pull/777#discussion_r782495972
- https://github.com/openshift/hypershift/pull/777#discussion_r782497553

Other enhancements:
- Moved `1001` uid value to config constant
- Simplified setting `r.SetDefaultSecurityContext`

