### PR TITLE
docs: Minor update to in-cluster development registry login steps

### DIFF
--- a/docs/content/contribute/develop-in-cluster.md
+++ b/docs/content/contribute/develop-in-cluster.md
@@ -44,7 +44,7 @@ to replace `<password>` with your actual `kubeadmin` password.
 
 ```shell linenums="1"
 oc login -u kubeadmin -p <password>
-oc registry login --skip-check --to=$HOME/.docker/config.json
+oc registry login --to=$HOME/.docker/config.json --skip-check --registry $(oc get routes --namespace openshift-image-registry default-route -o jsonpath='{.spec.host}')
 ```
 
 Finally, configure OCP to allow any authenticated user to pull images from the


### PR DESCRIPTION
Before this commit, the in-cluster development docs used an `oc registry login`
command which could sometimes log the user in to the cluster's internal instead
of external registry if the prior steps to enable the external registry hadn't
yet completed.

This commit updates the login command to make sure the registry login always
targets the external registry route.