### PR TITLE
replace m4.large default with m5.large

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -305,7 +305,7 @@ type KubevirtNodePoolPlatform struct {
 // AWSNodePoolPlatform specifies the configuration of a NodePool when operating
 // on AWS.
 type AWSNodePoolPlatform struct {
-	// InstanceType is an ec2 instance type for node instances (e.g. m4-large).
+	// InstanceType is an ec2 instance type for node instances (e.g. m5.large).
 	InstanceType string `json:"instanceType"`
 
 	// InstanceProfile is the AWS EC2 instance profile, which is a container for an IAM role that the EC2 instance uses.

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -28,7 +28,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	opts.AWSPlatform = core.AWSPlatformOptions{
 		AWSCredentialsFile: "",
 		Region:             "us-east-1",
-		InstanceType:       "m4.large",
+		InstanceType:       "m5.large",
 		RootVolumeType:     "gp3",
 		RootVolumeSize:     120,
 		RootVolumeIOPS:     0,

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -216,7 +216,7 @@ spec:
                         type: string
                       instanceType:
                         description: InstanceType is an ec2 instance type for node
-                          instances (e.g. m4-large).
+                          instances (e.g. m5.large).
                         type: string
                       resourceTags:
                         description: "ResourceTags is an optional list of additional

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -54,7 +54,7 @@ func NewCreateCommand() *cobra.Command {
 		ClusterName:    "example",
 		NodeCount:      2,
 		ReleaseImage:   "",
-		InstanceType:   "m4.large",
+		InstanceType:   "m5.large",
 		RootVolumeType: "gp3",
 		RootVolumeSize: 120,
 		RootVolumeIOPS: 0,

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -895,7 +895,7 @@ string
 </em>
 </td>
 <td>
-<p>InstanceType is an ec2 instance type for node instances (e.g. m4-large).</p>
+<p>InstanceType is an ec2 instance type for node instances (e.g. m5.large).</p>
 </td>
 </tr>
 <tr>

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -196,7 +196,7 @@ func (o *options) DefaultClusterOptions() core.CreateOptions {
 		PullSecretFile:            o.configurableClusterOptions.PullSecretFile,
 		ControlPlaneOperatorImage: o.configurableClusterOptions.ControlPlaneOperatorImage,
 		AWSPlatform: core.AWSPlatformOptions{
-			InstanceType:       "m4.large",
+			InstanceType:       "m5.large",
 			RootVolumeSize:     64,
 			RootVolumeType:     "gp3",
 			AWSCredentialsFile: o.configurableClusterOptions.AWSCredentialsFile,


### PR DESCRIPTION
There is no reason to ever use m4 over m5. m4's are
more expensive because it's legacy hardware. m5 is cheaper
and better.

/assign @csrwng 