### PR TITLE
docs: add region flag to the `create cluster` example in getting-started

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -79,6 +79,7 @@ Create a new cluster, specifying the domain of the public zone provided in the
 [Prerequisites](#prerequisites):
 
 ```shell linenums="1"
+REGION=us-east-1
 CLUSTER_NAME=example
 BASE_DOMAIN=example.com
 AWS_CREDS="$HOME/.aws/credentials"
@@ -89,7 +90,8 @@ hypershift create cluster aws \
 --node-pool-replicas=3 \
 --base-domain $BASE_DOMAIN \
 --pull-secret $PULL_SECRET \
---aws-creds $AWS_CREDS
+--aws-creds $AWS_CREDS \
+--region $REGION
 ```
 
 !!! important


### PR DESCRIPTION
Previously, the flow of the getting started guide made it easy to
mistakenly create a management cluster and a hosted cluster in
different regions. Fix this by adding region flag to the create
cluster command.