### PR TITLE
Add NetworkPolicies to HCP to block inter-namespace communication

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -391,6 +391,11 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Verbs:     []string{"*"},
 			},
 			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"networkpolicies"},
+				Verbs:     []string{"*"},
+			},
+			{
 				APIGroups: []string{
 					"bootstrap.cluster.x-k8s.io",
 					"controlplane.cluster.x-k8s.io",

--- a/hypershift-operator/controllers/manifests/networkpolicy/manifests.go
+++ b/hypershift-operator/controllers/manifests/networkpolicy/manifests.go
@@ -1,0 +1,33 @@
+package networkpolicy
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func OpenshiftIngressNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "openshift-ingress",
+		},
+	}
+}
+
+func SameNamespaceNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "same-namespace",
+		},
+	}
+}
+
+func KASNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "kas",
+		},
+	}
+}


### PR DESCRIPTION
Seals up HO to HCP service network communication after https://github.com/openshift/hypershift/pull/849