### PR TITLE
Crate cluster: Fix --wait panicing with a NPD

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -197,6 +197,7 @@ func apply(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, rend
 			object.SetLabels(map[string]string{util.AutoInfraLabelName: exampleOptions.InfraID})
 			var err error
 			if object.GetObjectKind().GroupVersionKind().Kind == "HostedCluster" {
+				hostedCluster = &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: object.GetNamespace(), Name: object.GetName()}}
 				err = client.Create(ctx, object)
 			} else {
 				err = client.Patch(ctx, object, crclient.Apply, crclient.ForceOwnership, crclient.FieldOwner("hypershift-cli"))
@@ -205,9 +206,6 @@ func apply(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, rend
 				return fmt.Errorf("failed to apply object %q: %w", key, err)
 			}
 			log.Info("Applied Kube resource", "kind", object.GetObjectKind().GroupVersionKind().Kind, "namespace", key.Namespace, "name", key.Name)
-			if object.GetObjectKind().GroupVersionKind().Kind == "HostedCluster" {
-				hostedCluster = &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: object.GetNamespace(), Name: object.GetName()}}
-			}
 		}
 
 		if waitForRollout {


### PR DESCRIPTION
We changed the create command to Create the HostedCluster rather than
ServerSide applying it to make sure it errors if a HostedCluster of that
name already exists.

Unfortunately, the deserializer clears the TypeMeta field when doing
anything other than the serverside apply, so the code that looked at the
object kind after the Create to find the HostedCluster will never find
anything. Fix it by storing the HostedCluster before doing the Create
call.