### PR TITLE
Add new awsconfig creds

### DIFF
--- a/cmd/bastion/aws/create.go
+++ b/cmd/bastion/aws/create.go
@@ -32,6 +32,8 @@ type CreateBastionOpts struct {
 	Region             string
 	SSHKeyFile         string
 	AWSCredentialsFile string
+	AWSKey             string
+	AWSSecretKey       string
 	Wait               bool
 }
 
@@ -148,7 +150,7 @@ func (o *CreateBastionOpts) Run(ctx context.Context) (string, string, error) {
 	}
 
 	awsSession := awsutil.NewSession("cli-create-bastion")
-	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, region)
+	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey, region)
 	ec2Client := ec2.New(awsSession, awsConfig)
 
 	// Ensure security group exists

--- a/cmd/bastion/aws/destroy.go
+++ b/cmd/bastion/aws/destroy.go
@@ -25,6 +25,8 @@ type DestroyBastionOpts struct {
 	InfraID            string
 	Region             string
 	AWSCredentialsFile string
+	AWSKey             string
+	AWSSecretKey       string
 }
 
 func NewDestroyCommand() *cobra.Command {
@@ -112,7 +114,7 @@ func (o *DestroyBastionOpts) Run(ctx context.Context) error {
 	}
 
 	awsSession := awsutil.NewSession("cli-destroy-bastion")
-	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, region)
+	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey, region)
 	ec2Client := ec2.New(awsSession, awsConfig)
 
 	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {

--- a/cmd/consolelogs/aws/getlogs.go
+++ b/cmd/consolelogs/aws/getlogs.go
@@ -26,6 +26,8 @@ type ConsoleLogOpts struct {
 	Name               string
 	Namespace          string
 	AWSCredentialsFile string
+	AWSKey             string
+	AWSSecretKey       string
 	OutputDir          string
 }
 
@@ -79,7 +81,7 @@ func (o *ConsoleLogOpts) Run(ctx context.Context) error {
 	infraID := hostedCluster.Spec.InfraID
 	region := hostedCluster.Spec.Platform.AWS.Region
 	awsSession := awsutil.NewSession("cli-console-logs")
-	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, region)
+	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey, region)
 	ec2Client := ec2.New(awsSession, awsConfig)
 
 	// Fetch any instances belonging to the cluster

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -19,6 +19,8 @@ type CreateInfraOptions struct {
 	Region             string
 	InfraID            string
 	AWSCredentialsFile string
+	AWSKey             string
+	AWSSecretKey       string
 	Name               string
 	BaseDomain         string
 	OutputFile         string
@@ -124,9 +126,8 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 	log.Info("Creating infrastructure", "id", o.InfraID)
 
 	awsSession := awsutil.NewSession("cli-create-infra")
-	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.Region)
-	ec2Client := ec2.New(awsSession, awsConfig)
-	route53Client := route53.New(awsSession, awsutil.NewRoute53Config(o.AWSCredentialsFile))
+	ec2Client := ec2.New(awsSession, awsutil.NewConfig(o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey, o.Region))
+	route53Client := route53.New(awsSession, awsutil.NewAWSRoute53Config(o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey))
 
 	var err error
 	if err = o.parseAdditionalTags(); err != nil {

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -25,6 +25,8 @@ import (
 type CreateIAMOptions struct {
 	Region                          string
 	AWSCredentialsFile              string
+	AWSKey                          string
+	AWSSecretKey                    string
 	OIDCStorageProviderS3BucketName string
 	OIDCStorageProviderS3Region     string
 	PublicZoneID                    string
@@ -143,10 +145,10 @@ func (o *CreateIAMOptions) CreateIAM(ctx context.Context, client crclient.Client
 
 	var errs []error
 	if o.OIDCStorageProviderS3BucketName == "" {
-		errs = append(errs, errors.New("mandatory --oidc-storage-provider-s3-bucket-name could not be discovered from cluster and wasn't excplicitly passed either"))
+		errs = append(errs, errors.New("mandatory --oidc-storage-provider-s3-bucket-name could not be discovered from the cluster's ConfigMap in 'kube-public' and wasn't excplicitly passed either"))
 	}
 	if o.OIDCStorageProviderS3Region == "" {
-		errs = append(errs, errors.New("mandatory --oidc-storage-provider-s3-region could not be discovered from cluster and wasn't explicitly passed either"))
+		errs = append(errs, errors.New("mandatory --oidc-storage-provider-s3-region could not be discovered from cluster's  ConfigMap in 'kube-public' and wasn't explicitly passed either"))
 	}
 	if err := utilerrors.NewAggregate(errs); err != nil {
 		return nil, err
@@ -156,7 +158,7 @@ func (o *CreateIAMOptions) CreateIAM(ctx context.Context, client crclient.Client
 	log.Info("Detected Issuer URL", "issuer", o.IssuerURL)
 
 	awsSession := awsutil.NewSession("cli-create-iam")
-	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.Region)
+	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey, o.Region)
 	iamClient := iam.New(awsSession, awsConfig)
 
 	results, err := o.CreateOIDCResources(iamClient)

--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -31,6 +31,8 @@ type DestroyInfraOptions struct {
 	Region             string
 	InfraID            string
 	AWSCredentialsFile string
+	AWSKey             string
+	AWSSecretKey       string
 	Name               string
 	BaseDomain         string
 }
@@ -92,10 +94,10 @@ func (o *DestroyInfraOptions) Run(ctx context.Context) error {
 
 func (o *DestroyInfraOptions) DestroyInfra(ctx context.Context) error {
 	awsSession := awsutil.NewSession("cli-destroy-infra")
-	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.Region)
+	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey, o.Region)
 	ec2Client := ec2.New(awsSession, awsConfig)
 	elbClient := elb.New(awsSession, awsConfig)
-	route53Client := route53.New(awsSession, awsutil.NewRoute53Config(o.AWSCredentialsFile))
+	route53Client := route53.New(awsSession, awsutil.NewAWSRoute53Config(o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey))
 	s3Client := s3.New(awsSession, awsConfig)
 
 	var errs []error

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -22,6 +22,8 @@ import (
 type DestroyIAMOptions struct {
 	Region             string
 	AWSCredentialsFile string
+	AWSKey             string
+	AWSSecretKey       string
 	InfraID            string
 }
 
@@ -80,7 +82,7 @@ func (o *DestroyIAMOptions) Run(ctx context.Context) error {
 
 func (o *DestroyIAMOptions) DestroyIAM(ctx context.Context) error {
 	awsSession := awsutil.NewSession("cli-destroy-iam")
-	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.Region)
+	awsConfig := awsutil.NewConfig(o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey, o.Region)
 	iamClient := iam.New(awsSession, awsConfig)
 
 	var err error

--- a/cmd/infra/aws/util/util.go
+++ b/cmd/infra/aws/util/util.go
@@ -19,24 +19,35 @@ func NewSession(agent string) *session.Session {
 	return awsSession
 }
 
-func NewConfig(credentialsFile, region string) *aws.Config {
+// NewAWSRoute53Config generates an AWS config with slightly different Retryer timings
+func NewAWSRoute53Config(credentialsFile string, credKey string, credSecretKey string) *aws.Config {
+
+	awsRoute53Config := NewConfig(credentialsFile, credKey, credSecretKey, "us-east-1")
+	awsRoute53Config.Retryer = client.DefaultRetryer{
+		NumMaxRetries:    10,
+		MinRetryDelay:    5 * time.Second,
+		MinThrottleDelay: 10 * time.Second,
+	}
+	return awsRoute53Config
+}
+
+// NewConfig allows support for a CredentialsFile or StaticCredential (UserKey & UserSecretKey)
+// [Default] if all values are provided is to use credentialsFile
+// This allows methods to be used by the CLI or vendored for other Go code
+func NewConfig(credentialsFile string, credKey string, credSecretKey string, region string) *aws.Config {
+
+	// Will be empty when using credentialsFile
+	creds := credentials.NewStaticCredentials(credKey, credSecretKey, "")
+	if credentialsFile != "" {
+		creds = credentials.NewSharedCredentials(credentialsFile, "default")
+	}
 	awsConfig := aws.NewConfig().
 		WithRegion(region).
-		WithCredentials(credentials.NewSharedCredentials(credentialsFile, "default"))
+		WithCredentials(creds)
 	awsConfig.Retryer = client.DefaultRetryer{
 		NumMaxRetries:    10,
 		MinRetryDelay:    5 * time.Second,
 		MinThrottleDelay: 5 * time.Second,
-	}
-	return awsConfig
-}
-
-func NewRoute53Config(credentialsFile string) *aws.Config {
-	awsConfig := NewConfig(credentialsFile, "us-east-1")
-	awsConfig.Retryer = client.DefaultRetryer{
-		NumMaxRetries:    10,
-		MinRetryDelay:    5 * time.Second,
-		MinThrottleDelay: 10 * time.Second,
 	}
 	return awsConfig
 }

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -249,7 +249,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	}
 	if opts.OIDCStorageProviderS3Credentials != "" {
 		awsSession := awsutil.NewSession("hypershift-operator-oidc-bucket")
-		awsConfig := awsutil.NewConfig(opts.OIDCStorageProviderS3Credentials, opts.OIDCStorageProviderS3Region)
+		awsConfig := awsutil.NewConfig(opts.OIDCStorageProviderS3Credentials, "", "", opts.OIDCStorageProviderS3Region)
 		s3Client := s3.New(awsSession, awsConfig)
 		hostedClusterReconciler.S3Client = s3Client
 		hostedClusterReconciler.OIDCStorageProviderS3BucketName = opts.OIDCStorageProviderS3BucketName

--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -85,6 +85,6 @@ func TestAutoRepair(t *testing.T) {
 
 func ec2Client(awsCredsFile, region string) *ec2.EC2 {
 	awsSession := awsutil.NewSession("e2e-autorepair")
-	awsConfig := awsutil.NewConfig(awsCredsFile, region)
+	awsConfig := awsutil.NewConfig(awsCredsFile, "", "", region)
 	return ec2.New(awsSession, awsConfig)
 }

--- a/test/e2e/util/dump/journals.go
+++ b/test/e2e/util/dump/journals.go
@@ -90,7 +90,7 @@ func DumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 
 	// Find worker machine IPs
 	awsSession := awsutil.NewSession("cli-destroy-bastion")
-	awsConfig := awsutil.NewConfig(awsCreds, hc.Spec.Platform.AWS.Region)
+	awsConfig := awsutil.NewConfig(awsCreds, "", "", hc.Spec.Platform.AWS.Region)
 	ec2Client := ec2.New(awsSession, awsConfig)
 
 	result, err := ec2Client.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{


### PR DESCRIPTION
This allows the hypershift CLI infra AWS to work with key and secretKey credential values, when integrated into controllers or other environments where the credentials file may not be available.

This is to address issue: #859 

This adds AWSKey and AWSSecretKey to the options we use for infra.aws.create and infra.aws.create_iam.  The same was added to the destroy.  This allows someone consuming the Go functions to include the credentials, but leaves the secret definition, access to the impelmenter