### PR TITLE
Add a ClusterVersionSucceeding condition to HostedCluster

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -957,6 +957,11 @@ const (
 	// is running on a management cluster outside AWS or is not configured with AWS
 	// credentials, the HostedCluster is not supported.
 	SupportedHostedCluster ConditionType = "SupportedHostedCluster"
+
+	// ClusterVersionSucceeding indicates the current status of the desired release
+	// version of the HostedCluster as indicated by the Failing condition in the
+	// underlying cluster's ClusterVersion.
+	ClusterVersionSucceeding ConditionType = "ClusterVersionSucceeding"
 )
 
 const (

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1734,6 +1734,11 @@ has been created for the specified NLB in the management VPC</p>
 </td>
 </tr><tr><td><p>&#34;ClusterVersionFailing&#34;</p></td>
 <td></td>
+</tr><tr><td><p>&#34;ClusterVersionSucceeding&#34;</p></td>
+<td><p>ClusterVersionSucceeding indicates the current status of the desired release
+version of the HostedCluster as indicated by the Failing condition in the
+underlying cluster&rsquo;s ClusterVersion.</p>
+</td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;Available&#34;</p></td>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -291,6 +291,39 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		hcluster.Status.Version = computeClusterVersionStatus(r.Clock, hcluster, hcp)
 	}
 
+	// Set the ClusterVersionSucceeding based on the hostedcontrolplane
+	{
+		condition := metav1.Condition{
+			Type:               string(hyperv1.ClusterVersionSucceeding),
+			Status:             metav1.ConditionUnknown,
+			Reason:             "ClusterVersionStatusUnknown",
+			ObservedGeneration: hcluster.Generation,
+		}
+		controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
+		hcp := controlplaneoperator.HostedControlPlane(controlPlaneNamespace.Name, hcluster.Name)
+		err := r.Client.Get(ctx, client.ObjectKeyFromObject(hcp), hcp)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to get hostedcontrolplane: %w", err)
+			}
+		} else {
+			failingCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionFailing))
+			if failingCond != nil {
+				switch failingCond.Status {
+				case metav1.ConditionTrue:
+					condition.Status = metav1.ConditionFalse
+					condition.Reason = failingCond.Reason
+					condition.Message = failingCond.Message
+				case metav1.ConditionFalse:
+					condition.Status = metav1.ConditionTrue
+					condition.Reason = failingCond.Reason
+					condition.Message = ""
+				}
+			}
+		}
+		meta.SetStatusCondition(&hcluster.Status.Conditions, condition)
+	}
+
 	// Reconcile unmanaged etcd client tls secret validation error status. Note only update status on validation error case to
 	// provide clear status to the user on the resource without having to look at operator logs.
 	{


### PR DESCRIPTION
This commit adds a `ClusterVersionSucceeding` condition to HostedCluster which
tracks the `Failing` condition of the hosted cluster's `ClusterVersion`
resource. This condition provides additional context about the health of the
hosted cluster in the steady state and during release version rollouts. During a
rollout, information about individual operator rollout status will be surfaced
through this new condition.