### PR TITLE
Add the `--timeout` to the hypershift create cli

### DIFF
--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -28,15 +28,14 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.MarkFlagRequired("agent-namespace")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT)
 		go func() {
 			<-sigs
-			cancel()
+			opts.Cancel()
 		}()
 
-		if err := CreateCluster(ctx, opts); err != nil {
+		if err := CreateCluster(opts.Ctx, opts); err != nil {
 			log.Error(err, "Failed to create cluster")
 			os.Exit(1)
 		}

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -48,15 +48,14 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.MarkFlagRequired("aws-creds")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT)
 		go func() {
 			<-sigs
-			cancel()
+			opts.Cancel()
 		}()
 
-		if err := CreateCluster(ctx, opts); err != nil {
+		if err := CreateCluster(opts.Ctx, opts); err != nil {
 			log.Error(err, "Failed to create cluster")
 			os.Exit(1)
 		}

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -26,6 +26,7 @@ func NewCreateCommands() *cobra.Command {
 		ServiceCIDR:                    "172.31.0.0/16",
 		PodCIDR:                        "10.132.0.0/14",
 		Wait:                           false,
+		Timeout:                        0,
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -54,8 +55,11 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ServiceCIDR, "service-cidr", opts.ServiceCIDR, "The CIDR of the service network")
 	cmd.PersistentFlags().StringVar(&opts.PodCIDR, "pod-cidr", opts.PodCIDR, "The CIDR of the pod network")
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
+	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
 
 	cmd.MarkPersistentFlagRequired("pull-secret")
+
+	opts.CreateContext()
 
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(none.NewCreateCommand(opts))

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -32,15 +32,14 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.ContainerDiskImage, "containerdisk", opts.KubevirtPlatform.ContainerDiskImage, "A reference to docker image with the embedded disk to be used to create the machines")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT)
 		go func() {
 			<-sigs
-			cancel()
+			opts.Cancel()
 		}()
 
-		if err := CreateCluster(ctx, opts); err != nil {
+		if err := CreateCluster(opts.Ctx, opts); err != nil {
 			log.Error(err, "Failed to create cluster")
 			os.Exit(1)
 		}

--- a/cmd/cluster/none/create.go
+++ b/cmd/cluster/none/create.go
@@ -27,15 +27,14 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.NonePlatform.APIServerAddress, "external-api-server-address", opts.NonePlatform.APIServerAddress, "The external API Server Address when using platform none")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT)
 		go func() {
 			<-sigs
-			cancel()
+			opts.Cancel()
 		}()
 
-		if err := CreateCluster(ctx, opts); err != nil {
+		if err := CreateCluster(opts.Ctx, opts); err != nil {
 			log.Error(err, "Failed to create cluster")
 			os.Exit(1)
 		}


### PR DESCRIPTION
When adding the `--wait` option to the hypershift create cluster command, if something went wrong, the command will stuck forever.

This PR adds the `--timeout` option, so the user can limit the time the command is running.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>