### PR TITLE
e2e: Fix periodic tests

### DIFF
--- a/cmd/cluster/aws/dump.go
+++ b/cmd/cluster/aws/dump.go
@@ -193,9 +193,9 @@ func (i *OCAdmInspect) Run(ctx context.Context, cmdArgs ...string) {
 	cmd := exec.CommandContext(ctx, i.oc, allArgs...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
-	err := cmd.Run()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Error(err, "error running inspect command")
+		log.Info("oc adm inspect returned an error", "args", allArgs, "error", err.Error(), "output", string(out))
 	}
 }
 
@@ -256,7 +256,7 @@ func outputLog(ctx context.Context, fileName string, req *restclient.Request, sk
 	b, err := req.DoRaw(ctx)
 	if err != nil {
 		if !skipLogErr {
-			log.Error(err, "Failed to get pod log", "req", req.URL().String())
+			log.Info("Failed to get pod log", "req", req.URL().String(), "error", err.Error())
 		}
 		return
 	}

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -26,6 +26,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 	t.Logf("Starting control plane upgrade test. FromImage: %s, toImage: %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
 
 	hostedCluster := e2eutil.CreateAWSCluster(t, ctx, client, clusterOpts, globalOpts.ArtifactDir)
 

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -7,54 +7,8 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 )
-
-// TestAWSCreateCluster implements a test that mimics the operation described in the
-// HyperShift quick start (creating a basic guest cluster).
-//
-// This test is meant to provide a first, fast signal to detect regression; it
-// is recommended to use it as a PR blocker test.
-func TestAWSCreateCluster(t *testing.T) {
-	t.Parallel()
-	g := NewWithT(t)
-
-	ctx, cancel := context.WithCancel(testContext)
-	defer cancel()
-
-	client := e2eutil.GetClientOrDie()
-
-	clusterOpts := globalOpts.DefaultClusterOptions()
-
-	hostedCluster := e2eutil.CreateAWSCluster(t, ctx, client, clusterOpts, globalOpts.ArtifactDir)
-
-	// Get the newly created nodepool
-	nodepool := &hyperv1.NodePool{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: hostedCluster.Namespace,
-			Name:      hostedCluster.Name,
-		},
-	}
-	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
-	t.Logf("Created nodepool. Namespace: %s, name: %s", nodepool.Namespace, nodepool.Name)
-
-	// Wait for nodes to report ready
-	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, *nodepool.Spec.NodeCount)
-
-	// Wait for the rollout to be reported complete
-	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
-	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
-
-	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, crclient.ObjectKeyFromObject(nodepool))
-	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-}
 
 func TestNoneCreateCluster(t *testing.T) {
 	t.Parallel()
@@ -77,5 +31,5 @@ func TestNoneCreateCluster(t *testing.T) {
 	e2eutil.WaitForConditionsOnHostedControlPlane(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
 
 	// etcd restarts for me once always and apiserver two times before running stable
-	//e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+	// e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -187,7 +187,7 @@ type configurableClusterOptions struct {
 
 func (o *options) DefaultClusterOptions() core.CreateOptions {
 	createOption := core.CreateOptions{
-		ReleaseImage:              o.PreviousReleaseImage,
+		ReleaseImage:              o.LatestReleaseImage,
 		GenerateSSH:               true,
 		SSHKeyFile:                "",
 		NodePoolReplicas:          2,

--- a/test/e2e/util/client.go
+++ b/test/e2e/util/client.go
@@ -7,8 +7,6 @@ import (
 	"k8s.io/client-go/rest"
 	cr "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	hyperapi "github.com/openshift/hypershift/api"
 )
 
 // GetConfigOrDie creates a REST config from current context
@@ -21,7 +19,7 @@ func GetConfigOrDie() *rest.Config {
 
 // GetClientOrDie creates a controller-runtime client for Kubernetes
 func GetClientOrDie() crclient.Client {
-	client, err := crclient.New(GetConfigOrDie(), crclient.Options{Scheme: hyperapi.Scheme})
+	client, err := crclient.New(GetConfigOrDie(), crclient.Options{Scheme: scheme})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to get kubernetes client: %v", err)
 		os.Exit(1)

--- a/test/e2e/util/scheme.go
+++ b/test/e2e/util/scheme.go
@@ -1,23 +1,9 @@
 package util
 
 import (
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	routev1 "github.com/openshift/api/route/v1"
-	securityv1 "github.com/openshift/api/security/v1"
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	hyperapi "github.com/openshift/hypershift/support/api"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	kasv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	capiaws "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
-	capiibm "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta1"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 var (
@@ -25,24 +11,10 @@ var (
 	// This scheme was born out of the requirement of certain
 	// GVKs in the testing environment that are not required by
 	// the client used by a running HyperShift instance.
-	scheme = runtime.NewScheme()
+	scheme = hyperapi.Scheme
 )
 
 func init() {
-	capiaws.AddToScheme(scheme)
-	capiibm.AddToScheme(scheme)
-	clientgoscheme.AddToScheme(scheme)
-	hyperv1.AddToScheme(scheme)
-	capiv1.AddToScheme(scheme)
-	configv1.AddToScheme(scheme)
-	operatorv1.AddToScheme(scheme)
-	securityv1.AddToScheme(scheme)
-	routev1.AddToScheme(scheme)
-	rbacv1.AddToScheme(scheme)
-	corev1.AddToScheme(scheme)
-	apiextensionsv1.AddToScheme(scheme)
-	kasv1beta1.AddToScheme(scheme)
-	prometheusoperatorv1.AddToScheme(scheme)
 	operatorsv1.AddToScheme(scheme)
 	operatorsv1alpha1.AddToScheme(scheme)
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	hyperapi "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/cluster/aws"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -100,7 +99,7 @@ func createCluster(t *testing.T, ctx context.Context, client crclient.Client, cl
 		deleteTimeout, cancel := context.WithTimeout(ctx, 1*time.Minute)
 		defer cancel()
 		DeleteNamespace(t, deleteTimeout, client, namespace.Name)
-		if t.Failed() {
+		if t.Failed() && len(artifactDir) != 0 {
 			clusterMgr.DumpCluster(ctx, hc, filepath.Join(artifactDir, testName, "delete-test-namespace"))
 		}
 	}
@@ -235,7 +234,7 @@ func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Clien
 	waitForGuestClientCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 	err = wait.PollUntil(5*time.Second, func() (done bool, err error) {
-		kubeClient, err := crclient.New(guestConfig, crclient.Options{Scheme: hyperapi.Scheme})
+		kubeClient, err := crclient.New(guestConfig, crclient.Options{Scheme: scheme})
 		if err != nil {
 			return false, nil
 		}


### PR DESCRIPTION
This commit fixes various e2e issues, and makes the full test suite work again
(i.e. the periodics).

* Before this commit, the periodic setup code was deploying the "previous"
release version passed to the e2e options and then waiting for the "latest"
version, causing rollouts to block forever. This is now fixed and made more
clear by having the global test setup default clusters to using the "latest"
release, and code which wants to do an upgrade must explicitly set options to
deploy the "previous" release.

* The TestAWSCreateCluster test has been deleted as everything it was doing is
covered (and more extensively) by TestUpgradeControlPlane.

* Minor fix: before this commit when e2e namespace teardown times out, artifacts
were being dumped even when no artifacts directory was specified. Now the dump
only happens when an artifacts directly is provided.