### PR TITLE
Fix kube scheduler health/liveness probes

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -17,6 +17,10 @@ import (
 	"github.com/openshift/hypershift/support/util"
 )
 
+const (
+	schedulerSecurePort = 10259
+)
+
 var (
 	volumeMounts = util.PodVolumeMounts{
 		schedulerContainerMain().Name: {
@@ -86,7 +90,7 @@ func buildSchedulerContainerMain(image, namespace string, featureGates []string,
 		c.Args = []string{
 			fmt.Sprintf("--config=%s", configPath),
 			fmt.Sprintf("--cert-dir=%s", certWorkDir),
-			"--port=0",
+			fmt.Sprintf("--secure-port=%d", schedulerSecurePort),
 			fmt.Sprintf("--authentication-kubeconfig=%s", kubeConfigPath),
 			fmt.Sprintf("--authorization-kubeconfig=%s", kubeConfigPath),
 			"-v=2",

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -46,8 +46,8 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/healthz",
-					Port:   intstr.FromInt(10251),
-					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(schedulerSecurePort),
+					Scheme: corev1.URISchemeHTTPS,
 				},
 			},
 			InitialDelaySeconds: 60,
@@ -62,8 +62,8 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/healthz",
-					Port:   intstr.FromInt(10251),
-					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(schedulerSecurePort),
+					Scheme: corev1.URISchemeHTTPS,
 				},
 			},
 			InitialDelaySeconds: 15,


### PR DESCRIPTION
In 4.10, the scheduler uses a secure port for its healthz endpoint and
it changed the default port that it listens on.
In this change we specify the secure port and use that same port for
liveness and readiness probes.