### PR TITLE
Use NLB for public KAS service type LoadBalancer

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -23,6 +23,9 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 	portSpec.Port = int32(apiServerPort)
 	portSpec.Protocol = corev1.ProtocolTCP
 	portSpec.TargetPort = intstr.FromInt(apiServerPort)
+	svc.ObjectMeta.Annotations = map[string]string{
+		"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
+	}
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:
 		if isPublic {


### PR DESCRIPTION
NLBs allow the source IP to pass through to the KAS pod so we can allow access based on source CIDR block in the `NetworkPolicy`