### PR TITLE
Add OIDC bucket and region to s3-credentials secret

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -206,22 +206,26 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 			panic(err)
 		}
 	}
-	operatorOIDCProviderS3Secret := assets.HyperShiftOperatorOIDCProviderS3Secret{
-		Namespace:                      operatorNamespace,
-		OIDCStorageProviderS3CredBytes: oidcStorageProviderS3CredBytes,
-	}.Build()
+	var operatorOIDCProviderS3Config *assets.HyperShiftOperatorOIDCProviderS3Secret
+	if opts.OIDCStorageProviderS3BucketName != "" {
+		operatorOIDCProviderS3Config = &assets.HyperShiftOperatorOIDCProviderS3Secret{
+			Namespace:                       operatorNamespace,
+			OIDCStorageProviderS3CredBytes:  oidcStorageProviderS3CredBytes,
+			OIDCStorageProviderS3BucketName: opts.OIDCStorageProviderS3BucketName,
+			OIDCStorageProviderS3Region:     opts.OIDCStorageProviderS3Region,
+		}
+	}
 	operatorDeployment := assets.HyperShiftOperatorDeployment{
-		Namespace:                       operatorNamespace,
-		OperatorImage:                   opts.HyperShiftImage,
-		ServiceAccount:                  operatorServiceAccount,
-		Replicas:                        opts.HyperShiftOperatorReplicas,
-		EnableOCPClusterMonitoring:      opts.EnableOCPClusterMonitoring,
-		EnableCIDebugOutput:             opts.EnableCIDebugOutput,
-		PrivatePlatform:                 opts.PrivatePlatform,
-		AWSPrivateRegion:                opts.AWSPrivateRegion,
-		AWSPrivateCreds:                 opts.AWSPrivateCreds,
-		OIDCStorageProviderS3BucketName: opts.OIDCStorageProviderS3BucketName,
-		OIDCStorageProviderS3Region:     opts.OIDCStorageProviderS3Region,
+		Namespace:                   operatorNamespace,
+		OperatorImage:               opts.HyperShiftImage,
+		ServiceAccount:              operatorServiceAccount,
+		Replicas:                    opts.HyperShiftOperatorReplicas,
+		EnableOCPClusterMonitoring:  opts.EnableOCPClusterMonitoring,
+		EnableCIDebugOutput:         opts.EnableCIDebugOutput,
+		PrivatePlatform:             opts.PrivatePlatform,
+		AWSPrivateRegion:            opts.AWSPrivateRegion,
+		AWSPrivateCreds:             opts.AWSPrivateCreds,
+		OIDCStorageProviderS3Config: operatorOIDCProviderS3Config,
 	}.Build()
 	operatorService := assets.HyperShiftOperatorService{
 		Namespace: operatorNamespace,
@@ -284,7 +288,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	objects = append(objects, serviceMonitor)
 	objects = append(objects, recordingRule)
 	if opts.OIDCStorageProviderS3BucketName != "" {
-		objects = append(objects, operatorOIDCProviderS3Secret)
+		objects = append(objects, operatorOIDCProviderS3Config.Build())
 		objects = append(objects, assets.OIDCStorageProviderS3ConfigMap(opts.OIDCStorageProviderS3BucketName, opts.OIDCStorageProviderS3Region))
 	}
 	return objects, nil


### PR DESCRIPTION
The `Deployment` generated by `hypershift install` includes OIDC bucket and
region information directly as container args. Having those fields in a configmap/secret
makes the generated `Deployment` reusable as the config information can be
supplied by external processes.

This patch modifies the generated s3 credentials secret `hypershift-operator-oidc-provider-s3-credentials`
to include the OIDC bucket name and region and sources them into the operator
deployment as ENV vars, so they can be interpolated into the container args.

This way, the deployment generated by `hypershift install` does not contain
OIDC configuration data directly but offloads that to the secret.

If `--oidc-storage-provider-s3-*` parameter are supplied to `hypershift install`,
the `Deployment` will change like this

```
***************
*** 23797,23802 ****
!         - --oidc-storage-provider-s3-bucket-name=bucket
!         - --oidc-storage-provider-s3-region=reg
--- 23797,23802 ----
!         - --oidc-storage-provider-s3-bucket-name=$(MY_OIDC_BUCKET)
!         - --oidc-storage-provider-s3-region=$(MY_OIDC_REGION)
***************
*** 23807,23810 ****
--- 23807,23820 ----
          env:
          - name: MY_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
+         - name: MY_OIDC_BUCKET
+           valueFrom:
+             secretKeyRef:
+               key: bucket
+               name: hypershift-operator-oidc-provider-s3-credentials
+         - name: MY_OIDC_REGION
+           valueFrom:
+             secretKeyRef:
+               key: region
+               name: hypershift-operator-oidc-provider-s3-credentials
```

and the `Secret` will change like this

```

  data:
+   bucket: YnVja2V0
    credentials: XXXXXXXX
+   region: cmVn
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>