### PR TITLE
Limit route53 record permissions to the clusters hostedzones

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -129,6 +129,9 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			InfraID:            infra.InfraID,
 			IssuerURL:          opts.AWSPlatform.IssuerURL,
 			AdditionalTags:     opts.AWSPlatform.AdditionalTags,
+			PrivateZoneID:      infra.PrivateZoneID,
+			PublicZoneID:       infra.PublicZoneID,
+			LocalZoneID:        infra.LocalZoneID,
 		}
 		iamInfo, err = opt.CreateIAM(ctx, client)
 		if err != nil {

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -40,6 +40,7 @@ type CreateInfraOutput struct {
 	BaseDomain      string `json:"baseDomain"`
 	PublicZoneID    string `json:"publicZoneID"`
 	PrivateZoneID   string `json:"privateZoneID"`
+	LocalZoneID     string `json:"localZoneID"`
 }
 
 const (
@@ -189,7 +190,7 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 	if err != nil {
 		return nil, err
 	}
-	_, err = o.CreatePrivateZone(ctx, route53Client, fmt.Sprintf("%s.%s", o.Name, hypershiftLocalZoneName), result.VPCID)
+	result.LocalZoneID, err = o.CreatePrivateZone(ctx, route53Client, fmt.Sprintf("%s.%s", o.Name, hypershiftLocalZoneName), result.VPCID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -27,6 +27,9 @@ type CreateIAMOptions struct {
 	AWSCredentialsFile              string
 	OIDCStorageProviderS3BucketName string
 	OIDCStorageProviderS3Region     string
+	PublicZoneID                    string
+	PrivateZoneID                   string
+	LocalZoneID                     string
 	InfraID                         string
 	IssuerURL                       string
 	OutputFile                      string
@@ -66,10 +69,16 @@ func NewCreateIAMCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3Region, "oidc-storage-provider-s3-region", "", "The region of the bucket in which the OIDC discovery document is stored")
 	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "Region where cluster infra should be created")
 	cmd.Flags().StringVar(&opts.OutputFile, "output-file", opts.OutputFile, "Path to file that will contain output information from infra resources (optional)")
+	cmd.Flags().StringVar(&opts.PublicZoneID, "public-zone-id", opts.PublicZoneID, "The id of the clusters public route53 zone")
+	cmd.Flags().StringVar(&opts.PrivateZoneID, "private-zone-id", opts.PrivateZoneID, "The id of the cluters private route53 zone")
+	cmd.Flags().StringVar(&opts.LocalZoneID, "local-zone-id", opts.LocalZoneID, "The id of the clusters local route53 zone")
 	cmd.Flags().StringSliceVar(&opts.AdditionalTags, "additional-tags", opts.AdditionalTags, "Additional tags to set on AWS resources")
 
 	cmd.MarkFlagRequired("aws-creds")
 	cmd.MarkFlagRequired("infra-id")
+	cmd.MarkFlagRequired("public-zone-id")
+	cmd.MarkFlagRequired("private-zone-id")
+	cmd.MarkFlagRequired("local-zone-id")
 	cmd.MarkFlagRequired("oidc-bucket-name")
 	cmd.MarkFlagRequired("oidc-bucket-region")
 


### PR DESCRIPTION
This changes the policies that grant route53 access to only allow
managing records in the clusters hosted zones. The ListHostedZones is
still unscoped, as it can not be scoped to a specific zone.

Ref https://issues.redhat.com/browse/HOSTEDCP-299