### PR TITLE
Generic dump command plus agent support

### DIFF
--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -1,7 +1,7 @@
 package dump
 
 import (
-	"github.com/openshift/hypershift/cmd/cluster/aws"
+	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/spf13/cobra"
 )
 
@@ -12,7 +12,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.AddCommand(aws.NewDumpCommand())
+	cmd.AddCommand(core.NewDumpCommand())
 
 	return cmd
 }

--- a/test/e2e/util/cluster/aws/cluster.go
+++ b/test/e2e/util/cluster/aws/cluster.go
@@ -79,11 +79,11 @@ func DumpHostedCluster(t *testing.T, ctx context.Context, hc *hyperv1.HostedClus
 				t.Errorf("Found %s messages in file %s", upsert.LoopDetectorWarningMessage, filename)
 			}
 		}
-		err := aws.DumpCluster(ctx, &aws.DumpOptions{
+		err := core.DumpCluster(ctx, &core.DumpOptions{
 			Namespace:   hc.Namespace,
 			Name:        hc.Name,
 			ArtifactDir: artifactDir,
-			LogCheckers: []aws.LogChecker{findKubeObjectUpdateLoops},
+			LogCheckers: []core.LogChecker{findKubeObjectUpdateLoops},
 		})
 		if err != nil {
 			t.Errorf("Failed to dump cluster: %v", err)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -28,7 +28,6 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/cmd/cluster/aws"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 )
 
@@ -392,7 +391,7 @@ func DumpGuestCluster(t *testing.T, ctx context.Context, client crclient.Client,
 
 	dumpDir := filepath.Join(destDir, "hostedcluster-"+hostedCluster.Name)
 	t.Logf("Dumping guest cluster. Namespace: %s, name: %s, dest: %s", hostedCluster.Namespace, hostedCluster.Name, dumpDir)
-	if err := aws.DumpGuestCluster(ctx, kubeconfigFile.Name(), dumpDir); err != nil {
+	if err := core.DumpGuestCluster(ctx, kubeconfigFile.Name(), dumpDir); err != nil {
 		t.Errorf("Failed to dump guest cluster: %v", err)
 		return
 	}


### PR DESCRIPTION
Moved the AWS implementation of cmd/dump to be generic and added
the resourced needed by the agent platform.