### PR TITLE
Fix CLI --timeout flag

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -48,14 +48,20 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.MarkFlagRequired("aws-creds")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		if opts.Timeout > 0 {
+			ctx, cancel = context.WithTimeout(context.Background(), opts.Timeout)
+		}
+		defer cancel()
+
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT)
 		go func() {
 			<-sigs
-			opts.Cancel()
+			cancel()
 		}()
 
-		if err := CreateCluster(opts.Ctx, opts); err != nil {
+		if err := CreateCluster(ctx, opts); err != nil {
 			log.Error(err, "Failed to create cluster")
 			os.Exit(1)
 		}

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -59,8 +59,6 @@ func NewCreateCommands() *cobra.Command {
 
 	cmd.MarkPersistentFlagRequired("pull-secret")
 
-	opts.CreateContext()
-
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(none.NewCreateCommand(opts))
 	cmd.AddCommand(agent.NewCreateCommand(opts))

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -58,24 +58,6 @@ type CreateOptions struct {
 	AgentPlatform                    AgentPlatformCreateOptions
 	Wait                             bool
 	Timeout                          time.Duration
-	Ctx                              context.Context
-	cancel                           context.CancelFunc
-}
-
-func (opts *CreateOptions) CreateContext() {
-	if opts.Ctx == nil {
-		if opts.Wait && opts.Timeout > 0 {
-			opts.Ctx, opts.cancel = context.WithTimeout(context.Background(), opts.Timeout)
-		} else {
-			opts.Ctx, opts.cancel = context.WithCancel(context.Background())
-		}
-	}
-}
-
-func (opts CreateOptions) Cancel() {
-	if opts.cancel != nil {
-		opts.cancel()
-	}
 }
 
 type AgentPlatformCreateOptions struct {
@@ -294,8 +276,6 @@ func Validate(ctx context.Context, opts *CreateOptions) error {
 }
 
 func CreateCluster(ctx context.Context, opts *CreateOptions, platformSpecificApply ApplyPlatformSpecifics) error {
-	defer opts.Cancel()
-
 	if opts.Wait && opts.NodePoolReplicas < 1 {
 		return errors.New("--wait requires --node-pool-replicas > 0")
 	}

--- a/cmd/cluster/none/create.go
+++ b/cmd/cluster/none/create.go
@@ -27,14 +27,20 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.NonePlatform.APIServerAddress, "external-api-server-address", opts.NonePlatform.APIServerAddress, "The external API Server Address when using platform none")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		if opts.Timeout > 0 {
+			ctx, cancel = context.WithTimeout(context.Background(), opts.Timeout)
+		}
+		defer cancel()
+
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT)
 		go func() {
 			<-sigs
-			opts.Cancel()
+			cancel()
 		}()
 
-		if err := CreateCluster(opts.Ctx, opts); err != nil {
+		if err := CreateCluster(ctx, opts); err != nil {
 			log.Error(err, "Failed to create cluster")
 			os.Exit(1)
 		}


### PR DESCRIPTION
Before this commit, the --timeout flag to `create cluster` didn't work
due to some bug with its stateful approach which I haven't debugged.
Instead, this commit just refactors the timeout handling to simply be
stateless and propagate a timeout context from each command's Run()
method which is trivial enough to just duplicate wherever needed.