### PR TITLE
Missing GroupVersion on AgentCluster

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -50,6 +50,13 @@ func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, create
 		return nil, err
 	}
 
+	// reconciliation strips TypeMeta. We repopulate the static values since they are necessary for
+	// downstream reconciliation of the CAPI Cluster resource.
+	agentCluster.TypeMeta = metav1.TypeMeta{
+		Kind:       "AgentCluster",
+		APIVersion: agentv1.GroupVersion.String(),
+	}
+
 	return agentCluster, nil
 }
 


### PR DESCRIPTION
This is in line with the AWS provider.  Without this the cluster.InfrastructureRef is missing the Kind and APIVersion, and therefore CAPI has trouble reconciling.