### PR TITLE
Update hypershift image reference

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -7,9 +7,7 @@ import (
 )
 
 var (
-	// TODO: This goes away when control-plane-operator becomes another component
-	// in the OCP payload.
-	HyperShiftImage = "quay.io/hypershift/hypershift:latest"
+	HyperShiftImage = "quay.io/hypershift/hypershift-operator:latest"
 )
 
 // https://docs.ci.openshift.org/docs/getting-started/useful-links/#services

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -20,7 +20,7 @@ you should adjust to your own environment.
 
     Install it using Go 1.17+:
        ```shell
-       go install github.com/openshift/hypershift@latest
+       go get -u github.com/openshift/hypershift@latest
        ```
 
 * Admin access to an OpenShift cluster (version 4.8+) specified by the `KUBECONFIG` environment variable.


### PR DESCRIPTION
As of https://github.com/openshift/release/pull/25398, the operator
image has changed, and the prior reference now refers to the control
plane operator shipped with OCP. This commit fixes the reference.

Also includes a minor docs update.

Fixes #803 