### PR TITLE
add probes to machine-approver to ensure it is functioning

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3258,6 +3258,34 @@ func reconcileMachineApproverDeployment(deployment *appsv1.Deployment, hc *hyper
 								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/metrics",
+									Port:   intstr.FromInt(9191),
+									Scheme: corev1.URISchemeHTTP,
+								},
+							},
+							InitialDelaySeconds: int32(60),
+							PeriodSeconds:       int32(60),
+							SuccessThreshold:    int32(1),
+							FailureThreshold:    int32(5),
+							TimeoutSeconds:      int32(5),
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/metrics",
+									Port:   intstr.FromInt(9191),
+									Scheme: corev1.URISchemeHTTP,
+								},
+							},
+							InitialDelaySeconds: int32(15),
+							PeriodSeconds:       int32(60),
+							SuccessThreshold:    int32(1),
+							FailureThreshold:    int32(3),
+							TimeoutSeconds:      int32(5),
+						},
 						Command: []string{"/usr/bin/machine-approver"},
 						Args:    args,
 					},


### PR DESCRIPTION
Currently machine-approver only has a metrics endpoint (no healthz) and no healthchecks on the pod. We need health probes to ensure the program is still functioning for monitoring and availability reasons.

This adds probes to the deployment to ensure it is monitored over time. Later prs if other probes come available can be made to adjust the endpoint being probed.

Details for probe are here:
https://github.com/openshift/cluster-machine-approver/blob/master/pkg/metrics/metrics.go#L13