### PR TITLE
Refactor context usage in the CLI, to reduce code duplication

### DIFF
--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -3,14 +3,12 @@ package agent
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
+
+	"github.com/spf13/cobra"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/spf13/cobra"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
@@ -27,24 +25,19 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AgentPlatform.AgentNamespace, "agent-namespace", opts.AgentPlatform.AgentNamespace, "The namespace in which to search for Agents")
 	cmd.MarkFlagRequired("agent-namespace")
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 		if opts.Timeout > 0 {
-			ctx, cancel = context.WithTimeout(context.Background(), opts.Timeout)
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
 		}
-		defer cancel()
-
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
 
 		if err := CreateCluster(ctx, opts); err != nil {
 			log.Error(err, "Failed to create cluster")
-			os.Exit(1)
+			return err
 		}
+		return nil
 	}
 
 	return cmd

--- a/cmd/cluster/agent/destroy.go
+++ b/cmd/cluster/agent/destroy.go
@@ -2,14 +2,12 @@ package agent
 
 import (
 	"context"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/none"
-	"github.com/spf13/cobra"
 )
 
 type DestroyOptions struct {
@@ -25,19 +23,13 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-
-		if err := DestroyCluster(ctx, opts); err != nil {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := DestroyCluster(cmd.Context(), opts); err != nil {
 			log.Error(err, "Failed to destroy cluster")
-			os.Exit(1)
+			return err
 		}
+
+		return nil
 	}
 
 	return cmd

--- a/cmd/cluster/aws/destroy.go
+++ b/cmd/cluster/aws/destroy.go
@@ -3,14 +3,12 @@ package aws
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
-	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/util/errors"
 )
 
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
@@ -33,19 +31,13 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 
 	cmd.MarkFlagRequired("aws-creds")
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-
-		if err := DestroyCluster(ctx, opts); err != nil {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := DestroyCluster(cmd.Context(), opts); err != nil {
 			log.Error(err, "Failed to destroy cluster")
-			os.Exit(1)
+			return err
 		}
+
+		return nil
 	}
 
 	return cmd

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -3,13 +3,14 @@ package cluster
 import (
 	"time"
 
+	"github.com/spf13/cobra"
+
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/cluster/agent"
 	"github.com/openshift/hypershift/cmd/cluster/aws"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/cluster/none"
-	"github.com/spf13/cobra"
 )
 
 func NewCreateCommands() *cobra.Command {
@@ -33,6 +34,7 @@ func NewCreateCommands() *cobra.Command {
 		Short:        "Creates basic functional HostedCluster resources",
 		SilenceUsage: true,
 	}
+
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A namespace to contain the generated resources")
 	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "A name for the cluster")
 	cmd.PersistentFlags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the cluster")

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -13,11 +13,6 @@ import (
 	"strings"
 	"time"
 
-	apifixtures "github.com/openshift/hypershift/api/fixtures"
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/cmd/util"
-	"github.com/openshift/hypershift/cmd/version"
-	hyperapi "github.com/openshift/hypershift/support/api"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,6 +20,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclient "k8s.io/client-go/kubernetes"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	apifixtures "github.com/openshift/hypershift/api/fixtures"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/cmd/version"
+	hyperapi "github.com/openshift/hypershift/support/api"
 )
 
 // ApplyPlatformSpecifics can be used to create platform specific values as well as enriching the fixure with additional values

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -11,10 +11,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
-	hyperapi "github.com/openshift/hypershift/api"
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/cmd/util"
-	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -24,6 +20,11 @@ import (
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperapi "github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 )
 
 type DumpOptions struct {
@@ -59,12 +60,12 @@ func NewDumpCommand() *cobra.Command {
 
 	cmd.MarkFlagRequired("artifact-dir")
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx := context.Background()
-		if err := DumpCluster(ctx, opts); err != nil {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := DumpCluster(cmd.Context(), opts); err != nil {
 			log.Error(err, "Error")
-			os.Exit(1)
+			return err
 		}
+		return nil
 	}
 	return cmd
 }

--- a/cmd/cluster/kubevirt/destroy.go
+++ b/cmd/cluster/kubevirt/destroy.go
@@ -1,15 +1,12 @@
 package kubevirt
 
 import (
-	"context"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/none"
-	"github.com/spf13/cobra"
 )
 
 type DestroyOptions struct {
@@ -25,19 +22,12 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-
-		if err := none.DestroyCluster(ctx, opts); err != nil {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := none.DestroyCluster(cmd.Context(), opts); err != nil {
 			log.Error(err, "Failed to destroy cluster")
-			os.Exit(1)
+			return err
 		}
+		return nil
 	}
 
 	return cmd

--- a/cmd/cluster/none/create.go
+++ b/cmd/cluster/none/create.go
@@ -3,14 +3,12 @@ package none
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
+
+	"github.com/spf13/cobra"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/spf13/cobra"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
@@ -26,24 +24,19 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.NonePlatform.APIServerAddress, "external-api-server-address", opts.NonePlatform.APIServerAddress, "The external API Server Address when using platform none")
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 		if opts.Timeout > 0 {
-			ctx, cancel = context.WithTimeout(context.Background(), opts.Timeout)
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
 		}
-		defer cancel()
-
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
 
 		if err := CreateCluster(ctx, opts); err != nil {
 			log.Error(err, "Failed to create cluster")
-			os.Exit(1)
+			return err
 		}
+		return nil
 	}
 
 	return cmd

--- a/cmd/cluster/none/destroy.go
+++ b/cmd/cluster/none/destroy.go
@@ -3,13 +3,11 @@ package none
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
 
-	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
 )
 
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
@@ -19,19 +17,12 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-
-		if err := DestroyCluster(ctx, opts); err != nil {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := DestroyCluster(cmd.Context(), opts); err != nil {
 			log.Error(err, "Failed to destroy cluster")
-			os.Exit(1)
+			return err
 		}
+		return nil
 	}
 
 	return cmd

--- a/cmd/consolelogs/aws/getlogs.go
+++ b/cmd/consolelogs/aws/getlogs.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -52,20 +50,13 @@ func NewCommand() *cobra.Command {
 	cmd.MarkFlagRequired("aws-creds")
 	cmd.MarkFlagRequired("output-dir")
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-
-		if err := opts.Run(ctx); err != nil {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := opts.Run(cmd.Context()); err != nil {
 			log.Error(err, "Failed to get console logs")
-			os.Exit(1)
+			return err
 		}
 		log.Info("Successfully retrieved console logs")
+		return nil
 	}
 
 	return cmd

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -1,10 +1,10 @@
 package create
 
 import (
-	"github.com/openshift/hypershift/cmd/cluster"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hypershift/cmd/bastion"
+	"github.com/openshift/hypershift/cmd/cluster"
 	"github.com/openshift/hypershift/cmd/infra"
 	"github.com/openshift/hypershift/cmd/kubeconfig"
 	"github.com/openshift/hypershift/cmd/nodepool"

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -1,10 +1,10 @@
 package aws
 
 import (
-	"github.com/openshift/hypershift/cmd/cluster"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hypershift/cmd/bastion"
+	"github.com/openshift/hypershift/cmd/cluster"
 	"github.com/openshift/hypershift/cmd/infra"
 )
 

--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -3,10 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -59,20 +56,13 @@ func NewDestroyCommand() *cobra.Command {
 	cmd.MarkFlagRequired("aws-creds")
 	cmd.MarkFlagRequired("base-domain")
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-
-		if err := opts.Run(ctx); err != nil {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := opts.Run(cmd.Context()); err != nil {
 			log.Error(err, "Failed to destroy infrastructure")
-			os.Exit(1)
+			return err
 		}
 		log.Info("Successfully destroyed infrastructure")
+		return nil
 	}
 
 	return cmd

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -3,10 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,15 +45,7 @@ func NewDestroyIAMCommand() *cobra.Command {
 	cmd.MarkFlagRequired("infra-id")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-
-		if err := opts.DestroyIAM(ctx); err != nil {
+		if err := opts.DestroyIAM(cmd.Context()); err != nil {
 			return err
 		}
 		log.Info("Successfully destroyed IAM infra")

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -20,22 +20,18 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 
 	"github.com/spf13/cobra"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperapi "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/install/assets"
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/cmd/version"
-
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Options struct {
@@ -101,14 +97,6 @@ func NewCommand() *cobra.Command {
 			return err
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-
 		switch {
 		case opts.Development:
 			opts.HyperShiftOperatorReplicas = 0
@@ -125,7 +113,7 @@ func NewCommand() *cobra.Command {
 		case opts.Render:
 			render(objects)
 		default:
-			err := apply(ctx, objects)
+			err := apply(cmd.Context(), objects)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Refactor the CLI to use the same context. Replace the `Run` function by `RunE` to return errors from the cmd implementation, instead of `exit(1)` from unexpected locations, the command abortion will be done from one place at the root command.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>