### PR TITLE
Hypershift operator: Add missing watches and unittest correct watches

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 	"time"
 
-	imageapi "github.com/openshift/api/image/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 	"github.com/openshift/hypershift/support/globalconfig"
-	"github.com/openshift/hypershift/support/releaseinfo"
+	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	corev1 "k8s.io/api/core/v1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,14 +72,6 @@ var cpObjects = []client.Object{
 	fakePackageServerService(),
 }
 
-type fakeReleaseProvider struct{}
-
-func (*fakeReleaseProvider) Lookup(ctx context.Context, image string, pullSecret []byte) (*releaseinfo.ReleaseImage, error) {
-	return &releaseinfo.ReleaseImage{
-		ImageStream: &imageapi.ImageStream{},
-	}, nil
-}
-
 func TestReconcileErrorHandling(t *testing.T) {
 
 	// get initial number of creates with no get errors
@@ -98,7 +89,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 			cpClient:               fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(cpObjects...).Build(),
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
-			releaseProvider:        &fakeReleaseProvider{},
+			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
 		}
 		_, err := r.Reconcile(context.Background(), controllerruntime.Request{})
 		if err != nil {
@@ -121,7 +112,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 			cpClient:               fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(cpObjects...).Build(),
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
-			releaseProvider:        &fakeReleaseProvider{},
+			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
 		}
 		r.Reconcile(context.Background(), controllerruntime.Request{})
 		if totalCreates-fakeClient.getErrorCount != fakeClient.createCount {

--- a/support/capabilities/fake/fake.go
+++ b/support/capabilities/fake/fake.go
@@ -1,0 +1,14 @@
+package fake
+
+import (
+	"github.com/openshift/hypershift/support/capabilities"
+)
+
+var _ capabilities.CapabiltyChecker = &FakeSupportAllCapabilities{}
+
+type FakeSupportAllCapabilities struct {
+}
+
+func (f *FakeSupportAllCapabilities) Has(capabilities ...capabilities.CapabilityType) bool {
+	return true
+}

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -10,6 +10,10 @@ import (
 	"k8s.io/client-go/discovery"
 )
 
+type CapabiltyChecker interface {
+	Has(capabilities ...CapabilityType) bool
+}
+
 type CapabilityType int
 
 const (

--- a/support/capabilities/management_cluster_capabilities_test.go
+++ b/support/capabilities/management_cluster_capabilities_test.go
@@ -16,6 +16,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ CapabiltyChecker = &ManagementClusterCapabilities{}
+
 func TestIsGroupVersionRegistered(t *testing.T) {
 
 	testCases := []struct {

--- a/support/releaseinfo/fake/fake.go
+++ b/support/releaseinfo/fake/fake.go
@@ -1,0 +1,23 @@
+package fake
+
+import (
+	"context"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/hypershift/support/releaseinfo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ releaseinfo.ProviderWithRegistryOverrides = &FakeReleaseProvider{}
+
+type FakeReleaseProvider struct{}
+
+func (*FakeReleaseProvider) Lookup(ctx context.Context, image string, pullSecret []byte) (*releaseinfo.ReleaseImage, error) {
+	return &releaseinfo.ReleaseImage{
+		ImageStream: &imagev1.ImageStream{ObjectMeta: metav1.ObjectMeta{Name: "4.10.0"}},
+	}, nil
+}
+
+func (*FakeReleaseProvider) GetRegistryOverrides() map[string]string {
+	return nil
+}

--- a/support/releaseinfo/registry_mirror_provider.go
+++ b/support/releaseinfo/registry_mirror_provider.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-var _ Provider = (*RegistryMirrorProviderDecorator)(nil)
+var _ ProviderWithRegistryOverrides = (*RegistryMirrorProviderDecorator)(nil)
 
 // RegistryMirrorProviderDecorator decorates another Provider to add user-specified
 // component name to image mappings. The Lookup implementation will first
@@ -37,4 +37,8 @@ func (p *RegistryMirrorProviderDecorator) Lookup(ctx context.Context, image stri
 		}
 	}
 	return releaseImage, nil
+}
+
+func (p *RegistryMirrorProviderDecorator) GetRegistryOverrides() map[string]string {
+	return p.RegistryOverrides
 }

--- a/support/releaseinfo/releaseinfo.go
+++ b/support/releaseinfo/releaseinfo.go
@@ -20,6 +20,11 @@ type Provider interface {
 	Lookup(ctx context.Context, image string, pullSecret []byte) (*ReleaseImage, error)
 }
 
+type ProviderWithRegistryOverrides interface {
+	Provider
+	GetRegistryOverrides() map[string]string
+}
+
 // ReleaseImage wraps an ImageStream with some utilities that help the user
 // discover constituent component image information.
 type ReleaseImage struct {


### PR DESCRIPTION
This change add a test to the hypershift operator that verifies that it
watches all object types it creates. It works by:
* Running a Reconcile() for a hostedcluter per supported platform
* Using a fakeclient that trackes what objecttypes get created
* Factoring out the set of types that are being watched
* Compaing the set of objects that are getting created with the ones
  that are being watched

Additionally, some changes where needed to allow unittesting this:
* The ReleaseProvider was defined as interface but then asserted to a
  concrete type because the interface lacked didn't expose
  RegistryOverrides. Use a new interface that includes those so we can
  use a fake implementation in tests
* The capabilites were configured through a struct that didn't export
  the map of supported capabilites. Replace the struct with an interface
  and add a fake implementation