### PR TITLE
Dump: Don't dump agent-specific resources when there is no agent NS

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -127,8 +127,10 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 		&agentv1.AgentCluster{},
 	}
 	resourceList := strings.Join(resourceTypes(resources), ",")
-	// Additional Agent platform resources
-	resourceList += ",clusterdeployment.hive.openshift.io,agentclusterinstall.extensions.hive.openshift.io"
+	if opts.AgentNamespace != "" {
+		// Additional Agent platform resources
+		resourceList += ",clusterdeployment.hive.openshift.io,agentclusterinstall.extensions.hive.openshift.io"
+	}
 	cmd.WithNamespace(controlPlaneNamespace).Run(ctx, resourceList)
 	cmd.WithNamespace(opts.Namespace).Run(ctx, resourceList)
 	cmd.WithNamespace("hypershift").Run(ctx, resourceList)


### PR DESCRIPTION
We don't install these CRDs through hypershift install, so the
corresponding apis dont exist which makes `ocm adm inspect` always
error. This doesn't fail the `dump` command but is confusing and blocks
the way for actually checking the success of the `oc` invocation.

/cc @ironcladlou 