### PR TITLE
use globalconfig when specified (fixes ibmcloud deployments)

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1565,7 +1565,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.C
 	p := oapi.NewOpenShiftAPIServerParams(hcp, globalConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 	oapicfg := manifests.OpenShiftAPIServerConfig(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, oapicfg, func() error {
-		return oapi.ReconcileConfig(oapicfg, p.OwnerRef, p.EtcdURL, p.IngressDomain(), p.MinTLSVersion(), p.CipherSuites(), p.Image, p.Ingress, p.Project)
+		return oapi.ReconcileConfig(oapicfg, p.OwnerRef, p.EtcdURL, p.IngressDomain(), p.MinTLSVersion(), p.CipherSuites(), p.Image, p.Project)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift apiserver config: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -50,7 +50,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig g
 		ProxyImage:              images["socks5-proxy"],
 		APIServer:               globalConfig.APIServer,
 		ServiceAccountIssuerURL: hcp.Spec.IssuerURL,
-		IngressSubDomain:        config.IngressSubdomain(hcp),
+		IngressSubDomain:        globalconfig.IngressDomain(hcp, globalConfig.Ingress),
 		AvailabilityProberImage: images[util.AvailabilityProberImageName],
 		Availability:            hcp.Spec.ControllerAvailabilityPolicy,
 		Image:                   globalConfig.Image,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
@@ -11,13 +11,13 @@ type IngressParams struct {
 	PlatformType     hyperv1.PlatformType
 }
 
-func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
+func NewIngressParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig) *IngressParams {
 	var replicas int32 = 2
 	if hcp.Spec.InfrastructureAvailabilityPolicy == hyperv1.SingleReplica {
 		replicas = 1
 	}
 	return &IngressParams{
-		IngressSubdomain: globalconfig.IngressDomain(hcp),
+		IngressSubdomain: globalconfig.IngressDomain(hcp, globalConfig.Ingress),
 		Replicas:         replicas,
 		PlatformType:     hcp.Spec.Platform.Type,
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -203,7 +203,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 	}
 
 	log.Info("reconciling ingress controller")
-	if err := r.reconcileIngressController(ctx, hcp); err != nil {
+	if err := r.reconcileIngressController(ctx, hcp, globalConfig); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile ingress controller: %w", err))
 	}
 
@@ -523,9 +523,9 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 	return errors.NewAggregate(errs)
 }
 
-func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig) error {
 	var errs []error
-	p := ingress.NewIngressParams(hcp)
+	p := ingress.NewIngressParams(hcp, globalConfig)
 	ingressController := manifests.IngressDefaultIngressController()
 	if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
 		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas)

--- a/support/globalconfig/ingress.go
+++ b/support/globalconfig/ingress.go
@@ -2,7 +2,6 @@ package globalconfig
 
 import (
 	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -18,12 +17,18 @@ func IngressConfig() *configv1.Ingress {
 }
 
 func ReconcileIngressConfig(cfg *configv1.Ingress, hcp *hyperv1.HostedControlPlane, globalConfig GlobalConfig) {
-	cfg.Spec.Domain = IngressDomain(hcp)
+	cfg.Spec.Domain = IngressDomain(hcp, globalConfig.Ingress)
 	if globalConfig.Ingress != nil {
 		cfg.Spec = globalConfig.Ingress.Spec
 	}
 }
 
-func IngressDomain(hcp *hyperv1.HostedControlPlane) string {
+func IngressDomain(hcp *hyperv1.HostedControlPlane, ingressConfig *configv1.Ingress) string {
+	if ingressConfig != nil {
+		if len(ingressConfig.Spec.AppsDomain) > 0 {
+			return ingressConfig.Spec.AppsDomain
+		}
+		return ingressConfig.Spec.Domain
+	}
 	return fmt.Sprintf("apps.%s", BaseDomain(hcp))
 }


### PR DESCRIPTION
Builds on Cesar's PR:
https://github.com/openshift/hypershift/pull/806

and fixes the remaining areas that need to properly account for subdomains. This is necessary to get IBMCloud deployments functional again.