### PR TITLE
fix machineTemplate deletion logic to prevent panics in the hypershift operator (fixes IBMCloud deploys)

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1179,6 +1179,10 @@ func (r *NodePoolReconciler) listMachineTemplates(nodePool *hyperv1.NodePool) ([
 		if err != nil {
 			return nil, err
 		}
+	default:
+		// need a default path that returns a value that does not cause the hypershift operator to crash
+		// if no explicit machineTemplate is defined safe to assume none exist
+		return nil, nil
 	}
 
 	machineTemplateList.SetGroupVersionKind(schema.GroupVersionKind{

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -942,7 +942,7 @@ func TestMachineTemplateBuildersPreexisting(t *testing.T) {
 	RunTestMachineTemplateBuilders(t, true)
 }
 
-func TestListMachineTemplates(t *testing.T) {
+func TestListMachineTemplatesAWS(t *testing.T) {
 	g := NewWithT(t)
 	c := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects().Build()
 	r := &NodePoolReconciler{
@@ -987,4 +987,29 @@ func TestListMachineTemplates(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(templates)).To(Equal(1))
 	g.Expect(templates[0].GetName()).To(Equal("template1"))
+}
+
+func TestListMachineTemplatesIBMCloud(t *testing.T) {
+	g := NewWithT(t)
+	c := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects().Build()
+	r := &NodePoolReconciler{
+		Client:                 c,
+		CreateOrUpdateProvider: upsert.New(false),
+	}
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: hyperv1.NodePoolSpec{
+			Platform: hyperv1.NodePoolPlatform{
+				Type: hyperv1.IBMCloudPlatform,
+			},
+		},
+	}
+	g.Expect(r.Client.Create(context.Background(), nodePool)).To(BeNil())
+
+	templates, err := r.listMachineTemplates(nodePool)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(len(templates)).To(Equal(0))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
some providers like None and currently IBM Cloud UPI (Satellite) do not have explicit machine template types. 

This PR changes that so the default is if something is not explicitly defined an empty list is returned which will allow a graceful skip of the machineTemplate deletion logic instead of a stopping cleanup of the nodepools.

Current code stops here:
https://github.com/openshift/hypershift/blob/767e7abff226c8559935a13b1287d377072e1633/hypershift-operator/controllers/nodepool/nodepool_controller.go#L150

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes regression found in IBMCloud regression tests

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.




