### PR TITLE
add reconciliation logic to ensure in cluster ingress operator is removed when cluster is at 4.9+

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -30,6 +31,15 @@ func IngressCert(ns string) *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ingress-crt",
 			Namespace: ns,
+		},
+	}
+}
+
+func InClusterIngressOperator() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-operator",
+			Namespace: "openshift-ingress-operator",
 		},
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -207,6 +207,13 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		errs = append(errs, fmt.Errorf("failed to reconcile ingress controller: %w", err))
 	}
 
+	// 4.9+ only ensure in-cluster ingress operator deployment is removed
+	log.Info("ensure legacy in-cluster ingress operator deployment removed")
+	err = r.client.Delete(ctx, manifests.InClusterIngressOperator())
+	if err != nil && !apierrors.IsNotFound(err) {
+		errs = append(errs, fmt.Errorf("failed to remove incluster ingress operator deployment: %w", err))
+	}
+
 	log.Info("reconciling kube control plane signer secret")
 	kubeControlPlaneSignerSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
clusters upgrading from 4.8+ (and when clusters are adopted from ibm-roks-toolkit to hypershift on a version boundary) need to have logic to ensure that the legacy deployment of the ingress-operator is removed. This adds logic to ensure that reconciliation is done to complete the migration of the ingress-operator to the management-cluster 