### PR TITLE
add release image annotation support for extra metadata that can tie downstream deployments to a given release image

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -32,6 +32,8 @@ const (
 	// it is important in some situations like CA rotation where components need to be fully restarted to pick up new CAs. It's also
 	// important in some recovery situations where a fresh start of the component helps fix symptoms a user might be experiencing.
 	RestartDateAnnotation = "hypershift.openshift.io/restart-date"
+	// ReleaseImageAnnotation is an annotation that can be used to see what release image a given deployment is tied to
+	ReleaseImageAnnotation = "hypershift.openshift.io/release-image"
 	// ClusterAPIManagerImage is an annotation that allows the specification of the cluster api manager image.
 	// This is a temporary workaround necessary for compliance reasons on the IBM Cloud side:
 	// no images can be pulled from registries outside of IBM Cloud's official regional registries

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -41,6 +41,7 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalCon
 	}
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
@@ -78,6 +78,7 @@ func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.Host
 	}
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	params.SetDefaultSecurityContext = setDefaultSecurityContext
 

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -39,6 +39,7 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane, images map[string]string, set
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	p.DeploymentConfig.SetColocation(hcp)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	p.DeploymentConfig.Replicas = 1
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -42,6 +42,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	p.DeploymentConfig.SetColocation(hcp)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	p.DeploymentConfig.Replicas = 1
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -270,6 +270,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 
 	switch hcp.Spec.Platform.Type {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -94,6 +94,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	}
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -61,6 +61,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	p.ServerDeploymentConfig.Replicas = 1
 	p.ServerDeploymentConfig.SetColocation(hcp)
 	p.ServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.ServerDeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	p.ServerDeploymentConfig.SetControlPlaneIsolation(hcp)
 
 	p.AgentDeploymentConfig.Resources = config.ResourcesSpec{
@@ -94,6 +95,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	}
 	p.AgentDeploymentConfig.SetMultizoneSpread(konnectivityAgentLabels())
 	p.AgentDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.AgentDeamonSetConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	p.AgentDeploymentConfig.SetColocation(hcp)
 	p.AgentDeploymentConfig.SetControlPlaneIsolation(hcp)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -103,6 +103,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig g
 	}
 	params.OpenShiftAPIServerDeploymentConfig.SetColocation(hcp)
 	params.OpenShiftAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.OpenShiftAPIServerDeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.OpenShiftAPIServerDeploymentConfig.SetControlPlaneIsolation(hcp)
 	params.OpenShiftOAuthAPIServerDeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
@@ -154,6 +155,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig g
 
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetColocation(hcp)
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.OpenShiftOAuthAPIServerDeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.Etcd.ManagementType {
 	case hyperv1.Unmanaged:

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -128,6 +128,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalco
 	}
 	p.DeploymentConfig.SetColocation(hcp)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -49,6 +49,7 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, global
 	}
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
@@ -41,6 +41,7 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images m
 	}
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 
 	params.PackageServerConfig = config.DeploymentConfig{
@@ -50,6 +51,7 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images m
 	}
 	params.PackageServerConfig.SetColocation(hcp)
 	params.PackageServerConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.PackageServerConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.PackageServerConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -75,6 +75,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 	params.DeploymentConfig.SetColocation(hcp)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -31,6 +31,13 @@ func (c *DeploymentConfig) SetRestartAnnotation(objectMetadata metav1.ObjectMeta
 	}
 }
 
+func (c *DeploymentConfig) SetReleaseImageAnnotation(releaseImage string) {
+	if c.AdditionalAnnotations == nil {
+		c.AdditionalAnnotations = make(AdditionalAnnotations)
+	}
+	c.AdditionalAnnotations[hyperv1.ReleaseImageAnnotation] = releaseImage
+}
+
 func (c *DeploymentConfig) SetMultizoneSpread(labels map[string]string) {
 	if c.Scheduling.Affinity == nil {
 		c.Scheduling.Affinity = &corev1.Affinity{}

--- a/support/config/deployment_test.go
+++ b/support/config/deployment_test.go
@@ -29,6 +29,26 @@ func TestSetRestartAnnotation(t *testing.T) {
 	}
 }
 
+func TestSetReleaseImageAnnotation(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{}
+	hcp.Spec.ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.8.26-x86_64"
+	hcp.Annotations = map[string]string{
+		hyperv1.ReleaseImageAnnotation: hcp.Spec.ReleaseImage,
+	}
+	cfg := &DeploymentConfig{}
+	cfg.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
+	if cfg.AdditionalAnnotations == nil {
+		t.Fatalf("Expecting additional annotations to be set")
+	}
+	value, isPresent := cfg.AdditionalAnnotations[hyperv1.ReleaseImageAnnotation]
+	if !isPresent {
+		t.Fatalf("Expected restart date annotation is not present")
+	}
+	if value != hcp.Spec.ReleaseImage {
+		t.Fatalf("Expected annotation value not set")
+	}
+}
+
 func TestSetMultizoneSpread(t *testing.T) {
 	labels := map[string]string{
 		"app":                         "etcd",


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently there is no way to tie the deployments in the master-control plane to a given release. Obviously in the normal happy path: we assume over time things will reconcile and match the normal desired state of the cluster. There are also a few statuses that look at the operator versions in the cluster.

However: in a managed cloud offering: the internals of a user cluster can be in various states based on how they are operating the cluster including unhealthy states that might block the rollout of some downstream components (like monitoring operator) but not the managed control-plane side.

This pr adds an annotation that holds the release image a deployment was reconciled with. We can then look at a given deployment (like the kube-apiserver) and easily be able to reference it to the release image that deployed it. This helps with auditing and for additional tracking on rollouts of components

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.
