### PR TITLE
properly toggle watch on routes so deployments into vanilla kube clusters aren't broken

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -211,7 +211,6 @@ func managedResources() []client.Object {
 		&corev1.Namespace{},
 		&corev1.ServiceAccount{},
 		&corev1.Service{},
-		&routev1.Route{},
 		&agentv1.AgentCluster{},
 		&capiibmv1.IBMVPCCluster{},
 		&capikubevirt.KubevirtCluster{},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -3,6 +3,7 @@ package hostedcluster
 import (
 	"context"
 	"fmt"
+	routev1 "github.com/openshift/api/route/v1"
 	"testing"
 	"time"
 
@@ -1133,6 +1134,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 		}
 	}
 	watchedResources := sets.String{}
+	watchedResources.Insert(fmt.Sprintf("%T", &routev1.Route{}))
 	for _, resource := range managedResources() {
 		watchedResources.Insert(fmt.Sprintf("%T", resource))
 	}


### PR DESCRIPTION
We cannot dictate watches on routes in case this is deployed in a IKS management cluster. That section is removed (and is already applied later when checking if the management cluster capability exists here:
https://github.com/openshift/hypershift/blob/5bc94158fe1e1a6d4c20775cb524a897947711dc/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go#L185