### PR TITLE
Add routev1.Route to hostedcluster_controller managedResources based on Routes capability

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1133,7 +1133,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 		}
 	}
 	watchedResources := sets.String{}
-	for _, resource := range managedResources() {
+	for _, resource := range r.managedResources() {
 		watchedResources.Insert(fmt.Sprintf("%T", resource))
 	}
 	if diff := cmp.Diff(client.createdTypes.List(), watchedResources.List()); diff != "" {


### PR DESCRIPTION
This is required due to changes introduced in https://github.com/openshift/hypershift/pull/887
that added a watch for Route without checking the management cluster capabilities
That cause issues in tests that don't use OCP as management cluster (e.g. AgentPlatform)
 