### PR TITLE
Fix HostedCluster doesn't exist validation

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -265,10 +265,12 @@ func GetAPIServerAddressByNode(ctx context.Context) (string, error) {
 func Validate(ctx context.Context, opts *CreateOptions) error {
 	if !opts.Render {
 		client := util.GetClientOrDie()
+		// Validate HostedCluster with this name doesn't exists in the namespace
 		cluster := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: opts.Namespace, Name: opts.Name}}
-		err := client.Get(ctx, crclient.ObjectKeyFromObject(cluster), cluster)
-		if !apierrors.IsNotFound(err) {
+		if err := client.Get(ctx, crclient.ObjectKeyFromObject(cluster), cluster); err == nil {
 			return fmt.Errorf("hostedcluster %s already exists", crclient.ObjectKeyFromObject(cluster))
+		} else if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("hostedcluster doesn't exist validation failed with error: %w", err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it:**

The validation that there is no cluster exist with this name
in the namespace (done before cluster creation) is wrong
Before this change, the "Cluster already exists" error was returned in case Get HostedCluster
returned error, which is not `NotFound` error

This fix change the validation to be as following:
1. validate HostedCluster `namespace/name` doesn't exists, if it does
   exists return error with relevant description