### PR TITLE
CMD refactoring: change hostedcluster CLI to create NodePool using NodePool CLI code

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -9,10 +9,15 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"time"
 
+	apifixtures "github.com/openshift/hypershift/api/fixtures"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	nodepoolcore "github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/cmd/version"
+	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -20,89 +25,52 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclient "k8s.io/client-go/kubernetes"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	apifixtures "github.com/openshift/hypershift/api/fixtures"
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/cmd/util"
-	"github.com/openshift/hypershift/cmd/version"
-	hyperapi "github.com/openshift/hypershift/support/api"
 )
 
-// ApplyPlatformSpecifics can be used to create platform specific values as well as enriching the fixure with additional values
-type ApplyPlatformSpecifics = func(ctx context.Context, fixture *apifixtures.ExampleOptions, options *CreateOptions) error
+type CreateClusterPlatformOptions interface {
+	// ApplyPlatformSpecifics can be used to create platform specific values as well as enriching the fixure with additional values
+	ApplyPlatformSpecifics(ctx context.Context, fixture *apifixtures.ExampleOptions, name, infraID, baseDomain string) error
+	// Validate checks if the platform options configured as expected, otherwise return error
+	Validate() error
+	// NodePoolPlatformOptions returns the options for the specific platform NodePool creation
+	NodePoolPlatformOptions() nodepoolcore.PlatformOptions
+}
 
 type CreateOptions struct {
 	Annotations                      []string
-	AutoRepair                       bool
 	ControlPlaneAvailabilityPolicy   string
 	ControlPlaneOperatorImage        string
 	EtcdStorageClass                 string
 	FIPS                             bool
 	GenerateSSH                      bool
 	InfrastructureAvailabilityPolicy string
-	InfrastructureJSON               string
 	InfraID                          string
 	Name                             string
 	Namespace                        string
 	BaseDomain                       string
 	NetworkType                      string
-	NodePoolReplicas                 int32
 	PullSecretFile                   string
 	ReleaseImage                     string
 	Render                           bool
 	SSHKeyFile                       string
 	ServiceCIDR                      string
 	PodCIDR                          string
-	NonePlatform                     NonePlatformCreateOptions
-	KubevirtPlatform                 KubevirtPlatformCreateOptions
-	AWSPlatform                      AWSPlatformOptions
-	AgentPlatform                    AgentPlatformCreateOptions
 	Wait                             bool
 	Timeout                          time.Duration
+	CreateNodePoolOptions            *nodepoolcore.CreateNodePoolOptions
 }
 
-type AgentPlatformCreateOptions struct {
-	APIServerAddress string
-	AgentNamespace   string
-}
-
-type NonePlatformCreateOptions struct {
-	APIServerAddress string
-}
-
-type KubevirtPlatformCreateOptions struct {
-	APIServerAddress   string
-	Memory             string
-	Cores              uint32
-	ContainerDiskImage string
-}
-
-type AWSPlatformOptions struct {
-	AWSCredentialsFile string
-	AdditionalTags     []string
-	IAMJSON            string
-	InstanceType       string
-	IssuerURL          string
-	PrivateZoneID      string
-	PublicZoneID       string
-	Region             string
-	RootVolumeIOPS     int64
-	RootVolumeSize     int64
-	RootVolumeType     string
-	EndpointAccess     string
-}
-
-func createCommonFixture(opts *CreateOptions) (*apifixtures.ExampleOptions, error) {
-	if len(opts.ReleaseImage) == 0 {
+func (o *CreateOptions) createCommonFixture() (*apifixtures.ExampleOptions, error) {
+	if len(o.ReleaseImage) == 0 {
 		defaultVersion, err := version.LookupDefaultOCPVersion()
 		if err != nil {
 			return nil, fmt.Errorf("release image is required when unable to lookup default OCP version: %w", err)
 		}
-		opts.ReleaseImage = defaultVersion.PullSpec
+		o.ReleaseImage = defaultVersion.PullSpec
 	}
 
 	annotations := map[string]string{}
-	for _, s := range opts.Annotations {
+	for _, s := range o.Annotations {
 		pair := strings.SplitN(s, "=", 2)
 		if len(pair) != 2 {
 			return nil, fmt.Errorf("invalid annotation: %s", s)
@@ -111,25 +79,25 @@ func createCommonFixture(opts *CreateOptions) (*apifixtures.ExampleOptions, erro
 		annotations[k] = v
 	}
 
-	if len(opts.ControlPlaneOperatorImage) > 0 {
-		annotations[hyperv1.ControlPlaneOperatorImageAnnotation] = opts.ControlPlaneOperatorImage
+	if len(o.ControlPlaneOperatorImage) > 0 {
+		annotations[hyperv1.ControlPlaneOperatorImageAnnotation] = o.ControlPlaneOperatorImage
 	}
 
-	pullSecret, err := ioutil.ReadFile(opts.PullSecretFile)
+	pullSecret, err := ioutil.ReadFile(o.PullSecretFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read pull secret file: %w", err)
 	}
 	var sshKey, sshPrivateKey []byte
-	if len(opts.SSHKeyFile) > 0 {
-		if opts.GenerateSSH {
+	if len(o.SSHKeyFile) > 0 {
+		if o.GenerateSSH {
 			return nil, fmt.Errorf("--generate-ssh and --ssh-key cannot be specified together")
 		}
-		key, err := ioutil.ReadFile(opts.SSHKeyFile)
+		key, err := ioutil.ReadFile(o.SSHKeyFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read ssh key file: %w", err)
 		}
 		sshKey = key
-	} else if opts.GenerateSSH {
+	} else if o.GenerateSSH {
 		sshKey, sshPrivateKey, err = generateSSHKeys()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate ssh keys: %w", err)
@@ -137,23 +105,21 @@ func createCommonFixture(opts *CreateOptions) (*apifixtures.ExampleOptions, erro
 	}
 
 	return &apifixtures.ExampleOptions{
-		InfraID:                          opts.InfraID,
+		InfraID:                          o.InfraID,
 		Annotations:                      annotations,
-		AutoRepair:                       opts.AutoRepair,
-		ControlPlaneAvailabilityPolicy:   hyperv1.AvailabilityPolicy(opts.ControlPlaneAvailabilityPolicy),
-		FIPS:                             opts.FIPS,
-		InfrastructureAvailabilityPolicy: hyperv1.AvailabilityPolicy(opts.InfrastructureAvailabilityPolicy),
-		Namespace:                        opts.Namespace,
-		Name:                             opts.Name,
-		NetworkType:                      hyperv1.NetworkType(opts.NetworkType),
-		NodePoolReplicas:                 opts.NodePoolReplicas,
+		ControlPlaneAvailabilityPolicy:   hyperv1.AvailabilityPolicy(o.ControlPlaneAvailabilityPolicy),
+		FIPS:                             o.FIPS,
+		InfrastructureAvailabilityPolicy: hyperv1.AvailabilityPolicy(o.InfrastructureAvailabilityPolicy),
+		Namespace:                        o.Namespace,
+		Name:                             o.Name,
+		NetworkType:                      hyperv1.NetworkType(o.NetworkType),
 		PullSecret:                       pullSecret,
-		ReleaseImage:                     opts.ReleaseImage,
+		ReleaseImage:                     o.ReleaseImage,
 		SSHPrivateKey:                    sshPrivateKey,
 		SSHPublicKey:                     sshKey,
-		EtcdStorageClass:                 opts.EtcdStorageClass,
-		ServiceCIDR:                      opts.ServiceCIDR,
-		PodCIDR:                          opts.PodCIDR,
+		EtcdStorageClass:                 o.EtcdStorageClass,
+		ServiceCIDR:                      o.ServiceCIDR,
+		PodCIDR:                          o.PodCIDR,
 	}, nil
 }
 
@@ -179,55 +145,24 @@ func generateSSHKeys() ([]byte, []byte, error) {
 	return publicBytes, privatePEM, nil
 }
 
-func apply(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, render bool, waitForRollout bool) error {
-
-	exampleObjects := exampleOptions.Resources().AsObjects()
-	switch {
-	case render:
-		for _, object := range exampleObjects {
-			err := hyperapi.YamlSerializer.Encode(object, os.Stdout)
-			if err != nil {
-				return fmt.Errorf("failed to encode objects: %w", err)
-			}
-			fmt.Println("---")
-		}
-	default:
-		client := util.GetClientOrDie()
-		var hostedCluster *hyperv1.HostedCluster
-		for _, object := range exampleObjects {
-			key := crclient.ObjectKeyFromObject(object)
-			object.SetLabels(map[string]string{util.AutoInfraLabelName: exampleOptions.InfraID})
-			var err error
-			if object.GetObjectKind().GroupVersionKind().Kind == "HostedCluster" {
-				hostedCluster = &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: object.GetNamespace(), Name: object.GetName()}}
-				err = client.Create(ctx, object)
-			} else {
-				err = client.Patch(ctx, object, crclient.Apply, crclient.ForceOwnership, crclient.FieldOwner("hypershift-cli"))
-			}
-			if err != nil {
-				return fmt.Errorf("failed to apply object %q: %w", key, err)
-			}
-			log.Info("Applied Kube resource", "kind", object.GetObjectKind().GroupVersionKind().Kind, "namespace", key.Namespace, "name", key.Name)
-		}
-
-		if waitForRollout {
-			log.Info("Waiting for cluster rollout")
-			return wait.PollInfiniteWithContext(ctx, 30*time.Second, func(ctx context.Context) (bool, error) {
-				hostedCluster := hostedCluster.DeepCopy()
-				if err := client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster); err != nil {
-					return false, fmt.Errorf("failed to get hostedcluster %s: %w", crclient.ObjectKeyFromObject(hostedCluster), err)
-				}
-				rolledOut := len(hostedCluster.Status.Version.History) > 0 && hostedCluster.Status.Version.History[0].CompletionTime != nil
-				if !rolledOut {
-					log.Info("Cluster rollout not finished yet, checking again in 30 seconds...")
-				}
-				return rolledOut, nil
-			})
-		}
-
-		return nil
+func waitForRollout(ctx context.Context, clusterName, clusterNamespace string, client crclient.Client) error {
+	log.Info("Waiting for cluster rollout")
+	hostedCluster := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		},
 	}
-	return nil
+	return wait.PollInfiniteWithContext(ctx, 30*time.Second, func(ctx context.Context) (bool, error) {
+		if err := client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster); err != nil {
+			return false, fmt.Errorf("failed to get hostedcluster %s: %w", crclient.ObjectKeyFromObject(hostedCluster), err)
+		}
+		rolledOut := len(hostedCluster.Status.Version.History) > 0 && hostedCluster.Status.Version.History[0].CompletionTime != nil
+		if !rolledOut {
+			log.Info("Cluster rollout not finished yet, checking again in 30 seconds...")
+		}
+		return rolledOut, nil
+	})
 }
 
 func GetAPIServerAddressByNode(ctx context.Context) (string, error) {
@@ -263,34 +198,79 @@ func GetAPIServerAddressByNode(ctx context.Context) (string, error) {
 	return apiServerAddress, nil
 }
 
-func Validate(ctx context.Context, opts *CreateOptions) error {
-	if !opts.Render {
+func (o *CreateOptions) validate(ctx context.Context, platformOpts CreateClusterPlatformOptions) error {
+	if !o.Render {
 		client := util.GetClientOrDie()
 		// Validate HostedCluster with this name doesn't exists in the namespace
-		cluster := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: opts.Namespace, Name: opts.Name}}
+		cluster := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: o.Namespace, Name: o.Name}}
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(cluster), cluster); err == nil {
 			return fmt.Errorf("hostedcluster %s already exists", crclient.ObjectKeyFromObject(cluster))
 		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("hostedcluster doesn't exist validation failed with error: %w", err)
 		}
 	}
+	if err := platformOpts.Validate(); err != nil {
+		return err
+	}
 
 	return nil
 }
 
-func CreateCluster(ctx context.Context, opts *CreateOptions, platformSpecificApply ApplyPlatformSpecifics) error {
-	if opts.Wait && opts.NodePoolReplicas < 1 {
-		return errors.New("--wait requires --node-pool-replicas > 0")
+func (o *CreateOptions) CreateExecFunc(platformOpts CreateClusterPlatformOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if o.Timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, o.Timeout)
+			defer cancel()
+		}
+
+		if err := o.CreateCluster(ctx, platformOpts); err != nil {
+			log.Error(err, "Failed to create cluster")
+			return err
+		}
+		return nil
 	}
-	exampleOptions, err := createCommonFixture(opts)
+}
+
+func (o *CreateOptions) CreateCluster(ctx context.Context, platformOpts CreateClusterPlatformOptions) error {
+	o.CreateNodePoolOptions.Render = o.Render
+	if err := o.validate(ctx, platformOpts); err != nil {
+		return err
+	}
+	if o.Wait && o.CreateNodePoolOptions.NodeCount < 1 {
+		return errors.New("--wait requires --node-count > 0")
+	}
+	exampleOptions, err := o.createCommonFixture()
 	if err != nil {
 		return err
 	}
 
 	// Apply platform specific options and create platform specific resources
-	if err := platformSpecificApply(ctx, exampleOptions, opts); err != nil {
+	if err := platformOpts.ApplyPlatformSpecifics(ctx, exampleOptions, o.Name, o.InfraID, o.BaseDomain); err != nil {
 		return err
 	}
 
-	return apply(ctx, exampleOptions, opts.Render, opts.Wait)
+	client := util.GetClientOrDie()
+
+	exampleResources := exampleOptions.Resources()
+	exampleObjects := exampleResources.AsObjects()
+	nodePoolObject, err := o.CreateNodePoolOptions.GenerateNodePoolObject(ctx, platformOpts.NodePoolPlatformOptions(), exampleResources.Cluster, client)
+	if err != nil {
+		return err
+	}
+	if nodePoolObject != nil {
+		exampleObjects = append(exampleObjects, nodePoolObject)
+	}
+
+	if err := util.ApplyObjects(ctx, exampleObjects, o.Render, exampleOptions.InfraID); err != nil {
+		return err
+	}
+	if !o.Render && o.Wait {
+		if err := waitForRollout(ctx, exampleOptions.Name, exampleOptions.Namespace, client); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -2,15 +2,20 @@ package kubevirt
 
 import (
 	"context"
-	"errors"
 	"fmt"
-
-	"github.com/spf13/cobra"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	nodepoolcore "github.com/openshift/hypershift/cmd/nodepool/core"
+	nodepoolkubevirt "github.com/openshift/hypershift/cmd/nodepool/kubevirt"
+	"github.com/spf13/cobra"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
+
+type KubevirtPlatformCreateOptions struct {
+	APIServerAddress string
+	NodePoolOptions  *nodepoolkubevirt.KubevirtPlatformCreateOptions
+}
 
 func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd := &cobra.Command{
@@ -19,71 +24,38 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	opts.KubevirtPlatform = core.KubevirtPlatformCreateOptions{
-		Memory:             "4Gi",
-		Cores:              2,
-		ContainerDiskImage: "",
-	}
+	platformOpts := &KubevirtPlatformCreateOptions{}
 
-	cmd.Flags().StringVar(&opts.KubevirtPlatform.Memory, "memory", opts.KubevirtPlatform.Memory, "The amount of memory which is visible inside the Guest OS (type BinarySI, e.g. 5Gi, 100Mi)")
-	cmd.Flags().Uint32Var(&opts.KubevirtPlatform.Cores, "cores", opts.KubevirtPlatform.Cores, "The number of cores inside the vmi, Must be a value greater or equal 1")
-	cmd.Flags().StringVar(&opts.KubevirtPlatform.ContainerDiskImage, "containerdisk", opts.KubevirtPlatform.ContainerDiskImage, "A reference to docker image with the embedded disk to be used to create the machines")
+	platformOpts.NodePoolOptions = nodepoolkubevirt.NewKubevirtPlatformCreateOptions(cmd)
 
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
-		if opts.Timeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
-			defer cancel()
-		}
-
-		if err := CreateCluster(ctx, opts); err != nil {
-			log.Error(err, "Failed to create cluster")
-			return err
-		}
-		return nil
-	}
+	cmd.RunE = opts.CreateExecFunc(platformOpts)
 
 	return cmd
 }
 
-func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
-	return core.CreateCluster(ctx, opts, applyPlatformSpecificsValues)
-}
-
-func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
-	if opts.KubevirtPlatform.APIServerAddress == "" {
-		if opts.KubevirtPlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx); err != nil {
+func (o *KubevirtPlatformCreateOptions) ApplyPlatformSpecifics(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, name, infraID, baseDomain string) (err error) {
+	if o.APIServerAddress == "" {
+		if o.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx); err != nil {
 			return err
 		}
 	}
 
-	if opts.NodePoolReplicas > -1 {
-		// TODO (nargaman): replace with official container image, after RFE-2501 is completed
-		// As long as there is no official container image
-		// The image must be provided by user
-		// Otherwise it must fail
-		if opts.KubevirtPlatform.ContainerDiskImage == "" {
-			return errors.New("the container disk image for the Kubevirt machine must be provided by user (\"--containerdisk\" flag)")
-		}
-	}
-
-	if opts.KubevirtPlatform.Cores < 1 {
-		return errors.New("the number of cores inside the machine must be a value greater or equal 1")
-	}
-
-	infraID := opts.InfraID
 	if len(infraID) == 0 {
-		infraID = fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
+		infraID = fmt.Sprintf("%s-%s", name, utilrand.String(5))
 	}
 	exampleOptions.InfraID = infraID
 	exampleOptions.BaseDomain = "example.com"
 
 	exampleOptions.Kubevirt = &apifixtures.ExampleKubevirtOptions{
-		APIServerAddress: opts.KubevirtPlatform.APIServerAddress,
-		Memory:           opts.KubevirtPlatform.Memory,
-		Cores:            opts.KubevirtPlatform.Cores,
-		Image:            opts.KubevirtPlatform.ContainerDiskImage,
+		APIServerAddress: o.APIServerAddress,
 	}
 	return nil
+}
+
+func (o *KubevirtPlatformCreateOptions) NodePoolPlatformOptions() nodepoolcore.PlatformOptions {
+	return o.NodePoolOptions
+}
+
+func (o *KubevirtPlatformCreateOptions) Validate() error {
+	return o.NodePoolOptions.Validate()
 }

--- a/cmd/log/log.go
+++ b/cmd/log/log.go
@@ -1,9 +1,18 @@
 package log
 
-import "github.com/openshift/hypershift/cmd/util"
+import (
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
 
-var log = util.Log
+var log = zap.New(zap.UseDevMode(true), func(o *zap.Options) {
+	o.TimeEncoder = zapcore.RFC3339TimeEncoder
+})
 
 func Error(err error, msg string, keysAndValues ...interface{}) {
 	log.Error(err, msg, keysAndValues...)
+}
+
+func Info(msg string, keysAndValues ...interface{}) {
+	log.Info(msg, keysAndValues...)
 }

--- a/cmd/nodepool/agent/create.go
+++ b/cmd/nodepool/agent/create.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"context"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/spf13/cobra"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type AgentPlatformCreateOptions struct{}
+
+func NewAgentPlatformCreateOptions(cmd *cobra.Command) *AgentPlatformCreateOptions {
+	platformOpts := &AgentPlatformCreateOptions{}
+
+	return platformOpts
+}
+
+func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "agent",
+		Short:        "Creates basic functional NodePool resources for Agent platform",
+		SilenceUsage: true,
+	}
+
+	platformOpts := NewAgentPlatformCreateOptions(cmd)
+
+	cmd.RunE = coreOpts.CreateExecFunc(platformOpts)
+
+	return cmd
+}
+
+func (o *AgentPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
+	return nil
+}
+
+func (o *AgentPlatformCreateOptions) Type() hyperv1.PlatformType {
+	return hyperv1.AgentPlatform
+}
+
+func (o *AgentPlatformCreateOptions) Validate() error {
+	return nil
+}

--- a/cmd/nodepool/aws/create.go
+++ b/cmd/nodepool/aws/create.go
@@ -3,8 +3,9 @@ package aws
 import (
 	"context"
 	"fmt"
+
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/cmd/log"
+	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,61 +20,76 @@ type AWSPlatformCreateOptions struct {
 	RootVolumeType  string
 	RootVolumeIOPS  int64
 	RootVolumeSize  int64
+	InfraOutput     *awsinfra.CreateInfraOutput
+	IamOutput       *awsinfra.CreateIAMOutput
 }
 
-func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
+func NewAWSPlatformCreateOptions(cmd *cobra.Command) *AWSPlatformCreateOptions {
 	platformOpts := &AWSPlatformCreateOptions{
 		InstanceType:   "m5.large",
 		RootVolumeType: "gp3",
 		RootVolumeSize: 120,
 		RootVolumeIOPS: 0,
 	}
+
+	cmd.Flags().StringVar(&platformOpts.InstanceType, "instance-type", platformOpts.InstanceType, "The AWS instance type of the NodePool")
+	cmd.Flags().StringVar(&platformOpts.RootVolumeType, "root-volume-type", platformOpts.RootVolumeType, "The type of the root volume (e.g. gp3, io2) for machines in the NodePool")
+	cmd.Flags().Int64Var(&platformOpts.RootVolumeIOPS, "root-volume-iops", platformOpts.RootVolumeIOPS, "The iops of the root volume for machines in the NodePool")
+	cmd.Flags().Int64Var(&platformOpts.RootVolumeSize, "root-volume-size", platformOpts.RootVolumeSize, "The size of the root volume (min: 8) for machines in the NodePool")
+
+	cmd.Flags().StringVar(&platformOpts.InstanceProfile, "instance-profile", platformOpts.InstanceProfile, "The AWS instance profile for the NodePool")
+
+	return platformOpts
+}
+
+func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "aws",
 		Short:        "Creates basic functional NodePool resources for AWS platform",
 		SilenceUsage: true,
 	}
 
-	cmd.Flags().StringVar(&platformOpts.InstanceType, "instance-type", platformOpts.InstanceType, "The AWS instance type of the NodePool")
+	platformOpts := NewAWSPlatformCreateOptions(cmd)
+
 	cmd.Flags().StringVar(&platformOpts.SubnetID, "subnet-id", platformOpts.SubnetID, "The AWS subnet ID in which to create the NodePool")
 	cmd.Flags().StringVar(&platformOpts.SecurityGroupID, "securitygroup-id", platformOpts.SecurityGroupID, "The AWS security group in which to create the NodePool")
-	cmd.Flags().StringVar(&platformOpts.InstanceProfile, "instance-profile", platformOpts.InstanceProfile, "The AWS instance profile for the NodePool")
-	cmd.Flags().StringVar(&platformOpts.RootVolumeType, "root-volume-type", platformOpts.RootVolumeType, "The type of the root volume (e.g. gp3, io2) for machines in the NodePool")
-	cmd.Flags().Int64Var(&platformOpts.RootVolumeIOPS, "root-volume-iops", platformOpts.RootVolumeIOPS, "The iops of the root volume for machines in the NodePool")
-	cmd.Flags().Int64Var(&platformOpts.RootVolumeSize, "root-volume-size", platformOpts.RootVolumeSize, "The size of the root volume (min: 8) for machines in the NodePool")
 
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := coreOpts.CreateNodePool(cmd.Context(), platformOpts); err != nil {
-			log.Error(err, "Failed to create nodepool")
-			return err
-		}
-		return nil
-	}
+	cmd.RunE = coreOpts.CreateExecFunc(platformOpts)
 
 	return cmd
 }
 
 func (o *AWSPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
 	if len(o.InstanceProfile) == 0 {
-		o.InstanceProfile = fmt.Sprintf("%s-worker", hcluster.Spec.InfraID)
+		if o.IamOutput != nil {
+			o.InstanceProfile = o.IamOutput.ProfileName
+		} else {
+			o.InstanceProfile = fmt.Sprintf("%s-worker", hcluster.Spec.InfraID)
+		}
 	}
 	if len(o.SubnetID) == 0 {
-		if hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {
+		if o.InfraOutput != nil {
+			o.SubnetID = o.InfraOutput.PrivateSubnetID
+		} else if hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {
 			o.SubnetID = *hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID
 		} else {
 			return fmt.Errorf("subnet ID was not specified and cannot be determined from HostedCluster")
 		}
 	}
 	if len(o.SecurityGroupID) == 0 {
-		defaultNodePool := &hyperv1.NodePool{}
-		if err := client.Get(ctx, types.NamespacedName{Namespace: hcluster.Namespace, Name: hcluster.Name}, defaultNodePool); err != nil {
-			return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool: %v", err)
+		if o.InfraOutput != nil {
+			o.SecurityGroupID = o.InfraOutput.SecurityGroupID
+		} else {
+			defaultNodePool := &hyperv1.NodePool{}
+			if err := client.Get(ctx, types.NamespacedName{Namespace: hcluster.Namespace, Name: hcluster.Name}, defaultNodePool); err != nil {
+				return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool: %v", err)
+			}
+			if defaultNodePool.Spec.Platform.AWS == nil || len(defaultNodePool.Spec.Platform.AWS.SecurityGroups) == 0 ||
+				defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID == nil {
+				return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool")
+			}
+			o.SecurityGroupID = *defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID
 		}
-		if defaultNodePool.Spec.Platform.AWS == nil || len(defaultNodePool.Spec.Platform.AWS.SecurityGroups) == 0 ||
-			defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID == nil {
-			return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool")
-		}
-		o.SecurityGroupID = *defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID
 	}
 	nodePool.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
 		InstanceType:    o.InstanceType,
@@ -97,4 +113,8 @@ func (o *AWSPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool 
 
 func (o *AWSPlatformCreateOptions) Type() hyperv1.PlatformType {
 	return hyperv1.AWSPlatform
+}
+
+func (o *AWSPlatformCreateOptions) Validate() error {
+	return nil
 }

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -3,14 +3,18 @@ package nodepool
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hypershift/cmd/nodepool/agent"
 	"github.com/openshift/hypershift/cmd/nodepool/aws"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
 	"github.com/openshift/hypershift/cmd/nodepool/kubevirt"
+	"github.com/openshift/hypershift/cmd/nodepool/none"
 )
 
 // The following lines are needed in order to validate that any platform implementing PlatformOptions satisfy the interface
 var _ core.PlatformOptions = &aws.AWSPlatformCreateOptions{}
 var _ core.PlatformOptions = &kubevirt.KubevirtPlatformCreateOptions{}
+var _ core.PlatformOptions = &agent.AgentPlatformCreateOptions{}
+var _ core.PlatformOptions = &none.NonePlatformCreateOptions{}
 
 func NewCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -19,24 +23,23 @@ func NewCreateCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	opts := &core.CreateNodePoolOptions{
-		Name:         "example",
-		Namespace:    "clusters",
-		ClusterName:  "example",
-		NodeCount:    2,
-		ReleaseImage: "",
-	}
+	opts := core.NewCreateNodePoolOptions(cmd, 2)
 
+	// All the flags added here would be included only in NodePool create command
+	// In order to include flag also in Cluster create command, add the flag in `cmd/nodepool/core/create.go`
 	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The name of the NodePool")
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace in which to create the NodePool")
-	cmd.PersistentFlags().Int32Var(&opts.NodeCount, "node-count", opts.NodeCount, "The number of nodes to create in the NodePool")
 	cmd.PersistentFlags().StringVar(&opts.ClusterName, "cluster-name", opts.ClusterName, "The name of the HostedCluster nodes in this pool will join")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes. If empty, defaults to the same release image as the HostedCluster.")
-
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying")
+
+	cmd.MarkPersistentFlagRequired("namespace")
+	cmd.MarkPersistentFlagRequired("cluster-name")
 
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
 	cmd.AddCommand(aws.NewCreateCommand(opts))
+	cmd.AddCommand(agent.NewCreateCommand(opts))
+	cmd.AddCommand(none.NewCreateCommand(opts))
 
 	return cmd
 }

--- a/cmd/nodepool/none/create.go
+++ b/cmd/nodepool/none/create.go
@@ -1,0 +1,44 @@
+package none
+
+import (
+	"context"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/spf13/cobra"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type NonePlatformCreateOptions struct{}
+
+func NewNonePlatformCreateOptions(cmd *cobra.Command) *NonePlatformCreateOptions {
+	platformOpts := &NonePlatformCreateOptions{}
+
+	return platformOpts
+}
+
+func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "none",
+		Short:        "Creates basic functional NodePool resources for None platform",
+		SilenceUsage: true,
+	}
+
+	platformOpts := NewNonePlatformCreateOptions(cmd)
+
+	cmd.RunE = coreOpts.CreateExecFunc(platformOpts)
+
+	return cmd
+}
+
+func (o *NonePlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
+	return nil
+}
+
+func (o *NonePlatformCreateOptions) Type() hyperv1.PlatformType {
+	return hyperv1.NonePlatform
+}
+
+func (o *NonePlatformCreateOptions) Validate() error {
+	return nil
+}

--- a/cmd/util/client.go
+++ b/cmd/util/client.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperapi "github.com/openshift/hypershift/api"
+	"github.com/openshift/hypershift/cmd/log"
 )
 
 const (
@@ -45,4 +47,36 @@ func ParseAWSTags(tags []string) (map[string]string, error) {
 		tagMap[parts[0]] = parts[1]
 	}
 	return tagMap, nil
+}
+
+func ApplyObjects(ctx context.Context, crcObjects []crclient.Object, render bool, infraID string) error {
+	switch {
+	case render:
+		for _, object := range crcObjects {
+			key := crclient.ObjectKeyFromObject(object)
+			err := hyperapi.YamlSerializer.Encode(object, os.Stdout)
+			if err != nil {
+				return fmt.Errorf("failed to encode objects: %w", err)
+			}
+			fmt.Println("---")
+			log.Info("Rendered Kube resource", "kind", object.GetObjectKind().GroupVersionKind().Kind, "namespace", key.Namespace, "name", key.Name)
+		}
+	default:
+		client := GetClientOrDie()
+		for _, object := range crcObjects {
+			key := crclient.ObjectKeyFromObject(object)
+			object.SetLabels(map[string]string{AutoInfraLabelName: infraID})
+			var err error
+			if object.GetObjectKind().GroupVersionKind().Kind == "HostedCluster" {
+				err = client.Create(ctx, object)
+			} else {
+				err = client.Patch(ctx, object, crclient.Apply, crclient.ForceOwnership, crclient.FieldOwner("hypershift-cli"))
+			}
+			if err != nil {
+				return fmt.Errorf("failed to apply object %q: %w", key, err)
+			}
+			log.Info("Applied Kube resource", "kind", object.GetObjectKind().GroupVersionKind().Kind, "namespace", key.Namespace, "name", key.Name)
+		}
+	}
+	return nil
 }

--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -30,10 +30,11 @@ func TestAutoRepair(t *testing.T) {
 	defer cancel()
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
-	clusterOpts.NodePoolReplicas = 3
-	clusterOpts.AutoRepair = true
+	awsOpts := globalOpts.DefaultAWSClusterOptions()
+	clusterOpts.CreateNodePoolOptions.NodeCount = 3
+	clusterOpts.CreateNodePoolOptions.AutoRepair = true
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, hyperv1.AWSPlatform, awsOpts, globalOpts.ArtifactDir)
 
 	// Get the newly created nodepool
 	nodepool := &hyperv1.NodePool{
@@ -61,7 +62,7 @@ func TestAutoRepair(t *testing.T) {
 	g.Expect(len(awsSpec)).NotTo(BeZero())
 	instanceID := awsSpec[strings.LastIndex(awsSpec, "/")+1:]
 	t.Logf("Terminating AWS instance: %s", instanceID)
-	ec2client := ec2Client(clusterOpts.AWSPlatform.AWSCredentialsFile, clusterOpts.AWSPlatform.Region)
+	ec2client := ec2Client(awsOpts.AWSCredentialsFile, awsOpts.Region)
 	_, err = ec2client.TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: []*string{aws.String(instanceID)},
 	})

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -29,8 +29,9 @@ func TestAutoscaling(t *testing.T) {
 	defer cancel()
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
+	awsOpts := globalOpts.DefaultAWSClusterOptions()
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, hyperv1.AWSPlatform, awsOpts, globalOpts.ArtifactDir)
 
 	// Get the newly created nodepool
 	nodepool := &hyperv1.NodePool{

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -37,9 +37,10 @@ func TestHAEtcdChaos(t *testing.T) {
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
-	clusterOpts.NodePoolReplicas = 0
+	clusterOpts.CreateNodePoolOptions.NodeCount = 0
+	awsOpts := globalOpts.DefaultAWSClusterOptions()
 
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, hyperv1.AWSPlatform, awsOpts, globalOpts.ArtifactDir)
 
 	t.Run("KillRandomMembers", testKillRandomMembers(ctx, client, cluster))
 	t.Run("KillAllMembers", testKillAllMembers(ctx, client, cluster))
@@ -58,9 +59,10 @@ func TestEtcdChaos(t *testing.T) {
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
-	clusterOpts.NodePoolReplicas = 0
+	clusterOpts.CreateNodePoolOptions.NodeCount = 0
+	awsOpts := globalOpts.DefaultAWSClusterOptions()
 
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, hyperv1.AWSPlatform, awsOpts, globalOpts.ArtifactDir)
 
 	t.Run("KillAllMembers", testKillAllMembers(ctx, client, cluster))
 }

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -27,8 +27,9 @@ func TestUpgradeControlPlane(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
+	awsOpts := globalOpts.DefaultAWSClusterOptions()
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, hyperv1.AWSPlatform, awsOpts, globalOpts.ArtifactDir)
 
 	// Get the newly created nodepool
 	nodepool := &hyperv1.NodePool{

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -40,7 +40,8 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 	client := e2eutil.GetClientOrDie()
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.KubevirtPlatform, globalOpts.ArtifactDir)
+	kubevirtOpts := globalOpts.DefaultKubevirtClusterOptions()
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, hyperv1.KubevirtPlatform, kubevirtOpts, globalOpts.ArtifactDir)
 
 	waitForHostedClusterAvailable := func() {
 		start := time.Now()
@@ -106,8 +107,9 @@ func TestNoneCreateCluster(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	clusterOpts.ControlPlaneAvailabilityPolicy = "SingleReplica"
+	noneOpts := globalOpts.DefaultNoneClusterOptions()
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, hyperv1.NonePlatform, noneOpts, globalOpts.ArtifactDir)
 
 	// Wait for the rollout to be reported complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -45,15 +45,16 @@ func TestOLM(t *testing.T) {
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions()
-	clusterOpts.NodePoolReplicas = 1
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	clusterOpts.CreateNodePoolOptions.NodeCount = 1
+	awsOpts := globalOpts.DefaultAWSClusterOptions()
+	cluster := e2eutil.CreateCluster(t, ctx, client, clusterOpts, hyperv1.AWSPlatform, awsOpts, globalOpts.ArtifactDir)
 
 	// Get guest client
 	t.Logf("Waiting for guest client to become available")
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, cluster)
 
 	// Wait for guest cluster nodes to become available
-	util.WaitForNReadyNodes(t, ctx, guestClient, clusterOpts.NodePoolReplicas)
+	util.WaitForNReadyNodes(t, ctx, guestClient, clusterOpts.CreateNodePoolOptions.NodeCount)
 
 	guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name
 	t.Logf("Hosted control plane namespace is %s", guestNamespace)

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -12,7 +12,6 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/cluster/aws"
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/cluster/none"
 	"github.com/openshift/hypershift/test/e2e/util/dump"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +34,7 @@ import (
 //
 // This function is intended (for now) to be the preferred default way of
 // creating a hosted cluster during a test.
-func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, opts *core.CreateOptions, platform hyperv1.PlatformType, artifactDir string) *hyperv1.HostedCluster {
+func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, opts *core.CreateOptions, platform hyperv1.PlatformType, platformOpts core.CreateClusterPlatformOptions, artifactDir string) *hyperv1.HostedCluster {
 	g := NewWithT(t)
 	start := time.Now()
 
@@ -68,10 +67,10 @@ func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, op
 	opts = createClusterOpts(hc, opts)
 
 	// Try and create the cluster. If it fails, immediately try and clean up.
-	t.Logf("Creating a new cluster. Options: %v", opts)
-	if err := createCluster(ctx, hc, opts); err != nil {
+	t.Logf("Creating a new cluster. Options: %v, PlatformOptions: %v", opts, platformOpts)
+	if err := opts.CreateCluster(ctx, platformOpts); err != nil {
 		t.Logf("failed to create cluster, tearing down: %v", err)
-		teardown(context.Background(), t, client, hc, opts, artifactDir)
+		teardown(context.Background(), t, client, hc, opts, platformOpts, artifactDir)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to create cluster")
 	}
 
@@ -79,14 +78,14 @@ func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, op
 	// fails, immediately try and clean up.
 	if err := client.Get(ctx, crclient.ObjectKeyFromObject(hc), hc); err != nil {
 		t.Logf("failed to get cluster that was created, tearing down: %v", err)
-		teardown(context.Background(), t, client, hc, opts, artifactDir)
+		teardown(context.Background(), t, client, hc, opts, platformOpts, artifactDir)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 	}
 
 	// Everything went well, so register the async cleanup handler and allow tests
 	// to proceed.
 	t.Logf("Successfully created hostedcluster %s/%s in %s", hc.Namespace, hc.Name, time.Since(start).Round(time.Second))
-	t.Cleanup(func() { teardown(context.Background(), t, client, hc, opts, artifactDir) })
+	t.Cleanup(func() { teardown(context.Background(), t, client, hc, opts, platformOpts, artifactDir) })
 
 	return hc
 }
@@ -98,8 +97,8 @@ func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, op
 // Note that most resource dumps are considered fatal to the tests. The reason
 // is that these dumps are critical to our ability to debug issues in CI, and so
 // we want to treat diagnostic dump failures as high priority bugs to resolve.
-func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyperv1.HostedCluster, opts *core.CreateOptions, artifactDir string) {
-	dumpCluster := newClusterDumper(hc, opts, artifactDir)
+func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyperv1.HostedCluster, opts *core.CreateOptions, platformOpts core.CreateClusterPlatformOptions, artifactDir string) {
+	dumpCluster := newClusterDumper(hc, platformOpts, artifactDir)
 
 	// First, do a dump of the cluster before tearing it down
 	t.Run("PreTeardownClusterDump", func(t *testing.T) {
@@ -117,7 +116,7 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 	t.Run(fmt.Sprintf("DestroyCluster_%d", destroyAttempt), func(t *testing.T) {
 		t.Logf("Waiting for cluster to be destroyed. Namespace: %s, name: %s", hc.Namespace, hc.Name)
 		err := wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
-			err := destroyCluster(ctx, hc, opts)
+			err := destroyCluster(ctx, hc, opts, platformOpts)
 			if err != nil {
 				t.Logf("Failed to destroy cluster, will retry: %v", err)
 				err := dumpCluster(ctx, t)
@@ -174,35 +173,21 @@ func createClusterOpts(hc *hyperv1.HostedCluster, opts *core.CreateOptions) *cor
 	return opts
 }
 
-// createCluster calls the correct cluster create CLI function based on the
-// cluster platform.
-func createCluster(ctx context.Context, hc *hyperv1.HostedCluster, opts *core.CreateOptions) error {
-	switch hc.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		return aws.CreateCluster(ctx, opts)
-	case hyperv1.NonePlatform:
-		return none.CreateCluster(ctx, opts)
-	case hyperv1.KubevirtPlatform:
-		return kubevirt.CreateCluster(ctx, opts)
-	default:
-		return fmt.Errorf("unsupported platform")
-	}
-}
-
 // destroyCluster calls the correct cluster destroy CLI function based on the
 // cluster platform and the options used to create the cluster.
-func destroyCluster(ctx context.Context, hc *hyperv1.HostedCluster, createOpts *core.CreateOptions) error {
+func destroyCluster(ctx context.Context, hc *hyperv1.HostedCluster, createOpts *core.CreateOptions, platformOpts core.CreateClusterPlatformOptions) error {
 	switch hc.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
+		awsOpts := platformOpts.(*aws.AWSPlatformOptions)
 		opts := &core.DestroyOptions{
 			Namespace: hc.Namespace,
 			Name:      hc.Name,
 			InfraID:   createOpts.InfraID,
 			AWSPlatform: core.AWSPlatformDestroyOptions{
 				BaseDomain:         createOpts.BaseDomain,
-				AWSCredentialsFile: createOpts.AWSPlatform.AWSCredentialsFile,
+				AWSCredentialsFile: awsOpts.AWSCredentialsFile,
 				PreserveIAM:        false,
-				Region:             createOpts.AWSPlatform.Region,
+				Region:             awsOpts.Region,
 			},
 			ClusterGracePeriod: 15 * time.Minute,
 		}
@@ -223,7 +208,7 @@ func destroyCluster(ctx context.Context, hc *hyperv1.HostedCluster, createOpts *
 // a cluster based on the cluster's platform. The output directory will be named
 // according to the test name. So, the returned dump function should be called
 // at most once per unique test name.
-func newClusterDumper(hc *hyperv1.HostedCluster, opts *core.CreateOptions, artifactDir string) func(ctx context.Context, t *testing.T) error {
+func newClusterDumper(hc *hyperv1.HostedCluster, platformOpts core.CreateClusterPlatformOptions, artifactDir string) func(ctx context.Context, t *testing.T) error {
 	return func(ctx context.Context, t *testing.T) error {
 		if len(artifactDir) == 0 {
 			t.Logf("Skipping cluster dump because no artifact directory was provided")
@@ -233,8 +218,9 @@ func newClusterDumper(hc *hyperv1.HostedCluster, opts *core.CreateOptions, artif
 
 		switch hc.Spec.Platform.Type {
 		case hyperv1.AWSPlatform:
+			awsOpts := platformOpts.(*aws.AWSPlatformOptions)
 			var dumpErrors []error
-			err := dump.DumpMachineConsoleLogs(ctx, hc, opts.AWSPlatform.AWSCredentialsFile, dumpDir)
+			err := dump.DumpMachineConsoleLogs(ctx, hc, awsOpts.AWSCredentialsFile, dumpDir)
 			if err != nil {
 				t.Logf("Failed saving machine console logs; this is nonfatal: %v", err)
 			}
@@ -242,7 +228,7 @@ func newClusterDumper(hc *hyperv1.HostedCluster, opts *core.CreateOptions, artif
 			if err != nil {
 				dumpErrors = append(dumpErrors, fmt.Errorf("failed to dump hosted cluster: %w", err))
 			}
-			err = dump.DumpJournals(t, ctx, hc, dumpDir, opts.AWSPlatform.AWSCredentialsFile)
+			err = dump.DumpJournals(t, ctx, hc, dumpDir, awsOpts.AWSCredentialsFile)
 			if err != nil {
 				t.Logf("Failed to dump machine journals; this is nonfatal: %v", err)
 			}


### PR DESCRIPTION
Refactor CMD code in order to remove duplicated code
In order to create NodePool as part of the cluster creation, also NodePool cmd objects are included in the cluster cmd objects
This change also require:

- organize cluster cmd objects and add platform interface
- Implement NodePool platform interface by None and Agent platforms, to allow creating empty NodePool by those platforms
- Expose "Infra cmd outputs" and "Iam cmd outputs" to NodePool CMD, in order to conclude NodePool flags during Cluster creation
- Use the same "ApplyObjects" utility in both Cluster CMD and NodePool CMD, in order to have the same behavior in both scenarios
