### PR TITLE
Set explicitOauthConfig as true when .OAuth is not nil

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -656,7 +656,8 @@ func (r *HostedControlPlaneReconciler) update(ctx context.Context, hostedControl
 
 	// Reconcile kubeadmin password
 	r.Log.Info("Reconciling kubeadmin password secret")
-	if err := r.reconcileKubeadminPassword(ctx, hostedControlPlane, globalConfig.OAuth == nil); err != nil {
+	explicitOauthConfig := globalConfig.OAuth != nil
+	if err := r.reconcileKubeadminPassword(ctx, hostedControlPlane, explicitOauthConfig); err != nil {
 		return fmt.Errorf("failed to ensure control plane: %w", err)
 	}
 


### PR DESCRIPTION
This PR https://github.com/openshift/hypershift/pull/787 intoduced a behaviour to prevent us reconciling the secret with user/pass for the guest cluster when the oauth config is set. However the boolean value passed through the reconciling function is wrongly inverted. This PR fixes it by seeting explicitOauthConfig as true when .OAuth != nil