### PR TITLE
Improve TestReconcileKubeadminPassword unit test to use real config

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -4,93 +4,109 @@ import (
 	"context"
 	"testing"
 
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
+	"github.com/openshift/hypershift/support/globalconfig"
+	"github.com/openshift/hypershift/support/upsert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/support/upsert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestReconcileKubeadminPassword(t *testing.T) {
-	type args struct {
-		ctx                 context.Context
-		hcp                 *hyperv1.HostedControlPlane
-		explicitOauthConfig bool
-	}
-	tests := []struct {
+	targetNamespace := "test"
+	OAuthConfig := `
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: "example"
+spec:
+  identityProviders:
+  - openID:
+      claims:
+        email:
+        - email
+        name:
+        - clientid1-secret-name
+        preferredUsername:
+        - preferred_username
+      clientID: clientid1
+      clientSecret:
+        name: clientid1-secret-name
+      issuer: https://example.com/identity
+    mappingMethod: lookup
+    name: IAM
+    type: OpenID
+`
+
+	testsCases := []struct {
 		name                 string
-		args                 args
+		hcp                  *hyperv1.HostedControlPlane
 		expectedOutputSecret *corev1.Secret
 	}{
 		{
-			name: "Oauth config specified results in no kubeadmin secret",
-			args: args{
-				ctx: context.TODO(),
-				hcp: &hyperv1.HostedControlPlane{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HostedControlPlane",
-						APIVersion: hyperv1.GroupVersion.String(),
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "master-cluster1",
-						Name:      "cluster1",
+			name: "When OAuth config specified results in no kubeadmin secret",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: targetNamespace,
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						Items: []runtime.RawExtension{
+							{
+								Raw: []byte(OAuthConfig),
+							},
+						},
 					},
 				},
-				explicitOauthConfig: true,
 			},
 			expectedOutputSecret: nil,
 		},
-
 		{
-			name: "Oauth config not specified results in default kubeadmin secret",
-			args: args{
-				ctx: context.TODO(),
-				hcp: &hyperv1.HostedControlPlane{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "HostedControlPlane",
-						APIVersion: hyperv1.GroupVersion.String(),
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "master-cluster1",
-						Name:      "cluster1",
-					},
+			name: "When Oauth config not specified results in default kubeadmin secret",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: targetNamespace,
+					Name:      "cluster1",
 				},
-				explicitOauthConfig: false,
 			},
-			expectedOutputSecret: common.KubeadminPasswordSecret("master-cluster1"),
+			expectedOutputSecret: common.KubeadminPasswordSecret(targetNamespace),
 		},
 	}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
 			fakeClient := fake.NewClientBuilder().Build()
 			r := &HostedControlPlaneReconciler{
 				Client:                 fakeClient,
 				Log:                    ctrl.LoggerFrom(context.TODO()),
 				CreateOrUpdateProvider: upsert.New(false),
-				EnableCIDebugOutput:    false,
-			}
-			if err := r.reconcileKubeadminPassword(testCase.args.ctx, testCase.args.hcp, testCase.args.explicitOauthConfig); err != nil {
-				t.Error(err)
 			}
 
-			actualSecret := common.KubeadminPasswordSecret("master-cluster1")
-			err := fakeClient.Get(testCase.args.ctx, client.ObjectKeyFromObject(actualSecret), actualSecret)
-			if testCase.expectedOutputSecret != nil {
-				if err != nil {
-					t.Error("unexpected error fetching kubeAdmin Secret: %w", err)
-				}
-				if val, ok := actualSecret.Data["password"]; !ok || len(val) == 0 {
-					t.Error("secret did not contain password key")
-				}
+			globalConfig, err := globalconfig.ParseGlobalConfig(context.Background(), tc.hcp.Spec.Configuration)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			err = r.reconcileKubeadminPassword(context.Background(), tc.hcp, globalConfig.OAuth != nil)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			actualSecret := common.KubeadminPasswordSecret(targetNamespace)
+			err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(actualSecret), actualSecret)
+			if tc.expectedOutputSecret != nil {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(actualSecret.Data).To(HaveKey("password"))
+				g.Expect(actualSecret.Data["password"]).ToNot(BeEmpty())
 			} else {
 				if !errors.IsNotFound(err) {
-					t.Error("kubeAdmin secret should not be found: %w", err)
+					g.Expect(err).NotTo(HaveOccurred())
 				}
 			}
 		})


### PR DESCRIPTION
https://github.com/openshift/hypershift/pull/787 intoduced a behaviour to prevent us reconciling the secret with user/pass for the guest cluster when the oauth config is set.

https://github.com/openshift/hypershift/pull/907 fixed a bug in the former PR.

This PR improves the unit test coverage to use the same real global config pointed in the docs as an example.