### PR TITLE
Fix serviceaccount name for AWS CSI controller

### DIFF
--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -128,7 +128,7 @@ func (o *DestroyIAMOptions) DestroyOIDCResources(ctx context.Context, iamClient 
 	if err = o.DestroyOIDCRole(iamClient, "openshift-image-registry"); err != nil {
 		return err
 	}
-	if err = o.DestroyOIDCRole(iamClient, "aws-ebs-csi-driver-operator"); err != nil {
+	if err = o.DestroyOIDCRole(iamClient, "aws-ebs-csi-driver-controller"); err != nil {
 		return err
 	}
 	if err = o.DestroyOIDCRole(iamClient, "cloud-controller"); err != nil {

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -393,8 +393,8 @@ func (o *CreateIAMOptions) CreateOIDCResources(iamClient iamiface.IAMAPI) (*Crea
 		Name:      "installer-cloud-credentials",
 	})
 
-	csiTrustPolicy := oidcTrustPolicy(providerARN, providerName, "system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator")
-	arn, err = o.CreateOIDCRole(iamClient, "aws-ebs-csi-driver-operator", csiTrustPolicy, awsEBSCSIPermPolicy)
+	csiTrustPolicy := oidcTrustPolicy(providerARN, providerName, "system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa")
+	arn, err = o.CreateOIDCRole(iamClient, "aws-ebs-csi-driver-controller", csiTrustPolicy, awsEBSCSIPermPolicy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It is the controller and not the operator that interacts with AWS, and
that uses a different SA. This change fixes dynamic provisioning of
volumes in AWS with a current 4.10 OCP.