### PR TITLE
kas: wait for etcd client service name before allowing startup

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -15,7 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	// TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -1263,7 +1263,7 @@ func (r *HostedControlPlaneReconciler) reconcileManagedEtcd(ctx context.Context,
 }
 
 func (r *HostedControlPlaneReconciler) reconcileUnmanagedEtcd(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
-	//reconcile client secret over
+	// reconcile client secret over
 	if hcp.Spec.Etcd.Unmanaged == nil || len(hcp.Spec.Etcd.Unmanaged.TLS.ClientSecret.Name) == 0 || len(hcp.Spec.Etcd.Unmanaged.Endpoint) == 0 {
 		return fmt.Errorf("etcd metadata not specified for unmanaged deployment")
 	}
@@ -1505,6 +1505,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 			hcp.Spec.SecretEncryption,
 			aesCBCActiveKey,
 			aesCBCBackupKey,
+			hcp.Spec.Etcd.ManagementType,
 		)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile api server deployment: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this commit, KAS was allowed to launch in parallel with etcd, leading to
a race between the KAS etcd client timeout and etcd initialization. When KAS
loses the race, the KAS container restarts, incurring a backoff/startup time
penalty and tripping the crashing pod detector in the e2e suite.

This commit improves startup reliability by adding an init container to KAS
which waits for the etcd client service name to resolve (via `nslookup`) to
prevent useless restarts when etcd isn't ready yet.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] ~Relevant issues have been referenced.~
- [x] ~This change includes docs.~
- [x] ~This change includes unit tests.~