### PR TITLE
Reduce the number of the docker image layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ COPY . .
 RUN make build
 
 FROM quay.io/openshift/origin-base:4.10
-COPY --from=builder /hypershift/bin/ignition-server /usr/bin/ignition-server
-COPY --from=builder /hypershift/bin/hypershift /usr/bin/hypershift
-COPY --from=builder /hypershift/bin/hypershift-operator /usr/bin/hypershift-operator
-COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
-COPY --from=builder /hypershift/bin/konnectivity-socks5-proxy /usr/bin/konnectivity-socks5-proxy
-COPY --from=builder /hypershift/bin/availability-prober /usr/bin/availability-prober
-COPY --from=builder /hypershift/bin/token-minter /usr/bin/token-minter
+COPY --from=builder /hypershift/bin/ignition-server \
+                    /hypershift/bin/hypershift \
+                    /hypershift/bin/hypershift-operator \
+                    /hypershift/bin/control-plane-operator \
+                    /hypershift/bin/konnectivity-socks5-proxy \
+                    /hypershift/bin/availability-prober \
+                    /hypershift/bin/token-minter \
+     /usr/bin/
 
 ENTRYPOINT /usr/bin/hypershift


### PR DESCRIPTION
This PR reduces the number of the image layers by using a single `COPY` Dockerfile command instead of a command per executable. 

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced. - n/a
- [ ] This change includes docs. - n/a
- [ ] This change includes unit tests. - n/a