### PR TITLE
Add basic docs for Hosted Cluster workload distribution

### DIFF
--- a/docs/content/how-to/distribute-hosted-cluster-workloads.md
+++ b/docs/content/how-to/distribute-hosted-cluster-workloads.md
@@ -1,0 +1,19 @@
+---
+title: Distribute Hosted Cluster workloads
+---
+
+# Distribute Hosted Cluster workloads
+
+HyperShift enables implementing the strategy to colocate and isolate pods for Hosted Clusters.
+As a management cluster operator you can leverage the following Node labels and taints: 
+
+`hypershift.openshift.io/control-plane: true`
+
+`hypershift.openshift.io/cluster: ${HostedControlPlane Namespace}`
+
+- Pods for a Hosted Cluster tolerate taints for control-plane and cluster.
+- Pods for a Hosted Cluster prefer to be scheduled into the same Node.
+- Pods for a Hosted Cluster prefer to be scheduled into control-plane Nodes.
+- Pods for a Hosted Cluster prefer to be scheduled into their own cluster Nodes. 
+
+If the `ControllerAvailabilityPolicy` is `HighlyAvailable` Pods for each Deployment within a Hosted Cluster will prefer to be scheduled across different failure domains.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - how-to/index.md
   - how-to/deploy-aws-private-clusters.md
   - how-to/oauth.md
+  - how-to/distribute-hosted-cluster-workloads.md
 - 'Reference':
   - reference/index.md
   - reference/api.md


### PR DESCRIPTION
**What this PR does / why we need it**:

This introduces high level docs for a management cluster operator to leverage `hypershift.openshift.io/control-plane: true` and `hypershift.openshift.io/cluster: ${HostedControlPlane Namespace}` to implement a Hosted Cluster workload distribution strategy.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.