### PR TITLE
Automatically infer infra cr GVK

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -50,13 +50,6 @@ func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, create
 		return nil, err
 	}
 
-	// reconciliation strips TypeMeta. We repopulate the static values since they are necessary for
-	// downstream reconciliation of the CAPI Cluster resource.
-	agentCluster.TypeMeta = metav1.TypeMeta{
-		Kind:       "AgentCluster",
-		APIVersion: agentv1.GroupVersion.String(),
-	}
-
 	return agentCluster, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -44,12 +44,6 @@ func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOr
 	if err != nil {
 		return nil, err
 	}
-	// reconciliation strips TypeMeta. We repopulate the static values since they are necessary for
-	// downstream reconciliation of the CAPI Cluster resource.
-	awsCluster.TypeMeta = metav1.TypeMeta{
-		Kind:       "AWSCluster",
-		APIVersion: capiawsv1.GroupVersion.String(),
-	}
 	return awsCluster, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
@@ -50,12 +50,6 @@ func (p IBMCloud) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, cre
 	if err != nil {
 		return nil, err
 	}
-	// reconciliation strips TypeMeta. We repopulate the static values since they are necessary for
-	// downstream reconciliation of the CAPI Cluster resource.
-	ibmCluster.TypeMeta = metav1.TypeMeta{
-		Kind:       "IBMVPCCluster",
-		APIVersion: capiibmv1.GroupVersion.String(),
-	}
 	return ibmCluster, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -38,10 +38,6 @@ func (p Kubevirt) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, cre
 	}); err != nil {
 		return nil, err
 	}
-	kubevirtCluster.TypeMeta = metav1.TypeMeta{
-		Kind:       "KubevirtCluster",
-		APIVersion: capikubevirt.GroupVersion.String(),
-	}
 
 	return kubevirtCluster, nil
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt_test.go
@@ -34,10 +34,6 @@ func TestReconcileCAPIInfraCR(t *testing.T) {
 				capiv1.ManagedByAnnotation: "external",
 			},
 		},
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "KubevirtCluster",
-			APIVersion: capikubevirt.GroupVersion.String(),
-		},
 		Status: capikubevirt.KubevirtClusterStatus{
 			Ready: true,
 		},


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
We currently require the type meta on the infra CR to be set correctly
which isn't done by default. Infer it instead to simplify implementing
new providers and remove one possible source of errors.

/assign @enxebre 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.