### PR TITLE
CLI: Simplify provider-specific kube resources

### DIFF
--- a/api/fixtures/example_aws.go
+++ b/api/fixtures/example_aws.go
@@ -5,8 +5,6 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ Resources = &ExampleAWSResources{}
-
 type ExampleAWSResources struct {
 	KubeCloudControllerAWSCreds  *corev1.Secret
 	NodePoolManagementAWSCreds   *corev1.Secret


### PR DESCRIPTION
Currently, the provider has to implement an `AsObjects` interface that
returns a slice of objects. The only implementation of this interface is
for AWS which is assiged to a variable of the interface type, which
forces a type assertion two lines later.

All of this is needlessly complicated, we can simply pass a slice of
client objects from the provider-specific part into the genreric part
instead.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.