### PR TITLE
 Hypershift operator: Ensure the oidc configmap

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -43,6 +43,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"
 	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
@@ -350,6 +351,22 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 			return fmt.Errorf("failed to reconcile default ingress controller: %w", err)
 		}
 		log.Info("reconciled default ingress controller")
+	}
+
+	if opts.OIDCStorageProviderS3BucketName != "" {
+		oidcStorageProviderS3ConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-public", Name: "oidc-storage-provider-s3-config"},
+		}
+		if _, err := controllerutil.CreateOrUpdate(ctx, apiReadingClient, oidcStorageProviderS3ConfigMap, func() error {
+			if oidcStorageProviderS3ConfigMap.Data == nil {
+				oidcStorageProviderS3ConfigMap.Data = map[string]string{}
+			}
+			oidcStorageProviderS3ConfigMap.Data["name"] = opts.OIDCStorageProviderS3BucketName
+			oidcStorageProviderS3ConfigMap.Data["region"] = opts.OIDCStorageProviderS3Region
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile the %s configmap: %w", crclient.ObjectKeyFromObject(oidcStorageProviderS3ConfigMap), err)
+		}
 	}
 
 	if err := setupMetrics(mgr); err != nil {


### PR DESCRIPTION
This makes the Hypershift operator populate the OIDC configmap in the
kube-public namespace which allows the `install` command to skip that
which in turn means its `--render` functionality can be extended to use
a pre-existing secret.


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.