### PR TITLE
remove incluster cloud controller manager operator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -72,6 +72,8 @@ var (
 		// for cco and auth  operators
 		"0000_50_cloud-credential-operator_01-operator-config.yaml",
 		"0000_50_cluster-authentication-operator_02_config.cr.yaml",
+		"0000_26_cloud-controller-manager-operator_12_clusteroperator.yaml",
+		"0000_26_cloud-controller-manager-operator_11_deployment.yaml",
 	}
 )
 


### PR DESCRIPTION
This removes the in cluster cloud controller manager. It should not be deployed as any cloud controllers should be deployed on the control plane side. Additionally it runs as host network which is getting flagged as a security problem (components should only run with host network when necessary).

Manifests I see in 4.9.15 release payload
```
[root@24b5227e4037 /]# cat /release-manifests/0000_26_cloud-controller-manager-operator_12_clusteroperator.yaml
apiVersion: config.openshift.io/v1
kind: ClusterOperator
metadata:
  name: cloud-controller-manager
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
    include.release.openshift.io/single-node-developer: "true"
    exclude.release.openshift.io/internal-openshift-hosted: "true"
spec: {}
status:
  versions:
    - name: operator
      version: "4.9.15"
  relatedObjects:
    - group: config.openshift.io
      name: cloud-controller-manager
      resource: clusteroperators
    - group: ""
      name: openshift-cloud-controller-manager
      resource: namespaces
    - group: ""
      name: openshift-cloud-controller-manager-operator
      resource: namespaces
```

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cluster-cloud-controller-manager-operator
  namespace: openshift-cloud-controller-manager-operator
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
    include.release.openshift.io/single-node-developer: "true"
  labels:
    k8s-app: cloud-manager-operator
spec:
  selector:
    matchLabels:
      k8s-app: cloud-manager-operator
  replicas: 1
  strategy:
    type: Recreate
  template:
    metadata:
      annotations:
        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
      labels:
        k8s-app: cloud-manager-operator
    spec:
      priorityClassName: system-node-critical
      serviceAccountName: cluster-cloud-controller-manager
      containers:
      - name: cluster-cloud-controller-manager
        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cc55a8dc013ba5bab6c41b2fa49fd42e3cc832d8d5849526c59e96866c345fb4
        command:
        - /bin/bash
        - -c
        - |
          #!/bin/bash
          set -o allexport
          if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
            source /etc/kubernetes/apiserver-url.env
          else
            URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
          fi
          exec /cluster-controller-manager-operator \
          --leader-elect=true \
          --leader-elect-lease-duration=137s \
          --leader-elect-renew-deadline=107s \
          --leader-elect-retry-period=26s \
          --leader-elect-resource-namespace=openshift-cloud-controller-manager-operator \
          "--images-json=/etc/cloud-controller-manager-config/images.json"
        env:
        - name: RELEASE_VERSION
          value: "4.9.15"
        resources:
          requests:
            cpu: 10m
            memory: 50Mi
        volumeMounts:
        - name: images
          mountPath: /etc/cloud-controller-manager-config/
        - mountPath: /etc/kubernetes
          name: host-etc-kube
          readOnly: true
      - name: config-sync-controllers
        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cc55a8dc013ba5bab6c41b2fa49fd42e3cc832d8d5849526c59e96866c345fb4
        command:
          - /bin/bash
          - -c
          - |
            #!/bin/bash
            set -o allexport
            if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
              source /etc/kubernetes/apiserver-url.env
            else
              URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
            fi
            exec /config-sync-controllers \
            --leader-elect=true \
            --leader-elect-lease-duration=137s \
            --leader-elect-renew-deadline=107s \
            --leader-elect-retry-period=26s \
            --leader-elect-resource-namespace=openshift-cloud-controller-manager-operator \
            --metrics-bind-address=:9258 \
            --health-addr=127.0.0.1:9259
        ports:
        - containerPort: 9258
          name: metrics
          protocol: TCP
        - containerPort: 9259
          name: healthz
          protocol: TCP
        resources:
          requests:
            cpu: 10m
            memory: 25Mi
        volumeMounts:
          - mountPath: /etc/kubernetes
            name: host-etc-kube
            readOnly: true
      hostNetwork: true
      nodeSelector:
        node-role.kubernetes.io/master: ""
      restartPolicy: Always
      tolerations:
      - key: node.cloudprovider.kubernetes.io/uninitialized
        effect: NoSchedule
        value: "true"
      - key: "node-role.kubernetes.io/master"
        operator: "Exists"
        effect: "NoSchedule"
      - key: "node.kubernetes.io/unreachable"
        operator: "Exists"
        effect: "NoExecute"
        tolerationSeconds: 120
      - key: "node.kubernetes.io/not-ready"
        operator: "Exists"
        effect: "NoExecute"
        tolerationSeconds: 120
      - key: "node.cloudprovider.kubernetes.io/uninitialized"
        operator: "Exists"
        effect: "NoSchedule"
        # CNI relies on CCM to fill in IP information on Node objects.
        # Therefore we must schedule before the CNI can mark the Node as ready.
      - key: "node.kubernetes.io/not-ready"
        operator: "Exists"
        effect: "NoSchedule"
      volumes:
      - name: images
        configMap:
          defaultMode: 420
          name: cloud-controller-manager-images
      - name: host-etc-kube
        hostPath:
          path: /etc/kubernetes
          type: Directory
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # 

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.