### PR TITLE
enable leader election for control plane operator to prevent race conditions on upgrades

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -90,7 +90,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&deploymentName, "deployment-name", "control-plane-operator", "The name of the deployment of this operator")
 	cmd.Flags().StringVar(&metricsAddr, "metrics-addr", "0.0.0.0:8080", "The address the metric endpoint binds to.")
 	cmd.Flags().StringVar(&healthProbeAddr, "health-probe-addr", "0.0.0.0:6060", "The address for the health probe endpoint.")
-	cmd.Flags().BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	cmd.Flags().BoolVar(&enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().StringVar(&hostedClusterConfigOperatorImage, "hosted-cluster-config-operator-image", "", "A specific operator image. (defaults to match this operator if running in a deployment)")
@@ -112,12 +112,14 @@ func NewStartCommand() *cobra.Command {
 		restConfig := ctrl.GetConfigOrDie()
 		restConfig.UserAgent = "hypershift-controlplane-manager"
 		mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-			Scheme:                 hyperapi.Scheme,
-			MetricsBindAddress:     metricsAddr,
-			Port:                   9443,
-			LeaderElection:         enableLeaderElection,
-			LeaderElectionID:       "b2ed43cb.hypershift.openshift.io",
-			HealthProbeBindAddress: healthProbeAddr,
+			Scheme:                     hyperapi.Scheme,
+			MetricsBindAddress:         metricsAddr,
+			Port:                       9443,
+			LeaderElection:             enableLeaderElection,
+			LeaderElectionID:           "b2ed43cb.hypershift.openshift.io",
+			LeaderElectionResourceLock: "leases",
+			LeaderElectionNamespace:    namespace,
+			HealthProbeBindAddress:     healthProbeAddr,
 			// We manage a service outside the HCP namespace, but we don't want to scope the cache for all objects
 			// to both namespaces so just read from the API.
 			ClientDisableCacheFor: []client.Object{&corev1.Service{}},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2159,6 +2159,13 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 			Resources: []string{"poddisruptionbudgets"},
 			Verbs:     []string{"*"},
 		},
+		{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{
+				"leases",
+			},
+			Verbs: []string{"*"},
+		},
 	}
 	return nil
 }


### PR DESCRIPTION
There is a race condition without leader election for the control plane operator when two instances are active at a given moment of time. It can lead to them simultaneous modifying deployments and resulting them in unexpected states (sometimes a merge of the data between the two versions of the operator). This pr enables leader election for the component by default to eliminate this reace condition


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # Race condition that can result in unexpected cluster states

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.