### PR TITLE
ensure all components respect the restart annotation.

### DIFF
--- a/docs/content/how-to/restart-control-plane-components.md
+++ b/docs/content/how-to/restart-control-plane-components.md
@@ -1,0 +1,45 @@
+# Restart Control Plane Components with Restart Annotation
+
+The Restart Annotation allows a user to trigger a rolling restart of all control-plane components in the management cluster. This is helpful in certain situations like when you want to force a reload of all the certificates components are using in the control plane. It is also a helpful operational debug step to see if a restart resolves any abnormalities being experienced in the control plane components.
+
+To utilize: the restart annotation is passed to the Hostedcluster object
+
+```
+apiVersion: hypershift.openshift.io/v1alpha1
+kind: HostedCluster
+metadata:
+  name: example
+  namespace: master
+  annotations:
+    hypershift.openshift.io/restart-date: "2022-01-31T12:56:54+0000"
+....
+```
+
+When that annotation is passed: every component in the clusters control plane will proceed to do a rolling restart. This will occur anytime a new value is passed to the restart date annotation.
+
+The list of components restarted are listed below:
+- catalog-operator
+- certified-operators-catalog
+- cluster-api
+- cluster-autoscaler
+- cluster-policy-controller
+- cluster-version-operator
+- community-operators-catalog
+- control-plane-operator
+- hosted-cluster-config-operator
+- ignition-server
+- ingress-operator
+- konnectivity-agent
+- konnectivity-server
+- kube-apiserver
+- kube-controller-manager
+- kube-scheduler
+- machine-approver
+- oauth-openshift
+- olm-operator
+- openshift-apiserver
+- openshift-controller-manager
+- openshift-oauth-apiserver
+- packageserver
+- redhat-marketplace-catalog
+- redhat-operators-catalog

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - how-to/deploy-aws-private-clusters.md
   - how-to/oauth.md
   - how-to/distribute-hosted-cluster-workloads.md
+  - how-to/restart-control-plane-components.md
 - 'Reference':
   - reference/index.md
   - reference/api.md

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1753,7 +1753,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 				RunAsUser: k8sutilspointer.Int64Ptr(config.DefaultSecurityContextUser),
 			}
 		}
-
+		hyperutil.SetRestartAnnotation(hcluster, ignitionServerDeployment)
 		hyperutil.SetColocation(hcluster, ignitionServerDeployment)
 		hyperutil.SetControlPlaneIsolation(hcluster, ignitionServerDeployment)
 		hyperutil.SetDefaultPriorityClass(ignitionServerDeployment)
@@ -2316,9 +2316,7 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 	}
 
 	hyperutil.SetColocation(hc, deployment)
-	// TODO (alberto): Reconsider enable this back when we face a real need
-	// with no better solution.
-	// hyperutil.SetRestartAnnotation(hc, deployment)
+	hyperutil.SetRestartAnnotation(hc, deployment)
 	hyperutil.SetControlPlaneIsolation(hc, deployment)
 	hyperutil.SetDefaultPriorityClass(deployment)
 	switch hc.Spec.ControllerAvailabilityPolicy {


### PR DESCRIPTION
This pr ensures all components respect the restart annotation. This is critical to support ca rotation because ignition server needs to reload the server certs after rotation which currently is not occuring. Additionally: it is opertionally expected from an ibm perspective that all components get restarted on a master refresh operation. This is an agreement we provide to customers that needs to be honored and is good operationally for all providers. There will be other situations in the future where an on demand restart is beneficial.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # Necessary to enable to support CA rotation and operational requirements for the IBM Cloud Satellite offering

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.