### PR TITLE
Rename creds rbac CRs for agent platform

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -22,7 +22,8 @@ import (
 
 const (
 	// TODO Pin to specific release
-	imageCAPAgent = "quay.io/edge-infrastructure/cluster-api-provider-agent:latest"
+	imageCAPAgent       = "quay.io/edge-infrastructure/cluster-api-provider-agent:latest"
+	credentialsRBACName = "cluster-api-agent"
 )
 
 type Agent struct{}
@@ -131,7 +132,7 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hcluster.Spec.Platform.Agent.AgentNamespace,
-			Name:      "agent-cluster-api",
+			Name:      credentialsRBACName,
 		},
 	}
 	_, err := createOrUpdate(ctx, c, role, func() error {
@@ -151,7 +152,7 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hcluster.Spec.Platform.Agent.AgentNamespace,
-			Name:      "cluster-api",
+			Name:      credentialsRBACName,
 		},
 	}
 	_, err = createOrUpdate(ctx, c, roleBinding, func() error {
@@ -165,7 +166,7 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 		roleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     "agent-cluster-api",
+			Name:     credentialsRBACName,
 		}
 		return nil
 	})

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
@@ -1,0 +1,52 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/upsert"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileCredentials(t *testing.T) {
+	g := NewGomegaWithT(t)
+	platform := &Agent{}
+	hostedCluster := &hyperv1.HostedCluster{
+		Spec: hyperv1.HostedClusterSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AgentPlatform,
+				Agent: &hyperv1.AgentPlatformSpec{
+					AgentNamespace: "test",
+				},
+			},
+		},
+	}
+	controlPlaneNamespace := "test"
+	client := fake.NewClientBuilder().Build()
+
+	err := platform.ReconcileCredentials(context.Background(),
+		client, upsert.New(false).CreateOrUpdate,
+		hostedCluster, controlPlaneNamespace)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	role := &rbacv1.Role{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+		Name:      credentialsRBACName,
+	}, role)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	roleBinding := &rbacv1.RoleBinding{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+		Name:      credentialsRBACName,
+	}, roleBinding)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(roleBinding.Subjects[0].Namespace).To(BeIdenticalTo(controlPlaneNamespace))
+	g.Expect(roleBinding.Subjects[0].Kind).To(BeIdenticalTo("ServiceAccount"))
+	g.Expect(roleBinding.Subjects[0].Name).To(BeIdenticalTo("capi-provider"))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
"Cloud Credentials" for the Agent platform are given as RBAC CRs which enable the capi provider to watch and bind agents from a specific namespace. With current naming if the hostedControlPlane namespace happens to be the same than hostedCluster.Spec.Platform.Agent.AgentNamespace RBAC naming might clash.
This PR sets RBAC naming for Agent platform consistent with other references and add unit tests.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #934

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.