### PR TITLE
Add multi-zone support to create infra aws

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -21,7 +21,7 @@ type ExampleResources struct {
 	Resources  []crclient.Object
 	SSHKey     *corev1.Secret
 	Cluster    *hyperv1.HostedCluster
-	NodePool   *hyperv1.NodePool
+	NodePools  []*hyperv1.NodePool
 }
 
 func (o *ExampleResources) AsObjects() []crclient.Object {
@@ -34,8 +34,8 @@ func (o *ExampleResources) AsObjects() []crclient.Object {
 	if o.SSHKey != nil {
 		objects = append(objects, o.SSHKey)
 	}
-	if o.NodePool != nil {
-		objects = append(objects, o.NodePool)
+	for _, nodePool := range o.NodePools {
+		objects = append(objects, nodePool)
 	}
 	return objects
 }
@@ -85,11 +85,15 @@ type ExampleKubevirtOptions struct {
 	Image            string
 }
 
+type ExampleAWSOptionsZones struct {
+	Name     string
+	SubnetID *string
+}
+
 type ExampleAWSOptions struct {
 	Region                      string
-	Zone                        string
+	Zones                       []ExampleAWSOptionsZones
 	VPCID                       string
-	SubnetID                    string
 	SecurityGroupID             string
 	InstanceProfile             string
 	InstanceType                string
@@ -189,9 +193,9 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 				CloudProviderConfig: &hyperv1.AWSCloudProviderConfig{
 					VPC: o.AWS.VPCID,
 					Subnet: &hyperv1.AWSResourceReference{
-						ID: &o.AWS.SubnetID,
+						ID: o.AWS.Zones[0].SubnetID,
 					},
-					Zone: o.AWS.Zone,
+					Zone: o.AWS.Zones[0].Name,
 				},
 				KubeCloudControllerCreds:  corev1.LocalObjectReference{Name: awsResources.KubeCloudControllerAWSCreds.Name},
 				NodePoolManagementCreds:   corev1.LocalObjectReference{Name: awsResources.NodePoolManagementAWSCreds.Name},
@@ -308,16 +312,26 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 		},
 	}
 
-	var nodePool *hyperv1.NodePool
-	if o.NodePoolReplicas > -1 {
-		nodePool = &hyperv1.NodePool{
+	if o.NodePoolReplicas <= -1 {
+		return &ExampleResources{
+			Namespace:  namespace,
+			PullSecret: pullSecret,
+			Resources:  resources,
+			SSHKey:     sshKeySecret,
+			Cluster:    cluster,
+			NodePools:  []*hyperv1.NodePool{},
+		}
+	}
+
+	defaultNodePool := func(name string) *hyperv1.NodePool {
+		return &hyperv1.NodePool{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "NodePool",
 				APIVersion: hyperv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace.Name,
-				Name:      o.Name,
+				Name:      name,
 			},
 			Spec: hyperv1.NodePoolSpec{
 				Management: hyperv1.NodePoolManagement{
@@ -334,14 +348,18 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 				},
 			},
 		}
+	}
 
-		switch nodePool.Spec.Platform.Type {
-		case hyperv1.AWSPlatform:
+	var nodePools []*hyperv1.NodePool
+	switch cluster.Spec.Platform.Type {
+	case hyperv1.AWSPlatform:
+		for _, zone := range o.AWS.Zones {
+			nodePool := defaultNodePool(fmt.Sprintf("%s-%s", cluster.Name, zone.Name))
 			nodePool.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
 				InstanceType:    o.AWS.InstanceType,
 				InstanceProfile: o.AWS.InstanceProfile,
 				Subnet: &hyperv1.AWSResourceReference{
-					ID: &o.AWS.SubnetID,
+					ID: zone.SubnetID,
 				},
 				SecurityGroups: []hyperv1.AWSResourceReference{
 					{
@@ -354,38 +372,40 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 					IOPS: o.AWS.RootVolumeIOPS,
 				},
 			}
-		case hyperv1.KubevirtPlatform:
-			runAlways := kubevirtv1.RunStrategyAlways
-			guestQuantity := apiresource.MustParse(o.Kubevirt.Memory)
-			nodePool.Spec.Platform.Kubevirt = &hyperv1.KubevirtNodePoolPlatform{
-				NodeTemplate: &capikubevirt.VirtualMachineTemplateSpec{
-					Spec: kubevirtv1.VirtualMachineSpec{
-						RunStrategy: &runAlways,
-						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-							Spec: kubevirtv1.VirtualMachineInstanceSpec{
-								Domain: kubevirtv1.DomainSpec{
-									CPU:    &kubevirtv1.CPU{Cores: o.Kubevirt.Cores},
-									Memory: &kubevirtv1.Memory{Guest: &guestQuantity},
-									Devices: kubevirtv1.Devices{
-										Disks: []kubevirtv1.Disk{
-											{
-												Name: "containervolume",
-												DiskDevice: kubevirtv1.DiskDevice{
-													Disk: &kubevirtv1.DiskTarget{
-														Bus: "virtio",
-													},
+			nodePools = append(nodePools, nodePool)
+		}
+	case hyperv1.KubevirtPlatform:
+		nodePool := defaultNodePool(cluster.Name)
+		runAlways := kubevirtv1.RunStrategyAlways
+		guestQuantity := apiresource.MustParse(o.Kubevirt.Memory)
+		nodePool.Spec.Platform.Kubevirt = &hyperv1.KubevirtNodePoolPlatform{
+			NodeTemplate: &capikubevirt.VirtualMachineTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineSpec{
+					RunStrategy: &runAlways,
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								CPU:    &kubevirtv1.CPU{Cores: o.Kubevirt.Cores},
+								Memory: &kubevirtv1.Memory{Guest: &guestQuantity},
+								Devices: kubevirtv1.Devices{
+									Disks: []kubevirtv1.Disk{
+										{
+											Name: "containervolume",
+											DiskDevice: kubevirtv1.DiskDevice{
+												Disk: &kubevirtv1.DiskTarget{
+													Bus: "virtio",
 												},
 											},
 										},
 									},
 								},
-								Volumes: []kubevirtv1.Volume{
-									{
-										Name: "containervolume",
-										VolumeSource: kubevirtv1.VolumeSource{
-											ContainerDisk: &kubevirtv1.ContainerDiskSource{
-												Image: o.Kubevirt.Image,
-											},
+							},
+							Volumes: []kubevirtv1.Volume{
+								{
+									Name: "containervolume",
+									VolumeSource: kubevirtv1.VolumeSource{
+										ContainerDisk: &kubevirtv1.ContainerDiskSource{
+											Image: o.Kubevirt.Image,
 										},
 									},
 								},
@@ -393,8 +413,9 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 						},
 					},
 				},
-			}
+			},
 		}
+		nodePools = append(nodePools, nodePool)
 	}
 
 	return &ExampleResources{
@@ -403,7 +424,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 		Resources:  resources,
 		SSHKey:     sshKeySecret,
 		Cluster:    cluster,
-		NodePool:   nodePool,
+		NodePools:  nodePools,
 	}
 }
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -90,6 +90,7 @@ type AWSPlatformOptions struct {
 	RootVolumeSize     int64
 	RootVolumeType     string
 	EndpointAccess     string
+	Zones              []string
 }
 
 func createCommonFixture(opts *CreateOptions) (*apifixtures.ExampleOptions, error) {

--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -39,7 +39,7 @@ func TestAutoRepair(t *testing.T) {
 	nodepool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedCluster.Namespace,
-			Name:      hostedCluster.Name,
+			Name:      e2eutil.NodePoolName(hostedCluster.Name, clusterOpts.AWSPlatform.Zones[0]),
 		},
 	}
 	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -36,7 +36,7 @@ func TestAutoscaling(t *testing.T) {
 	nodepool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedCluster.Namespace,
-			Name:      hostedCluster.Name,
+			Name:      e2eutil.NodePoolName(hostedCluster.Name, clusterOpts.AWSPlatform.Zones[0]),
 		},
 	}
 	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -34,7 +34,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 	nodepool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedCluster.Namespace,
-			Name:      hostedCluster.Name,
+			Name:      e2eutil.NodePoolName(hostedCluster.Name, clusterOpts.AWSPlatform.Zones[0]),
 		},
 	}
 	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -71,7 +71,7 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 	nodepool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedCluster.Namespace,
-			Name:      hostedCluster.Name,
+			Name:      e2eutil.NodePoolName(hostedCluster.Name, clusterOpts.AWSPlatform.Zones[0]),
 		},
 	}
 	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -54,6 +54,7 @@ func init() {
 func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.AWSCredentialsFile, "e2e.aws-credentials-file", "", "path to AWS credentials")
 	flag.StringVar(&globalOpts.configurableClusterOptions.Region, "e2e.aws-region", "us-east-1", "AWS region for clusters")
+	flag.StringVar(&globalOpts.configurableClusterOptions.Zone, "e2e.aws-zone", "us-east-1a", "AWS zone for clusters")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PullSecretFile, "e2e.pull-secret-file", "", "path to pull secret")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AWSEndpointAccess, "e2e.aws-endpoint-access", "", "endpoint access profile for the cluster")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "container disk image to use for kubevirt nodes")
@@ -181,6 +182,7 @@ type options struct {
 type configurableClusterOptions struct {
 	AWSCredentialsFile         string
 	Region                     string
+	Zone                       string
 	PullSecretFile             string
 	BaseDomain                 string
 	ControlPlaneOperatorImage  string
@@ -206,6 +208,7 @@ func (o *options) DefaultClusterOptions() core.CreateOptions {
 			AWSCredentialsFile: o.configurableClusterOptions.AWSCredentialsFile,
 			Region:             o.configurableClusterOptions.Region,
 			EndpointAccess:     o.configurableClusterOptions.AWSEndpointAccess,
+			Zones:              []string{o.configurableClusterOptions.Zone},
 		},
 		KubevirtPlatform: core.KubevirtPlatformCreateOptions{
 			ContainerDiskImage: o.configurableClusterOptions.KubeVirtContainerDiskImage,

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -258,3 +258,7 @@ func newClusterDumper(hc *hyperv1.HostedCluster, opts *core.CreateOptions, artif
 		}
 	}
 }
+
+func NodePoolName(hcName, zone string) string {
+	return fmt.Sprintf("%s-%s", hcName, zone)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable multi-zone infra support for guest cluster so we can start testing multizone guest clusters in CI.

Note: This does not enable the functionality e2e.  Just the infra creation.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.