### PR TITLE
fix the node pool name in the kubevirt 2e2 test

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -71,7 +71,7 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 	nodepool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedCluster.Namespace,
-			Name:      e2eutil.NodePoolName(hostedCluster.Name, clusterOpts.AWSPlatform.Zones[0]),
+			Name:      hostedCluster.Name,
 		},
 	}
 	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)


### PR DESCRIPTION
The expected node pool name in the kubevirt test was changed to include AWS zone, where there is no AWS zone in kubevirt cluster, an so the test is fails because it can't find the node pool with the wrong name.

This PR reverts the naming change in the kubevirt test.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.