### PR TITLE
Reconcile AWS infra CR with NodePool subnets

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -6,23 +6,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt"
-	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
-	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
-	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
-	"github.com/openshift/hypershift/support/upsert"
-	"go.uber.org/zap/zapcore"
-	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
-	capibmv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta1"
-	"sigs.k8s.io/cluster-api/api/v1beta1"
-
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/autoscaler"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
+	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
+	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
+	"github.com/openshift/hypershift/support/upsert"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -32,6 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
+	capiawsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	capibmv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta1"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1150,4 +1149,82 @@ func (c *createTypeTrackingClient) Create(ctx context.Context, obj crclient.Obje
 	}
 	c.createdTypes.Insert(fmt.Sprintf("%T", obj))
 	return c.Client.Create(ctx, obj, opts...)
+}
+
+func TestReconcileAWSSubnets(t *testing.T) {
+	g := NewGomegaWithT(t)
+	hcNamespace := "test"
+	hcName := "test"
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: hcNamespace,
+		},
+		Spec: hyperv1.NodePoolSpec{
+			ClusterName: hcName,
+			Platform: hyperv1.NodePoolPlatform{
+				Type: hyperv1.AWSPlatform,
+				AWS: &hyperv1.AWSNodePoolPlatform{
+					Subnet: &hyperv1.AWSResourceReference{
+						ID: pointer.StringPtr("1"),
+					},
+				},
+			},
+		},
+	}
+
+	nodePool2 := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test2",
+			Namespace: hcNamespace,
+		},
+		Spec: hyperv1.NodePoolSpec{
+			ClusterName: hcName,
+			Platform: hyperv1.NodePoolPlatform{
+				Type: hyperv1.AWSPlatform,
+				AWS: &hyperv1.AWSNodePoolPlatform{
+					Subnet: &hyperv1.AWSResourceReference{
+						ID: pointer.StringPtr("2"),
+					},
+				},
+			},
+		},
+	}
+
+	infraCRName := "test"
+	infraCRNamespace := "hcp"
+	infraCR := &capiawsv1.AWSCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      infraCRName,
+			Namespace: infraCRNamespace,
+		},
+		Spec: capiawsv1.AWSClusterSpec{},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(infraCR, nodePool, nodePool2).Build()
+	r := &HostedClusterReconciler{
+		Client:         client,
+		createOrUpdate: func(reconcile.Request) upsert.CreateOrUpdateFN { return ctrl.CreateOrUpdate },
+	}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: hcNamespace, Name: hcName}}
+	createOrUpdate := r.createOrUpdate(req)
+
+	err := r.reconcileAWSSubnets(context.Background(), createOrUpdate, infraCR, req.Namespace, req.Name)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	freshInfraCR := &capiawsv1.AWSCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      infraCRName,
+			Namespace: infraCRNamespace,
+		}}
+	err = client.Get(context.Background(), crclient.ObjectKeyFromObject(freshInfraCR), freshInfraCR)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(freshInfraCR.Spec.NetworkSpec.Subnets).To(BeEquivalentTo([]capiawsv1.SubnetSpec{
+		{
+			ID: "1",
+		},
+		{
+			ID: "2",
+		},
+	}))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
There's an bug in CAPI AWS provider which prevent Machines from targeting subnets ids which are not present on the infra CR.
This PR is a workaround by keeping the infra CR subnets in sync with what is required by NodePools.
This should be dropped once https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2864 gets merged.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

ref https://issues.redhat.com/browse/HOSTEDCP-278

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.