### PR TITLE
Fix hot reconcile on AWSCluster

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -335,20 +335,6 @@ func reconcileAWSCluster(awsCluster *capiawsv1.AWSCluster, hcluster *hyperv1.Hos
 
 		if hcluster.Spec.Platform.AWS.CloudProviderConfig != nil {
 			awsCluster.Spec.NetworkSpec.VPC.ID = hcluster.Spec.Platform.AWS.CloudProviderConfig.VPC
-
-			// TODO: This https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2728
-			// broke our assumption in CAPA 0.7 for externally managed infrastructure.
-			// This effectively limit our ability to span NodePools across multiple subnets.
-			// In a follow up we need to either enable upstream back to support arbitrary subnets IDs
-			// in the awsMachine CR or possibly expose a slice of available subnets for NodePools in hcluster.Spec.Platform.AWS.
-			if hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet != nil &&
-				hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID != nil {
-				awsCluster.Spec.NetworkSpec.Subnets = []capiawsv1.SubnetSpec{
-					{
-						ID: *hcluster.Spec.Platform.AWS.CloudProviderConfig.Subnet.ID,
-					},
-				}
-			}
 		}
 
 		if len(hcluster.Spec.Platform.AWS.ResourceTags) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/openshift/hypershift/pull/948 introduced a hot reconcile loop due to fighting between `reconcileAWSCluster` and `reconcileAWSSubnets`.  Should allow `reconcileAWSSubnets` to set the `Subnets`.

https://github.com/openshift/hypershift/blob/91493d704cd498bb3eaaabd434901cb3c4d4982c/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go#L3765

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.