### PR TITLE
hostedcluster platform: Add kubevirt validation line and remove mockgen comment

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -20,8 +20,8 @@ var _ Platform = aws.AWS{}
 var _ Platform = ibmcloud.IBMCloud{}
 var _ Platform = none.None{}
 var _ Platform = agent.Agent{}
+var _ Platform = kubevirt.Kubevirt{}
 
-//go:generate mockgen -source=./platform.go -destination=./mock/platform_generated.go -package=mock
 type Platform interface {
 	// ReconcileCAPIInfraCR is called during HostedCluster reconciliation prior to reconciling the CAPI Cluster CR.
 	// Implementations should use the given input and client to create and update the desired state of the


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor fixes for code added in PR #779
* Add kubevirt platform object to interface validations lines
* Remove GoMock generate comment left in the code and not used

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.