### PR TITLE
Fix issue of NodePool not created for Agent and None platforms

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -416,6 +416,10 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 			},
 		}
 		nodePools = append(nodePools, nodePool)
+	case hyperv1.NonePlatform, hyperv1.AgentPlatform:
+		nodePools = append(nodePools, defaultNodePool(cluster.Name))
+	default:
+		panic("Unsupported platform")
 	}
 
 	return &ExampleResources{


### PR DESCRIPTION
**What this PR does / why we need it**:

Since PR #944 NodePool is not created for None and Agent platforms
Add Default case to the switch/case to handle those platforms

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.