### PR TITLE
Add Agent platform type under NodePool cmd

### DIFF
--- a/cmd/nodepool/agent/create.go
+++ b/cmd/nodepool/agent/create.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"context"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+	"github.com/spf13/cobra"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type AgentPlatformCreateOptions struct{}
+
+func NewAgentPlatformCreateOptions(cmd *cobra.Command) *AgentPlatformCreateOptions {
+	platformOpts := &AgentPlatformCreateOptions{}
+
+	return platformOpts
+}
+
+func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "agent",
+		Short:        "Creates basic functional NodePool resources for Agent platform",
+		SilenceUsage: true,
+	}
+
+	platformOpts := NewAgentPlatformCreateOptions(cmd)
+
+	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
+
+	return cmd
+}
+
+func (o *AgentPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
+	return nil
+}
+
+func (o *AgentPlatformCreateOptions) Type() hyperv1.PlatformType {
+	return hyperv1.AgentPlatform
+}
+
+func (o *AgentPlatformCreateOptions) Validate() error {
+	return nil
+}

--- a/cmd/nodepool/aws/create.go
+++ b/cmd/nodepool/aws/create.go
@@ -3,8 +3,8 @@ package aws
 import (
 	"context"
 	"fmt"
+
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,13 +42,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	cmd.Flags().Int64Var(&platformOpts.RootVolumeIOPS, "root-volume-iops", platformOpts.RootVolumeIOPS, "The iops of the root volume for machines in the NodePool")
 	cmd.Flags().Int64Var(&platformOpts.RootVolumeSize, "root-volume-size", platformOpts.RootVolumeSize, "The size of the root volume (min: 8) for machines in the NodePool")
 
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := coreOpts.CreateNodePool(cmd.Context(), platformOpts); err != nil {
-			log.Error(err, "Failed to create nodepool")
-			return err
-		}
-		return nil
-	}
+	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
 
 	return cmd
 }

--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -6,8 +6,10 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/cmd/util"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,13 +31,23 @@ type PlatformOptions interface {
 	Type() hyperv1.PlatformType
 }
 
+func (o *CreateNodePoolOptions) CreateRunFunc(platformOpts PlatformOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := o.CreateNodePool(cmd.Context(), platformOpts); err != nil {
+			log.Error(err, "Failed to create nodepool")
+			return err
+		}
+		return nil
+	}
+}
+
 func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts PlatformOptions) error {
 	client := util.GetClientOrDie()
 
 	hcluster := &hyperv1.HostedCluster{}
 	err := client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.ClusterName}, hcluster)
 	if err != nil {
-		return fmt.Errorf("failed to get HostedCluster %s/%s: %w", o.Namespace, o.Name, err)
+		return fmt.Errorf("failed to get HostedCluster %s/%s: %w", o.Namespace, o.ClusterName, err)
 	}
 
 	if platformOpts.Type() != hcluster.Spec.Platform.Type {

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -3,6 +3,7 @@ package nodepool
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hypershift/cmd/nodepool/agent"
 	"github.com/openshift/hypershift/cmd/nodepool/aws"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
 	"github.com/openshift/hypershift/cmd/nodepool/kubevirt"
@@ -11,6 +12,7 @@ import (
 // The following lines are needed in order to validate that any platform implementing PlatformOptions satisfy the interface
 var _ core.PlatformOptions = &aws.AWSPlatformCreateOptions{}
 var _ core.PlatformOptions = &kubevirt.KubevirtPlatformCreateOptions{}
+var _ core.PlatformOptions = &agent.AgentPlatformCreateOptions{}
 
 func NewCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,6 +39,7 @@ func NewCreateCommand() *cobra.Command {
 
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
 	cmd.AddCommand(aws.NewCreateCommand(opts))
+	cmd.AddCommand(agent.NewCreateCommand(opts))
 
 	return cmd
 }

--- a/cmd/nodepool/kubevirt/create.go
+++ b/cmd/nodepool/kubevirt/create.go
@@ -10,7 +10,6 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
 )
 
@@ -42,13 +41,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	// Otherwise it must fail
 	cmd.MarkFlagRequired("containerdisk")
 
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := coreOpts.CreateNodePool(cmd.Context(), platformOpts); err != nil {
-			log.Error(err, "Failed to create nodepool")
-			return err
-		}
-		return nil
-	}
+	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
 
 	return cmd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Since changed the NodePool to be platform aware (PR #832)
In order to create NodePool for specific platform, the platform must implement specific sub command
Therfore add the subcommands Agent platform, although the NodePool platformSpec is empty for those platforms

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.