### PR TITLE
Check that total number of per-object updates in the api doesn't exceed 50

### DIFF
--- a/test/e2e/util/dump/dump.go
+++ b/test/e2e/util/dump/dump.go
@@ -22,6 +22,9 @@ func DumpHostedCluster(ctx context.Context, hc *hyperv1.HostedCluster, artifactD
 		if bytes.Contains(content, []byte(upsert.LoopDetectorWarningMessage)) {
 			allErrors = append(allErrors, fmt.Errorf("found %s messages in file %s", upsert.LoopDetectorWarningMessage, filename))
 		}
+		if bytes.Contains(content, []byte(upsert.LoopDetectorTooManyUpdatesWarningMessage)) {
+			allErrors = append(allErrors, fmt.Errorf("found %s messages in file %s", upsert.LoopDetectorTooManyUpdatesWarningMessage, filename))
+		}
 	}
 	err := core.DumpCluster(ctx, &core.DumpOptions{
 		Namespace:   hc.Namespace,


### PR DESCRIPTION
This extends the loopdetector to verify we don't ever update an object
more than 50 times. This is intended to catch situations where
components stomp each others changes, as we might miss those if there is
a no-op update in between.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.