### PR TITLE
fix replica param quoting in openshift-template generation

### DIFF
--- a/cmd/install/install_render.go
+++ b/cmd/install/install_render.go
@@ -125,7 +125,7 @@ func hyperShiftOperatorTemplateManifest(opts *Options) (crclient.Object, error) 
 
 	// patch those manifests, where the template parameter placeholder was not injectable with opts (e.g. type mistmatch)
 	patches := []ObjectPatch{
-		{Kind: "Deployment", Name: "operator", Path: []string{"spec", "replicas"}, Value: fmt.Sprintf("${%s}", TemplateParamOperatorReplicas)},
+		{Kind: "Deployment", Name: "operator", Path: []string{"spec", "replicas"}, Value: fmt.Sprintf("${{%s}}", TemplateParamOperatorReplicas)},
 	}
 	templateParameters = append(
 		templateParameters,

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -203,7 +203,7 @@ objects:
     name: operator
     namespace: ${NAMESPACE}
   spec:
-    replicas: ${OPERATOR_REPLICAS}
+    replicas: ${{OPERATOR_REPLICAS}}
     selector:
       matchLabels:
         name: operator


### PR DESCRIPTION
**What this PR does / why we need it**
The current template generation code wrongly quotes the int typed field
`.spec.replicas` of the operator deployment. the resulting template can not processesd.

`.spec.replicas` needs to be an int32 so having a quotes placeholder in
the openshift template is invalid. instead an the double curly bracket
syntax needs to be used to indicate that a value should be treated as
unquoted in the resulting manifests.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>