### PR TITLE
add logic to ensure control plane operator and hostedconfigoperator a…

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -28,6 +28,9 @@ const (
 	// ControlPlaneOperatorImageAnnotation is a annotation that allows the specification of the control plane operator image.
 	// This is used for development and e2e workflows
 	ControlPlaneOperatorImageAnnotation = "hypershift.openshift.io/control-plane-operator-image"
+	// DesiredControlPlaneOperatorImageAnnotation is an annotation that is used to specify the desired image of the control-plane-operator
+	// that is expected to reconcile a specific version of an instance of a HostedControlPlane
+	DesiredControlPlaneOperatorImageAnnotation = "hypershift.openshift.io/desired-control-plane-operator-image"
 	// RestartDateAnnotation is a annotation that can be used to trigger a rolling restart of all components managed by hypershift.
 	// it is important in some situations like CA rotation where components need to be fully restarted to pick up new CAs. It's also
 	// important in some recovery situations where a fresh start of the component helps fix symptoms a user might be experiencing.

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -229,6 +229,14 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 				},
 			},
 			{
+				Name: "POD_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
+				},
+			},
+			{
 				Name:  "OPENSHIFT_RELEASE_VERSION",
 				Value: openShiftVersion,
 			},

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
@@ -26,8 +27,11 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
+	"github.com/openshift/hypershift/support/util"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -37,6 +41,10 @@ const (
 	defaultReleaseVersion    = "0.0.1-snapshot"
 	defaultKubernetesVersion = "0.0.1-snapshot-kubernetes"
 	konnectivityAgentImage   = "registry.ci.openshift.org/hypershift/apiserver-network-proxy:latest"
+)
+
+var (
+	setupLog = ctrl.Log.WithName("setup")
 )
 
 func NewCommand() *cobra.Command {
@@ -208,6 +216,19 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 			"konnectivity-agent": konnectivityAgentImage,
 		},
 	}
+	podResource := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace,
+			Name:      os.Getenv("POD_NAME"),
+		},
+	}
+	lookupContext, lookupContextCancel := context.WithTimeout(ctx, 60*time.Second)
+	activeImage, err := util.LookupActiveContainerImage(lookupContext, cpCluster.GetAPIReader(), podResource, "hosted-cluster-config-operator")
+	lookupContextCancel()
+	if err != nil {
+		setupLog.Error(err, "unable to detect active pod image")
+		os.Exit(1)
+	}
 	operatorConfig := &operator.HostedClusterConfigOperatorConfig{
 		TargetCreateOrUpdateProvider: &operator.LabelEnforcingUpsertProvider{
 			Upstream:  upsert.New(o.enableCIDebugOutput),
@@ -231,6 +252,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		KonnectivityPort:    o.KonnectivityPort,
 		OAuthAddress:        o.OAuthAddress,
 		OAuthPort:           o.OAuthPort,
+		ActiveImage:         activeImage,
 	}
 	return operatorConfig.Start(ctx)
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -5,21 +5,6 @@ import (
 	"crypto/md5"
 	"fmt"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
-	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
-
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
@@ -41,7 +26,22 @@ import (
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
+	cpoutil "github.com/openshift/hypershift/support/util"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 const (
@@ -64,6 +64,7 @@ type reconciler struct {
 	oauthAddress              string
 	oauthPort                 int32
 	versions                  map[string]string
+	activeImage               string
 }
 
 // eventHandler is the handler used throughout. As this controller reconciles all kind of different resources
@@ -93,6 +94,7 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 		oauthAddress:              opts.OAuthAddress,
 		oauthPort:                 opts.OAuthPort,
 		versions:                  opts.Versions,
+		activeImage:               opts.ActiveImage,
 	}})
 	if err != nil {
 		return fmt.Errorf("failed to construct controller: %w", err)
@@ -143,6 +145,10 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		return fmt.Errorf("failed to get hosted control plane %s/%s: %w", r.hcpNamespace, r.hcpName, err)
 	}
 
+	if !cpoutil.IsCPOCompatibleWithHCP(hcp.Annotations, r.activeImage) {
+		log.Info("No-oping until recreated with expected image", "activeImage", r.activeImage)
+		return nil
+	}
 	globalConfig, err := globalconfig.ParseGlobalConfig(ctx, hcp.Spec.Configuration)
 	if err != nil {
 		return fmt.Errorf("failed to parse global config for control plane %s/%s: %w", r.hcpNamespace, r.hcpName, err)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -32,6 +32,8 @@ type testClient struct {
 
 var randomSource = rand.New(rand.NewSource(time.Now().UnixNano()))
 
+const activeImage = "myimage:1"
+
 func (c *testClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 	c.createCount++
 	return c.Client.Create(ctx, obj, opts...)
@@ -94,6 +96,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
 			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
+			activeImage:            activeImage,
 		}
 		_, err := r.Reconcile(context.Background(), controllerruntime.Request{})
 		if err != nil {
@@ -117,6 +120,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
 			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
+			activeImage:            activeImage,
 		}
 		r.Reconcile(context.Background(), controllerruntime.Request{})
 		if totalCreates-fakeClient.getErrorCount != fakeClient.createCount {
@@ -133,6 +137,8 @@ func (*simpleCreateOrUpdater) CreateOrUpdate(ctx context.Context, c client.Clien
 
 func fakeHCP() *hyperv1.HostedControlPlane {
 	hcp := manifests.HostedControlPlane("bar", "foo")
+	hcp.Annotations = map[string]string{}
+	hcp.Annotations[hyperv1.ControlPlaneOperatorImageAnnotation] = activeImage
 	hcp.Status.ControlPlaneEndpoint.Host = "server"
 	hcp.Status.ControlPlaneEndpoint.Port = 1234
 	return hcp

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -60,6 +60,7 @@ type HostedClusterConfigOperatorConfig struct {
 	KonnectivityPort             int32
 	OAuthAddress                 string
 	OAuthPort                    int32
+	ActiveImage                  string
 
 	kubeClient kubeclient.Interface
 }

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedapicache"
@@ -154,7 +155,19 @@ func NewStartCommand() *cobra.Command {
 			setupLog.Error(err, "unable to detect cluster capabilities")
 			os.Exit(1)
 		}
-
+		podResource := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      os.Getenv("POD_NAME"),
+			},
+		}
+		lookupContext, lookupContextCancel := context.WithTimeout(ctx, 60*time.Second)
+		activeImage, err := util.LookupActiveContainerImage(lookupContext, mgr.GetAPIReader(), podResource, "control-plane-operator")
+		lookupContextCancel()
+		if err != nil {
+			setupLog.Error(err, "unable to detect active pod image")
+			os.Exit(1)
+		}
 		lookupOperatorImage := func(deployments appsv1client.DeploymentInterface, name, userSpecifiedImage string) (string, error) {
 			if len(userSpecifiedImage) > 0 {
 				setupLog.Info("using image from arguments", "image", userSpecifiedImage)
@@ -238,6 +251,7 @@ func NewStartCommand() *cobra.Command {
 			HostedAPICache:                apiCacheController.GetCache(),
 			CreateOrUpdateProvider:        upsert.New(enableCIDebugOutput),
 			EnableCIDebugOutput:           enableCIDebugOutput,
+			ActiveImage:                   activeImage,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")
 			os.Exit(1)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -615,22 +615,22 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Reconcile the HostedControlPlane pull secret by resolving the source secret
 	// reference from the HostedCluster and syncing the secret in the control plane namespace.
+	var pullSecret corev1.Secret
 	{
-		var src corev1.Secret
-		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.PullSecret.Name}, &src); err != nil {
+		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.GetNamespace(), Name: hcluster.Spec.PullSecret.Name}, &pullSecret); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get pull secret %s: %w", hcluster.Spec.PullSecret.Name, err)
 		}
 		dst := controlplaneoperator.PullSecret(controlPlaneNamespace.Name)
 		_, err = createOrUpdate(ctx, r.Client, dst, func() error {
-			srcData, srcHasData := src.Data[".dockerconfigjson"]
+			srcData, srcHasData := pullSecret.Data[corev1.DockerConfigJsonKey]
 			if !srcHasData {
-				return fmt.Errorf("hostedcluster pull secret %q must have a .dockerconfigjson key", src.Name)
+				return fmt.Errorf("hostedcluster pull secret %q must have a .dockerconfigjson key", pullSecret.Name)
 			}
 			dst.Type = corev1.SecretTypeDockerConfigJson
 			if dst.Data == nil {
 				dst.Data = map[string][]byte{}
 			}
-			dst.Data[".dockerconfigjson"] = srcData
+			dst.Data[corev1.DockerConfigJsonKey] = srcData
 			return nil
 		})
 		if err != nil {
@@ -855,10 +855,15 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	cpoImage, err := getControlPlaneOperatorImage(ctx, hcluster.Annotations, hcluster.Spec.Release.Image, r.ReleaseProvider, r.HypershiftOperatorImage, pullSecret.Data[corev1.DockerConfigJsonKey])
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to lookup expected hypershift component image: %w", err)
+	}
+
 	// Reconcile the HostedControlPlane
 	hcp := controlplaneoperator.HostedControlPlane(controlPlaneNamespace.Name, hcluster.Name)
 	_, err = createOrUpdate(ctx, r.Client, hcp, func() error {
-		return reconcileHostedControlPlane(hcp, hcluster)
+		return reconcileHostedControlPlane(hcp, hcluster, cpoImage)
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile hostedcontrolplane: %w", err)
@@ -989,7 +994,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile the control plane operator
-	err = r.reconcileControlPlaneOperator(ctx, createOrUpdate, hcluster, hcp)
+	err = r.reconcileControlPlaneOperator(ctx, createOrUpdate, hcluster, hcp, cpoImage)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile control plane operator: %w", err)
 	}
@@ -1027,7 +1032,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // reconcileHostedControlPlane reconciles the given HostedControlPlane, which
 // will be mutated.
-func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hyperv1.HostedCluster) error {
+func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hyperv1.HostedCluster, cpoImage string) error {
 	// Always initialize the HostedControlPlane with an image matching
 	// the HostedCluster.
 	if hcp.ObjectMeta.CreationTimestamp.IsZero() {
@@ -1063,6 +1068,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 			hcp.Annotations[key] = val
 		}
 	}
+	hcp.Annotations[hyperv1.DesiredControlPlaneOperatorImageAnnotation] = cpoImage
 
 	hcp.Spec.PullSecret = corev1.LocalObjectReference{Name: controlplaneoperator.PullSecret(hcp.Namespace).Name}
 	if len(hcluster.Spec.SSHKey.Name) > 0 {
@@ -1318,7 +1324,7 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, cre
 
 // reconcileControlPlaneOperator orchestrates reconciliation of the control plane
 // operator components.
-func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane) error {
+func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane, cpoImage string) error {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
@@ -1368,22 +1374,9 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 		return fmt.Errorf("failed to reconcile controlplane operator rolebinding: %w", err)
 	}
 
-	// Reconcile operator deployment
-	var pullSecret corev1.Secret
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: hcluster.Namespace, Name: hcluster.Spec.PullSecret.Name}, &pullSecret); err != nil {
-		return fmt.Errorf("failed to get pull secret: %w", err)
-	}
-	pullSecretBytes, ok := pullSecret.Data[corev1.DockerConfigJsonKey]
-	if !ok {
-		return fmt.Errorf("expected %s key in pull secret", corev1.DockerConfigJsonKey)
-	}
-	controlPlaneOperatorImage, err := getControlPlaneOperatorImage(ctx, hcluster, r.ReleaseProvider, r.HypershiftOperatorImage, pullSecretBytes)
-	if err != nil {
-		return err
-	}
 	controlPlaneOperatorDeployment := controlplaneoperator.OperatorDeployment(controlPlaneNamespace.Name)
 	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
-		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, r.AvailabilityProberImage, r.SocksProxyImage, r.TokenMinterImage, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()))
+		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, cpoImage, r.AvailabilityProberImage, r.SocksProxyImage, r.TokenMinterImage, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()))
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator deployment: %w", err)
@@ -1870,15 +1863,13 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, creat
 // 2. The hypershift image specified in the release payload indicated by the
 //    HostedCluster's release field
 // 3. The hypershift-operator's own image for release versions 4.9 and 4.10
-// 4. The registry.ci.openshift.org/hypershift/hypershift:4.8 image for release
-//    version 4.8
 //
 // If no image can be found according to these rules, an error is returned.
-func getControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster, releaseProvider releaseinfo.Provider, hypershiftOperatorImage string, pullSecret []byte) (string, error) {
-	if val, ok := hc.Annotations[hyperv1.ControlPlaneOperatorImageAnnotation]; ok {
+func getControlPlaneOperatorImage(ctx context.Context, objectAnnotations map[string]string, releaseImage string, releaseProvider releaseinfo.Provider, hypershiftOperatorImage string, pullSecret []byte) (string, error) {
+	if val, ok := objectAnnotations[hyperv1.ControlPlaneOperatorImageAnnotation]; ok {
 		return val, nil
 	}
-	releaseInfo, err := releaseProvider.Lookup(ctx, hc.Spec.Release.Image, pullSecret)
+	releaseInfo, err := releaseProvider.Lookup(ctx, releaseImage, pullSecret)
 	if err != nil {
 		return "", err
 	}
@@ -1892,12 +1883,9 @@ func getControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 	}
 
 	versionMajMin := fmt.Sprintf("%d.%d", version.Major, version.Minor)
-	pullSpec := "registry.ci.openshift.org/hypershift/hypershift"
 	switch versionMajMin {
 	case "4.9", "4.10":
 		return hypershiftOperatorImage, nil
-	case "4.8":
-		return fmt.Sprintf("%s:%s", pullSpec, versionMajMin), nil
 	default:
 		return "", fmt.Errorf("unsupported release image with version %s", versionMajMin)
 	}
@@ -1931,6 +1919,14 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 								ValueFrom: &corev1.EnvVarSource{
 									FieldRef: &corev1.ObjectFieldSelector{
 										FieldPath: "metadata.namespace",
+									},
+								},
+							},
+							{
+								Name: "POD_NAME",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.name",
 									},
 								},
 							},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -3,6 +3,7 @@ package hostedcluster
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/hypershift/support/releaseinfo"
 	"testing"
 	"time"
 
@@ -41,6 +42,8 @@ import (
 var Now = metav1.NewTime(time.Now())
 var Later = metav1.NewTime(Now.Add(5 * time.Minute))
 
+const activeImage = "myimage:latest"
+
 func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 	// TODO: the spec/status comparison of control plane is a weak check; the
 	// conditions should give us more information about e.g. whether that
@@ -67,6 +70,10 @@ func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 				},
 			},
 			ControlPlane: hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						hyperv1.ControlPlaneOperatorImageAnnotation: activeImage,
+					}},
 				Spec:   hyperv1.HostedControlPlaneSpec{},
 				Status: hyperv1.HostedControlPlaneStatus{},
 			},
@@ -89,9 +96,12 @@ func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 				},
 			},
 			ControlPlane: hyperv1.HostedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: Now},
-				Spec:       hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
-				Status:     hyperv1.HostedControlPlaneStatus{ReleaseImage: "a"},
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: Now,
+					Annotations: map[string]string{
+						hyperv1.ControlPlaneOperatorImageAnnotation: activeImage,
+					}},
+				Spec:   hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
+				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a"},
 			},
 			ExpectedImage: "b",
 		},
@@ -113,9 +123,11 @@ func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 				},
 			},
 			ControlPlane: hyperv1.HostedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: Now},
-				Spec:       hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
-				Status:     hyperv1.HostedControlPlaneStatus{ReleaseImage: "a"},
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: Now, Annotations: map[string]string{
+					hyperv1.ControlPlaneOperatorImageAnnotation: activeImage,
+				}},
+				Spec:   hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
+				Status: hyperv1.HostedControlPlaneStatus{ReleaseImage: "a"},
 			},
 			ExpectedImage: "b",
 		},
@@ -124,7 +136,7 @@ func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			updated := test.ControlPlane.DeepCopy()
-			err := reconcileHostedControlPlane(updated, &test.Cluster)
+			err := reconcileHostedControlPlane(updated, &test.Cluster, activeImage)
 			if err != nil {
 				t.Error(err)
 			}
@@ -467,7 +479,7 @@ func TestReconcileHostedControlPlaneAPINetwork(t *testing.T) {
 			hostedCluster := &hyperv1.HostedCluster{}
 			hostedCluster.Spec.Networking.APIServer = test.networking
 			hostedControlPlane := &hyperv1.HostedControlPlane{}
-			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster)
+			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster, activeImage)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1245,4 +1257,48 @@ func TestReconcileAWSSubnets(t *testing.T) {
 	err = client.Get(context.Background(), crclient.ObjectKeyFromObject(freshAWSEndpointService), freshAWSEndpointService)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(freshAWSEndpointService.Spec.SubnetIDs).To(BeEquivalentTo([]string{"1", "2"}))
+}
+
+func TestGetControlPlaneOperatorImage(t *testing.T) {
+	fakeReleaseImage := "myimage:1"
+	fakePullSecret := []byte(`pullsecret`)
+	fakeReleaseProvider := &fakereleaseprovider.FakeReleaseProvider{}
+	testsCases := []struct {
+		name                         string
+		inputAnnotations             map[string]string
+		inputReleaseImage            string
+		inputReleaseProvider         releaseinfo.Provider
+		inputHypershiftOperatorImage string
+		inputPullSecret              []byte
+		expectedImage                string
+	}{
+		{
+			name:                         "hypershift image is used if no annotation specified",
+			inputAnnotations:             nil,
+			inputReleaseImage:            fakeReleaseImage,
+			inputReleaseProvider:         fakeReleaseProvider,
+			inputHypershiftOperatorImage: "image1",
+			inputPullSecret:              fakePullSecret,
+			expectedImage:                "image1",
+		},
+		{
+			name: "Image override annotation is used when specified",
+			inputAnnotations: map[string]string{
+				hyperv1.ControlPlaneOperatorImageAnnotation: "image2",
+			},
+			inputReleaseImage:            fakeReleaseImage,
+			inputReleaseProvider:         fakeReleaseProvider,
+			inputHypershiftOperatorImage: "image1",
+			inputPullSecret:              fakePullSecret,
+			expectedImage:                "image2",
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			componentImage, err := getControlPlaneOperatorImage(context.Background(), tc.inputAnnotations, tc.inputReleaseImage, tc.inputReleaseProvider, tc.inputHypershiftOperatorImage, tc.inputPullSecret)
+			g.Expect(err).To(BeNil())
+			g.Expect(componentImage).To(BeEquivalentTo(tc.expectedImage))
+		})
+	}
 }

--- a/support/util/cpocheck.go
+++ b/support/util/cpocheck.go
@@ -1,0 +1,9 @@
+package util
+
+import hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+
+// IsCPOCompatibleWithHCP checks to see if the active image in a control-plane-operator component matches the
+// expected image listed in the HCP object
+func IsCPOCompatibleWithHCP(hcpAnnotations map[string]string, activeImage string) bool {
+	return hcpAnnotations[hyperv1.DesiredControlPlaneOperatorImageAnnotation] == activeImage
+}

--- a/support/util/cpocheck_test.go
+++ b/support/util/cpocheck_test.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"testing"
+)
+
+func TestIsCPOCompatibleWithHCP(t *testing.T) {
+	testImage := "myimage:1"
+	tests := map[string]struct {
+		inputAnnotations map[string]string
+		inputActualImage string
+		expectedResult   bool
+	}{
+		"when no annotations exist an incompatible result (false) is returned": {
+			inputAnnotations: nil,
+			inputActualImage: testImage,
+			expectedResult:   false,
+		},
+		"when the cpo annotation does not match the actual image an incompatible result (false) is returned": {
+			inputAnnotations: map[string]string{},
+			inputActualImage: testImage,
+			expectedResult:   false,
+		},
+		"when the cpo annotation matches the actual image a compatible result (true) is returned": {
+			inputAnnotations: map[string]string{
+				hyperv1.DesiredControlPlaneOperatorImageAnnotation: testImage,
+			},
+			inputActualImage: testImage,
+			expectedResult:   true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			isComptabile := IsCPOCompatibleWithHCP(test.inputAnnotations, test.inputActualImage)
+			g.Expect(isComptabile).To(Equal(test.expectedResult))
+		})
+	}
+}

--- a/support/util/imagefetch.go
+++ b/support/util/imagefetch.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// LookupActiveContainerImage returns the image for a specified container in a specified pod
+func LookupActiveContainerImage(ctx context.Context, clientReader client.Reader, pod *corev1.Pod, containerName string) (string, error) {
+	err := clientReader.Get(ctx, client.ObjectKeyFromObject(pod), pod)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod: %w", err)
+	}
+	for _, container := range pod.Spec.Containers {
+		// can't use downward API to pass an image id so need to look it up
+		if container.Name == containerName {
+			return container.Image, nil
+		}
+	}
+	return "", fmt.Errorf("couldn't locate image id in pod")
+}

--- a/support/util/imagefetch_test.go
+++ b/support/util/imagefetch_test.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"context"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestLookupActiveContainerImage(t *testing.T) {
+	fakePodName := "mypod"
+	fakeNamespace := "mynamespace"
+	containerToFindName := "container-to-find"
+	containerToFindImage := "container-to-find-image"
+	fakeInputObjects := []runtime.Object{
+		&corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      fakePodName,
+				Namespace: fakeNamespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "random-container",
+						Image: "random-image",
+					},
+					{
+						Name:  containerToFindName,
+						Image: containerToFindImage,
+					},
+				},
+			},
+		},
+	}
+	testsCases := []struct {
+		name               string
+		inputResources     []runtime.Object
+		inputPod           *corev1.Pod
+		inputContainerName string
+		expectedImage      string
+		expectedError      bool
+	}{
+		{
+			name:           "valid pod and container returns the associated image",
+			inputResources: fakeInputObjects,
+			inputPod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      fakePodName,
+					Namespace: fakeNamespace,
+				},
+			},
+			inputContainerName: containerToFindName,
+			expectedImage:      containerToFindImage,
+			expectedError:      false,
+		},
+		{
+			name:           "invalid pod returns an error",
+			inputResources: fakeInputObjects,
+			inputPod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "random-name",
+					Namespace: fakeNamespace,
+				},
+			},
+			inputContainerName: containerToFindName,
+			expectedImage:      "",
+			expectedError:      true,
+		},
+		{
+			name:           "invalid container name returns an error",
+			inputResources: fakeInputObjects,
+			inputPod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      fakePodName,
+					Namespace: fakeNamespace,
+				},
+			},
+			inputContainerName: "invalid-name",
+			expectedImage:      "",
+			expectedError:      true,
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			client := fake.NewClientBuilder().WithRuntimeObjects(tc.inputResources...).Build()
+			activeImage, err := LookupActiveContainerImage(context.Background(), client, tc.inputPod, tc.inputContainerName)
+			if tc.expectedError {
+				g.Expect(err).ToNot(gomega.BeNil())
+			} else {
+				g.Expect(err).To(gomega.BeNil())
+				g.Expect(activeImage).To(gomega.BeEquivalentTo(tc.expectedImage))
+			}
+		})
+	}
+}


### PR DESCRIPTION
…re at expected version before reconciling a release update

This solves race conditions when upgrading a cluster (mostly across minor versions) that can result in the operator having orphaned resources. The operators will now nop when they aren't at the expected image version for a given release payload. Ultimately, they will be recreated, detect that they match the expected version, and then begin the reconciliation process. Solves: https://github.com/openshift/hypershift/issues/945


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://github.com/openshift/hypershift/issues/945

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.