### PR TITLE
e2e: add AWS multizone support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ PROMTOOL=GO111MODULE=on GOFLAGS=-mod=vendor go run github.com/prometheus/prometh
 GO_GCFLAGS ?= -gcflags=all='-N -l'
 GO=GO111MODULE=on GOFLAGS=-mod=vendor go
 GO_BUILD_RECIPE=CGO_ENABLED=0 $(GO) build $(GO_GCFLAGS)
+GO_E2E_RECIPE=CGO_ENABLED=0 $(GO) test $(GO_GCFLAGS) -tags e2e -c
 
 OUT_DIR ?= bin
 
@@ -146,7 +147,7 @@ test: build
 
 .PHONY: e2e
 e2e:
-	$(GO) test -tags e2e -c -o bin/test-e2e ./test/e2e
+	$(GO_E2E_RECIPE) -o bin/test-e2e ./test/e2e
 	$(GO_BUILD_RECIPE) -o bin/test-setup ./test/setup
 
 # Run go fmt against code

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,25 +29,18 @@ func TestUpgradeControlPlane(t *testing.T) {
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
 
-	// Get the newly created nodepool
-	nodepool := &hyperv1.NodePool{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: hostedCluster.Namespace,
-			Name:      e2eutil.NodePoolName(hostedCluster.Name, clusterOpts.AWSPlatform.Zones[0]),
-		},
-	}
-	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
-
 	// Sanity check the cluster by waiting for the nodes to report ready
 	t.Logf("Waiting for guest client to become available")
 	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, *nodepool.Spec.NodeCount)
+
+	// Wait for Nodes to be Ready
+	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
 
 	// Wait for the first rollout to be complete
 	t.Logf("Waiting for initial cluster rollout. Image: %s", globalOpts.PreviousReleaseImage)
 	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.PreviousReleaseImage)
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	err := client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
 	// Update the cluster image
@@ -65,6 +57,6 @@ func TestUpgradeControlPlane(t *testing.T) {
 	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
-	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, crclient.ObjectKeyFromObject(nodepool))
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add e2e support for multizone guest clusters via a new `--e2e.aws-zones` flag

Depends on https://github.com/openshift/hypershift/pull/951

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.