### PR TITLE
only add oidc mounts and arguments when they are specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,8 @@ app-sre-saas-template: hypershift
 	bin/hypershift install \
 		--oidc-storage-provider-s3-bucket-name=bucket \
 		--oidc-storage-provider-s3-secret=oidc-s3-creds \
+		--oidc-storage-provider-s3-region=us-east-1 \
+		--oidc-storage-provider-s3-secret-key=credentials \
 		--enable-ocp-cluster-monitoring=false \
 		--enable-ci-debug-output=false \
 		render --template --format yaml > $(DIR)/hack/app-sre/saas_template.yaml

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -140,29 +140,30 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 			},
 		},
 	}
-
-	args = append(args,
-		"--oidc-storage-provider-s3-bucket-name="+o.OIDCBucketName,
-		"--oidc-storage-provider-s3-region="+o.OIDCBucketRegion,
-		"--oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/"+o.OIDCStorageProviderS3SecretKey,
-	)
-	oidcVolumeMount = []corev1.VolumeMount{
-		{
-			Name:      "oidc-storage-provider-s3-creds",
-			MountPath: "/etc/oidc-storage-provider-s3-creds",
-		},
-	}
-	oidcVolumeCred = []corev1.Volume{
-		{
-			Name: "oidc-storage-provider-s3-creds",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: o.OIDCStorageProviderS3Secret.Name,
+	if len(o.OIDCBucketName) > 0 && len(o.OIDCBucketRegion) > 0 && len(o.OIDCStorageProviderS3SecretKey) > 0 &&
+		o.OIDCStorageProviderS3Secret != nil && len(o.OIDCStorageProviderS3Secret.Name) > 0 {
+		args = append(args,
+			"--oidc-storage-provider-s3-bucket-name="+o.OIDCBucketName,
+			"--oidc-storage-provider-s3-region="+o.OIDCBucketRegion,
+			"--oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/"+o.OIDCStorageProviderS3SecretKey,
+		)
+		oidcVolumeMount = []corev1.VolumeMount{
+			{
+				Name:      "oidc-storage-provider-s3-creds",
+				MountPath: "/etc/oidc-storage-provider-s3-creds",
+			},
+		}
+		oidcVolumeCred = []corev1.Volume{
+			{
+				Name: "oidc-storage-provider-s3-creds",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: o.OIDCStorageProviderS3Secret.Name,
+					},
 				},
 			},
-		},
+		}
 	}
-
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -1,0 +1,143 @@
+package assets
+
+import (
+	"fmt"
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
+	testNamespace := "hypershift"
+	testOperatorImage := "myimage"
+	tests := map[string]struct {
+		inputBuildParameters HyperShiftOperatorDeployment
+		expectedVolumeMounts []corev1.VolumeMount
+		expectedVolumes      []corev1.Volume
+		expectedArgs         []string
+	}{
+		"empty oidc paramaters result in no volume mounts": {
+			inputBuildParameters: HyperShiftOperatorDeployment{
+				Namespace: &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNamespace,
+					},
+				},
+				OperatorImage: testOperatorImage,
+				ServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hypershift",
+					},
+				},
+				Replicas:        3,
+				PrivatePlatform: string(hyperv1.NonePlatform),
+			},
+			expectedVolumeMounts: nil,
+			expectedVolumes:      nil,
+			expectedArgs: []string{
+				"run",
+				"--namespace=$(MY_NAMESPACE)",
+				"--deployment-name=operator",
+				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
+				fmt.Sprintf("--enable-ci-debug-output=%t", false),
+				fmt.Sprintf("--private-platform=%s", string(hyperv1.NonePlatform)),
+			},
+		},
+		"specify oidc parameters result in appropriate volumes and volumeMounts": {
+			inputBuildParameters: HyperShiftOperatorDeployment{
+				Namespace: &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNamespace,
+					},
+				},
+				OperatorImage: testOperatorImage,
+				ServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hypershift",
+					},
+				},
+				Replicas:         3,
+				PrivatePlatform:  string(hyperv1.AWSPlatform),
+				OIDCBucketRegion: "us-east-1",
+				OIDCStorageProviderS3Secret: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "oidc-s3-secret",
+					},
+				},
+				OIDCBucketName:                 "oidc-bucket",
+				OIDCStorageProviderS3SecretKey: "mykey",
+			},
+			expectedArgs: []string{
+				"run",
+				"--namespace=$(MY_NAMESPACE)",
+				"--deployment-name=operator",
+				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
+				fmt.Sprintf("--enable-ci-debug-output=%t", false),
+				fmt.Sprintf("--private-platform=%s", string(hyperv1.AWSPlatform)),
+				"--oidc-storage-provider-s3-bucket-name=" + "oidc-bucket",
+				"--oidc-storage-provider-s3-region=" + "us-east-1",
+				"--oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/" + "mykey",
+			},
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "oidc-storage-provider-s3-creds",
+					MountPath: "/etc/oidc-storage-provider-s3-creds",
+				},
+				{
+					Name:      "credentials",
+					MountPath: "/etc/provider",
+				},
+				{
+					Name:      "token",
+					MountPath: "/var/run/secrets/openshift/serviceaccount",
+				},
+			},
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "oidc-storage-provider-s3-creds",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "oidc-s3-secret",
+						},
+					},
+				},
+				{
+					Name: "credentials",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: awsCredsSecretName,
+						},
+					},
+				},
+				{
+					Name: "token",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+										Audience: "openshift",
+										Path:     "token",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			deployment := test.inputBuildParameters.Build()
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(BeEquivalentTo(test.expectedArgs))
+			g.Expect(deployment.Spec.Template.Spec.Volumes).To(BeEquivalentTo(test.expectedVolumes))
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(BeEquivalentTo(test.expectedVolumeMounts))
+		})
+	}
+}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -73,6 +73,10 @@ func (o *Options) Validate() error {
 	if len(o.OIDCStorageProviderS3CredentialsSecret) > 0 && len(o.OIDCStorageProviderS3Credentials) > 0 {
 		errs = append(errs, fmt.Errorf("only one of --oidc-storage-provider-s3-secret or --oidc-storage-provider-s3-credentials is supported"))
 	}
+	if (len(o.OIDCStorageProviderS3CredentialsSecret) > 0 || len(o.OIDCStorageProviderS3Credentials) > 0) &&
+		(len(o.OIDCStorageProviderS3BucketName) == 0 || len(o.OIDCStorageProviderS3Region) == 0 || len(o.OIDCStorageProviderS3CredentialsSecretKey) == 0) {
+		errs = append(errs, fmt.Errorf("all required oidc information is not set"))
+	}
 	return errors.NewAggregate(errs)
 }
 

--- a/cmd/install/install_render_test.go
+++ b/cmd/install/install_render_test.go
@@ -48,7 +48,7 @@ func VerifyTemplateParameterPresent(template map[string]interface{}, paramName s
 }
 
 func TestMultiDocYamlRendering(t *testing.T) {
-	out, err := ExecuteTestCommand([]string{"--oidc-storage-provider-s3-bucket-name", "bucket", "--oidc-storage-provider-s3-secret", "secret", "render", "--format", "yaml"})
+	out, err := ExecuteTestCommand([]string{"--oidc-storage-provider-s3-bucket-name", "bucket", "--oidc-storage-provider-s3-secret", "secret", "--oidc-storage-provider-s3-region", "us-east-1", "--oidc-storage-provider-s3-bucket-name", "mybucket", "render", "--format", "yaml"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestMultiDocYamlRendering(t *testing.T) {
 }
 
 func TestTemplateYamlRendering(t *testing.T) {
-	template, err := ExecuteTemplateYamlGenerationCommand([]string{"--oidc-storage-provider-s3-bucket-name", "bucket", "--oidc-storage-provider-s3-secret", "secret", "render", "--format", "yaml", "--template"})
+	template, err := ExecuteTemplateYamlGenerationCommand([]string{"--oidc-storage-provider-s3-bucket-name", "bucket", "--oidc-storage-provider-s3-region", "us-east-1", "--oidc-storage-provider-s3-secret", "secret", "render", "--format", "yaml", "--template"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func ExecuteJsonGenerationCommand(args []string) (map[string]interface{}, error)
 }
 
 func TestJsonListRendering(t *testing.T) {
-	doc, err := ExecuteJsonGenerationCommand([]string{"--oidc-storage-provider-s3-bucket-name", "bucket", "--oidc-storage-provider-s3-secret", "secret", "render", "--format", "json"})
+	doc, err := ExecuteJsonGenerationCommand([]string{"--oidc-storage-provider-s3-bucket-name", "bucket", "--oidc-storage-provider-s3-region", "us-east-1", "--oidc-storage-provider-s3-secret", "secret", "render", "--format", "json"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestJsonListRendering(t *testing.T) {
 }
 
 func TestJsonTemplateRendering(t *testing.T) {
-	doc, err := ExecuteJsonGenerationCommand([]string{"--oidc-storage-provider-s3-bucket-name", "bucket", "--oidc-storage-provider-s3-secret", "secret", "render", "--format", "json", "--template"})
+	doc, err := ExecuteJsonGenerationCommand([]string{"--oidc-storage-provider-s3-bucket-name", "bucket", "--oidc-storage-provider-s3-region", "us-east-1", "--oidc-storage-provider-s3-secret", "secret", "render", "--format", "json", "--template"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -1,0 +1,58 @@
+package install
+
+import (
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"testing"
+)
+
+func TestOptions_Validate(t *testing.T) {
+	tests := map[string]struct {
+		inputOptions Options
+		expectError  bool
+	}{
+		"when aws private platform without private creds and region it errors": {
+			inputOptions: Options{
+				PrivatePlatform: string(hyperv1.AWSPlatform),
+			},
+			expectError: true,
+		},
+		"when empty private platform is specified it errors": {
+			inputOptions: Options{},
+			expectError:  true,
+		},
+		"when partially specified oauth creds used (OIDCStorageProviderS3Credentials) it errors": {
+			inputOptions: Options{
+				OIDCStorageProviderS3Credentials: "mycreds",
+			},
+			expectError: true,
+		},
+		"when partially specified oauth creds used (OIDCStorageProviderS3CredentialsSecret) it errors": {
+			inputOptions: Options{
+				OIDCStorageProviderS3CredentialsSecret: "mysecret",
+			},
+			expectError: true,
+		},
+		"when all data specified there is no error": {
+			inputOptions: Options{
+				PrivatePlatform:                           string(hyperv1.NonePlatform),
+				OIDCStorageProviderS3CredentialsSecret:    "mysecret",
+				OIDCStorageProviderS3Region:               "us-east-1",
+				OIDCStorageProviderS3CredentialsSecretKey: "mykey",
+				OIDCStorageProviderS3BucketName:           "mybucket",
+			},
+			expectError: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			err := test.inputOptions.Validate()
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -103,8 +103,8 @@ func NewStartCommand() *cobra.Command {
 		IgnitionServerImage:              "",
 		RegistryOverrides:                map[string]string{},
 		PrivatePlatform:                  string(hyperv1.NonePlatform),
-		OIDCStorageProviderS3Region:      "us-east-1",
-		OIDCStorageProviderS3Credentials: "/etc/oidc-storage-provider-s3-creds/credentials",
+		OIDCStorageProviderS3Region:      "",
+		OIDCStorageProviderS3Credentials: "",
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace this operator lives in")


### PR DESCRIPTION
A previous pr regressed the standard behavior where oidc mounts/config were not added to the hypershift operator unless specified. PR is: https://github.com/openshift/hypershift/pull/949. This PR returns to the old behavior and adds unit tests to ensure this path is not broken in the future


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # Regression in None AWS install path

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.