### PR TITLE
remove invalid error return when KubeadminPasswordSecret not found.

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -661,6 +661,10 @@ func (r *reconciler) reconcileOpenshiftOAuthAPIServerEndpoints(ctx context.Conte
 func (r *reconciler) reconcileKubeadminPasswordHashSecret(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	kubeadminPasswordSecret := manifests.KubeadminPasswordSecret(hcp.Namespace)
 	if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			// kubeAdminPasswordHash will not exist when a user specifies an explicit oauth config
+			return nil
+		}
 		return fmt.Errorf("failed to get kubeadmin password secret: %w", err)
 	}
 	kubeadminPasswordHashSecret := manifests.KubeadminPasswordHashSecret()


### PR DESCRIPTION
An invalid error is getting returned in the hosted-cluster-config-operator when the kubeadminPasswordSecret is not found. This secret will not exist in clusters with explicit oauth configurations specified and should not return an error when not found.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # Fixes invalid error being thown during reconcilation

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.