### PR TITLE
Add support for AdditionalTrustBundle

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -97,6 +97,10 @@ type HostedControlPlaneSpec struct {
 	// +optional
 	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
 
+	// AdditionalTrustBundle references a ConfigMap containing a PEM-encoded X.509 certificate bundle
+	// +optional
+	AdditionalTrustBundle *corev1.LocalObjectReference `json:"additionalTrustBundle,omitempty"`
+
 	// SecretEncryption contains metadata about the kubernetes secret encryption strategy being used for the
 	// cluster when applicable.
 	// +optional

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -226,6 +226,12 @@ type HostedClusterSpec struct {
 	// +immutable
 	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
 
+	// AdditionalTrustBundle is a reference to a ConfigMap containing a
+	// PEM-encoded X.509 certificate bundle that will be added to the hosted controlplane and nodes
+	//
+	// +optional
+	AdditionalTrustBundle *corev1.LocalObjectReference `json:"additionalTrustBundle,omitempty"`
+
 	// SecretEncryption specifies a Kubernetes secret encryption strategy for the
 	// control plane.
 	//

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -763,6 +763,11 @@ func (in *HostedClusterSpec) DeepCopyInto(out *HostedClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AdditionalTrustBundle != nil {
+		in, out := &in.AdditionalTrustBundle, &out.AdditionalTrustBundle
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	if in.SecretEncryption != nil {
 		in, out := &in.SecretEncryption, &out.SecretEncryption
 		*out = new(SecretEncryptionSpec)
@@ -927,6 +932,11 @@ func (in *HostedControlPlaneSpec) DeepCopyInto(out *HostedControlPlaneSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.AdditionalTrustBundle != nil {
+		in, out := &in.AdditionalTrustBundle, &out.AdditionalTrustBundle
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
 	}
 	if in.SecretEncryption != nil {
 		in, out := &in.SecretEncryption, &out.SecretEncryption

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -30,6 +30,7 @@ func NewCreateCommands() *cobra.Command {
 		Wait:                           false,
 		Timeout:                        0,
 		ExternalDNSDomain:              "",
+		AdditionalTrustBundle:          "",
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -48,6 +49,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", opts.Render, "Render output as YAML to stdout instead of applying")
 	cmd.PersistentFlags().StringVar(&opts.ControlPlaneOperatorImage, "control-plane-operator-image", opts.ControlPlaneOperatorImage, "Override the default image used to deploy the control plane operator")
 	cmd.PersistentFlags().StringVar(&opts.SSHKeyFile, "ssh-key", opts.SSHKeyFile, "Path to an SSH key file")
+	cmd.PersistentFlags().StringVar(&opts.AdditionalTrustBundle, "additional-trust-bundle", opts.AdditionalTrustBundle, "Path to a file with user CA bundle")
 	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If >-1, create a default NodePool with this many replicas")
 	cmd.PersistentFlags().StringArrayVar(&opts.Annotations, "annotations", opts.Annotations, "Annotations to apply to the hostedcluster (key=value). Can be specified multiple times.")
 	cmd.PersistentFlags().BoolVar(&opts.FIPS, "fips", opts.FIPS, "Enables FIPS mode for nodes in the cluster")

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -33,6 +33,7 @@ import (
 type ApplyPlatformSpecifics = func(ctx context.Context, fixture *apifixtures.ExampleOptions, options *CreateOptions) error
 
 type CreateOptions struct {
+	AdditionalTrustBundle            string
 	Annotations                      []string
 	AutoRepair                       bool
 	ControlPlaneAvailabilityPolicy   string
@@ -150,7 +151,16 @@ func createCommonFixture(opts *CreateOptions) (*apifixtures.ExampleOptions, erro
 		}
 	}
 
+	var userCABundle []byte
+	if len(opts.AdditionalTrustBundle) > 0 {
+		userCABundle, err = ioutil.ReadFile(opts.AdditionalTrustBundle)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read additional trust bundle file: %w", err)
+		}
+	}
+
 	return &apifixtures.ExampleOptions{
+		AdditionalTrustBundle:            string(userCABundle),
 		InfraID:                          opts.InfraID,
 		Annotations:                      annotations,
 		AutoRepair:                       opts.AutoRepair,

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -68,6 +68,16 @@ spec:
           spec:
             description: Spec is the desired behavior of the HostedCluster.
             properties:
+              additionalTrustBundle:
+                description: AdditionalTrustBundle is a reference to a ConfigMap containing
+                  a PEM-encoded X.509 certificate bundle that will be added to the
+                  hosted controlplane and nodes
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
               auditWebhook:
                 description: "AuditWebhook contains metadata for configuring an audit
                   webhook endpoint for a cluster to process cluster audit events.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -41,6 +41,15 @@ spec:
           spec:
             description: HostedControlPlaneSpec defines the desired state of HostedControlPlane
             properties:
+              additionalTrustBundle:
+                description: AdditionalTrustBundle references a ConfigMap containing
+                  a PEM-encoded X.509 certificate bundle
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
               apiAdvertiseAddress:
                 description: APIAdvertiseAddress is the address at which the APIServer
                   listens inside a worker.

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/support/images"
+	"github.com/openshift/hypershift/support/util"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -245,6 +246,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 }
 
 type HyperShiftOperatorDeployment struct {
+	AdditionalTrustBundle          *corev1.ConfigMap
 	Namespace                      *corev1.Namespace
 	OperatorImage                  string
 	Images                         map[string]string
@@ -307,6 +309,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 			},
 		}
 	}
+
 	image := o.OperatorImage
 
 	if mapImage, ok := o.Images["hypershift-operator"]; ok {
@@ -408,6 +411,11 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 				},
 			},
 		},
+	}
+
+	if o.AdditionalTrustBundle != nil {
+		// Add trusted-ca mount with optional configmap
+		util.DeploymentAddTrustBundleVolume(&corev1.LocalObjectReference{Name: o.AdditionalTrustBundle.Name}, deployment)
 	}
 
 	privatePlatformType := hyperv1.PlatformType(o.PrivatePlatform)

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -42,6 +42,7 @@ import (
 )
 
 type Options struct {
+	AdditionalTrustBundle                     string
 	Namespace                                 string
 	HyperShiftImage                           string
 	ImageRefsFile                             string
@@ -151,6 +152,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSDomainFilter, "external-dns-domain-filter", "", "Restrict external-dns to changes within the specifed domain.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableAdminRBACGeneration, "enable-admin-rbac-generation", false, "Generate RBAC manifests for hosted cluster admins")
 	cmd.PersistentFlags().StringVar(&opts.ImageRefsFile, "image-refs", opts.ImageRefsFile, "Image references to user in Hypershift installation")
+	cmd.PersistentFlags().StringVar(&opts.AdditionalTrustBundle, "additional-trust-bundle", opts.AdditionalTrustBundle, "Path to a file with user CA bundle")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		opts.ApplyDefaults()
@@ -299,6 +301,24 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 		}
 	}
 
+	var userCABundleCM *corev1.ConfigMap
+	if opts.AdditionalTrustBundle != "" {
+		userCABundle, err := ioutil.ReadFile(opts.AdditionalTrustBundle)
+		if err != nil {
+			return nil, err
+		}
+		userCABundleCM = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "user-ca-bundle",
+				Namespace: operatorNamespace.Name,
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": string(userCABundle),
+			},
+		}
+		objects = append(objects, userCABundleCM)
+	}
+
 	if len(opts.ExternalDNSProvider) > 0 {
 		externalDNSServiceAccount := assets.ExternalDNSServiceAccount{
 			Namespace: operatorNamespace,
@@ -348,6 +368,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	}
 
 	operatorDeployment := assets.HyperShiftOperatorDeployment{
+		AdditionalTrustBundle:          userCABundleCM,
 		Namespace:                      operatorNamespace,
 		OperatorImage:                  opts.HyperShiftImage,
 		ServiceAccount:                 operatorServiceAccount,

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -147,7 +147,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, config *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, config *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, additionalTrustBundle *corev1.LocalObjectReference) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
@@ -173,6 +173,10 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 			},
 		},
 	}
+	if additionalTrustBundle != nil {
+		util.DeploymentAddTrustBundleVolume(additionalTrustBundle, deployment)
+	}
+
 	config.ApplyTo(deployment)
 	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiInternalPort), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "kubeconfig"

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2278,7 +2278,7 @@ func (r *HostedControlPlaneReconciler) reconcileHostedClusterConfigOperator(ctx 
 
 	deployment := manifests.ConfigOperatorDeployment(hcp.Namespace)
 	if _, err = r.CreateOrUpdate(ctx, r.Client, deployment, func() error {
-		return configoperator.ReconcileDeployment(deployment, p.Image, hcp.Name, p.OpenShiftVersion, p.KubernetesVersion, p.OwnerRef, &p.DeploymentConfig, p.AvailabilityProberImage, r.EnableCIDebugOutput, hcp.Spec.Platform.Type, hcp.Spec.APIPort, infraStatus.KonnectivityHost, infraStatus.KonnectivityPort, infraStatus.OAuthHost, infraStatus.OAuthPort, hcp.Spec.ReleaseImage)
+		return configoperator.ReconcileDeployment(deployment, p.Image, hcp.Name, p.OpenShiftVersion, p.KubernetesVersion, p.OwnerRef, &p.DeploymentConfig, p.AvailabilityProberImage, r.EnableCIDebugOutput, hcp.Spec.Platform.Type, hcp.Spec.APIPort, infraStatus.KonnectivityHost, infraStatus.KonnectivityPort, infraStatus.OAuthHost, infraStatus.OAuthPort, hcp.Spec.ReleaseImage, hcp.Spec.AdditionalTrustBundle)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile config operator deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -41,6 +41,15 @@ func MetricsClientCertSecret(ns string) *corev1.Secret {
 	}
 }
 
+func UserCAConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-ca-bundle",
+			Namespace: ns,
+		},
+	}
+}
+
 func EtcdClientSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
@@ -13,6 +13,7 @@ type MCSParams struct {
 	OwnerRef       config.OwnerRef
 	RootCA         *corev1.Secret
 	CombinedCA     *corev1.ConfigMap
+	UserCA         *corev1.ConfigMap
 	PullSecret     *corev1.Secret
 	DNS            *configv1.DNS
 	Infrastructure *configv1.Infrastructure
@@ -21,7 +22,7 @@ type MCSParams struct {
 	InstallConfig  *globalconfig.InstallConfig
 }
 
-func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Secret, combinedCA *corev1.ConfigMap, globalConfig globalconfig.GlobalConfig) *MCSParams {
+func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Secret, combinedCA, userCA *corev1.ConfigMap, globalConfig globalconfig.GlobalConfig) *MCSParams {
 	dns := globalconfig.DNSConfig()
 	globalconfig.ReconcileDNSConfig(dns, hcp)
 
@@ -38,6 +39,7 @@ func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Se
 		OwnerRef:       config.OwnerRefFrom(hcp),
 		RootCA:         rootCA,
 		CombinedCA:     combinedCA,
+		UserCA:         userCA,
 		PullSecret:     pullSecret,
 		DNS:            dns,
 		Infrastructure: infra,

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
@@ -44,6 +44,14 @@ func ReconcileMachineConfigServerConfig(cm *corev1.ConfigMap, p *MCSParams) erro
 		return err
 	}
 
+	if p.UserCA != nil {
+		serializedUserCA, err := serialize(p.UserCA)
+		if err != nil {
+			return err
+		}
+		cm.Data["user-ca-bundle-config.yaml"] = serializedUserCA
+	}
+
 	cm.Data["root-ca.crt"] = string(p.RootCA.Data[pki.CASignerCertMapKey])
 	cm.Data["combined-ca.crt"] = p.CombinedCA.Data[pki.CASignerCertMapKey]
 	cm.Data["cluster-dns-02-config.yaml"] = serializedDNS

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/pki.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/pki.go
@@ -13,3 +13,21 @@ func RootCASecret(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func ControlPlaneUserCABundle(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-ca-bundle",
+			Namespace: ns,
+		},
+	}
+}
+
+func UserCABundle() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-ca-bundle",
+			Namespace: "openshift-config",
+		},
+	}
+}

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -357,6 +357,21 @@ nodes to pull content.</p>
 </tr>
 <tr>
 <td>
+<code>additionalTrustBundle</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AdditionalTrustBundle is a reference to a ConfigMap containing a
+PEM-encoded X.509 certificate bundle that will be added to the hosted controlplane and nodes</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>secretEncryption</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">
@@ -2580,6 +2595,21 @@ nodes to pull content.</p>
 </tr>
 <tr>
 <td>
+<code>additionalTrustBundle</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AdditionalTrustBundle is a reference to a ConfigMap containing a
+PEM-encoded X.509 certificate bundle that will be added to the hosted controlplane and nodes</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>secretEncryption</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">
@@ -3054,6 +3084,20 @@ ClusterConfiguration
 <td>
 <em>(Optional)</em>
 <p>ImageContentSources lists sources/repositories for the release-image content.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>additionalTrustBundle</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AdditionalTrustBundle references a ConfigMap containing a PEM-encoded X.509 certificate bundle</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -19692,6 +19692,16 @@ objects:
             spec:
               description: Spec is the desired behavior of the HostedCluster.
               properties:
+                additionalTrustBundle:
+                  description: AdditionalTrustBundle is a reference to a ConfigMap
+                    containing a PEM-encoded X.509 certificate bundle that will be
+                    added to the hosted controlplane and nodes
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
                 auditWebhook:
                   description: "AuditWebhook contains metadata for configuring an
                     audit webhook endpoint for a cluster to process cluster audit
@@ -20867,6 +20877,15 @@ objects:
             spec:
               description: HostedControlPlaneSpec defines the desired state of HostedControlPlane
               properties:
+                additionalTrustBundle:
+                  description: AdditionalTrustBundle references a ConfigMap containing
+                    a PEM-encoded X.509 certificate bundle
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
                 apiAdvertiseAddress:
                   description: APIAdvertiseAddress is the address at which the APIServer
                     listens inside a worker.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1885,6 +1885,11 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 		}
 		proxy.SetEnvVars(&ignitionServerDeployment.Spec.Template.Spec.Containers[0].Env)
 
+		if hcluster.Spec.AdditionalTrustBundle != nil {
+			// Add trusted-ca mount with optional configmap
+			util.DeploymentAddTrustBundleVolume(hcluster.Spec.AdditionalTrustBundle, ignitionServerDeployment)
+		}
+
 		// set security context
 		if r.SetDefaultSecurityContext {
 			ignitionServerDeployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
@@ -2209,6 +2214,11 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 				},
 			},
 		})
+	}
+
+	if hc.Spec.AdditionalTrustBundle != nil {
+		// Add trusted-ca mount with optional configmap
+		util.DeploymentAddTrustBundleVolume(hc.Spec.AdditionalTrustBundle, deployment)
 	}
 
 	// set security context

--- a/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
@@ -118,6 +118,15 @@ func SSHKey(controlPlaneNamespace string) *corev1.Secret {
 	}
 }
 
+func UserCABundle(controlPlaneNamespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-ca-bundle",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
 func PodMonitor(controlPlaneNamespace string) *prometheusoperatorv1.PodMonitor {
 	return &prometheusoperatorv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{

--- a/support/util/volumes.go
+++ b/support/util/volumes.go
@@ -1,10 +1,28 @@
 package util
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func BuildVolume(volume *corev1.Volume, buildFn func(*corev1.Volume)) corev1.Volume {
 	buildFn(volume)
 	return *volume
+}
+
+func DeploymentAddTrustBundleVolume(trustBundleConfigMap *corev1.LocalObjectReference, deployment *appsv1.Deployment) {
+	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:      "trusted-ca",
+		MountPath: "/etc/pki/ca-trust/extracted/pem",
+		ReadOnly:  true,
+	})
+	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: "trusted-ca",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: *trustBundleConfigMap,
+				Items:                []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"}},
+			},
+		},
+	})
 }


### PR DESCRIPTION
This adds initial support for a new HostedCluster API `additionalTrustBundle` which allows user provided CA certs to be provided, similar to the [standalone installer](https://github.com/openshift/installer/blob/master/docs/user/customization.md#platform-customization)

This is useful when you want to use a local container registry that uses a self-signed cert - this is a common scenario for developing on-prem scenarios, particularly disconnected and ipv6 where access to an upstream registry is not possible.

The expected usage is to reference a local object reference, e.g `ConfigMap` in the `clusters` namespace:

```
spec:
  additionalTrustBundle:
    name: user-ca-bundle
```

If the management cluster already contains such a ConfigMap, it may be copied from the `openshift-config` namespace, e.g:

```
oc patch cm user-ca-bundle -p '{"metadata":{ "namespace":"clusters"}}' -n openshift-config --dry-run=client -o yaml | oc apply -f -
```

Partially-Fixes https://issues.redhat.com/browse/HOSTEDCP-291

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.