### PR TITLE
Partial revert "bump 4.9 refs to 4.10"

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/certified-operator-index:v4.10
+          image: registry.redhat.io/redhat/certified-operator-index:v4.9
           imagePullPolicy: Always
           ports:
             - containerPort: 50051

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/community-operator-index:v4.10
+          image: registry.redhat.io/redhat/community-operator-index:v4.9
           imagePullPolicy: Always
           ports:
             - containerPort: 50051

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/redhat-marketplace-index:v4.10
+          image: registry.redhat.io/redhat/redhat-marketplace-index:v4.9
           imagePullPolicy: Always
           ports:
             - containerPort: 50051

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/redhat-operator-index:v4.10
+          image: registry.redhat.io/redhat/redhat-operator-index:v4.9
           imagePullPolicy: Always
           ports:
             - containerPort: 50051


### PR DESCRIPTION
https://github.com/openshift/hypershift/pull/966 is causing `TestOLM` to fail in the periodics.
Revert until we have a root cause.

**What this PR does / why we need it**:
`TestOLM` is failing in the periodics after this commit.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-e2e-aws-periodic/1489569576726302720

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-e2e-aws-periodic/1489660131149877248

```
    olm_test.go:201: 
        csv never installed
        Unexpected error:
            <*errors.errorString | 0xc000098050>: {
                s: "timed out waiting for the condition",
            }
            timed out waiting for the condition
        occurred
```

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.