### PR TITLE
add update target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,11 @@ all: build e2e
 
 build: ignition-server hypershift-operator control-plane-operator konnectivity-socks5-proxy hypershift availability-prober token-minter
 
+.PHONY: update
+update: deps api api-docs app-sre-saas-template
+
 .PHONY: verify
-verify: staticcheck deps api fmt vet promtool api-docs app-sre-saas-template
+verify: update staticcheck fmt vet promtool
 	git diff-index --cached --quiet --ignore-submodules HEAD --
 	git diff-files --quiet --ignore-submodules
 	$(eval STATUS = $(shell git status -s))


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the only make target we have for generating files is `verify`.  However, this returns non-zero if there is an update.

This PR adds a new `update` target that runs all the targets that can update files and doesn't return an error if there is an update.

After this PR, `update` is for generating file updates and `verify` ensures generated files are up-to-date and also runs code checking targets which do not generate code.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.