### PR TITLE
Release 4.8 olm images

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/certified-operator-index:v4.10
+          image: registry.redhat.io/redhat/certified-operator-index:v4.8
           imagePullPolicy: Always
           ports:
             - containerPort: 50051

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/community-operator-index:v4.10
+          image: registry.redhat.io/redhat/community-operator-index:v4.8
           imagePullPolicy: Always
           ports:
             - containerPort: 50051

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/redhat-marketplace-index:v4.10
+          image: registry.redhat.io/redhat/redhat-marketplace-index:v4.8
           imagePullPolicy: Always
           ports:
             - containerPort: 50051

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/redhat-operator-index:v4.10
+          image: registry.redhat.io/redhat/redhat-operator-index:v4.8
           imagePullPolicy: Always
           ports:
             - containerPort: 50051


### PR DESCRIPTION
The static manifests were locked into v4.10 earlier when they should be adjusted to match the release payload. Adjusting to match release-4.8


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # Proper version match of images

**Checklist**
- [ X ] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.