### PR TITLE
ensure ingressController exposed as nodePort for IBM Cloud Satellite …

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
@@ -1,0 +1,154 @@
+package ingress
+
+import (
+	. "github.com/onsi/gomega"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestReconcileDefaultIngressController(t *testing.T) {
+	fakeIngressDomain := "example.com"
+	fakeInputReplicas := int32(3)
+	testsCases := []struct {
+		name                      string
+		inputIngressController    *operatorv1.IngressController
+		inputIngressDomain        string
+		inputPlatformType         hyperv1.PlatformType
+		inputReplicas             int32
+		inputIsIBMCloudUPI        bool
+		expectedIngressController *operatorv1.IngressController
+	}{
+		{
+			name:                   "IBM Cloud UPI uses Nodeport publishing strategy",
+			inputIngressController: manifests.IngressDefaultIngressController(),
+			inputIngressDomain:     fakeIngressDomain,
+			inputPlatformType:      hyperv1.IBMCloudPlatform,
+			inputReplicas:          fakeInputReplicas,
+			inputIsIBMCloudUPI:     true,
+			expectedIngressController: &operatorv1.IngressController{
+				ObjectMeta: manifests.IngressDefaultIngressController().ObjectMeta,
+				Spec: operatorv1.IngressControllerSpec{
+					Domain:   fakeIngressDomain,
+					Replicas: &fakeInputReplicas,
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.NodePortServiceStrategyType,
+						NodePort: &operatorv1.NodePortStrategy{
+							Protocol: operatorv1.TCPProtocol,
+						},
+					},
+					NodePlacement: &operatorv1.NodePlacement{
+						Tolerations: []corev1.Toleration{
+							{
+								Key:   "dedicated",
+								Value: "edge",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                   "IBM Cloud Non-UPI uses LoadBalancer publishing strategy",
+			inputIngressController: manifests.IngressDefaultIngressController(),
+			inputIngressDomain:     fakeIngressDomain,
+			inputPlatformType:      hyperv1.IBMCloudPlatform,
+			inputReplicas:          fakeInputReplicas,
+			inputIsIBMCloudUPI:     false,
+			expectedIngressController: &operatorv1.IngressController{
+				ObjectMeta: manifests.IngressDefaultIngressController().ObjectMeta,
+				Spec: operatorv1.IngressControllerSpec{
+					Domain:   fakeIngressDomain,
+					Replicas: &fakeInputReplicas,
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							Scope: operatorv1.ExternalLoadBalancer,
+						},
+					},
+					NodePlacement: &operatorv1.NodePlacement{
+						Tolerations: []corev1.Toleration{
+							{
+								Key:   "dedicated",
+								Value: "edge",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                   "Kubevirt uses HostNetwork publishing strategy",
+			inputIngressController: manifests.IngressDefaultIngressController(),
+			inputIngressDomain:     fakeIngressDomain,
+			inputPlatformType:      hyperv1.KubevirtPlatform,
+			inputReplicas:          fakeInputReplicas,
+			inputIsIBMCloudUPI:     false,
+			expectedIngressController: &operatorv1.IngressController{
+				ObjectMeta: manifests.IngressDefaultIngressController().ObjectMeta,
+				Spec: operatorv1.IngressControllerSpec{
+					Domain:   fakeIngressDomain,
+					Replicas: &fakeInputReplicas,
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.HostNetworkStrategyType,
+					},
+					DefaultCertificate: &corev1.LocalObjectReference{
+						Name: manifests.IngressDefaultIngressControllerCert().Name,
+					},
+				},
+			},
+		},
+		{
+			name:                   "None Platform uses HostNetwork publishing strategy",
+			inputIngressController: manifests.IngressDefaultIngressController(),
+			inputIngressDomain:     fakeIngressDomain,
+			inputPlatformType:      hyperv1.NonePlatform,
+			inputReplicas:          fakeInputReplicas,
+			inputIsIBMCloudUPI:     false,
+			expectedIngressController: &operatorv1.IngressController{
+				ObjectMeta: manifests.IngressDefaultIngressController().ObjectMeta,
+				Spec: operatorv1.IngressControllerSpec{
+					Domain:   fakeIngressDomain,
+					Replicas: &fakeInputReplicas,
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.HostNetworkStrategyType,
+					},
+					DefaultCertificate: &corev1.LocalObjectReference{
+						Name: manifests.IngressDefaultIngressControllerCert().Name,
+					},
+				},
+			},
+		},
+		{
+			name:                   "AWS uses Loadbalancer publishing strategy",
+			inputIngressController: manifests.IngressDefaultIngressController(),
+			inputIngressDomain:     fakeIngressDomain,
+			inputPlatformType:      hyperv1.AWSPlatform,
+			inputReplicas:          fakeInputReplicas,
+			inputIsIBMCloudUPI:     false,
+			expectedIngressController: &operatorv1.IngressController{
+				ObjectMeta: manifests.IngressDefaultIngressController().ObjectMeta,
+				Spec: operatorv1.IngressControllerSpec{
+					Domain:   fakeIngressDomain,
+					Replicas: &fakeInputReplicas,
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+					},
+					DefaultCertificate: &corev1.LocalObjectReference{
+						Name: manifests.IngressDefaultIngressControllerCert().Name,
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			err := ReconcileDefaultIngressController(tc.inputIngressController, tc.inputIngressDomain, tc.inputPlatformType, tc.inputReplicas, tc.inputIsIBMCloudUPI)
+			g.Expect(err).To(BeNil())
+			g.Expect(tc.inputIngressController).To(BeEquivalentTo(tc.expectedIngressController))
+		})
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -528,7 +528,7 @@ func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv
 	p := ingress.NewIngressParams(hcp, globalConfig)
 	ingressController := manifests.IngressDefaultIngressController()
 	if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
-		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas)
+		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, (hcp.Spec.Platform.IBMCloud != nil && hcp.Spec.Platform.IBMCloud.ProviderType == configv1.IBMCloudProviderTypeUPI))
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
 	}


### PR DESCRIPTION
…so ingress operator rolls out

This exposes the load balancer service in IBMCloud Satellite paths as a node port so the ingress operator can fully rollout. Currently, it uses LoadBalancer. In Satellite environments there is not a LoadBalancer provider by default therefore that strategy should not be used


Previous path:
```
Tylers-MacBook-Pro:hypershift tylerlisowski$ kubectl --kubeconfig /tmp/c7vcvau10qflf8nns0pg-admin-kubeconfig get clusteroperator
NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
console                                    4.8.28    False       False         False      63m
csi-snapshot-controller                    4.8.28    True        False         False      62m
dns                                        4.8.28    True        False         False      61m
image-registry                             4.8.28    True        False         False      61m
ingress                                              False       True          True       44m
```

New path result:
```
kubectl --kubeconfig /tmp/c7vcvau10qflf8nns0pg-admin-kubeconfig get clusteroperators
NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
console                                    4.8.28    False       False         False      139m
csi-snapshot-controller                    4.8.28    True        False         False      138m
dns                                        4.8.28    True        False         False      137m
image-registry                             4.8.28    True        False         False      137m
ingress                                    4.8.28    True        False         False      36s
kube-apiserver                             4.8.28    True        False         False      4h37m
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.