### PR TITLE
Add a Script to install OpenShift Virtualization on a CI cluster

### DIFF
--- a/hack/ci/install-cnv.sh
+++ b/hack/ci/install-cnv.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -ex
+
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cnv
+EOF
+
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-cnv-group
+  namespace: openshift-cnv
+spec:
+  targetNamespaces:
+  - openshift-cnv
+EOF
+
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/kubevirt-hyperconverged.openshift-cnv: ''
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kubevirt-hyperconverged
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+sleep 60
+
+RETRIES=30
+CSV=
+for i in $(seq ${RETRIES}); do
+  if [[ -z ${CSV} ]]; then
+    CSV=$(oc get subscription -n openshift-cnv kubevirt-hyperconverged -o jsonpath='{.status.installedCSV}')
+  fi
+  if [[ -z ${CSV} ]]; then
+    echo "Try ${i}/${RETRIES}: can't get the CSV yet. Checking again in 30 seconds"
+    sleep 30
+  fi
+  if [[ $(oc get csv -n openshift-cnv ${CSV} -o jsonpath={.status.phase}) == "Succeeded" ]]; then
+    echo "CNV is deployed"
+    break
+  else
+    echo "Try ${i}/${RETRIES}: CNV is not deployed yet. Checking again in 30 seconds"
+    sleep 30
+  fi
+done
+
+if [[ $(oc get csv -n openshift-cnv ${CSV} -o jsonpath={.status.phase}) != "Succeeded" ]]; then
+  echo "Error: Failed to deploy CNV"
+  echo "CSV ${CSV} YAML"
+  oc get CSV ${CSV} -n openshift-cnv -o yaml
+  echo
+  echo "CSV ${CSV} Describe"
+  oc describe CSV ${CSV} -n openshift-cnv
+  exit 1
+fi
+
+oc create -f - <<EOF
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+EOF
+
+oc wait hyperconverged -n openshift-cnv kubevirt-hyperconverged --for=condition=Available --timeout=15m


### PR DESCRIPTION
To make the E2E kubevirt provider tests more readable, this PR adds a script to replace the embedded script in the test configuration at openshift/release repository.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.