### PR TITLE
support multizone in e2e-all tests

### DIFF
--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -15,9 +15,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestAutoRepair(t *testing.T) {
@@ -30,26 +28,23 @@ func TestAutoRepair(t *testing.T) {
 	defer cancel()
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
-	clusterOpts.NodePoolReplicas = 3
+	numZones := int32(len(clusterOpts.AWSPlatform.Zones))
+	if numZones <= 1 {
+		clusterOpts.NodePoolReplicas = 3
+	} else if numZones == 2 {
+		clusterOpts.NodePoolReplicas = 2
+	} else {
+		clusterOpts.NodePoolReplicas = 1
+	}
 	clusterOpts.AutoRepair = true
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
 
-	// Get the newly created nodepool
-	nodepool := &hyperv1.NodePool{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: hostedCluster.Namespace,
-			Name:      e2eutil.NodePoolName(hostedCluster.Name, clusterOpts.AWSPlatform.Zones[0]),
-		},
-	}
-	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
-	t.Logf("Created nodepool: %s", crclient.ObjectKeyFromObject(nodepool))
-
 	// Perform some very basic assertions about the guest cluster
 	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
 	// TODO (alberto): have ability to label and get Nodes by NodePool. NodePool.Status.Nodes?
-	nodes := e2eutil.WaitForNReadyNodes(t, testContext, guestClient, *nodepool.Spec.NodeCount)
+	numNodes := clusterOpts.NodePoolReplicas * numZones
+	nodes := e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
 
 	// Wait for the rollout to be reported complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
@@ -62,15 +57,15 @@ func TestAutoRepair(t *testing.T) {
 	instanceID := awsSpec[strings.LastIndex(awsSpec, "/")+1:]
 	t.Logf("Terminating AWS instance: %s", instanceID)
 	ec2client := ec2Client(clusterOpts.AWSPlatform.AWSCredentialsFile, clusterOpts.AWSPlatform.Region)
-	_, err = ec2client.TerminateInstances(&ec2.TerminateInstancesInput{
+	_, err := ec2client.TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: []*string{aws.String(instanceID)},
 	})
 	g.Expect(err).NotTo(HaveOccurred(), "failed to terminate AWS instance")
 
 	// Wait for nodes to be ready again, without the node that was terminated
-	t.Logf("Waiting for %d available nodes without %s", *nodepool.Spec.NodeCount, nodeToReplace)
+	t.Logf("Waiting for %d available nodes without %s", numNodes, nodeToReplace)
 	err = wait.PollUntil(30*time.Second, func() (done bool, err error) {
-		nodes := e2eutil.WaitForNReadyNodes(t, testContext, guestClient, *nodepool.Spec.NodeCount)
+		nodes := e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
 		for _, node := range nodes {
 			if node.Name == nodeToReplace {
 				return false, nil

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -32,11 +32,12 @@ func TestAutoscaling(t *testing.T) {
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
 
-	// Get the newly created nodepool
+	// Get one of the newly created NodePools
+	zone := clusterOpts.AWSPlatform.Zones[0]
 	nodepool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedCluster.Namespace,
-			Name:      e2eutil.NodePoolName(hostedCluster.Name, clusterOpts.AWSPlatform.Zones[0]),
+			Name:      e2eutil.NodePoolName(hostedCluster.Name, zone),
 		},
 	}
 	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
@@ -46,7 +47,8 @@ func TestAutoscaling(t *testing.T) {
 	// Perform some very basic assertions about the guest cluster
 	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
 	// TODO (alberto): have ability to label and get Nodes by NodePool. NodePool.Status.Nodes?
-	nodes := e2eutil.WaitForNReadyNodes(t, testContext, guestClient, *nodepool.Spec.NodeCount)
+	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	nodes := e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
 
 	// Wait for the rollout to be reported complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
@@ -55,13 +57,13 @@ func TestAutoscaling(t *testing.T) {
 	// Enable autoscaling.
 	err = client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
-	var max int32 = 3
+	var max int32 = 2
 
 	// This Deployment have replicas=2 with
 	// anti-affinity rules resulting in scheduling constraints
 	// that prevent the cluster from ever scaling back down to 1:
 	// aws-ebs-csi-driver-controller
-	var min int32 = 2
+	var min int32 = 1
 	nodepool.Spec.AutoScaling = &hyperv1.NodePoolAutoScaling{
 		Min: min,
 		Max: max,
@@ -85,14 +87,15 @@ func TestAutoscaling(t *testing.T) {
 	// be used, not enough to have more than 1 pod per
 	// node.
 	workloadMemRequest := resource.MustParse(fmt.Sprintf("%v", 0.6*float32(bytes)))
-	workload := newWorkLoad(max, workloadMemRequest, "", globalOpts.LatestReleaseImage)
+	workload := newWorkLoad(max, workloadMemRequest, "", globalOpts.LatestReleaseImage, zone)
 	err = guestClient.Create(testContext, workload)
 	g.Expect(err).NotTo(HaveOccurred())
 	t.Logf("Created workload. Node: %s, memcapacity: %s", nodes[0].Name, memCapacity.String())
 
-	// Wait for 3 nodes.
+	// Wait for one more node.
 	// TODO (alberto): have ability for NodePool to label Nodes and let workload target specific Nodes.
-	_ = e2eutil.WaitForNReadyNodes(t, testContext, guestClient, max)
+	numNodes = numNodes + 1
+	_ = e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
 
 	// Delete workload.
 	cascadeDelete := metav1.DeletePropagationForeground
@@ -102,13 +105,14 @@ func TestAutoscaling(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	t.Logf("Deleted workload")
 
-	// Wait for exactly 1 node.
-	_ = e2eutil.WaitForNReadyNodes(t, testContext, guestClient, min)
+	// Wait for one less node.
+	numNodes = numNodes - 1
+	_ = e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
 
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 }
 
-func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, image string) *batchv1.Job {
+func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, image string, zone string) *batchv1.Job {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "autoscaling-workload",
@@ -138,6 +142,9 @@ func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, ima
 						},
 					},
 					RestartPolicy: corev1.RestartPolicy("Never"),
+					NodeSelector: map[string]string{
+						"topology.kubernetes.io/zone": zone,
+					},
 				},
 			},
 			BackoffLimit: pointer.Int32Ptr(4),

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -53,7 +53,8 @@ func TestOLM(t *testing.T) {
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, cluster)
 
 	// Wait for guest cluster nodes to become available
-	util.WaitForNReadyNodes(t, ctx, guestClient, clusterOpts.NodePoolReplicas)
+	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
+	util.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
 
 	guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name
 	t.Logf("Hosted control plane namespace is %s", guestNamespace)


### PR DESCRIPTION
**What this PR does / why we need it**:
Tests run in e2e-all are not passing because they weren't modified with multi-zone awareness.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.