### PR TITLE
move subnetID reconcilation for AWSEndpointServices

### DIFF
--- a/api/v1alpha1/endpointservice_types.go
+++ b/api/v1alpha1/endpointservice_types.go
@@ -25,9 +25,10 @@ const (
 // AWSEndpointServiceSpec defines the desired state of AWSEndpointService
 type AWSEndpointServiceSpec struct {
 	// The name of the NLB for which an Endpoint Service should be configured
-	NetworkLoadBalancerName string `json:"networkLoadBalancerName,omitempty"`
+	NetworkLoadBalancerName string `json:"networkLoadBalancerName"`
 
 	// SubnetIDs is the list of subnet IDs to which guest nodes can attach
+	// +optional
 	SubnetIDs []string `json:"subnetIDs,omitempty"`
 
 	// Tags to apply to the EndpointService

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_awsendpointservices.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_awsendpointservices.yaml
@@ -73,6 +73,8 @@ spec:
                 items:
                   type: string
                 type: array
+            required:
+            - networkLoadBalancerName
             type: object
           status:
             description: AWSEndpointServiceStatus defines the observed state of AWSEndpointService

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -17336,6 +17336,8 @@ objects:
                   items:
                     type: string
                   type: array
+              required:
+              - networkLoadBalancerName
               type: object
             status:
               description: AWSEndpointServiceStatus defines the observed state of

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3797,21 +3797,5 @@ func (r *HostedClusterReconciler) reconcileAWSSubnets(ctx context.Context, creat
 	if err != nil {
 		return fmt.Errorf("failed to reconcile networks for CAPA Infra CR: %w", err)
 	}
-
-	// Reconcile subnet IDs in AWSEndpointService CRs
-	awsEndpointServiceList := hyperv1.AWSEndpointServiceList{}
-	if err := r.List(ctx, &awsEndpointServiceList, &client.ListOptions{Namespace: hcpNamespace}); err != nil {
-		return fmt.Errorf("failed to list AWSEndpointServices in namespace %s: %w", hcpNamespace, err)
-	}
-	for _, eps := range awsEndpointServiceList.Items {
-		_, err = createOrUpdate(ctx, r.Client, &eps, func() error {
-			eps.Spec.SubnetIDs = subnetIDs
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("failed to reconcile subnetIDs for AWSEndpointService %s: %w", eps.Name, err)
-		}
-	}
-
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1201,16 +1201,7 @@ func TestReconcileAWSSubnets(t *testing.T) {
 		Spec: capiawsv1.AWSClusterSpec{},
 	}
 
-	epsName := "test"
-	awsEndpointService := &hyperv1.AWSEndpointService{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      epsName,
-			Namespace: hcpNamespace,
-		},
-		Spec: hyperv1.AWSEndpointServiceSpec{},
-	}
-
-	client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(infraCR, nodePool, nodePool2, awsEndpointService).Build()
+	client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(infraCR, nodePool, nodePool2).Build()
 	r := &HostedClusterReconciler{
 		Client:         client,
 		createOrUpdate: func(reconcile.Request) upsert.CreateOrUpdateFN { return ctrl.CreateOrUpdate },
@@ -1236,13 +1227,4 @@ func TestReconcileAWSSubnets(t *testing.T) {
 			ID: "2",
 		},
 	}))
-
-	freshAWSEndpointService := &hyperv1.AWSEndpointService{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      epsName,
-			Namespace: hcpNamespace,
-		}}
-	err = client.Get(context.Background(), crclient.ObjectKeyFromObject(freshAWSEndpointService), freshAWSEndpointService)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(freshAWSEndpointService.Spec.SubnetIDs).To(BeEquivalentTo([]string{"1", "2"}))
 }

--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -19,6 +20,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
@@ -27,6 +31,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -42,9 +47,38 @@ type AWSEndpointServiceReconciler struct {
 	elbv2Client elbv2iface.ELBV2API
 }
 
+func mapNodePoolToAWSEndpointServicesFunc(c client.Client) func(obj client.Object) []reconcile.Request {
+	return func(obj client.Object) []reconcile.Request {
+		nodePool, ok := obj.(*hyperv1.NodePool)
+		if !ok {
+			return []reconcile.Request{}
+		}
+
+		// This is a pretty fragile but without a client or context with which to list the
+		// AWSEndpointServices and no way to return and error from here, hardcoding the known
+		// names of the potential AWSEndpointServices (won't exist if Public) is a way to do it.
+		hcpNamespace := fmt.Sprintf("%s-%s", nodePool.Namespace, nodePool.Spec.ClusterName)
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: hcpNamespace,
+					Name:      "kube-apiserver-private",
+				},
+			},
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: hcpNamespace,
+					Name:      fmt.Sprintf("router-%s", hcpNamespace),
+				},
+			},
+		}
+	}
+}
+
 func (r *AWSEndpointServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	_, err := ctrl.NewControllerManagedBy(mgr).
 		For(&hyperv1.AWSEndpointService{}).
+		Watches(&source.Kind{Type: &hyperv1.NodePool{}}, handler.EnqueueRequestsFromMapFunc(mapNodePoolToAWSEndpointServicesFunc(r))).
 		Build(r)
 	if err != nil {
 		return fmt.Errorf("failed setting up with a controller manager: %w", err)
@@ -116,8 +150,15 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// Reconcile the AWSEndpointService
-	if err = reconcileAWSEndpointService(ctx, awsEndpointService, r.ec2Client, r.elbv2Client); err != nil {
+	// Reconcile the AWSEndpointService Spec
+	if _, err := r.CreateOrUpdate(ctx, r.Client, awsEndpointService, func() error {
+		return reconcileAWSEndpointServiceSpec(ctx, r, awsEndpointService)
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile AWSEndpointService spec: %w", err)
+	}
+
+	// Reconcile the AWSEndpointService Status
+	if err = reconcileAWSEndpointServiceStatus(ctx, awsEndpointService, r.ec2Client, r.elbv2Client); err != nil {
 		meta.SetStatusCondition(&awsEndpointService.Status.Conditions, metav1.Condition{
 			Type:    string(hyperv1.AWSEndpointServiceAvailable),
 			Status:  metav1.ConditionFalse,
@@ -128,7 +169,7 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, err
 		}
 		// Most likely cause of error here is the NLB is not yet active.  This can take ~2m so
-		// a longer requeue time is warranted.  The ratelimits AWS calls and updates to the CR.
+		// a longer requeue time is warranted.  This ratelimits AWS calls and updates to the CR.
 		log.Info("reconcilation failed, retrying in 20s", "err", err)
 		return ctrl.Result{RequeueAfter: lbNotActiveRequeueDuration}, nil
 	}
@@ -148,7 +189,62 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{}, nil
 }
 
-func reconcileAWSEndpointService(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, ec2Client ec2iface.EC2API, elbv2Client elbv2iface.ELBV2API) error {
+func reconcileAWSEndpointServiceSpec(ctx context.Context, c client.Client, awsEndpointService *hyperv1.AWSEndpointService) error {
+	return reconcileAWSEndpointServiceSubnetIDs(ctx, c, awsEndpointService)
+}
+
+func reconcileAWSEndpointServiceSubnetIDs(ctx context.Context, c client.Client, awsEndpointService *hyperv1.AWSEndpointService) error {
+	hcps := &hyperv1.HostedControlPlaneList{}
+	hcpNamespace := awsEndpointService.Namespace
+	if err := c.List(ctx, hcps, client.InNamespace(hcpNamespace)); err != nil {
+		return fmt.Errorf("failed to list HostedControlPlanes in namespace %s: %w", hcpNamespace, err)
+	}
+	if len(hcps.Items) != 1 {
+		return fmt.Errorf("unexpected number of HostedControlPlanes in namespace %s: expected 1, got %d", hcpNamespace, len(hcps.Items))
+	}
+	hcp := hcps.Items[0]
+	hostedClusterName := hcp.Name
+	nodePoolNamespace := strings.TrimSuffix(hcp.Namespace, fmt.Sprintf("-%s", hcp.Name))
+	subnetIDs, err := listSubnetIDs(ctx, c, hostedClusterName, nodePoolNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to list subnetIDs: %w", err)
+	}
+	awsEndpointService.Spec.SubnetIDs = subnetIDs
+	return nil
+}
+
+func listNodePools(ctx context.Context, c client.Client, nodePoolNamespace string, clusterName string) ([]hyperv1.NodePool, error) {
+	nodePoolList := &hyperv1.NodePoolList{}
+	if err := c.List(ctx, nodePoolList, &client.ListOptions{Namespace: nodePoolNamespace}); err != nil {
+		return nil, fmt.Errorf("failed to list NodePools in namespace %s for cluster %s : %w", nodePoolNamespace, clusterName, err)
+	}
+	filtered := []hyperv1.NodePool{}
+	for i, nodePool := range nodePoolList.Items {
+		if nodePool.Spec.ClusterName == clusterName {
+			filtered = append(filtered, nodePoolList.Items[i])
+		}
+	}
+	return filtered, nil
+}
+
+func listSubnetIDs(ctx context.Context, c client.Client, clusterName, nodePoolNamespace string) ([]string, error) {
+	nodePools, err := listNodePools(ctx, c, nodePoolNamespace, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	subnetIDs := []string{}
+	for _, nodePool := range nodePools {
+		if nodePool.Spec.Platform.AWS != nil &&
+			nodePool.Spec.Platform.AWS.Subnet != nil &&
+			nodePool.Spec.Platform.AWS.Subnet.ID != nil {
+			subnetIDs = append(subnetIDs, *nodePool.Spec.Platform.AWS.Subnet.ID)
+		}
+	}
+	sort.Strings(subnetIDs)
+	return subnetIDs, nil
+}
+
+func reconcileAWSEndpointServiceStatus(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, ec2Client ec2iface.EC2API, elbv2Client elbv2iface.ELBV2API) error {
 	log, err := logr.FromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("no logger found: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/openshift/hypershift/pull/951 accidentally worked due to the `NodePool` being updated after the creation of the `AWSEndpointServices`, however, reconciliation of `.spec.subnetIDs` on `AWSEndpointServices` currently happens on a controller that doesn't watch `AWSEndpointServices`.

This moves the reconciliation of `subnetIDs` to the `AWSEndpointServiceReconciler` and adds a `NodePool` watch to that controller.

The mapping of `NodePools` <-> `AWSEndpointServices` is a little fragile.  I'm open to suggestions.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.