### PR TITLE
skip annotating cluster scoped resources

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer.go
+++ b/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer.go
@@ -18,6 +18,10 @@ func createOrUpdateWithAnnotationFactory(upstream upsert.CreateOrUpdateProvider)
 				if err := f(); err != nil {
 					return err
 				}
+				if obj.GetNamespace() == "" {
+					// don't tag cluster scoped resources
+					return nil
+				}
 				annotations := obj.GetAnnotations()
 				if annotations == nil {
 					annotations = map[string]string{}


### PR DESCRIPTION
**What this PR does / why we need it**:
When running multiple clusters, annotating cluster scoped resources results in hot reconcile loop.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.