### PR TITLE
use leases for hypershift-operator leader election

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -142,11 +142,12 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.UserAgent = "hypershift-operator-manager"
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme:             hyperapi.Scheme,
-		MetricsBindAddress: opts.MetricsAddr,
-		Port:               9443,
-		LeaderElection:     opts.EnableLeaderElection,
-		LeaderElectionID:   "b2ed43ca.hypershift.openshift.io",
+		Scheme:                     hyperapi.Scheme,
+		MetricsBindAddress:         opts.MetricsAddr,
+		Port:                       9443,
+		LeaderElection:             opts.EnableLeaderElection,
+		LeaderElectionID:           "hypershift-operator-leader-elect",
+		LeaderElectionResourceLock: "leases",
 	})
 	if err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
HCO components switched to `Leases` in https://github.com/openshift/hypershift/pull/935.  The RBAC permissions to use `leases` was added to the `hypershift-operator` `Role` in https://github.com/openshift/hypershift/pull/366, but `LeaderElectionResourceLock` was not changed in for the `hypershift-operator` `Manager`.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.