### PR TITLE
[kubevirt] Add auto-detection of the correct RHCOS base image

### DIFF
--- a/api/fixtures/example_kubevirt.go
+++ b/api/fixtures/example_kubevirt.go
@@ -1,0 +1,123 @@
+package fixtures
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/util"
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+)
+
+func ExampleKubeVirtTemplate(o *ExampleKubevirtOptions) *hyperv1.KubevirtNodePoolPlatform {
+	runAlways := kubevirtv1.RunStrategyAlways
+	guestQuantity := apiresource.MustParse(o.Memory)
+	exampleTemplate := &hyperv1.KubevirtNodePoolPlatform{
+		NodeTemplate: &capikubevirt.VirtualMachineTemplateSpec{
+			Spec: kubevirtv1.VirtualMachineSpec{
+				RunStrategy: &runAlways,
+				Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							CPU:    &kubevirtv1.CPU{Cores: o.Cores},
+							Memory: &kubevirtv1.Memory{Guest: &guestQuantity},
+							Devices: kubevirtv1.Devices{
+								Interfaces: []kubevirtv1.Interface{
+									{
+										Name: "default",
+										InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+											Bridge: &kubevirtv1.InterfaceBridge{},
+										},
+									},
+								},
+							},
+						},
+						Networks: []kubevirtv1.Network{
+							{
+								Name: "default",
+								NetworkSource: kubevirtv1.NetworkSource{
+									Pod: &kubevirtv1.PodNetwork{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	exampleTemplate.NodeTemplate.Spec.Template.Spec.Domain.Devices.Disks = []kubevirtv1.Disk{
+		{
+			Name: util.RHCOSMagicVolumeName,
+			DiskDevice: kubevirtv1.DiskDevice{
+				Disk: &kubevirtv1.DiskTarget{
+					Bus: "virtio",
+				},
+			},
+		},
+	}
+	if o.Image != "" {
+		exampleTemplate.NodeTemplate.Spec.Template.Spec.Volumes = []kubevirtv1.Volume{
+			{
+				Name: util.RHCOSMagicVolumeName,
+				VolumeSource: kubevirtv1.VolumeSource{
+					ContainerDisk: &kubevirtv1.ContainerDiskSource{
+						Image: o.Image,
+					},
+				},
+			},
+		}
+	} else {
+		dataVolume := defaultDataVolume()
+		setDataVolumeDefaults(&dataVolume, o)
+		exampleTemplate.NodeTemplate.Spec.DataVolumeTemplates = []kubevirtv1.DataVolumeTemplateSpec{dataVolume}
+		exampleTemplate.NodeTemplate.Spec.Template.Spec.Volumes = []kubevirtv1.Volume{
+			{
+				Name: util.RHCOSMagicVolumeName,
+				VolumeSource: kubevirtv1.VolumeSource{
+					DataVolume: &kubevirtv1.DataVolumeSource{
+						Name: util.RHCOSMagicVolumeName,
+					},
+				},
+			},
+		}
+	}
+	return exampleTemplate
+}
+
+func defaultDataVolume() kubevirtv1.DataVolumeTemplateSpec {
+	return kubevirtv1.DataVolumeTemplateSpec{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: util.RHCOSMagicVolumeName,
+		},
+		Spec: v1beta1.DataVolumeSpec{
+			Source: &v1beta1.DataVolumeSource{
+				HTTP: &v1beta1.DataVolumeSourceHTTP{URL: util.RHCOSOpenStackURLParam},
+			},
+		},
+	}
+}
+func setDataVolumeDefaults(spec *kubevirtv1.DataVolumeTemplateSpec, o *ExampleKubevirtOptions) {
+	if spec.Spec.Storage == nil {
+		spec.Spec.Storage = &v1beta1.StorageSpec{
+			Resources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]apiresource.Quantity{
+					corev1.ResourceStorage: util.KubeVirtVolumeDefaultSize,
+				},
+			},
+			StorageClassName: &o.RootVolumeStorageClass,
+		}
+	}
+	if o.RootVolumeSize != 0 {
+		size := apiresource.MustParse(fmt.Sprintf("%vGi", o.RootVolumeSize))
+		spec.Spec.Storage.Resources = corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]apiresource.Quantity{
+				corev1.ResourceStorage: size,
+			},
+		}
+	}
+}

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -10,6 +10,7 @@ import (
 const (
 	NodePoolValidReleaseImageConditionType       = "ValidReleaseImage"
 	NodePoolValidAMIConditionType                = "ValidAMI"
+	NodePoolValidRHCOSImageConditionType         = "ValidRHCOSImage"
 	NodePoolConfigValidConfigConditionType       = "ValidConfig"
 	NodePoolUpdateManagementEnabledConditionType = "UpdateManagementEnabled"
 	NodePoolAutoscalingEnabledConditionType      = "AutoscalingEnabled"

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -78,6 +78,9 @@ type KubevirtPlatformCreateOptions struct {
 	Memory                    string
 	Cores                     uint32
 	ContainerDiskImage        string
+	ContainerDiskRepo         string
+	RootVolumeSize            int64
+	RootVolumeStorageClass    string
 }
 
 type AWSPlatformOptions struct {

--- a/cmd/nodepool/kubevirt/create.go
+++ b/cmd/nodepool/kubevirt/create.go
@@ -2,11 +2,12 @@ package kubevirt
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/openshift/hypershift/api/fixtures"
+	"github.com/openshift/hypershift/cmd/util"
 	"github.com/spf13/cobra"
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
-	kubevirtv1 "kubevirt.io/api/core/v1"
-	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
@@ -14,9 +15,12 @@ import (
 )
 
 type KubevirtPlatformCreateOptions struct {
-	Memory             string
-	Cores              uint32
-	ContainerDiskImage string
+	Memory                 string
+	Cores                  uint32
+	ContainerDiskImage     string
+	ContainerDiskRepo      string
+	RootVolumeSize         uint32
+	RootVolumeStorageClass string
 }
 
 func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
@@ -33,7 +37,10 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 
 	cmd.Flags().StringVar(&platformOpts.Memory, "memory", platformOpts.Memory, "The amount of memory which is visible inside the Guest OS (type BinarySI, e.g. 5Gi, 100Mi)")
 	cmd.Flags().Uint32Var(&platformOpts.Cores, "cores", platformOpts.Cores, "The number of cores inside the vmi, Must be a value greater or equal 1")
+	cmd.Flags().StringVar(&platformOpts.RootVolumeStorageClass, "root-volume-storage-class", platformOpts.RootVolumeStorageClass, "The storage class to use for machines in the NodePool")
+	cmd.Flags().Uint32Var(&platformOpts.RootVolumeSize, "root-volume-size", platformOpts.RootVolumeSize, "The size of the root volume for machines in the NodePool in Gi")
 	cmd.Flags().StringVar(&platformOpts.ContainerDiskImage, "containerdisk", platformOpts.ContainerDiskImage, "A reference to docker image with the embedded disk to be used to create the machines")
+	cmd.Flags().StringVar(&platformOpts.ContainerDiskRepo, "containerdisk-repository", platformOpts.ContainerDiskRepo, "A reference to docker image registry with the embedded disk to be used to create the machines, the tag will be auto-discovered")
 
 	// TODO (nargaman): replace with official container image, after RFE-2501 is completed
 	// As long as there is no official container image
@@ -47,61 +54,23 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 }
 
 func (o *KubevirtPlatformCreateOptions) UpdateNodePool(_ context.Context, nodePool *hyperv1.NodePool, _ *hyperv1.HostedCluster, _ crclient.Client) error {
-	runAlways := kubevirtv1.RunStrategyAlways
-	guestQuantity := apiresource.MustParse(o.Memory)
-	nodePool.Spec.Platform.Kubevirt = &hyperv1.KubevirtNodePoolPlatform{
-		NodeTemplate: &capikubevirt.VirtualMachineTemplateSpec{
-			Spec: kubevirtv1.VirtualMachineSpec{
-				RunStrategy: &runAlways,
-				Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-					Spec: kubevirtv1.VirtualMachineInstanceSpec{
-						Domain: kubevirtv1.DomainSpec{
-							CPU:    &kubevirtv1.CPU{Cores: o.Cores},
-							Memory: &kubevirtv1.Memory{Guest: &guestQuantity},
-							Devices: kubevirtv1.Devices{
-								Disks: []kubevirtv1.Disk{
-									{
-										Name: "containervolume",
-										DiskDevice: kubevirtv1.DiskDevice{
-											Disk: &kubevirtv1.DiskTarget{
-												Bus: "virtio",
-											},
-										},
-									},
-								},
-								Interfaces: []kubevirtv1.Interface{
-									kubevirtv1.Interface{
-										Name: "default",
-										InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
-											Bridge: &kubevirtv1.InterfaceBridge{},
-										},
-									},
-								},
-							},
-						},
-						Volumes: []kubevirtv1.Volume{
-							{
-								Name: "containervolume",
-								VolumeSource: kubevirtv1.VolumeSource{
-									ContainerDisk: &kubevirtv1.ContainerDiskSource{
-										Image: o.ContainerDiskImage,
-									},
-								},
-							},
-						},
-						Networks: []kubevirtv1.Network{
-							kubevirtv1.Network{
-								Name: "default",
-								NetworkSource: kubevirtv1.NetworkSource{
-									Pod: &kubevirtv1.PodNetwork{},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+	// TODO (nargaman): replace with official container image, after RFE-2501 is completed
+	// As long as there is no official container image
+	// The image must be provided by user
+	// Otherwise it must fail
+	if (o.ContainerDiskImage != "" && o.ContainerDiskRepo != "") && (o.RootVolumeSize > 0 || o.RootVolumeStorageClass != "") {
+		return errors.New("container disk options (\"--containerdisk*\" flag) can not be used together with customized root volume options (\"--root-volume-*\" flags)")
 	}
+	if o.ContainerDiskRepo != "" {
+		o.ContainerDiskImage = fmt.Sprintf("%v:%v", o.ContainerDiskRepo, util.RHCOSOpenStackChecksumParameter)
+	}
+	nodePool.Spec.Platform.Kubevirt = fixtures.ExampleKubeVirtTemplate(&fixtures.ExampleKubevirtOptions{
+		Memory:                 o.Memory,
+		Cores:                  o.Cores,
+		Image:                  o.ContainerDiskImage,
+		RootVolumeSize:         o.RootVolumeSize,
+		RootVolumeStorageClass: o.RootVolumeStorageClass,
+	})
 	return nil
 }
 

--- a/cmd/util/kubevirt.go
+++ b/cmd/util/kubevirt.go
@@ -1,0 +1,11 @@
+package util
+
+import "k8s.io/apimachinery/pkg/api/resource"
+
+const (
+	RHCOSOpenStackChecksumParameter string = "{rhcos:openstack:checksum}"
+	RHCOSMagicVolumeName            string = "rhcos"
+	RHCOSOpenStackURLParam          string = "{rhcos:openstack:url}"
+)
+
+var KubeVirtVolumeDefaultSize = resource.MustParse("16Gi")

--- a/docs/content/how-to/kubevirt-platform.md
+++ b/docs/content/how-to/kubevirt-platform.md
@@ -32,6 +32,43 @@ hypershift install
 
 ## Create a HostedCluster
 
+### Hosted cluster with automatic RHCOS version detection
+
+!!! note
+
+    RHCOS will be imported into a PVC. A working storage provider
+    is needed.
+
+```shell linenums="1"
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+
+hypershift create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas=3 \
+--pull-secret $PULL_SECRET \
+```
+
+### Hosted cluster with autodetected RHCOS container disk
+
+!!! note
+
+    This uses inofficial kubevirt community maintained containerdisks of
+    RHCOS. No working storage provider is needed.
+
+```shell linenums="1"
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+
+hypershift create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas=3 \
+--pull-secret $PULL_SECRET \
+--containerdisk-repository quay.io/containerdisks/rhcos \
+```
+
+### Hosted cluster with a custom RHCOS container disk (development)
+
 Create a new cluster, specifying the RHCOS container disk image and the pull secret
 provided in the [Prerequisites](#prerequisites):
 

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	k8s.io/kube-scheduler v0.23.1
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 	kubevirt.io/api v0.0.0-20211117075245-c94ce62baf5a
+	kubevirt.io/containerized-data-importer-api v1.41.0
 	sigs.k8s.io/apiserver-network-proxy v0.0.24
 	sigs.k8s.io/cluster-api v1.0.2
 	sigs.k8s.io/cluster-api-provider-aws v1.1.0
@@ -119,7 +120,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
-	kubevirt.io/containerized-data-importer-api v1.41.0 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk v0.2.1 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect

--- a/hypershift-operator/controllers/nodepool/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt.go
@@ -1,15 +1,44 @@
 package nodepool
 
 import (
+	"strings"
+
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 )
 
-func kubevirtMachineTemplateSpec(nodePool *hyperv1.NodePool) *capikubevirt.KubevirtMachineTemplateSpec {
+const (
+	rhcosOpenStackChecksumParam string = "{rhcos:openstack:checksum}"
+	rhcosOpenStackURLParam      string = "{rhcos:openstack:url}"
+)
+
+func kubevirtMachineTemplateSpec(nodePool *hyperv1.NodePool, rhcosInfo kubevirtRHCOSDetails) *capikubevirt.KubevirtMachineTemplateSpec {
+
+	template := nodePool.Spec.Platform.Kubevirt.NodeTemplate.DeepCopy()
+
+	dataVolumeTemplates := template.Spec.DataVolumeTemplates
+	for i, dv := range dataVolumeTemplates {
+		if dv.Spec.Source != nil && dv.Spec.Source.Registry != nil &&
+			dv.Spec.Source.Registry.URL != nil && strings.Contains(*dv.Spec.Source.Registry.URL, rhcosOpenStackChecksumParam) {
+			image := strings.ReplaceAll(*dv.Spec.Source.Registry.URL, rhcosOpenStackChecksumParam, rhcosInfo.Checksum)
+			dataVolumeTemplates[i].Spec.Source.Registry.URL = &image
+		}
+		if dv.Spec.Source != nil && dv.Spec.Source.HTTP != nil &&
+			strings.Contains(dv.Spec.Source.HTTP.URL, rhcosOpenStackURLParam) {
+			url := strings.ReplaceAll(dv.Spec.Source.HTTP.URL, rhcosOpenStackURLParam, rhcosInfo.OpenStackDownloadURL)
+			dataVolumeTemplates[i].Spec.Source.HTTP.URL = url
+		}
+	}
+	volumes := template.Spec.Template.Spec.Volumes
+	for i, volume := range volumes {
+		if volume.ContainerDisk != nil && strings.Contains(volume.ContainerDisk.Image, rhcosOpenStackChecksumParam) {
+			volumes[i].ContainerDisk.Image = strings.ReplaceAll(volume.ContainerDisk.Image, rhcosOpenStackChecksumParam, rhcosInfo.Checksum)
+		}
+	}
 	return &capikubevirt.KubevirtMachineTemplateSpec{
 		Template: capikubevirt.KubevirtMachineTemplateResource{
 			Spec: capikubevirt.KubevirtMachineSpec{
-				VirtualMachineTemplate: *nodePool.Spec.Platform.Kubevirt.NodeTemplate,
+				VirtualMachineTemplate: *template,
 			},
 		},
 	}

--- a/hypershift-operator/controllers/nodepool/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt_test.go
@@ -47,7 +47,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := kubevirtMachineTemplateSpec(tc.nodePool)
+			result := kubevirtMachineTemplateSpec(tc.nodePool, kubevirtRHCOSDetails{})
 			if !equality.Semantic.DeepEqual(tc.expected, result) {
 				t.Errorf(cmp.Diff(tc.expected, result))
 			}
@@ -69,7 +69,7 @@ func generateNodeTemplate(memory string, cpu uint32, image string) *capikubevirt
 						Devices: kubevirtv1.Devices{
 							Disks: []kubevirtv1.Disk{
 								{
-									Name: "containervolume",
+									Name: "rhcos",
 									DiskDevice: kubevirtv1.DiskDevice{
 										Disk: &kubevirtv1.DiskTarget{
 											Bus: "virtio",
@@ -81,7 +81,7 @@ func generateNodeTemplate(memory string, cpu uint32, image string) *capikubevirt
 					},
 					Volumes: []kubevirtv1.Volume{
 						{
-							Name: "containervolume",
+							Name: "rhcos",
 							VolumeSource: kubevirtv1.VolumeSource{
 								ContainerDisk: &kubevirtv1.ContainerDiskSource{
 									Image: image,

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -919,7 +919,7 @@ func RunTestMachineTemplateBuilders(t *testing.T, preCreateMachineTemplate bool)
 	expectedMachineTemplateSpecJSON, err := json.Marshal(expectedMachineTemplate.Spec)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	template, mutateTemplate, machineTemplateSpecJSON, err := machineTemplateBuilders(hcluster, nodePool, infraID, ami)
+	template, mutateTemplate, machineTemplateSpecJSON, err := machineTemplateBuilders(hcluster, nodePool, infraID, &rhcosDetails{AWS: awsRHCOSDetails{AMI: ami}})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(machineTemplateSpecJSON).To(BeIdenticalTo(string(expectedMachineTemplateSpecJSON)))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The RHCOS version is now automatically detected based on the release payload. In order to leverage this new information, new ways exist to inject a proper RHCOS image into the NodePool:

***Full automatic injection***

In this case users simply don't specify a root disk on the NodePool teample. Hypershift will figure out the right RHCOS version and inject a DataVolume which imports the correct RHCOS version from the official RHCOS openstack download sources. The new commandline flags `--root-volume-storage-class` and `--root-volume-size` flags can be used to fill the new `KubeVirtRootVolume` API parts of the platform.

If a working storage provider is present, a cluster can now be created like this:

```bash
$ hypershift create cluster kubevirt --pull-secret /home/rmohr/pull-secret.txt
```

or in a more advanced example

```bash
$ hypershift create cluster kubevirt --pull-secret /home/rmohr/pull-secret.txt --root-volume-size 16 --root-volume-storage-class=myblockstorageclass
```

***ContainerDisk***

 The checksum is used to cross-reference the
release payload version with the quay.io/containerdisks/rhcos version.

Check for containerDisks or DataVolumeTemplates which are named
`rhcos` and have in their container source `{rhcos:openstack:checksum}`
set and replace it with the discovered rhcos container version.

As an example: `quay.io/containerdisks/rhcos:{rhcos:openstack:checksum} would be
replaced be modified to `quay.io/containerdisks/rhcos:mytag`, if `mytag`
would be discovered in the release payload.

On the `hypershift` client, a new flag called `--containerdisk-repository` was added to the kubevirt platform which can be pointend to any rhcos repository (e.g. `quay.io/containerdisks/rhcos`) which contains containerdisks which are tagged with the `sha256sum` of the openstack qcow2 image of rhcos.

A minimal example to make use of this feature is

```bash
$ hypershift create cluster kubevirt --pull-secret /home/rmohr/pull-secret.txt --containerdisk-repository quay.io/containerdisks/rhcos
```

***Customized HTTP DataVolume import***

Checks for a DataVolumeTemplates which is named
`rhcos` and have in its http source `{rhcos:openstack:url}`
set and replace it with the discovered rhcos download url.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.