### PR TITLE
Hypershift operator: Enable leader election by default

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -98,7 +98,7 @@ func NewStartCommand() *cobra.Command {
 		Namespace:                        "hypershift",
 		DeploymentName:                   "operator",
 		MetricsAddr:                      "0",
-		EnableLeaderElection:             false,
+		EnableLeaderElection:             true,
 		ControlPlaneOperatorImage:        "",
 		IgnitionServerImage:              "",
 		RegistryOverrides:                map[string]string{},
@@ -142,12 +142,13 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.UserAgent = "hypershift-operator-manager"
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme:                     hyperapi.Scheme,
-		MetricsBindAddress:         opts.MetricsAddr,
-		Port:                       9443,
-		LeaderElection:             opts.EnableLeaderElection,
-		LeaderElectionID:           "hypershift-operator-leader-elect",
-		LeaderElectionResourceLock: "leases",
+		Scheme:                        hyperapi.Scheme,
+		MetricsBindAddress:            opts.MetricsAddr,
+		Port:                          9443,
+		LeaderElection:                opts.EnableLeaderElection,
+		LeaderElectionID:              "hypershift-operator-leader-elect",
+		LeaderElectionResourceLock:    "leases",
+		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)


### PR DESCRIPTION
We don't currently use leader election, which means that if the operator
image gets updated, we have two concurrent operators running that race
with each other, leading to a lot of back-and-forth updates to the
deployments created for a hostedcluster:

```
$ k get pod
NAME                                              READY   STATUS              RESTARTS      AGE
capi-provider-6b845f68d7-28clq                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-28dzq                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-2zljk                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-2zrgg                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-45qj4                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-47ffw                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-4jzpt                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-4z562                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-4zjpz                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-5bp6d                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-5pw7c                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-bb29l                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-bnzcs                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-d95r6                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-fkj28                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-fp5l2                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-g55rm                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-hlbrb                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-jpb2g                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-km4b8                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-lhnmt                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-lmdvr                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-mtg4k                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-mw6gf                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-mxwbg                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-n7pxb                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-nln8z                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-q4b6f                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-qb8fd                    0/2     ContainerCreating   0             10m
capi-provider-6b845f68d7-qv7qv                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-r2b4w                    0/2     Terminating         0             10m
capi-provider-6b845f68d7-smjdq                    0/2     Terminating         0             11m
capi-provider-6b845f68d7-zhxdc                    0/2     Terminating         0             11m
capi-provider-7ff8f49968-jfv6c                    2/2     Running             0             55m
catalog-operator-7988c5f9cc-rts2x                 2/2     Running             0             54m
certified-operators-catalog-84444d865c-258sz      1/1     Running             0             54m
cluster-api-79dfb4dbc6-2bp5n                      1/1     Running             0             55m
cluster-autoscaler-6f59467757-5hhmh               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-8hv5t               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-bgv5l               0/1     Terminating         0             10m
cluster-autoscaler-6f59467757-c4cjw               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-flvnf               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-gndfj               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-hrfjf               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-k6z84               0/1     Terminating         0             10m
cluster-autoscaler-6f59467757-kdlg4               0/1     Terminating         0             10m
cluster-autoscaler-6f59467757-kp5kw               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-kqrbv               0/1     Terminating         0             10m
cluster-autoscaler-6f59467757-kvfll               0/1     Terminating         0             10m
cluster-autoscaler-6f59467757-lqd9h               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-mg5r9               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-njz4h               0/1     Terminating         0             10m
cluster-autoscaler-6f59467757-nr29q               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-pvv9d               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-q6hzj               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-qqmsx               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-s5d8n               0/1     Terminating         0             10m
cluster-autoscaler-6f59467757-srkz5               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-tvxvl               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-xmp5p               0/1     Terminating         0             11m
cluster-autoscaler-6f59467757-zf4lw               1/1     Running             0             10m
cluster-policy-controller-5fc487cb9c-28fmh        1/1     Running             0             54m
cluster-version-operator-6bf45779cc-v4xsn         2/2     Running             0             54m
community-operators-catalog-6c9c87f477-c79h9      1/1     Running             0             54m
control-plane-operator-67dc5d8dbb-2pt84           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-2rl7v           0/2     Terminating         0             10m
control-plane-operator-67dc5d8dbb-4858v           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-4nbvt           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-56p8k           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-84pfz           0/2     Terminating         0             10m
control-plane-operator-67dc5d8dbb-fx9jb           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-hb6kj           0/2     Terminating         0             10m
control-plane-operator-67dc5d8dbb-hbfg8           0/2     Terminating         0             10m
control-plane-operator-67dc5d8dbb-hdwpr           0/2     Terminating         0             10m
control-plane-operator-67dc5d8dbb-hn5d9           0/2     Terminating         0             10m
control-plane-operator-67dc5d8dbb-hxc8t           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-j7nz9           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-nvrh5           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-q8xbx           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-r2clk           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-rc5zf           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-sbw5t           0/2     Terminating         0             10m
control-plane-operator-67dc5d8dbb-t28rb           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-vd52q           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-vhzgn           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-w2xcp           0/2     Terminating         0             11m
control-plane-operator-67dc5d8dbb-whszr           0/2     Terminating         0             10m
control-plane-operator-67dc5d8dbb-x5c9m           0/2     Terminating         0             10m
control-plane-operator-67dc5d8dbb-xlxfr           0/2     ErrImagePull        0             10m
control-plane-operator-67dc5d8dbb-xpkz2           0/2     Terminating         0             11m
control-plane-operator-7bb78d485c-wlbkt           2/2     Running             0             55m
etcd-0                                            1/1     Running             0             54m
hosted-cluster-config-operator-5dfdb8d5cc-6srvb   1/1     Running             0             54m
ignition-server-6ccb8b64f6-4wglt                  0/1     Terminating         0             10m
ignition-server-6ccb8b64f6-59m7w                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-6xdkz                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-c7qpr                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-czjfc                  1/1     Terminating         0             11m
ignition-server-6ccb8b64f6-d7f9t                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-dhrx8                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-gl688                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-gv4dl                  1/1     Running             0             10m
ignition-server-6ccb8b64f6-j6n8l                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-kcbpz                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-l6b4h                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-mg9pf                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-mpw42                  0/1     Terminating         0             10m
ignition-server-6ccb8b64f6-nrklr                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-p4sn2                  0/1     Terminating         0             10m
ignition-server-6ccb8b64f6-pbhck                  0/1     Terminating         0             10m
ignition-server-6ccb8b64f6-qjqsh                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-r8gk8                  0/1     Terminating         0             10m
ignition-server-6ccb8b64f6-tg6bc                  0/1     Terminating         0             11m
ignition-server-6ccb8b64f6-vqgk9                  0/1     Terminating         0             10m
ignition-server-6ccb8b64f6-w62dc                  0/1     Terminating         0             10m
ignition-server-6ccb8b64f6-w68v4                  0/1     Terminating         0             11m
ingress-operator-74b4db76b9-slhcn                 2/2     Running             0             54m
konnectivity-agent-6788687c47-4mb4j               1/1     Running             0             54m
konnectivity-server-547f658b58-92ll8              1/1     Running             0             54m
kube-apiserver-676988bdf6-fgp7g                   3/3     Running             0             54m
kube-controller-manager-5847488777-5c82z          2/2     Running             0             47m
kube-scheduler-799b7595c4-tqqms                   1/1     Running             0             54m
machine-approver-58699bcb7c-2dwwq                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-429fm                 0/1     Terminating         0             10m
machine-approver-58699bcb7c-6bcrb                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-6g5sq                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-7nmnq                 0/1     Terminating         0             10m
machine-approver-58699bcb7c-8bgqh                 0/1     Terminating         0             10m
machine-approver-58699bcb7c-8dvdh                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-9b2lh                 0/1     Terminating         0             10m
machine-approver-58699bcb7c-cdhps                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-chstn                 0/1     Terminating         0             10m
machine-approver-58699bcb7c-f9vq7                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-fntfw                 0/1     Terminating         0             10m
machine-approver-58699bcb7c-ft8vt                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-g4h7p                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-gkg4v                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-gm5r4                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-gvt4w                 0/1     Terminating         0             10m
machine-approver-58699bcb7c-lvnl4                 1/1     Running             0             10m
machine-approver-58699bcb7c-rmpdl                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-s5k7s                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-x5zzv                 0/1     Terminating         0             11m
machine-approver-58699bcb7c-zsms4                 0/1     Terminating         0             11m
oauth-openshift-7954d645f7-vl7c8                  1/1     Running             0             51m
olm-operator-859f5dbc88-4l2lx                     2/2     Running             0             54m
openshift-apiserver-65b4fc75cf-zm7mh              2/2     Running             0             47m
openshift-controller-manager-899cb75cb-rppgt      1/1     Running             0             54m
openshift-oauth-apiserver-5c48665d66-7wrxx        1/1     Running             1 (50m ago)   54m
packageserver-74f6b84675-wsp5q                    2/2     Running             0             54m
redhat-marketplace-catalog-85dc87f8c5-xpb5b       1/1     Running             0             54m
redhat-operators-catalog-55fd67689d-dss7d         1/1     Running             0             54m
```

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.