### PR TITLE
Enable etcd encryption by default, support STS creds for AWS KMS provider

### DIFF
--- a/api/fixtures/example_aws.go
+++ b/api/fixtures/example_aws.go
@@ -9,6 +9,7 @@ type ExampleAWSResources struct {
 	KubeCloudControllerAWSCreds  *corev1.Secret
 	NodePoolManagementAWSCreds   *corev1.Secret
 	ControlPlaneOperatorAWSCreds *corev1.Secret
+	KMSProviderAWSCreds          *corev1.Secret
 }
 
 func (o *ExampleAWSResources) AsObjects() []crclient.Object {
@@ -21,6 +22,9 @@ func (o *ExampleAWSResources) AsObjects() []crclient.Object {
 	}
 	if o.ControlPlaneOperatorAWSCreds != nil {
 		objects = append(objects, o.ControlPlaneOperatorAWSCreds)
+	}
+	if o.KMSProviderAWSCreds != nil {
+		objects = append(objects, o.KMSProviderAWSCreds)
 	}
 	return objects
 }

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -44,6 +44,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().Int64Var(&opts.AWSPlatform.RootVolumeSize, "root-volume-size", opts.AWSPlatform.RootVolumeSize, "The size of the root volume (min: 8) for machines in the NodePool")
 	cmd.Flags().StringSliceVar(&opts.AWSPlatform.AdditionalTags, "additional-tags", opts.AWSPlatform.AdditionalTags, "Additional tags to set on AWS resources")
 	cmd.Flags().StringVar(&opts.AWSPlatform.EndpointAccess, "endpoint-access", opts.AWSPlatform.EndpointAccess, "Access for control plane endpoints (Public, PublicAndPrivate, Private)")
+	cmd.Flags().StringVar(&opts.AWSPlatform.EtcdKMSKeyARN, "kms-key-arn", opts.AWSPlatform.EtcdKMSKeyARN, "The ARN of the KMS key to use for Etcd encryption. If not supplied, etcd encryption will default to using a generated AESCBC key.")
 
 	cmd.MarkFlagRequired("aws-creds")
 
@@ -134,6 +135,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			PrivateZoneID:      infra.PrivateZoneID,
 			PublicZoneID:       infra.PublicZoneID,
 			LocalZoneID:        infra.LocalZoneID,
+			KMSKeyARN:          opts.AWSPlatform.EtcdKMSKeyARN,
 		}
 		iamInfo, err = opt.CreateIAM(ctx, client)
 		if err != nil {
@@ -174,6 +176,8 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		KubeCloudControllerRoleARN:  iamInfo.KubeCloudControllerRoleARN,
 		NodePoolManagementRoleARN:   iamInfo.NodePoolManagementRoleARN,
 		ControlPlaneOperatorRoleARN: iamInfo.ControlPlaneOperatorRoleARN,
+		KMSProviderRoleARN:          iamInfo.KMSProviderRoleARN,
+		KMSKeyARN:                   iamInfo.KMSKeyARN,
 		RootVolumeSize:              opts.AWSPlatform.RootVolumeSize,
 		RootVolumeType:              opts.AWSPlatform.RootVolumeType,
 		RootVolumeIOPS:              opts.AWSPlatform.RootVolumeIOPS,

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -92,6 +92,7 @@ type AWSPlatformOptions struct {
 	RootVolumeType     string
 	EndpointAccess     string
 	Zones              []string
+	EtcdKMSKeyARN      string
 }
 
 func createCommonFixture(opts *CreateOptions) (*apifixtures.ExampleOptions, error) {

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -35,6 +35,7 @@ type CreateIAMOptions struct {
 	InfraID                         string
 	IssuerURL                       string
 	OutputFile                      string
+	KMSKeyARN                       string
 	AdditionalTags                  []string
 
 	additionalIAMTags []*iam.Tag
@@ -46,10 +47,12 @@ type CreateIAMOutput struct {
 	InfraID     string                       `json:"infraID"`
 	IssuerURL   string                       `json:"issuerURL"`
 	Roles       []hyperv1.AWSRoleCredentials `json:"roles"`
+	KMSKeyARN   string                       `json:"kmsKeyARN"`
 
 	KubeCloudControllerRoleARN  string `json:"kubeCloudControllerRoleARN"`
 	NodePoolManagementRoleARN   string `json:"nodePoolManagementRoleARN"`
 	ControlPlaneOperatorRoleARN string `json:"controlPlaneOperatorRoleARN"`
+	KMSProviderRoleARN          string `json:"kmsProviderRoleARN"`
 }
 
 func NewCreateIAMCommand() *cobra.Command {
@@ -74,6 +77,7 @@ func NewCreateIAMCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.PublicZoneID, "public-zone-id", opts.PublicZoneID, "The id of the clusters public route53 zone")
 	cmd.Flags().StringVar(&opts.PrivateZoneID, "private-zone-id", opts.PrivateZoneID, "The id of the cluters private route53 zone")
 	cmd.Flags().StringVar(&opts.LocalZoneID, "local-zone-id", opts.LocalZoneID, "The id of the clusters local route53 zone")
+	cmd.Flags().StringVar(&opts.KMSKeyARN, "kms-key-arn", opts.KMSKeyARN, "The ARN of the KMS key to use for Etcd encryption. If not supplied, etcd encryption will default to using a generated AESCBC key.")
 	cmd.Flags().StringSliceVar(&opts.AdditionalTags, "additional-tags", opts.AdditionalTags, "Additional tags to set on AWS resources")
 
 	cmd.MarkFlagRequired("aws-creds")
@@ -162,6 +166,7 @@ func (o *CreateIAMOptions) CreateIAM(ctx context.Context, client crclient.Client
 	}
 	profileName := DefaultProfileName(o.InfraID)
 	results.ProfileName = profileName
+	results.KMSKeyARN = o.KMSKeyARN
 	err = o.CreateWorkerInstanceProfile(iamClient, profileName)
 	if err != nil {
 		return nil, err

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -135,6 +135,9 @@ func (o *DestroyIAMOptions) DestroyOIDCResources(ctx context.Context, iamClient 
 	if err := o.DestroyOIDCRole(iamClient, "cloud-network-config-controller"); err != nil {
 		return err
 	}
+	if err := o.DestroyOIDCRole(iamClient, "kms-provider"); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -206,7 +206,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 					return err
 				}
 			case hyperv1.AWS:
-				err := applyAWSKMSConfig(&deployment.Spec.Template.Spec, secretEncryptionData.KMS.AWS.ActiveKey, secretEncryptionData.KMS.AWS.BackupKey, secretEncryptionData.KMS.AWS.Auth, secretEncryptionData.KMS.AWS.Region, images.AWSKMS)
+				err := applyAWSKMSConfig(&deployment.Spec.Template.Spec, secretEncryptionData.KMS.AWS.ActiveKey, secretEncryptionData.KMS.AWS.BackupKey, secretEncryptionData.KMS.AWS.Auth, secretEncryptionData.KMS.AWS.Region, images.AWSKMS, images.TokenMinterImage)
 				if err != nil {
 					return err
 				}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -87,6 +87,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			CLI:                   images["cli"],
 			ClusterConfigOperator: images["cluster-config-operator"],
 			TokenMinterImage:      images["token-minter"],
+			AWSKMS:                images["aws-kms-provider"],
 		},
 	}
 	if hcp.Spec.APIAdvertiseAddress != nil {

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -64,6 +64,9 @@ const (
 	// TODO: Include konnectivity image in release payload
 	konnectivityServerImage = "registry.ci.openshift.org/hypershift/apiserver-network-proxy:latest"
 	konnectivityAgentImage  = "registry.ci.openshift.org/hypershift/apiserver-network-proxy:latest"
+
+	// Default AWS KMS provider image. Can be overriden with annotation on HostedCluster
+	awsKMSProviderImage = "registry.ci.openshift.org/hypershift/aws-encryption-provider:latest"
 )
 
 func NewStartCommand() *cobra.Command {
@@ -230,6 +233,7 @@ func NewStartCommand() *cobra.Command {
 					"konnectivity-agent":             konnectivityAgentImage,
 					"socks5-proxy":                   socks5ProxyImage,
 					"token-minter":                   tokenMinterImage,
+					"aws-kms-provider":               awsKMSProviderImage,
 				},
 			},
 			RegistryOverrides: registryOverrides,


### PR DESCRIPTION

**What this PR does / why we need it**:
[CLI: encrypt etcd by default](https://github.com/openshift/hypershift/commit/a2aba330d83a2a621d28f959385f2da0ae555d4d)
Adds flag `--aws-kms-key` to both `create iam aws` and
`create cluster aws` commands to allow specifying an existing KMS key to
use in encrypting etcd secrets. If this flag is specified, an IAM role
is created that allows the kms encryption plugin to use the key for
encryption/decryption.

If no KMS key is specified, a 32-byte AESCBC key is generated and
configured as the default encryption method.

[Set the default AWS KMS provider image](https://github.com/openshift/hypershift/commit/2349ab0003b2638df9dfb20396ebc3db48df4b21)
The AWS KMS provider is now built by CI under the hypershift
organization. This sets up the image built by CI as the default image
used by the Kube API server when creating the KMS provider container.
The image can still be overriden by an annotation on the HostedCluster
resource.

[Add token minter for kms provider plugin on KAS deployment](https://github.com/openshift/hypershift/commit/0af9ba0a859a42e391fb87d6ba3858f4aff4b7b7)
The STS role (and credential) that we now generate for the AWS KMS
provider requires that the KMS provider have access to the token that
corresponds to the credential. This change adds an additional container
to mint the service account token so that the KMS provider can use it.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/HOSTEDCP-318

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.