### PR TITLE
Re-Enable guest cluster dump in e2e

### DIFF
--- a/test/e2e/util/dump/dump.go
+++ b/test/e2e/util/dump/dump.go
@@ -16,7 +16,7 @@ import (
 // DumpHostedCluster dumps the contents of the hosted cluster to the given artifact
 // directory, and returns an error if any aspect of that operation fails. The loop
 // detector is configured to return an error when any warnings are detected.
-func DumpHostedCluster(ctx context.Context, hc *hyperv1.HostedCluster, artifactDir string) error {
+func DumpHostedCluster(ctx context.Context, hc *hyperv1.HostedCluster, dumpGuestCluster bool, artifactDir string) error {
 	var allErrors []error
 	findKubeObjectUpdateLoops := func(filename string, content []byte) {
 		if bytes.Contains(content, []byte(upsert.LoopDetectorWarningMessage)) {
@@ -24,10 +24,11 @@ func DumpHostedCluster(ctx context.Context, hc *hyperv1.HostedCluster, artifactD
 		}
 	}
 	err := core.DumpCluster(ctx, &core.DumpOptions{
-		Namespace:   hc.Namespace,
-		Name:        hc.Name,
-		ArtifactDir: artifactDir,
-		LogCheckers: []core.LogChecker{findKubeObjectUpdateLoops},
+		Namespace:        hc.Namespace,
+		Name:             hc.Name,
+		ArtifactDir:      artifactDir,
+		LogCheckers:      []core.LogChecker{findKubeObjectUpdateLoops},
+		DumpGuestCluster: dumpGuestCluster,
 	})
 	if err != nil {
 		allErrors = append(allErrors, fmt.Errorf("failed to dump cluster: %w", err))

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -103,13 +103,11 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 
 	// First, do a dump of the cluster before tearing it down
 	t.Run("PreTeardownClusterDump", func(t *testing.T) {
-		err := dumpCluster(ctx, t)
+		err := dumpCluster(ctx, t, true)
 		if err != nil {
 			t.Errorf("Failed to dump cluster: %v", err)
 		}
 	})
-
-	// TODO: DumpGuestCluster was taking far too long and so was disabled. This needs revisited.
 
 	// Try repeatedly to destroy the cluster gracefully. For each failure, dump
 	// the current cluster to help debug teardown lifecycle issues.
@@ -120,7 +118,7 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 			err := destroyCluster(ctx, hc, opts)
 			if err != nil {
 				t.Logf("Failed to destroy cluster, will retry: %v", err)
-				err := dumpCluster(ctx, t)
+				err := dumpCluster(ctx, t, false)
 				if err != nil {
 					t.Logf("Failed to dump cluster during destroy; this is nonfatal: %v", err)
 				}
@@ -149,7 +147,7 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 		err := DeleteNamespace(t, deleteTimeout, client, hc.Name)
 		if err != nil {
 			t.Errorf("Failed to delete test namespace: %v", err)
-			err := dumpCluster(ctx, t)
+			err := dumpCluster(ctx, t, false)
 			if err != nil {
 				t.Errorf("Failed to dump cluster: %v", err)
 			}
@@ -223,8 +221,8 @@ func destroyCluster(ctx context.Context, hc *hyperv1.HostedCluster, createOpts *
 // a cluster based on the cluster's platform. The output directory will be named
 // according to the test name. So, the returned dump function should be called
 // at most once per unique test name.
-func newClusterDumper(hc *hyperv1.HostedCluster, opts *core.CreateOptions, artifactDir string) func(ctx context.Context, t *testing.T) error {
-	return func(ctx context.Context, t *testing.T) error {
+func newClusterDumper(hc *hyperv1.HostedCluster, opts *core.CreateOptions, artifactDir string) func(ctx context.Context, t *testing.T, dumpGuestCluster bool) error {
+	return func(ctx context.Context, t *testing.T, dumpGuestCluster bool) error {
 		if len(artifactDir) == 0 {
 			t.Logf("Skipping cluster dump because no artifact directory was provided")
 			return nil
@@ -238,7 +236,7 @@ func newClusterDumper(hc *hyperv1.HostedCluster, opts *core.CreateOptions, artif
 			if err != nil {
 				t.Logf("Failed saving machine console logs; this is nonfatal: %v", err)
 			}
-			err = dump.DumpHostedCluster(ctx, hc, dumpDir)
+			err = dump.DumpHostedCluster(ctx, hc, dumpGuestCluster, dumpDir)
 			if err != nil {
 				dumpErrors = append(dumpErrors, fmt.Errorf("failed to dump hosted cluster: %w", err))
 			}
@@ -248,7 +246,7 @@ func newClusterDumper(hc *hyperv1.HostedCluster, opts *core.CreateOptions, artif
 			}
 			return utilerrors.NewAggregate(dumpErrors)
 		case hyperv1.NonePlatform, hyperv1.KubevirtPlatform:
-			err := dump.DumpHostedCluster(ctx, hc, dumpDir)
+			err := dump.DumpHostedCluster(ctx, hc, dumpGuestCluster, dumpDir)
 			if err != nil {
 				return fmt.Errorf("failed to dump hosted cluster: %w", err)
 			}


### PR DESCRIPTION
We really want this to be able to debug e2e runs that fail due to
clusteroperators not becoming ready. I tried this locally, and it
consistently takes ~90 seconds to do a dump (n=3) which seems
reasonable. To be sure, I also added a log that will show how long it
took in CI.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.