### PR TITLE
AWS: Use availability prober in capi provider

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -602,7 +602,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile Platform specifics.
-	p, err := platform.GetPlatform(hcluster)
+	p, err := platform.GetPlatform(hcluster, r.AvailabilityProberImage)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -883,7 +883,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile CAPI Provider Deployment.
-	capiProviderDeploymentSpec, err := p.CAPIProviderDeploymentSpec(hcluster, r.TokenMinterImage)
+	capiProviderDeploymentSpec, err := p.CAPIProviderDeploymentSpec(hcluster, r.TokenMinterImage, hcp)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -54,7 +54,7 @@ func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, create
 	return agentCluster, nil
 }
 
-func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := imageCAPAgent
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIAgentProviderImage]; ok {
 		providerImage = override

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
@@ -53,7 +53,7 @@ func (p IBMCloud) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, cre
 	return ibmCluster, nil
 }
 
-func (p IBMCloud) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+func (p IBMCloud) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	return nil, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -52,7 +52,7 @@ func reconcileKubevirtCluster(kubevirtCluster *capikubevirt.KubevirtCluster, hcl
 	kubevirtCluster.Status.Ready = true
 }
 
-func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := imageCAPK
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIKubeVirtProviderImage]; ok {
 		providerImage = override

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/none/none.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/none/none.go
@@ -19,7 +19,7 @@ func (p None) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createO
 	return nil, nil
 }
 
-func (p None) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error) {
+func (p None) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	return nil, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -37,7 +37,7 @@ type Platform interface {
 	// the CAPI provider Deployment.
 	// It should return a CAPI provider DeploymentSpec with the specific needs for a particular platform.
 	// E.g particular volumes and secrets for credentials, containers, etc.
-	CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string) (*appsv1.DeploymentSpec, error)
+	CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, tokenMinterImage string, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error)
 
 	// ReconcileCredentials is responsible for reconciling resources related to cloud credentials
 	// from the HostedCluster namespace into to the HostedControlPlaneNamespace. So they can be used by
@@ -59,11 +59,11 @@ type Platform interface {
 	CAPIProviderPolicyRules() []rbacv1.PolicyRule
 }
 
-func GetPlatform(hcluster *hyperv1.HostedCluster) (Platform, error) {
+func GetPlatform(hcluster *hyperv1.HostedCluster, availabilityProberImage string) (Platform, error) {
 	var platform Platform
 	switch hcluster.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
-		platform = &aws.AWS{}
+		platform = aws.New(availabilityProberImage)
 	case hyperv1.IBMCloudPlatform:
 		platform = &ibmcloud.IBMCloud{}
 	case hyperv1.NonePlatform:


### PR DESCRIPTION
The AWS capi provider currently always errors for some time during
startup when a new cluster is created, because there is no token,
because the KAS is not up yet so the token minter sidecar can't mint
one. This change makes us use the availability prober init container to
avoid going into backoff due to this.

Using the availability prober required two new things to be available to
the provider:
* The HCP in case it uses a non-default apiserver port
* The Availability prober image

For the first, the existing provider interface was extended, as we only
have construct the hcp right before calling CAPIProviderDeploymentSpec.

For the static availability prober image we avoid extending the
interface for every provider for something that is only needed by AWS by
passing it into the provider at construction time.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.