### PR TITLE
Cluster create CMD: change code structure to have platform separation

### DIFF
--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -10,8 +10,14 @@ import (
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/log"
 )
+
+type CreateOptions struct {
+	APIServerAddress   string
+	Memory             string
+	Cores              uint32
+	ContainerDiskImage string
+}
 
 func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd := &cobra.Command{
@@ -20,41 +26,24 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	opts.KubevirtPlatform = core.KubevirtPlatformCreateOptions{
+	platformOpts := CreateOptions{
 		Memory:             "4Gi",
 		Cores:              2,
 		ContainerDiskImage: "",
 	}
 
-	cmd.Flags().StringVar(&opts.KubevirtPlatform.Memory, "memory", opts.KubevirtPlatform.Memory, "The amount of memory which is visible inside the Guest OS (type BinarySI, e.g. 5Gi, 100Mi)")
-	cmd.Flags().Uint32Var(&opts.KubevirtPlatform.Cores, "cores", opts.KubevirtPlatform.Cores, "The number of cores inside the vmi, Must be a value greater or equal 1")
-	cmd.Flags().StringVar(&opts.KubevirtPlatform.ContainerDiskImage, "containerdisk", opts.KubevirtPlatform.ContainerDiskImage, "A reference to docker image with the embedded disk to be used to create the machines")
+	cmd.Flags().StringVar(&platformOpts.Memory, "memory", platformOpts.Memory, "The amount of memory which is visible inside the Guest OS (type BinarySI, e.g. 5Gi, 100Mi)")
+	cmd.Flags().Uint32Var(&platformOpts.Cores, "cores", platformOpts.Cores, "The number of cores inside the vmi, Must be a value greater or equal 1")
+	cmd.Flags().StringVar(&platformOpts.ContainerDiskImage, "containerdisk", platformOpts.ContainerDiskImage, "A reference to docker image with the embedded disk to be used to create the machines")
 
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
-		if opts.Timeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
-			defer cancel()
-		}
-
-		if err := CreateCluster(ctx, opts); err != nil {
-			log.Log.Error(err, "Failed to create cluster")
-			return err
-		}
-		return nil
-	}
+	cmd.RunE = opts.CreateRunFunc(&platformOpts)
 
 	return cmd
 }
 
-func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
-	return core.CreateCluster(ctx, opts, applyPlatformSpecificsValues)
-}
-
-func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
-	if opts.KubevirtPlatform.APIServerAddress == "" {
-		if opts.KubevirtPlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx); err != nil {
+func (o *CreateOptions) ApplyPlatformSpecifics(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
+	if o.APIServerAddress == "" {
+		if o.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx); err != nil {
 			return err
 		}
 	}
@@ -64,12 +53,12 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		// As long as there is no official container image
 		// The image must be provided by user
 		// Otherwise it must fail
-		if opts.KubevirtPlatform.ContainerDiskImage == "" {
+		if o.ContainerDiskImage == "" {
 			return errors.New("the container disk image for the Kubevirt machine must be provided by user (\"--containerdisk\" flag)")
 		}
 	}
 
-	if opts.KubevirtPlatform.Cores < 1 {
+	if o.Cores < 1 {
 		return errors.New("the number of cores inside the machine must be a value greater or equal 1")
 	}
 
@@ -81,10 +70,10 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	exampleOptions.BaseDomain = "example.com"
 
 	exampleOptions.Kubevirt = &apifixtures.ExampleKubevirtOptions{
-		APIServerAddress: opts.KubevirtPlatform.APIServerAddress,
-		Memory:           opts.KubevirtPlatform.Memory,
-		Cores:            opts.KubevirtPlatform.Cores,
-		Image:            opts.KubevirtPlatform.ContainerDiskImage,
+		APIServerAddress: o.APIServerAddress,
+		Memory:           o.Memory,
+		Cores:            o.Cores,
+		Image:            o.ContainerDiskImage,
 	}
 	return nil
 }

--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -28,7 +28,9 @@ func TestAutoRepair(t *testing.T) {
 	defer cancel()
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
-	numZones := int32(len(clusterOpts.AWSPlatform.Zones))
+	awsClusterOpts := globalOpts.DefaultAWSClusterOptions()
+
+	numZones := int32(len(awsClusterOpts.Zones))
 	if numZones <= 1 {
 		clusterOpts.NodePoolReplicas = 3
 	} else if numZones == 2 {
@@ -38,7 +40,7 @@ func TestAutoRepair(t *testing.T) {
 	}
 	clusterOpts.AutoRepair = true
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, &awsClusterOpts, globalOpts.ArtifactDir)
 
 	// Perform some very basic assertions about the guest cluster
 	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
@@ -56,7 +58,7 @@ func TestAutoRepair(t *testing.T) {
 	g.Expect(len(awsSpec)).NotTo(BeZero())
 	instanceID := awsSpec[strings.LastIndex(awsSpec, "/")+1:]
 	t.Logf("Terminating AWS instance: %s", instanceID)
-	ec2client := ec2Client(clusterOpts.AWSPlatform.AWSCredentialsFile, clusterOpts.AWSPlatform.Region)
+	ec2client := ec2Client(awsClusterOpts.AWSCredentialsFile, awsClusterOpts.Region)
 	_, err := ec2client.TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: []*string{aws.String(instanceID)},
 	})

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -29,11 +29,12 @@ func TestAutoscaling(t *testing.T) {
 	defer cancel()
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
+	awsClusterOpts := globalOpts.DefaultAWSClusterOptions()
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, &awsClusterOpts, globalOpts.ArtifactDir)
 
 	// Get one of the newly created NodePools
-	zone := clusterOpts.AWSPlatform.Zones[0]
+	zone := awsClusterOpts.Zones[0]
 	nodepool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedCluster.Namespace,
@@ -47,7 +48,7 @@ func TestAutoscaling(t *testing.T) {
 	// Perform some very basic assertions about the guest cluster
 	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
 	// TODO (alberto): have ability to label and get Nodes by NodePool. NodePool.Status.Nodes?
-	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(awsClusterOpts.Zones))
 	nodes := e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
 
 	// Wait for the rollout to be reported complete

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -36,10 +36,12 @@ func TestHAEtcdChaos(t *testing.T) {
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions()
+	awsClusterOpts := globalOpts.DefaultAWSClusterOptions()
+
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.NodePoolReplicas = 0
 
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, &awsClusterOpts, globalOpts.ArtifactDir)
 
 	t.Run("KillRandomMembers", testKillRandomMembers(ctx, client, cluster))
 	t.Run("KillAllMembers", testKillAllMembers(ctx, client, cluster))
@@ -57,10 +59,12 @@ func TestEtcdChaos(t *testing.T) {
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions()
+	awsClusterOpts := globalOpts.DefaultAWSClusterOptions()
+
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.NodePoolReplicas = 0
 
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, &awsClusterOpts, globalOpts.ArtifactDir)
 
 	t.Run("KillAllMembers", testKillAllMembers(ctx, client, cluster))
 }

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -25,17 +25,19 @@ func TestUpgradeControlPlane(t *testing.T) {
 	t.Logf("Starting control plane upgrade test. FromImage: %s, toImage: %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
+	awsClusterOpts := globalOpts.DefaultAWSClusterOptions()
+
 	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, &awsClusterOpts, globalOpts.ArtifactDir)
 
 	// Sanity check the cluster by waiting for the nodes to report ready
 	t.Logf("Waiting for guest client to become available")
 	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
 
 	// Wait for Nodes to be Ready
-	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(awsClusterOpts.Zones))
 	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
 
 	// Wait for the first rollout to be complete

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -40,7 +40,9 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 	client := e2eutil.GetClientOrDie()
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.KubevirtPlatform, globalOpts.ArtifactDir)
+	kubevirtClusterOpts := globalOpts.DefaultKubevirtClusterOptions()
+
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.KubevirtPlatform, &kubevirtClusterOpts, globalOpts.ArtifactDir)
 
 	waitForHostedClusterAvailable := func() {
 		start := time.Now()
@@ -105,9 +107,10 @@ func TestNoneCreateCluster(t *testing.T) {
 	client := e2eutil.GetClientOrDie()
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
+	noneClusterOpts := globalOpts.DefaultNoneClusterOptions()
 	clusterOpts.ControlPlaneAvailabilityPolicy = "SingleReplica"
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, &noneClusterOpts, globalOpts.ArtifactDir)
 
 	// Wait for the rollout to be reported complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -45,15 +45,17 @@ func TestOLM(t *testing.T) {
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions()
+	awsClusterOpts := globalOpts.DefaultAWSClusterOptions()
+
 	clusterOpts.NodePoolReplicas = 1
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, &awsClusterOpts, globalOpts.ArtifactDir)
 
 	// Get guest client
 	t.Logf("Waiting for guest client to become available")
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, cluster)
 
 	// Wait for guest cluster nodes to become available
-	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
+	numNodes := clusterOpts.NodePoolReplicas * int32(len(awsClusterOpts.Zones))
 	util.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
 
 	guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name


### PR DESCRIPTION
**What this PR does / why we need it**:
Change cluster create CMD to more "Object Oriented" structure, in order to have
more separation between platform parametes and behavior.
Each platform parameters should be handled and managed in the platform cmd object
and not in the core cmd object.
This change also affect e2e tests, changed the e2e tests to use the new objects structure.
This change is done as preparation for the following changes:
1. Change API server default publishing strategy for NONE platforms (issue #1009)
2. Change Cluster create CMD to use NodePool create CMD code (issue #1010)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.