### PR TITLE
Update ignition token rotation flow

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -65,6 +65,7 @@ const (
 	nodePoolAnnotationCurrentConfigVersion    = "hypershift.openshift.io/nodePoolCurrentConfigVersion"
 	nodePoolAnnotationPlatformMachineTemplate = "hypershift.openshift.io/nodePoolPlatformMachineTemplate"
 	nodePoolCoreIgnitionConfigLabel           = "hypershift.openshift.io/core-ignition-config"
+	TokenSecretTokenGenerationTime            = "hypershift.openshift.io/last-token-generation-time"
 	TokenSecretReleaseKey                     = "release"
 	TokenSecretTokenKey                       = "token"
 	TokenSecretConfigKey                      = "config"
@@ -448,7 +449,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		return ctrl.Result{}, fmt.Errorf("failed to compress config: %w", err)
 	}
 
-	// Token Secrets are immutable and follow "prefixName-configVersionHash" naming convention.
+	// Token Secrets exist for each NodePool config/version and follow "prefixName-configVersionHash" naming convention.
 	// Ensure old configVersionHash resources are deleted, i.e token Secret and userdata Secret.
 	if isUpdatingVersion || isUpdatingConfig {
 		tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfigVersion])
@@ -592,7 +593,10 @@ func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.No
 }
 
 func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool, compressedConfig []byte) error {
-	tokenSecret.Immutable = k8sutilspointer.BoolPtr(true)
+	// The token secret controller updates expired token IDs for token Secrets.
+	// When that happens the NodePool controller reconciles the userData Secret with the new token ID.
+	// Therefore this secret is mutable.
+	tokenSecret.Immutable = k8sutilspointer.BoolPtr(false)
 	if tokenSecret.Annotations == nil {
 		tokenSecret.Annotations = make(map[string]string)
 	}
@@ -602,6 +606,7 @@ func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool
 
 	if tokenSecret.Data == nil {
 		tokenSecret.Data = map[string][]byte{}
+		tokenSecret.Annotations[TokenSecretTokenGenerationTime] = time.Now().Format(time.RFC3339Nano)
 		tokenSecret.Data[TokenSecretTokenKey] = []byte(uuid.New().String())
 		tokenSecret.Data[TokenSecretReleaseKey] = []byte(nodePool.Spec.Release.Image)
 		tokenSecret.Data[TokenSecretConfigKey] = compressedConfig

--- a/ignition-server/README.md
+++ b/ignition-server/README.md
@@ -1,0 +1,19 @@
+# Ignition Server
+Ignition server is an HTTP request multiplexer.
+It serves Ignition payloads over the /ignition endpoint for a particular "Bearer $token" passed through the "Authorization" Header.
+
+## TokenSecret controller
+This is the controller that generates and caches the Ignition payloads served by the Ignition server.
+Each NodePool creates a token Secret for a given release/config pair.
+The TokenSecret controller watches token Secrets and:
+ - Maintain an in memory cache for token/release-config payload pairs.
+ - Manage the rotation of any token after the current one has lived TTL/2. This results in both tokens for the same release/config pair coexisting during a TTL/2 duration.
+ - Expires and eventually removes any token after the TTL.
+
+i.e a token is active a total of 22 hours, 11 main and then 11 in the rotated spot.
+
+## Ignition provider
+An interface to be implemented to produce a valid ignition payload out of a given release/config pair.
+
+### MachineConfigServer Provider
+An Ignition provider implementation which runs pods of the Machine Config Server ephemerally in order to produce a valid ignition payload.

--- a/ignition-server/controllers/cache.go
+++ b/ignition-server/controllers/cache.go
@@ -26,18 +26,16 @@ type entry struct {
 }
 
 func (c *ExpiringCache) Get(key string) (value CacheValue, ok bool) {
+	c.garbageCollect()
+
 	c.RLock()
 	defer c.RUnlock()
-
-	c.garbageCollect()
 
 	result, ok := c.cache[key]
 	if !ok {
 		return CacheValue{}, false
 	}
 
-	// Renew expiring time everytime time we Get.
-	result.expiry = time.Now().Add(c.ttl)
 	return result.value, ok
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this PR:
The ignition-server/tokensecret-controller would delete the token Secret after a UUID ttl expired eventhough it was containing same the version/config.

After this PR:
The token Secret is the same for the whole NodePool lifetime as far as the version/config pair does not change.
The ignition-server/tokensecret-controller manages token ID rotation by periodically creating a new tokenID for the existing Secret and persisting it in the cache.

This has some positive consequences:
- Rotation happens every time a token ID is beyond half of its ttl enabling an overlapping period of ttl/2 at max with the old token ID.
Overlapping fixes racing scenarios where a Machine is created with a userdata pointing to a tokenID that gets expired right before the Machine have the chance to boot and fetch ign config.

- During token ID rotation there's no need to invoke the ignition-provider implementation to generate a new payload since we are only rotating the tokenID but the value must remain the same for the lifecycle of the token Secret.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://github.com/openshift/hypershift/issues/1008

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.