### PR TITLE
RBAC manifest creation for Hosted Cluster admin personas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ app-sre-saas-template: hypershift
 		--oidc-storage-provider-s3-secret-key=credentials \
 		--enable-ocp-cluster-monitoring=false \
 		--enable-ci-debug-output=false \
+		--enable-admin-rbac-generation=true \
 		render --template --format yaml > $(DIR)/hack/app-sre/saas_template.yaml
 
 # Run tests

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -805,8 +805,6 @@ func (o HyperShiftClientClusterRoleBinding) Build() *rbacv1.ClusterRoleBinding {
 type HyperShiftReaderClusterRole struct{}
 
 func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
-	clusterOperatorRole := HyperShiftOperatorClusterRole{}.Build()
-
 	role := &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRole",
@@ -815,26 +813,101 @@ func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hypershift-readers",
 		},
-		Rules: make([]rbacv1.PolicyRule, len(clusterOperatorRole.Rules)),
-	}
-
-	// replace verbs on PolicyRules copied from the hypershift-operator clusterrole
-	for idx, policyRule := range clusterOperatorRole.Rules {
-		policyRule.Verbs = []string{"get", "list", "watch"}
-		// within the core group remove secrets
-		if policyRule.APIGroups[0] == "" {
-			policyRule.Resources = []string{
-				"events",
-				"configmaps",
-				"pods",
-				"pods/log",
-				"nodes",
-				"namespaces",
-				"serviceaccounts",
-				"services",
-			}
-		}
-		role.Rules[idx] = policyRule
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"hypershift.openshift.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"config.openshift.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"apiextensions.k8s.io"},
+				Resources: []string{"customresourcedefinitions"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"networkpolicies"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{
+					"bootstrap.cluster.x-k8s.io",
+					"controlplane.cluster.x-k8s.io",
+					"infrastructure.cluster.x-k8s.io",
+					"machines.cluster.x-k8s.io",
+					"exp.infrastructure.cluster.x-k8s.io",
+					"addons.cluster.x-k8s.io",
+					"exp.cluster.x-k8s.io",
+					"cluster.x-k8s.io",
+				},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"operator.openshift.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"route.openshift.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"security.openshift.io"},
+				Resources: []string{"securitycontextconstraints"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{
+					"events",
+					"configmaps",
+					"pods",
+					"pods/log",
+					"nodes",
+					"namespaces",
+					"serviceaccounts",
+					"services",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"etcd.database.coreos.com"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"machine.openshift.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"monitoring.coreos.com"},
+				Resources: []string{"podmonitors"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"capi-provider.agent-install.openshift.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
 	}
 	return role
 }

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -813,7 +813,7 @@ func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "hypershift-reader",
+			Name: "hypershift-readers",
 		},
 		Rules: make([]rbacv1.PolicyRule, len(clusterOperatorRole.Rules)),
 	}
@@ -851,7 +851,7 @@ func (o HyperShiftReaderClusterRoleBinding) Build() *rbacv1.ClusterRoleBinding {
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "hypershift-reader",
+			Name: "hypershift-readers",
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -328,7 +328,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 
 		readerRoleBinding := assets.HyperShiftReaderClusterRoleBinding{
 			ClusterRole: readerClusterRole,
-			GroupName:   "hypershift-reader",
+			GroupName:   "hypershift-readers",
 		}.Build()
 		objects = append(objects, readerRoleBinding)
 	}

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -24655,7 +24655,7 @@ objects:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
-    name: hypershift-reader
+    name: hypershift-readers
   rules:
   - apiGroups:
     - hypershift.openshift.io
@@ -24795,15 +24795,15 @@ objects:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
-    name: hypershift-reader
+    name: hypershift-readers
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: hypershift-reader
+    name: hypershift-readers
   subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: hypershift-reader
+    name: hypershift-readers
 parameters:
 - name: OPERATOR_IMG
   value: quay.io/hypershift/hypershift-operator

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -24616,6 +24616,194 @@ objects:
       plural: ""
     conditions: []
     storedVersions: []
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: hypershift-client
+  rules:
+  - apiGroups:
+    - hypershift.openshift.io
+    resources:
+    - hostedclusters
+    - nodepools
+    verbs:
+    - '*'
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    name: hypershift-client
+    namespace: ${NAMESPACE}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: hypershift-client
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: hypershift-client
+  subjects:
+  - kind: ServiceAccount
+    name: hypershift-client
+    namespace: ${NAMESPACE}
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: hypershift-client
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: hypershift-reader
+  rules:
+  - apiGroups:
+    - hypershift.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - config.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    - controlplane.cluster.x-k8s.io
+    - infrastructure.cluster.x-k8s.io
+    - machines.cluster.x-k8s.io
+    - exp.infrastructure.cluster.x-k8s.io
+    - addons.cluster.x-k8s.io
+    - exp.cluster.x-k8s.io
+    - cluster.x-k8s.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - operator.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - security.openshift.io
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    - configmaps
+    - pods
+    - pods/log
+    - nodes
+    - namespaces
+    - serviceaccounts
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - etcd.database.coreos.com
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - machine.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - podmonitors
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - capi-provider.agent-install.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: hypershift-reader
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: hypershift-reader
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: hypershift-reader
 parameters:
 - name: OPERATOR_IMG
   value: quay.io/hypershift/hypershift-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
introduce RBAC artifact generation for hypershift admin personas / services
those artifacts are generated when the `--enable-admin-rbac-generation` flag
is provided during `hypershift install`

persona: hypershift-client

used by a client leveraging hypershift as a service to create hosted clusters
* hypershift-client ClusterRole
  full permissions on the hostedcluster and nodepool CRs
* hypershift-client ServiceAccount
* hypershift-client ClusterRoleBinding
  binds the hypershift-client ClusterRole to hypershift-client SA and Group Ref
  the groups itself must be provided by other means

persona: hypershift-readers

used by admins to investigate hosted clusters and the hypershift operator.
* hypershift-readers ClusterRole
  same permission subjects as the hypershift-operator ClusterRole but restricted
  to get, list, watch. access to secrets is not granted
* hypershift-readers ClusterRoleBinding
  binds the hypershift-readers ClusterRole to a Group called hypershift-readers
  the group itself must be provided by other means

fixes [HOSTEDCP-306](https://issues.redhat.com/browse/HOSTEDCP-306)
fixes [APPSRE-4335](https://issues.redhat.com/browse/APPSRE-4335)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>