### PR TITLE
e2e: make upgrade test HC HighlyAvailable

### DIFF
--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -26,6 +26,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
+	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade test fails occasionally with a restart of the `kube-apiserver`.  The KAS only tries to resolve the etcd name for 15s before failing, resulting in a container-level restart, which causes e2e to fail.  If single replica etcd goes down between the init container that verifies the etcd DNS can resolve and when the KAS starts, we can see this flake.

Switching to an HA control plane will allow etcd to say available during the upgrade and avoid this issue.  This also verifies that our upgrades function in an HC control plane, which we currently do not test.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.