### PR TITLE
use CreateOrUpdate for OLM collect profiles resources

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1912,9 +1912,11 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 
 	// Collect Profiles
 	collectProfilesConfigMap := manifests.CollectProfilesConfigMap(hcp.Namespace)
-	olm.ReconcileCollectProfilesConfigMap(collectProfilesConfigMap, p.OwnerRef)
-	if err := r.Create(ctx, collectProfilesConfigMap); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed to reconcile collect profiles cronjob: %w", err)
+	if _, err := r.CreateOrUpdate(ctx, r, collectProfilesConfigMap, func() error {
+		olm.ReconcileCollectProfilesConfigMap(collectProfilesConfigMap, p.OwnerRef)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile collect profiles config map: %w", err)
 	}
 
 	collectProfilesCronJob := manifests.CollectProfilesCronJob(hcp.Namespace)
@@ -1930,7 +1932,7 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 		olm.ReconcileCollectProfilesRole(collectProfilesRole, p.OwnerRef)
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to reconcile collect profiles cronjob: %w", err)
+		return fmt.Errorf("failed to reconcile collect profiles role: %w", err)
 	}
 
 	collectProfilesRoleBinding := manifests.CollectProfilesRoleBinding(hcp.Namespace)
@@ -1938,13 +1940,15 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 		olm.ReconcileCollectProfilesRoleBinding(collectProfilesRoleBinding, p.OwnerRef)
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to reconcile collect profiles cronjob: %w", err)
+		return fmt.Errorf("failed to reconcile collect profiles rolebinding: %w", err)
 	}
 
 	collectProfilesSecret := manifests.CollectProfilesSecret(hcp.Namespace)
-	olm.ReconcileCollectProfilesSecret(collectProfilesSecret, p.OwnerRef)
-	if err := r.Create(ctx, collectProfilesSecret); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed to reconcile collect profiles cronjob: %w", err)
+	if _, err := r.CreateOrUpdate(ctx, r, collectProfilesSecret, func() error {
+		olm.ReconcileCollectProfilesSecret(collectProfilesSecret, p.OwnerRef)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile collect profiles secret: %w", err)
 	}
 
 	collectProfilesServiceAccount := manifests.CollectProfilesServiceAccount(hcp.Namespace)
@@ -1952,7 +1956,7 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 		olm.ReconcileCollectProfilesServiceAccount(collectProfilesServiceAccount, p.OwnerRef)
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to reconcile collect profiles cronjob: %w", err)
+		return fmt.Errorf("failed to reconcile collect profiles serviceaccount: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/openshift/hypershift/pull/583 introduced two direct calls to `Create` rather than `CreateOrUpdate`.  The result in about half the mutating calls from the CPOs in CI being 409 Conflict on these two resources: secret `pprof-cert` and configmap `olm-collect-profiles`.  

This PR switches to `CreateOrUpdate` to avoid these calls and reduce the CPO mutating call volume by roughly 50%.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.