### PR TITLE
enable CPO caching for services

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	"github.com/spf13/cobra"
@@ -127,9 +126,6 @@ func NewStartCommand() *cobra.Command {
 			RenewDeadline:                 &renewDeadline,
 			RetryPeriod:                   &retryPeriod,
 			HealthProbeBindAddress:        healthProbeAddr,
-			// We manage a service outside the HCP namespace, but we don't want to scope the cache for all objects
-			// to both namespaces so just read from the API.
-			ClientDisableCacheFor: []client.Object{&corev1.Service{}},
 			NewCache: cache.BuilderWithOptions(cache.Options{
 				DefaultSelector:   cache.ObjectSelector{Field: fields.OneTermEqualSelector("metadata.namespace", namespace)},
 				SelectorsByObject: cache.SelectorsByObject{&operatorv1.IngressController{}: {Field: fields.OneTermEqualSelector("metadata.namespace", manifests.IngressPrivateIngressController("").Namespace)}},


### PR DESCRIPTION
**What this PR does / why we need it**:
CPO currently doesn't cache `services` due to a single service we care about outside the HCP namespace, namely the service for the private ingress we create when the `endpointAccess` is `PublicAndPrivate` or `Private`.

This reworks the code to use a separate client in that single case so we can cache services in the HCP namespace.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.