### PR TITLE
DNM: update konnectivity images with latest upstream code

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -62,8 +62,8 @@ func main() {
 
 const (
 	// TODO: Include konnectivity image in release payload
-	konnectivityServerImage = "registry.ci.openshift.org/hypershift/apiserver-network-proxy:latest"
-	konnectivityAgentImage  = "registry.ci.openshift.org/hypershift/apiserver-network-proxy:latest"
+	konnectivityServerImage = "us.icr.io/armada-master/rh-apiserver-network-proxy:447353321e2f10876043125b225b64d3aece3cb5"
+	konnectivityAgentImage  = "us.icr.io/armada-master/rh-apiserver-network-proxy:447353321e2f10876043125b225b64d3aece3cb5"
 
 	// Default AWS KMS provider image. Can be overriden with annotation on HostedCluster
 	awsKMSProviderImage = "registry.ci.openshift.org/hypershift/aws-encryption-provider:latest"


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR is only for testing purpose. It uses the latest Konnectivity image coming from https://github.com/openshift/apiserver-network-proxy/pull/13

**Which issue(s) this PR fixes** 

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.