### PR TITLE
install: reject bucket names containing dots to prevent HTTPS errors

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -77,6 +77,9 @@ func (o *Options) Validate() error {
 		(len(o.OIDCStorageProviderS3BucketName) == 0 || len(o.OIDCStorageProviderS3Region) == 0 || len(o.OIDCStorageProviderS3CredentialsSecretKey) == 0) {
 		errs = append(errs, fmt.Errorf("all required oidc information is not set"))
 	}
+	if strings.Contains(o.OIDCStorageProviderS3BucketName, ".") {
+		errs = append(errs, fmt.Errorf("oidc bucket name must not contain dots (.); see the notes on HTTPS at https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"))
+	}
 	return errors.NewAggregate(errs)
 }
 


### PR DESCRIPTION
This commit adds a validation which ensures the `--oidc-storage-provider-s3-bucket-name`
flag does not contain dots (.), because such buckets will have invalid certificates that
cause the OIDC provider setup to fail in ways that are hard to diagnose.

See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] ~Relevant issues have been referenced.~
- [ ] ~This change includes docs.~
- [ ] ~This change includes unit tests.~