### PR TITLE
Kubevirt platform: Add service-publishing-strategy flag

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -73,10 +73,11 @@ type NonePlatformCreateOptions struct {
 }
 
 type KubevirtPlatformCreateOptions struct {
-	APIServerAddress   string
-	Memory             string
-	Cores              uint32
-	ContainerDiskImage string
+	ServicePublishingStrategy string
+	APIServerAddress          string
+	Memory                    string
+	Cores                     uint32
+	ContainerDiskImage        string
 }
 
 type AWSPlatformOptions struct {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/version"
 	"github.com/openshift/hypershift/test/e2e/podtimingcontroller"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
@@ -210,9 +211,10 @@ func (o *options) DefaultClusterOptions() core.CreateOptions {
 			EndpointAccess:     o.configurableClusterOptions.AWSEndpointAccess,
 		},
 		KubevirtPlatform: core.KubevirtPlatformCreateOptions{
-			ContainerDiskImage: o.configurableClusterOptions.KubeVirtContainerDiskImage,
-			Cores:              2,
-			Memory:             "4Gi",
+			ServicePublishingStrategy: kubevirt.IngressServicePublishingStrategy,
+			ContainerDiskImage:        o.configurableClusterOptions.KubeVirtContainerDiskImage,
+			Cores:                     2,
+			Memory:                    "4Gi",
 		},
 		ServiceCIDR: "172.31.0.0/16",
 		PodCIDR:     "10.132.0.0/14",


### PR DESCRIPTION
**What this PR does / why we need it**:
Add service-publishing-strategy new flag in order to allow changing the cluster service expose type
    Supported options: NodePool (Select a random node to expose service access through), Ingress (Use LoadBalancer and Route to expose services)
    Default value: Ingress

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.