### PR TITLE
cli: include Node resources in cluster dump

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -105,6 +105,8 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 	}
 	cmd.WithNamespace(opts.Namespace).Run(ctx, objectNames...)
 
+	cmd.Run(ctx, objectType(&corev1.Node{}))
+
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(opts.Namespace, opts.Name).Name
 
 	resources := []client.Object{


### PR DESCRIPTION
This commit adds Node resources to the `dump` command.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] ~Relevant issues have been referenced.~
- [ ] ~This change includes docs.~
- [ ] ~This change includes unit tests.~