### PR TITLE
include pod in CPO recording rules for multiple CPOs on upgrades

### DIFF
--- a/cmd/install/assets/recordingrules/hypershift.yaml
+++ b/cmd/install/assets/recordingrules/hypershift.yaml
@@ -3,21 +3,21 @@ groups:
   interval: "30s"
   rules:
   - record: hypershift:controlplane:component_api_requests_total
-    expr: sum by (app, namespace, code, method) (
+    expr: sum by (app, namespace, code, method, pod) (
             sum(rest_client_requests_total) by (pod, namespace, code, method)
           * on (pod, namespace) group_left(app)
             label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""}, "app", "$1", "label_app", "(.*)")
           )
 
   - record: hypershift:controlplane:component_memory_usage
-    expr: sum by (app, namespace) (
+    expr: sum by (app, namespace, pod) (
             sum(container_memory_usage_bytes{container!="POD",container!=""}) by (pod, namespace)
           * on (pod, namespace) group_left(app)
             label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""}, "app", "$1", "label_app", "(.*)")
           )
 
   - record: hypershift:controlplane:component_cpu_usage_seconds
-    expr: avg by (app, namespace) (
+    expr: avg by (app, namespace, pod) (
             sum(
               rate(
                 container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
@@ -27,7 +27,7 @@ groups:
             label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""}, "app", "$1", "label_app", "(.*)")
           )
           /
-          count by (app, namespace) (
+          count by (app, namespace, pod) (
             sum(
               rate(
                 container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -355,19 +355,19 @@ objects:
     - interval: 30s
       name: hypershift.rules
       rules:
-      - expr: sum by (app, namespace, code, method) ( sum(rest_client_requests_total)
+      - expr: sum by (app, namespace, code, method, pod) ( sum(rest_client_requests_total)
           by (pod, namespace, code, method) * on (pod, namespace) group_left(app)
           label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""},
           "app", "$1", "label_app", "(.*)") )
         record: hypershift:controlplane:component_api_requests_total
-      - expr: sum by (app, namespace) ( sum(container_memory_usage_bytes{container!="POD",container!=""})
+      - expr: sum by (app, namespace, pod) ( sum(container_memory_usage_bytes{container!="POD",container!=""})
           by (pod, namespace) * on (pod, namespace) group_left(app) label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""},
           "app", "$1", "label_app", "(.*)") )
         record: hypershift:controlplane:component_memory_usage
-      - expr: avg by (app, namespace) ( sum( rate( container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
+      - expr: avg by (app, namespace, pod) ( sum( rate( container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
           ) ) by (pod, namespace) * on (pod, namespace) group_left(app) label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""},
-          "app", "$1", "label_app", "(.*)") ) / count by (app, namespace) ( sum( rate(
-          container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
+          "app", "$1", "label_app", "(.*)") ) / count by (app, namespace, pod) ( sum(
+          rate( container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
           ) ) by (pod, namespace) * on (pod, namespace) group_left(app) label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""},
           "app", "$1", "label_app", "(.*)") )
         record: hypershift:controlplane:component_cpu_usage_seconds


### PR DESCRIPTION
**What this PR does / why we need it**:
During upgrades, there are two CPO pods.  Because our recording rules currently sum them we can't separate them for dashboard viewing or budget enforcement.

This PR maintains the pod separation.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.