### PR TITLE
fix(cpo): Reduce CPO cluster permissions

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -618,7 +618,7 @@ func (r *HostedControlPlaneReconciler) update(ctx context.Context, hostedControl
 	}
 
 	// Reconcile cluster version operator
-	r.Log.Info("Reonciling Cluster Version Operator")
+	r.Log.Info("Reconciling Cluster Version Operator")
 	if err = r.reconcileClusterVersionOperator(ctx, hostedControlPlane, releaseImage); err != nil {
 		return fmt.Errorf("failed to reconcile cluster version operator: %w", err)
 	}

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -247,37 +247,39 @@ func NewStartCommand() *cobra.Command {
 			os.Exit(1)
 		}
 
-		controllerName := "PrivateKubeAPIServerServiceObserver"
-		if err := (&awsprivatelink.PrivateServiceObserver{
-			Client:                 mgr.GetClient(),
-			ControllerName:         controllerName,
-			ServiceNamespace:       namespace,
-			ServiceName:            manifests.KubeAPIServerPrivateServiceName,
-			HCPNamespace:           namespace,
-			CreateOrUpdateProvider: upsert.New(enableCIDebugOutput),
-		}).SetupWithManager(ctx, mgr); err != nil {
-			controllerName := awsprivatelink.ControllerName(manifests.KubeAPIServerPrivateServiceName)
-			setupLog.Error(err, "unable to create controller", "controller", controllerName)
-			os.Exit(1)
-		}
+		if mgmtClusterCaps.Has(capabilities.CapabilityRoute) {
+			controllerName := "PrivateKubeAPIServerServiceObserver"
+			if err := (&awsprivatelink.PrivateServiceObserver{
+				Client:                 mgr.GetClient(),
+				ControllerName:         controllerName,
+				ServiceNamespace:       namespace,
+				ServiceName:            manifests.KubeAPIServerPrivateServiceName,
+				HCPNamespace:           namespace,
+				CreateOrUpdateProvider: upsert.New(enableCIDebugOutput),
+			}).SetupWithManager(ctx, mgr); err != nil {
+				controllerName := awsprivatelink.ControllerName(manifests.KubeAPIServerPrivateServiceName)
+				setupLog.Error(err, "unable to create controller", "controller", controllerName)
+				os.Exit(1)
+			}
 
-		controllerName = "PrivateIngressServiceObserver"
-		if err := (&awsprivatelink.PrivateServiceObserver{
-			Client:                 mgr.GetClient(),
-			ControllerName:         controllerName,
-			ServiceNamespace:       "openshift-ingress",
-			ServiceName:            fmt.Sprintf("router-%s", namespace),
-			HCPNamespace:           namespace,
-			CreateOrUpdateProvider: upsert.New(enableCIDebugOutput),
-		}).SetupWithManager(ctx, mgr); err != nil {
-			controllerName := awsprivatelink.ControllerName(fmt.Sprintf("router-%s", namespace))
-			setupLog.Error(err, "unable to create controller", "controller", controllerName)
-			os.Exit(1)
-		}
+			controllerName = "PrivateIngressServiceObserver"
+			if err := (&awsprivatelink.PrivateServiceObserver{
+				Client:                 mgr.GetClient(),
+				ControllerName:         controllerName,
+				ServiceNamespace:       "openshift-ingress",
+				ServiceName:            fmt.Sprintf("router-%s", namespace),
+				HCPNamespace:           namespace,
+				CreateOrUpdateProvider: upsert.New(enableCIDebugOutput),
+			}).SetupWithManager(ctx, mgr); err != nil {
+				controllerName := awsprivatelink.ControllerName(fmt.Sprintf("router-%s", namespace))
+				setupLog.Error(err, "unable to create controller", "controller", controllerName)
+				os.Exit(1)
+			}
 
-		if err := (&awsprivatelink.AWSEndpointServiceReconciler{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "aws-endpoint-service")
-			os.Exit(1)
+			if err := (&awsprivatelink.AWSEndpointServiceReconciler{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "aws-endpoint-service")
+				os.Exit(1)
+			}
 		}
 
 		if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1330,31 +1330,13 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 		return fmt.Errorf("failed to reconcile controlplane operator service account: %w", err)
 	}
 
-	// Reconcile operator cluster role
-	controlPlaneOperatorClusterRole := controlplaneoperator.OperatorClusterRole()
-	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRole, func() error {
-		return reconcileControlPlaneOperatorClusterRole(controlPlaneOperatorClusterRole)
-	})
-	if err != nil {
-		return fmt.Errorf("failed to reconcile controlplane operator cluster role: %w", err)
-	}
-
-	// Reconcile operator cluster role binding
-	controlPlaneOperatorClusterRoleBinding := controlplaneoperator.OperatorClusterRoleBinding(controlPlaneNamespace.Name)
-	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorClusterRoleBinding, func() error {
-		return reconcileControlPlaneOperatorClusterRoleBinding(controlPlaneOperatorClusterRoleBinding, controlPlaneOperatorClusterRole, controlPlaneOperatorServiceAccount)
-	})
-	if err != nil {
-		return fmt.Errorf("failed to reconcile controlplane operator clusterrolebinding: %w", err)
-	}
-
 	// Reconcile operator role
 	controlPlaneOperatorRole := controlplaneoperator.OperatorRole(controlPlaneNamespace.Name)
 	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorRole, func() error {
 		return reconcileControlPlaneOperatorRole(controlPlaneOperatorRole)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to reconcile controlplane operator clusterrole: %w", err)
+		return fmt.Errorf("failed to reconcile controlplane operator role: %w", err)
 	}
 
 	// Reconcile operator role binding
@@ -1364,6 +1346,44 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator rolebinding: %w", err)
+	}
+
+	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityRoute) {
+		// Reconcile operator role - for ingress
+		controlPlaneOperatorIngressRole := controlplaneoperator.OperatorIngressRole("openshift-ingress", controlPlaneNamespace.Name)
+		_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorIngressRole, func() error {
+			return reconcileControlPlaneOperatorIngressRole(controlPlaneOperatorIngressRole)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to reconcile controlplane operator ingress role: %w", err)
+		}
+
+		// Reconcile operator role binding - for ingress
+		controlPlaneOperatorIngressRoleBinding := controlplaneoperator.OperatorIngressRoleBinding("openshift-ingress", controlPlaneNamespace.Name)
+		_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorIngressRoleBinding, func() error {
+			return reconcileControlPlaneOperatorIngressRoleBinding(controlPlaneOperatorIngressRoleBinding, controlPlaneOperatorIngressRole, controlPlaneOperatorServiceAccount)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to reconcile controlplane operator ingress rolebinding: %w", err)
+		}
+
+		// Reconcile operator role - for ingress operator
+		controlPlaneOperatorIngressOperatorRole := controlplaneoperator.OperatorIngressOperatorRole("openshift-ingress-operator", controlPlaneNamespace.Name)
+		_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorIngressOperatorRole, func() error {
+			return reconcilecontrolPlaneOperatorIngressOperatorRole(controlPlaneOperatorIngressOperatorRole)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to reconcile controlplane operator ingress operator role: %w", err)
+		}
+
+		// Reconcile operator role binding - for ingress operator
+		controlPlaneOperatorIngressOperatorRoleBinding := controlplaneoperator.OperatorIngressOperatorRoleBinding("openshift-ingress-operator", controlPlaneNamespace.Name)
+		_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorIngressOperatorRoleBinding, func() error {
+			return reconcilecontrolPlaneOperatorIngressOperatorRoleBinding(controlPlaneOperatorIngressOperatorRoleBinding, controlPlaneOperatorIngressOperatorRole, controlPlaneOperatorServiceAccount)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to reconcile controlplane operator ingress operator rolebinding: %w", err)
+		}
 	}
 
 	// Reconcile operator deployment
@@ -1381,7 +1401,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	}
 	controlPlaneOperatorDeployment := controlplaneoperator.OperatorDeployment(controlPlaneNamespace.Name)
 	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
-		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, r.AvailabilityProberImage, r.SocksProxyImage, r.TokenMinterImage, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()))
+		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, r.AvailabilityProberImage, r.SocksProxyImage, r.TokenMinterImage, r.SetDefaultSecurityContext, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()))
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator deployment: %w", err)
@@ -1895,7 +1915,7 @@ func getControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 	return hypershiftOperatorImage, nil
 }
 
-func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, cpoImage, proberImage, socksImage, minterImage string, sa *corev1.ServiceAccount, enableCIDebugOutput bool, registryOverrideCommandLine string) error {
+func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, cpoImage, proberImage, socksImage, minterImage string, setDefaultSecurityContext bool, sa *corev1.ServiceAccount, enableCIDebugOutput bool, registryOverrideCommandLine string) error {
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -1930,10 +1950,6 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 								Name:  "OPERATE_ON_RELEASE_IMAGE",
 								Value: hc.Spec.Release.Image,
 							},
-						},
-						// needed since control plane operator runs with anyuuid scc
-						SecurityContext: &corev1.SecurityContext{
-							RunAsUser: k8sutilspointer.Int64Ptr(1000),
 						},
 						Command: []string{"/usr/bin/control-plane-operator"},
 						Args: []string{"run", "--namespace", "$(MY_NAMESPACE)", "--deployment-name", "control-plane-operator",
@@ -2050,62 +2066,17 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 		})
 	}
 
+	// set security context
+	if setDefaultSecurityContext {
+		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsUser: k8sutilspointer.Int64Ptr(config.DefaultSecurityContextUser),
+		}
+	}
+
 	hyperutil.SetColocation(hc, deployment)
 	hyperutil.SetRestartAnnotation(hc, deployment)
 	hyperutil.SetControlPlaneIsolation(hc, deployment)
 	hyperutil.SetDefaultPriorityClass(deployment)
-	return nil
-}
-
-func reconcileControlPlaneOperatorClusterRole(role *rbacv1.ClusterRole) error {
-	role.Rules = []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{"apiextensions.k8s.io"},
-			Resources: []string{"customresourcedefinitions"},
-			Verbs:     []string{"*"},
-		},
-		{
-			APIGroups: []string{"config.openshift.io"},
-			Resources: []string{"*"},
-			Verbs:     []string{"get", "list", "watch"},
-		},
-		{
-			APIGroups: []string{"operator.openshift.io"},
-			Resources: []string{"*"},
-			Verbs:     []string{"*"},
-		},
-		{
-			APIGroups: []string{"security.openshift.io"},
-			Resources: []string{"securitycontextconstraints"},
-			Verbs:     []string{"*"},
-		},
-		{
-			APIGroups: []string{"rbac.authorization.k8s.io"},
-			Resources: []string{"*"},
-			Verbs:     []string{"*"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"services"},
-			Verbs:     []string{"get", "list", "watch"},
-		},
-	}
-	return nil
-}
-
-func reconcileControlPlaneOperatorClusterRoleBinding(binding *rbacv1.ClusterRoleBinding, role *rbacv1.ClusterRole, sa *corev1.ServiceAccount) error {
-	binding.RoleRef = rbacv1.RoleRef{
-		APIGroup: "rbac.authorization.k8s.io",
-		Kind:     "ClusterRole",
-		Name:     role.Name,
-	}
-	binding.Subjects = []rbacv1.Subject{
-		{
-			Kind:      "ServiceAccount",
-			Name:      sa.Name,
-			Namespace: sa.Namespace,
-		},
-	}
 	return nil
 }
 
@@ -2129,6 +2100,11 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 				"monitoring.coreos.com",
 			},
 			Resources: []string{"*"},
+			Verbs:     []string{"*"},
+		},
+		{
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"roles", "rolebindings"},
 			Verbs:     []string{"*"},
 		},
 		{
@@ -2156,16 +2132,6 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 			Verbs:     []string{"*"},
 		},
 		{
-			APIGroups: []string{"etcd.database.coreos.com"},
-			Resources: []string{"*"},
-			Verbs:     []string{"*"},
-		},
-		{
-			APIGroups: []string{"machine.openshift.io"},
-			Resources: []string{"*"},
-			Verbs:     []string{"*"},
-		},
-		{
 			APIGroups: []string{"batch"},
 			Resources: []string{"cronjobs", "jobs"},
 			Verbs:     []string{"*"},
@@ -2187,6 +2153,64 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 }
 
 func reconcileControlPlaneOperatorRoleBinding(binding *rbacv1.RoleBinding, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
+	binding.RoleRef = rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     role.Name,
+	}
+
+	binding.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+		},
+	}
+
+	return nil
+}
+
+func reconcileControlPlaneOperatorIngressRole(role *rbacv1.Role) error {
+	role.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"services"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+	return nil
+}
+
+func reconcileControlPlaneOperatorIngressRoleBinding(binding *rbacv1.RoleBinding, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
+	binding.RoleRef = rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     role.Name,
+	}
+
+	binding.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+		},
+	}
+
+	return nil
+}
+
+func reconcilecontrolPlaneOperatorIngressOperatorRole(role *rbacv1.Role) error {
+	role.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"operator.openshift.io"},
+			Resources: []string{"ingresscontrollers"},
+			Verbs:     []string{"*"},
+		},
+	}
+	return nil
+}
+
+func reconcilecontrolPlaneOperatorIngressOperatorRoleBinding(binding *rbacv1.RoleBinding, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
 	binding.RoleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "Role",
@@ -2996,6 +3020,25 @@ func deleteNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace)
 	return true, nil
 }
 
+func deleteControlPlaneOperatorRBAC(ctx context.Context, c client.Client, rbacNamespace string, controlPlaneNamespace string) error {
+	rbacMeta := metav1.ObjectMeta{
+		Name:      "control-plane-operator-" + controlPlaneNamespace,
+		Namespace: rbacNamespace,
+	}
+
+	err := c.Delete(ctx, &rbacv1.Role{ObjectMeta: rbacMeta})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error deleting Role: %w", err)
+	}
+
+	err = c.Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: rbacMeta})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error deleting RoleBinding: %w", err)
+	}
+
+	return nil
+}
+
 func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.HostedCluster) (bool, error) {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name
 	log := ctrl.LoggerFrom(ctx)
@@ -3028,6 +3071,18 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	if exists {
 		log.Info("Waiting for awsendpointservice deletion", "controlPlaneNamespace", controlPlaneNamespace)
 		return false, nil
+	}
+
+	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityRoute) {
+		err = deleteControlPlaneOperatorRBAC(ctx, r.Client, "openshift-ingress", controlPlaneNamespace)
+		if err != nil {
+			return false, fmt.Errorf("failed to clean up control plane operator ingress RBAC: %w", err)
+		}
+
+		err = deleteControlPlaneOperatorRBAC(ctx, r.Client, "openshift-ingress-operator", controlPlaneNamespace)
+		if err != nil {
+			return false, fmt.Errorf("failed to clean up control plane operator ingress operator RBAC: %w", err)
+		}
 	}
 
 	// There are scenarios where CAPI might not be operational e.g None Platform.

--- a/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
@@ -28,22 +28,6 @@ func OperatorServiceAccount(controlPlaneOperatorNamespace string) *corev1.Servic
 	}
 }
 
-func OperatorClusterRole() *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "control-plane-operator",
-		},
-	}
-}
-
-func OperatorClusterRoleBinding(controlPlaneOperatorNamespace string) *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "control-plane-operator-" + controlPlaneOperatorNamespace,
-		},
-	}
-}
-
 func OperatorRole(controlPlaneOperatorNamespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
@@ -58,6 +42,42 @@ func OperatorRoleBinding(controlPlaneOperatorNamespace string) *rbacv1.RoleBindi
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneOperatorNamespace,
 			Name:      "control-plane-operator",
+		},
+	}
+}
+
+func OperatorIngressRole(ingressNamespace string, controlPlaneOperatorNamespace string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ingressNamespace,
+			Name:      "control-plane-operator-" + controlPlaneOperatorNamespace,
+		},
+	}
+}
+
+func OperatorIngressRoleBinding(ingressNamespace string, controlPlaneOperatorNamespace string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ingressNamespace,
+			Name:      "control-plane-operator-" + controlPlaneOperatorNamespace,
+		},
+	}
+}
+
+func OperatorIngressOperatorRole(ingressOperatorNamespace string, controlPlaneOperatorNamespace string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ingressOperatorNamespace,
+			Name:      "control-plane-operator-" + controlPlaneOperatorNamespace,
+		},
+	}
+}
+
+func OperatorIngressOperatorRoleBinding(ingressOperatorNamespace string, controlPlaneOperatorNamespace string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ingressOperatorNamespace,
+			Name:      "control-plane-operator-" + controlPlaneOperatorNamespace,
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Removes CPO's ClusterRole/ClusterRoleBinding
- Updates CPO's securitycontext from explicit to use default
- Adjusts CPO's existing Role
- Creates additional Role/RoleBinding for ingress service reads
- Creates additional Role/RoleBinding for ingress operator ingresscontroller crud
- Conditionally activates awsprivatelink controllers based on Route capability

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #1026 

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

**Note**
Have verified that control plane is able to get rolled out with these changes.
```
NAME                                                 READY   STATUS      RESTARTS   AGE
catalog-operator-7fc9847d5f-85fmz                    2/2     Running     0          9m23s
certified-operators-catalog-675b86bbbf-9tvxd         1/1     Running     0          9m24s
certified-operators-catalog-rollout-27420333-57mbs   0/1     Completed   0          4m5s
cloud-controller-manager-7c75877b89-h2p2b            1/1     Running     0          6m15s
cloud-controller-manager-7c75877b89-htcjp            1/1     Running     0          6m15s
cloud-controller-manager-7c75877b89-tvdxs            1/1     Running     0          6m15s
cluster-api-57987f99bd-c4sq5                         1/1     Running     0          9m46s
cluster-api-57987f99bd-g72bh                         1/1     Running     0          9m46s
cluster-api-57987f99bd-tn8pq                         1/1     Running     0          9m46s
cluster-autoscaler-7c9fbd559c-mhbws                  1/1     Running     0          9m17s
cluster-policy-controller-8445b79ccc-lmx7k           1/1     Running     0          9m26s
cluster-policy-controller-8445b79ccc-w6stl           1/1     Running     0          9m26s
cluster-policy-controller-8445b79ccc-zl9wx           1/1     Running     0          9m26s
cluster-version-operator-6c568f5f99-7jf8q            2/2     Running     0          9m26s
community-operators-catalog-6df994c5b5-vccpp         1/1     Running     0          9m23s
community-operators-catalog-rollout-27420333-rtwtv   0/1     Completed   0          4m5s
control-plane-operator-87bf8457f-q69q5               1/1     Running     0          9m45s
etcd-hide-test-5-88mzsjs4h4                          3/3     Running     0          8m15s
etcd-hide-test-5-bm4475hd78                          3/3     Running     0          7m59s
etcd-hide-test-5-wxnkvr8lvw                          3/3     Running     0          10m
etcd-operator-84fd47d866-65qqc                       4/4     Running     4          10m
etcd-operator-84fd47d866-d7nw7                       4/4     Running     4          10m
etcd-operator-84fd47d866-ksqgf                       4/4     Running     4          10m
etcd-restore-operator-cert-creator-tddwg             0/1     Completed   0          10m
hosted-cluster-config-operator-cc7d7644d-9c9xx       1/1     Running     0          9m24s
ignition-server-cbfcd686d-5lj92                      1/1     Running     0          9m44s
ignition-server-cbfcd686d-v4dmb                      1/1     Running     0          9m44s
ignition-server-cbfcd686d-vh8xd                      1/1     Running     0          9m45s
ingress-operator-59986b6f4c-xpkx6                    2/2     Running     0          9m25s
konnectivity-agent-746dc879b9-77twf                  1/1     Running     0          9m29s
konnectivity-agent-746dc879b9-djvtg                  1/1     Running     0          9m29s
konnectivity-agent-746dc879b9-t9nd8                  1/1     Running     0          9m29s
konnectivity-server-6f8d7d8fc-94jdf                  1/1     Running     0          9m29s
kube-apiserver-58457cddb9-26jgb                      2/2     Running     2          9m28s
kube-apiserver-58457cddb9-rbjx8                      2/2     Running     2          9m28s
kube-apiserver-58457cddb9-v672v                      2/2     Running     2          9m28s
kube-controller-manager-5f74d96685-4xcsd             1/1     Running     0          9m28s
kube-controller-manager-5f74d96685-v2rlp             1/1     Running     0          9m28s
kube-controller-manager-5f74d96685-wwj4c             1/1     Running     0          9m28s
kube-scheduler-8c5d9779f-l9wtd                       1/1     Running     0          9m28s
kube-scheduler-8c5d9779f-vnh8d                       1/1     Running     0          9m28s
kube-scheduler-8c5d9779f-vqxcd                       1/1     Running     0          9m28s
machine-approver-6fd5f798df-zxfft                    1/1     Running     0          9m16s
oauth-openshift-6b8964bbc9-27gcn                     1/1     Running     0          9m26s
oauth-openshift-6b8964bbc9-bsvwd                     1/1     Running     0          9m26s
oauth-openshift-6b8964bbc9-mvxnc                     1/1     Running     0          9m26s
olm-collect-profiles-27420333-48v74                  0/1     Completed   0          4m5s
olm-operator-68c587cf9f-dc6zs                        2/2     Running     0          9m22s
openshift-apiserver-67dc55bc7-6jpwb                  2/2     Running     0          9m28s
openshift-apiserver-67dc55bc7-z6k2x                  2/2     Running     0          9m27s
openshift-apiserver-67dc55bc7-zf7bk                  2/2     Running     0          9m27s
openshift-controller-manager-7849ff8459-9z8r4        1/1     Running     0          9m26s
openshift-controller-manager-7849ff8459-cld5l        1/1     Running     0          9m26s
openshift-controller-manager-7849ff8459-lrpbd        1/1     Running     0          9m26s
openshift-oauth-apiserver-66686d6845-hrftp           1/1     Running     0          9m27s
openshift-oauth-apiserver-66686d6845-mrvgp           1/1     Running     0          9m27s
openshift-oauth-apiserver-66686d6845-nfmvv           1/1     Running     0          9m27s
packageserver-595c7c896b-52zh4                       2/2     Running     0          9m22s
packageserver-595c7c896b-8bc4w                       2/2     Running     0          9m22s
packageserver-595c7c896b-q7qzt                       2/2     Running     0          9m22s
redhat-marketplace-catalog-56c9658865-wg99s          1/1     Running     0          9m23s
redhat-marketplace-catalog-rollout-27420333-rnjlr    0/1     Completed   0          4m5s
redhat-operators-catalog-65756747dd-ds4bx            1/1     Running     0          9m23s
redhat-operators-catalog-rollout-27420333-sg9q2      0/1     Completed   0          4m5s
```