### PR TITLE
Fix RESTMapper used by HosteAPICache in Control Plane Operator

### DIFF
--- a/control-plane-operator/controllers/hostedapicache/cache_controller.go
+++ b/control-plane-operator/controllers/hostedapicache/cache_controller.go
@@ -38,7 +38,7 @@ type HostedAPICacheReconciler struct {
 func RegisterHostedAPICacheReconciler(mgr ctrl.Manager, cacheCtx context.Context, cacheLog logr.Logger, scope manifests.KubeconfigScope) (*HostedAPICacheReconciler, error) {
 	r := &HostedAPICacheReconciler{
 		Client:         mgr.GetClient(),
-		hostedAPICache: newHostedAPICache(cacheCtx, cacheLog, mgr.GetScheme(), mgr.GetRESTMapper()),
+		hostedAPICache: newHostedAPICache(cacheCtx, cacheLog, mgr.GetScheme()),
 		scope:          scope,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this change, the HostedAPICache controller was creating a cache
with the RESTMapper from the management cluster. This caused an error
initializing the cache if a ClusterVersion resource did not exist in the
management cluster but did exist in the guest cluster.

This commit replaces the code to create the cache directly with code to
create a controller-runtime cluster and then gets the cache from it.
This results in the proper RESTMapper (from the guest cluster) being
used for the cache.


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.