### PR TITLE
MGMTBUGSM-108: Adding clusterrole for agent provider

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -173,6 +173,55 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 	if err != nil {
 		return fmt.Errorf("failed to reconcile Agent RoleBinding: %w", err)
 	}
+
+	return p.reconcileClusterRole(ctx, c, createOrUpdate, controlPlaneNamespace)
+}
+
+func (p Agent) reconcileClusterRole(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	controlPlaneNamespace string) error {
+
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: credentialsRBACName,
+		},
+	}
+	_, err := createOrUpdate(ctx, c, role, func() error {
+		role.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"cluster.open-cluster-management.io"},
+				Resources: []string{"managedclustersets/join"},
+				Verbs:     []string{"create"},
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile Agent ClusterRole: %w", err)
+	}
+
+	roleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-%s", credentialsRBACName, controlPlaneNamespace),
+		},
+	}
+	_, err = createOrUpdate(ctx, c, roleBinding, func() error {
+		roleBinding.Subjects = []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "capi-provider",
+				Namespace: controlPlaneNamespace,
+			},
+		}
+		roleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     credentialsRBACName,
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile Agent ClusterRoleBinding: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds cluster role for agent provide. It is needed due to ACM changes that blocks clusterdeployment creation in case we don't have specific cluster rile

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2057060
**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.