### PR TITLE
Default to using bridge binding for kubevirt platform VMs

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -524,6 +524,14 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 											},
 										},
 									},
+									Interfaces: []kubevirtv1.Interface{
+										kubevirtv1.Interface{
+											Name: "default",
+											InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+												Bridge: &kubevirtv1.InterfaceBridge{},
+											},
+										},
+									},
 								},
 							},
 							Volumes: []kubevirtv1.Volume{
@@ -533,6 +541,14 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 										ContainerDisk: &kubevirtv1.ContainerDiskSource{
 											Image: o.Kubevirt.Image,
 										},
+									},
+								},
+							},
+							Networks: []kubevirtv1.Network{
+								kubevirtv1.Network{
+									Name: "default",
+									NetworkSource: kubevirtv1.NetworkSource{
+										Pod: &kubevirtv1.PodNetwork{},
 									},
 								},
 							},

--- a/cmd/nodepool/kubevirt/create.go
+++ b/cmd/nodepool/kubevirt/create.go
@@ -69,6 +69,14 @@ func (o *KubevirtPlatformCreateOptions) UpdateNodePool(_ context.Context, nodePo
 										},
 									},
 								},
+								Interfaces: []kubevirtv1.Interface{
+									kubevirtv1.Interface{
+										Name: "default",
+										InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+											Bridge: &kubevirtv1.InterfaceBridge{},
+										},
+									},
+								},
 							},
 						},
 						Volumes: []kubevirtv1.Volume{
@@ -78,6 +86,14 @@ func (o *KubevirtPlatformCreateOptions) UpdateNodePool(_ context.Context, nodePo
 									ContainerDisk: &kubevirtv1.ContainerDiskSource{
 										Image: o.ContainerDiskImage,
 									},
+								},
+							},
+						},
+						Networks: []kubevirtv1.Network{
+							kubevirtv1.Network{
+								Name: "default",
+								NetworkSource: kubevirtv1.NetworkSource{
+									Pod: &kubevirtv1.PodNetwork{},
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

Unlike vanilla KubeVirt installs, Kubevirt installed by CNV defaults to using the masquerade network interface binding. That binding uses NAT with the pod network which makes all the KubeVirt hypershift tenant nodes look like they have the same IP address. The result is a non-functional cluster.

We didn't notice this at first because we were testing locally with a setup similar to minikube+kubevirt. Once we transitioned to testing OCP+CNV the issue was obvious.