### PR TITLE
add resource requests to CAPI manager container

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sutilspointer "k8s.io/utils/pointer"
@@ -116,6 +117,12 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 						Name:            "manager",
 						Image:           providerImage,
 						ImagePullPolicy: corev1.PullAlways,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+							},
+						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      "credentials",


### PR DESCRIPTION
**What this PR does / why we need it**:
The periodic jobs currently create 7 HCs at once.  This puts the worker nodes in the test cluster under CPU contention.  The CAPI manager currently runs with no resource request, which results in the kubelet placing it in the `BestEffort` QoS cgroup that gets almost no CPU when there is contention.  When this happens, the CAPI manager is not able to respond to requests on its healthz endpoint and the liveness probe failure causes it to restart.  This, in turn, causes the overall job to fail.

The PR sets resource requests for this container so that it gets a larger share of CPU when the node is under contention.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.