### PR TITLE
e2e: raise CPO read budget

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -376,7 +376,7 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 			{
 				name:   "control-plane-operator read",
 				query:  fmt.Sprintf("sum(hypershift:controlplane:component_api_requests_total{method=\"GET\", namespace=~\"%s\"}) by (pod)", namespace),
-				budget: 600,
+				budget: 800,
 			},
 			{
 				name:   "control-plane-operator mutate",


### PR DESCRIPTION
I set the CPO read budget to tight initially and it caused a periodic to fail
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-e2e-aws-periodic/1496817236092915712

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.