### PR TITLE
Azure: Add cloudconfigs to KCM and KAS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/config.go
@@ -2,12 +2,15 @@ package cloud
 
 import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 )
 
 func ProviderConfigKey(provider string) string {
 	switch provider {
 	case aws.Provider:
 		return aws.ProviderConfigKey
+	case azure.Provider:
+		return azure.CloudConfigKey
 	default:
 		return ""
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1225,6 +1225,12 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure cloud config: %w", err)
 		}
+		withSecrets := manifests.AzureProviderConfigWithCredentials(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, withSecrets, func() error {
+			return azure.ReconcileCloudConfigWithCredentials(withSecrets, hcp, credentialsSecret)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile Azure cloud config with credentials: %w", err)
+		}
 	}
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
@@ -185,7 +186,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 		applyPortieriesConfig(&deployment.Spec.Template.Spec, images.Portieris)
 	}
 	applyNamedCertificateMounts(namedCertificates, &deployment.Spec.Template.Spec)
-	applyCloudConfigVolumeMount(cloudProviderConfigRef, &deployment.Spec.Template.Spec)
+	applyCloudConfigVolumeMount(cloudProviderConfigRef, &deployment.Spec.Template.Spec, cloudProviderName)
 	util.ApplyCloudProviderCreds(&deployment.Spec.Template.Spec, cloudProviderName, cloudProviderCreds, images.TokenMinterImage, kasContainerMain().Name)
 
 	if auditWebhookRef != nil {
@@ -568,19 +569,22 @@ func kasVolumeCloudConfig() *corev1.Volume {
 	}
 }
 
-func buildKASVolumeCloudConfig(configMapName string) func(v *corev1.Volume) {
+func buildKASVolumeCloudConfig(configMapName, providerName string) func(v *corev1.Volume) {
 	return func(v *corev1.Volume) {
-		if v.ConfigMap == nil {
-			v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+		if providerName == azure.Provider {
+			v.Secret = &corev1.SecretVolumeSource{SecretName: configMapName}
+		} else {
+			v.ConfigMap = &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+				DefaultMode:          pointer.Int32(420),
+			}
 		}
-		v.ConfigMap.DefaultMode = pointer.Int32Ptr(420)
-		v.ConfigMap.Name = configMapName
 	}
 }
 
-func applyCloudConfigVolumeMount(configRef *corev1.LocalObjectReference, podSpec *corev1.PodSpec) {
+func applyCloudConfigVolumeMount(configRef *corev1.LocalObjectReference, podSpec *corev1.PodSpec, cloudProviderName string) {
 	if configRef != nil && configRef.Name != "" {
-		podSpec.Volumes = append(podSpec.Volumes, util.BuildVolume(kasVolumeCloudConfig(), buildKASVolumeCloudConfig(configRef.Name)))
+		podSpec.Volumes = append(podSpec.Volumes, util.BuildVolume(kasVolumeCloudConfig(), buildKASVolumeCloudConfig(configRef.Name, cloudProviderName)))
 		var container *corev1.Container
 		for i, c := range podSpec.Containers {
 			if c.Name == kasContainerMain().Name {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -12,6 +12,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
@@ -279,6 +280,9 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		params.CloudProvider = aws.Provider
 		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AWSProviderConfig("").Name}
 		params.CloudProviderCreds = &corev1.LocalObjectReference{Name: hcp.Spec.Platform.AWS.KubeCloudControllerCreds.Name}
+	case hyperv1.AzurePlatform:
+		params.CloudProvider = azure.Provider
+		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}
 	}
 	if hcp.Spec.AuditWebhook != nil && len(hcp.Spec.AuditWebhook.Name) > 0 {
 		params.AuditWebhookRef = hcp.Spec.AuditWebhook

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -10,6 +10,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
@@ -101,6 +102,9 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 		params.CloudProvider = aws.Provider
 		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AWSProviderConfig("").Name}
 		params.CloudProviderCreds = &corev1.LocalObjectReference{Name: hcp.Spec.Platform.AWS.KubeCloudControllerCreds.Name}
+	case hyperv1.AzurePlatform:
+		params.CloudProvider = azure.Provider
+		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}
 	}
 
 	switch hcp.Spec.ControllerAvailabilityPolicy {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
@@ -13,3 +13,12 @@ func AzureProviderConfig(ns string) *corev1.ConfigMap {
 		},
 	}
 }
+
+func AzureProviderConfigWithCredentials(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-cloud-config",
+			Namespace: ns,
+		},
+	}
+}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

This is the last piece after which Azure should be generally working as expected: It adds the cloud provider configs to KCM and KAS.

Azure is a bit special here, in that it uses the cloud-config to configure credentials rather than having a distinct way of doing that. We already have a cloudconfig for nodes, which uses the instance identity for authentication. This can't work for KAS and KCM, so we create a second cloudconfig that holds the literal credentials and use that.

Since it holds credentials, we put this cloud-config into a secret rather than a configmap.

Ref https://issues.redhat.com/browse/HOSTEDCP-242

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.