### PR TITLE
Hypershift operator: Default the infraID

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -97,10 +97,9 @@ type HostedClusterSpec struct {
 	// will be used to associate various cloud resources with the HostedCluster
 	// and its associated NodePools.
 	//
-	// TODO(dan): consider moving this to .platform.aws.infraID
-	//
+	// +optional
 	// +immutable
-	InfraID string `json:"infraID"`
+	InfraID string `json:"infraID,omitempty"`
 
 	// Platform specifies the underlying infrastructure provider for the cluster
 	// and is used to configure platform specific behavior.

--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -2,10 +2,8 @@ package agent
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
@@ -57,9 +55,6 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	}
 
 	infraID := opts.InfraID
-	if len(infraID) == 0 {
-		infraID = fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
-	}
 	exampleOptions.InfraID = infraID
 	exampleOptions.BaseDomain = opts.BaseDomain
 	if exampleOptions.BaseDomain == "" {

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -6,15 +6,14 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/spf13/cobra"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
-
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
 	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/support/infraid"
+	"github.com/spf13/cobra"
 )
 
 func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
@@ -98,7 +97,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	}
 	if infra == nil {
 		if len(infraID) == 0 {
-			infraID = fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
+			infraID = infraid.New(opts.Name)
 		}
 		opt := awsinfra.CreateInfraOptions{
 			Region:             opts.AWSPlatform.Region,

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -12,8 +12,8 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	azureinfra "github.com/openshift/hypershift/cmd/infra/azure"
 	"github.com/openshift/hypershift/cmd/log"
+	"github.com/openshift/hypershift/support/infraid"
 	"github.com/spf13/cobra"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/yaml"
 )
 
@@ -75,7 +75,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			return fmt.Errorf("failed to deserialize infra json file: %w", err)
 		}
 	} else {
-		infraID := fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
+		infraID := infraid.New(opts.Name)
 		infra, err = (&azureinfra.CreateInfraOptions{
 			Name:            opts.Name,
 			Location:        opts.AzurePlatform.Location,

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -17,7 +17,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclient "k8s.io/client-go/kubernetes"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -292,10 +291,6 @@ func Validate(ctx context.Context, opts *CreateOptions) error {
 func CreateCluster(ctx context.Context, opts *CreateOptions, platformSpecificApply ApplyPlatformSpecifics) error {
 	if opts.Wait && opts.NodePoolReplicas < 1 {
 		return errors.New("--wait requires --node-pool-replicas > 0")
-	}
-
-	if opts.InfraID == "" {
-		opts.InfraID = fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
 	}
 
 	exampleOptions, err := createCommonFixture(opts)

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -3,10 +3,8 @@ package kubevirt
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/spf13/cobra"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
@@ -74,9 +72,6 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	}
 
 	infraID := opts.InfraID
-	if len(infraID) == 0 {
-		infraID = fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
-	}
 	exampleOptions.InfraID = infraID
 	exampleOptions.BaseDomain = "example.com"
 

--- a/cmd/cluster/none/create.go
+++ b/cmd/cluster/none/create.go
@@ -2,10 +2,8 @@ package none
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
@@ -58,9 +56,6 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	}
 
 	infraID := opts.InfraID
-	if len(infraID) == 0 {
-		infraID = fmt.Sprintf("%s-%s", opts.Name, utilrand.String(5))
-	}
 	exampleOptions.InfraID = infraID
 	exampleOptions.BaseDomain = opts.BaseDomain
 	if exampleOptions.BaseDomain == "" {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -298,10 +298,9 @@ spec:
                   type: object
                 type: array
               infraID:
-                description: "InfraID is a globally unique identifier for the cluster.
+                description: InfraID is a globally unique identifier for the cluster.
                   This identifier will be used to associate various cloud resources
-                  with the HostedCluster and its associated NodePools. \n TODO(dan):
-                  consider moving this to .platform.aws.infraID"
+                  with the HostedCluster and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
                 description: InfrastructureAvailabilityPolicy specifies the availability
@@ -922,7 +921,6 @@ spec:
                     type: string
                 type: object
             required:
-            - infraID
             - issuerURL
             - networking
             - platform

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -106,10 +106,10 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>InfraID is a globally unique identifier for the cluster. This identifier
 will be used to associate various cloud resources with the HostedCluster
 and its associated NodePools.</p>
-<p>TODO(dan): consider moving this to .platform.aws.infraID</p>
 </td>
 </tr>
 <tr>
@@ -2260,10 +2260,10 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>InfraID is a globally unique identifier for the cluster. This identifier
 will be used to associate various cloud resources with the HostedCluster
 and its associated NodePools.</p>
-<p>TODO(dan): consider moving this to .platform.aws.infraID</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -19886,10 +19886,9 @@ objects:
                     type: object
                   type: array
                 infraID:
-                  description: "InfraID is a globally unique identifier for the cluster.
+                  description: InfraID is a globally unique identifier for the cluster.
                     This identifier will be used to associate various cloud resources
-                    with the HostedCluster and its associated NodePools. \n TODO(dan):
-                    consider moving this to .platform.aws.infraID"
+                    with the HostedCluster and its associated NodePools.
                   type: string
                 infrastructureAvailabilityPolicy:
                   description: InfrastructureAvailabilityPolicy specifies the availability
@@ -20518,7 +20517,6 @@ objects:
                       type: string
                   type: object
               required:
-              - infraID
               - issuerURL
               - networking
               - platform

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -54,6 +54,7 @@ import (
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/infraid"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
@@ -559,6 +560,14 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer to cluster: %w", err)
+		}
+	}
+
+	// Default the infraID if unset
+	if hcluster.Spec.InfraID == "" {
+		hcluster.Spec.InfraID = infraid.New(hcluster.Name)
+		if err := r.Update(ctx, hcluster); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update hostedcluster after defaulting the InfraID: %w", err)
 		}
 	}
 

--- a/support/infraid/infraid.go
+++ b/support/infraid/infraid.go
@@ -1,0 +1,40 @@
+package infraid
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+)
+
+func New(clusterName string) string {
+	return generateInfraID(clusterName, 27)
+}
+
+const (
+	randomLen = 5
+)
+
+// generateInfraID is a straight copy of
+// https://github.com/openshift/installer/blob/3d19350885d593ee2b1d9ecd7612c2d697dab2a3/pkg/asset/installconfig/clusterid.go#L60
+func generateInfraID(base string, maxLen int) string {
+	maxBaseLen := maxLen - (randomLen + 1)
+
+	// replace all characters that are not `alphanum` or `-` with `-`
+	re := regexp.MustCompile("[^A-Za-z0-9-]")
+	base = re.ReplaceAllString(base, "-")
+
+	// replace all multiple dashes in a sequence with single one.
+	re = regexp.MustCompile(`-{2,}`)
+	base = re.ReplaceAllString(base, "-")
+
+	// truncate to maxBaseLen
+	if len(base) > maxBaseLen {
+		base = base[:maxBaseLen]
+	}
+	base = strings.TrimRight(base, "-")
+
+	// add random chars to the end to randomize
+	return fmt.Sprintf("%s-%s", base, utilrand.String(randomLen))
+}


### PR DESCRIPTION
The infraID is expected to be always set inside the cluster
infrastructure, despite not beeing needed by all platforms. Default it
in the hostedcluster reconciler.

Ref https://issues.redhat.com/browse/HOSTEDCP-280

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.