### PR TITLE
Fix CPO shutdown to prevent leak of lease hold

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -292,7 +292,6 @@ func NewStartCommand() *cobra.Command {
 		setupLog.Info("starting manager")
 		if err := mgr.Start(ctx); err != nil {
 			setupLog.Error(err, "problem running manager")
-			os.Exit(1)
 		}
 	}
 


### PR DESCRIPTION
Before this commit, the context cancellation handling in the control-plane-operator entrypoint had an `os.Exit()` call which races with deferred shutdown behavior, leading to the orphaning of the lease hold and causing a long delay upon restart waiting for the lease to expire.

This commit removes the `os.Exit()` call so the lease is returned on exit, so that subsequent restarts will not have to wait to regain the lease.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] ~Relevant issues have been referenced.~
- [ ] ~This change includes docs.~
- [ ] ~This change includes unit tests.~