### PR TITLE
Remove outdated binary from ko.yaml

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -11,10 +11,6 @@ builds:
   main: ./ignition-server
   flags:
   - -mod=vendor
-- id: hosted-cluster-config-operator
-  main: ./hosted-cluster-config-operator
-  flags:
-  - -mod=vendor
 - id: konnectivity-socks5-proxy
   main: ./konnectivity-socks5-proxy
   flags:


### PR DESCRIPTION
Before this commit, `ko` v1.0.0 fails because of an outdated reference to the now deleted hosted-cluster-config-operator binary in `ko.yaml`. This commit removes the bad entry and fixes the tool.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] ~Relevant issues have been referenced.~
- [ ] ~This change includes docs.~
- [ ] ~This change includes unit tests.~