### PR TITLE
Enable ServiceMonitor support for kube-apiserver

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -11,10 +11,6 @@ builds:
   main: ./ignition-server
   flags:
   - -mod=vendor
-- id: hosted-cluster-config-operator
-  main: ./hosted-cluster-config-operator
-  flags:
-  - -mod=vendor
 - id: konnectivity-socks5-proxy
   main: ./konnectivity-socks5-proxy
   flags:

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1508,6 +1508,28 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 		r.Log.Info("Reconciled api server pdb", "result", result)
 	}
 
+	rootCASecret := manifests.RootCASecret(hcp.Namespace)
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(rootCASecret), rootCASecret); err != nil {
+		return err
+	}
+	metricsClientSecret := manifests.KASMetricsClientCert(hcp.Namespace)
+	if result, err := r.CreateOrUpdate(ctx, r, metricsClientSecret, func() error {
+		return pki.ReconcileKASMetricsClientCertSecret(metricsClientSecret, rootCASecret, config.OwnerRefFrom(hcp))
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile kas metrics client cert secret: %w", err)
+	} else {
+		r.Log.Info("Reconciled api server metrics client cert secret", "result", result)
+	}
+
+	serviceMonitor := manifests.KASServiceMonitor(hcp.Namespace)
+	if result, err := r.CreateOrUpdate(ctx, r, serviceMonitor, func() error {
+		return kas.ReconcileServiceMonitor(serviceMonitor, int(p.APIServerPort), config.OwnerRefFrom(hcp))
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile kas service monitor: %w", err)
+	} else {
+		r.Log.Info("Reconciled api server service monitor", "result", result)
+	}
+
 	kubeAPIServerDeployment := manifests.KASDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, kubeAPIServerDeployment, func() error {
 		return kas.ReconcileKubeAPIServerDeployment(kubeAPIServerDeployment,
@@ -1524,6 +1546,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 			aesCBCActiveKey,
 			aesCBCBackupKey,
 			hcp.Spec.Etcd.ManagementType,
+			p.APIServerPort,
 		)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile api server deployment: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -49,6 +49,7 @@ var (
 			kasVolumeKubeletClientCert().Name:      "/etc/kubernetes/certs/kubelet",
 			kasVolumeKubeletClientCA().Name:        "/etc/kubernetes/certs/kubelet-ca",
 			kasVolumeKonnectivityClientCert().Name: "/etc/kubernetes/certs/konnectivity-client",
+			kasVolumeMetricsClientCert().Name:      "/etc/kubernetes/certs/metrics-client",
 			kasVolumeEgressSelectorConfig().Name:   "/etc/kubernetes/egress-selector",
 		},
 	}
@@ -93,6 +94,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	aesCBCActiveKey []byte,
 	aesCBCBackupKey []byte,
 	etcdMgmtType hyperv1.EtcdManagementType,
+	port int32,
 ) error {
 
 	configBytes, ok := config.Data[KubeAPIServerConfigKey]
@@ -148,7 +150,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 			},
 			Containers: []corev1.Container{
 				util.BuildContainer(kasContainerApplyBootstrap(), buildKASContainerApplyBootstrap(images.CLI)),
-				util.BuildContainer(kasContainerMain(), buildKASContainerMain(images.HyperKube)),
+				util.BuildContainer(kasContainerMain(), buildKASContainerMain(images.HyperKube, port)),
 			},
 			Volumes: []corev1.Volume{
 				util.BuildVolume(kasVolumeBootstrapManifests(), buildKASVolumeBootstrapManifests),
@@ -168,6 +170,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 				util.BuildVolume(kasVolumeKubeletClientCert(), buildKASVolumeKubeletClientCert),
 				util.BuildVolume(kasVolumeKubeletClientCA(), buildKASVolumeKubeletClientCA),
 				util.BuildVolume(kasVolumeKonnectivityClientCert(), buildKASVolumeKonnectivityClientCert),
+				util.BuildVolume(kasVolumeMetricsClientCert(), buildKASVolumeMetricsClientCert),
 				util.BuildVolume(kasVolumeEgressSelectorConfig(), buildKASVolumeEgressSelectorConfig),
 				util.BuildVolume(kasVolumeKubeconfig(), buildKASVolumeKubeconfig),
 			},
@@ -315,7 +318,7 @@ func kasContainerMain() *corev1.Container {
 	}
 }
 
-func buildKASContainerMain(image string) func(c *corev1.Container) {
+func buildKASContainerMain(image string, port int32) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
@@ -341,6 +344,13 @@ func buildKASContainerMain(image string) func(c *corev1.Container) {
 		}}
 		c.WorkingDir = volumeMounts.Path(c.Name, kasVolumeWorkLogs().Name)
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+		c.Ports = []corev1.ContainerPort{
+			{
+				Name:          "client",
+				ContainerPort: port,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		}
 	}
 }
 
@@ -463,6 +473,20 @@ func buildKASVolumeKonnectivityClientCert(v *corev1.Volume) {
 	}
 	v.Secret.DefaultMode = pointer.Int32Ptr(420)
 	v.Secret.SecretName = manifests.KonnectivityClientSecret("").Name
+}
+
+func kasVolumeMetricsClientCert() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "metrics-client",
+	}
+}
+
+func buildKASVolumeMetricsClientCert(v *corev1.Volume) {
+	if v.Secret == nil {
+		v.Secret = &corev1.SecretVolumeSource{}
+	}
+	v.Secret.DefaultMode = pointer.Int32Ptr(420)
+	v.Secret.SecretName = manifests.KASMetricsClientCert("").Name
 }
 
 func kasVolumeAggregatorCert() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -14,6 +14,16 @@ import (
 func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy, owner *metav1.OwnerReference, apiServerPort int, isPublic bool) error {
 	util.EnsureOwnerRef(svc, owner)
 	svc.Spec.Selector = kasLabels()
+
+	// Ensure labels propagate to endpoints so service
+	// monitors can select them
+	if svc.Labels == nil {
+		svc.Labels = map[string]string{}
+	}
+	for k, v := range kasLabels() {
+		svc.Labels[k] = v
+	}
+
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
@@ -1,0 +1,112 @@
+package kas
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, apiServerPort int, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sm)
+
+	sm.Spec.Selector.MatchLabels = kasLabels()
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+	targetPort := intstr.FromInt(apiServerPort)
+	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
+		{
+			Interval:   "15s",
+			TargetPort: &targetPort,
+			Scheme:     "https",
+			TLSConfig: &prometheusoperatorv1.TLSConfig{
+				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
+					ServerName: "kube-apiserver",
+					Cert: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.KASMetricsClientCert(sm.Namespace).Name,
+							},
+							Key: "tls.crt",
+						},
+					},
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: manifests.KASMetricsClientCert(sm.Namespace).Name,
+						},
+						Key: "tls.key",
+					},
+					CA: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.KASMetricsClientCert(sm.Namespace).Name,
+							},
+							Key: "ca.crt",
+						},
+					},
+				},
+			},
+			MetricRelabelConfigs: []*prometheusoperatorv1.RelabelConfig{
+				{
+					Action:       "drop",
+					Regex:        "etcd_(debugging|disk|server).*",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "apiserver_admission_controller_admission_latencies_seconds_.*",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "apiserver_admission_step_admission_latencies_seconds_.*",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "transformation_(transformation_latencies_microseconds|failures_total)",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "network_plugin_operations_latency_microseconds|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)",
+					SourceLabels: []string{"__name__", "le"},
+				},
+			},
+		},
+	}
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -3,9 +3,10 @@ package manifests
 import (
 	"fmt"
 
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	// TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -152,6 +153,24 @@ func KASAuthenticationTokenWebhookConfigSecret(controlPlaneNamespace string) *co
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kas-authentication-token-webhook-config",
 			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
+func KASMetricsClientCert(controlPlaneNamespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kas-metrics-cert",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
+func KASServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
+	return &prometheusoperatorv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver",
+			Namespace: ns,
 		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -70,6 +70,10 @@ func ReconcileIngressOperatorClientCertSecret(secret, ca *corev1.Secret, ownerRe
 	return reconcileSignedCert(secret, ca, ownerRef, "system:serviceaccount:openshift-ingress-operator:ingress-operator", []string{"system:serviceaccounts"}, X509UsageClientServerAuth)
 }
 
+func ReconcileKASMetricsClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSignedCert(secret, ca, ownerRef, "system:kas-metrics-client", []string{"kubernetes"}, X509UsageClientServerAuth)
+}
+
 func nextIP(ip net.IP) net.IP {
 	nextIP := net.IP(make([]byte, len(ip)))
 	copy(nextIP, ip)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -68,3 +68,11 @@ func CSRRenewalClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		},
 	}
 }
+
+func KASMetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kas-metrics-client",
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -226,3 +226,19 @@ func ReconcileCSRRenewalClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
 	}
 	return nil
 }
+
+func ReconcileKASMetricsClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:monitoring",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "User",
+			Name:     "system:kas-metrics-client",
+		},
+	}
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -506,6 +506,7 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 		{manifest: manifests.NamespaceSecurityAllocationControllerClusterRoleBinding, reconcile: rbac.ReconcileNamespaceSecurityAllocationControllerClusterRoleBinding},
 		{manifest: manifests.NodeBootstrapperClusterRoleBinding, reconcile: rbac.ReconcileNodeBootstrapperClusterRoleBinding},
 		{manifest: manifests.CSRRenewalClusterRoleBinding, reconcile: rbac.ReconcileCSRRenewalClusterRoleBinding},
+		{manifest: manifests.KASMetricsClientClusterRoleBinding, reconcile: rbac.ReconcileKASMetricsClusterRoleBinding},
 	}
 
 	var errs []error


### PR DESCRIPTION
This commit adds a ServiceMonitor to the control plane kube-apiserver
component, secured with TLS using a client certificate generates specifically
for this purpose scoped to the `system:monitoring` cluster role. This enables
end users to aggregate control plane API server metrics.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] ~Relevant issues have been referenced.~
- [ ] ~This change includes docs.~
- [ ] ~This change includes unit tests.~