### PR TITLE
e2e: fix CPO budget queries

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -375,34 +375,34 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 		}{
 			{
 				name:   "control-plane-operator read",
-				query:  fmt.Sprintf("sum(hypershift:controlplane:component_api_requests_total{method=\"GET\", namespace=~\"%s\"}) by (pod)", namespace),
+				query:  fmt.Sprintf(`sum(hypershift:controlplane:component_api_requests_total{app="control-plane-operator", method="GET", namespace=~"%s"}) by (pod)`, namespace),
 				budget: 800,
 			},
 			{
 				name:   "control-plane-operator mutate",
-				query:  fmt.Sprintf("sum(hypershift:controlplane:component_api_requests_total{method!=\"GET\", namespace=~\"%s\"}) by (pod)", namespace),
+				query:  fmt.Sprintf(`sum(hypershift:controlplane:component_api_requests_total{app="control-plane-operator", method!="GET", namespace=~"%s"}) by (pod)`, namespace),
 				budget: 400,
 			},
 			{
 				name:   "control-plane-operator no 404 deletes",
-				query:  fmt.Sprintf("sum(hypershift:controlplane:component_api_requests_total{method=\"DELETE\", code=\"404\", namespace=~\"%s\"}) by (pod)", namespace),
+				query:  fmt.Sprintf(`sum(hypershift:controlplane:component_api_requests_total{app="control-plane-operator", method="DELETE", code="404", namespace=~"%s"}) by (pod)`, namespace),
 				budget: 0,
 			},
 			// hypershift-operator budget can not be per HC so metric will be significantly under budget for all but the last test(s) to complete on a particular test cluster
 			// These budgets will also need to scale up with additional tests that create HostedClusters
 			{
 				name:   "hypershift-operator read",
-				query:  "sum(hypershift:operator:component_api_requests_total{method=\"GET\"})",
+				query:  `sum(hypershift:operator:component_api_requests_total{method="GET"})`,
 				budget: 1500,
 			},
 			{
 				name:   "hypershift-operator mutate",
-				query:  "sum(hypershift:operator:component_api_requests_total{method!=\"GET\"})",
+				query:  `sum(hypershift:operator:component_api_requests_total{method!="GET"})`,
 				budget: 2000,
 			},
 			{
 				name:   "hypershift-operator no 404 deletes",
-				query:  "sum(hypershift:operator:component_api_requests_total{method=\"DELETE\", code=\"404\"})",
+				query:  `sum(hypershift:operator:component_api_requests_total{method="DELETE", code="404"})`,
 				budget: 0,
 			},
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
The budget query for CPO read/mutate/delete-404 doesn't filter by `app=control-plane-operator` and thus sums activity from other components as well.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.