### PR TITLE
Azure: Validate cloud credential secret is valid

### DIFF
--- a/support/capabilities/fake/fake.go
+++ b/support/capabilities/fake/fake.go
@@ -5,10 +5,16 @@ import (
 )
 
 var _ capabilities.CapabiltyChecker = &FakeSupportAllCapabilities{}
+var _ capabilities.CapabiltyChecker = &FakeSupportNoCapabilities{}
 
-type FakeSupportAllCapabilities struct {
-}
+type FakeSupportAllCapabilities struct{}
 
 func (f *FakeSupportAllCapabilities) Has(capabilities ...capabilities.CapabilityType) bool {
 	return true
+}
+
+type FakeSupportNoCapabilities struct{}
+
+func (f *FakeSupportNoCapabilities) Has(capabilities ...capabilities.CapabilityType) bool {
+	return false
 }


### PR DESCRIPTION
This makes us validate that the azure cloud credential secret is valid
and use it as an input to the ValidConfiguration condition. If this
condition is `false`, the hypershift operator will not reconcile a
cluster.

/cc @enxebre 

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.