### PR TITLE
Let NodePool controller wait if infraID is empty

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -194,6 +194,13 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
 	ignEndpoint := hcluster.Status.IgnitionEndpoint
 	infraID := hcluster.Spec.InfraID
+	if err := validateInfraID(infraID); err != nil {
+		// We don't return the error here as reconciling won't solve the input problem.
+		// An update event will trigger reconciliation.
+		// TODO (alberto): consider this an condition failure reason when revisiting conditions.
+		log.Error(err, "Invalid infraID, waiting.")
+		return reconcile.Result{}, nil
+	}
 
 	// 1. - Reconcile conditions according to current state of the world.
 
@@ -1429,4 +1436,11 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 	}
 
 	return template, mutateTemplate, string(machineTemplateSpecJSON), nil
+}
+
+func validateInfraID(infraID string) error {
+	if infraID == "" {
+		return fmt.Errorf("infraID can't be empty")
+	}
+	return nil
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -1013,3 +1013,12 @@ func TestListMachineTemplatesIBMCloud(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(templates)).To(Equal(0))
 }
+
+func TestValidateInfraID(t *testing.T) {
+	g := NewWithT(t)
+	err := validateInfraID("")
+	g.Expect(err).To(HaveOccurred())
+
+	err = validateInfraID("123")
+	g.Expect(err).ToNot(HaveOccurred())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The NodePool controller assumes infraID as contractual info (particularly uses it for naming generation). This https://github.com/openshift/hypershift/pull/1055 introduced a race so MachineDepoyment could be created without the infraID in the name.

This PR let the NodePool controller wait until th infraID is set in the HC API.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://github.com/openshift/hypershift/issues/1059

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.