### PR TITLE
e2e: fix API budget assertions

### DIFF
--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -76,7 +76,6 @@ func TestAutoRepair(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred(), "failed to wait for new node to become available")
 
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-	e2eutil.EnsureAPIBudget(t, ctx, client, hostedCluster)
 }
 
 func ec2Client(awsCredsFile, region string) *ec2.EC2 {

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -110,7 +110,6 @@ func TestAutoscaling(t *testing.T) {
 	_ = e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
 
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-	e2eutil.EnsureAPIBudget(t, ctx, client, hostedCluster)
 }
 
 func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, image string, zone string) *batchv1.Job {

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -60,6 +60,5 @@ func TestUpgradeControlPlane(t *testing.T) {
 
 	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-	e2eutil.EnsureAPIBudget(t, ctx, client, hostedCluster)
 	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, client, hostedCluster)
 }

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -134,6 +134,11 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 		}
 	})
 
+	// All clusters created during tests should ultimately conform to our API
+	// budget. This should be checked after deletion to ensure that API operations
+	// for the full lifecycle are accounted for.
+	EnsureAPIBudget(t, ctx, client, hc)
+
 	// Finally, delete the test namespace containing the HostedCluster/NodePool
 	// resources.
 	//


### PR DESCRIPTION
Before this commit, API budget assertions were executed inline with main test
code while the cluster under test was still alive. Because of this, the
Prometheus queries could not account for metrics which occur only during
teardown.

This commit improves the accounting by moving the API budget assertions into the
test fixture so that the check happens uniformly following cluster teardown in
the fixture code itself. Test authors should no longer call `EnsureAPIBudget`
directly unless there's a special case.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] ~Relevant issues have been referenced.~
- [ ] ~This change includes docs.~
- [ ] ~This change includes unit tests.~