### PR TITLE
Fix getname func

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1307,7 +1307,7 @@ func getName(base, suffix string, maxLength int) string {
 	baseLength := maxLength - 10 - len(suffix)
 
 	// if the suffix is too long, ignore it
-	if baseLength < 0 {
+	if baseLength < 1 {
 		prefix := base[0:min(len(base), max(0, maxLength-9))]
 		// Calculate hash on initial base-suffix string
 		shortName := fmt.Sprintf("%s-%s", prefix, hashStruct(name))

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3,6 +3,7 @@ package nodepool
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -1021,4 +1022,25 @@ func TestValidateInfraID(t *testing.T) {
 
 	err = validateInfraID("123")
 	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestGetName(t *testing.T) {
+	g := NewWithT(t)
+
+	alphaNumeric := regexp.MustCompile(`^[a-z0-9]*$`)
+	base := "infraID-clusterName" // length 19
+	suffix := "nodePoolName"      // length 12
+	length := len(base) + len(suffix)
+
+	// When maxLength == base+suffix
+	name := getName(base, suffix, length)
+	g.Expect(alphaNumeric.MatchString(string(name[0]))).To(BeTrue())
+
+	// When maxLength < base+suffix
+	name = getName(base, suffix, length-1)
+	g.Expect(alphaNumeric.MatchString(string(name[0]))).To(BeTrue())
+
+	// When maxLength > base+suffix
+	name = getName(base, suffix, length+1)
+	g.Expect(alphaNumeric.MatchString(string(name[0]))).To(BeTrue())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Because of the multi az work we are appending the az to NodePool names generated by the cli, which resulted in a long enough name to uncover a bug in the function that generates the name of the MD

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://github.com/openshift/hypershift/issues/1059

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.