### PR TITLE
force copy in openshift-apiserver trust anchor init container script

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -152,7 +152,7 @@ func buildOASTrustAnchorGenerator(oasImage string) func(*corev1.Container) {
 		c.Command = []string{
 			"/bin/bash",
 			"-c",
-			"cp /etc/pki/ca-trust/extracted/pem/* /run/ca-trust-generated/ && " +
+			"cp -f /etc/pki/ca-trust/extracted/pem/* /run/ca-trust-generated/ && " +
 				"if ! [[ -f /run/service-ca-signer/service-ca.crt ]]; then exit 0; fi && " +
 				"chmod 0666 /run/ca-trust-generated/tls-ca-bundle.pem && " +
 				"echo '#service signer ca' >> /run/ca-trust-generated/tls-ca-bundle.pem && " +


### PR DESCRIPTION
**What this PR does / why we need it**:
Init containers must tolerate being rerun.
https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#pod-restart-reasons

In the case, that the files already exist in the emptyDir, the OASTrustAnchorGenerator init container fails because the destination files are read-only.

Forcing the `cp` fixes this.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.