### PR TITLE
Produce config metrics for telemetry

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	// TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -116,6 +117,7 @@ func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Watches(&source.Kind{Type: &corev1.ServiceAccount{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Watches(&source.Kind{Type: &policyv1beta1.PodDisruptionBudget{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
+		Watches(&source.Kind{Type: &prometheusoperatorv1.PodMonitor{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Watches(&source.Channel{Source: r.HostedAPICache.Events()}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Build(r)
 	if err != nil {
@@ -2123,6 +2125,25 @@ func (r *HostedControlPlaneReconciler) reconcileHostedClusterConfigOperator(ctx 
 		return configoperator.ReconcileDeployment(deployment, p.Image, hcp.Name, p.OpenShiftVersion, p.KubernetesVersion, p.OwnerRef, &p.DeploymentConfig, p.AvailabilityProberImage, r.EnableCIDebugOutput, hcp.Spec.Platform.Type, hcp.Spec.APIPort, infraStatus.KonnectivityHost, infraStatus.KonnectivityPort, infraStatus.OAuthHost, infraStatus.OAuthPort, hcp.Spec.ReleaseImage)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile config operator deployment: %w", err)
+	}
+
+	podMonitor := manifests.ConfigOperatorPodMonitor(hcp.Namespace)
+	if _, err := r.CreateOrUpdate(ctx, r.Client, podMonitor, func() error {
+		podMonitor.Spec.Selector = *deployment.Spec.Selector
+		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
+			Interval: "15s",
+			Port:     "metrics",
+		}}
+		podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{hcp.Namespace}}
+		podMonitor.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: hyperv1.GroupVersion.String(),
+			Kind:       "HostedControlPlane",
+			Name:       hcp.Name,
+			UID:        hcp.UID,
+		}})
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile pod monitor for config operator: %w", err)
 	}
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/configoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/configoperator.go
@@ -4,6 +4,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 func ConfigOperatorDeployment(ns string) *appsv1.Deployment {
@@ -32,4 +35,11 @@ func ConfigOperatorServiceAccount(ns string) *corev1.ServiceAccount {
 	sa.Name = "hosted-cluster-config-operator"
 	sa.Namespace = ns
 	return sa
+}
+
+func ConfigOperatorPodMonitor(ns string) *prometheusoperatorv1.PodMonitor {
+	return &prometheusoperatorv1.PodMonitor{ObjectMeta: metav1.ObjectMeta{
+		Namespace: ns,
+		Name:      "hosted-cluster-config-operator",
+	}}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/configmetrics"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/cmca"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
@@ -233,5 +234,6 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		OAuthPort:             o.OAuthPort,
 		OperateOnReleaseImage: os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
 	}
+	configmetrics.Register(mgr.GetCache())
 	return operatorConfig.Start(ctx)
 }

--- a/control-plane-operator/hostedclusterconfigoperator/configmetrics/configmetrics.go
+++ b/control-plane-operator/hostedclusterconfigoperator/configmetrics/configmetrics.go
@@ -1,0 +1,111 @@
+package configmetrics
+
+/*
+package configmetrics is mostly a straight copy of https://github.com/openshift/cluster-kube-apiserver-operator/blob/5435d65b520191ba74fb2cd8c84a4f5bdf604178/pkg/operator/configmetrics/configmetrics.go
+with some slight adjustments to use a controller-runtime cache rather than a standard informer and to use the controller-runtime metrics registry rather than the client-go legacyregistry.
+*/
+
+import (
+	"context"
+
+	"github.com/blang/semver"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	configv1 "github.com/openshift/api/config/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Register exposes core platform metrics that relate to the configuration
+// of Kubernetes.
+// TODO: in the future this may move to cluster-config-operator.
+func Register(cache crclient.Reader) {
+	metrics.Registry.MustRegister(&configMetrics{
+		cloudProvider: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cluster_infrastructure_provider",
+			Help: "Reports whether the cluster is configured with an infrastructure provider. type is unset if no cloud provider is recognized or set to the constant used by the Infrastructure config. region is set when the cluster clearly identifies a region within the provider. The value is 1 if a cloud provider is set or 0 if it is unset.",
+		}, []string{"type", "region"}),
+		featureSet: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cluster_feature_set",
+			Help: "Reports the feature set the cluster is configured to expose. name corresponds to the featureSet field of the cluster. The value is 1 if a cloud provider is supported.",
+		}, []string{"name"}),
+		proxyEnablement: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cluster_proxy_enabled",
+			Help: "Reports whether the cluster has been configured to use a proxy. type is which type of proxy configuration has been set - http for an http proxy, https for an https proxy, and trusted_ca if a custom CA was specified.",
+		}, []string{"type"}),
+		cache: cache,
+	})
+}
+
+// configMetrics implements metrics gathering for this component.
+type configMetrics struct {
+	cloudProvider   *prometheus.GaugeVec
+	featureSet      *prometheus.GaugeVec
+	proxyEnablement *prometheus.GaugeVec
+	cache           crclient.Reader
+}
+
+func (m *configMetrics) Create(version *semver.Version) bool {
+	return true
+}
+
+// Describe reports the metadata for metrics to the prometheus collector.
+func (m *configMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- m.cloudProvider.WithLabelValues("", "").Desc()
+	ch <- m.featureSet.WithLabelValues("").Desc()
+	ch <- m.proxyEnablement.WithLabelValues("").Desc()
+}
+
+// Collect calculates metrics from the cached config and reports them to the prometheus collector.
+func (m *configMetrics) Collect(ch chan<- prometheus.Metric) {
+	infra := &configv1.Infrastructure{}
+	if err := m.cache.Get(context.Background(), crclient.ObjectKey{Name: "cluster"}, infra); err == nil {
+		if status := infra.Status.PlatformStatus; status != nil {
+			var g prometheus.Gauge
+			var value float64 = 1
+			switch {
+			// it is illegal to set type to empty string, so let the default case handle
+			// empty string (so we can detect it) while preserving the constant None here
+			case status.Type == configv1.NonePlatformType:
+				g = m.cloudProvider.WithLabelValues(string(status.Type), "")
+				value = 0
+			case status.AWS != nil:
+				g = m.cloudProvider.WithLabelValues(string(status.Type), status.AWS.Region)
+			case status.GCP != nil:
+				g = m.cloudProvider.WithLabelValues(string(status.Type), status.GCP.Region)
+			default:
+				g = m.cloudProvider.WithLabelValues(string(status.Type), "")
+			}
+			g.Set(value)
+			ch <- g
+		}
+	}
+	features := &configv1.FeatureGate{}
+	if err := m.cache.Get(context.Background(), crclient.ObjectKey{Name: "cluster"}, features); err == nil {
+		ch <- booleanGaugeValue(
+			m.featureSet.WithLabelValues(string(features.Spec.FeatureSet)),
+			features.Spec.FeatureSet == configv1.Default,
+		)
+	}
+	proxy := &configv1.Proxy{}
+	if err := m.cache.Get(context.Background(), crclient.ObjectKey{Name: "cluster"}, proxy); err == nil {
+		ch <- booleanGaugeValue(m.proxyEnablement.WithLabelValues("http"), len(proxy.Spec.HTTPProxy) > 0)
+		ch <- booleanGaugeValue(m.proxyEnablement.WithLabelValues("https"), len(proxy.Spec.HTTPSProxy) > 0)
+		ch <- booleanGaugeValue(m.proxyEnablement.WithLabelValues("trusted_ca"), len(proxy.Spec.TrustedCA.Name) > 0)
+	}
+}
+
+func booleanGaugeValue(g prometheus.Gauge, value bool) prometheus.Gauge {
+	if value {
+		g.Set(1)
+	} else {
+		g.Set(0)
+	}
+	return g
+}
+
+func (m *configMetrics) ClearState() {}
+
+func (m *configMetrics) FQName() string {
+	return "cluster_kube_apiserver_operator"
+}

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -85,6 +85,7 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 		RenewDeadline:                 &renewDeadline,
 		RetryPeriod:                   &retryPeriod,
 		HealthProbeBindAddress:        ":6060",
+		MetricsBindAddress:            "0.0.0.0:8080",
 
 		NewClient: func(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
 			client, err := cluster.DefaultNewClient(cache, config, options, uncachedObjects...)
@@ -108,6 +109,7 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 				&configv1.Image{}:          allSelector,
 				&configv1.Project{}:        allSelector,
 				&configv1.ClusterVersion{}: allSelector,
+				&configv1.FeatureGate{}:    allSelector,
 			},
 			DefaultSelector: cache.ObjectSelector{Label: cacheLabelSelector()},
 		}),

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1417,7 +1417,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	}
 
 	// Reconcile operator PodMonitor
-	podMonitor := controlplaneoperator.PodMonitor(controlPlaneNamespace.Name, hcluster.Name)
+	podMonitor := controlplaneoperator.PodMonitor(controlPlaneNamespace.Name)
 	if _, err := createOrUpdate(ctx, r.Client, podMonitor, func() error {
 		podMonitor.Spec.Selector = *controlPlaneOperatorDeployment.Spec.Selector
 		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{

--- a/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
@@ -118,11 +118,11 @@ func SSHKey(controlPlaneNamespace string) *corev1.Secret {
 	}
 }
 
-func PodMonitor(controlPlaneNamespace string, hostedClusterName string) *prometheusoperatorv1.PodMonitor {
+func PodMonitor(controlPlaneNamespace string) *prometheusoperatorv1.PodMonitor {
 	return &prometheusoperatorv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
-			Name:      hostedClusterName,
+			Name:      "controlplane-operator",
 		},
 	}
 }


### PR DESCRIPTION
This change makes the hosted cluster config operator emit a couple of
metrics that are usually generated by the apiserver operator. It also
adds a podmonitor for the HCCO, because so far we haven't been scraping
its metrics.

Ref https://issues.redhat.com/browse/HOSTEDCP-294

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.