### PR TITLE
Agent: each hostedcluster provider should have it's own role binding

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -152,7 +152,7 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hcluster.Spec.Platform.Agent.AgentNamespace,
-			Name:      credentialsRBACName,
+			Name:      fmt.Sprintf("%s-%s", credentialsRBACName, controlPlaneNamespace),
 		},
 	}
 	_, err = createOrUpdate(ctx, c, roleBinding, func() error {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -43,7 +44,7 @@ func TestReconcileCredentials(t *testing.T) {
 	roleBinding := &rbacv1.RoleBinding{}
 	err = client.Get(context.Background(), types.NamespacedName{
 		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
-		Name:      credentialsRBACName,
+		Name:      fmt.Sprintf("%s-%s", credentialsRBACName, controlPlaneNamespace),
 	}, roleBinding)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(roleBinding.Subjects[0].Namespace).To(BeIdenticalTo(controlPlaneNamespace))


### PR DESCRIPTION
**What this PR does / why we need it**:
Create rolebinding in agent namespace for each hostedcluster that wants to use this namespace

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.