### PR TITLE
Remove choosing Agents by minimum CPU and RAM

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -413,14 +413,6 @@ type Volume struct {
 // AgentNodePoolPlatform specifies the configuration of a NodePool when operating
 // on the Agent platform.
 type AgentNodePoolPlatform struct {
-	// MinCPUs specifies the minimum number of CPU cores required.
-	// +optional
-	MinCPUs int32 `json:"minCPUs,omitempty"`
-
-	// MinMemoryMiB specifies the minimum amount of RAM required, in MiB.
-	// +optional
-	MinMemoryMiB int32 `json:"minMemoryMiB,omitempty"`
-
 	// AgentLabelSelector contains labels that must be set on an Agent in order to
 	// be selected for a Machine.
 	// +optional

--- a/cmd/install/assets/cluster-api-provider-agent/capi-provider.agent-install.openshift.io_agentmachines.yaml
+++ b/cmd/install/assets/cluster-api-provider-agent/capi-provider.agent-install.openshift.io_agentmachines.yaml
@@ -81,16 +81,6 @@ spec:
                       are ANDed.
                     type: object
                 type: object
-              minCPUs:
-                description: MinCPUs specifies the minimum number of CPU cores that
-                  this Machine requires.
-                format: int32
-                type: integer
-              minMemoryMiB:
-                description: MinMemoryMiB specifies the minimum amount of RAM that
-                  this Machine requires, in MiB.
-                format: int32
-                type: integer
               providerID:
                 description: ProviderID is the host's motherboard serial formatted
                   as agent://12345678-1234-1234-1234-123456789abc

--- a/cmd/install/assets/cluster-api-provider-agent/capi-provider.agent-install.openshift.io_agentmachinetemplates.yaml
+++ b/cmd/install/assets/cluster-api-provider-agent/capi-provider.agent-install.openshift.io_agentmachinetemplates.yaml
@@ -95,16 +95,6 @@ spec:
                               only "value". The requirements are ANDed.
                             type: object
                         type: object
-                      minCPUs:
-                        description: MinCPUs specifies the minimum number of CPU cores
-                          that this Machine requires.
-                        format: int32
-                        type: integer
-                      minMemoryMiB:
-                        description: MinMemoryMiB specifies the minimum amount of
-                          RAM that this Machine requires, in MiB.
-                        format: int32
-                        type: integer
                       providerID:
                         description: ProviderID is the host's motherboard serial formatted
                           as agent://12345678-1234-1234-1234-123456789abc

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -259,16 +259,6 @@ spec:
                               only "value". The requirements are ANDed.
                             type: object
                         type: object
-                      minCPUs:
-                        description: MinCPUs specifies the minimum number of CPU cores
-                          required.
-                        format: int32
-                        type: integer
-                      minMemoryMiB:
-                        description: MinMemoryMiB specifies the minimum amount of
-                          RAM required, in MiB.
-                        format: int32
-                        type: integer
                     type: object
                   aws:
                     description: AWS specifies the configuration used when operating

--- a/docs/content/how-to/agent-platform.md
+++ b/docs/content/how-to/agent-platform.md
@@ -32,7 +32,5 @@ Upon scaling down a NodePool, Agents will be unbound from the corresponding clus
   (agent_namespace is the namespace where the Agent CRs reside)
 * Scale up the Nodepool:
 	* Optionally specify which Agents to choose:
-		* NodePool.Spec.MinCPUs (the minimum number of CPU cores required)
-		* NodePool.Spec.MinMemoryMiB (the minimum amount of RAM required, in MiB)
 		* NodePool.Spec.AgentLabelSelector (labels that must be set on an Agent in order to be selected)
 	* Set NodePool.Spec.NodeCount to the desired number of nodes

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1398,30 +1398,6 @@ on the Agent platform.</p>
 <tbody>
 <tr>
 <td>
-<code>minCPUs</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MinCPUs specifies the minimum number of CPU cores required.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minMemoryMiB</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MinMemoryMiB specifies the minimum amount of RAM required, in MiB.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>agentLabelSelector</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#labelselector-v1-meta">

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/openshift/api v0.0.0-20220124143425-d74727069f6f
-	github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220206195825-03d0b4a038df
+	github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220227135922-dd6353f609dc
 	github.com/operator-framework/api v0.10.7
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.51.1

--- a/go.sum
+++ b/go.sum
@@ -1030,8 +1030,8 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/openshift/api v0.0.0-20220124143425-d74727069f6f h1:iOTv1WudhVm2UsoST+L+ZrA5A9w57h9vmQsdlBuqG6g=
 github.com/openshift/api v0.0.0-20220124143425-d74727069f6f/go.mod h1:F/eU6jgr6Q2VhMu1mSpMmygxAELd7+BUxs3NHZ25jV4=
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
-github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220206195825-03d0b4a038df h1:6XaS0G71VIcSzoX8voFICE8tdn2oB92I5K0yY2G5U1M=
-github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220206195825-03d0b4a038df/go.mod h1:SKABBM8Idpzg3hSwtf7/nPQU6zcRuU3i+IsDxMvQQLk=
+github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220227135922-dd6353f609dc h1:/CaKFCqrrle4NE8YLwcAavCQp37MPF2TliFenPWF8FM=
+github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220227135922-dd6353f609dc/go.mod h1:SKABBM8Idpzg3hSwtf7/nPQU6zcRuU3i+IsDxMvQQLk=
 github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20211223062810-ef64d5ff1cde h1:DVqRkxwYQ+4KV5mGP2XCai9eB4puQ07zth8XwROHf0E=
 github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20211223062810-ef64d5ff1cde/go.mod h1:Z4fR4Cg8/z9GEys79MU+8CpX98aZQqI+tl9YIao0KxQ=
 github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca h1:F1MEnOMwSrTA0YAkO0he9ip9w0JhYzI/iCB2mXmaSPg=

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -3849,16 +3849,6 @@ objects:
                         are ANDed.
                       type: object
                   type: object
-                minCPUs:
-                  description: MinCPUs specifies the minimum number of CPU cores that
-                    this Machine requires.
-                  format: int32
-                  type: integer
-                minMemoryMiB:
-                  description: MinMemoryMiB specifies the minimum amount of RAM that
-                    this Machine requires, in MiB.
-                  format: int32
-                  type: integer
                 providerID:
                   description: ProviderID is the host's motherboard serial formatted
                     as agent://12345678-1234-1234-1234-123456789abc
@@ -4090,16 +4080,6 @@ objects:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        minCPUs:
-                          description: MinCPUs specifies the minimum number of CPU
-                            cores that this Machine requires.
-                          format: int32
-                          type: integer
-                        minMemoryMiB:
-                          description: MinMemoryMiB specifies the minimum amount of
-                            RAM that this Machine requires, in MiB.
-                          format: int32
-                          type: integer
                         providerID:
                           description: ProviderID is the host's motherboard serial
                             formatted as agent://12345678-1234-1234-1234-123456789abc
@@ -22011,16 +21991,6 @@ objects:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        minCPUs:
-                          description: MinCPUs specifies the minimum number of CPU
-                            cores required.
-                          format: int32
-                          type: integer
-                        minMemoryMiB:
-                          description: MinMemoryMiB specifies the minimum amount of
-                            RAM required, in MiB.
-                          format: int32
-                          type: integer
                       type: object
                     aws:
                       description: AWS specifies the configuration used when operating

--- a/hypershift-operator/controllers/nodepool/agent.go
+++ b/hypershift-operator/controllers/nodepool/agent.go
@@ -8,8 +8,6 @@ import (
 func agentMachineTemplateSpec(nodePool *hyperv1.NodePool) *agentv1.AgentMachineTemplateSpec {
 	spec := agentv1.AgentMachineSpec{}
 	if nodePool.Spec.Platform.Agent != nil {
-		spec.MinCPUs = nodePool.Spec.Platform.Agent.MinCPUs
-		spec.MinMemoryMiB = nodePool.Spec.Platform.Agent.MinMemoryMiB
 		spec.AgentLabelSelector = nodePool.Spec.Platform.Agent.AgentLabelSelector
 	}
 	return &agentv1.AgentMachineTemplateSpec{

--- a/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/agentmachine_types.go
+++ b/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/agentmachine_types.go
@@ -24,14 +24,6 @@ import (
 
 // AgentMachineSpec defines the desired state of AgentMachine
 type AgentMachineSpec struct {
-	// MinCPUs specifies the minimum number of CPU cores that this Machine requires.
-	// +optional
-	MinCPUs int32 `json:"minCPUs,omitempty"`
-
-	// MinMemoryMiB specifies the minimum amount of RAM that this Machine requires, in MiB.
-	// +optional
-	MinMemoryMiB int32 `json:"minMemoryMiB,omitempty"`
-
 	// AgentLabelSelector contains the labels that must be set on an Agent in order to be selected for this Machine.
 	// +optional
 	AgentLabelSelector *metav1.LabelSelector `json:"agentLabelSelector,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -303,7 +303,7 @@ github.com/openshift/api/operator/v1alpha1
 github.com/openshift/api/osin/v1
 github.com/openshift/api/route/v1
 github.com/openshift/api/security/v1
-# github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220206195825-03d0b4a038df
+# github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220227135922-dd6353f609dc
 ## explicit; go 1.16
 github.com/openshift/cluster-api-provider-agent/api/v1alpha1
 # github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca


### PR DESCRIPTION
**What this PR does / why we need it**:

Users can already choose Agents according to labels.  While minimum
CPU/RAM is helpful, there are lots of other helpful properties, like
maximum CPU/RAM, disks, networks, GPUs, etc.  Rather than including them
all in the Spec, users should manually add labels as they desire.  In
the future, we will create an auto-labeling mechanism for Agents.


**Which issue(s) this PR fixes**
Fixes #[MGMT-9423](https://issues.redhat.com/browse/MGMT-9423)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.