### PR TITLE
e2e: exclude catalog rollout pods is EnsureHCPContainersHaveResourceRequests

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -426,9 +426,9 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 				}
 				for _, sample := range vector {
 					if float64(sample.Value) > budget.budget {
-						t.Errorf("over budget: budget: %.0f, actual: %.0f", budget.budget, sample.Value)
+						t.Errorf("pod %s over budget: budget: %.0f, actual: %.0f", sample.Metric["pod"], budget.budget, sample.Value)
 					} else {
-						t.Logf("within budget: budget: %.0f, actual: %.0f", budget.budget, sample.Value)
+						t.Logf("pod %s within budget: budget: %.0f, actual: %.0f", sample.Metric["pod"], budget.budget, sample.Value)
 					}
 				}
 			})
@@ -444,6 +444,9 @@ func EnsureHCPContainersHaveResourceRequests(t *testing.T, ctx context.Context, 
 			t.Fatalf("failed to list pods: %v", err)
 		}
 		for _, pod := range podList.Items {
+			if strings.Contains(pod.Name, "-catalog-rollout-") {
+				continue
+			}
 			for _, container := range pod.Spec.Containers {
 				if container.Resources.Requests == nil {
 					t.Errorf("container %s in pod %s has no resource requests", container.Name, pod.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Catalog rollout pods can be scheduled on the HCP by OLM during the testing process and they do not have resource request.  These pods are outside our direct control.  This PR excludes them from the check.

Caused this failure
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-e2e-aws-periodic/1497994977861439488


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.