### PR TITLE
feat: Preserve container resources for control plane components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
@@ -30,6 +30,12 @@ var (
 )
 
 func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, image string, deploymentConfig config.DeploymentConfig, availabilityProberImage string, apiServerPort *int32) error {
+	// preserve existing resource requirements for main CPC container
+	mainContainer := util.FindContainer(cpcContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	maxSurge := intstr.FromInt(1)
 	maxUnavailable := intstr.FromInt(0)
 	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -78,6 +78,13 @@ var (
 
 func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, image, cliImage string) error {
 	ownerRef.ApplyTo(deployment)
+
+	// preserve existing resource requirements for main CVO container
+	mainContainer := util.FindContainer(cvoContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: cvoLabels,

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -53,6 +53,12 @@ var (
 )
 
 func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev1.ConfigMap, p *KubeControllerManagerParams, apiPort *int32) error {
+	// preserve existing resource requirements for main KCM container
+	mainContainer := util.FindContainer(kcmContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		p.DeploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	deployment.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: kcmLabels,
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -63,6 +63,12 @@ func openShiftAPIServerLabels() map[string]string {
 func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config *corev1.ConfigMap, deploymentConfig config.DeploymentConfig, image string, socks5ProxyImage string, etcdURL string, availabilityProberImage string, apiPort *int32) error {
 	ownerRef.ApplyTo(deployment)
 
+	// preserve existing resource requirements for main OAS container
+	mainContainer := util.FindContainer(oasContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	configBytes, ok := config.Data[openshiftAPIServerConfigKey]
 	if !ok {
 		return fmt.Errorf("openshift apiserver configuration is not expected to be empty")

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -47,6 +47,12 @@ func openShiftOAuthAPIServerLabels() map[string]string {
 func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, p *OAuthDeploymentParams, apiPort *int32) error {
 	ownerRef.ApplyTo(deployment)
 
+	// preserve existing resource requirements for main oauth apiserver container
+	mainContainer := util.FindContainer(oauthContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		p.DeploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	maxUnavailable := intstr.FromInt(1)
 	maxSurge := intstr.FromInt(3)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -50,6 +50,13 @@ func oauthLabels() map[string]string {
 
 func ReconcileDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment, ownerRef config.OwnerRef, config *corev1.ConfigMap, image string, deploymentConfig config.DeploymentConfig, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, availabilityProberImage string, apiPort *int32, namedCertificates []configv1.APIServerNamedServingCert) error {
 	ownerRef.ApplyTo(deployment)
+
+	// preserve existing resource requirements for main oauth container
+	mainContainer := util.FindContainer(oauthContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	deployment.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: oauthLabels(),
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
@@ -39,6 +39,12 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	}
 	configHash := util.ComputeHash(configBytes)
 
+	// preserve existing resource requirements for main OCM container
+	mainContainer := util.FindContainer(ocmContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	maxSurge := intstr.FromInt(1)
 	maxUnavailable := intstr.FromInt(0)
 	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -36,6 +36,13 @@ var (
 
 func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, featureGates []string, policy configv1.ConfigMapNameReference, availabilityProberImage string, apiPort *int32) error {
 	ownerRef.ApplyTo(deployment)
+
+	// preserve existing resource requirements for main scheduler container
+	mainContainer := util.FindContainer(schedulerContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		config.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	maxSurge := intstr.FromInt(3)
 	maxUnavailable := intstr.FromInt(1)
 	deployment.Spec = appsv1.DeploymentSpec{

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -22,6 +22,15 @@ type DeploymentConfig struct {
 	Resources                 ResourcesSpec         `json:"resources"`
 }
 
+func (c *DeploymentConfig) SetContainerResourcesIfPresent(container *corev1.Container) {
+	resources := container.Resources
+	if len(resources.Requests) > 0 || len(resources.Limits) > 0 {
+		if c.Resources != nil {
+			c.Resources[container.Name] = resources
+		}
+	}
+}
+
 func (c *DeploymentConfig) SetRestartAnnotation(objectMetadata metav1.ObjectMeta) {
 	if _, ok := objectMetadata.Annotations[hyperv1.RestartDateAnnotation]; ok {
 		if c.AdditionalAnnotations == nil {

--- a/support/util/containers.go
+++ b/support/util/containers.go
@@ -13,6 +13,15 @@ func BuildContainer(container *corev1.Container, buildFn func(*corev1.Container)
 	return *container
 }
 
+func FindContainer(name string, containers []corev1.Container) *corev1.Container {
+	for i, c := range containers {
+		if c.Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
 // AvailabilityProberImageName is the name under which components can find the availability prober
 // image in the release image.
 const AvailabilityProberImageName = "availability-prober"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Preserve and honor container resource specs for:
  - cluster-policy-controller
  - cluster-version-operator
  - kube-controller-manager
  - openshift-apiserver
  - oauth-apiserver
  - oauth-server
  - openshift-controller-manager
  - kube-scheduler
  - control-plane-operator
- Move `findContainer()` to `utils.FindContainer()` shared containers lib
- Create `DeploymentConfig.SetContainerResourcesIfPresent()` method
  

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #1067

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.