### PR TITLE
add command line flags for specifying images for the machine-approver, cluster-autoscaler, and capi manager instance

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -94,18 +94,6 @@ const (
 	finalizer                      = "hypershift.openshift.io/finalizer"
 	hostedClusterAnnotation        = "hypershift.openshift.io/cluster"
 	clusterDeletionRequeueDuration = 5 * time.Second
-
-	// Image built from https://github.com/openshift/kubernetes-autoscaler/tree/release-4.10
-	// Upstream canonical image is k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
-	imageClusterAutoscaler = "quay.io/openshift/origin-cluster-autoscaler:4.10.0"
-
-	// Image built from https://github.com/openshift/cluster-machine-approver/tree/release-4.10
-	imageMachineApprover = "quay.io/openshift/origin-cluster-machine-approver:4.10.0"
-
-	// Image built from https://github.com/openshift/cluster-api/tree/release-1.0
-	// Upstream canonical image comes from https://console.cloud.google.com/gcr/images/k8s-staging-cluster-api/global/
-	// us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v1.0.0
-	imageCAPI = "registry.ci.openshift.org/hypershift/cluster-api:v1.0.0"
 )
 
 // NoopReconcile is just a default mutation function that does nothing.
@@ -137,6 +125,15 @@ type HostedClusterReconciler struct {
 
 	// SocksProxyImage is the image used to deploy the socks proxy service.
 	SocksProxyImage string
+
+	// CAPIManagerImage is the image to use for the CAPI manager.
+	CAPIManagerImage string
+
+	// MachineApproverImage is the image to use for the machine approver.
+	MachineApproverImage string
+
+	// ClusterAutoscalerImage is the image to use for the cluster autoscaler.
+	ClusterAutoscalerImage string
 
 	// SetDefaultSecurityContext is used to configure Security Context for containers
 	SetDefaultSecurityContext bool
@@ -1205,7 +1202,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, crea
 	}
 
 	// Reconcile CAPI manager deployment
-	capiImage := imageCAPI
+	capiImage := r.CAPIManagerImage
 	if _, ok := hcluster.Annotations[hyperv1.ClusterAPIManagerImage]; ok {
 		capiImage = hcluster.Annotations[hyperv1.ClusterAPIManagerImage]
 	}
@@ -1869,7 +1866,7 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, creat
 		}
 
 		// Reconcile autoscaler deployment
-		clusterAutoScalerImage := imageClusterAutoscaler
+		clusterAutoScalerImage := r.ClusterAutoscalerImage
 		if _, ok := hcluster.Annotations[hyperv1.ClusterAutoscalerImage]; ok {
 			clusterAutoScalerImage = hcluster.Annotations[hyperv1.ClusterAutoscalerImage]
 		}
@@ -3205,7 +3202,7 @@ func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, 
 		kubeconfigSecretName := machineapprover.KASServiceKubeconfigSecret(controlPlaneNamespaceName).Name
 
 		// Reconcile machine-approver deployment
-		image := imageMachineApprover
+		image := r.MachineApproverImage
 		if _, ok := hcluster.Annotations[hyperv1.MachineApproverImage]; ok {
 			image = hcluster.Annotations[hyperv1.MachineApproverImage]
 		}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -405,7 +405,7 @@ func TestClusterAutoscalerArgs(t *testing.T) {
 			hc := &hyperv1.HostedCluster{}
 			hc.Name = "name"
 			hc.Namespace = "namespace"
-			err := reconcileAutoScalerDeployment(deployment, hc, sa, secret, test.AutoscalerOptions, imageClusterAutoscaler, "availability-prober:latest", false)
+			err := reconcileAutoScalerDeployment(deployment, hc, sa, secret, test.AutoscalerOptions, "cluster-autoscaler:latest", "availability-prober:latest", false)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
This PR add command line flags for specifying the default image utilized for the machine-approver, cluster-autoscaler, and capi manager instance. The current architecture that Red Hat is using is one version of these components across all downstream clusters the operator manages. In addition: the hypershift-operator controls the versions of the CRDs these resources so it makes sense at least for now that these images correspond with the hypershift-operator versus getting versioned on a per cluster basis. Solves: https://github.com/openshift/hypershift/issues/1078

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://github.com/openshift/hypershift/issues/1078

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.