### PR TITLE
Azure: Use same credentials file format as installer

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -125,13 +125,14 @@ type ExampleAzureOptions struct {
 	SecurityGroupName string
 }
 
-// TODO: This format is made up by using the env var keys as keys.
-// Is there any kind of official file format for this?
+// AzureCreds is the fileformat we expect for credentials. It is copied from the installer
+// to allow using the same crededentials file for both:
+// https://github.com/openshift/installer/blob/8fca1ade5b096d9b2cd312c4599881d099439288/pkg/asset/installconfig/azure/session.go#L36
 type AzureCreds struct {
-	SubscriptionID string `json:"AZURE_SUBSCRIPTION_ID"`
-	TenantID       string `json:"AZURE_TENANT_ID"`
-	ClientID       string `json:"AZURE_CLIENT_ID"`
-	ClientSecret   string `json:"AZURE_CLIENT_SECRET"`
+	SubscriptionID string `json:"subscriptionId,omitempty"`
+	ClientID       string `json:"clientId,omitempty"`
+	ClientSecret   string `json:"clientSecret,omitempty"`
+	TenantID       string `json:"tenantId,omitempty"`
 }
 
 func (o ExampleOptions) Resources() *ExampleResources {
@@ -527,7 +528,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 										},
 									},
 									Interfaces: []kubevirtv1.Interface{
-										kubevirtv1.Interface{
+										{
 											Name: "default",
 											InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
 												Bridge: &kubevirtv1.InterfaceBridge{},
@@ -547,7 +548,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 								},
 							},
 							Networks: []kubevirtv1.Network{
-								kubevirtv1.Network{
+								{
 									Name: "default",
 									NetworkSource: kubevirtv1.NetworkSource{
 										Pod: &kubevirtv1.PodNetwork{},

--- a/docs/content/how-to/create-azure-cluster.md
+++ b/docs/content/how-to/create-azure-cluster.md
@@ -9,10 +9,10 @@ In order to authenticate with Azure, an Application must be created through the 
 Afterwards, create a credentials file that looks like this:
 
 ```
-AZURE_SUBSCRIPTION_ID: <your_subscription_id>
-AZURE_TENANT_ID: <your_tenant_id>
-AZURE_CLIENT_ID: <your_client_id>
-AZURE_CLIENT_SECRET: <your_client_secret>
+subscriptionId: <your_subscription_id>
+tenantId: <your_tenant_id>
+clientId: <your_client_id>
+clientSecret: <your_client_secret>
 ```
 
 ## Creating the cluster


### PR DESCRIPTION
This easens interoperability. There doesn't seem to be an official
format we could be using. The type is copied to avoid depending on the
installer.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.