### PR TITLE
Add ServiceMonitor support to KCM

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -50,7 +50,6 @@ var (
 			kasVolumeKubeletClientCert().Name:      "/etc/kubernetes/certs/kubelet",
 			kasVolumeKubeletClientCA().Name:        "/etc/kubernetes/certs/kubelet-ca",
 			kasVolumeKonnectivityClientCert().Name: "/etc/kubernetes/certs/konnectivity-client",
-			kasVolumeMetricsClientCert().Name:      "/etc/kubernetes/certs/metrics-client",
 			kasVolumeEgressSelectorConfig().Name:   "/etc/kubernetes/egress-selector",
 		},
 	}
@@ -171,7 +170,6 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 				util.BuildVolume(kasVolumeKubeletClientCert(), buildKASVolumeKubeletClientCert),
 				util.BuildVolume(kasVolumeKubeletClientCA(), buildKASVolumeKubeletClientCA),
 				util.BuildVolume(kasVolumeKonnectivityClientCert(), buildKASVolumeKonnectivityClientCert),
-				util.BuildVolume(kasVolumeMetricsClientCert(), buildKASVolumeMetricsClientCert),
 				util.BuildVolume(kasVolumeEgressSelectorConfig(), buildKASVolumeEgressSelectorConfig),
 				util.BuildVolume(kasVolumeKubeconfig(), buildKASVolumeKubeconfig),
 			},
@@ -474,20 +472,6 @@ func buildKASVolumeKonnectivityClientCert(v *corev1.Volume) {
 	}
 	v.Secret.DefaultMode = pointer.Int32Ptr(420)
 	v.Secret.SecretName = manifests.KonnectivityClientSecret("").Name
-}
-
-func kasVolumeMetricsClientCert() *corev1.Volume {
-	return &corev1.Volume{
-		Name: "metrics-client",
-	}
-}
-
-func buildKASVolumeMetricsClientCert(v *corev1.Volume) {
-	if v.Secret == nil {
-		v.Secret = &corev1.SecretVolumeSource{}
-	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(420)
-	v.Secret.SecretName = manifests.KASMetricsClientCert("").Name
 }
 
 func kasVolumeAggregatorCert() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -34,6 +34,7 @@ var (
 			kcmVolumeCertDir().Name:       "/var/run/kubernetes",
 			kcmVolumeClusterSigner().Name: "/etc/kubernetes/certs/cluster-signer",
 			kcmVolumeServiceSigner().Name: "/etc/kubernetes/certs/service-signer",
+			kcmVolumeServerCert().Name:    "/etc/kubernetes/certs/server",
 		},
 	}
 	serviceServingCAMount = util.PodVolumeMounts{
@@ -46,15 +47,18 @@ var (
 			kcmVolumeCloudConfig().Name: "/etc/kubernetes/cloud",
 		},
 	}
-	kcmLabels = map[string]string{
+)
+
+func kcmLabels() map[string]string {
+	return map[string]string{
 		"app":                         "kube-controller-manager",
 		hyperv1.ControlPlaneComponent: "kube-controller-manager",
 	}
-)
+}
 
 func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev1.ConfigMap, p *KubeControllerManagerParams, apiPort *int32) error {
 	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: kcmLabels,
+		MatchLabels: kcmLabels(),
 	}
 	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 	maxSurge := intstr.FromInt(3)
@@ -67,7 +71,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev
 	if deployment.Spec.Template.ObjectMeta.Labels == nil {
 		deployment.Spec.Template.ObjectMeta.Labels = map[string]string{}
 	}
-	for k, v := range kcmLabels {
+	for k, v := range kcmLabels() {
 		deployment.Spec.Template.ObjectMeta.Labels[k] = v
 	}
 
@@ -83,7 +87,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev
 	deployment.Spec.Template.Spec = corev1.PodSpec{
 		AutomountServiceAccountToken: pointer.BoolPtr(false),
 		Containers: []corev1.Container{
-			util.BuildContainer(kcmContainerMain(), buildKCMContainerMain(p.HyperkubeImage, args)),
+			util.BuildContainer(kcmContainerMain(), buildKCMContainerMain(p.HyperkubeImage, args, DefaultPort)),
 		},
 		Volumes: []corev1.Volume{
 			util.BuildVolume(kcmVolumeConfig(), buildKCMVolumeConfig),
@@ -93,6 +97,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev
 			util.BuildVolume(kcmVolumeClusterSigner(), buildKCMVolumeClusterSigner),
 			util.BuildVolume(kcmVolumeCertDir(), buildKCMVolumeCertDir),
 			util.BuildVolume(kcmVolumeServiceSigner(), buildKCMVolumeServiceSigner),
+			util.BuildVolume(kcmVolumeServerCert(), buildKCMVolumeServerCert),
 		},
 	}
 	p.DeploymentConfig.ApplyTo(deployment)
@@ -112,7 +117,7 @@ func kcmContainerMain() *corev1.Container {
 	}
 }
 
-func buildKCMContainerMain(image string, args []string) func(c *corev1.Container) {
+func buildKCMContainerMain(image string, args []string, port int32) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.Command = []string{
@@ -121,6 +126,13 @@ func buildKCMContainerMain(image string, args []string) func(c *corev1.Container
 		}
 		c.Args = args
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+		c.Ports = []corev1.ContainerPort{
+			{
+				Name:          "client",
+				ContainerPort: port,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		}
 	}
 }
 
@@ -228,6 +240,19 @@ func buildKCMVolumeCloudConfig(cloudProviderConfigName string, cloudProviderName
 	}
 }
 
+func kcmVolumeServerCert() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "server-crt",
+	}
+}
+func buildKCMVolumeServerCert(v *corev1.Volume) {
+	if v.Secret == nil {
+		v.Secret = &corev1.SecretVolumeSource{}
+	}
+	v.Secret.DefaultMode = pointer.Int32Ptr(420)
+	v.Secret.SecretName = manifests.KCMServerCertSecret("").Name
+}
+
 type serviceCAVolumeBuilder string
 
 func (name serviceCAVolumeBuilder) buildKCMVolumeServiceServingCA(v *corev1.Volume) {
@@ -293,6 +318,8 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 		fmt.Sprintf("--service-cluster-ip-range=%s", p.ServiceCIDR),
 		"--use-service-account-credentials=true",
 		"--experimental-cluster-signing-duration=17520h",
+		fmt.Sprintf("--tls-cert-file=%s", cpath(kcmVolumeServerCert().Name, corev1.TLSCertKey)),
+		fmt.Sprintf("--tls-private-key-file=%s", cpath(kcmVolumeServerCert().Name, corev1.TLSPrivateKeyKey)),
 	}...)
 	for _, f := range p.FeatureGates() {
 		args = append(args, fmt.Sprintf("--feature-gates=%s", f))

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -110,7 +110,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.Replicas = 3
-		params.DeploymentConfig.SetMultizoneSpread(kcmLabels)
+		params.DeploymentConfig.SetMultizoneSpread(kcmLabels())
 	default:
 		params.Replicas = 1
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/service.go
@@ -1,0 +1,37 @@
+package kcm
+
+import (
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ReconcileService(svc *corev1.Service, owner config.OwnerRef) error {
+	owner.ApplyTo(svc)
+	svc.Spec.Selector = kcmLabels()
+
+	// Ensure labels propagate to endpoints so service monitors can select them
+	if svc.Labels == nil {
+		svc.Labels = map[string]string{}
+	}
+	for k, v := range kcmLabels() {
+		svc.Labels[k] = v
+	}
+
+	svc.Spec.Type = corev1.ServiceTypeClusterIP
+
+	if len(svc.Spec.Ports) == 0 {
+		svc.Spec.Ports = []corev1.ServicePort{
+			{
+				Name: "client",
+			},
+		}
+	}
+
+	svc.Spec.Ports[0].Port = DefaultPort
+	svc.Spec.Ports[0].Name = "client"
+	svc.Spec.Ports[0].TargetPort = intstr.FromString("client")
+	svc.Spec.Ports[0].Protocol = corev1.ProtocolTCP
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
@@ -1,0 +1,72 @@
+package kcm
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sm)
+
+	sm.Spec.Selector.MatchLabels = kcmLabels()
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+	targetPort := intstr.FromString("client")
+	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
+		{
+			Interval:   "15s",
+			TargetPort: &targetPort,
+			Scheme:     "https",
+			TLSConfig: &prometheusoperatorv1.TLSConfig{
+				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
+					ServerName: "kube-controller-manager",
+					Cert: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.KCMMetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "tls.crt",
+						},
+					},
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: manifests.KCMMetricsClientCertSecret(sm.Namespace).Name,
+						},
+						Key: "tls.key",
+					},
+					CA: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.KCMMetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "ca.crt",
+						},
+					},
+				},
+			},
+			MetricRelabelConfigs: []*prometheusoperatorv1.RelabelConfig{
+				{
+					Action:       "drop",
+					Regex:        "etcd_(debugging|disk|request|server).*",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "rest_client_request_latency_seconds_(bucket|count|sum)",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)",
+					SourceLabels: []string{"__name__"},
+				},
+			},
+		},
+	}
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -157,15 +157,6 @@ func KASAuthenticationTokenWebhookConfigSecret(controlPlaneNamespace string) *co
 	}
 }
 
-func KASMetricsClientCert(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kas-metrics-cert",
-			Namespace: controlPlaneNamespace,
-		},
-	}
-}
-
 func KASServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
 	return &prometheusoperatorv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kcm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kcm.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,24 @@ func ServiceServingCA(ns string) *corev1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "service-serving-ca",
 			Namespace: ns,
+		},
+	}
+}
+
+func KCMServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
+	return &prometheusoperatorv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func KCMService(controlPlaneNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-controller-manager",
+			Namespace: controlPlaneNamespace,
 		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -104,6 +104,33 @@ func KASMachineBootstrapClientCertSecret(ns string) *corev1.Secret {
 	}
 }
 
+func KASMetricsClientCert(controlPlaneNamespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kas-metrics-cert",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
+func KCMServerCertSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kcm-server",
+			Namespace: ns,
+		},
+	}
+}
+
+func KCMMetricsClientCertSecret(controlPlaneNamespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kcm-metrics-cert",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
 func ServiceAccountSigningKeySecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -71,7 +71,7 @@ func ReconcileIngressOperatorClientCertSecret(secret, ca *corev1.Secret, ownerRe
 }
 
 func ReconcileKASMetricsClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCert(secret, ca, ownerRef, "system:kas-metrics-client", []string{"kubernetes"}, X509UsageClientServerAuth)
+	return reconcileSignedCert(secret, ca, ownerRef, "system:kas-metrics-client", []string{"kubernetes"}, X509UsageClientAuth)
 }
 
 func nextIP(ip net.IP) net.IP {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kcm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kcm.go
@@ -1,0 +1,22 @@
+package pki
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ReconcileKCMServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	dnsNames := []string{
+		fmt.Sprintf("kube-controller-manager.%s.svc", secret.Namespace),
+		fmt.Sprintf("kube-controller-manager.%s.svc.cluster.local", secret.Namespace),
+		"kube-controller-manager",
+		"localhost",
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "kube-controller-manager", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+}
+
+func ReconcileKCMMetricsClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSignedCert(secret, ca, ownerRef, "system:kcm-metrics-client", []string{"kubernetes"}, X509UsageClientAuth)
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -76,3 +76,11 @@ func KASMetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		},
 	}
 }
+
+func KCMMetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kcm-metrics-client",
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -242,3 +242,19 @@ func ReconcileKASMetricsClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
 	}
 	return nil
 }
+
+func ReconcileKCMMetricsClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:monitoring",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "User",
+			Name:     "system:kcm-metrics-client",
+		},
+	}
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -507,6 +507,7 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 		{manifest: manifests.NodeBootstrapperClusterRoleBinding, reconcile: rbac.ReconcileNodeBootstrapperClusterRoleBinding},
 		{manifest: manifests.CSRRenewalClusterRoleBinding, reconcile: rbac.ReconcileCSRRenewalClusterRoleBinding},
 		{manifest: manifests.KASMetricsClientClusterRoleBinding, reconcile: rbac.ReconcileKASMetricsClusterRoleBinding},
+		{manifest: manifests.KCMMetricsClientClusterRoleBinding, reconcile: rbac.ReconcileKCMMetricsClusterRoleBinding},
 	}
 
 	var errs []error


### PR DESCRIPTION
This commit adds ServiceMonitor support to kube-controller-manager. It also
cleans up the ServiceMonitor support for kube-apiserver to remove an unnecessary
certificate mount, fix the cert usage parameter, and refactor the code to be
uniform with other PKI logic.

The ServiceMonitor has relabelling rules that mirror those provided by OCP.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] ~Relevant issues have been referenced.~
- [ ] ~This change includes docs.~
- [ ] ~This change includes unit tests.~