### PR TITLE
Get autoscaler/machine-approver images from the payload

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -405,7 +405,7 @@ func TestClusterAutoscalerArgs(t *testing.T) {
 			hc := &hyperv1.HostedCluster{}
 			hc.Name = "name"
 			hc.Namespace = "namespace"
-			err := reconcileAutoScalerDeployment(deployment, hc, sa, secret, test.AutoscalerOptions, imageClusterAutoscaler, "availability-prober:latest", false)
+			err := reconcileAutoScalerDeployment(deployment, hc, sa, secret, test.AutoscalerOptions, "clusterAutoscalerImage", "availabilityProberImage", false)
 			if err != nil {
 				t.Error(err)
 			}

--- a/hypershift-operator/controllers/util/deployment.go
+++ b/hypershift-operator/controllers/util/deployment.go
@@ -22,6 +22,13 @@ const (
 	DebugDeploymentsAnnotation = "hypershift.openshift.io/debug-deployments"
 )
 
+func SetReleaseImageAnnotation(deployment *appsv1.Deployment, releaseImage string) {
+	if deployment.Annotations == nil {
+		deployment.Annotations = make(map[string]string)
+	}
+	deployment.Annotations[hyperv1.ReleaseImageAnnotation] = releaseImage
+}
+
 func SetDefaultPriorityClass(deployment *appsv1.Deployment) {
 	deployment.Spec.Template.Spec.PriorityClassName = DefaultPriorityClass
 }

--- a/support/releaseinfo/fake/fake.go
+++ b/support/releaseinfo/fake/fake.go
@@ -3,6 +3,8 @@ package fake
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+
 	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +16,21 @@ type FakeReleaseProvider struct{}
 
 func (*FakeReleaseProvider) Lookup(ctx context.Context, image string, pullSecret []byte) (*releaseinfo.ReleaseImage, error) {
 	return &releaseinfo.ReleaseImage{
-		ImageStream: &imagev1.ImageStream{ObjectMeta: metav1.ObjectMeta{Name: "4.10.0"}},
+		ImageStream: &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Name: "4.10.0"},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{
+						Name: "cluster-autoscaler",
+						From: &corev1.ObjectReference{Name: ""},
+					},
+					{
+						Name: "cluster-machine-approver",
+						From: &corev1.ObjectReference{Name: ""},
+					},
+				},
+			},
+		},
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
These components watch both management cluster (Machine scalable resources) and guest cluster.
Originally we were pinning the images to a version that would cross any HostedCluster.
This PR let us pick them from each particular payload resulting in some benefits:
- Each hostedCluster runs the component version that was tested with that particular kube/ocp version
- No additional work needed to productise the images as they com from the payload.

Since CAPI CRDs should be backward compatible, having different controller versions shouldn't cause an issue.
Once the CAPI image is in the payload we can do the same for it.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.