### PR TITLE
Add ServiceMonitor support for OpenShift API server

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_apiserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_apiserver.go
@@ -1,10 +1,11 @@
 package manifests
 
 import (
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	//TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	// TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -38,6 +39,15 @@ func OpenShiftAPIServerPodDisruptionBudget(ns string) *policyv1beta1.PodDisrupti
 
 func OpenShiftAPIServerDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-apiserver",
+			Namespace: ns,
+		},
+	}
+}
+
+func OpenShiftAPIServerServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
+	return &prometheusoperatorv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openshift-apiserver",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -149,6 +149,15 @@ func OpenShiftAPIServerCertSecret(ns string) *corev1.Secret {
 	}
 }
 
+func OpenShiftAPIMetricsClientCertSecret(controlPlaneNamespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-apiserver-metrics-cert",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
 func OpenShiftOAuthAPIServerCertSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -25,6 +25,9 @@ import (
 
 const (
 	configHashAnnotation = "openshift-apiserver.hypershift.openshift.io/config-hash"
+
+	// defaultOAPIPort is the default secure listen port for the OAPI server
+	defaultOAPIPort int32 = 8443
 )
 
 var (
@@ -94,7 +97,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		AutomountServiceAccountToken: pointer.BoolPtr(false),
 		InitContainers:               []corev1.Container{util.BuildContainer(oasTrustAnchorGenerator(), buildOASTrustAnchorGenerator(image))},
 		Containers: []corev1.Container{
-			util.BuildContainer(oasContainerMain(), buildOASContainerMain(image, strings.Split(etcdUrlData.Host, ":")[0])),
+			util.BuildContainer(oasContainerMain(), buildOASContainerMain(image, strings.Split(etcdUrlData.Host, ":")[0], defaultOAPIPort)),
 			util.BuildContainer(oasSocks5ProxyContainer(), buildOASSocks5ProxyContainer(socks5ProxyImage)),
 		},
 		Volumes: []corev1.Volume{
@@ -180,7 +183,7 @@ func buildOASSocks5ProxyContainer(socks5ProxyImage string) func(c *corev1.Contai
 	}
 }
 
-func buildOASContainerMain(image string, etcdHostname string) func(c *corev1.Container) {
+func buildOASContainerMain(image string, etcdHostname string, port int32) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		cpath := func(volume, file string) string {
 			return path.Join(volumeMounts.Path(c.Name, volume), file)
@@ -215,6 +218,13 @@ func buildOASContainerMain(image string, etcdHostname string) func(c *corev1.Con
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 		c.WorkingDir = volumeMounts.Path(oasContainerMain().Name, oasVolumeWorkLogs().Name)
+		c.Ports = []corev1.ContainerPort{
+			{
+				Name:          "https",
+				ContainerPort: port,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		}
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/service.go
@@ -16,13 +16,16 @@ const (
 )
 
 var (
-	openshiftAPIServerLabels = map[string]string{"app": "openshift-apiserver", hyperv1.ControlPlaneComponent: "openshift-apiserver"}
-	oauthAPIServerLabels     = map[string]string{"app": "openshift-oauth-apiserver", hyperv1.ControlPlaneComponent: "openshift-oauth-apiserver"}
-	olmPackageServerLabels   = map[string]string{"app": "packageserver", hyperv1.ControlPlaneComponent: "packageserver"}
+	oauthAPIServerLabels   = map[string]string{"app": "openshift-oauth-apiserver", hyperv1.ControlPlaneComponent: "openshift-oauth-apiserver"}
+	olmPackageServerLabels = map[string]string{"app": "packageserver", hyperv1.ControlPlaneComponent: "packageserver"}
 )
 
+func openshiftAPIServerLabels() map[string]string {
+	return map[string]string{"app": "openshift-apiserver", hyperv1.ControlPlaneComponent: "openshift-apiserver"}
+}
+
 func ReconcileOpenShiftAPIService(svc *corev1.Service, ownerRef config.OwnerRef) error {
-	return reconcileAPIService(svc, ownerRef, openshiftAPIServerLabels, OpenShiftAPIServerPort)
+	return reconcileAPIService(svc, ownerRef, openshiftAPIServerLabels(), OpenShiftAPIServerPort)
 }
 
 func ReconcileOAuthAPIService(svc *corev1.Service, ownerRef config.OwnerRef) error {
@@ -35,6 +38,7 @@ func ReconcileOLMPackageServerService(svc *corev1.Service, ownerRef config.Owner
 
 func reconcileAPIService(svc *corev1.Service, ownerRef config.OwnerRef, labels map[string]string, targetPort int) error {
 	ownerRef.ApplyTo(svc)
+	svc.Labels = openshiftAPIServerLabels()
 	svc.Spec.Selector = labels
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/servicemonitor.go
@@ -1,0 +1,77 @@
+package oapi
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sm)
+
+	sm.Spec.Selector.MatchLabels = openshiftAPIServerLabels()
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+	targetPort := intstr.FromString("https")
+	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
+		{
+			Interval:   "15s",
+			TargetPort: &targetPort,
+			Scheme:     "https",
+			TLSConfig: &prometheusoperatorv1.TLSConfig{
+				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
+					ServerName: "openshift-apiserver",
+					Cert: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.OpenShiftAPIMetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "tls.crt",
+						},
+					},
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: manifests.OpenShiftAPIMetricsClientCertSecret(sm.Namespace).Name,
+						},
+						Key: "tls.key",
+					},
+					CA: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.OpenShiftAPIMetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "ca.crt",
+						},
+					},
+				},
+			},
+			MetricRelabelConfigs: []*prometheusoperatorv1.RelabelConfig{
+				{
+					Action:       "drop",
+					Regex:        "etcd_(debugging|disk|server).*",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "apiserver_admission_controller_admission_latencies_seconds_.*",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "apiserver_admission_step_admission_latencies_seconds_.*",
+					SourceLabels: []string{"__name__"},
+				},
+				{
+					Action:       "drop",
+					Regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)",
+					SourceLabels: []string{"__name__", "le"},
+				},
+			},
+		},
+	}
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
@@ -19,6 +19,10 @@ func ReconcileOpenShiftAPIServerCertSecret(secret, ca *corev1.Secret, ownerRef c
 	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-apiserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
 }
 
+func ReconcileOpenShiftAPIServerMetricsClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSignedCert(secret, ca, ownerRef, "system:openshift-apiserver-metrics-client", []string{"kubernetes"}, X509UsageClientAuth)
+}
+
 func ReconcileOpenShiftOAuthAPIServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
 	dnsNames := []string{
 		"openshift-oauth-apiserver",

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -84,3 +84,11 @@ func KCMMetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		},
 	}
 }
+
+func OpenShiftAPIServerMetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-apiserver-metrics-client",
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -258,3 +258,19 @@ func ReconcileKCMMetricsClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
 	}
 	return nil
 }
+
+func ReconcileOpenShiftAPIServerMetricsClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:monitoring",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "User",
+			Name:     "system:openshift-apiserver-metrics-client",
+		},
+	}
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -508,6 +508,7 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 		{manifest: manifests.CSRRenewalClusterRoleBinding, reconcile: rbac.ReconcileCSRRenewalClusterRoleBinding},
 		{manifest: manifests.KASMetricsClientClusterRoleBinding, reconcile: rbac.ReconcileKASMetricsClusterRoleBinding},
 		{manifest: manifests.KCMMetricsClientClusterRoleBinding, reconcile: rbac.ReconcileKCMMetricsClusterRoleBinding},
+		{manifest: manifests.OpenShiftAPIServerMetricsClientClusterRoleBinding, reconcile: rbac.ReconcileOpenShiftAPIServerMetricsClusterRoleBinding},
 	}
 
 	var errs []error


### PR DESCRIPTION
This commit adds a ServiceMonitor to the OpenShift API server component,
using the same label rules present by default in OCP.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] ~Relevant issues have been referenced.~
- [ ] ~This change includes docs.~
- [ ] ~This change includes unit tests.~