### PR TITLE
Azure: Use random string rather than infraID as storage account name

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -13,6 +13,7 @@ import (
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/log"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
@@ -291,7 +292,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context) (*CreateInfraOutput, error
 	storageAccountClient := storage.NewAccountsClient(creds.SubscriptionID)
 	storageAccountClient.Authorizer = authorizer
 
-	storageAccountName := "cluster" + o.InfraID
+	storageAccountName := "cluster" + utilrand.String(5)
 	storageAccountFuture, err := storageAccountClient.Create(ctx, *rg.Name, storageAccountName, storage.AccountCreateParameters{
 		Sku:      &storage.Sku{Name: storage.SkuNamePremiumLRS, Tier: storage.SkuTierStandard},
 		Location: utilpointer.String(o.Location),


### PR DESCRIPTION
The storage account is in the resource group so its name doesn't really
matter for cleanup. It has however some limitations wrt format, it must
be max 24 characters long and lower alphanumeric. This broke when we
added defaulting for the infraids, which also introduced a new format
that is too long and contains hyphens. This leads to failure:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/26666/rehearse-26666-periodic-ci-openshift-hypershift-main-periodics-e2e-conformance-azure/1499088629878755328#1:build-log.txt%3A79

What we do here matches what the installer does:
https://github.com/openshift/installer/blob/8fca1ade5b096d9b2cd312c4599881d099439288/data/data/azure/vnet/main.tf#L23

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
/cc @csrwng @sjenning 