### PR TITLE
Add ServiceMonitor support for openshift-controller-manager

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
@@ -27,21 +27,21 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, apiServerP
 					Cert: prometheusoperatorv1.SecretOrConfigMap{
 						Secret: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.KASMetricsClientCert(sm.Namespace).Name,
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
 							},
 							Key: "tls.crt",
 						},
 					},
 					KeySecret: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: manifests.KASMetricsClientCert(sm.Namespace).Name,
+							Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
 						},
 						Key: "tls.key",
 					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
 						Secret: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.KASMetricsClientCert(sm.Namespace).Name,
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
@@ -27,21 +27,21 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 					Cert: prometheusoperatorv1.SecretOrConfigMap{
 						Secret: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.KCMMetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
 							},
 							Key: "tls.crt",
 						},
 					},
 					KeySecret: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: manifests.KCMMetricsClientCertSecret(sm.Namespace).Name,
+							Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
 						},
 						Key: "tls.key",
 					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
 						Secret: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.KCMMetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_cm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_cm.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,24 @@ func OpenShiftControllerManagerConfig(ns string) *corev1.ConfigMap {
 
 func OpenShiftControllerManagerDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func OpenShiftControllerService(controlPlaneNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-controller-manager",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
+func OpenShiftControllerServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
+	return &prometheusoperatorv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openshift-controller-manager",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -32,6 +32,15 @@ func CombinedCAConfigMap(ns string) *corev1.ConfigMap {
 	}
 }
 
+func MetricsClientCertSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "metrics-client",
+			Namespace: ns,
+		},
+	}
+}
+
 func EtcdClientSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -104,29 +113,11 @@ func KASMachineBootstrapClientCertSecret(ns string) *corev1.Secret {
 	}
 }
 
-func KASMetricsClientCert(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kas-metrics-cert",
-			Namespace: controlPlaneNamespace,
-		},
-	}
-}
-
 func KCMServerCertSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kcm-server",
 			Namespace: ns,
-		},
-	}
-}
-
-func KCMMetricsClientCertSecret(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kcm-metrics-cert",
-			Namespace: controlPlaneNamespace,
 		},
 	}
 }
@@ -145,15 +136,6 @@ func OpenShiftAPIServerCertSecret(ns string) *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openshift-apiserver-cert",
 			Namespace: ns,
-		},
-	}
-}
-
-func OpenShiftAPIMetricsClientCertSecret(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "openshift-apiserver-metrics-cert",
-			Namespace: controlPlaneNamespace,
 		},
 	}
 }
@@ -266,15 +248,6 @@ func OLMPackageServerCertSecret(ns string) *corev1.Secret {
 	}
 }
 
-func OLMProfileCollectorCertSecret(ns string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "olm-profile-collector",
-			Namespace: ns,
-		},
-	}
-}
-
 func OLMOperatorServingCertSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -306,16 +279,6 @@ func IBMCloudKASKMSWDEKSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kp-wdek-secret",
-			Namespace: ns,
-		},
-	}
-}
-
-// IBMCloudKASKMSKPCustomerAuthSecret ...
-func IBMCloudKASKMSKPCustomerAuthSecret(ns string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kp-customer-auth",
 			Namespace: ns,
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/config.go
@@ -107,6 +107,7 @@ func reconcileConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, deploy
 	cfg.KubeClientConfig.KubeConfig = cpath(ocmVolumeKubeconfig().Name, kas.KubeconfigKey)
 	cfg.ServingInfo = &configv1.HTTPServingInfo{
 		ServingInfo: configv1.ServingInfo{
+			BindAddress: fmt.Sprintf("0.0.0.0:%d", servingPort),
 			CertInfo: configv1.CertInfo{
 				CertFile: cpath(ocmVolumeServingCert().Name, corev1.TLSCertKey),
 				KeyFile:  cpath(ocmVolumeServingCert().Name, corev1.TLSPrivateKeyKey),

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,8 @@ import (
 
 const (
 	configHashAnnotation = "openshift-controller-manager.hypershift.openshift.io/config-hash"
+
+	servingPort int32 = 8443
 )
 
 var (
@@ -27,10 +30,14 @@ var (
 			ocmVolumeKubeconfig().Name:  "/etc/kubernetes/secrets/svc-kubeconfig",
 		},
 	}
-	openShiftControllerManagerLabels = map[string]string{
-		"app": "openshift-controller-manager",
-	}
 )
+
+func openShiftControllerManagerLabels() map[string]string {
+	return map[string]string{
+		"app":                         "openshift-controller-manager",
+		hyperv1.ControlPlaneComponent: "openshift-controller-manager",
+	}
+}
 
 func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, image string, config *corev1.ConfigMap, deploymentConfig config.DeploymentConfig) error {
 	configBytes, ok := config.Data[configKey]
@@ -47,9 +54,9 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		MaxUnavailable: &maxUnavailable,
 	}
 	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: openShiftControllerManagerLabels,
+		MatchLabels: openShiftControllerManagerLabels(),
 	}
-	deployment.Spec.Template.ObjectMeta.Labels = openShiftControllerManagerLabels
+	deployment.Spec.Template.ObjectMeta.Labels = openShiftControllerManagerLabels()
 	deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
 		configHashAnnotation: configHash,
 	}
@@ -82,6 +89,13 @@ func buildOCMContainerMain(image string) func(*corev1.Container) {
 			path.Join(volumeMounts.Path(c.Name, ocmVolumeConfig().Name), configKey),
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+		c.Ports = []corev1.ContainerPort{
+			{
+				Name:          "https",
+				ContainerPort: servingPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		}
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -54,7 +54,7 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, global
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.DeploymentConfig.Replicas = 3
-		params.DeploymentConfig.SetMultizoneSpread(openShiftControllerManagerLabels)
+		params.DeploymentConfig.SetMultizoneSpread(openShiftControllerManagerLabels())
 	default:
 		params.DeploymentConfig.Replicas = 1
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/service.go
@@ -1,0 +1,27 @@
+package ocm
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/openshift/hypershift/support/config"
+)
+
+func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(svc)
+	svc.Labels = openShiftControllerManagerLabels()
+	svc.Spec.Selector = openShiftControllerManagerLabels()
+	var portSpec corev1.ServicePort
+	if len(svc.Spec.Ports) > 0 {
+		portSpec = svc.Spec.Ports[0]
+	} else {
+		svc.Spec.Ports = []corev1.ServicePort{portSpec}
+	}
+	portSpec.Name = "https"
+	portSpec.Port = servingPort
+	portSpec.Protocol = corev1.ProtocolTCP
+	portSpec.TargetPort = intstr.FromString("https")
+	svc.Spec.Type = corev1.ServiceTypeClusterIP
+	svc.Spec.Ports[0] = portSpec
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/servicemonitor.go
@@ -1,4 +1,4 @@
-package oapi
+package ocm
 
 import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -11,7 +11,7 @@ import (
 func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef config.OwnerRef) error {
 	ownerRef.ApplyTo(sm)
 
-	sm.Spec.Selector.MatchLabels = openshiftAPIServerLabels()
+	sm.Spec.Selector.MatchLabels = openShiftControllerManagerLabels()
 	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
 		MatchNames: []string{sm.Namespace},
 	}
@@ -23,7 +23,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{
 				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
-					ServerName: "openshift-apiserver",
+					ServerName: "openshift-controller-manager",
 					Cert: prometheusoperatorv1.SecretOrConfigMap{
 						Secret: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
@@ -51,23 +51,8 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 			MetricRelabelConfigs: []*prometheusoperatorv1.RelabelConfig{
 				{
 					Action:       "drop",
-					Regex:        "etcd_(debugging|disk|server).*",
+					Regex:        "etcd_(debugging|disk|request|server).*",
 					SourceLabels: []string{"__name__"},
-				},
-				{
-					Action:       "drop",
-					Regex:        "apiserver_admission_controller_admission_latencies_seconds_.*",
-					SourceLabels: []string{"__name__"},
-				},
-				{
-					Action:       "drop",
-					Regex:        "apiserver_admission_step_admission_latencies_seconds_.*",
-					SourceLabels: []string{"__name__"},
-				},
-				{
-					Action:       "drop",
-					Regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)",
-					SourceLabels: []string{"__name__", "le"},
 				},
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -70,10 +70,6 @@ func ReconcileIngressOperatorClientCertSecret(secret, ca *corev1.Secret, ownerRe
 	return reconcileSignedCert(secret, ca, ownerRef, "system:serviceaccount:openshift-ingress-operator:ingress-operator", []string{"system:serviceaccounts"}, X509UsageClientServerAuth)
 }
 
-func ReconcileKASMetricsClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCert(secret, ca, ownerRef, "system:kas-metrics-client", []string{"kubernetes"}, X509UsageClientAuth)
-}
-
 func nextIP(ip net.IP) net.IP {
 	nextIP := net.IP(make([]byte, len(ip)))
 	copy(nextIP, ip)

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kcm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kcm.go
@@ -16,7 +16,3 @@ func ReconcileKCMServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRe
 	}
 	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "kube-controller-manager", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
 }
-
-func ReconcileKCMMetricsClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCert(secret, ca, ownerRef, "system:kcm-metrics-client", []string{"kubernetes"}, X509UsageClientAuth)
-}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
@@ -19,10 +19,6 @@ func ReconcileOpenShiftAPIServerCertSecret(secret, ca *corev1.Secret, ownerRef c
 	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-apiserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
 }
 
-func ReconcileOpenShiftAPIServerMetricsClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCert(secret, ca, ownerRef, "system:openshift-apiserver-metrics-client", []string{"kubernetes"}, X509UsageClientAuth)
-}
-
 func ReconcileOpenShiftOAuthAPIServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
 	dnsNames := []string{
 		"openshift-oauth-apiserver",

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/sa.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/sa.go
@@ -31,3 +31,7 @@ func ReconcileServiceAccountSigningKeySecret(secret *corev1.Secret, ownerRef con
 	secret.Data[ServiceSignerPublicKey] = publicKeyBytes
 	return nil
 }
+
+func ReconcileMetricsSAClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSignedCert(secret, ca, ownerRef, "system:serviceaccount:hypershift:prometheus", []string{"kubernetes"}, X509UsageClientAuth)
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -69,26 +69,10 @@ func CSRRenewalClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	}
 }
 
-func KASMetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+func MetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kas-metrics-client",
-		},
-	}
-}
-
-func KCMMetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kcm-metrics-client",
-		},
-	}
-}
-
-func OpenShiftAPIServerMetricsClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "openshift-apiserver-metrics-client",
+			Name: "hypershift-metrics-client",
 		},
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -227,50 +227,20 @@ func ReconcileCSRRenewalClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
 	return nil
 }
 
-func ReconcileKASMetricsClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
-	r.RoleRef = rbacv1.RoleRef{
-		APIGroup: rbacv1.SchemeGroupVersion.Group,
-		Kind:     "ClusterRole",
-		Name:     "system:monitoring",
-	}
-	r.Subjects = []rbacv1.Subject{
-		{
+func ReconcileGenericMetricsClusterRoleBinding(cn string) func(*rbacv1.ClusterRoleBinding) error {
+	return func(r *rbacv1.ClusterRoleBinding) error {
+		r.RoleRef = rbacv1.RoleRef{
 			APIGroup: rbacv1.SchemeGroupVersion.Group,
-			Kind:     "User",
-			Name:     "system:kas-metrics-client",
-		},
+			Kind:     "ClusterRole",
+			Name:     "system:monitoring",
+		}
+		r.Subjects = []rbacv1.Subject{
+			{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "User",
+				Name:     cn,
+			},
+		}
+		return nil
 	}
-	return nil
-}
-
-func ReconcileKCMMetricsClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
-	r.RoleRef = rbacv1.RoleRef{
-		APIGroup: rbacv1.SchemeGroupVersion.Group,
-		Kind:     "ClusterRole",
-		Name:     "system:monitoring",
-	}
-	r.Subjects = []rbacv1.Subject{
-		{
-			APIGroup: rbacv1.SchemeGroupVersion.Group,
-			Kind:     "User",
-			Name:     "system:kcm-metrics-client",
-		},
-	}
-	return nil
-}
-
-func ReconcileOpenShiftAPIServerMetricsClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
-	r.RoleRef = rbacv1.RoleRef{
-		APIGroup: rbacv1.SchemeGroupVersion.Group,
-		Kind:     "ClusterRole",
-		Name:     "system:monitoring",
-	}
-	r.Subjects = []rbacv1.Subject{
-		{
-			APIGroup: rbacv1.SchemeGroupVersion.Group,
-			Kind:     "User",
-			Name:     "system:openshift-apiserver-metrics-client",
-		},
-	}
-	return nil
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -506,9 +506,7 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 		{manifest: manifests.NamespaceSecurityAllocationControllerClusterRoleBinding, reconcile: rbac.ReconcileNamespaceSecurityAllocationControllerClusterRoleBinding},
 		{manifest: manifests.NodeBootstrapperClusterRoleBinding, reconcile: rbac.ReconcileNodeBootstrapperClusterRoleBinding},
 		{manifest: manifests.CSRRenewalClusterRoleBinding, reconcile: rbac.ReconcileCSRRenewalClusterRoleBinding},
-		{manifest: manifests.KASMetricsClientClusterRoleBinding, reconcile: rbac.ReconcileKASMetricsClusterRoleBinding},
-		{manifest: manifests.KCMMetricsClientClusterRoleBinding, reconcile: rbac.ReconcileKCMMetricsClusterRoleBinding},
-		{manifest: manifests.OpenShiftAPIServerMetricsClientClusterRoleBinding, reconcile: rbac.ReconcileOpenShiftAPIServerMetricsClusterRoleBinding},
+		{manifest: manifests.MetricsClientClusterRoleBinding, reconcile: rbac.ReconcileGenericMetricsClusterRoleBinding("system:serviceaccount:hypershift:prometheus")},
 	}
 
 	var errs []error


### PR DESCRIPTION
This commit adds ServiceMonitor support to the openshift-controller-manager
component, using the same label rules as OCP. It also refactors the existing
ServiceMonitor code so that they all share a single client certificate bound to
the `system:monitoring` role in the guest cluster. This was done to prevent
unnecessary secret and certificate sprawl.

**Checklist**
- [x] Subject and description added to both, commit and PR.
