### PR TITLE
Purge all non-entrypoint calls to `os.Exit()`

### DIFF
--- a/cmd/bastion/aws/create.go
+++ b/cmd/bastion/aws/create.go
@@ -102,7 +102,10 @@ func (o *CreateBastionOpts) Run(ctx context.Context) (string, string, error) {
 
 	if len(o.Name) > 0 {
 		// Find HostedCluster and get AWS creds
-		c := util.GetClientOrDie()
+		c, err := util.GetClient()
+		if err != nil {
+			return "", "", err
+		}
 
 		var hostedCluster hyperv1.HostedCluster
 		if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {

--- a/cmd/bastion/aws/destroy.go
+++ b/cmd/bastion/aws/destroy.go
@@ -86,7 +86,10 @@ func (o *DestroyBastionOpts) Run(ctx context.Context) error {
 
 	if len(o.Name) > 0 {
 		// Find HostedCluster and get AWS creds
-		c := util.GetClientOrDie()
+		c, err := util.GetClient()
+		if err != nil {
+			return err
+		}
 
 		var hostedCluster hyperv1.HostedCluster
 		if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -73,7 +73,10 @@ func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
 }
 
 func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
-	client := util.GetClientOrDie()
+	client, err := util.GetClient()
+	if err != nil {
+		return err
+	}
 	infraID := opts.InfraID
 
 	// Load or create infrastructure for the cluster

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -203,7 +203,10 @@ func apply(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, rend
 			fmt.Println("---")
 		}
 	default:
-		client := util.GetClientOrDie()
+		client, err := util.GetClient()
+		if err != nil {
+			return err
+		}
 		var hostedCluster *hyperv1.HostedCluster
 		for _, object := range exampleObjects {
 			key := crclient.ObjectKeyFromObject(object)
@@ -249,7 +252,14 @@ func GetAPIServerAddressByNode(ctx context.Context) (string, error) {
 	// - NodeExternalIP
 	// - NodeInternalIP
 	apiServerAddress := ""
-	kubeClient := kubeclient.NewForConfigOrDie(util.GetConfigOrDie())
+	config, err := util.GetConfig()
+	if err != nil {
+		return "", err
+	}
+	kubeClient, err := kubeclient.NewForConfig(config)
+	if err != nil {
+		return "", err
+	}
 	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{Limit: 1})
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch node objects: %w", err)
@@ -276,7 +286,10 @@ func GetAPIServerAddressByNode(ctx context.Context) (string, error) {
 
 func Validate(ctx context.Context, opts *CreateOptions) error {
 	if !opts.Render {
-		client := util.GetClientOrDie()
+		client, err := util.GetClient()
+		if err != nil {
+			return err
+		}
 		// Validate HostedCluster with this name doesn't exists in the namespace
 		cluster := &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: opts.Namespace, Name: opts.Name}}
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(cluster), cluster); err == nil {

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -81,8 +81,14 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 	if err != nil || len(ocCommand) == 0 {
 		return fmt.Errorf("cannot find oc command")
 	}
-	cfg := util.GetConfigOrDie()
-	c := util.GetClientOrDie()
+	cfg, err := util.GetConfig()
+	if err != nil {
+		return err
+	}
+	c, err := util.GetClient()
+	if err != nil {
+		return err
+	}
 	allNodePools := &hyperv1.NodePoolList{}
 	if err = c.List(ctx, allNodePools, client.InNamespace(opts.Namespace)); err != nil {
 		log.Log.Error(err, "Cannot list nodepools")

--- a/cmd/consolelogs/aws/getlogs.go
+++ b/cmd/consolelogs/aws/getlogs.go
@@ -64,7 +64,10 @@ func NewCommand() *cobra.Command {
 }
 
 func (o *ConsoleLogOpts) Run(ctx context.Context) error {
-	c := util.GetClientOrDie()
+	c, err := util.GetClient()
+	if err != nil {
+		return err
+	}
 
 	var hostedCluster hyperv1.HostedCluster
 	if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -89,7 +89,12 @@ func NewCreateIAMCommand() *cobra.Command {
 	cmd.MarkFlagRequired("oidc-bucket-region")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := opts.Run(cmd.Context(), util.GetClientOrDie()); err != nil {
+		client, err := util.GetClient()
+		if err != nil {
+			log.Log.Error(err, "failed to create client")
+			return err
+		}
+		if err := opts.Run(cmd.Context(), client); err != nil {
 			log.Log.Error(err, "Failed to create infrastructure")
 			return err
 		}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -149,7 +149,10 @@ func NewCommand() *cobra.Command {
 }
 
 func apply(ctx context.Context, objects []crclient.Object) error {
-	client := util.GetClientOrDie()
+	client, err := util.GetClient()
+	if err != nil {
+		return err
+	}
 	for _, object := range objects {
 		var objectBytes bytes.Buffer
 		err := hyperapi.YamlSerializer.Encode(object, &objectBytes)

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -78,7 +78,10 @@ func render(ctx context.Context, opts Options) error {
 		kubejson.DefaultMetaFactory, scheme, scheme,
 		kubejson.SerializerOptions{Yaml: true, Pretty: true, Strict: true},
 	)
-	c := util.GetClientOrDie()
+	c, err := util.GetClient()
+	if err != nil {
+		return err
+	}
 
 	var kubeConfig *clientcmdapiv1.Config
 	switch {

--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -42,10 +42,13 @@ func (o *CreateNodePoolOptions) CreateRunFunc(platformOpts PlatformOptions) func
 }
 
 func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts PlatformOptions) error {
-	client := util.GetClientOrDie()
+	client, err := util.GetClient()
+	if err != nil {
+		return err
+	}
 
 	hcluster := &hyperv1.HostedCluster{}
-	err := client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.ClusterName}, hcluster)
+	err = client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.ClusterName}, hcluster)
 	if err != nil {
 		return fmt.Errorf("failed to get HostedCluster %s/%s: %w", o.Namespace, o.ClusterName, err)
 	}

--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -22,7 +22,8 @@ func TestAutoRepair(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	client := e2eutil.GetClientOrDie()
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
@@ -57,7 +58,7 @@ func TestAutoRepair(t *testing.T) {
 	instanceID := awsSpec[strings.LastIndex(awsSpec, "/")+1:]
 	t.Logf("Terminating AWS instance: %s", instanceID)
 	ec2client := ec2Client(clusterOpts.AWSPlatform.AWSCredentialsFile, clusterOpts.AWSPlatform.Region)
-	_, err := ec2client.TerminateInstances(&ec2.TerminateInstancesInput{
+	_, err = ec2client.TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: []*string{aws.String(instanceID)},
 	})
 	g.Expect(err).NotTo(HaveOccurred(), "failed to terminate AWS instance")

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -23,7 +23,8 @@ func TestAutoscaling(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	client := e2eutil.GetClientOrDie()
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
@@ -40,7 +41,7 @@ func TestAutoscaling(t *testing.T) {
 			Name:      e2eutil.NodePoolName(hostedCluster.Name, zone),
 		},
 	}
-	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
+	err = client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
 	t.Logf("Created nodepool. Namespace: %s, name: %s", nodepool.Namespace, nodepool.Name)
 

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -28,11 +28,13 @@ import (
 // of chaotic etcd tests which ensure no data is lost in the chaos.
 func TestHAEtcdChaos(t *testing.T) {
 	t.Parallel()
+	g := NewWithT(t)
 
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	client := e2eutil.GetClientOrDie()
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions()
@@ -49,11 +51,13 @@ func TestHAEtcdChaos(t *testing.T) {
 // chaotic etcd tests which ensure no data is lost in the chaos.
 func TestEtcdChaos(t *testing.T) {
 	t.Parallel()
+	g := NewWithT(t)
 
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	client := e2eutil.GetClientOrDie()
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions()

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -20,7 +20,8 @@ func TestUpgradeControlPlane(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	client := e2eutil.GetClientOrDie()
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	t.Logf("Starting control plane upgrade test. FromImage: %s, toImage: %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
 
@@ -41,7 +42,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 	// Wait for the first rollout to be complete
 	t.Logf("Waiting for initial cluster rollout. Image: %s", globalOpts.PreviousReleaseImage)
 	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.PreviousReleaseImage)
-	err := client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
 	// Update the cluster image

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -37,7 +37,8 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 
 	t.Parallel()
 	g := NewWithT(t)
-	client := e2eutil.GetClientOrDie()
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.KubevirtPlatform, globalOpts.ArtifactDir)
@@ -74,7 +75,7 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 			Name:      hostedCluster.Name,
 		},
 	}
-	err := client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
+	err = client.Get(testContext, crclient.ObjectKeyFromObject(nodepool), nodepool)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
 	t.Logf("Created nodepool. Namespace: %s, name: %s", nodepool.Namespace, nodepool.Name)
 
@@ -98,11 +99,13 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 
 func TestNoneCreateCluster(t *testing.T) {
 	t.Parallel()
+	g := NewWithT(t)
 
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	client := e2eutil.GetClientOrDie()
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	clusterOpts.ControlPlaneAvailabilityPolicy = "SingleReplica"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -114,7 +114,12 @@ func main(m *testing.M) int {
 }
 
 func e2eObserverControllers(ctx context.Context, log logr.Logger, artifactDir string) {
-	mgr, err := ctrl.NewManager(e2eutil.GetConfigOrDie(), manager.Options{MetricsBindAddress: "0"})
+	config, err := e2eutil.GetConfig()
+	if err != nil {
+		log.Error(err, "failed to construct config for observers")
+		return
+	}
+	mgr, err := ctrl.NewManager(config, manager.Options{MetricsBindAddress: "0"})
 	if err != nil {
 		log.Error(err, "failed to construct manager for observers")
 		return

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -41,7 +41,8 @@ func TestOLM(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	client := e2eutil.GetClientOrDie()
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions()
@@ -66,7 +67,7 @@ func TestOLM(t *testing.T) {
 			Namespace: guestNamespace,
 		},
 	}
-	err := wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+	err = wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(redhatCatalogDeployment), redhatCatalogDeployment); err != nil {
 			t.Logf("failed to get Red Hat Catalog deployment %s/%s: %s", redhatCatalogDeployment.Namespace, redhatCatalogDeployment.Name, err)
 			return false, nil

--- a/test/e2e/util/client.go
+++ b/test/e2e/util/client.go
@@ -2,27 +2,32 @@ package util
 
 import (
 	"fmt"
-	"os"
 
 	"k8s.io/client-go/rest"
 	cr "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetConfigOrDie creates a REST config from current context
-func GetConfigOrDie() *rest.Config {
-	cfg := cr.GetConfigOrDie()
+// GetConfig creates a REST config from current context
+func GetConfig() (*rest.Config, error) {
+	cfg, err := cr.GetConfig()
+	if err != nil {
+		return nil, err
+	}
 	cfg.QPS = 100
 	cfg.Burst = 100
-	return cfg
+	return cfg, nil
 }
 
-// GetClientOrDie creates a controller-runtime client for Kubernetes
-func GetClientOrDie() crclient.Client {
-	client, err := crclient.New(GetConfigOrDie(), crclient.Options{Scheme: scheme})
+// GetClient creates a controller-runtime client for Kubernetes
+func GetClient() (crclient.Client, error) {
+	config, err := GetConfig()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to get kubernetes client: %v", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("unable to get kubernetes config: %w", err)
 	}
-	return client
+	client, err := crclient.New(config, crclient.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get kubernetes client: %w", err)
+	}
+	return client, nil
 }

--- a/test/e2e/util/dump/journals.go
+++ b/test/e2e/util/dump/journals.go
@@ -34,7 +34,10 @@ func DumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 	sshKeySecret := &corev1.Secret{}
 	sshKeySecret.Name = secretName
 	sshKeySecret.Namespace = hc.Namespace
-	kubeClient := cmdutil.GetClientOrDie()
+	kubeClient, err := cmdutil.GetClient()
+	if err != nil {
+		return err
+	}
 	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(sshKeySecret), sshKeySecret); err != nil {
 		return err
 	}

--- a/test/setup/main.go
+++ b/test/setup/main.go
@@ -85,7 +85,12 @@ func monitoringCommand() *cobra.Command {
 		ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 		ctx := ctrl.SetupSignalHandler()
 
-		if err := opts.Configure(ctx, e2eutil.GetClientOrDie()); err != nil {
+		cl, err := e2eutil.GetClient()
+		if err != nil {
+			log.Error(err, "failed to get k8s client")
+			os.Exit(1)
+		}
+		if err := opts.Configure(ctx, cl); err != nil {
 			log.Error(err, "failed to configure monitoring")
 			os.Exit(1)
 		}


### PR DESCRIPTION
This commit purges all identified direct calls to `os.Exit()` outside the
context of entrypoints and very specific deliberate uses. Before this commit,
some of these calls (e.g. to get a client or destroy a cluster) could cause e.g.
an e2e run to immediately terminate without cleaning up when signalled at a
point where the signal coincides with one of the code paths leading to
`os.Exit()`.
