### PR TITLE
add token expiration support to prevent nodepool upgrades from killing in flight provisions.

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -26,6 +26,12 @@ const (
 	IgnitionCACertMissingReason   string = "IgnitionCACertMissing"
 )
 
+const (
+	// IgnitionServerTokenExpirationTimestampAnnotation holds the time that a ignition token expires and should be
+	// removed from the cluster.
+	IgnitionServerTokenExpirationTimestampAnnotation = "hypershift.openshift.io/ignition-token-expiration-timestamp"
+)
+
 func init() {
 	SchemeBuilder.Register(&NodePool{})
 	SchemeBuilder.Register(&NodePoolList{})

--- a/ignition-server/README.md
+++ b/ignition-server/README.md
@@ -12,6 +12,12 @@ The TokenSecret controller watches token Secrets and:
 
 i.e a token is active a total of 11 hours, 5.5 main and then 5.5 in the rotated spot.
 
+### Token Deletion 
+
+Token secrets and the associated tokens are revoked/deleted immediately when the corresponding nodePool is deleted. 
+
+When a NodePool is upgraded or goes through a config change, a new token secret is created that corresponds to the updated config value and the old token secret is marked with an expiration date by the NodePool controller. Once the expiration date has passed: the old token secret is deleted and the associated tokens are revoked. This strategy is done to allow in flight provisions that occurred in proximity to the nodePool upgrade to complete.
+
 ## Ignition provider
 An interface to be implemented to produce a valid ignition payload out of a given release/config pair.
 


### PR DESCRIPTION
This pr enhances how ignition tokens are cleaned on nodepool upgrades. Previously on an upgrade: all ignition tokens were revoked as soon as the config was updated. The problem with this approach is outlined in issue: https://github.com/openshift/hypershift/issues/1020. To summarize: immediate revocation does not account for in flight provisions that were executed with the old token. This means these in flight operations would fail. This is a problem for consumers of the offering that should be addressed: provisions should never have the potential to fail. To fix this: when an upgrade occurs: old tokens are marked for expiration. The expiration time is based on the amount of time necessary to allow all in flight provisions to complete (new provisions will use the updated token). After that time: the ignition-server will proceed to delete the secret. The behavior on nodePool delete is unchanged: all tokens are revoked when the nodePool is deleted


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://github.com/openshift/hypershift/issues/1020

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.