### PR TITLE
Azure: Work around a bug that lb services with port 6443 don't work

### DIFF
--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -29,7 +29,6 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AzurePlatform.CredentialsFile, "azure-creds", opts.AzurePlatform.CredentialsFile, "Path to an Azure credentials file (required)")
 	cmd.Flags().StringVar(&opts.AzurePlatform.Location, "location", opts.AzurePlatform.Location, "Location for the cluster")
 	cmd.Flags().StringVar(&opts.AzurePlatform.InstanceType, "instance-type", opts.AzurePlatform.InstanceType, "The instance type to use for nodes")
-	cmd.Flags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the cluster")
 
 	cmd.MarkFlagRequired("azure-creds")
 

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -36,7 +36,7 @@ func ReconcileIngressOperatorKubeconfigSecret(secret, ca *corev1.Secret, ownerRe
 }
 
 func InClusterKASURL(namespace string, apiServerPort int32) string {
-	return fmt.Sprintf("https://%s:%d", manifests.KASService(namespace).Name, apiServerPort)
+	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, apiServerPort)
 }
 
 func InClusterKASReadyURL(namespace string, securePort *int32) string {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -6,6 +6,7 @@ import (
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
 	// TODO: Switch to k8s.io/api/policy/v1 when all management clusters at 1.21+ OR 4.8_openshift+
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,15 +126,6 @@ func KASConfig(controlPlaneNamespace string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kas-config",
-			Namespace: controlPlaneNamespace,
-		},
-	}
-}
-
-func KASService(controlPlaneNamespace string) *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver",
 			Namespace: controlPlaneNamespace,
 		},
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1117,7 +1117,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 	r := &HostedClusterReconciler{
 		Client:                        client,
 		Clock:                         clock.RealClock{},
-		ManagementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
+		ManagementClusterCapabilities: fakecapabilities.NewSupportAllExcept(capabilities.CapabilityConfigOpenshiftIO),
 		createOrUpdate:                func(reconcile.Request) upsert.CreateOrUpdateFN { return ctrl.CreateOrUpdate },
 		ReleaseProvider:               &fakereleaseprovider.FakeReleaseProvider{},
 	}

--- a/support/capabilities/fake/fake.go
+++ b/support/capabilities/fake/fake.go
@@ -6,6 +6,7 @@ import (
 
 var _ capabilities.CapabiltyChecker = &FakeSupportAllCapabilities{}
 var _ capabilities.CapabiltyChecker = &FakeSupportNoCapabilities{}
+var _ capabilities.CapabiltyChecker = &FakeCapabilitiesSupportAllExcept{}
 
 type FakeSupportAllCapabilities struct{}
 
@@ -17,4 +18,26 @@ type FakeSupportNoCapabilities struct{}
 
 func (f *FakeSupportNoCapabilities) Has(capabilities ...capabilities.CapabilityType) bool {
 	return false
+}
+
+func NewSupportAllExcept(capas ...capabilities.CapabilityType) capabilities.CapabiltyChecker {
+	notSupported := make(map[capabilities.CapabilityType]struct{}, len(capas))
+	for _, capability := range capas {
+		notSupported[capability] = struct{}{}
+	}
+	return &FakeCapabilitiesSupportAllExcept{NotSupported: notSupported}
+}
+
+type FakeCapabilitiesSupportAllExcept struct {
+	NotSupported map[capabilities.CapabilityType]struct{}
+}
+
+func (f *FakeCapabilitiesSupportAllExcept) Has(capabilities ...capabilities.CapabilityType) bool {
+	for _, capability := range capabilities {
+		if _, notSupported := f.NotSupported[capability]; notSupported {
+			return false
+		}
+	}
+
+	return true
 }

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -3,6 +3,7 @@ package capabilities
 import (
 	"sync"
 
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 
@@ -23,6 +24,10 @@ const (
 	// CapabilitySecurityContextConstraint indicates if the management cluster
 	// supports security context constraints
 	CapabilitySecurityContextConstraint
+
+	// CapabilityConfigOpenshiftIO indicates if the cluster supports the
+	// config.openshift.io api
+	CapabilityConfigOpenshiftIO
 )
 
 // ManagementClusterCapabilities holds all information about optional capabilities of
@@ -92,6 +97,14 @@ func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterfa
 	}
 	if hasSccCap {
 		discoveredCapabilities[CapabilitySecurityContextConstraint] = struct{}{}
+	}
+
+	hasConfigCap, err := isGroupVersionRegistered(client, configv1.GroupVersion)
+	if err != nil {
+		return nil, err
+	}
+	if hasConfigCap {
+		discoveredCapabilities[CapabilityConfigOpenshiftIO] = struct{}{}
 	}
 
 	return &ManagementClusterCapabilities{capabilities: discoveredCapabilities}, nil


### PR DESCRIPTION
Azureclusters have a bug that results in LB services with port 6443
always failing to provision a LB. Work around it by checking the
platform of the management cluster and if its azure, use a different
port.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.