### PR TITLE
Add missing readiness probes on HA deployments

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -49,6 +49,22 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 			SuccessThreshold:    1,
 		},
 	}
+	p.ServerDeploymentConfig.ReadinessProbes = config.ReadinessProbes{
+		konnectivityServerContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       60,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+			TimeoutSeconds:      5,
+		},
+	}
 	p.ServerDeploymentConfig.Resources = config.ResourcesSpec{
 		konnectivityServerContainer().Name: {
 			Requests: corev1.ResourceList{

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -126,7 +126,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig g
 			},
 		},
 		ReadinessProbes: config.ReadinessProbes{
-			oasContainerMain().Name: {
+			oauthContainerMain().Name: {
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Scheme: corev1.URISchemeHTTPS,
@@ -141,7 +141,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig g
 			},
 		},
 		Resources: map[string]corev1.ResourceRequirements{
-			oasContainerMain().Name: {
+			oauthContainerMain().Name: {
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("200Mi"),
 					corev1.ResourceCPU:    resource.MustParse("150m"),


### PR DESCRIPTION
This PR adds readiness probes to two HA deployments: konnectivity-server and openshift-oauth-apiserver.

Issue: https://github.com/openshift/hypershift/issues/408#issuecomment-1057410802

Implementation details:
- konnectivity-server has :2041/readyz endpoint but it can not be used for the probe - :2041/healthz is used instead.
- openshift-oauth-apiserver already has readiness probe but due to a bug it does not work - the bug is fixed now. The same kind of bug is also fixed for resource request.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.