### PR TITLE
Enable --base-domain cli option with kubevirt provider

### DIFF
--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -87,7 +87,12 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 
 	infraID := opts.InfraID
 	exampleOptions.InfraID = infraID
-	exampleOptions.BaseDomain = "example.com"
+
+	if opts.BaseDomain != "" {
+		exampleOptions.BaseDomain = opts.BaseDomain
+	} else {
+		exampleOptions.BaseDomain = "example.com"
+	}
 
 	exampleOptions.Kubevirt = &apifixtures.ExampleKubevirtOptions{
 		ServicePublishingStrategy: opts.KubevirtPlatform.ServicePublishingStrategy,


### PR DESCRIPTION
When creating a hosted cluster with the hypershift cli, the base-domain option is ignored for the kubevirt platform. If a base domain is set like this, ```hypershift create cluster ... --base-domain <foo> ```, then it should be configured on the hosted cluster object when kubevirt is in use. 