### PR TITLE
Add support for azure.Credentials

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -41,6 +41,7 @@ type CreateInfraOptions struct {
 	Location        string
 	InfraID         string
 	CredentialsFile string
+	Credentials     *apifixtures.AzureCreds
 	OutputFile      string
 }
 
@@ -112,9 +113,14 @@ func resourceGroupName(clusterName, infraID string) string {
 }
 
 func (o *CreateInfraOptions) Run(ctx context.Context) (*CreateInfraOutput, error) {
-	creds, err := readCredentials(o.CredentialsFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read the credentials: %w", err)
+	creds := o.Credentials
+	if creds == nil {
+		var err error
+		creds, err = readCredentials(o.CredentialsFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the credentials: %w", err)
+		}
+		fmt.Printf("Using credentilas: %s", o.CredentialsFile)
 	}
 
 	authorizer, err := auth.ClientCredentialsConfig{
@@ -187,7 +193,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context) (*CreateInfraOutput, error
 		}})
 		if err != nil {
 			if try < 99 {
-				log.Log.Info("Rolle assignment failed, retrying...", "try", strconv.Itoa(try), "err", err)
+				log.Log.Info("Role assignment failed, retrying...", "try", strconv.Itoa(try), "err", err)
 				time.Sleep(time.Second)
 				continue
 			}

--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/log"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +17,7 @@ type DestroyInfraOptions struct {
 	Location        string
 	InfraID         string
 	CredentialsFile string
+	Credentials     *apifixtures.AzureCreds
 }
 
 func NewDestroyCommand() *cobra.Command {
@@ -52,11 +54,14 @@ func NewDestroyCommand() *cobra.Command {
 }
 
 func (o *DestroyInfraOptions) Run(ctx context.Context) error {
-	creds, err := readCredentials(o.CredentialsFile)
-	if err != nil {
-		return fmt.Errorf("failed to read the credentials: %w", err)
+	creds := o.Credentials
+	if creds == nil {
+		var err error
+		creds, err = readCredentials(o.CredentialsFile)
+		if err != nil {
+			return fmt.Errorf("failed to read the credentials: %w", err)
+		}
 	}
-
 	authorizer, err := auth.ClientCredentialsConfig{
 		TenantID:     creds.TenantID,
 		ClientID:     creds.ClientID,


### PR DESCRIPTION
* This allows Go functions to call the Run method without having a local credentialsFile
* Optionally allow the input Options to contain the osServicePrincipal information as an azure fixture.
* If credentials fixture is not passed in the options, default to looking for the credentialsFile
* Support options for Azure destroy as well

Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] <s>This change includes docs.</s>
- [x] This change includes unit tests. (Existing testing covers this)