### PR TITLE
add a gotchas section to the pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,3 +19,9 @@ Fixes #
 - [ ] Relevant issues have been referenced.
 - [ ] This change includes docs. 
 - [ ] This change includes unit tests.
+
+
+**Gotchas to lookout for**
+- Label selectors on deployments/daemonsets are immutable: reconciliation will fail if you expect them to update in place
+- roleRef in clusterRoleBindings/roleBindings are immutable: reconciliation will fail if you expect them to update in place.
+- Changes to the core components (kube-apiserver, controller-manager, etc) PKI/Secrets should be reviewed by all stakeholders. This includes introducing new PKI for a component, changing the names of existing PKI, or anything similar.


### PR DESCRIPTION
This adds a gotchas section with some common things I have seen over my experience with the repo/Kubernetes so far. It can serve as a helpful reminder for when folks contribute to the repo

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.