### PR TITLE
Add ServiceMonitor support to OLM components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1968,6 +1968,12 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile catalog operator metrics service: %w", err)
 	}
+	catalogOperatorServiceMonitor := manifests.CatalogOperatorServiceMonitor(hcp.Namespace)
+	if _, err := r.CreateOrUpdate(ctx, r, catalogOperatorServiceMonitor, func() error {
+		return olm.ReconcileCatalogServiceMonitor(catalogOperatorServiceMonitor, p.OwnerRef)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile catalog operator service monitor: %w", err)
+	}
 	catalogOperatorDeployment := manifests.CatalogOperatorDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, catalogOperatorDeployment, func() error {
 		return olm.ReconcileCatalogOperatorDeployment(catalogOperatorDeployment, p.OwnerRef, p.OLMImage, p.ProxyImage, p.OperatorRegistryImage, p.ReleaseVersion, p.DeploymentConfig, p.AvailabilityProberImage, hcp.Spec.APIPort)
@@ -1980,6 +1986,13 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 		return olm.ReconcileOLMOperatorMetricsService(olmOperatorMetricsService, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile olm operator metrics service: %w", err)
+	}
+
+	olmOperatorServiceMonitor := manifests.OLMOperatorServiceMonitor(hcp.Namespace)
+	if _, err := r.CreateOrUpdate(ctx, r, olmOperatorServiceMonitor, func() error {
+		return olm.ReconcileOLMOperatorServiceMonitor(olmOperatorServiceMonitor, p.OwnerRef)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile olm operator service monitor: %w", err)
 	}
 
 	olmOperatorDeployment := manifests.OLMOperatorDeployment(hcp.Namespace)

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/olm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/olm.go
@@ -1,8 +1,9 @@
 package manifests
 
 import (
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	//TODO: Switch to k8s.io/api/batch/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	// TODO: Switch to k8s.io/api/batch/v1 when all management clusters at 1.21+ OR 4.8_openshift+
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -174,6 +175,15 @@ func CatalogOperatorDeployment(ns string) *appsv1.Deployment {
 	}
 }
 
+func CatalogOperatorServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
+	return &prometheusoperatorv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "catalog-operator",
+			Namespace: ns,
+		},
+	}
+}
+
 // OLM Operator
 
 func OLMOperatorMetricsService(ns string) *corev1.Service {
@@ -187,6 +197,15 @@ func OLMOperatorMetricsService(ns string) *corev1.Service {
 
 func OLMOperatorDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "olm-operator",
+			Namespace: ns,
+		},
+	}
+}
+
+func OLMOperatorServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
+	return &prometheusoperatorv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "olm-operator",
 			Namespace: ns,

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-metrics-service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-metrics-service.yaml
@@ -2,12 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: catalog-operator-metrics
+  labels:
+    app: catalog-operator
+    hypershift.openshift.io/control-plane-component: catalog-operator
 spec:
   type: ClusterIP
   ports:
     - name: https-metrics
       port: 8443
       protocol: TCP
-      targetPort: 8443
+      targetPort: metrics
   selector:
     app: catalog-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-operator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             secretName: catalog-operator-serving-cert
         - name: profile-collector
           secret:
-            secretName: pprof-cert
+            secretName: metrics-client
         - name: kubeconfig
           secret:
             secretName: service-network-admin-kubeconfig
@@ -57,7 +57,7 @@ spec:
             - --tls-key
             - /srv-cert/tls.key
             - --client-ca
-            - /client-ca/tls.crt
+            - /client-ca/ca.crt
             - -kubeconfig
             - /etc/openshift/kubeconfig/kubeconfig
           image: OLM_OPERATOR_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
@@ -40,5 +40,5 @@ spec:
                 name: olm-collect-profiles
             - name: secret-volume
               secret:
-                secretName: pprof-cert
+                secretName: metrics-client
           restartPolicy: Never

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-metrics-service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-metrics-service.yaml
@@ -2,12 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: olm-operator-metrics
+  labels:
+    app: olm-operator
+    hypershift.openshift.io/control-plane-component: olm-operator
 spec:
   type: ClusterIP
   ports:
     - name: https-metrics
       port: 8443
       protocol: TCP
-      targetPort: 8443
+      targetPort: metrics
   selector:
     app: olm-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             secretName: olm-operator-serving-cert
         - name: client-ca
           secret:
-            secretName: pprof-cert
+            secretName: metrics-client
         - name: kubeconfig
           secret:
             secretName: service-network-admin-kubeconfig
@@ -54,7 +54,7 @@ spec:
             - --tls-key
             - /srv-cert/tls.key
             - --client-ca
-            - /client-ca/tls.crt
+            - /client-ca/ca.crt
           image: OLM_OPERATOR_IMAGE
           imagePullPolicy: IfNotPresent
           ports:

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -4,8 +4,13 @@ import (
 	"fmt"
 	"math/big"
 
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	//TODO: Switch to k8s.io/api/batch/v1 when all management clusters at 1.21+ OR 4.8_openshift+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	// TODO: Switch to k8s.io/api/batch/v1 when all management clusters at 1.21+ OR 4.8_openshift+
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -19,6 +24,10 @@ var (
 	redHatMarketplaceCatalogService = MustService("assets/catalog-redhat-marketplace.service.yaml")
 	redHatOperatorsCatalogService   = MustService("assets/catalog-redhat-operators.service.yaml")
 )
+
+func catalogLabels() map[string]string {
+	return map[string]string{"app": "catalog-operator", hyperv1.ControlPlaneComponent: "catalog-operator"}
+}
 
 func ReconcileCertifiedOperatorsService(svc *corev1.Service, ownerRef config.OwnerRef) error {
 	return reconcileCatalogService(svc, ownerRef, certifiedCatalogService)
@@ -138,5 +147,58 @@ func ReconcileCatalogRolloutRoleBinding(roleBinding *rbacv1.RoleBinding, ownerRe
 	ownerRef.ApplyTo(roleBinding)
 	roleBinding.RoleRef = catalogRolloutRoleBinding.DeepCopy().RoleRef
 	roleBinding.Subjects = catalogRolloutRoleBinding.DeepCopy().Subjects
+	return nil
+}
+
+func ReconcileCatalogServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sm)
+
+	sm.Spec.Selector.MatchLabels = catalogLabels()
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+	targetPort := intstr.FromString("metrics")
+	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
+		{
+			Interval:   "15s",
+			TargetPort: &targetPort,
+			Scheme:     "https",
+			TLSConfig: &prometheusoperatorv1.TLSConfig{
+				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
+					ServerName: "catalog-operator-metrics",
+					Cert: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "tls.crt",
+						},
+					},
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+						},
+						Key: "tls.key",
+					},
+					CA: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "ca.crt",
+						},
+					},
+				},
+			},
+			MetricRelabelConfigs: []*prometheusoperatorv1.RelabelConfig{
+				{
+					Action:       "drop",
+					Regex:        "etcd_(debugging|disk|server).*",
+					SourceLabels: []string{"__name__"},
+				},
+			},
+		},
+	}
+
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -1,9 +1,13 @@
 package olm
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/support/config"
@@ -18,6 +22,10 @@ var (
 	olmOperatorDeployment     = MustDeployment("assets/olm-operator-deployment.yaml")
 )
 
+func olmOperatorLabels() map[string]string {
+	return map[string]string{"app": "olm-operator", hyperv1.ControlPlaneComponent: "olm-operator"}
+}
+
 func ReconcileCatalogOperatorMetricsService(svc *corev1.Service, ownerRef config.OwnerRef) error {
 	ownerRef.ApplyTo(svc)
 
@@ -25,6 +33,7 @@ func ReconcileCatalogOperatorMetricsService(svc *corev1.Service, ownerRef config
 	// This field is immutable as shown here: https://github.com/kubernetes/api/blob/62998e98c313b2ca15b1da278aa702bdd7b84cb0/core/v1/types.go#L4114-L4130
 	// As such, to avoid an error when updating the object, only update the fields OLM specifies.
 	catalogOperatorMetricsServiceDeepCopy := catalogOperatorMetricsService.DeepCopy()
+	svc.Labels = catalogOperatorMetricsServiceDeepCopy.Labels
 	svc.Spec.Ports = catalogOperatorMetricsServiceDeepCopy.Spec.Ports
 	svc.Spec.Type = catalogOperatorMetricsServiceDeepCopy.Spec.Type
 	svc.Spec.Selector = catalogOperatorMetricsServiceDeepCopy.Spec.Selector
@@ -69,6 +78,7 @@ func ReconcileOLMOperatorMetricsService(svc *corev1.Service, ownerRef config.Own
 	// This field is immutable as shown here: https://github.com/kubernetes/api/blob/62998e98c313b2ca15b1da278aa702bdd7b84cb0/core/v1/types.go#L4114-L4130
 	// As such, to avoid an error when updating the object, only update the fields OLM specifies.
 	olmOperatorMetricsServiceDeepCopy := olmOperatorMetricsService.DeepCopy()
+	svc.Labels = olmOperatorMetricsService.Labels
 	svc.Spec.Ports = olmOperatorMetricsServiceDeepCopy.Spec.Ports
 	svc.Spec.Type = olmOperatorMetricsServiceDeepCopy.Spec.Type
 	svc.Spec.Selector = olmOperatorMetricsServiceDeepCopy.Spec.Selector
@@ -100,5 +110,58 @@ func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef conf
 	}
 	dc.ApplyTo(deployment)
 	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec)
+	return nil
+}
+
+func ReconcileOLMOperatorServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sm)
+
+	sm.Spec.Selector.MatchLabels = olmOperatorLabels()
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+	targetPort := intstr.FromString("metrics")
+	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
+		{
+			Interval:   "15s",
+			TargetPort: &targetPort,
+			Scheme:     "https",
+			TLSConfig: &prometheusoperatorv1.TLSConfig{
+				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
+					ServerName: "olm-operator-metrics",
+					Cert: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "tls.crt",
+						},
+					},
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+						},
+						Key: "tls.key",
+					},
+					CA: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "ca.crt",
+						},
+					},
+				},
+			},
+			MetricRelabelConfigs: []*prometheusoperatorv1.RelabelConfig{
+				{
+					Action:       "drop",
+					Regex:        "etcd_(debugging|disk|server).*",
+					SourceLabels: []string{"__name__"},
+				},
+			},
+		},
+	}
+
 	return nil
 }


### PR DESCRIPTION
This commit adds ServiceMonitor support to the OLM and OLM catalog
operators. The metrics label configuration is the same as OCP for
those components.
