### PR TITLE
Add ServiceMonitor support to CVO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/cvo.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/cvo.go
@@ -1,7 +1,9 @@
 package manifests
 
 import (
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -10,6 +12,24 @@ func ClusterVersionOperatorDeployment(ns string) *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster-version-operator",
 			Namespace: ns,
+		},
+	}
+}
+
+func ClusterVersionOperatorServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
+	return &prometheusoperatorv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-version-operator",
+			Namespace: ns,
+		},
+	}
+}
+
+func ClusterVersionOperatorService(controlPlaneNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-version-operator",
+			Namespace: controlPlaneNamespace,
 		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -283,3 +283,12 @@ func IBMCloudKASKMSWDEKSecret(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func ClusterVersionOperatorServerCertSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cvo-server",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/cvo.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/cvo.go
@@ -1,0 +1,19 @@
+package pki
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/hypershift/support/config"
+)
+
+func ReconcileCVOServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	dnsNames := []string{
+		fmt.Sprintf("cluster-version-operator.%s.svc", secret.Namespace),
+		fmt.Sprintf("cluster-version-operator.%s.svc.cluster.local", secret.Namespace),
+		"cluster-version-operator",
+		"localhost",
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "cluster-version-operator", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+}


### PR DESCRIPTION
This commit adds ServiceMonitor support to the CVO. The label config
follows OCP.
