### PR TITLE
Fix create nodepool azure command

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -428,8 +428,11 @@ type AgentNodePoolPlatform struct {
 }
 
 type AzureNodePoolPlatform struct {
-	VMSize  string `json:"vmsize"`
-	ImageID string `json:"imageID"`
+	VMSize string `json:"vmsize"`
+	// ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
+	// subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
+	// +optional
+	ImageID string `json:"imageID,omitempty"`
 	// +kubebuilder:default:=120
 	// +kubebuilder:validation:Minimum=16
 	// +optional

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -423,11 +423,13 @@ spec:
                         minimum: 16
                         type: integer
                       imageID:
+                        description: 'ImageID is the id of the image to boot from.
+                          If unset, the default image at the location below will be
+                          used: subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd'
                         type: string
                       vmsize:
                         type: string
                     required:
-                    - imageID
                     - vmsize
                     type: object
                   ibmcloud:

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -19,6 +19,12 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 		Short:        "Creates an Azure nodepool",
 		SilenceUsage: true,
 	}
+	o := &opts{
+		instanceType: "Standard_D4s_v4",
+		diskSize:     120,
+	}
+	cmd.Flags().StringVar(&o.instanceType, "instance-type", o.instanceType, "The instance type to use for the nodepool")
+	cmd.Flags().Int32Var(&o.diskSize, "root-disk-size", o.diskSize, "The size of the root disk for machines in the NodePool (minimum 16)")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -29,7 +35,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 			cancel()
 		}()
 
-		if err := coreOpts.CreateNodePool(ctx, opts{}); err != nil {
+		if err := coreOpts.CreateNodePool(ctx, o); err != nil {
 			log.Log.Error(err, "Failed to create nodepool")
 			os.Exit(1)
 		}
@@ -38,9 +44,17 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	return cmd
 }
 
-type opts struct{}
+type opts struct {
+	instanceType string
+	diskSize     int32
+}
 
-func (opts) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
+func (o *opts) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
+	nodePool.Spec.Platform.Type = hyperv1.AzurePlatform
+	nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
+		VMSize:     o.instanceType,
+		DiskSizeGB: o.diskSize,
+	}
 	return nil
 }
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1521,6 +1521,9 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
+subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -22169,11 +22169,13 @@ objects:
                           minimum: 16
                           type: integer
                         imageID:
+                          description: 'ImageID is the id of the image to boot from.
+                            If unset, the default image at the location below will
+                            be used: subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd'
                           type: string
                         vmsize:
                           type: string
                       required:
-                      - imageID
                       - vmsize
                       type: object
                     ibmcloud:

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -1,0 +1,42 @@
+package nodepool
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+func TestBootImage(t *testing.T) {
+	testCases := []struct {
+		name     string
+		hcluster *hyperv1.HostedCluster
+		nodepool *hyperv1.NodePool
+		expected string
+	}{
+		{
+			name: "Nodepool has image set, it is being used",
+			nodepool: &hyperv1.NodePool{Spec: hyperv1.NodePoolSpec{Platform: hyperv1.NodePoolPlatform{Azure: &hyperv1.AzureNodePoolPlatform{
+				ImageID: "nodepool-image",
+			}}}},
+			expected: "nodepool-image",
+		},
+		{
+			name: "Default bootimage is used",
+			hcluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{Azure: &hyperv1.AzurePlatformSpec{
+				SubscriptionID:    "123-123",
+				ResourceGroupName: "rg-name",
+			}}}},
+			nodepool: &hyperv1.NodePool{Spec: hyperv1.NodePoolSpec{Platform: hyperv1.NodePoolPlatform{Azure: &hyperv1.AzureNodePoolPlatform{}}}},
+			expected: "/subscriptions/123-123/resourceGroups/rg-name/providers/Microsoft.Compute/images/rhcos.x86_64.vhd",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := bootImage(tc.hcluster, tc.nodepool)
+			if result != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This was never fully implemented. In order to fix it, the bootImageId
was moved from the nodepool to the cluster, because it is unique per
cluster and never changes. Otherwise if there is no nodepool, we are
unable to find it.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.