### PR TITLE
Azure: Stop logging errors during role assignment retry

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"strconv"
 	"strings"
 	"time"
 
@@ -186,6 +185,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context) (*CreateInfraOutput, error
 		return nil, fmt.Errorf("failed to generate uuid for role assignment name: %w", err)
 	}
 
+	log.Log.Info("Assigning role to managed identity, this may take some time")
 	for try := 0; try < 100; try++ {
 		_, err := roleAssignmentClient.Create(ctx, *rg.ID, roleAssignmentName, authorization.RoleAssignmentCreateParameters{RoleAssignmentProperties: &authorization.RoleAssignmentProperties{
 			RoleDefinitionID: roleDefinitions.Values()[0].ID,
@@ -193,7 +193,6 @@ func (o *CreateInfraOptions) Run(ctx context.Context) (*CreateInfraOutput, error
 		}})
 		if err != nil {
 			if try < 99 {
-				log.Log.Info("Role assignment failed, retrying...", "try", strconv.Itoa(try), "err", err)
 				time.Sleep(time.Second)
 				continue
 			}


### PR DESCRIPTION
Presumambly due to eventual consistency on Azure, the role assignment
always needs some retries. Do not log an error for each retry, as that
looks like something went wrong which is not the case.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.