### PR TITLE
fix dns crd reconciliation for ibm cloud or providers that provide a subdomain

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -97,7 +97,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 		AuthConfig: kcpv1.MasterAuthConfig{
 			OAuthMetadataFile: cpath(kasVolumeOauthMetadata().Name, OauthMetadataConfigKey),
 		},
-		ConsolePublicURL:             "",
+		ConsolePublicURL:             p.ConsolePublicURL,
 		ImagePolicyConfig:            imagePolicyConfig(p.InternalRegistryHostName, p.ExternalRegistryHostNames),
 		ProjectConfig:                projectConfig(p.DefaultNodeSelector),
 		ServiceAccountPublicKeyFiles: []string{cpath(kasVolumeServiceAccountKey().Name, pki.ServiceSignerPublicKey)},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -52,6 +52,7 @@ type KubeAPIServerParams struct {
 	APIServerPort        int32                        `json:"apiServerPort"`
 	KubeConfigRef        *hyperv1.KubeconfigSecretRef `json:"kubeConfigRef"`
 	AuditWebhookRef      *corev1.LocalObjectReference `json:"auditWebhookRef"`
+	ConsolePublicURL     string                       `json:"consolePublicURL"`
 	config.DeploymentConfig
 	config.OwnerRef
 
@@ -66,6 +67,8 @@ type KubeAPIServerServiceParams struct {
 }
 
 func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig, images map[string]string, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {
+	dns := globalconfig.DNSConfig()
+	globalconfig.ReconcileDNSConfig(dns, hcp)
 	params := &KubeAPIServerParams{
 		APIServer:            globalConfig.APIServer,
 		FeatureGate:          globalConfig.FeatureGate,
@@ -82,6 +85,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		ServiceCIDR:          hcp.Spec.ServiceCIDR,
 		PodCIDR:              hcp.Spec.PodCIDR,
 		Availability:         hcp.Spec.ControllerAvailabilityPolicy,
+		ConsolePublicURL:     fmt.Sprintf("console-openshift-console.%s", dns.Spec.BaseDomain),
 
 		Images: KubeAPIServerImages{
 			HyperKube:             images["hyperkube"],
@@ -376,6 +380,7 @@ func (p *KubeAPIServerParams) ConfigParams() KubeAPIServerConfigParams {
 		FeatureGates:                 p.FeatureGates(),
 		NodePortRange:                p.ServiceNodePortRange(),
 		AuditWebhookEnabled:          p.AuditWebhookRef != nil,
+		ConsolePublicURL:             p.ConsolePublicURL,
 	}
 }
 
@@ -398,6 +403,7 @@ type KubeAPIServerConfigParams struct {
 	FeatureGates                 []string
 	NodePortRange                string
 	AuditWebhookEnabled          bool
+	ConsolePublicURL             string
 }
 
 func (p *KubeAPIServerParams) TLSSecurityProfile() *configv1.TLSSecurityProfile {

--- a/support/globalconfig/dns.go
+++ b/support/globalconfig/dns.go
@@ -18,7 +18,11 @@ func DNSConfig() *configv1.DNS {
 }
 
 func ReconcileDNSConfig(dns *configv1.DNS, hcp *hyperv1.HostedControlPlane) {
-	dns.Spec.BaseDomain = BaseDomain(hcp)
+	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+		dns.Spec.BaseDomain = hcp.Spec.DNS.BaseDomain
+	} else {
+		dns.Spec.BaseDomain = BaseDomain(hcp)
+	}
 	if len(hcp.Spec.DNS.PublicZoneID) > 0 {
 		dns.Spec.PublicZone = &configv1.DNSZone{
 			ID: hcp.Spec.DNS.PublicZoneID,

--- a/support/globalconfig/dns_test.go
+++ b/support/globalconfig/dns_test.go
@@ -1,0 +1,86 @@
+package globalconfig
+
+import (
+	"fmt"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestReconcileDNSConfig(t *testing.T) {
+	fakeHCPName := "cluster"
+	fakeBaseDomain := "example.com"
+	fakePublicZoneID := "publiczone1"
+	fakePrivateZoneID := "privatezone1"
+	testsCases := []struct {
+		name              string
+		inputHCP          *hyperv1.HostedControlPlane
+		inputDNSConfig    *configv1.DNS
+		expectedDNSConfig *configv1.DNS
+	}{
+		{
+			name:           "when DNS parameters specified on the HostedControlPlane then they are copied to the DNS object",
+			inputDNSConfig: DNSConfig(),
+			inputHCP: &hyperv1.HostedControlPlane{
+				ObjectMeta: v1.ObjectMeta{
+					Name: fakeHCPName,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					DNS: hyperv1.DNSSpec{
+						BaseDomain:    fakeBaseDomain,
+						PrivateZoneID: fakePrivateZoneID,
+						PublicZoneID:  fakePublicZoneID,
+					},
+				},
+			},
+			expectedDNSConfig: &configv1.DNS{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.DNSSpec{
+					BaseDomain: fmt.Sprintf("%s.%s", fakeHCPName, fakeBaseDomain),
+					PublicZone: &configv1.DNSZone{
+						ID: fakePublicZoneID,
+					},
+					PrivateZone: &configv1.DNSZone{
+						ID: fakePrivateZoneID,
+					},
+				},
+			},
+		},
+		{
+			name:           "when IBM Cloud platform is used then the base domain is set to the value on the HostedControlPlane",
+			inputDNSConfig: DNSConfig(),
+			inputHCP: &hyperv1.HostedControlPlane{
+				ObjectMeta: v1.ObjectMeta{
+					Name: fakeHCPName,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					DNS: hyperv1.DNSSpec{
+						BaseDomain: fakeBaseDomain,
+					},
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.IBMCloudPlatform,
+					},
+				},
+			},
+			expectedDNSConfig: &configv1.DNS{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.DNSSpec{
+					BaseDomain: fakeBaseDomain,
+				},
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ReconcileDNSConfig(tc.inputDNSConfig, tc.inputHCP)
+			g.Expect(tc.expectedDNSConfig).To(BeEquivalentTo(tc.inputDNSConfig))
+		})
+	}
+}


### PR DESCRIPTION
Currently the DNS CRD instance is not getting set properly in IBM Cloud deployments. It is using the default value that I believe is fine for the AWS/upstream openshift dedicated use cases where the cluster name is added after the base domain in the spec. However: that is not the case in IBM Cloud where the specified base domain is the base domain of the cluster (should not have the cluster preprended to it. We specify this through the DNS config already but hypershift is not respecting it and is always using the default value. In addition: Hypershift is currently missing the redirect standard OCP and ROKS deploys offer to the console from the master API endpoint. This enables that functionality by setting ConsolePublicURL appropriately.

Example currently in hypershift:
```
apiVersion: config.openshift.io/v1
kind: DNS
metadata:
  creationTimestamp: "2022-03-06T18:58:42Z"
  generation: 1
  labels:
    hypershift.io/managed: "true"
  name: cluster
  resourceVersion: "1078"
  uid: 7ab515c6-409b-4a94-a2d5-e07520adaf9c
spec:
  baseDomain: c8ig44h10gqakshf6pfg.tyler-hyp-20220306-1-9e37478581b5d9de33607f5926d1d18f-0000.upi.prestg.stg.containers.appdomain.cloud
```

This does not match the subdomain that is generated in Akamai which is 
`canonical name = tyler-hyp-20220306-1-9e37478581b5d9de33607f5926d1d18f-0000.upi.prestg.stg.containers.appdomain.cloud`

Example shown below of ROKS toolkit cluster
```
- apiVersion: config.openshift.io/v1
  kind: DNS
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"config.openshift.io/v1","kind":"DNS","metadata":{"annotations":{},"creationTimestamp":null,"name":"cluster"},"spec":{"baseDomain":"bts-oc4-prtester-15b0bf3714b2d9d344c3b8647edb7860-0000.us-south.stg.containers.appdomain.cloud"},"status":{}}
    creationTimestamp: "2021-11-02T07:49:21Z"
    generation: 1
    name: cluster
    resourceVersion: "779"
    uid: f3c26c51-75a3-42a0-a48c-567de77db8cc
  spec:
    baseDomain: bts-oc4-prtester-15b0bf3714b2d9d344c3b8647edb7860-0000.us-south.stg.containers.appdomain.cloud
```

For validating the console url: before this change if you go to 
KUBE_APISERVER_URL/console : it would not redirect you and would fail

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.