### PR TITLE
Azure: Fix credentials log

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -120,7 +120,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context) (*CreateInfraOutput, error
 		if err != nil {
 			return nil, fmt.Errorf("failed to read the credentials: %w", err)
 		}
-		fmt.Printf("Using credentilas: %s", o.CredentialsFile)
+		log.Log.Info("Using credentials from file", "path", o.CredentialsFile)
 	}
 
 	authorizer, err := auth.ClientCredentialsConfig{


### PR DESCRIPTION
It uses fmt.Printf rather than the normal logger, has a typo and misses
a trailing newline, resulting in a logline that looks something like
this:
```
Using credentilas: /home/alvaro/.azure/osServicePrincipal.json2022-03-09T11:52:34-05:00	INFO	Successfuly created resourceGroup	{"name": "alvaro-test-alvaro-test-rsdlw"}
```

Fix that.

/cc @jnpacker 

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.