### PR TITLE
Azure: Add multi-AZ support

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -437,6 +437,10 @@ type AzureNodePoolPlatform struct {
 	// +kubebuilder:validation:Minimum=16
 	// +optional
 	DiskSizeGB int32 `json:"diskSizeGB,omitempty"`
+	// AvailabilityZone of the nodepool. Must not be specified for clusters
+	// in a location that does not support AvailabilityZone.
+	// +optional
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -31,6 +31,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AzurePlatform.Location, "location", opts.AzurePlatform.Location, "Location for the cluster")
 	cmd.Flags().StringVar(&opts.AzurePlatform.InstanceType, "instance-type", opts.AzurePlatform.InstanceType, "The instance type to use for nodes")
 	cmd.Flags().Int32Var(&opts.AzurePlatform.DiskSizeGB, "root-disk-size", opts.AzurePlatform.DiskSizeGB, "The size of the root disk for machines in the NodePool (minimum 16)")
+	cmd.Flags().StringSliceVar(&opts.AzurePlatform.AvailabilityZones, "availablity-zones", opts.AzurePlatform.AvailabilityZones, "The availablity zones in which NodePools will be created. Must be left unspecified if the region does not support AZs. If set, one nodepool per zone will be created.")
 
 	cmd.MarkFlagRequired("azure-creds")
 
@@ -104,6 +105,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		InstanceType:      opts.AzurePlatform.InstanceType,
 		SecurityGroupName: infra.SecurityGroupName,
 		DiskSizeGB:        opts.AzurePlatform.DiskSizeGB,
+		AvailabilityZones: opts.AzurePlatform.AvailabilityZones,
 	}
 
 	azureCredsRaw, err := ioutil.ReadFile(opts.AzurePlatform.CredentialsFile)

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -98,10 +98,11 @@ type AWSPlatformOptions struct {
 }
 
 type AzurePlatformOptions struct {
-	CredentialsFile string
-	Location        string
-	InstanceType    string
-	DiskSizeGB      int32
+	CredentialsFile   string
+	Location          string
+	InstanceType      string
+	DiskSizeGB        int32
+	AvailabilityZones []string
 }
 
 func createCommonFixture(opts *CreateOptions) (*apifixtures.ExampleOptions, error) {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -417,6 +417,11 @@ spec:
                     type: object
                   azure:
                     properties:
+                      availabilityZone:
+                        description: AvailabilityZone of the nodepool. Must not be
+                          specified for clusters in a location that does not support
+                          AvailabilityZone.
+                        type: string
                       diskSizeGB:
                         default: 120
                         format: int32

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -25,6 +25,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&o.instanceType, "instance-type", o.instanceType, "The instance type to use for the nodepool")
 	cmd.Flags().Int32Var(&o.diskSize, "root-disk-size", o.diskSize, "The size of the root disk for machines in the NodePool (minimum 16)")
+	cmd.Flags().StringVar(&o.availabilityZone, "availability-zone", o.availabilityZone, "The availabilityZone for the nodepool. Must be left unspecified if in a region that doesn't support AZs")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -45,15 +46,17 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 }
 
 type opts struct {
-	instanceType string
-	diskSize     int32
+	instanceType     string
+	diskSize         int32
+	availabilityZone string
 }
 
 func (o *opts) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
 	nodePool.Spec.Platform.Type = hyperv1.AzurePlatform
 	nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-		VMSize:     o.instanceType,
-		DiskSizeGB: o.diskSize,
+		VMSize:           o.instanceType,
+		DiskSizeGB:       o.diskSize,
+		AvailabilityZone: o.availabilityZone,
 	}
 	return nil
 }

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1537,6 +1537,19 @@ int32
 <em>(Optional)</em>
 </td>
 </tr>
+<tr>
+<td>
+<code>availabilityZone</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AvailabilityZone of the nodepool. Must not be specified for clusters
+in a location that does not support AvailabilityZone.</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###AzurePlatformSpec { #hypershift.openshift.io/v1alpha1.AzurePlatformSpec }

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -22163,6 +22163,11 @@ objects:
                       type: object
                     azure:
                       properties:
+                        availabilityZone:
+                          description: AvailabilityZone of the nodepool. Must not
+                            be specified for clusters in a location that does not
+                            support AvailabilityZone.
+                          type: string
                         diskSizeGB:
                           default: 120
                           format: int32

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -34,6 +34,7 @@ func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1
 		Identity:               capiazure.VMIdentityUserAssigned,
 		UserAssignedIdentities: []capiazure.UserAssignedIdentity{{ProviderID: hcluster.Spec.Platform.Azure.MachineIdentityID}},
 		SSHPublicKey:           sshKey,
+		FailureDomain:          failureDomain(nodePool),
 	}}}, nil
 }
 
@@ -56,4 +57,11 @@ func bootImage(hcluster *hyperv1.HostedCluster, nodepool *hyperv1.NodePool) stri
 		return nodepool.Spec.Platform.Azure.ImageID
 	}
 	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/rhcos.x86_64.vhd", hcluster.Spec.Platform.Azure.SubscriptionID, hcluster.Spec.Platform.Azure.ResourceGroupName)
+}
+
+func failureDomain(nodepool *hyperv1.NodePool) *string {
+	if nodepool.Spec.Platform.Azure.AvailabilityZone == "" {
+		return nil
+	}
+	return utilpointer.String(nodepool.Spec.Platform.Azure.AvailabilityZone)
 }


### PR DESCRIPTION
This adds multi-az support to Azure, which is rather simple as the only
thing required is a config option on the nodepool. Not all locations
support AZs, so it is optional.

Ref https://issues.redhat.com/browse/HOSTEDCP-322

/cc @enxebre 

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.