### PR TITLE
Give control-plane-operator access to the pull secret

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1986,6 +1986,11 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 				},
 			},
 			Spec: corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{
+						Name: "pull-secret",
+					},
+				},
 				ServiceAccountName: sa.Name,
 				Containers: []corev1.Container{
 					{


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that the release payload image can also be fetched if it requires
autentication.

It seems like since yesterday `quay.io/openshift-release-dev/ocp-v4.0-art-dev` requires authentication. When the pull secret is available to control-plane-operator, it can come up successfully.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.