### PR TITLE
Surface cloud error conditions for HostedCluster resources

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1032,6 +1032,21 @@ const (
 	HostedClusterUnhealthyComponentsReason = "UnhealthyControlPlaneComponents"
 	InvalidConfigurationReason             = "InvalidConfiguration"
 
+	DeploymentNotFoundReason      = "DeploymentNotFound"
+	DeploymentStatusUnknownReason = "DeploymentStatusUnknown"
+
+	HostedControlPlaneComponentsUnavailableReason = "ComponentsUnavailable"
+	KubeconfigUnavailableReason                   = "KubeconfigUnavailable"
+	ClusterVersionStatusUnknownReason             = "ClusterVersionStatusUnknown"
+
+	StatusUnknownReason = "StatusUnknown"
+	AsExpectedReason    = "AsExpected"
+
+	EtcdQuorumAvailableReason     = "QuorumAvailable"
+	EtcdQuorumUnavailableReason   = "QuorumUnavailable"
+	EtcdStatusUnknownReason       = "EtcdStatusUnknown"
+	EtcdStatefulSetNotFoundReason = "StatefulSetNotFound"
+
 	UnsupportedHostedClusterReason = "UnsupportedHostedCluster"
 
 	UnmanagedEtcdStatusUnknownReason = "UnmanagedEtcdStatusUnknown"
@@ -1144,6 +1159,7 @@ type ClusterConfiguration struct {
 // +kubebuilder:printcolumn:name="Progress",type="string",JSONPath=".status.version.history[?(@.state!=\"\")].state",description="Progress"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].status",description="Available"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].reason",description="Reason"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].message",description="Message"
 type HostedCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -40,6 +40,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=="Available")].reason
       name: Reason
       type: string
+    - description: Message
+      jsonPath: .status.conditions[?(@.type=="Available")].message
+      name: Message
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -691,6 +691,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Resources: []string{
 					"events",
 					"configmaps",
+					"persistentvolumeclaims",
 					"pods",
 					"pods/log",
 					"secrets",

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -5,9 +5,11 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/openshift/hypershift/support/capabilities"
+	"github.com/openshift/hypershift/support/events"
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
@@ -21,6 +23,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,6 +81,7 @@ type InfrastructureStatus struct {
 	OpenShiftAPIHost        string
 	OauthAPIServerHost      string
 	PackageServerAPIAddress string
+	Message                 string
 }
 
 func (s InfrastructureStatus) IsReady() bool {
@@ -110,6 +116,7 @@ func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		WithOptions(controller.Options{
 			RateLimiter: workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 10*time.Second),
 		}).
+		Watches(&source.Kind{Type: &corev1.Event{}}, handler.EnqueueRequestsFromMapFunc(r.hostedControlPlaneInNamespace)).
 		Watches(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Watches(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
 		Watches(&source.Kind{Type: &appsv1.StatefulSet{}}, &handler.EnqueueRequestForOwner{OwnerType: &hyperv1.HostedControlPlane{}}).
@@ -201,7 +208,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		newCondition := metav1.Condition{
 			Type:   string(hyperv1.EtcdAvailable),
 			Status: metav1.ConditionUnknown,
-			Reason: "EtcdStatusUnknown",
+			Reason: hyperv1.EtcdStatusUnknownReason,
 		}
 		switch hostedControlPlane.Spec.Etcd.ManagementType {
 		case hyperv1.Managed:
@@ -212,25 +219,17 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 					newCondition = metav1.Condition{
 						Type:   string(hyperv1.EtcdAvailable),
 						Status: metav1.ConditionFalse,
-						Reason: "StatefulSetNotFound",
+						Reason: hyperv1.EtcdStatefulSetNotFoundReason,
 					}
 				} else {
 					return ctrl.Result{}, fmt.Errorf("failed to fetch etcd statefulset %s/%s: %w", sts.Namespace, sts.Name, err)
 				}
 			} else {
-				if sts.Status.ReadyReplicas >= *sts.Spec.Replicas/2+1 {
-					newCondition = metav1.Condition{
-						Type:   string(hyperv1.EtcdAvailable),
-						Status: metav1.ConditionTrue,
-						Reason: "QuorumAvailable",
-					}
-				} else {
-					newCondition = metav1.Condition{
-						Type:   string(hyperv1.EtcdAvailable),
-						Status: metav1.ConditionFalse,
-						Reason: "QuorumUnavailable",
-					}
+				conditionPtr, err := r.etcdStatefulSetCondition(ctx, sts)
+				if err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to get etcd statefulset status: %w", err)
 				}
+				newCondition = *conditionPtr
 			}
 		case hyperv1.Unmanaged:
 			r.Log.Info("Assuming Etcd cluster is running in unmanaged etcd strategy")
@@ -250,15 +249,16 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		newCondition := metav1.Condition{
 			Type:   string(hyperv1.KubeAPIServerAvailable),
 			Status: metav1.ConditionUnknown,
-			Reason: "StatusUnknown",
+			Reason: hyperv1.StatusUnknownReason,
 		}
 		deployment := manifests.KASDeployment(hostedControlPlane.Namespace)
 		if err := r.Get(ctx, client.ObjectKeyFromObject(deployment), deployment); err != nil {
 			if apierrors.IsNotFound(err) {
 				newCondition = metav1.Condition{
-					Type:   string(hyperv1.KubeAPIServerAvailable),
-					Status: metav1.ConditionFalse,
-					Reason: "DeploymentNotFound",
+					Type:    string(hyperv1.KubeAPIServerAvailable),
+					Status:  metav1.ConditionFalse,
+					Reason:  hyperv1.DeploymentNotFoundReason,
+					Message: "Kube APIServer deployment not found",
 				}
 			} else {
 				return ctrl.Result{}, fmt.Errorf("failed to fetch Kube APIServer deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
@@ -268,14 +268,14 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 			newCondition = metav1.Condition{
 				Type:   string(hyperv1.KubeAPIServerAvailable),
 				Status: metav1.ConditionFalse,
-				Reason: "DeploymentStatusUnknown",
+				Reason: hyperv1.DeploymentStatusUnknownReason,
 			}
 			for _, cond := range deployment.Status.Conditions {
 				if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
 					newCondition = metav1.Condition{
 						Type:   string(hyperv1.KubeAPIServerAvailable),
 						Status: metav1.ConditionTrue,
-						Reason: "AsExpected",
+						Reason: hyperv1.AsExpectedReason,
 					}
 					break
 				}
@@ -285,40 +285,13 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
 	}
 
-	// Reconcile hostedcontrolplane availability and Ready flag
-	{
-		newCondition := metav1.Condition{
-			Type:   string(hyperv1.HostedControlPlaneAvailable),
-			Status: metav1.ConditionUnknown,
-			Reason: "StatusUnknown",
-		}
-		if meta.IsStatusConditionPresentAndEqual(hostedControlPlane.Status.Conditions, string(hyperv1.KubeAPIServerAvailable), metav1.ConditionTrue) &&
-			meta.IsStatusConditionPresentAndEqual(hostedControlPlane.Status.Conditions, string(hyperv1.EtcdAvailable), metav1.ConditionTrue) {
-			hostedControlPlane.Status.Ready = true
-			newCondition = metav1.Condition{
-				Type:   string(hyperv1.HostedControlPlaneAvailable),
-				Status: metav1.ConditionTrue,
-				Reason: "AsExpected",
-			}
-		} else {
-			hostedControlPlane.Status.Ready = false
-			newCondition = metav1.Condition{
-				Type:    string(hyperv1.HostedControlPlaneAvailable),
-				Status:  metav1.ConditionFalse,
-				Reason:  "ComponentsUnavailable",
-				Message: "Not all dependent components are available yet",
-			}
-		}
-		newCondition.ObservedGeneration = hostedControlPlane.Generation
-		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
-	}
-
+	// Reconcile infrastructure status
 	{
 		r.Log.Info("Reconciling infrastructure status")
 		newCondition := metav1.Condition{
 			Type:   string(hyperv1.InfrastructureReady),
 			Status: metav1.ConditionUnknown,
-			Reason: "StatusUnknown",
+			Reason: hyperv1.StatusUnknownReason,
 		}
 		infraStatus, err := r.reconcileInfrastructureStatus(ctx, hostedControlPlane)
 		if err != nil {
@@ -338,14 +311,18 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 				newCondition = metav1.Condition{
 					Type:   string(hyperv1.InfrastructureReady),
 					Status: metav1.ConditionTrue,
-					Reason: "AsExpected",
+					Reason: hyperv1.AsExpectedReason,
 				}
 			} else {
+				message := "Cluster infrastructure is still provisioning"
+				if len(infraStatus.Message) > 0 {
+					message = infraStatus.Message
+				}
 				newCondition = metav1.Condition{
 					Type:    string(hyperv1.InfrastructureReady),
 					Status:  metav1.ConditionFalse,
 					Reason:  "WaitingOnInfrastructureReady",
-					Message: "Cluster infrastructure is still provisioning",
+					Message: message,
 				}
 				r.Log.Info("Infrastructure is not yet ready")
 			}
@@ -364,7 +341,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 				return metav1.Condition{
 					Type:    string(hyperv1.ClusterVersionFailing),
 					Status:  metav1.ConditionUnknown,
-					Reason:  "StatusUnknown",
+					Reason:  hyperv1.ClusterVersionStatusUnknownReason,
 					Message: fmt.Sprintf("failed to get clusterversion: %v", err),
 				}
 			}
@@ -383,12 +360,53 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return metav1.Condition{
 				Type:   string(hyperv1.ClusterVersionFailing),
 				Status: metav1.ConditionFalse,
-				Reason: "AsExpected",
+				Reason: hyperv1.AsExpectedReason,
 			}
 		}()
 		newCondition.ObservedGeneration = hostedControlPlane.Generation
 		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
 		r.Log.Info("Finished reconciling hosted cluster version conditions")
+	}
+
+	// Reconcile hostedcontrolplane availability and Ready flag
+	{
+		infrastructureCondition := meta.FindStatusCondition(hostedControlPlane.Status.Conditions, string(hyperv1.InfrastructureReady))
+		kubeConfigAvailable := hostedControlPlane.Status.KubeConfig != nil
+		etcdCondition := meta.FindStatusCondition(hostedControlPlane.Status.Conditions, string(hyperv1.EtcdAvailable))
+		kubeAPIServerCondition := meta.FindStatusCondition(hostedControlPlane.Status.Conditions, string(hyperv1.KubeAPIServerAvailable))
+
+		status := metav1.ConditionFalse
+		var reason, message string
+		switch {
+		case infrastructureCondition == nil && etcdCondition == nil && kubeAPIServerCondition == nil:
+			reason = hyperv1.StatusUnknownReason
+			message = ""
+		case infrastructureCondition != nil && infrastructureCondition.Status == metav1.ConditionFalse:
+			reason = infrastructureCondition.Reason
+			message = infrastructureCondition.Message
+		case !kubeConfigAvailable:
+			reason = hyperv1.KubeconfigUnavailableReason
+			message = "The hosted control plane kubeconfig is not available"
+		case etcdCondition != nil && etcdCondition.Status == metav1.ConditionFalse:
+			reason = etcdCondition.Reason
+			message = etcdCondition.Message
+		case kubeAPIServerCondition != nil && kubeAPIServerCondition.Status == metav1.ConditionFalse:
+			reason = kubeAPIServerCondition.Reason
+			message = kubeAPIServerCondition.Message
+		default:
+			reason = hyperv1.AsExpectedReason
+			message = ""
+			status = metav1.ConditionTrue
+		}
+		hostedControlPlane.Status.Ready = (status == metav1.ConditionTrue)
+		condition := metav1.Condition{
+			Type:               string(hyperv1.HostedControlPlaneAvailable),
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: hostedControlPlane.Generation,
+		}
+		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, condition)
 	}
 
 	kubeconfig := manifests.KASExternalKubeconfigSecret(hostedControlPlane.Namespace, hostedControlPlane.Spec.KubeConfig)
@@ -842,31 +860,49 @@ func (r *HostedControlPlaneReconciler) reconcileInfrastructure(ctx context.Conte
 }
 
 func (r *HostedControlPlaneReconciler) reconcileInfrastructureStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (InfrastructureStatus, error) {
-	var infraStatus InfrastructureStatus
-	var err error
-	if infraStatus.APIHost, infraStatus.APIPort, err = r.reconcileAPIServerServiceStatus(ctx, hcp); err != nil {
-		return infraStatus, err
+	var (
+		infraStatus InfrastructureStatus
+		errs        []error
+		err         error
+		msg         string
+		messages    []string
+	)
+	if infraStatus.APIHost, infraStatus.APIPort, msg, err = r.reconcileAPIServerServiceStatus(ctx, hcp); err != nil {
+		errs = append(errs, err)
 	}
-	if infraStatus.KonnectivityHost, infraStatus.KonnectivityPort, err = r.reconcileKonnectivityServiceStatus(ctx, hcp); err != nil {
-		return infraStatus, err
+	if len(msg) > 0 {
+		messages = append(messages, msg)
 	}
-	if infraStatus.OAuthHost, infraStatus.OAuthPort, err = r.reconcileOAuthServiceStatus(ctx, hcp); err != nil {
-		return infraStatus, err
+	if infraStatus.KonnectivityHost, infraStatus.KonnectivityPort, msg, err = r.reconcileKonnectivityServiceStatus(ctx, hcp); err != nil {
+		errs = append(errs, err)
+	}
+	if len(msg) > 0 {
+		messages = append(messages, msg)
+	}
+	if infraStatus.OAuthHost, infraStatus.OAuthPort, msg, err = r.reconcileOAuthServiceStatus(ctx, hcp); err != nil {
+		errs = append(errs, err)
+	}
+	if len(msg) > 0 {
+		messages = append(messages, msg)
 	}
 	if infraStatus.OpenShiftAPIHost, err = r.reconcileOpenShiftAPIServerServiceStatus(ctx, hcp); err != nil {
-		return infraStatus, err
+		errs = append(errs, err)
 	}
 	if infraStatus.OauthAPIServerHost, err = r.reconcileOAuthAPIServerServiceStatus(ctx, hcp); err != nil {
-		return infraStatus, err
+		errs = append(errs, err)
 	}
 	if infraStatus.PackageServerAPIAddress, err = r.reconcileOLMPackageServerServiceStatus(ctx, hcp); err != nil {
-		return infraStatus, err
+		errs = append(errs, err)
 	}
 
-	return infraStatus, nil
+	if len(messages) > 0 {
+		infraStatus.Message = strings.Join(messages, "; ")
+	}
+
+	return infraStatus, utilerrors.NewAggregate(errs)
 }
 
-func (r *HostedControlPlaneReconciler) reconcileAPIServerServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, err error) {
+func (r *HostedControlPlaneReconciler) reconcileAPIServerServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, message string, err error) {
 	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.APIServer)
 	if serviceStrategy == nil {
 		err = fmt.Errorf("APIServer service strategy not specified")
@@ -884,14 +920,14 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerServiceStatus(ctx conte
 			return
 		}
 		p := kas.NewKubeAPIServerServiceParams(hcp)
-		return kas.ReconcileServiceStatus(svc, serviceStrategy, p.APIServerPort)
-
+		return kas.ReconcileServiceStatus(svc, serviceStrategy, p.APIServerPort, events.NewMessageCollector(ctx, r.Client))
 	}
 
-	return kas.ReconcilePrivateServiceStatus(hcp.Name)
+	host, port, err = kas.ReconcilePrivateServiceStatus(hcp.Name)
+	return
 }
 
-func (r *HostedControlPlaneReconciler) reconcileKonnectivityServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, err error) {
+func (r *HostedControlPlaneReconciler) reconcileKonnectivityServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, message string, err error) {
 	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.Konnectivity)
 	if serviceStrategy == nil {
 		err = fmt.Errorf("konnectivity service strategy not specified")
@@ -918,10 +954,10 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivityServiceStatus(ctx co
 			return
 		}
 	}
-	return konnectivity.ReconcileServerServiceStatus(svc, route, serviceStrategy)
+	return konnectivity.ReconcileServerServiceStatus(svc, route, serviceStrategy, events.NewMessageCollector(ctx, r.Client))
 }
 
-func (r *HostedControlPlaneReconciler) reconcileOAuthServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, err error) {
+func (r *HostedControlPlaneReconciler) reconcileOAuthServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, message string, err error) {
 	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.OAuthServer)
 	if serviceStrategy == nil {
 		err = fmt.Errorf("OAuth strategy not specified")
@@ -2300,4 +2336,69 @@ func reconcileKubeadminPasswordSecret(secret *corev1.Secret, hcp *hyperv1.Hosted
 		*password = string(existingPassword)
 	}
 	return nil
+}
+
+func (r *HostedControlPlaneReconciler) hostedControlPlaneInNamespace(resource client.Object) []reconcile.Request {
+	hcpList := &hyperv1.HostedControlPlaneList{}
+	if err := r.List(context.Background(), hcpList, &client.ListOptions{
+		Namespace: resource.GetNamespace(),
+	}); err != nil {
+		r.Log.Error(err, "failed to list hosted control planes in namespace", "namespace", resource.GetNamespace())
+		return nil
+	}
+	if len(hcpList.Items) > 1 {
+		r.Log.Error(fmt.Errorf("more than one HostedControlPlane resource found in namespace %s", resource.GetNamespace()), "unexpected number of HostedControlPlane resources")
+		return nil
+	}
+	var result []reconcile.Request
+	for _, hcp := range hcpList.Items {
+		result = append(result, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: hcp.Namespace, Name: hcp.Name}})
+	}
+	return result
+}
+
+func (r *HostedControlPlaneReconciler) etcdStatefulSetCondition(ctx context.Context, sts *appsv1.StatefulSet) (*metav1.Condition, error) {
+	if sts.Status.ReadyReplicas >= *sts.Spec.Replicas/2+1 {
+		return &metav1.Condition{
+			Type:   string(hyperv1.EtcdAvailable),
+			Status: metav1.ConditionTrue,
+			Reason: hyperv1.EtcdQuorumAvailableReason,
+		}, nil
+	}
+
+	var message string
+
+	// Check that any etcd PVCs have been provisioned
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(ctx, pvcList, &client.ListOptions{
+		Namespace:     sts.Namespace,
+		LabelSelector: labels.SelectorFromValidatedSet(labels.Set{"app": "etcd"}),
+	}); err != nil {
+		return nil, err
+	}
+
+	messageCollector := events.NewMessageCollector(ctx, r.Client)
+	for _, pvc := range pvcList.Items {
+		if pvc.Status.Phase != corev1.ClaimBound {
+			eventMessages, err := messageCollector.ErrorMessages(&pvc)
+			if err != nil {
+				return nil, err
+			}
+			if len(eventMessages) > 0 {
+				message = fmt.Sprintf("Etcd volume claim %s pending: %s", pvc.Name, strings.Join(eventMessages, "; "))
+				break
+			}
+		}
+	}
+
+	if len(message) == 0 {
+		message = "Etcd has not yet reached quorum"
+	}
+	return &metav1.Condition{
+		Type:    string(hyperv1.EtcdAvailable),
+		Status:  metav1.ConditionFalse,
+		Reason:  hyperv1.EtcdQuorumUnavailableReason,
+		Message: message,
+	}, nil
+
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
+	"time"
 
 	"k8s.io/utils/pointer"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -20,6 +23,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -236,7 +240,8 @@ func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, private bool
 	return nil
 }
 
-func ReconcileServerServiceStatus(svc *corev1.Service, route *routev1.Route, strategy *hyperv1.ServicePublishingStrategy) (host string, port int32, err error) {
+func ReconcileServerServiceStatus(svc *corev1.Service, route *routev1.Route, strategy *hyperv1.ServicePublishingStrategy, messageCollector events.MessageCollector) (host string, port int32, message string, err error) {
+
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:
 		if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
@@ -245,6 +250,16 @@ func ReconcileServerServiceStatus(svc *corev1.Service, route *routev1.Route, str
 			return
 		}
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			message = fmt.Sprintf("Konnectivity load balancer is not provisioned; %v since creation", duration.ShortHumanDuration(time.Since(svc.ObjectMeta.CreationTimestamp.Time)))
+			var messages []string
+			messages, err = messageCollector.ErrorMessages(svc)
+			if err != nil {
+				err = fmt.Errorf("failed to get events for service %s/%s: %w", svc.Namespace, svc.Name, err)
+				return
+			}
+			if len(messages) > 0 {
+				message = fmt.Sprintf("Konnectivity load balancer is not provisioned: %s", strings.Join(messages, "; "))
+			}
 			return
 		}
 		switch {

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -2,8 +2,10 @@ package oauth
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -50,7 +52,7 @@ func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *h
 	return nil
 }
 
-func ReconcileServiceStatus(svc *corev1.Service, route *routev1.Route, strategy *hyperv1.ServicePublishingStrategy) (host string, port int32, err error) {
+func ReconcileServiceStatus(svc *corev1.Service, route *routev1.Route, strategy *hyperv1.ServicePublishingStrategy) (host string, port int32, message string, err error) {
 	switch strategy.Type {
 	case hyperv1.Route:
 		if strategy.Route != nil && strategy.Route.Hostname != "" {
@@ -59,6 +61,7 @@ func ReconcileServiceStatus(svc *corev1.Service, route *routev1.Route, strategy 
 			return
 		}
 		if route.Spec.Host == "" {
+			message = fmt.Sprintf("OAuth service route does not contain valid host; %v since creation", duration.ShortHumanDuration(time.Since(route.ObjectMeta.CreationTimestamp.Time)))
 			return
 		}
 		port = RouteExternalPort

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/clusteroperators.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/clusteroperators.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	configv1 "github.com/openshift/api/config/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
@@ -279,25 +280,25 @@ func (r *reconciler) clusterOperatorStatus(coInfo ClusterOperatorInfo, currentSt
 			Type:               configv1.OperatorAvailable,
 			Status:             configv1.ConditionTrue,
 			LastTransitionTime: now,
-			Reason:             "AsExpected",
+			Reason:             hyperv1.AsExpectedReason,
 		},
 		{
 			Type:               configv1.OperatorProgressing,
 			Status:             configv1.ConditionFalse,
 			LastTransitionTime: now,
-			Reason:             "AsExpected",
+			Reason:             hyperv1.AsExpectedReason,
 		},
 		{
 			Type:               configv1.OperatorDegraded,
 			Status:             configv1.ConditionFalse,
 			LastTransitionTime: now,
-			Reason:             "AsExpected",
+			Reason:             hyperv1.AsExpectedReason,
 		},
 		{
 			Type:               configv1.OperatorUpgradeable,
 			Status:             configv1.ConditionTrue,
 			LastTransitionTime: now,
-			Reason:             "AsExpected",
+			Reason:             hyperv1.AsExpectedReason,
 		},
 	}
 	for _, condition := range conditions {

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -11,14 +11,17 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator"
 	"github.com/openshift/hypershift/support/capabilities"
+	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/util"
 	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	"github.com/spf13/cobra"
@@ -126,12 +129,26 @@ func NewStartCommand() *cobra.Command {
 			RetryPeriod:                   &retryPeriod,
 			HealthProbeBindAddress:        healthProbeAddr,
 			NewCache: cache.BuilderWithOptions(cache.Options{
-				DefaultSelector:   cache.ObjectSelector{Field: fields.OneTermEqualSelector("metadata.namespace", namespace)},
-				SelectorsByObject: cache.SelectorsByObject{&operatorv1.IngressController{}: {Field: fields.OneTermEqualSelector("metadata.namespace", manifests.IngressPrivateIngressController("").Namespace)}},
+				DefaultSelector: cache.ObjectSelector{Field: fields.OneTermEqualSelector("metadata.namespace", namespace)},
+				SelectorsByObject: cache.SelectorsByObject{
+					&operatorv1.IngressController{}: {Field: fields.OneTermEqualSelector("metadata.namespace", manifests.IngressPrivateIngressController("").Namespace)},
+					// We watch warning events to be able to surface cloud provider errors as conditions
+					// Surfacing cloud-provider specific status is discussed in:
+					// https://github.com/kubernetes/kubernetes/issues/70159
+					// https://github.com/kubernetes/kubernetes/issues/52670
+					&corev1.Event{}: {Field: fields.AndSelectors(fields.OneTermEqualSelector("metadata.namespace", namespace), fields.OneTermEqualSelector("type", "warning"))},
+				},
 			}),
 		})
 		if err != nil {
 			setupLog.Error(err, "unable to start manager")
+			os.Exit(1)
+		}
+		if err = mgr.GetFieldIndexer().IndexField(ctx, &corev1.Event{}, events.EventInvolvedObjectUIDField, func(object crclient.Object) []string {
+			event := object.(*corev1.Event)
+			return []string{string(event.InvolvedObject.UID)}
+		}); err != nil {
+			setupLog.Error(err, "failed to setup event involvedObject.uid index")
 			os.Exit(1)
 		}
 

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -139,6 +139,7 @@ objects:
     resources:
     - events
     - configmaps
+    - persistentvolumeclaims
     - pods
     - pods/log
     - secrets
@@ -19649,6 +19650,10 @@ objects:
       - description: Reason
         jsonPath: .status.conditions[?(@.type=="Available")].reason
         name: Reason
+        type: string
+      - description: Message
+        jsonPath: .status.conditions[?(@.type=="Available")].message
+        name: Message
         type: string
       name: v1alpha1
       schema:

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -336,7 +336,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		condition := metav1.Condition{
 			Type:               string(hyperv1.ClusterVersionSucceeding),
 			Status:             metav1.ConditionUnknown,
-			Reason:             "ClusterVersionStatusUnknown",
+			Reason:             hyperv1.ClusterVersionStatusUnknownReason,
 			ObservedGeneration: hcluster.Generation,
 		}
 		controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
@@ -456,7 +456,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		condition := metav1.Condition{
 			Type:   string(hyperv1.ValidHostedControlPlaneConfiguration),
 			Status: metav1.ConditionUnknown,
-			Reason: "StatusUnknown",
+			Reason: hyperv1.StatusUnknownReason,
 		}
 		if hcp != nil {
 			validConfigHCPCondition := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidHostedControlPlaneConfiguration))
@@ -2214,6 +2214,7 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 			Resources: []string{
 				"events",
 				"configmaps",
+				"persistentvolumeclaims",
 				"pods",
 				"pods/log",
 				"secrets",
@@ -2912,50 +2913,27 @@ func computeClusterVersionStatus(clock clock.Clock, hcluster *hyperv1.HostedClus
 // given HostedCluster and returns it.
 func computeHostedClusterAvailability(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) metav1.Condition {
 	// Determine whether the hosted control plane is available.
-	hcpAvailable := false
+	hcpAvailableStatus := metav1.ConditionFalse
+	hcpAvailableMessage := "The hosted control plane is unavailable"
+	hcpAvailableReason := hyperv1.HostedClusterUnhealthyComponentsReason
+	var hcpAvailableCondition *metav1.Condition
 	if hcp != nil {
-		hcpAvailable = meta.IsStatusConditionTrue(hcp.Status.Conditions, string(hyperv1.HostedControlPlaneAvailable))
+		hcpAvailableCondition = meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.HostedControlPlaneAvailable))
 	}
-
-	// Determine whether the kubeconfig is available.
-	// TODO: is it a good idea to compute hc status based on other field within
-	// the same resource like this? does it imply an ordering requirement that
-	// kubeconfig status must come before availability status? would extracting
-	// the kubeconfig as an argument help by making that dependency explicit?
-	kubeConfigAvailable := hcluster.Status.KubeConfig != nil
-
-	// Managed etcd availability isn't reported at this granularity yet, so always
-	// assume managed etcd is available. If etcd is configured as unmanaged, consider
-	// etcd available once the unmanaged available condition is true.
-	etcdAvailable := hcluster.Spec.Etcd.ManagementType == hyperv1.Managed ||
-		meta.IsStatusConditionTrue(hcluster.Status.Conditions, string(hyperv1.UnmanagedEtcdAvailable))
-
-	switch {
-	case hcpAvailable && kubeConfigAvailable && etcdAvailable:
-		return metav1.Condition{
-			Type:               string(hyperv1.HostedClusterAvailable),
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: hcluster.Generation,
-			Reason:             hyperv1.HostedClusterAsExpectedReason,
+	if hcpAvailableCondition != nil {
+		hcpAvailableStatus = hcpAvailableCondition.Status
+		hcpAvailableMessage = hcpAvailableCondition.Message
+		if hcpAvailableStatus == metav1.ConditionTrue {
+			hcpAvailableReason = hyperv1.HostedClusterAsExpectedReason
+			hcpAvailableMessage = ""
 		}
-	default:
-		var messages []string
-		if !hcpAvailable {
-			messages = append(messages, "the hosted control plane is unavailable")
-		}
-		if !kubeConfigAvailable {
-			messages = append(messages, "the hosted control plane kubeconfig is unavailable")
-		}
-		if !etcdAvailable {
-			messages = append(messages, "etcd is unavailable")
-		}
-		return metav1.Condition{
-			Type:               string(hyperv1.HostedClusterAvailable),
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: hcluster.Generation,
-			Reason:             hyperv1.HostedClusterUnhealthyComponentsReason,
-			Message:            strings.Join(messages, "; "),
-		}
+	}
+	return metav1.Condition{
+		Type:               string(hyperv1.HostedClusterAvailable),
+		Status:             hcpAvailableStatus,
+		ObservedGeneration: hcluster.Generation,
+		Reason:             hcpAvailableReason,
+		Message:            hcpAvailableMessage,
 	}
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -288,7 +288,7 @@ func TestComputeHostedClusterAvailability(t *testing.T) {
 				Status: metav1.ConditionFalse,
 			},
 		},
-		"missing kubeconfig should cause unavailability": {
+		"hosted controlplane with availability false should cause unavailability": {
 			Cluster: hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
 					Etcd: hyperv1.EtcdSpec{ManagementType: hyperv1.Managed},
@@ -296,10 +296,10 @@ func TestComputeHostedClusterAvailability(t *testing.T) {
 				Status: hyperv1.HostedClusterStatus{},
 			},
 			ControlPlane: &hyperv1.HostedControlPlane{
-				Spec: hyperv1.HostedControlPlaneSpec{},
+				Spec: hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},
 				Status: hyperv1.HostedControlPlaneStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hyperv1.HostedControlPlaneAvailable), Status: metav1.ConditionTrue},
+						{Type: string(hyperv1.HostedControlPlaneAvailable), Status: metav1.ConditionFalse},
 					},
 				},
 			},
@@ -313,9 +313,7 @@ func TestComputeHostedClusterAvailability(t *testing.T) {
 				Spec: hyperv1.HostedClusterSpec{
 					Etcd: hyperv1.EtcdSpec{ManagementType: hyperv1.Managed},
 				},
-				Status: hyperv1.HostedClusterStatus{
-					KubeConfig: &corev1.LocalObjectReference{Name: "foo"},
-				},
+				Status: hyperv1.HostedClusterStatus{},
 			},
 			ControlPlane: &hyperv1.HostedControlPlane{
 				Spec: hyperv1.HostedControlPlaneSpec{ReleaseImage: "a"},

--- a/support/events/message.go
+++ b/support/events/message.go
@@ -1,0 +1,60 @@
+package events
+
+import (
+	"context"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	EventInvolvedObjectUIDField = "involvedObject.uid"
+)
+
+type MessageCollector interface {
+	ErrorMessages(resource crclient.Object) ([]string, error)
+}
+
+type messageCollector struct {
+	ctx    context.Context
+	client crclient.Client
+}
+
+func NewMessageCollector(ctx context.Context, client crclient.Client) MessageCollector {
+	return &messageCollector{
+		ctx:    ctx,
+		client: client,
+	}
+}
+
+func (c *messageCollector) ErrorMessages(resource crclient.Object) ([]string, error) {
+	events := &corev1.EventList{}
+	if err := c.client.List(c.ctx, events, &crclient.ListOptions{
+		Namespace:     resource.GetNamespace(),
+		FieldSelector: fields.OneTermEqualSelector(EventInvolvedObjectUIDField, string(resource.GetUID())),
+	}); err != nil {
+		return nil, err
+	}
+	sort.Slice(events.Items, func(i, j int) bool {
+		// comparison is reversed to result in most recent first
+		return events.Items[j].CreationTimestamp.Time.Before(events.Items[i].CreationTimestamp.Time)
+	})
+	messageMap := map[string]string{}
+	for _, event := range events.Items {
+		if event.Type == "Normal" {
+			continue
+		}
+		// Only keep one message per event reason
+		if _, hasMessage := messageMap[event.Reason]; !hasMessage {
+			messageMap[event.Reason] = event.Message
+		}
+	}
+	messages := make([]string, 0, len(messageMap))
+	for _, msg := range messageMap {
+		messages = append(messages, msg)
+	}
+	return messages, nil
+}

--- a/support/events/message_test.go
+++ b/support/events/message_test.go
@@ -1,0 +1,96 @@
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const fakeObjUID = "1234567890"
+
+func TestErrorMessages(t *testing.T) {
+	ev := func(msg, etype, reason string) corev1.Event {
+		return corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: msg,
+			},
+			Type: etype,
+			InvolvedObject: corev1.ObjectReference{
+				UID: fakeObjUID,
+			},
+			Message: msg,
+			Reason:  reason,
+		}
+	}
+	evl := func(events ...corev1.Event) []corev1.Event {
+		start := time.Now()
+		// ensure events have distinct times
+		for i := range events {
+			events[i].CreationTimestamp = metav1.NewTime(start.Add(time.Duration(i) * 10 * time.Second))
+		}
+		return events
+	}
+	tests := []struct {
+		name     string
+		events   []corev1.Event
+		expected []string
+	}{
+		{
+			name:     "single event",
+			events:   evl(ev("msg1", corev1.EventTypeWarning, "r1")),
+			expected: []string{"msg1"},
+		},
+		{
+			name:     "no warning events",
+			events:   evl(ev("msg1", corev1.EventTypeNormal, "r1")),
+			expected: []string{},
+		},
+		{
+			name: "warning and info events",
+			events: evl(
+				ev("msg1", corev1.EventTypeNormal, "r1"),
+				ev("msg2", corev1.EventTypeWarning, "r2"),
+			),
+			expected: []string{"msg2"},
+		},
+		{
+			name: "multiple events with same reason",
+			events: evl(
+				ev("msg1", corev1.EventTypeWarning, "rr"),
+				ev("msg2", corev1.EventTypeWarning, "rr"),
+				ev("msg3", corev1.EventTypeWarning, "rr"),
+			),
+			// Expect only the most recent message to be returned
+			expected: []string{"msg3"},
+		},
+		{
+			name: "multiple events with different reasons",
+			events: evl(
+				ev("msg1", corev1.EventTypeWarning, "r1"),
+				ev("msg2", corev1.EventTypeWarning, "r1"),
+				ev("msg3", corev1.EventTypeWarning, "r2"),
+			),
+			expected: []string{"msg3", "msg2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			eventList := &corev1.EventList{
+				Items: test.events,
+			}
+			fakeObj := &corev1.Pod{}
+			client := fake.NewClientBuilder().WithLists(eventList).Build()
+			collector := NewMessageCollector(context.Background(), client)
+			result, err := collector.ErrorMessages(fakeObj)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duration
+
+import (
+	"fmt"
+	"time"
+)
+
+// ShortHumanDuration returns a succint representation of the provided duration
+// with limited precision for consumption by humans.
+func ShortHumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return fmt.Sprintf("<invalid>")
+	} else if seconds < 0 {
+		return fmt.Sprintf("0s")
+	} else if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	} else if minutes := int(d.Minutes()); minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	} else if hours := int(d.Hours()); hours < 24 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*365 {
+		return fmt.Sprintf("%dd", hours/24)
+	}
+	return fmt.Sprintf("%dy", int(d.Hours()/24/365))
+}
+
+// HumanDuration returns a succint representation of the provided duration
+// with limited precision for consumption by humans. It provides ~2-3 significant
+// figures of duration.
+func HumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return fmt.Sprintf("<invalid>")
+	} else if seconds < 0 {
+		return fmt.Sprintf("0s")
+	} else if seconds < 60*2 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := int(d / time.Minute)
+	if minutes < 10 {
+		s := int(d/time.Second) % 60
+		if s == 0 {
+			return fmt.Sprintf("%dm", minutes)
+		}
+		return fmt.Sprintf("%dm%ds", minutes, s)
+	} else if minutes < 60*3 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	hours := int(d / time.Hour)
+	if hours < 8 {
+		m := int(d/time.Minute) % 60
+		if m == 0 {
+			return fmt.Sprintf("%dh", hours)
+		}
+		return fmt.Sprintf("%dh%dm", hours, m)
+	} else if hours < 48 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*8 {
+		h := hours % 24
+		if h == 0 {
+			return fmt.Sprintf("%dd", hours/24)
+		}
+		return fmt.Sprintf("%dd%dh", hours/24, h)
+	} else if hours < 24*365*2 {
+		return fmt.Sprintf("%dd", hours/24)
+	} else if hours < 24*365*8 {
+		dy := int(hours/24) % 365
+		if dy == 0 {
+			return fmt.Sprintf("%dy", hours/24/365)
+		}
+		return fmt.Sprintf("%dy%dd", hours/24/365, dy)
+	}
+	return fmt.Sprintf("%dy", int(hours/24/365))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -605,6 +605,7 @@ k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/cache
 k8s.io/apimachinery/pkg/util/clock
 k8s.io/apimachinery/pkg/util/diff
+k8s.io/apimachinery/pkg/util/duration
 k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/pkg/util/intstr


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves the reporting of HostedCluster status by surfacing
error conditions that can typically result from cloud provider errors.

- Adds a message column to the output of `oc get hostedclusters`
- Uses events to provide better status messages for the provisioning of
  load balancer services and pvcs.
- Adds events as resources to watch in the CPO.
- Surfaces the more detailed messages in the Available condition of the
  HostedCluster resource.

Because of limitations with status reporting from cloud providers, this
change is delegating implementation of part of our API (status conditions)
to component events which are not guaranteed to be emitted reliably and
are not persistent past the event's TTL. However, we still want to
experiment with the use of events given the potential value for UX.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-324](https://issues.redhat.com/browse/HOSTEDCP-324)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.