### PR TITLE
prevent privilege esclation by explicitly not allowing the escalate and bind verbs with rbac on the control plane operator

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -389,6 +389,18 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Verbs:     []string{"*"},
 			},
 			{
+				APIGroups: []string{"batch"},
+				Resources: []string{"cronjobs", "jobs"},
+				Verbs:     []string{"*"},
+			},
+			{
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{
+					"leases",
+				},
+				Verbs: []string{"*"},
+			},
+			{
 				APIGroups: []string{"networking.k8s.io"},
 				Resources: []string{"networkpolicies"},
 				Verbs:     []string{"*"},
@@ -403,8 +415,14 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 					"addons.cluster.x-k8s.io",
 					"exp.cluster.x-k8s.io",
 					"cluster.x-k8s.io",
+					"monitoring.coreos.com",
 				},
 				Resources: []string{"*"},
+				Verbs:     []string{"*"},
+			},
+			{
+				APIGroups: []string{"policy"},
+				Resources: []string{"poddisruptionbudgets"},
 				Verbs:     []string{"*"},
 			},
 			{
@@ -425,7 +443,15 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"rbac.authorization.k8s.io"},
 				Resources: []string{"*"},
-				Verbs:     []string{"*"},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"create",
+					"update",
+					"patch",
+					"delete",
+				},
 			},
 			{
 				APIGroups: []string{""},
@@ -439,12 +465,13 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 					"namespaces",
 					"serviceaccounts",
 					"services",
+					"endpoints",
 				},
 				Verbs: []string{"*"},
 			},
 			{
 				APIGroups: []string{"apps"},
-				Resources: []string{"deployments"},
+				Resources: []string{"deployments", "statefulsets"},
 				Verbs:     []string{"*"},
 			},
 			{
@@ -465,6 +492,16 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"capi-provider.agent-install.openshift.io"},
 				Resources: []string{"*"},
+				Verbs:     []string{"*"},
+			},
+			{
+				APIGroups: []string{"operator.openshift.io"},
+				Resources: []string{"ingresscontrollers"},
+				Verbs:     []string{"*"},
+			},
+			{
+				APIGroups: []string{"kubevirt.io"},
+				Resources: []string{"virtualmachineinstances", "virtualmachines"},
 				Verbs:     []string{"*"},
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-rollout.role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-rollout.role.yaml
@@ -5,7 +5,6 @@ metadata:
 rules:
 - apiGroups:
   - apps
-  - extensions
   resources:
   - deployments
   resourceNames:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -66,6 +66,19 @@ objects:
     verbs:
     - '*'
   - apiGroups:
+    - batch
+    resources:
+    - cronjobs
+    - jobs
+    verbs:
+    - '*'
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - '*'
+  - apiGroups:
     - networking.k8s.io
     resources:
     - networkpolicies
@@ -80,8 +93,15 @@ objects:
     - addons.cluster.x-k8s.io
     - exp.cluster.x-k8s.io
     - cluster.x-k8s.io
+    - monitoring.coreos.com
     resources:
     - '*'
+    verbs:
+    - '*'
+  - apiGroups:
+    - policy
+    resources:
+    - poddisruptionbudgets
     verbs:
     - '*'
   - apiGroups:
@@ -107,7 +127,13 @@ objects:
     resources:
     - '*'
     verbs:
-    - '*'
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
   - apiGroups:
     - ""
     resources:
@@ -120,12 +146,14 @@ objects:
     - namespaces
     - serviceaccounts
     - services
+    - endpoints
     verbs:
     - '*'
   - apiGroups:
     - apps
     resources:
     - deployments
+    - statefulsets
     verbs:
     - '*'
   - apiGroups:
@@ -154,6 +182,19 @@ objects:
     - capi-provider.agent-install.openshift.io
     resources:
     - '*'
+    verbs:
+    - '*'
+  - apiGroups:
+    - operator.openshift.io
+    resources:
+    - ingresscontrollers
+    verbs:
+    - '*'
+  - apiGroups:
+    - kubevirt.io
+    resources:
+    - virtualmachineinstances
+    - virtualmachines
     verbs:
     - '*'
 - apiVersion: rbac.authorization.k8s.io/v1

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2166,7 +2166,15 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 		{
 			APIGroups: []string{"rbac.authorization.k8s.io"},
 			Resources: []string{"roles", "rolebindings"},
-			Verbs:     []string{"*"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"patch",
+				"delete",
+			},
 		},
 		{
 			APIGroups: []string{"route.openshift.io"},


### PR DESCRIPTION
Currently the control-plane-operator can escalate it's privileges as documented in this link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping. This is due to the fact the control plane operator has escalate and bind privileges implicitly included due to the wildcard in the verb section. That means they can go and edit the rbac that gets assigned to it and increase it's scope. That ability should not be allowed and instead any necessary rbac should be explicitly granted to the control-plane-operator through the hypershift operator

Without these changes: RBAC is effectively useless on these operators as if you get access to the service account token you can just edit the RBAC roles and grant yourself or others additional access. 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.