### PR TITLE
Agent: each hostedcluster provider should have it's own role and role binding in the agent namespace

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3019,31 +3019,11 @@ func deleteAWSEndpointServices(ctx context.Context, c client.Client, namespace s
 	return false, nil
 }
 
-func deleteIfNeeded(ctx context.Context, c client.Client, o client.Object) (exists bool, err error) {
-	if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error getting %T: %w", o, err)
-	}
-	if o.GetDeletionTimestamp() != nil {
-		return true, nil
-	}
-	if err := c.Delete(ctx, o); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error deleting %T: %w", o, err)
-	}
-
-	return true, nil
-}
-
 func deleteControlPlaneOperatorRBAC(ctx context.Context, c client.Client, rbacNamespace string, controlPlaneNamespace string) error {
-	if _, err := deleteIfNeeded(ctx, c, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "control-plane-operator-" + controlPlaneNamespace, Namespace: rbacNamespace}}); err != nil {
+	if _, err := hyperutil.DeleteIfNeeded(ctx, c, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "control-plane-operator-" + controlPlaneNamespace, Namespace: rbacNamespace}}); err != nil {
 		return err
 	}
-	if _, err := deleteIfNeeded(ctx, c, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "control-plane-operator-" + controlPlaneNamespace, Namespace: rbacNamespace}}); err != nil {
+	if _, err := hyperutil.DeleteIfNeeded(ctx, c, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "control-plane-operator-" + controlPlaneNamespace, Namespace: rbacNamespace}}); err != nil {
 		return err
 	}
 	return nil
@@ -3059,7 +3039,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	}
 
 	if hc != nil && len(hc.Spec.InfraID) > 0 {
-		exists, err := deleteIfNeeded(ctx, r.Client, &capiv1.Cluster{
+		exists, err := hyperutil.DeleteIfNeeded(ctx, r.Client, &capiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      hc.Spec.InfraID,
 				Namespace: controlPlaneNamespace,
@@ -3072,6 +3052,17 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 			log.Info("Waiting for cluster deletion", "clusterName", hc.Spec.InfraID, "controlPlaneNamespace", controlPlaneNamespace)
 			return false, nil
 		}
+	}
+
+	// Cleanup Platform specifics.
+	p, err := platform.GetPlatform(hc, r.AvailabilityProberImage, r.TokenMinterImage)
+	if err != nil {
+		return false, err
+	}
+
+	if err = p.DeleteCredentials(ctx, r.Client, hc,
+		controlPlaneNamespace); err != nil {
+		return false, err
 	}
 
 	exists, err := deleteAWSEndpointServices(ctx, r.Client, controlPlaneNamespace)
@@ -3099,7 +3090,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	// We want to ensure the HCP resource is deleted before deleting the Namespace.
 	// Otherwise the CPO will be deleted leaving the HCP in a perpetual terminating state preventing further progress.
 	// NOTE: The advancing case is when Get() or Delete() returns an error that the HCP is not found
-	exists, err = deleteIfNeeded(ctx, r.Client, controlplaneoperator.HostedControlPlane(controlPlaneNamespace, hc.Name))
+	exists, err = hyperutil.DeleteIfNeeded(ctx, r.Client, controlplaneoperator.HostedControlPlane(controlPlaneNamespace, hc.Name))
 	if err != nil {
 		return false, err
 	}
@@ -3114,7 +3105,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 
 	// Block until the namespace is deleted, so that if a hostedcluster is deleted and then re-created with the same name
 	// we don't error initially because we can not create new content in a namespace that is being deleted.
-	exists, err = deleteIfNeeded(ctx, r.Client, &corev1.Namespace{
+	exists, err = hyperutil.DeleteIfNeeded(ctx, r.Client, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: controlPlaneNamespace},
 	})
 	if err != nil {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	hyperutil "github.com/openshift/hypershift/hypershift-operator/controllers/util"
 
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
@@ -22,8 +23,8 @@ import (
 
 const (
 	// TODO Pin to specific release
-	imageCAPAgent       = "quay.io/edge-infrastructure/cluster-api-provider-agent:latest"
-	credentialsRBACName = "cluster-api-agent"
+	imageCAPAgent         = "quay.io/edge-infrastructure/cluster-api-provider-agent:latest"
+	CredentialsRBACPrefix = "cluster-api-agent"
 )
 
 type Agent struct{}
@@ -132,7 +133,7 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hcluster.Spec.Platform.Agent.AgentNamespace,
-			Name:      credentialsRBACName,
+			Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
 		},
 	}
 	_, err := createOrUpdate(ctx, c, role, func() error {
@@ -152,7 +153,7 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hcluster.Spec.Platform.Agent.AgentNamespace,
-			Name:      credentialsRBACName,
+			Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
 		},
 	}
 	_, err = createOrUpdate(ctx, c, roleBinding, func() error {
@@ -166,7 +167,7 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 		roleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     credentialsRBACName,
+			Name:     fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
 		}
 		return nil
 	})
@@ -182,7 +183,7 @@ func (p Agent) reconcileClusterRole(ctx context.Context, c client.Client, create
 
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: credentialsRBACName,
+			Name: CredentialsRBACPrefix,
 		},
 	}
 	_, err := createOrUpdate(ctx, c, role, func() error {
@@ -201,7 +202,7 @@ func (p Agent) reconcileClusterRole(ctx context.Context, c client.Client, create
 
 	roleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s", credentialsRBACName, controlPlaneNamespace),
+			Name: fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
 		},
 	}
 	_, err = createOrUpdate(ctx, c, roleBinding, func() error {
@@ -215,7 +216,7 @@ func (p Agent) reconcileClusterRole(ctx context.Context, c client.Client, create
 		roleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     credentialsRBACName,
+			Name:     CredentialsRBACPrefix,
 		}
 		return nil
 	})
@@ -263,5 +264,18 @@ func reconcileAgentCluster(agentCluster *agentv1.AgentCluster, hcluster *hyperv1
 		Port: hcp.Status.ControlPlaneEndpoint.Port,
 	}
 
+	return nil
+}
+
+func (Agent) DeleteCredentials(ctx context.Context, c client.Client,
+	hc *hyperv1.HostedCluster,
+	controlPlaneNamespace string) error {
+
+	if _, err := hyperutil.DeleteIfNeeded(ctx, c, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace), Namespace: hc.Spec.Platform.Agent.AgentNamespace}}); err != nil {
+		return fmt.Errorf("failed to clean up CAPI provider role: %w", err)
+	}
+	if _, err := hyperutil.DeleteIfNeeded(ctx, c, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace), Namespace: hc.Spec.Platform.Agent.AgentNamespace}}); err != nil {
+		return fmt.Errorf("failed to clean up CAPI provider rolebinding: %w", err)
+	}
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,17 +38,64 @@ func TestReconcileCredentials(t *testing.T) {
 	role := &rbacv1.Role{}
 	err = client.Get(context.Background(), types.NamespacedName{
 		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
-		Name:      credentialsRBACName,
+		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
 	}, role)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	roleBinding := &rbacv1.RoleBinding{}
 	err = client.Get(context.Background(), types.NamespacedName{
 		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
-		Name:      credentialsRBACName,
+		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
 	}, roleBinding)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(roleBinding.Subjects[0].Namespace).To(BeIdenticalTo(controlPlaneNamespace))
 	g.Expect(roleBinding.Subjects[0].Kind).To(BeIdenticalTo("ServiceAccount"))
 	g.Expect(roleBinding.Subjects[0].Name).To(BeIdenticalTo("capi-provider"))
+}
+
+func TestDeleteCredentials(t *testing.T) {
+	g := NewGomegaWithT(t)
+	platform := &Agent{}
+	hostedCluster := &hyperv1.HostedCluster{
+		Spec: hyperv1.HostedClusterSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AgentPlatform,
+				Agent: &hyperv1.AgentPlatformSpec{
+					AgentNamespace: "test",
+				},
+			},
+		},
+	}
+	controlPlaneNamespace := "test"
+	client := fake.NewClientBuilder().Build()
+
+	// test noop
+	err := platform.DeleteCredentials(context.Background(),
+		client,
+		hostedCluster, controlPlaneNamespace)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Create the creds
+	err = platform.ReconcileCredentials(context.Background(),
+		client, upsert.New(false).CreateOrUpdate,
+		hostedCluster, controlPlaneNamespace)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = platform.DeleteCredentials(context.Background(),
+		client,
+		hostedCluster, controlPlaneNamespace)
+	g.Expect(err).ToNot(HaveOccurred())
+	role := &rbacv1.Role{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
+	}, role)
+	g.Expect(apierrors.IsNotFound(err)).To(Equal(true))
+
+	roleBinding := &rbacv1.RoleBinding{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
+	}, roleBinding)
+	g.Expect(apierrors.IsNotFound(err)).To(Equal(true))
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -383,3 +383,7 @@ func reconcileAWSCluster(awsCluster *capiawsv1.AWSCluster, hcluster *hyperv1.Hos
 func (AWS) CAPIProviderPolicyRules() []rbacv1.PolicyRule {
 	return nil
 }
+
+func (AWS) DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error {
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -153,3 +153,7 @@ func (a *Azure) ReconcileSecretEncryption(ctx context.Context, c client.Client, 
 func (a *Azure) CAPIProviderPolicyRules() []rbacv1.PolicyRule {
 	return nil
 }
+
+func (a *Azure) DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error {
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud/ibmcloud.go
@@ -106,3 +106,7 @@ func (IBMCloud) ReconcileSecretEncryption(ctx context.Context, c client.Client, 
 func (IBMCloud) CAPIProviderPolicyRules() []rbacv1.PolicyRule {
 	return nil
 }
+
+func (IBMCloud) DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error {
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -165,3 +165,7 @@ func (Kubevirt) CAPIProviderPolicyRules() []rbacv1.PolicyRule {
 		},
 	}
 }
+
+func (Kubevirt) DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error {
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/none/none.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/none/none.go
@@ -38,3 +38,7 @@ func (None) ReconcileSecretEncryption(ctx context.Context, c client.Client, crea
 func (None) CAPIProviderPolicyRules() []rbacv1.PolicyRule {
 	return nil
 }
+
+func (None) DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error {
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -50,6 +50,10 @@ type Platform interface {
 	// by the CAPI provider in order to manage the resources by this platform
 	// Return nil if no aditional policy rule is required
 	CAPIProviderPolicyRules() []rbacv1.PolicyRule
+
+	// DeleteCredentials is responsible for deleting resources related to platform credentials
+	// So they won't leak on upon hostedcluster deletion
+	DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error
 }
 
 func GetPlatform(hcluster *hyperv1.HostedCluster, availabilityProberImage string, tokenMinterImage string) (Platform, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Create role and rolebinding in agent namespace for each hostedcluster that wants to use this namespace
Cleanup the role and rolebinding in agent namespace upon hostedcluster deletion

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.