### PR TITLE
feat(cpo): Support OLM catalog placement

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -102,6 +102,16 @@ type HostedControlPlaneSpec struct {
 	// provided: reconciliation is paused on the resource until the field is removed.
 	// +optional
 	PausedUntil *string `json:"pausedUntil,omitempty"`
+
+	// OLMCatalogPlacement specifies the placement of OLM catalog components. By default,
+	// this is set to management and OLM catalog components are deployed onto the management
+	// cluster. If set to guest, the OLM catalog components will be deployed onto the guest
+	// cluster.
+	//
+	// +kubebuilder:default=management
+	// +optional
+	// +immutable
+	OLMCatalogPlacement OLMCatalogPlacement `json:"olmCatalogPlacement,omitempty"`
 }
 
 // AvailabilityPolicy specifies a high level availability policy for components.

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -229,7 +229,31 @@ type HostedClusterSpec struct {
 	// provided: reconciliation is paused on the resource until the field is removed.
 	// +optional
 	PausedUntil *string `json:"pausedUntil,omitempty"`
+
+	// OLMCatalogPlacement specifies the placement of OLM catalog components. By default,
+	// this is set to management and OLM catalog components are deployed onto the management
+	// cluster. If set to guest, the OLM catalog components will be deployed onto the guest
+	// cluster.
+	//
+	// +kubebuilder:default=management
+	// +optional
+	// +immutable
+	OLMCatalogPlacement OLMCatalogPlacement `json:"olmCatalogPlacement,omitempty"`
 }
+
+// OLMCatalogPlacement is an enum specifying the placement of OLM catalog components.
+// +kubebuilder:validation:Enum=management;guest
+type OLMCatalogPlacement string
+
+const (
+	// ManagementOLMCatalogPlacement indicates OLM catalog components will be placed in
+	// the management cluster.
+	ManagementOLMCatalogPlacement OLMCatalogPlacement = "management"
+
+	// GuestOLMCatalogPlacement indicates OLM catalog components will be placed in
+	// the guest cluster.
+	GuestOLMCatalogPlacement OLMCatalogPlacement = "guest"
+)
 
 // ImageContentSource specifies image mirrors that can be used by cluster nodes
 // to pull content. For cluster workloads, if a container image registry host of
@@ -284,7 +308,7 @@ type ServicePublishingStrategy struct {
 type PublishingStrategyType string
 
 var (
-	// LoadBalancer exposes  a service with a LoadBalancer kube service.
+	// LoadBalancer exposes a service with a LoadBalancer kube service.
 	LoadBalancer PublishingStrategyType = "LoadBalancer"
 	// NodePort exposes a service with a NodePort kube service.
 	NodePort PublishingStrategyType = "NodePort"

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -358,6 +358,16 @@ spec:
                 - podCIDR
                 - serviceCIDR
                 type: object
+              olmCatalogPlacement:
+                default: management
+                description: OLMCatalogPlacement specifies the placement of OLM catalog
+                  components. By default, this is set to management and OLM catalog
+                  components are deployed onto the management cluster. If set to guest,
+                  the OLM catalog components will be deployed onto the guest cluster.
+                enum:
+                - management
+                - guest
+                type: string
               pausedUntil:
                 description: 'PausedUntil is a field that can be used to pause reconciliation
                   on a resource. Either a date can be provided in RFC3339 format or

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -274,6 +274,16 @@ spec:
                 - OpenShiftSDN
                 - Calico
                 type: string
+              olmCatalogPlacement:
+                default: management
+                description: OLMCatalogPlacement specifies the placement of OLM catalog
+                  components. By default, this is set to management and OLM catalog
+                  components are deployed onto the management cluster. If set to guest,
+                  the OLM catalog components will be deployed onto the guest cluster.
+                enum:
+                - management
+                - guest
+                type: string
               pausedUntil:
                 description: 'PausedUntil is a field that can be used to pause reconciliation
                   on a resource. Either a date can be provided in RFC3339 format or

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1893,98 +1893,100 @@ func (r *HostedControlPlaneReconciler) reconcileIngressOperatorKubeconfig(ctx co
 func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage, packageServerAddress string) error {
 	p := olm.NewOperatorLifecycleManagerParams(hcp, releaseImage.ComponentImages(), releaseImage.Version(), r.SetDefaultSecurityContext)
 
-	certifiedOperatorsService := manifests.CertifiedOperatorsService(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, certifiedOperatorsService, func() error {
-		return olm.ReconcileCertifiedOperatorsService(certifiedOperatorsService, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile certified operators service: %w", err)
-	}
-	communityOperatorsService := manifests.CommunityOperatorsService(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, communityOperatorsService, func() error {
-		return olm.ReconcileCommunityOperatorsService(communityOperatorsService, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile community operators service: %w", err)
-	}
-	marketplaceOperatorsService := manifests.RedHatMarketplaceOperatorsService(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, marketplaceOperatorsService, func() error {
-		return olm.ReconcileRedHatMarketplaceOperatorsService(marketplaceOperatorsService, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile marketplace operators service: %w", err)
-	}
-	redHatOperatorsService := manifests.RedHatOperatorsService(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, redHatOperatorsService, func() error {
-		return olm.ReconcileRedHatOperatorsService(redHatOperatorsService, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile red hat operators service: %w", err)
-	}
+	if hcp.Spec.OLMCatalogPlacement == hyperv1.ManagementOLMCatalogPlacement {
+		certifiedOperatorsService := manifests.CertifiedOperatorsService(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, certifiedOperatorsService, func() error {
+			return olm.ReconcileCertifiedOperatorsService(certifiedOperatorsService, p.OwnerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile certified operators service: %w", err)
+		}
+		communityOperatorsService := manifests.CommunityOperatorsService(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, communityOperatorsService, func() error {
+			return olm.ReconcileCommunityOperatorsService(communityOperatorsService, p.OwnerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile community operators service: %w", err)
+		}
+		marketplaceOperatorsService := manifests.RedHatMarketplaceOperatorsService(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, marketplaceOperatorsService, func() error {
+			return olm.ReconcileRedHatMarketplaceOperatorsService(marketplaceOperatorsService, p.OwnerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile marketplace operators service: %w", err)
+		}
+		redHatOperatorsService := manifests.RedHatOperatorsService(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, redHatOperatorsService, func() error {
+			return olm.ReconcileRedHatOperatorsService(redHatOperatorsService, p.OwnerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile red hat operators service: %w", err)
+		}
 
-	certifiedOperatorsDeployment := manifests.CertifiedOperatorsDeployment(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, certifiedOperatorsDeployment, func() error {
-		return olm.ReconcileCertifiedOperatorsDeployment(certifiedOperatorsDeployment, p.OwnerRef, p.DeploymentConfig)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile certified operators deployment: %w", err)
-	}
-	communityOperatorsDeployment := manifests.CommunityOperatorsDeployment(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, communityOperatorsDeployment, func() error {
-		return olm.ReconcileCommunityOperatorsDeployment(communityOperatorsDeployment, p.OwnerRef, p.DeploymentConfig)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile community operators deployment: %w", err)
-	}
-	marketplaceOperatorsDeployment := manifests.RedHatMarketplaceOperatorsDeployment(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, marketplaceOperatorsDeployment, func() error {
-		return olm.ReconcileRedHatMarketplaceOperatorsDeployment(marketplaceOperatorsDeployment, p.OwnerRef, p.DeploymentConfig)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile marketplace operators deployment: %w", err)
-	}
-	redHatOperatorsDeployment := manifests.RedHatOperatorsDeployment(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, redHatOperatorsDeployment, func() error {
-		return olm.ReconcileRedHatOperatorsDeployment(redHatOperatorsDeployment, p.OwnerRef, p.DeploymentConfig)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile red hat operators deployment: %w", err)
-	}
+		certifiedOperatorsDeployment := manifests.CertifiedOperatorsDeployment(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, certifiedOperatorsDeployment, func() error {
+			return olm.ReconcileCertifiedOperatorsDeployment(certifiedOperatorsDeployment, p.OwnerRef, p.DeploymentConfig)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile certified operators deployment: %w", err)
+		}
+		communityOperatorsDeployment := manifests.CommunityOperatorsDeployment(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, communityOperatorsDeployment, func() error {
+			return olm.ReconcileCommunityOperatorsDeployment(communityOperatorsDeployment, p.OwnerRef, p.DeploymentConfig)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile community operators deployment: %w", err)
+		}
+		marketplaceOperatorsDeployment := manifests.RedHatMarketplaceOperatorsDeployment(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, marketplaceOperatorsDeployment, func() error {
+			return olm.ReconcileRedHatMarketplaceOperatorsDeployment(marketplaceOperatorsDeployment, p.OwnerRef, p.DeploymentConfig)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile marketplace operators deployment: %w", err)
+		}
+		redHatOperatorsDeployment := manifests.RedHatOperatorsDeployment(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, redHatOperatorsDeployment, func() error {
+			return olm.ReconcileRedHatOperatorsDeployment(redHatOperatorsDeployment, p.OwnerRef, p.DeploymentConfig)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile red hat operators deployment: %w", err)
+		}
 
-	catalogRolloutSA := manifests.CatalogRolloutServiceAccount(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, catalogRolloutSA, func() error {
-		return olm.ReconcileCatalogRolloutServiceAccount(catalogRolloutSA, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile catalog rollout service account: %w", err)
-	}
-	catalogRolloutRole := manifests.CatalogRolloutRole(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, catalogRolloutRole, func() error {
-		return olm.ReconcileCatalogRolloutRole(catalogRolloutRole, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile catalog rollout role: %w", err)
-	}
-	catalogRolloutRoleBinding := manifests.CatalogRolloutRoleBinding(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, catalogRolloutRoleBinding, func() error {
-		return olm.ReconcileCatalogRolloutRoleBinding(catalogRolloutRoleBinding, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile catalog rollout rolebinding: %w", err)
-	}
+		catalogRolloutSA := manifests.CatalogRolloutServiceAccount(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, catalogRolloutSA, func() error {
+			return olm.ReconcileCatalogRolloutServiceAccount(catalogRolloutSA, p.OwnerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile catalog rollout service account: %w", err)
+		}
+		catalogRolloutRole := manifests.CatalogRolloutRole(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, catalogRolloutRole, func() error {
+			return olm.ReconcileCatalogRolloutRole(catalogRolloutRole, p.OwnerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile catalog rollout role: %w", err)
+		}
+		catalogRolloutRoleBinding := manifests.CatalogRolloutRoleBinding(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, catalogRolloutRoleBinding, func() error {
+			return olm.ReconcileCatalogRolloutRoleBinding(catalogRolloutRoleBinding, p.OwnerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile catalog rollout rolebinding: %w", err)
+		}
 
-	certifiedOperatorsCronJob := manifests.CertifiedOperatorsCronJob(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, certifiedOperatorsCronJob, func() error {
-		return olm.ReconcileCertifiedOperatorsCronJob(certifiedOperatorsCronJob, p.OwnerRef, p.CLIImage)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile certified operators cronjob: %w", err)
-	}
-	communityOperatorsCronJob := manifests.CommunityOperatorsCronJob(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, communityOperatorsCronJob, func() error {
-		return olm.ReconcileCommunityOperatorsCronJob(communityOperatorsCronJob, p.OwnerRef, p.CLIImage)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile community operators cronjob: %w", err)
-	}
-	marketplaceOperatorsCronJob := manifests.RedHatMarketplaceOperatorsCronJob(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, marketplaceOperatorsCronJob, func() error {
-		return olm.ReconcileRedHatMarketplaceOperatorsCronJob(marketplaceOperatorsCronJob, p.OwnerRef, p.CLIImage)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile marketplace operators cronjob: %w", err)
-	}
-	redHatOperatorsCronJob := manifests.RedHatOperatorsCronJob(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r, redHatOperatorsCronJob, func() error {
-		return olm.ReconcileRedHatOperatorsCronJob(redHatOperatorsCronJob, p.OwnerRef, p.CLIImage)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile red hat operators cronjob: %w", err)
+		certifiedOperatorsCronJob := manifests.CertifiedOperatorsCronJob(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, certifiedOperatorsCronJob, func() error {
+			return olm.ReconcileCertifiedOperatorsCronJob(certifiedOperatorsCronJob, p.OwnerRef, p.CLIImage)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile certified operators cronjob: %w", err)
+		}
+		communityOperatorsCronJob := manifests.CommunityOperatorsCronJob(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, communityOperatorsCronJob, func() error {
+			return olm.ReconcileCommunityOperatorsCronJob(communityOperatorsCronJob, p.OwnerRef, p.CLIImage)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile community operators cronjob: %w", err)
+		}
+		marketplaceOperatorsCronJob := manifests.RedHatMarketplaceOperatorsCronJob(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, marketplaceOperatorsCronJob, func() error {
+			return olm.ReconcileRedHatMarketplaceOperatorsCronJob(marketplaceOperatorsCronJob, p.OwnerRef, p.CLIImage)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile marketplace operators cronjob: %w", err)
+		}
+		redHatOperatorsCronJob := manifests.RedHatOperatorsCronJob(hcp.Namespace)
+		if _, err := r.CreateOrUpdate(ctx, r, redHatOperatorsCronJob, func() error {
+			return olm.ReconcileRedHatOperatorsCronJob(redHatOperatorsCronJob, p.OwnerRef, p.CLIImage)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile red hat operators cronjob: %w", err)
+		}
 	}
 
 	catalogOperatorMetricsService := manifests.CatalogOperatorMetricsService(hcp.Namespace)
@@ -2001,7 +2003,7 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 	}
 	catalogOperatorDeployment := manifests.CatalogOperatorDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, catalogOperatorDeployment, func() error {
-		return olm.ReconcileCatalogOperatorDeployment(catalogOperatorDeployment, p.OwnerRef, p.OLMImage, p.ProxyImage, p.OperatorRegistryImage, p.ReleaseVersion, p.DeploymentConfig, p.AvailabilityProberImage, hcp.Spec.APIPort)
+		return olm.ReconcileCatalogOperatorDeployment(catalogOperatorDeployment, p.OwnerRef, p.OLMImage, p.ProxyImage, p.OperatorRegistryImage, p.ReleaseVersion, p.DeploymentConfig, p.AvailabilityProberImage, hcp.Spec.APIPort, p.NoProxy)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile catalog operator deployment: %w", err)
 	}
@@ -2022,14 +2024,14 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 
 	olmOperatorDeployment := manifests.OLMOperatorDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, olmOperatorDeployment, func() error {
-		return olm.ReconcileOLMOperatorDeployment(olmOperatorDeployment, p.OwnerRef, p.OLMImage, p.ProxyImage, p.ReleaseVersion, p.DeploymentConfig, p.AvailabilityProberImage, hcp.Spec.APIPort)
+		return olm.ReconcileOLMOperatorDeployment(olmOperatorDeployment, p.OwnerRef, p.OLMImage, p.ProxyImage, p.ReleaseVersion, p.DeploymentConfig, p.AvailabilityProberImage, hcp.Spec.APIPort, p.NoProxy)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile olm operator deployment: %w", err)
 	}
 
 	packageServerDeployment := manifests.OLMPackageServerDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, packageServerDeployment, func() error {
-		return olm.ReconcilePackageServerDeployment(packageServerDeployment, p.OwnerRef, p.OLMImage, p.ProxyImage, p.ReleaseVersion, p.PackageServerConfig, p.AvailabilityProberImage, hcp.Spec.APIPort)
+		return olm.ReconcilePackageServerDeployment(packageServerDeployment, p.OwnerRef, p.OLMImage, p.ProxyImage, p.ReleaseVersion, p.PackageServerConfig, p.AvailabilityProberImage, hcp.Spec.APIPort, p.NoProxy)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile packageserver deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
@@ -21,24 +21,6 @@ spec:
         hypershift.openshift.io/control-plane-component: packageserver
     spec:
       containers:
-      - name: socks5-proxy
-        command:
-          - "/usr/bin/konnectivity-socks5-proxy"
-        args:
-          - run
-        image: SOCKS5_PROXY_IMAGE
-        env:
-          - name: KUBECONFIG
-            value: /etc/openshift/kubeconfig/kubeconfig
-        ports:
-          - containerPort: 8090
-        volumeMounts:
-          - mountPath: /etc/konnectivity-proxy-tls
-            name: oas-konnectivity-proxy-cert
-            readOnly: true
-          - mountPath: /etc/openshift/kubeconfig
-            name: kubeconfig
-            readOnly: true
       - command:
         - /bin/package-server
         - -v=4
@@ -99,6 +81,24 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+      - name: socks5-proxy
+        command:
+          - "/usr/bin/konnectivity-socks5-proxy"
+        args:
+          - run
+        image: SOCKS5_PROXY_IMAGE
+        env:
+          - name: KUBECONFIG
+            value: /etc/openshift/kubeconfig/kubeconfig
+        ports:
+          - containerPort: 8090
+        volumeMounts:
+          - mountPath: /etc/konnectivity-proxy-tls
+            name: oas-konnectivity-proxy-cert
+            readOnly: true
+          - mountPath: /etc/openshift/kubeconfig
+            name: kubeconfig
+            readOnly: true
       restartPolicy: Always
       securityContext: {}
       terminationGracePeriodSeconds: 30

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -1,6 +1,8 @@
 package olm
 
 import (
+	"strings"
+
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -40,7 +42,7 @@ func ReconcileCatalogOperatorMetricsService(svc *corev1.Service, ownerRef config
 	return nil
 }
 
-func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, operatorRegistryImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, apiPort *int32) error {
+func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, operatorRegistryImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, apiPort *int32, noProxy []string) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = catalogOperatorDeployment.DeepCopy().Spec
 	for i, container := range deployment.Spec.Template.Spec.Containers {
@@ -64,6 +66,8 @@ func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef 
 			deployment.Spec.Template.Spec.Containers[0].Env[i].Value = olmImage
 		case "OPERATOR_REGISTRY_IMAGE":
 			deployment.Spec.Template.Spec.Containers[0].Env[i].Value = operatorRegistryImage
+		case "NO_PROXY":
+			deployment.Spec.Template.Spec.Containers[0].Env[i].Value = strings.Join(noProxy, ",")
 		}
 	}
 	dc.ApplyTo(deployment)
@@ -86,7 +90,7 @@ func ReconcileOLMOperatorMetricsService(svc *corev1.Service, ownerRef config.Own
 	return nil
 }
 
-func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, apiPort *int32) error {
+func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, apiPort *int32, noProxy []string) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = olmOperatorDeployment.DeepCopy().Spec
 	for i, container := range deployment.Spec.Template.Spec.Containers {
@@ -106,6 +110,8 @@ func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef conf
 		switch env.Name {
 		case "RELEASE_VERSION":
 			deployment.Spec.Template.Spec.Containers[0].Env[i].Value = releaseVersion
+		case "NO_PROXY":
+			deployment.Spec.Template.Spec.Containers[0].Env[i].Value = strings.Join(noProxy, ",")
 		}
 	}
 	dc.ApplyTo(deployment)

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
@@ -1,6 +1,8 @@
 package olm
 
 import (
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -15,7 +17,7 @@ var (
 	packageServerDeployment = MustDeployment("assets/packageserver-deployment.yaml")
 )
 
-func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, apiPort *int32) error {
+func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, apiPort *int32, noProxy []string) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = packageServerDeployment.DeepCopy().Spec
 	for i, container := range deployment.Spec.Template.Spec.Containers {
@@ -35,6 +37,8 @@ func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef co
 		switch env.Name {
 		case "RELEASE_VERSION":
 			deployment.Spec.Template.Spec.Containers[0].Env[i].Value = releaseVersion
+		case "NO_PROXY":
+			deployment.Spec.Template.Spec.Containers[0].Env[i].Value = strings.Join(noProxy, ",")
 		}
 	}
 	dc.ApplyTo(deployment)

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
@@ -20,6 +20,7 @@ type OperatorLifecycleManagerParams struct {
 	DeploymentConfig        config.DeploymentConfig
 	PackageServerConfig     config.DeploymentConfig
 	AvailabilityProberImage string
+	NoProxy                 []string
 	config.OwnerRef
 }
 
@@ -31,6 +32,7 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images m
 		OperatorRegistryImage:   images["operator-registry"],
 		ReleaseVersion:          releaseVersion,
 		AvailabilityProberImage: images[util.AvailabilityProberImageName],
+		NoProxy:                 []string{"kube-apiserver"},
 		OwnerRef:                config.OwnerRefFrom(hcp),
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
@@ -63,6 +65,10 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images m
 
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	params.PackageServerConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+
+	if hcp.Spec.OLMCatalogPlacement == "management" {
+		params.NoProxy = append(params.NoProxy, "certified-operators", "community-operators", "redhat-operators", "redhat-marketplace")
+	}
 
 	return params
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs.go
@@ -5,33 +5,33 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
-func ReconcileCertifiedOperatorsCatalogSource(cs *operatorsv1alpha1.CatalogSource) {
-	reconcileCatalogSource(cs, "certified-operators:50051", "Certified Operators", -200)
+func ReconcileCertifiedOperatorsCatalogSource(cs *operatorsv1alpha1.CatalogSource, p *OperatorLifecycleManagerParams) {
+	reconcileCatalogSource(cs, "certified-operators:50051", p.CertifiedOperatorsImage, "Certified Operators", -200, p.OLMCatalogPlacement)
 }
 
-func ReconcileCommunityOperatorsCatalogSource(cs *operatorsv1alpha1.CatalogSource) {
-	reconcileCatalogSource(cs, "community-operators:50051", "Community Operators", -400)
+func ReconcileCommunityOperatorsCatalogSource(cs *operatorsv1alpha1.CatalogSource, p *OperatorLifecycleManagerParams) {
+	reconcileCatalogSource(cs, "community-operators:50051", p.CommunityOperatorsImage, "Community Operators", -400, p.OLMCatalogPlacement)
 }
 
-func ReconcileRedHatMarketplaceCatalogSource(cs *operatorsv1alpha1.CatalogSource) {
-	reconcileCatalogSource(cs, "redhat-marketplace:50051", "Red Hat Marketplace", -300)
+func ReconcileRedHatMarketplaceCatalogSource(cs *operatorsv1alpha1.CatalogSource, p *OperatorLifecycleManagerParams) {
+	reconcileCatalogSource(cs, "redhat-marketplace:50051", p.RedHatMarketplaceImage, "Red Hat Marketplace", -300, p.OLMCatalogPlacement)
 }
 
-func ReconcileRedHatOperatorsCatalogSource(cs *operatorsv1alpha1.CatalogSource) {
-	reconcileCatalogSource(cs, "redhat-operators:50051", "Red Hat Operators", -100)
+func ReconcileRedHatOperatorsCatalogSource(cs *operatorsv1alpha1.CatalogSource, p *OperatorLifecycleManagerParams) {
+	reconcileCatalogSource(cs, "redhat-operators:50051", p.RedHatOperatorsImage, "Red Hat Operators", -100, p.OLMCatalogPlacement)
 }
 
-func reconcileCatalogSource(cs *operatorsv1alpha1.CatalogSource, address, displayName string, priority int) {
+func reconcileCatalogSource(cs *operatorsv1alpha1.CatalogSource, address string, image string, displayName string, priority int, placement hyperv1.OLMCatalogPlacement) {
 	if cs.Annotations == nil {
 		cs.Annotations = map[string]string{}
 	}
 	cs.Annotations["target.workload.openshift.io/management"] = `{"effect": "PreferredDuringScheduling"}`
 	cs.Spec = operatorsv1alpha1.CatalogSourceSpec{
 		SourceType:  operatorsv1alpha1.SourceTypeGrpc,
-		Address:     address,
 		DisplayName: displayName,
 		Publisher:   "Red Hat",
 		Priority:    priority,
@@ -40,5 +40,11 @@ func reconcileCatalogSource(cs *operatorsv1alpha1.CatalogSource, address, displa
 				Interval: &metav1.Duration{Duration: 10 * time.Minute},
 			},
 		},
+	}
+	if placement == hyperv1.ManagementOLMCatalogPlacement {
+		cs.Spec.Address = address
+	}
+	if placement == hyperv1.GuestOLMCatalogPlacement {
+		cs.Spec.Image = image
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
@@ -1,0 +1,29 @@
+package olm
+
+import (
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+type OperatorLifecycleManagerParams struct {
+	CertifiedOperatorsImage string
+	CommunityOperatorsImage string
+	RedHatMarketplaceImage  string
+	RedHatOperatorsImage    string
+	OLMCatalogPlacement     hyperv1.OLMCatalogPlacement
+}
+
+func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, releaseVersion string) *OperatorLifecycleManagerParams {
+	tag := strings.Join(strings.Split(releaseVersion, ".")[:2], ".")
+
+	params := &OperatorLifecycleManagerParams{
+		CertifiedOperatorsImage: "registry.redhat.io/redhat/certified-operator-index:v" + tag,
+		CommunityOperatorsImage: "registry.redhat.io/redhat/community-operator-index:v" + tag,
+		RedHatMarketplaceImage:  "registry.redhat.io/redhat/redhat-marketplace-index:v" + tag,
+		RedHatOperatorsImage:    "registry.redhat.io/redhat/redhat-operator-index:v" + tag,
+		OLMCatalogPlacement:     hcp.Spec.OLMCatalogPlacement,
+	}
+
+	return params
+}

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -379,6 +379,28 @@ provided: reconciliation is paused on the resource until that date. If the boole
 provided: reconciliation is paused on the resource until the field is removed.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>olmCatalogPlacement</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.OLMCatalogPlacement">
+OLMCatalogPlacement
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OLMCatalogPlacement specifies the placement of OLM catalog components. By default,
+this is set to management and OLM catalog components are deployed onto the management
+cluster. If set to guest, the OLM catalog components will be deployed onto the guest
+cluster.</p>
+<p>
+Value must be one of:
+&#34;guest&#34;, 
+&#34;management&#34;
+</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2556,6 +2578,28 @@ provided: reconciliation is paused on the resource until that date. If the boole
 provided: reconciliation is paused on the resource until the field is removed.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>olmCatalogPlacement</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.OLMCatalogPlacement">
+OLMCatalogPlacement
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OLMCatalogPlacement specifies the placement of OLM catalog components. By default,
+this is set to management and OLM catalog components are deployed onto the management
+cluster. If set to guest, the OLM catalog components will be deployed onto the guest
+cluster.</p>
+<p>
+Value must be one of:
+&#34;guest&#34;, 
+&#34;management&#34;
+</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###HostedClusterStatus { #hypershift.openshift.io/v1alpha1.HostedClusterStatus }
@@ -2981,6 +3025,28 @@ string
 Either a date can be provided in RFC3339 format or a boolean. If a date is
 provided: reconciliation is paused on the resource until that date. If the boolean true is
 provided: reconciliation is paused on the resource until the field is removed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>olmCatalogPlacement</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1alpha1.OLMCatalogPlacement">
+OLMCatalogPlacement
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OLMCatalogPlacement specifies the placement of OLM catalog components. By default,
+this is set to management and OLM catalog components are deployed onto the management
+cluster. If set to guest, the OLM catalog components will be deployed onto the guest
+cluster.</p>
+<p>
+Value must be one of:
+&#34;guest&#34;, 
+&#34;management&#34;
+</p>
 </td>
 </tr>
 </tbody>
@@ -4326,6 +4392,32 @@ assigned when the service is created.</p>
 </td>
 </tr>
 </tbody>
+</table>
+###OLMCatalogPlacement { #hypershift.openshift.io/v1alpha1.OLMCatalogPlacement }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+</p>
+<p>
+<p>OLMCatalogPlacement is an enum specifying the placement of OLM catalog components.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;guest&#34;</p></td>
+<td><p>GuestOLMCatalogPlacement indicates OLM catalog components will be placed in
+the guest cluster.</p>
+</td>
+</tr><tr><td><p>&#34;management&#34;</p></td>
+<td><p>ManagementOLMCatalogPlacement indicates OLM catalog components will be placed in
+the management cluster.</p>
+</td>
+</tr></tbody>
 </table>
 ###PersistentVolumeEtcdStorageSpec { #hypershift.openshift.io/v1alpha1.PersistentVolumeEtcdStorageSpec }
 <p>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -19969,6 +19969,17 @@ objects:
                   - podCIDR
                   - serviceCIDR
                   type: object
+                olmCatalogPlacement:
+                  default: management
+                  description: OLMCatalogPlacement specifies the placement of OLM
+                    catalog components. By default, this is set to management and
+                    OLM catalog components are deployed onto the management cluster.
+                    If set to guest, the OLM catalog components will be deployed onto
+                    the guest cluster.
+                  enum:
+                  - management
+                  - guest
+                  type: string
                 pausedUntil:
                   description: 'PausedUntil is a field that can be used to pause reconciliation
                     on a resource. Either a date can be provided in RFC3339 format
@@ -21059,6 +21070,17 @@ objects:
                   enum:
                   - OpenShiftSDN
                   - Calico
+                  type: string
+                olmCatalogPlacement:
+                  default: management
+                  description: OLMCatalogPlacement specifies the placement of OLM
+                    catalog components. By default, this is set to management and
+                    OLM catalog components are deployed onto the management cluster.
+                    If set to guest, the OLM catalog components will be deployed onto
+                    the guest cluster.
+                  enum:
+                  - management
+                  - guest
                   type: string
                 pausedUntil:
                   description: 'PausedUntil is a field that can be used to pause reconciliation

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1155,6 +1155,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 
 	hcp.Spec.Configuration = hcluster.Spec.Configuration.DeepCopy()
 	hcp.Spec.PausedUntil = hcluster.Spec.PausedUntil
+	hcp.Spec.OLMCatalogPlacement = hcluster.Spec.OLMCatalogPlacement
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for OLM catalog placement API for HostedCluster and HostedControlPlane. This will toggle the placement of OLM catalogs to be deployed on management cluster or guest cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #1075

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.