### PR TITLE
Run the konnektivity agent DS with hostnetwork

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -35,7 +35,7 @@ func konnectivityAgentLabels() map[string]string {
 	}
 }
 
-func ReconcileAgentDaemonSet(daemonset *appsv1.DaemonSet, deploymentConfig config.DeploymentConfig, image string, host string, port int32) {
+func ReconcileAgentDaemonSet(daemonset *appsv1.DaemonSet, deploymentConfig config.DeploymentConfig, image string, host string, port int32, platform hyperv1.PlatformType) {
 	daemonset.Spec = appsv1.DaemonSetSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: konnectivityAgentLabels(),
@@ -57,6 +57,11 @@ func ReconcileAgentDaemonSet(daemonset *appsv1.DaemonSet, deploymentConfig confi
 				},
 			},
 		},
+	}
+	if platform != hyperv1.IBMCloudPlatform {
+		daemonset.Spec.Template.Spec.HostNetwork = true
+		// Default is not the default, it means that the kubelets will re-use the hosts DNS resolver
+		daemonset.Spec.Template.Spec.DNSPolicy = corev1.DNSDefault
 	}
 	deploymentConfig.ApplyToDaemonSet(daemonset)
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -587,7 +587,7 @@ func (r *reconciler) reconcileKonnectivityAgent(ctx context.Context, hcp *hyperv
 
 	agentDaemonset := manifests.KonnectivityAgentDaemonSet()
 	if _, err := r.CreateOrUpdate(ctx, r.client, agentDaemonset, func() error {
-		konnectivity.ReconcileAgentDaemonSet(agentDaemonset, p.DeploymentConfig, p.Image, p.ExternalAddress, p.ExternalPort)
+		konnectivity.ReconcileAgentDaemonSet(agentDaemonset, p.DeploymentConfig, p.Image, p.ExternalAddress, p.ExternalPort, hcp.Spec.Platform.Type)
 		return nil
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile konnectivity agent daemonset: %w", err))


### PR DESCRIPTION
So it is possible to retrieve logs even when the SDN doesn't work, which
is helpful for debugging. The healthcheck address was changed to
localhost to avoid exposing a port.

Relevant slack discussion: https://coreos.slack.com/archives/C01C8502FMM/p1640019194217000

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.