### PR TITLE
e2e: support dns indirection

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -304,7 +304,7 @@ type ServicePublishingStrategy struct {
 	// LoadBalancer configures exposing a service using a LoadBalancer.
 	LoadBalancer *LoadBalancerPublishingStrategy `json:"loadBalancer,omitempty"`
 
-	// Route configures exposing a service using a LoadBalancer.
+	// Route configures exposing a service using a Route.
 	Route *RoutePublishingStrategy `json:"route,omitempty"`
 }
 
@@ -357,14 +357,14 @@ type NodePortPublishingStrategy struct {
 
 // LoadBalancerPublishingStrategy specifies setting used to expose a service as a LoadBalancer.
 type LoadBalancerPublishingStrategy struct {
-	// Hostname is the DNS name that will be created via external-dns pointing to the LoadBalancer.
+	// Hostname is the name of the DNS record that will be created pointing to the LoadBalancer.
 	// +optional
 	Hostname string `json:"hostname,omitempty"`
 }
 
 // RoutePublishingStrategy specifies options for exposing a service as a Route.
 type RoutePublishingStrategy struct {
-	// Hostname is the DNS name that will be created via external-dns pointing to the Route.
+	// Hostname is the name of the DNS record that will be created pointing to the Route.
 	// +optional
 	Hostname string `json:"hostname,omitempty"`
 }

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -160,6 +160,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	exampleOptions.PrivateZoneID = infra.PrivateZoneID
 	exampleOptions.PublicZoneID = infra.PublicZoneID
 	exampleOptions.InfraID = infraID
+	exampleOptions.ExternalDNSDomain = opts.ExternalDNSDomain
 	var zones []apifixtures.ExampleAWSOptionsZones
 	for _, outputZone := range infra.Zones {
 		zones = append(zones, apifixtures.ExampleAWSOptionsZones{

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -29,6 +29,7 @@ func NewCreateCommands() *cobra.Command {
 		PodCIDR:                        "10.132.0.0/14",
 		Wait:                           false,
 		Timeout:                        0,
+		ExternalDNSDomain:              "",
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -39,6 +40,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A namespace to contain the generated resources")
 	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "A name for the cluster")
 	cmd.PersistentFlags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the cluster")
+	cmd.PersistentFlags().StringVar(&opts.ExternalDNSDomain, "external-dns-domain", opts.ExternalDNSDomain, "Sets hostname to opinionated values in the specificed domain for services with publishing type LoadBalancer or Route.")
 	cmd.PersistentFlags().StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico or OpenshiftSDN.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the cluster")
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Path to a pull secret (required)")

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -54,6 +54,7 @@ type CreateOptions struct {
 	SSHKeyFile                       string
 	ServiceCIDR                      string
 	PodCIDR                          string
+	ExternalDNSDomain                string
 	NonePlatform                     NonePlatformCreateOptions
 	KubevirtPlatform                 KubevirtPlatformCreateOptions
 	AWSPlatform                      AWSPlatformOptions

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -897,8 +897,8 @@ spec:
                             using a LoadBalancer.
                           properties:
                             hostname:
-                              description: Hostname is the DNS name that will be created
-                                via external-dns pointing to the LoadBalancer.
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the LoadBalancer.
                               type: string
                           type: object
                         nodePort:
@@ -920,11 +920,11 @@ spec:
                           type: object
                         route:
                           description: Route configures exposing a service using a
-                            LoadBalancer.
+                            Route.
                           properties:
                             hostname:
-                              description: Hostname is the DNS name that will be created
-                                via external-dns pointing to the Route.
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the Route.
                               type: string
                           type: object
                         type:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -803,8 +803,8 @@ spec:
                             using a LoadBalancer.
                           properties:
                             hostname:
-                              description: Hostname is the DNS name that will be created
-                                via external-dns pointing to the LoadBalancer.
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the LoadBalancer.
                               type: string
                           type: object
                         nodePort:
@@ -826,11 +826,11 @@ spec:
                           type: object
                         route:
                           description: Route configures exposing a service using a
-                            LoadBalancer.
+                            Route.
                           properties:
                             hostname:
-                              description: Hostname is the DNS name that will be created
-                                via external-dns pointing to the Route.
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the Route.
                               type: string
                           type: object
                         type:

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -231,7 +231,9 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 				Value: "/etc/provider/credentials",
 			},
 			corev1.EnvVar{
-				Name:  "AWS_REGION",
+				Name: "AWS_REGION",
+				// external-dns only makes route53 requests which is a global service,
+				// thus we can assume us-east-1 without having to request it on the command line
 				Value: "us-east-1",
 			})
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--aws-zone-type=public")

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3686,7 +3686,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Hostname is the DNS name that will be created via external-dns pointing to the LoadBalancer.</p>
+<p>Hostname is the name of the DNS record that will be created pointing to the LoadBalancer.</p>
 </td>
 </tr>
 </tbody>
@@ -4781,7 +4781,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Hostname is the DNS name that will be created via external-dns pointing to the Route.</p>
+<p>Hostname is the name of the DNS record that will be created pointing to the Route.</p>
 </td>
 </tr>
 </tbody>
@@ -4940,7 +4940,7 @@ RoutePublishingStrategy
 </em>
 </td>
 <td>
-<p>Route configures exposing a service using a LoadBalancer.</p>
+<p>Route configures exposing a service using a Route.</p>
 </td>
 </tr>
 </tbody>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -20521,8 +20521,8 @@ objects:
                               using a LoadBalancer.
                             properties:
                               hostname:
-                                description: Hostname is the DNS name that will be
-                                  created via external-dns pointing to the LoadBalancer.
+                                description: Hostname is the name of the DNS record
+                                  that will be created pointing to the LoadBalancer.
                                 type: string
                             type: object
                           nodePort:
@@ -20544,11 +20544,11 @@ objects:
                             type: object
                           route:
                             description: Route configures exposing a service using
-                              a LoadBalancer.
+                              a Route.
                             properties:
                               hostname:
-                                description: Hostname is the DNS name that will be
-                                  created via external-dns pointing to the Route.
+                                description: Hostname is the name of the DNS record
+                                  that will be created pointing to the Route.
                                 type: string
                             type: object
                           type:
@@ -21612,8 +21612,8 @@ objects:
                               using a LoadBalancer.
                             properties:
                               hostname:
-                                description: Hostname is the DNS name that will be
-                                  created via external-dns pointing to the LoadBalancer.
+                                description: Hostname is the name of the DNS record
+                                  that will be created pointing to the LoadBalancer.
                                 type: string
                             type: object
                           nodePort:
@@ -21635,11 +21635,11 @@ objects:
                             type: object
                           route:
                             description: Route configures exposing a service using
-                              a LoadBalancer.
+                              a Route.
                             properties:
                               hostname:
-                                description: Hostname is the DNS name that will be
-                                  created via external-dns pointing to the Route.
+                                description: Hostname is the name of the DNS record
+                                  that will be created pointing to the Route.
                                 type: string
                             type: object
                           type:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -58,6 +58,7 @@ func TestMain(m *testing.M) {
 	flag.Var(&globalOpts.configurableClusterOptions.Zone, "e2e.aws-zones", "AWS zones for clusters")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PullSecretFile, "e2e.pull-secret-file", "", "path to pull secret")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AWSEndpointAccess, "e2e.aws-endpoint-access", "", "endpoint access profile for the cluster")
+	flag.StringVar(&globalOpts.configurableClusterOptions.ExternalDNSDomain, "e2e.external-dns-domain", "", "domain that external-dns will use to create DNS records for HCP endpoints")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "container disk image to use for kubevirt nodes")
 	flag.IntVar(&globalOpts.configurableClusterOptions.NodePoolReplicas, "e2e.node-pool-replicas", 2, "the number of replicas for each node pool in the cluster")
 	flag.StringVar(&globalOpts.LatestReleaseImage, "e2e.latest-release-image", "", "The latest OCP release image for use by tests")
@@ -193,6 +194,7 @@ type configurableClusterOptions struct {
 	BaseDomain                 string
 	ControlPlaneOperatorImage  string
 	AWSEndpointAccess          string
+	ExternalDNSDomain          string
 	KubeVirtContainerDiskImage string
 	NodePoolReplicas           int
 }
@@ -207,6 +209,7 @@ func (o *options) DefaultClusterOptions() core.CreateOptions {
 		BaseDomain:                o.configurableClusterOptions.BaseDomain,
 		PullSecretFile:            o.configurableClusterOptions.PullSecretFile,
 		ControlPlaneOperatorImage: o.configurableClusterOptions.ControlPlaneOperatorImage,
+		ExternalDNSDomain:         o.configurableClusterOptions.ExternalDNSDomain,
 		AWSPlatform: core.AWSPlatformOptions{
 			InstanceType:       "m5.large",
 			RootVolumeSize:     64,


### PR DESCRIPTION
e2e support for external-dns and DNS indirection to HCP endpoints.

There is a new `--e2e.external-dns-domain` flag to support this.

Also has a separate commit for fixing remaining nits from #1145 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.