### PR TITLE
Switching KubeVirt platform's default ingress to NodePort

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -19,9 +19,16 @@ func ReconcileDefaultIngressController(ingressController *operatorv1.IngressCont
 		ingressController.Spec.Replicas = &(replicas)
 	}
 	switch platformType {
-	case hyperv1.NonePlatform, hyperv1.KubevirtPlatform:
+	case hyperv1.NonePlatform:
 		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
 			Type: operatorv1.HostNetworkStrategyType,
+		}
+		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
+			Name: manifests.IngressDefaultIngressControllerCert().Name,
+		}
+	case hyperv1.KubevirtPlatform:
+		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+			Type: operatorv1.NodePortServiceStrategyType,
 		}
 		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
 			Name: manifests.IngressDefaultIngressControllerCert().Name,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
@@ -1,12 +1,13 @@
 package ingress
 
 import (
+	"testing"
+
 	. "github.com/onsi/gomega"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
 )
 
 func TestReconcileDefaultIngressController(t *testing.T) {
@@ -80,7 +81,7 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 			},
 		},
 		{
-			name:                   "Kubevirt uses HostNetwork publishing strategy",
+			name:                   "Kubevirt uses NodePort publishing strategy",
 			inputIngressController: manifests.IngressDefaultIngressController(),
 			inputIngressDomain:     fakeIngressDomain,
 			inputPlatformType:      hyperv1.KubevirtPlatform,
@@ -92,7 +93,7 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 					Domain:   fakeIngressDomain,
 					Replicas: &fakeInputReplicas,
 					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
-						Type: operatorv1.HostNetworkStrategyType,
+						Type: operatorv1.NodePortServiceStrategyType,
 					},
 					DefaultCertificate: &corev1.LocalObjectReference{
 						Name: manifests.IngressDefaultIngressControllerCert().Name,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
@@ -5,9 +5,10 @@ import (
 	"encoding/hex"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 )
 
-func ReconcileRegistryConfig(cfg *imageregistryv1.Config, isPlatformNone bool) {
+func ReconcileRegistryConfig(cfg *imageregistryv1.Config, platform hyperv1.PlatformType) {
 	cfg.Spec.DefaultRoute = false
 	if cfg.Spec.HTTPSecret == "" {
 		cfg.Spec.HTTPSecret = generateImageRegistrySecret()
@@ -26,7 +27,7 @@ func ReconcileRegistryConfig(cfg *imageregistryv1.Config, isPlatformNone bool) {
 	cfg.Spec.Requests.Write.MaxRunning = 0
 	cfg.Spec.Requests.Write.MaxWaitInQueue.Reset()
 
-	if isPlatformNone {
+	if platform == hyperv1.KubevirtPlatform || platform == hyperv1.NonePlatform {
 		cfg.Spec.Storage = imageregistryv1.ImageRegistryConfigStorage{EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{}}
 	} else {
 		cfg.Spec.Storage.EmptyDir = nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -209,7 +209,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		log.Info("reconciling registry config")
 		registryConfig := manifests.Registry()
 		if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
-			registry.ReconcileRegistryConfig(registryConfig, r.platformType == hyperv1.NonePlatform)
+			registry.ReconcileRegistryConfig(registryConfig, r.platformType)
 			return nil
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile imageregistry config: %w", err))

--- a/hack/ci/install-cnv.sh
+++ b/hack/ci/install-cnv.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+# The kubevirt tests require wildcard routes to be allowed
+oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
+
 oc apply -f - <<EOF
 apiVersion: v1
 kind: Namespace

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1145,7 +1145,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	// Pass through Platform spec.
 	hcp.Spec.Platform = *hcluster.Spec.Platform.DeepCopy()
 	switch hcluster.Spec.Platform.Type {
-	case hyperv1.AgentPlatform, hyperv1.KubevirtPlatform:
+	case hyperv1.AgentPlatform:
 		// Agent platform uses None platform for the hcp.
 		hcp.Spec.Platform.Type = hyperv1.NonePlatform
 	}

--- a/test/e2e/util/kubevirt.go
+++ b/test/e2e/util/kubevirt.go
@@ -2,12 +2,17 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -19,8 +24,6 @@ func WaitForKubeVirtMachines(t *testing.T, ctx context.Context, client crclient.
 	g := NewWithT(t)
 	start := time.Now()
 
-	localCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
-	defer cancel()
 	t.Logf("Waiting for %d kubevirt machines to come online", count)
 
 	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
@@ -45,7 +48,7 @@ func WaitForKubeVirtMachines(t *testing.T, ctx context.Context, client crclient.
 		}
 
 		return true, nil
-	}, localCtx.Done())
+	}, ctx.Done())
 	g.Expect(err).NotTo(HaveOccurred(), "timeout waiting for kubevirt machines to become ready")
 
 	t.Logf("KubeVirtMachines are ready in %s", time.Since(start).Round(time.Second))
@@ -57,8 +60,6 @@ func WaitForKubeVirtCluster(t *testing.T, ctx context.Context, client crclient.C
 
 	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
 
-	localCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
-	defer cancel()
 	t.Logf("Waiting for kubevirt cluster to come online")
 	err := wait.PollUntil(5*time.Second, func() (done bool, err error) {
 		var kvClusterList capikubevirt.KubevirtClusterList
@@ -75,8 +76,85 @@ func WaitForKubeVirtCluster(t *testing.T, ctx context.Context, client crclient.C
 		}
 
 		return kvClusterList.Items[0].Status.Ready, nil
-	}, localCtx.Done())
+	}, ctx.Done())
 	g.Expect(err).NotTo(HaveOccurred(), "timeout waiting for kubevirt cluster to become ready")
 
 	t.Logf("KubeVirtCluster is ready in %s", time.Since(start).Round(time.Second))
+}
+
+func CreateKubeVirtClusterWildcardRoute(t *testing.T, ctx context.Context, client crclient.Client, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster, baseDomain string) {
+
+	g := NewWithT(t)
+
+	// manifests for default ingress nodeport on guest cluster
+	defaultIngressNodePortService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router-nodeport-default",
+			Namespace: "openshift-ingress",
+		},
+	}
+
+	detectedHTTPSNodePort := int32(0)
+	err := guestClient.Get(ctx, crclient.ObjectKeyFromObject(defaultIngressNodePortService), defaultIngressNodePortService)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get guest's default ingress NodePort service.")
+	for _, port := range defaultIngressNodePortService.Spec.Ports {
+		if port.Port == 443 {
+			detectedHTTPSNodePort = port.NodePort
+			break
+		}
+	}
+	g.Expect(detectedHTTPSNodePort).NotTo(Equal(0), "failed to detect port for default ingress router's https node port service")
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+
+	// Manifests for clusterIP on management cluster
+	cpService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-ingress",
+			Namespace: hcpNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "https-443",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       443,
+					TargetPort: intstr.FromInt(int(detectedHTTPSNodePort)),
+				},
+			},
+			Selector: map[string]string{
+				"kubevirt.io": "virt-launcher",
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+	// Manifests for route
+	cpRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-ingress",
+			Namespace: hcpNamespace,
+		},
+		Spec: routev1.RouteSpec{
+			Host:           fmt.Sprintf("data.apps.%s.%s", hostedCluster.Name, baseDomain),
+			WildcardPolicy: routev1.WildcardPolicySubdomain,
+			TLS: &routev1.TLSConfig{
+				Termination: routev1.TLSTerminationPassthrough,
+			},
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromString("https-443"),
+			},
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: cpService.Name,
+			},
+		},
+	}
+
+	t.Logf("Created mgmt service for default tenant cluster ingress")
+	err = client.Create(ctx, cpService)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create guest clusters default apps service on mgmt cluster")
+
+	t.Logf("Created mgmt route for default tenant cluster ingress")
+	err = client.Create(ctx, cpRoute)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create guest clusters default apps route on mgmt cluster")
 }


### PR DESCRIPTION
Previously, Clusters using the KubeVirt platform would get stuck at a partial install. This was primarily due ingress routing failures which prevented console from working and also prevented guest cluster API access.

Our ingress issues are mostly resolved by switching from HostNetwork to NodePort for the guest cluster
s default ingress. Before this change, when we used HostNetwork for ingress, we didn't have a way to accurately select which VMs were running the HA proxy instances when routing default ingress traffic. This made it difficult to target the correct VMs when routing traffic. NodePort allows us to target all VMs when routing traffic.

By switching to NodePort for ingress and exposing the cluster API using routes and a LB ( #1032) we now have the ability to completely install an ocp tenant cluster using the KubeVirt platform. The e2e tests have now been updated to fully exercise the guest api access and verify a complete install.

## NOTE e2e test wildcard *.apps routing

In order to avoid needing to create a LB+DNS entry for the KubeVirt cluster's default ingress, we have deployed a trick in the e2e tests which leverages the mgmt cluster's existing LB and wildcard *.apps DNS entry.

It works like this.

Let's say the mgmt cluster's default ingress is DNS record is`*.apps.mgmt-cluster.example.com`. If we use the base domain `apps.mgmt-cluster.example.com` for our tenant cluster, then the tenant cluster's default ingress will become something like `*.apps.tenant-cluster.apps.mgmt-cluster.example.com`. By making the tenant cluster's default ingress a subdomain of the mgmt cluster's wildcard DNS record, we can use the mgmt cluster's existing ingress to route to the tenant cluster's default ingress.

In this example, our e2e tests get ingress for the tenant cluster to work by simply creating a subdomain route on the mgmt cluster that routes everything from `*.apps.tenant-cluster.apps.mgmt-cluster.example.com` on the mgmt cluster to the kubevirt VMs. see the ```CreateKubeVirtClusterWildcardRoute``` function in this PR for more details.

In production, someone could deploy a similar trick to this if they wanted, or they could create an external LB + DNS entry which routes to all the kubevirt VMs in the tenant cluster. Either way works now that we're using NodePort and all VMs are routeable for ingress.

As a follow up to this PR, the quickstart guide will be updated to document the different methods for getting default ingress to work for KubeVirt tenant clusters.






