### PR TITLE
Alow hypershift operator to grant RBAC permissions to the cpai-provider-agent

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -720,6 +720,11 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Resources: []string{"virtualmachineinstances", "virtualmachines"},
 				Verbs:     []string{"*"},
 			},
+			{
+				APIGroups: []string{"agent-install.openshift.io"},
+				Resources: []string{"agents"},
+				Verbs:     []string{"*"},
+			},
 		},
 	}
 	return role

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -197,6 +197,12 @@ objects:
     - virtualmachines
     verbs:
     - '*'
+  - apiGroups:
+    - agent-install.openshift.io
+    resources:
+    - agents
+    verbs:
+    - '*'
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR should allow hypershift operator to grant RBAC permissions to the cpai-provider-agent so it can access agents
This used to work until https://github.com/openshift/hypershift/pull/1136
Note that we plan to remove the role in the agent namespace from hypershift management, but until we do (require changes in docs tests and code) this PR should allow the capi-provider-agent to keep working. 

https://issues.redhat.com/browse/MGMT-9635

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.