### PR TITLE
Remove capi-provider-agent role from hypershift management

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -3,6 +3,7 @@ package fixtures
 import (
 	"crypto/rand"
 	"fmt"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -306,6 +307,26 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 				AgentNamespace: o.Agent.AgentNamespace,
 			},
 		}
+		agentResources := &ExampleAgentResources{
+			&rbacv1.Role{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Role",
+					APIVersion: rbacv1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: o.Agent.AgentNamespace,
+					Name:      "capi-provider-role",
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"agent-install.openshift.io"},
+						Resources: []string{"agents"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+		}
+		resources = agentResources.AsObjects()
 		services = o.getServicePublishingStrategyMappingByAPIServerAddress(o.Agent.APIServerAddress)
 	case o.Kubevirt != nil:
 		platformSpec = hyperv1.PlatformSpec{

--- a/api/fixtures/example_agent.go
+++ b/api/fixtures/example_agent.go
@@ -1,0 +1,14 @@
+package fixtures
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ExampleAgentResources struct {
+	CAPIProviderAgentRole *rbacv1.Role
+}
+
+func (o *ExampleAgentResources) AsObjects() []crclient.Object {
+	return []crclient.Object{o.CAPIProviderAgentRole}
+}

--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"fmt"
-
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/docs/content/how-to/agent/create-agent-cluster.md
+++ b/docs/content/how-to/agent/create-agent-cluster.md
@@ -445,6 +445,25 @@ spec:
 EOF
 ~~~
 
+> **NOTE**: If you wish to use an `InfraEnv` (and its associated `Agents`) from a namespace that isn't the ${HOSTED_CLUSTER_NS}, you must create a role for capi-provider-agent in that namespace (this is the same namespace as specified in the hosted cluster Spec (`spec.platform.agent.agentNamespace`).
+~~~sh
+envsubst <<"EOF" | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: capi-provider-role
+  namespace: ${INFRA_ENV_NS}
+rules:
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  verbs:
+  - '*'
+EOF
+~~~
+
 This will generate a custom ISO for the host to be installed.
 
 ~~~sh

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
@@ -35,13 +35,6 @@ func TestReconcileCredentials(t *testing.T) {
 		hostedCluster, controlPlaneNamespace)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	role := &rbacv1.Role{}
-	err = client.Get(context.Background(), types.NamespacedName{
-		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
-		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
-	}, role)
-	g.Expect(err).ToNot(HaveOccurred())
-
 	roleBinding := &rbacv1.RoleBinding{}
 	err = client.Get(context.Background(), types.NamespacedName{
 		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
@@ -81,18 +74,20 @@ func TestDeleteCredentials(t *testing.T) {
 		hostedCluster, controlPlaneNamespace)
 	g.Expect(err).ToNot(HaveOccurred())
 
+	// Verify the roleBinding exists
+	roleBinding := &rbacv1.RoleBinding{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
+	}, roleBinding)
+	g.Expect(err).ToNot(HaveOccurred())
+
 	err = platform.DeleteCredentials(context.Background(),
 		client,
 		hostedCluster, controlPlaneNamespace)
 	g.Expect(err).ToNot(HaveOccurred())
-	role := &rbacv1.Role{}
-	err = client.Get(context.Background(), types.NamespacedName{
-		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
-		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
-	}, role)
-	g.Expect(apierrors.IsNotFound(err)).To(Equal(true))
 
-	roleBinding := &rbacv1.RoleBinding{}
+	roleBinding = &rbacv1.RoleBinding{}
 	err = client.Get(context.Background(), types.NamespacedName{
 		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
 		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),


### PR DESCRIPTION
**What this PR does / why we need it**:
 Remove the role allowing capi-provider-agent to list agents on another namespace from hypershift management
Create the role during cluster create agent instead

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/MGMT-9633

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. - WIP 
- [ ] This change includes unit tests.