### PR TITLE
add clusterid label to admin kubeconfig secret

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -962,6 +962,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if !srcHasData {
 				return fmt.Errorf("controlplane kubeconfig secret %q must have a %q key", client.ObjectKeyFromObject(src), key)
 			}
+			dest.Labels = hcluster.Labels
 			dest.Type = corev1.SecretTypeOpaque
 			if dest.Data == nil {
 				dest.Data = map[string][]byte{}


### PR DESCRIPTION
This adds a label to the resource created in the hostedcluster namespace to allow for label queries on resources created in that namespace. The idea is to be able to have a query using label selectors to get all resources in the centralized hostedcluster namespace associated with a an individual hostedcluster. This is the one piece that is created in that namespace that the user does not have control over specifying labels on. This adds a label that can be utilized for the selector.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.