### PR TITLE
Allow overriding images at the hypershift operator level

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -63,6 +63,10 @@ const (
 	// a HostedControlPlane.
 	ClusterAPIAgentProviderImage = "hypershift.openshift.io/capi-provider-agent-image"
 
+	// ClusterAPIAzureProviderImage overrides the CAPI Azure provider image to use for
+	// a HostedControlPlane.
+	ClusterAPIAzureProviderImage = "hypershift.openshift.io/capi-provider-azure-image"
+
 	// AESCBCKeySecretKey defines the Kubernetes secret key name that contains the aescbc encryption key
 	// in the AESCBC secret encryption strategy
 	AESCBCKeySecretKey = "key"

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -3,12 +3,15 @@ package agent
 import (
 	"context"
 	"fmt"
+	"os"
+
 	hyperutil "github.com/openshift/hypershift/hypershift-operator/controllers/util"
 
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
+	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,6 +60,9 @@ func (p Agent) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, create
 
 func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := imageCAPAgent
+	if envImage := os.Getenv(images.AgentCAPIProviderEnvVar); len(envImage) > 0 {
+		providerImage = envImage
+	}
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIAgentProviderImage]; ok {
 		providerImage = override
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -3,9 +3,11 @@ package aws
 import (
 	"context"
 	"fmt"
+	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -62,6 +64,9 @@ func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOr
 
 func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := imageCAPA
+	if envImage := os.Getenv(images.AWSCAPIProviderEnvVar); len(envImage) > 0 {
+		providerImage = envImage
+	}
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIProviderAWSImage]; ok {
 		providerImage = override
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -2,8 +2,10 @@ package kubevirt
 
 import (
 	"context"
+	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -54,6 +56,9 @@ func reconcileKubevirtCluster(kubevirtCluster *capikubevirt.KubevirtCluster, hcl
 
 func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
 	providerImage := imageCAPK
+	if envImage := os.Getenv(images.KubevirtCAPIProviderEnvVar); len(envImage) > 0 {
+		providerImage = envImage
+	}
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIKubeVirtProviderImage]; ok {
 		providerImage = override
 	}

--- a/support/images/envvars.go
+++ b/support/images/envvars.go
@@ -1,0 +1,26 @@
+package images
+
+// Image environment variable constants
+const (
+	CAPIEnvVar                  = "IMAGE_CLUSTER_API"
+	AgentCAPIProviderEnvVar     = "IMAGE_AGENT_CAPI_PROVIDER"
+	AWSEncryptionProviderEnvVar = "IMAGE_AWS_ENCRYPTION_PROVIDER"
+	AWSCAPIProviderEnvVar       = "IMAGE_AWS_CAPI_PROVIDER"
+	AzureCAPIProviderEnvVar     = "IMAGE_AZURE_CAPI_PROVIDER"
+	KubevirtCAPIProviderEnvVar  = "IMAGE_KUBEVIRT_CAPI_PROVIDER"
+	KonnectivityEnvVar          = "IMAGE_KONNECTIVITY"
+)
+
+// TagMapping returns a mapping between tags in an image-refs ImageStream
+// and the corresponding environment variable expected by the HyperShift operator
+func TagMapping() map[string]string {
+	return map[string]string{
+		"apiserver-network-proxy":       KonnectivityEnvVar,
+		"aws-encryption-provider":       AWSEncryptionProviderEnvVar,
+		"cluster-api":                   CAPIEnvVar,
+		"cluster-api-provider-agent":    AgentCAPIProviderEnvVar,
+		"cluster-api-provider-aws":      AWSCAPIProviderEnvVar,
+		"cluster-api-provider-azure":    AzureCAPIProviderEnvVar,
+		"cluster-api-provider-kubevirt": KubevirtCAPIProviderEnvVar,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an image-refs flag to the install command that accepts an imagestream
YAML file that contains tags for images used by the HyperShift operator.
The images are then specified as environment variables on the hypershift
operator and propagated to the appropriate components.

Per-HostedCluster annotations still oveerride any operator-level environment
variables.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [HOSTEDCP-339](https://issues.redhat.com/browse/HOSTEDCP-339)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.