### PR TITLE
Increase terminationGracePeriodSeconds on select Hypershift HA deploy…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -128,6 +128,9 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 				}
 			}),
 		},
+		// The OAS takes up to 75 seconds to finish its graceful shutdown, give it enough time
+		// to do that + 15 seconds margin -> 90s.
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(90),
 	}
 
 	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec)

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
@@ -42,7 +42,7 @@ func openShiftControllerManagerLabels() map[string]string {
 func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, image string, config *corev1.ConfigMap, deploymentConfig config.DeploymentConfig) error {
 	configBytes, ok := config.Data[configKey]
 	if !ok {
-		return fmt.Errorf("openshift apiserver configuration is not expected to be empty")
+		return fmt.Errorf("openshift controller manager configuration is not expected to be empty")
 	}
 	configHash := util.ComputeHash(configBytes)
 
@@ -75,6 +75,9 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		util.BuildVolume(ocmVolumeServingCert(), buildOCMVolumeServingCert),
 		util.BuildVolume(ocmVolumeKubeconfig(), buildOCMVolumeKubeconfig),
 	}
+	// The OCM takes up to 75 seconds to finish its graceful shutdown, give it enough time
+	// to do that + 15 seconds margin -> 90s.
+	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64Ptr(90)
 	deploymentConfig.ApplyTo(deployment)
 	return nil
 }


### PR DESCRIPTION
This PR increases "terminationGracePeriodSeconds" on the following Hypershift HA deployments to 90 seconds because these pods don't terminate in 30 seconds (default).

GitHub issue: https://github.com/openshift/hypershift/issues/1144

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.