### PR TITLE
Fix events message unit test flake

### DIFF
--- a/support/events/message_test.go
+++ b/support/events/message_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -90,6 +91,8 @@ func TestErrorMessages(t *testing.T) {
 			collector := NewMessageCollector(context.Background(), client)
 			result, err := collector.ErrorMessages(fakeObj)
 			g.Expect(err).ToNot(HaveOccurred())
+			sort.Strings(result)
+			sort.Strings(test.expected)
 			g.Expect(result).To(Equal(test.expected))
 		})
 	}


### PR DESCRIPTION


**What this PR does / why we need it**:
Fixes events message unit test
Events by reason are added to a map and their resulting order is unpredictable. Sorting result and expected removes differences in order

**Checklist**
- [x] Subject and description added to both, commit and PR.
