### PR TITLE
Remove CAPI-provider-agent ClusterRole from hypershift Agent platform

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -740,9 +740,19 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Resources: []string{"virtualmachineinstances", "virtualmachines"},
 				Verbs:     []string{"*"},
 			},
-			{
+			{ // This allows hypershift operator to grant RBAC permissions for agents, clusterDeployments and agentClusterInstalls to the capi-provider-agent
 				APIGroups: []string{"agent-install.openshift.io"},
 				Resources: []string{"agents"},
+				Verbs:     []string{"*"},
+			},
+			{
+				APIGroups: []string{"extensions.hive.openshift.io"},
+				Resources: []string{"agentclusterinstalls"},
+				Verbs:     []string{"*"},
+			},
+			{
+				APIGroups: []string{"hive.openshift.io"},
+				Resources: []string{"clusterdeployments"},
 				Verbs:     []string{"*"},
 			},
 		},

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -204,6 +204,18 @@ objects:
     - agents
     verbs:
     - '*'
+  - apiGroups:
+    - extensions.hive.openshift.io
+    resources:
+    - agentclusterinstalls
+    verbs:
+    - '*'
+  - apiGroups:
+    - hive.openshift.io
+    resources:
+    - clusterdeployments
+    verbs:
+    - '*'
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -160,55 +160,6 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 	if err != nil {
 		return fmt.Errorf("failed to reconcile Agent RoleBinding: %w", err)
 	}
-
-	return p.reconcileClusterRole(ctx, c, createOrUpdate, controlPlaneNamespace)
-}
-
-func (p Agent) reconcileClusterRole(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
-	controlPlaneNamespace string) error {
-
-	role := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: CredentialsRBACPrefix,
-		},
-	}
-	_, err := createOrUpdate(ctx, c, role, func() error {
-		role.Rules = []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"cluster.open-cluster-management.io"},
-				Resources: []string{"managedclustersets/join"},
-				Verbs:     []string{"create"},
-			},
-		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to reconcile Agent ClusterRole: %w", err)
-	}
-
-	roleBinding := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
-		},
-	}
-	_, err = createOrUpdate(ctx, c, roleBinding, func() error {
-		roleBinding.Subjects = []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      "capi-provider",
-				Namespace: controlPlaneNamespace,
-			},
-		}
-		roleBinding.RoleRef = rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     CredentialsRBACPrefix,
-		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to reconcile Agent ClusterRoleBinding: %w", err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove CAPI-provider-agent ClusterRole from hypershift Agent platform
Alow hypershift operator to grant RBAC permissions for clusterdeployments and agentClusterInstalls to the cpai-provider-agent

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/MGMT-9591, https://issues.redhat.com/browse/MGMT-9674


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.