### PR TITLE
ensure token minter, socks proxy, and availablity prober are versioned with the control plane operator to prevent large scale restarts on hypershift operator upgrades for IBM Cloud

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2027,9 +2027,6 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 						Args: []string{"run", "--namespace", "$(MY_NAMESPACE)", "--deployment-name", "control-plane-operator",
 							"--metrics-addr", "0.0.0.0:8080", fmt.Sprintf("--enable-ci-debug-output=%t", enableCIDebugOutput),
 							fmt.Sprintf("--registry-overrides=%s", registryOverrideCommandLine),
-							"--socks5-proxy-image", socksImage,
-							"--availability-prober-image", proberImage,
-							"--token-minter-image", minterImage,
 						},
 						Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 8080}},
 						LivenessProbe: &corev1.Probe{
@@ -2065,6 +2062,13 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 				},
 			},
 		},
+	}
+	// TODO: these images will ultimately go away when the CPO is adjusted to have proper subcommands for those images
+	// and that is integrated into all active release payloads.
+	if hc.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--socks5-proxy-image", socksImage,
+			"--availability-prober-image", proberImage,
+			"--token-minter-image", minterImage)
 	}
 
 	if envImage := os.Getenv(images.KonnectivityEnvVar); len(envImage) > 0 {


### PR DESCRIPTION
This PR removes passing the socks proxy, avalability prober, and token-minter images from the hypershift operator to all the downstream namespaces for IBM Cloud deployments. Instead: the version of the control-plane-operator is utilized. This prevents large scale deployment rollouts on any hypershift operator update (that then propogates across all hostedclusters it manages)

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://github.com/openshift/hypershift/issues/1156

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.