### PR TITLE
dev: specify a more useful `ko` base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -27,3 +27,4 @@ builds:
   main: ./token-minter
   flags:
   - -mod=vendor
+defaultBaseImage: gcr.io/distroless/static:debug-nonroot


### PR DESCRIPTION
Before this commit, images built with `ko` used a base image that included
no debugging/userland tools. This commit updates the base image to use the
"debug" variant of the base image which is nominally larger but includes
a busybox userland, which is far more useful by default for a low cost.
