### PR TITLE
Resources: Improve runtime of test

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -3,13 +3,14 @@ package resources
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"math/rand"
-	"testing"
-	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
@@ -42,6 +43,13 @@ var initialObjects = []client.Object{
 	globalconfig.ImageConfig(),
 	globalconfig.ProjectConfig(),
 	globalconfig.BuildConfig(),
+	// Not running bcrypt hashing for the kubeadmin secret massively speeds up the tests, 4s vs 0.1s (and for -race its ~10x that)
+	&corev1.Secret{
+		ObjectMeta: manifests.KubeadminPasswordHashSecret().ObjectMeta,
+		Data: map[string][]byte{
+			"kubeadmin": []byte("something"),
+		},
+	},
 }
 
 func shouldNotError(key client.ObjectKey) bool {


### PR DESCRIPTION
The test is currently extremely slow and takes about 20 minutes with
`-race -count=25`. Improve that by pre-creating the secret that holds
the bcrypt hash of the kubeadm password, which makes the reconciliation
skip the calculation of said hash and brings the runtime with above
parameters down to ~20 seconds.

Needed for https://github.com/openshift/hypershift/pull/1166

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.