### PR TITLE
Converge helper binaries and ignition-server into CPO binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,9 @@ COPY . .
 RUN make build
 
 FROM quay.io/openshift/origin-base:4.10
-COPY --from=builder /hypershift/bin/ignition-server \
-                    /hypershift/bin/hypershift \
+COPY --from=builder /hypershift/bin/hypershift \
                     /hypershift/bin/hypershift-operator \
                     /hypershift/bin/control-plane-operator \
-                    /hypershift/bin/konnectivity-socks5-proxy \
-                    /hypershift/bin/availability-prober \
-                    /hypershift/bin/token-minter \
      /usr/bin/
 
 ENTRYPOINT /usr/bin/hypershift

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 
 all: build e2e
 
-build: ignition-server hypershift-operator control-plane-operator konnectivity-socks5-proxy hypershift availability-prober token-minter
+build: hypershift-operator control-plane-operator hypershift
 
 .PHONY: update
 update: deps api api-docs app-sre-saas-template
@@ -60,11 +60,6 @@ $(STATICCHECK): $(TOOLS_DIR)/go.mod # Build staticcheck from tools folder.
 $(GENAPIDOCS): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR); GO111MODULE=on GOFLAGS=-mod=vendor go build -tags=tools -o $(GENAPIDOCS) github.com/ahmetb/gen-crd-api-reference-docs
 
-# Build ignition-server binary
-.PHONY: ignition-server
-ignition-server:
-	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/ignition-server ./ignition-server
-
 # Build hypershift-operator binary
 .PHONY: hypershift-operator
 hypershift-operator:
@@ -74,22 +69,9 @@ hypershift-operator:
 control-plane-operator:
 	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/control-plane-operator ./control-plane-operator
 
-# Build konnectivity-socks5-proxy binary
-.PHONY: konnectivity-socks5-proxy
-konnectivity-socks5-proxy:
-	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/konnectivity-socks5-proxy ./konnectivity-socks5-proxy
-
 .PHONY: hypershift
 hypershift:
 	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift .
-
-.PHONY: availability-prober
-availability-prober:
-	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/availability-prober ./availability-prober
-
-.PHONY: token-minter
-token-minter:
-	$(GO_BUILD_RECIPE) -o bin/token-minter ./token-minter
 
 # Run this when updating any of the types in the api package to regenerate the
 # deepcopy code and CRD manifest files.

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -161,12 +161,12 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 		)
 		dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, corev1.Container{
 			Name:    "token-minter",
-			Command: []string{"/usr/bin/token-minter"},
+			Command: []string{"/usr/bin/control-plane-operator", "token-minter"},
 			Args: []string{
-				"-service-account-namespace=openshift-ingress-operator",
-				"-service-account-name=ingress-operator",
-				"-token-file=/var/run/secrets/openshift/serviceaccount/token",
-				"-kubeconfig=/etc/kubernetes/kubeconfig",
+				"--service-account-namespace=openshift-ingress-operator",
+				"--service-account-name=ingress-operator",
+				"--token-file=/var/run/secrets/openshift/serviceaccount/token",
+				"--kubeconfig=/etc/kubernetes/kubeconfig",
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -203,7 +203,7 @@ func ingressOperatorSocks5ProxyContainer(socks5ProxyImage string) corev1.Contain
 	c := corev1.Container{
 		Name:    socks5ProxyContainerName,
 		Image:   socks5ProxyImage,
-		Command: []string{"/usr/bin/konnectivity-socks5-proxy"},
+		Command: []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy"},
 		Args:    []string{"run"},
 		Env: []corev1.EnvVar{{
 			Name:  "KUBECONFIG",

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/aws_kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/aws_kms.go
@@ -206,11 +206,11 @@ func buildKASContainerAWSKMSTokenMinter(image string) func(*corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.ImagePullPolicy = corev1.PullAlways
-		c.Command = []string{"/usr/bin/token-minter"}
+		c.Command = []string{"/usr/bin/control-plane-operator", "token-minter"}
 		c.Args = []string{
-			"-service-account-namespace=kube-system",
-			"-service-account-name=kms-provider",
-			"-token-audience=openshift",
+			"--service-account-namespace=kube-system",
+			"--service-account-name=kms-provider",
+			"--token-audience=openshift",
 			fmt.Sprintf("-token-file=%s", path.Join(awsKMSVolumeMounts.Path(c.Name, kasVolumeAWSKMSCloudProviderToken().Name), "token")),
 			fmt.Sprintf("-kubeconfig=%s", path.Join(awsKMSVolumeMounts.Path(c.Name, kasVolumeLocalhostKubeconfig().Name), KubeconfigKey)),
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -175,7 +175,7 @@ func buildOASTrustAnchorGenerator(oasImage string) func(*corev1.Container) {
 func buildOASSocks5ProxyContainer(socks5ProxyImage string) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = socks5ProxyImage
-		c.Command = []string{"/usr/bin/konnectivity-socks5-proxy"}
+		c.Command = []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy"}
 		c.Args = []string{"run"}
 		c.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-operator-deployment.yaml
@@ -95,7 +95,8 @@ spec:
               value: kube-apiserver,redhat-operators,certified-operators,community-operators,redhat-marketplace
         - name: socks5-proxy
           command:
-            - "/usr/bin/konnectivity-socks5-proxy"
+            - /usr/bin/control-plane-operator
+            - konnectivity-socks5-proxy
           args:
             - run
           image: SOCKS5_PROXY_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
@@ -92,7 +92,8 @@ spec:
               memory: 160Mi
         - name: socks5-proxy
           command:
-            - "/usr/bin/konnectivity-socks5-proxy"
+            - /usr/bin/control-plane-operator
+            - konnectivity-socks5-proxy
           args:
             - run
           image: SOCKS5_PROXY_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
@@ -83,7 +83,8 @@ spec:
           readOnly: true
       - name: socks5-proxy
         command:
-          - "/usr/bin/konnectivity-socks5-proxy"
+          - /usr/bin/control-plane-operator
+          - konnectivity-socks5-proxy
         args:
           - run
         image: SOCKS5_PROXY_IMAGE

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -6,14 +6,18 @@ import (
 	"os"
 	"time"
 
+	availabilityprober "github.com/openshift/hypershift/availability-prober"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedapicache"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator"
+	ignitionserver "github.com/openshift/hypershift/ignition-server"
+	konnectivitysocks5proxy "github.com/openshift/hypershift/konnectivity-socks5-proxy"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/util"
+	tokenminter "github.com/openshift/hypershift/token-minter"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +59,10 @@ func main() {
 	}
 	cmd.AddCommand(NewStartCommand())
 	cmd.AddCommand(hostedclusterconfigoperator.NewCommand())
+	cmd.AddCommand(konnectivitysocks5proxy.NewStartCommand())
+	cmd.AddCommand(availabilityprober.NewStartCommand())
+	cmd.AddCommand(tokenminter.NewStartCommand())
+	cmd.AddCommand(ignitionserver.NewStartCommand())
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -29,16 +29,14 @@ const (
 	imageCAPA = "registry.ci.openshift.org/hypershift/cluster-api-aws-controller:v1.1.0"
 )
 
-func New(availabilityProberImage string, tokenMinterImage string) *AWS {
+func New(controlPlaneOperatorImage string) *AWS {
 	return &AWS{
-		avaiabilityProberImage: availabilityProberImage,
-		tokenMinterImage:       tokenMinterImage,
+		controlPlaneOperatorImage: controlPlaneOperatorImage,
 	}
 }
 
 type AWS struct {
-	avaiabilityProberImage string
-	tokenMinterImage       string
+	controlPlaneOperatorImage string
 }
 
 func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
@@ -194,7 +192,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 					},
 					{
 						Name:            "token-minter",
-						Image:           p.tokenMinterImage,
+						Image:           p.controlPlaneOperatorImage,
 						ImagePullPolicy: corev1.PullAlways,
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -206,13 +204,13 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 								MountPath: "/etc/kubernetes",
 							},
 						},
-						Command: []string{"/usr/bin/token-minter"},
+						Command: []string{"/usr/bin/control-plane-operator", "token-minter"},
 						Args: []string{
-							"-service-account-namespace=kube-system",
-							"-service-account-name=capa-controller-manager",
-							"-token-audience=openshift",
-							"-token-file=/var/run/secrets/openshift/serviceaccount/token",
-							"-kubeconfig=/etc/kubernetes/kubeconfig",
+							"--service-account-namespace=kube-system",
+							"--service-account-name=capa-controller-manager",
+							"--token-audience=openshift",
+							"--token-file=/var/run/secrets/openshift/serviceaccount/token",
+							"--kubeconfig=/etc/kubernetes/kubeconfig",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -225,7 +223,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 			},
 		},
 	}
-	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Namespace, hcp.Spec.APIPort), p.avaiabilityProberImage, &deploymentSpec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Namespace, hcp.Spec.APIPort), p.controlPlaneOperatorImage, &deploymentSpec.Template.Spec)
 	return deploymentSpec, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -56,11 +56,11 @@ type Platform interface {
 	DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error
 }
 
-func GetPlatform(hcluster *hyperv1.HostedCluster, availabilityProberImage string, tokenMinterImage string) (Platform, error) {
+func GetPlatform(hcluster *hyperv1.HostedCluster, controlplaneOperatorImage string) (Platform, error) {
 	var platform Platform
 	switch hcluster.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
-		platform = aws.New(availabilityProberImage, tokenMinterImage)
+		platform = aws.New(controlplaneOperatorImage)
 	case hyperv1.IBMCloudPlatform:
 		platform = &ibmcloud.IBMCloud{}
 	case hyperv1.NonePlatform:

--- a/ignition-server/main.go
+++ b/ignition-server/main.go
@@ -1,4 +1,4 @@
-package main
+package ignitionserver
 
 import (
 	"context"
@@ -30,6 +30,14 @@ const namespaceEnvVariableName = "MY_NAMESPACE"
 var ignPathPattern = regexp.MustCompile("^/ignition[^/ ]*$")
 var payloadStore = controllers.NewPayloadStore()
 
+type Options struct {
+	Addr              string
+	CertFile          string
+	KeyFile           string
+	RegistryOverrides map[string]string
+	Platform          string
+}
+
 // This is an https server that enable us to satisfy
 // 1 - 1 relation between clusters and ign endpoints.
 // It runs a token Secret controller.
@@ -39,33 +47,9 @@ var payloadStore = controllers.NewPayloadStore()
 // A token represents a given cluster version (and in the future also a machine Config) at any given point in time.
 // For a request to succeed a token needs to be passed in the Header.
 // TODO (alberto): Metrics.
-func main() {
-	cmd := &cobra.Command{
-		Use: "ignition-server",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-			os.Exit(1)
-		},
-	}
-	cmd.AddCommand(NewStartCommand())
-
-	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-}
-
-type Options struct {
-	Addr              string
-	CertFile          string
-	KeyFile           string
-	RegistryOverrides map[string]string
-	Platform          string
-}
-
 func NewStartCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "start",
+		Use:   "ignition-server",
 		Short: "Starts the ignition server",
 	}
 

--- a/konnectivity-socks5-proxy/http_proxy.go
+++ b/konnectivity-socks5-proxy/http_proxy.go
@@ -1,4 +1,4 @@
-package main
+package konnectivitysocks5proxy
 
 import (
 	"bufio"

--- a/support/util/cloudprovidercreds.go
+++ b/support/util/cloudprovidercreds.go
@@ -112,7 +112,7 @@ func buildCloudProviderTokenMinterContainer(image string, args []string) func(c 
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.ImagePullPolicy = corev1.PullAlways
-		c.Command = []string{"/usr/bin/token-minter"}
+		c.Command = []string{"/usr/bin/control-plane-operator", "token-minter"}
 		c.Args = args
 		c.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -127,11 +127,11 @@ func tokenMinterArgs() []string {
 		return path.Join(cloudProviderTokenVolumeMount("").Path(cloudProviderInitContainerTokenMinter().Name, vol), file)
 	}
 	return []string{
-		"-service-account-namespace=kube-system",
-		"-service-account-name=kube-controller-manager",
-		"-token-audience=openshift",
-		fmt.Sprintf("-token-file=%s", cpath(cloudProviderTokenVolume().Name, "token")),
-		fmt.Sprintf("-kubeconfig=%s", cpath(cloudProviderTokenKubeconfigVolume().Name, KubeconfigKey)),
+		"--service-account-namespace=kube-system",
+		"--service-account-name=kube-controller-manager",
+		"--token-audience=openshift",
+		fmt.Sprintf("--token-file=%s", cpath(cloudProviderTokenVolume().Name, "token")),
+		fmt.Sprintf("--kubeconfig=%s", cpath(cloudProviderTokenKubeconfigVolume().Name, KubeconfigKey)),
 	}
 }
 

--- a/support/util/containers.go
+++ b/support/util/containers.go
@@ -36,7 +36,8 @@ func AvailabilityProber(target string, image string, spec *corev1.PodSpec, o ...
 		Image:           image,
 		ImagePullPolicy: corev1.PullAlways,
 		Command: []string{
-			"/usr/bin/availability-prober",
+			"/usr/bin/control-plane-operator",
+			"availability-prober",
 			"--target",
 			target,
 		},


### PR DESCRIPTION
This makes them part of the payload and thus avoids rotating most of the
controlplane when the hypershift operator gets updated.

Ref https://github.com/openshift/hypershift/issues/1156

This will break running with a CPO from release-4.10, I will submit a forwarding PR for that once this merges.

/cc @relyt0925 @csrwng 

Fixes https://github.com/openshift/hypershift/issues/1156

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.