### PR TITLE
Unify hypershift install make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,11 +219,7 @@ run-local:
 	bin/hypershift-operator run
 
 .PHONY: ci-install-hypershift
-ci-install-hypershift:
-	bin/hypershift install --hypershift-image $(HYPERSHIFT_RELEASE_LATEST) \
-		--oidc-storage-provider-s3-credentials=/etc/hypershift-pool-aws-credentials/credentials \
-		--oidc-storage-provider-s3-bucket-name=hypershift-ci-oidc \
-		--oidc-storage-provider-s3-region=us-east-1
+ci-install-hypershift: ci-install-hypershift-private
 
 .PHONY: ci-install-hypershift-private
 ci-install-hypershift-private:


### PR DESCRIPTION
Periodics were broken by https://github.com/openshift/release/pull/27079 because the hypershift install step configures hypershift with private cluster support in some tests and not in others.

Unify the make targets so that hypershift is always installed with private cluster support.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.