### PR TITLE
Alow hypershift operator to grant RBAC permissions for agentClusterInstalls to the cpai-provider-agent

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -745,6 +745,16 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Resources: []string{"agents"},
 				Verbs:     []string{"*"},
 			},
+			{
+				APIGroups: []string{"extensions.hive.openshift.io"},
+				Resources: []string{"agentclusterinstalls"},
+				Verbs:     []string{"*"},
+			},
+			{
+				APIGroups: []string{"hive.openshift.io"},
+				Resources: []string{"clusterdeployments"},
+				Verbs:     []string{"*"},
+			},
 		},
 	}
 	return role

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -204,6 +204,18 @@ objects:
     - agents
     verbs:
     - '*'
+  - apiGroups:
+    - extensions.hive.openshift.io
+    resources:
+    - agentclusterinstalls
+    verbs:
+    - '*'
+  - apiGroups:
+    - hive.openshift.io
+    resources:
+    - clusterdeployments
+    verbs:
+    - '*'
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:


### PR DESCRIPTION


**What this PR does / why we need it**:
The Agent platform is broken without it due to
https://github.com/openshift/hypershift/pull/1136

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/MGMT-9674

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.