### PR TITLE
Make clusterID optional in HostedControlPlane clusterID

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -34,10 +34,15 @@ type HostedControlPlaneSpec struct {
 	// NetworkType specifies the SDN provider used for cluster networking.
 	NetworkType NetworkType                 `json:"networkType"`
 	SSHKey      corev1.LocalObjectReference `json:"sshKey"`
-	ClusterID   string                      `json:"clusterID"`
-	InfraID     string                      `json:"infraID"`
-	Platform    PlatformSpec                `json:"platform"`
-	DNS         DNSSpec                     `json:"dns"`
+	// ClusterID is the unique id that identifies the cluster externally.
+	// Making it optional here allows us to keep compatibility with previous
+	// versions of the control-plane-operator that have no knowledge of this
+	// field.
+	// +optional
+	ClusterID string       `json:"clusterID,omitempty"`
+	InfraID   string       `json:"infraID"`
+	Platform  PlatformSpec `json:"platform"`
+	DNS       DNSSpec      `json:"dns"`
 
 	// APIPort is the port at which the APIServer listens inside a worker
 	// +optional

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -66,6 +66,10 @@ spec:
                     type: string
                 type: object
               clusterID:
+                description: ClusterID is the unique id that identifies the cluster
+                  externally. Making it optional here allows us to keep compatibility
+                  with previous versions of the control-plane-operator that have no
+                  knowledge of this field.
                 type: string
               configuration:
                 description: 'Configuration embeds resources that correspond to the
@@ -863,7 +867,6 @@ spec:
                     type: string
                 type: object
             required:
-            - clusterID
             - dns
             - etcd
             - infraID

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2844,6 +2844,11 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>ClusterID is the unique id that identifies the cluster externally.
+Making it optional here allows us to keep compatibility with previous
+versions of the control-plane-operator that have no knowledge of this
+field.</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -20892,6 +20892,10 @@ objects:
                       type: string
                   type: object
                 clusterID:
+                  description: ClusterID is the unique id that identifies the cluster
+                    externally. Making it optional here allows us to keep compatibility
+                    with previous versions of the control-plane-operator that have
+                    no knowledge of this field.
                   type: string
                 configuration:
                   description: 'Configuration embeds resources that correspond to
@@ -21699,7 +21703,6 @@ objects:
                       type: string
                   type: object
               required:
-              - clusterID
               - dns
               - etcd
               - infraID


### PR DESCRIPTION

**What this PR does / why we need it**:
Previous versions of control plane operators have no knowledge of new
fields added to the HostedControlPlane resource. In order to maintain
backwards compatibility we cannot add any required fields to the
HostedControlPlane type.

This change makes the `clusterID` field optional to maintain
compatibility with previous control-plane-operators.

**Checklist**
- [x] Subject and description added to both, commit and PR.