### PR TITLE
Introduce `OIDCConfigurationInvalid` condition for OIDC setup validation

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1044,6 +1044,10 @@ const (
 	// ReconciliationPaused indicates if reconciliation of the hostedcluster is
 	// paused.
 	ReconciliationPaused ConditionType = "ReconciliationPaused"
+
+	// OIDCConfigurationInvalid indicates if an AWS cluster's OIDC condition is
+	// detected as invalid.
+	OIDCConfigurationInvalid ConditionType = "OIDCConfigurationInvalid"
 )
 
 const (
@@ -1078,6 +1082,8 @@ const (
 	UnmanagedEtcdAsExpected          = "UnmanagedEtcdAsExpected"
 
 	InsufficientClusterCapabilitiesReason = "InsufficientClusterCapabilities"
+
+	OIDCConfigurationInvalidReason = "OIDCConfigurationInvalid"
 )
 
 // HostedClusterStatus is the latest observed status of a HostedCluster.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2019,6 +2019,10 @@ HostedCluster is available to handle ignition requests.</p>
 <td></td>
 </tr><tr><td><p>&#34;KubeAPIServerAvailable&#34;</p></td>
 <td></td>
+</tr><tr><td><p>&#34;OIDCConfigurationInvalid&#34;</p></td>
+<td><p>OIDCConfigurationInvalid indicates if an AWS cluster&rsquo;s OIDC condition is
+detected as invalid.</p>
+</td>
 </tr><tr><td><p>&#34;ReconciliationPaused&#34;</p></td>
 <td><p>ReconciliationPaused indicates if reconciliation of the hostedcluster is
 paused.</p>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/blang/semver"
@@ -1064,7 +1065,23 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	switch hcluster.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		if err := r.reconcileAWSOIDCDocuments(ctx, log, hcluster, hcp); err != nil {
+			meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+				Type:               string(hyperv1.OIDCConfigurationInvalid),
+				Status:             metav1.ConditionTrue,
+				Reason:             hyperv1.OIDCConfigurationInvalidReason,
+				ObservedGeneration: hcluster.Generation,
+				Message:            err.Error(),
+			})
+			if statusErr := r.Client.Status().Update(ctx, hcluster); statusErr != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to reconcile AWS OIDC documents: %s, failed to update status: %w", err, statusErr)
+			}
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile the AWS OIDC documents: %w", err)
+		}
+		if meta.IsStatusConditionTrue(hcluster.Status.Conditions, string(hyperv1.OIDCConfigurationInvalid)) {
+			meta.RemoveStatusCondition(&hcluster.Status.Conditions, string(hyperv1.OIDCConfigurationInvalid))
+			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+			}
 		}
 	}
 
@@ -3943,7 +3960,21 @@ func (r *HostedClusterReconciler) reconcileAWSOIDCDocuments(ctx context.Context,
 			Key:    aws.String(hcluster.Spec.InfraID + path),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to upload %s to the %s s3 bucket: %w", path, r.OIDCStorageProviderS3BucketName, err)
+			wrapped := fmt.Errorf("failed to upload %s to the %s s3 bucket", path, r.OIDCStorageProviderS3BucketName)
+			if awsErr := awserr.Error(nil); errors.As(err, &awsErr) {
+				switch awsErr.Code() {
+				case s3.ErrCodeNoSuchBucket:
+					wrapped = fmt.Errorf("%w: %s: this could be a misconfiguration of the hypershift operator; check the --aws-oidc-bucket-name flag", wrapped, awsErr.Code())
+				default:
+					// Generally, the underlying message from AWS has unique per-request
+					// info not suitable for publishing as condition messages, so just
+					// return the code. If other specific error types can be handled, add
+					// new switch cases and try to provide more actionable info to the
+					// user.
+					wrapped = fmt.Errorf("%w: aws returned an error: %s", wrapped, awsErr.Code())
+				}
+			}
+			return wrapped
 		}
 	}
 


### PR DESCRIPTION
This commit introduces a new `OIDCConfigurationInvalid` condition for
HostedCluster. If OIDC documents cannot be reconciled for a cluster,
`OIDCConfigurationInvalid=True`, otherwise `OIDCConfigurationInvalid` is
removed. The message associated with the condition tries to provide some more
helpful context about what might be wrong to help the user correct the issue.
More error interpretation can be added in the future.
