### PR TITLE
Fix OLM container restart flakes in CI

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-operator-deployment.yaml
@@ -66,6 +66,7 @@ spec:
             - containerPort: 8443
               name: metrics
           livenessProbe:
+            initialDelaySeconds: 60
             httpGet:
               path: /healthz
               port: 8443

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             - containerPort: 8443
               name: metrics
           livenessProbe:
+            initialDelaySeconds: 60
             httpGet:
               path: /healthz
               port: 8443

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
@@ -71,7 +72,12 @@ func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef 
 		}
 	}
 	dc.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+		o.KubeconfigVolumeName = "kubeconfig"
+		o.RequiredAPIs = []schema.GroupVersionKind{
+			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},
+		}
+	})
 	return nil
 }
 
@@ -115,7 +121,12 @@ func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef conf
 		}
 	}
 	dc.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+		o.KubeconfigVolumeName = "kubeconfig"
+		o.RequiredAPIs = []schema.GroupVersionKind{
+			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},
+		}
+	})
 	return nil
 }
 


### PR DESCRIPTION
This is another source of flakes in the periodics: `olm-operator` and `catalog-operator` container restarts.

This happens because the availability prober blocks main container start until the guest KAS is up, but does not check if the CRDs that OLM components will watch are also installed.  Thus the container starts but the component is unable to establish watches on the CRDs until they are installed into the guest cluster by the CVO.  During this time, the liveness probe is failing.  If the watches can not be established within 30s (failureThreshold: 30, period: 10), the container is killed and restarted, resulting in a test failure.

This PR does two things to prevent this:
- `availability-prober` init container now waits for one of the OLM CRDs to be available before allowing the main container to start
- `initialDelaySeconds` is set to `60` on the liveness probes so the components have time to come up and establish there watches

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.