### PR TITLE
add required-api to availablity prober for OLM and HCCO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -125,6 +125,10 @@ func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef conf
 		o.KubeconfigVolumeName = "kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},
+			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "Subscription"},
+			{Group: "operators.coreos.com", Version: "v2", Kind: "OperatorCondition"},
+			{Group: "operators.coreos.com", Version: "v1", Kind: "OperatorGroup"},
+			{Group: "operators.coreos.com", Version: "v1", Kind: "OLMConfig"},
 		}
 	})
 	return nil


### PR DESCRIPTION
Still seeing CI flakes where informer caches timeout on their watches for types the CVO has not yet installed

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.