### PR TITLE
Revert "PKI: Use ECDSA keys by default"

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,0 @@
-[allowlist]
-  description = "Allowlist"
-  paths = [
-    '''control-plane-operator\/controllers\/hostedcontrolplane\/pki\/cert_test\.go''',
-  ]

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -28,15 +28,11 @@ func reconcileSelfSignedCA(secret *corev1.Secret, ownerRef config.OwnerRef, cn, 
 	if err != nil {
 		return fmt.Errorf("failed to generate CA (cn=%s,ou=%s): %w", cn, ou, err)
 	}
-	privKeyPem, err := certs.PrivateKeyToPem(key)
-	if err != nil {
-		return fmt.Errorf("failed to serialize private key to PEM: %w", err)
-	}
 	if secret.Data == nil {
 		secret.Data = map[string][]byte{}
 	}
 	secret.Data[CASignerCertMapKey] = certs.CertToPem(crt)
-	secret.Data[CASignerKeyMapKey] = privKeyPem
+	secret.Data[CASignerKeyMapKey] = certs.PrivateKeyToPem(key)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/cert_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/cert_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -13,68 +12,7 @@ import (
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func rsaRootCA() *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "rsa",
-		},
-		Data: map[string][]byte{
-			CASignerCertMapKey: []byte(`-----BEGIN CERTIFICATE-----
-MIIDizCCAnOgAwIBAgIUU8MSwNvrwDfka3vMf67IGWxK3zYwDQYJKoZIhvcNAQEL
-BQAwVDELMAkGA1UEBhMCWFgxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UE
-CgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UEAwwHcm9vdC1jYTAgFw0yMjAz
-MTgwMDM5MzZaGA8yMTIyMDIyMjAwMzkzNlowVDELMAkGA1UEBhMCWFgxFTATBgNV
-BAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQ
-MA4GA1UEAwwHcm9vdC1jYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-ALNltzcqG+vJ0wK9FNuNgavGayfiO9nMh1Bl49ybO356XCVnf0Wt4noKaqbfsUuT
-1xgHj4dX6319NNgWjkQbI6HIgJWxXmNbhuC2Lr9ZQ0RcR9tKu9P50jlDAaP3AFrH
-sUHghHovqh9rYOb9vY1Rvit4tt5akl5c3sYn693/aqeA/vM0cJm4++CQCblHTyYh
-zF/+s/KZ2kD670IVBJYX4/tq5pVjV2g7PYJQblR4RS0CrFf37pj5EdHm8dvitO21
-9aLF6izXTvT1hoHdQvBGraIujIG6oT+P0EAWxfneOYPX1BOYGNH38rk90j3OzWYg
-w40OeZI3fP5lpS/KljyXNgcCAwEAAaNTMFEwHQYDVR0OBBYEFEI1WTEJDpk939vr
-YsdLDATHICIZMB8GA1UdIwQYMBaAFEI1WTEJDpk939vrYsdLDATHICIZMA8GA1Ud
-EwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAIZT6bIp4RhsZLjC0p7LSH4v
-aN+2JZKEMmCf/xgbJPizaZOvfyMykHIumGFXQmV1dser/pg3o5uAd9V6OhLXib6u
-lhyx0tWhcEi2WkMME/TMdwWKKt7RpnMPp1Aq8ZDCMArVWsqhYbjRFR7+Mz/+U46Y
-3Tl3wkWi+598ruiSKOZodwk1Nl0Sc3zR9/GphnmwKmXFukgdTv4HtGTjA8c3s+hB
-50WT43ndKOQLWaBkWhvev2vBz3K3ZAi1ENoDjFYwtLym1AlisLlKOOUeC6ChpLAr
-NakE7TNr5654KIzEGFHLA3h4UxNl33/m5zFgL0ByZTtCA1cvAnlLGOn7/MgN0Y4=
------END CERTIFICATE-----
-`),
-			CASignerKeyMapKey: []byte(`-----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAs2W3Nyob68nTAr0U242Bq8ZrJ+I72cyHUGXj3Js7fnpcJWd/
-Ra3iegpqpt+xS5PXGAePh1frfX002BaORBsjociAlbFeY1uG4LYuv1lDRFxH20q7
-0/nSOUMBo/cAWsexQeCEei+qH2tg5v29jVG+K3i23lqSXlzexifr3f9qp4D+8zRw
-mbj74JAJuUdPJiHMX/6z8pnaQPrvQhUElhfj+2rmlWNXaDs9glBuVHhFLQKsV/fu
-mPkR0ebx2+K07bX1osXqLNdO9PWGgd1C8Eatoi6MgbqhP4/QQBbF+d45g9fUE5gY
-0ffyuT3SPc7NZiDDjQ55kjd8/mWlL8qWPJc2BwIDAQABAoIBAFdNV6UD3ASZ+hMq
-Gv1hVspWTA1jvkaWjv8kJohUDtbVCwS04i3xmfZUHWTKFUi3UISEIWf29EXkaZQD
-HgaswmFX5qNyZoGpp/CxF/zMnrykv99K9i8JMzHklubJLCYBahSqAy5HBd42bjjb
-IKSmNAqJu0xn/TToswzxnooxYyDSB0oKyfEDIXz97MA61G7SeL3FLORT8+WjP0kc
-1FoIRHo5awG0z61ShA1rC0jByHjjaj96VehT7ZspurINiFQM9bR5tWhxYgtQumvv
-QvQQ2FYMTZY8/S7cvBqMDi3APz5E7bMUMey5nArKQfQIQ2cVuBt4vxR/eUc4zV3y
-JIVI3mECgYEA6u0bMeQUh301+foSR71B5oW47MvVbM/ThEM8GaCWWNKp1OVlS0cy
-Q1ToB5yxDDh150lMNJauN1NnjYczguk9788osKwOxlzjNbE05jQ/9NH964ghpNLT
-ltx522JiMMHTp4mjJmkdYtKWRGs2Mehhij3UFQrqsThJODK3Gb4Hh1ECgYEAw31u
-2fEzcuLWunn+vPSbSbZs5TtjtdbggF46to2JlReshL5B7WKa0mm2ctcKzn94p0VD
-woczvqgEjOBJCvI2p3WoHCXPDjQE0RAGKi/UwnhrWylFvH3+XZiOhLd1w+phxGYL
-q73vGL1GE/85PrrxT088v4bev/PpWrB86kQZQdcCgYBmkwaHvyVzjyktL5IhvrHy
-fDqlMc7LRub83fp02hgrSjgbG9ohh0GcAouZH0JyqohYZzmd0Jja0VDqi7jjFQIV
-HiePFGETHWWbgPcu+GtgcvvihjriY6c9PKD8ODXVQhwvD7qrv8Oz7WztDL7KBcPo
-/1wFoBGfNYtKvWITHFTfMQKBgQCyo7zYjAFnysJORYzzPtNo2LtJ/qtvT5x3saQV
-jeFbzPZplzLHqoOwI8oFx1yotvOaZ0E0UjiG0SLXWV1mE1C+VlX44tQDNqXwJaR8
-iJjz3Pa9p0mCpd/7x5z0ynFjRptwzY98sWP8R3nybBfzqwE4aEArBSQoZMupg/2i
-Vfh+oQKBgQDUho++wrV1Djf7f1Tsf+Dz6MjaKi7HOG0i4Y/5BNLBOecMx2vnj0xT
-3tO8SI3Xp9lgqsTPsjKb/BKV1YnaM+OOCuLWGOC6A9/5CLdkVd1SPyv0/gWFa/xG
-cbB8e1/poskGpVSBbY2tUDSRqteUR7irvQlwpTCWATjjuBW7hd9knQ==
------END RSA PRIVATE KEY-----
-`),
-		},
-	}
-}
 
 func TestReconcileSignedCertWithKeysAndAddresses(t *testing.T) {
 	t.Parallel()
@@ -84,146 +22,124 @@ func TestReconcileSignedCertWithKeysAndAddresses(t *testing.T) {
 		t.Fatalf("failed go generate CA: %v", err)
 	}
 
-	caKeyPem, err := certs.PrivateKeyToPem(caKey)
-	if err != nil {
-		t.Fatalf("failed to serialize CA key to pem: %v", err)
-	}
-	ed25519RootCA := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "ed25519",
-		},
+	caSecret := &corev1.Secret{
 		Data: map[string][]byte{
 			CASignerCertMapKey: certs.CertToPem(caCert),
-			CASignerKeyMapKey:  caKeyPem,
+			CASignerKeyMapKey:  certs.PrivateKeyToPem(caKey),
 		},
 	}
 
-	// Run all tests with a RSA and ED25519 CA to ensure compatibility
-	for _, caSecret := range []*corev1.Secret{rsaRootCA(), ed25519RootCA} {
-		t.Run(caSecret.Name+" ca", func(t *testing.T) {
-			testCases := []struct {
-				name         string
-				secret       func() (*corev1.Secret, error)
-				expectUpdate bool
-			}{
-				{
-					name: "Valid secret, no change",
-					secret: func() (*corev1.Secret, error) {
-						cfg := &certs.CertCfg{
-							Subject:      pkix.Name{CommonName: "foo", Organization: []string{"org"}},
-							KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-							ExtKeyUsages: X509UsageServerAuth,
-							Validity:     certs.ValidityOneYear,
-							DNSNames:     []string{"foo.svc.local"},
-							IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
-						}
-						key, cert, err := certs.GenerateSignedCertificate(caKey, caCert, cfg)
-						if err != nil {
-							return nil, err
-						}
-						privKeyPem, err := certs.PrivateKeyToPem(key)
-						if err != nil {
-							return nil, fmt.Errorf("failed to serialize private key to pem: %v", err)
-						}
-						return &corev1.Secret{
-							Data: map[string][]byte{
-								corev1.TLSPrivateKeyKey: privKeyPem,
-								corev1.TLSCertKey:       certs.CertToPem(cert),
-							},
-						}, nil
+	testCases := []struct {
+		name         string
+		secret       func() (*corev1.Secret, error)
+		expectUpdate bool
+	}{
+		{
+			name: "Valid secret, no change",
+			secret: func() (*corev1.Secret, error) {
+				cfg := &certs.CertCfg{
+					Subject:      pkix.Name{CommonName: "foo", Organization: []string{"org"}},
+					KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+					ExtKeyUsages: X509UsageServerAuth,
+					Validity:     certs.ValidityOneYear,
+					DNSNames:     []string{"foo.svc.local"},
+					IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+				}
+				key, cert, err := certs.GenerateSignedCertificate(caKey, caCert, cfg)
+				if err != nil {
+					return nil, err
+				}
+				return &corev1.Secret{
+					Data: map[string][]byte{
+						corev1.TLSPrivateKeyKey: certs.PrivateKeyToPem(key),
+						corev1.TLSCertKey:       certs.CertToPem(cert),
 					},
-					expectUpdate: false,
-				},
-				{
-					name: "Expires in one day, cert is re-generated",
-					secret: func() (*corev1.Secret, error) {
-						cfg := &certs.CertCfg{
-							Subject:      pkix.Name{CommonName: "foo", Organization: []string{"org"}},
-							KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-							ExtKeyUsages: X509UsageServerAuth,
-							Validity:     24 * time.Hour,
-							DNSNames:     []string{"foo.svc.local"},
-							IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
-						}
-						key, cert, err := certs.GenerateSignedCertificate(caKey, caCert, cfg)
-						if err != nil {
-							return nil, err
-						}
-						privKeyPem, err := certs.PrivateKeyToPem(key)
-						if err != nil {
-							return nil, fmt.Errorf("failed to serialize private key to pem: %v", err)
-						}
-						return &corev1.Secret{
-							Data: map[string][]byte{
-								corev1.TLSPrivateKeyKey: privKeyPem,
-								corev1.TLSCertKey:       certs.CertToPem(cert),
-							},
-						}, nil
+				}, nil
+			},
+			expectUpdate: false,
+		},
+		{
+			name: "Expires in one day, cert is re-generated",
+			secret: func() (*corev1.Secret, error) {
+				cfg := &certs.CertCfg{
+					Subject:      pkix.Name{CommonName: "foo", Organization: []string{"org"}},
+					KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+					ExtKeyUsages: X509UsageServerAuth,
+					Validity:     24 * time.Hour,
+					DNSNames:     []string{"foo.svc.local"},
+					IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+				}
+				key, cert, err := certs.GenerateSignedCertificate(caKey, caCert, cfg)
+				if err != nil {
+					return nil, err
+				}
+				return &corev1.Secret{
+					Data: map[string][]byte{
+						corev1.TLSPrivateKeyKey: certs.PrivateKeyToPem(key),
+						corev1.TLSCertKey:       certs.CertToPem(cert),
 					},
-					expectUpdate: true,
-				},
-				{
-					name: "Empty secret gets filled",
-					secret: func() (*corev1.Secret, error) {
-						return &corev1.Secret{}, nil
+				}, nil
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "Empty secret gets filled",
+			secret: func() (*corev1.Secret, error) {
+				return &corev1.Secret{}, nil
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "Garbage entries get replaced",
+			secret: func() (*corev1.Secret, error) {
+				return &corev1.Secret{
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte("not a cert"),
+						corev1.TLSPrivateKeyKey: []byte("not a key"),
 					},
-					expectUpdate: true,
-				},
-				{
-					name: "Garbage entries get replaced",
-					secret: func() (*corev1.Secret, error) {
-						return &corev1.Secret{
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       []byte("not a cert"),
-								corev1.TLSPrivateKeyKey: []byte("not a key"),
-							},
-						}, nil
-					},
-					expectUpdate: true,
-				},
-			}
-
-			for _, tc := range testCases {
-				t.Run(tc.name, func(t *testing.T) {
-
-					secret, err := tc.secret()
-					if err != nil {
-						t.Fatalf("failed to generate secret: %v", err)
-					}
-					initialKey, initalCert := secret.Data[corev1.TLSPrivateKeyKey], secret.Data[corev1.TLSCertKey]
-
-					if err := reconcileSignedCertWithKeysAndAddresses(
-						secret,
-						caSecret,
-						config.OwnerRef{},
-						"foo",
-						[]string{"org"},
-						X509UsageServerAuth,
-						corev1.TLSCertKey,
-						corev1.TLSPrivateKeyKey,
-						CASignerCertMapKey,
-						[]string{"foo.svc.local"},
-						[]string{"127.0.0.1"},
-					); err != nil {
-						t.Fatalf("reconcileSignedCertWithKeysAndAddresses failed: %v", err)
-					}
-
-					didUpdate := !bytes.Equal(initialKey, secret.Data[corev1.TLSPrivateKeyKey]) && !bytes.Equal(initalCert, secret.Data[corev1.TLSCertKey])
-					if didUpdate != tc.expectUpdate {
-						t.Errorf("expectUpdate: %t differs froma actual %t", tc.expectUpdate, didUpdate)
-					}
-
-					if !hasCAHash(secret, caSecret) {
-						t.Error("secret doesn't have ca hash")
-					}
-
-					if diff := cmp.Diff(string(secret.Data[CASignerCertMapKey]), string(caSecret.Data[CASignerCertMapKey])); diff != "" {
-						t.Errorf("Cacert differs from expected: %s", diff)
-					}
-				})
-			}
-
-		})
+				}, nil
+			},
+			expectUpdate: true,
+		},
 	}
 
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			secret, err := tc.secret()
+			if err != nil {
+				t.Fatalf("failed to generate secret: %v", err)
+			}
+			initialKey, initalCert := secret.Data[corev1.TLSPrivateKeyKey], secret.Data[corev1.TLSCertKey]
+
+			if err := reconcileSignedCertWithKeysAndAddresses(
+				secret,
+				caSecret,
+				config.OwnerRef{},
+				"foo",
+				[]string{"org"},
+				X509UsageServerAuth,
+				corev1.TLSCertKey,
+				corev1.TLSPrivateKeyKey,
+				CASignerCertMapKey,
+				[]string{"foo.svc.local"},
+				[]string{"127.0.0.1"},
+			); err != nil {
+				t.Fatalf("reconcileSignedCertWithKeysAndAddresses failed: %v", err)
+			}
+
+			didUpdate := !bytes.Equal(initialKey, secret.Data[corev1.TLSPrivateKeyKey]) && !bytes.Equal(initalCert, secret.Data[corev1.TLSCertKey])
+			if didUpdate != tc.expectUpdate {
+				t.Errorf("expectUpdate: %t differs froma actual %t", tc.expectUpdate, didUpdate)
+			}
+
+			if !hasCAHash(secret, caSecret) {
+				t.Error("secret doesn't have ca hash")
+			}
+
+			if diff := cmp.Diff(string(secret.Data[CASignerCertMapKey]), string(caSecret.Data[CASignerCertMapKey])); diff != "" {
+				t.Errorf("Cacert differs from expected: %s", diff)
+			}
+		})
+	}
 }

--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
@@ -27,6 +26,8 @@ import (
 )
 
 const (
+	keySize = 2048
+
 	ValidityOneDay   = 24 * time.Hour
 	ValidityOneYear  = 365 * ValidityOneDay
 	ValidityTenYears = 10 * ValidityOneYear
@@ -43,8 +44,14 @@ type CertCfg struct {
 	IsCA         bool
 }
 
+// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
+type rsaPublicKey struct {
+	N *big.Int
+	E int
+}
+
 // GenerateSelfSignedCertificate generates a key/cert pair defined by CertCfg.
-func GenerateSelfSignedCertificate(cfg *CertCfg) (*ecdsa.PrivateKey, *x509.Certificate, error) {
+func GenerateSelfSignedCertificate(cfg *CertCfg) (*rsa.PrivateKey, *x509.Certificate, error) {
 	key, err := PrivateKey()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to generate private key")
@@ -58,8 +65,8 @@ func GenerateSelfSignedCertificate(cfg *CertCfg) (*ecdsa.PrivateKey, *x509.Certi
 }
 
 // GenerateSignedCertificate generate a key and cert defined by CertCfg and signed by CA.
-func GenerateSignedCertificate(caKey crypto.Signer, caCert *x509.Certificate,
-	cfg *CertCfg) (*ecdsa.PrivateKey, *x509.Certificate, error) {
+func GenerateSignedCertificate(caKey *rsa.PrivateKey, caCert *x509.Certificate,
+	cfg *CertCfg) (*rsa.PrivateKey, *x509.Certificate, error) {
 
 	// create a private key
 	key, err := PrivateKey()
@@ -86,14 +93,18 @@ func GenerateSignedCertificate(caKey crypto.Signer, caCert *x509.Certificate,
 	return key, cert, nil
 }
 
-// PrivateKey generates an ecdsa private key using the P512 curve and returns the value.
-// The returned private key is FIPS compliant
-func PrivateKey() (*ecdsa.PrivateKey, error) {
-	return ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+// PrivateKey generates an RSA Private key and returns the value
+func PrivateKey() (*rsa.PrivateKey, error) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return nil, errors.Wrap(err, "error generating RSA private key")
+	}
+
+	return rsaKey, nil
 }
 
 // SelfSignedCertificate creates a self signed certificate
-func SelfSignedCertificate(cfg *CertCfg, key crypto.Signer) (*x509.Certificate, error) {
+func SelfSignedCertificate(cfg *CertCfg, key *rsa.PrivateKey) (*x509.Certificate, error) {
 	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
 	if err != nil {
 		return nil, err
@@ -127,9 +138,9 @@ func SelfSignedCertificate(cfg *CertCfg, key crypto.Signer) (*x509.Certificate, 
 func signedCertificate(
 	cfg *CertCfg,
 	csr *x509.CertificateRequest,
-	key crypto.Signer,
+	key *rsa.PrivateKey,
 	caCert *x509.Certificate,
-	caKey crypto.Signer,
+	caKey *rsa.PrivateKey,
 ) (*x509.Certificate, error) {
 	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
 	if err != nil {
@@ -149,7 +160,7 @@ func signedCertificate(
 		Version:               3,
 		BasicConstraintsValid: true,
 	}
-	pub := caCert.PublicKey
+	pub := caCert.PublicKey.(*rsa.PublicKey)
 	certTmpl.SubjectKeyId, err = generateSubjectKeyID(pub)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set subject key identifier")
@@ -163,47 +174,35 @@ func signedCertificate(
 
 // generateSubjectKeyID generates a SHA-1 hash of the subject public key.
 func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
-	publicKeyBytes, err := x509.MarshalPKIXPublicKey(pub)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal public key: %w", err)
+	var publicKeyBytes []byte
+	var err error
+
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		publicKeyBytes, err = asn1.Marshal(rsaPublicKey{N: pub.N, E: pub.E})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to Marshal ans1 public key")
+		}
+	case *ecdsa.PublicKey:
+		publicKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
+	default:
+		return nil, errors.New("only RSA and ECDSA public keys supported")
 	}
 
 	hash := sha1.Sum(publicKeyBytes)
 	return hash[:], nil
 }
 
-// PrivateKeyToPem converts a PrivateKey object to a byte slice
-func PrivateKeyToPem(key crypto.Signer) ([]byte, error) {
-	switch key := key.(type) {
-	case *rsa.PrivateKey:
-		keyInBytes := x509.MarshalPKCS1PrivateKey(key)
-		return pem.EncodeToMemory(
-			&pem.Block{
-				Type:  "RSA PRIVATE KEY",
-				Bytes: keyInBytes,
-			},
-		), nil
-	case *ecdsa.PrivateKey:
-		derKey, err := x509.MarshalECPrivateKey(key)
-		if err != nil {
-			return nil, err
-		}
-		return pem.EncodeToMemory(&pem.Block{
-			Type:  "EC PRIVATE KEY",
-			Bytes: derKey,
-		}), nil
-	case ed25519.PrivateKey:
-		b, err := x509.MarshalPKCS8PrivateKey(key)
-		if err != nil {
-			return nil, err
-		}
-		return pem.EncodeToMemory(&pem.Block{
-			Type:  "PRIVATE KEY",
-			Bytes: b,
-		}), nil
-	default:
-		return nil, fmt.Errorf("unknown private key type %T", key)
-	}
+// PrivateKeyToPem converts an rsa.PrivateKey object to pem string
+func PrivateKeyToPem(key *rsa.PrivateKey) []byte {
+	keyInBytes := x509.MarshalPKCS1PrivateKey(key)
+	keyinPem := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: keyInBytes,
+		},
+	)
+	return keyinPem
 }
 
 // CertToPem converts an x509.Certificate object to a pem string
@@ -229,47 +228,27 @@ func CSRToPem(cert *x509.CertificateRequest) []byte {
 }
 
 // PublicKeyToPem converts an rsa.PublicKey object to pem string
-func PublicKeyToPem(key crypto.PublicKey) ([]byte, error) {
+func PublicKeyToPem(key *rsa.PublicKey) ([]byte, error) {
 	keyInBytes, err := x509.MarshalPKIXPublicKey(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to MarshalPKIXPublicKey")
 	}
 	keyinPem := pem.EncodeToMemory(
 		&pem.Block{
-			Type:  "PUBLIC KEY",
+			Type:  "RSA PUBLIC KEY",
 			Bytes: keyInBytes,
 		},
 	)
 	return keyinPem, nil
 }
 
-// PemToPrivateKey converts a data block to private key
-func PemToPrivateKey(data []byte) (crypto.Signer, error) {
+// PemToPrivateKey converts a data block to rsa.PrivateKey.
+func PemToPrivateKey(data []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(data)
 	if block == nil {
 		return nil, errors.Errorf("could not find a PEM block in the private key")
 	}
-	switch block.Type {
-	case "RSA PRIVATE KEY":
-		return x509.ParsePKCS1PrivateKey(block.Bytes)
-	case "EC PRIVATE KEY":
-		return x509.ParseECPrivateKey(block.Bytes)
-	case "PRIVATE KEY":
-		keyRaw, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		// I can not see a success codepath in x509.ParsePKCS8PrivateKey
-		// that does not return a crypto.Signer, it seems to be done to
-		// futureproof it.
-		cryptoSigner, ok := keyRaw.(crypto.Signer)
-		if !ok {
-			return nil, fmt.Errorf("private key was not of type crypto.Signer but %T", keyRaw)
-		}
-		return cryptoSigner, nil
-	default:
-		return nil, fmt.Errorf("unknown key type %q", block.Type)
-	}
+	return x509.ParsePKCS1PrivateKey(block.Bytes)
 }
 
 // PemToCertificate converts a data block to x509.Certificate.
@@ -285,17 +264,32 @@ func Base64(data []byte) string {
 	return base64.StdEncoding.EncodeToString(data)
 }
 
+func parsePemKeypair(key, certificate []byte) (*rsa.PrivateKey, *x509.Certificate, error) {
+	privKey, err := PemToPrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := PemToCertificate(certificate)
+	if err != nil {
+		return nil, nil, err
+	}
+	rsaPublicKey, ok := cert.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, nil, fmt.Errorf("certificate does not have a RSA public key but a %T, not supported", cert.PublicKey)
+	}
+
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.5:src/crypto/tls/tls.go;drc=860704317e02d699e4e4a24103853c4782d746c1;l=310
+	if rsaPublicKey.N.Cmp(privKey.N) != 0 {
+		return nil, nil, errors.New("private key does not match certificate")
+	}
+
+	return privKey, cert, nil
+}
+
 func ValidateKeyPair(pemKey, pemCertificate []byte, cfg *CertCfg, minimumRemainingValidity time.Duration) error {
-	tlsCert, err := tls.X509KeyPair(pemCertificate, pemKey)
+	_, cert, err := parsePemKeypair(pemKey, pemCertificate)
 	if err != nil {
-		return fmt.Errorf("failed to load keypair: %w", err)
-	}
-	if n := len(tlsCert.Certificate); n != 1 {
-		return fmt.Errorf("expected exactly one certificate, got %d", n)
-	}
-	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
-	if err != nil {
-		return fmt.Errorf("failed to parse certificate: %w", err)
+		return fmt.Errorf("failed to parse keypair: %w", err)
 	}
 
 	var errs []error

--- a/support/certs/tls_test.go
+++ b/support/certs/tls_test.go
@@ -54,11 +54,7 @@ func TestValidateKeyPairConsidersAllFields(t *testing.T) {
 			for current := val.Field(i).Interface(); reflect.DeepEqual(current, val.Field(i).Interface()); fuzzer.Fuzz(val.Field(i).Addr().Interface()) {
 			}
 
-			privKey, err := certs.PrivateKeyToPem(key)
-			if err != nil {
-				t.Fatalf("failed to convert private key to pem: %v", err)
-			}
-			err = certs.ValidateKeyPair(privKey, certs.CertToPem(cert), cfg, 0)
+			err = certs.ValidateKeyPair(certs.PrivateKeyToPem(key), certs.CertToPem(cert), cfg, 0)
 			if err == nil {
 				t.Error("ValidateKeyPair returned a nil error, should have detected the change")
 			}
@@ -101,11 +97,7 @@ func TestValidateKeyPairConsidersExpiration(t *testing.T) {
 				t.Fatalf("GenerateSelfSignedCertificate failed: %v", err)
 			}
 
-			privKey, err := certs.PrivateKeyToPem(key)
-			if err != nil {
-				t.Fatalf("failed to convert private key to pem: %v", err)
-			}
-			err = certs.ValidateKeyPair(privKey, certs.CertToPem(cert), cfg, time.Minute)
+			err = certs.ValidateKeyPair(certs.PrivateKeyToPem(key), certs.CertToPem(cert), cfg, time.Minute)
 			isValid := err == nil
 			if isValid != tc.expectValid {
 				t.Errorf("expected valid: %t, actual valid: %t, error from ValidateKeyPair: %v", tc.expectValid, isValid, err)
@@ -161,16 +153,13 @@ func TestValidateKeyPairItempotency(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			cfg := &certs.CertCfg{}
 			fuzzer.Fuzz(cfg)
+
 			key, cert, err := certs.GenerateSignedCertificate(caKey, caCert, cfg)
 			if err != nil {
 				t.Fatalf("GenerateSelfSignedCertificate failed: %v", err)
 			}
 
-			privKey, err := certs.PrivateKeyToPem(key)
-			if err != nil {
-				t.Fatalf("failed to convert private key to pem: %v", err)
-			}
-			if err := certs.ValidateKeyPair(privKey, certs.CertToPem(cert), cfg, 0); err != nil {
+			if err := certs.ValidateKeyPair(certs.PrivateKeyToPem(key), certs.CertToPem(cert), cfg, 0); err != nil {
 				t.Errorf("validation failed when config was unchanged: %v", err)
 			}
 		})


### PR DESCRIPTION
This reverts https://github.com/openshift/hypershift/pull/1167

The console stopped working after this with `ERR_SSL_VERSION_OR_CIPHER_MISMATCH`.  Root cause is yet unknown but we need to get back to working.  We should also stay aligned with standalone OCP on this.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.