### PR TITLE
enable external-dns registry

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -3,6 +3,7 @@ package assets
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/support/images"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -175,8 +176,9 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								"--source=openshift-route",
 								fmt.Sprintf("--domain-filter=%s", o.DomainFilter),
 								fmt.Sprintf("--provider=%s", o.Provider),
-								"--registry=noop",
-								"--txt-owner-id=hypershift",
+								"--registry=txt",
+								"--txt-suffix=-external-dns",
+								fmt.Sprintf("--txt-owner-id=%s", uuid.NewString()),
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
 							LivenessProbe: &corev1.Probe{


### PR DESCRIPTION
Without the registry, external-dns from different management clusters with stomp each other's record.  In order to avoid this we need to enable the TXT record based registry.  However, we can't create a TXT record with the same name as a CNAME.  We also need a unique TXT owner id so each instance of external-dns in each management cluster can identify the records it should sync.

This PR enables the registry and sets a `-external-dns` suffix to be added to TXT record to avoid conflict with the CNAME records created for Routes.  It also sets the TXT owner-id to a generated UUID to identify a particular external-dns instance operating in a shared public zone.

Required before https://github.com/openshift/hypershift/pull/1163

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.