### PR TITLE
Registry configuration: reconcile only what we need to changes

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
@@ -5,32 +5,28 @@ import (
 	"encoding/hex"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 )
 
-func ReconcileRegistryConfig(cfg *imageregistryv1.Config, platform hyperv1.PlatformType) {
-	cfg.Spec.DefaultRoute = false
+func ReconcileRegistryConfig(cfg *imageregistryv1.Config, platform hyperv1.PlatformType, availabilityPolicy hyperv1.AvailabilityPolicy) {
+	// Only initialize number of replicas if creating the config
+	if cfg.ResourceVersion == "" {
+		switch availabilityPolicy {
+		case hyperv1.SingleReplica:
+			cfg.Spec.Replicas = 1
+		default:
+			cfg.Spec.Replicas = 2
+		}
+	}
+	if cfg.Spec.ManagementState == "" {
+		cfg.Spec.ManagementState = operatorv1.Managed
+	}
 	if cfg.Spec.HTTPSecret == "" {
 		cfg.Spec.HTTPSecret = generateImageRegistrySecret()
 	}
-	cfg.Spec.Logging = 2
-	cfg.Spec.ManagementState = imageregistryv1.StorageManagementStateManaged
-	cfg.Spec.Proxy.HTTP = ""
-	cfg.Spec.Proxy.HTTPS = ""
-	cfg.Spec.Proxy.NoProxy = ""
-	cfg.Spec.ReadOnly = false
-	cfg.Spec.Replicas = 1
-	cfg.Spec.Requests.Read.MaxInQueue = 0
-	cfg.Spec.Requests.Read.MaxRunning = 0
-	cfg.Spec.Requests.Read.MaxWaitInQueue.Reset()
-	cfg.Spec.Requests.Write.MaxInQueue = 0
-	cfg.Spec.Requests.Write.MaxRunning = 0
-	cfg.Spec.Requests.Write.MaxWaitInQueue.Reset()
-
 	if platform == hyperv1.KubevirtPlatform || platform == hyperv1.NonePlatform {
 		cfg.Spec.Storage = imageregistryv1.ImageRegistryConfigStorage{EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{}}
-	} else {
-		cfg.Spec.Storage.EmptyDir = nil
 	}
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -199,17 +199,13 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		errs = append(errs, fmt.Errorf("failed to reconcile rbac: %w", err))
 	}
 
-	// IBMCloud platform should not be constantly reconciled as we allow customers to change initial deployment.
-	// Initial deployment handled by managed service wrapping hypershift
-	if r.platformType != hyperv1.IBMCloudPlatform {
-		log.Info("reconciling registry config")
-		registryConfig := manifests.Registry()
-		if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
-			registry.ReconcileRegistryConfig(registryConfig, r.platformType)
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile imageregistry config: %w", err))
-		}
+	log.Info("reconciling registry config")
+	registryConfig := manifests.Registry()
+	if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
+		registry.ReconcileRegistryConfig(registryConfig, r.platformType, hcp.Spec.InfrastructureAvailabilityPolicy)
+		return nil
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile imageregistry config: %w", err))
 	}
 
 	log.Info("reconciling ingress controller")


### PR DESCRIPTION
**What this PR does / why we need it**:
In its current state, the hosted cluster config operator overwrites any
changes made by the guest cluster admin to the registry configuration.
This prevents changes like enabling a route or increasing the number of
replicas.

This commit limits what we change to things we need to change and leave
everything else as is.


**Checklist**
- [x] Subject and description added to both, commit and PR.