### PR TITLE
Rename nodepool.spec.nodeCount to replicas

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -529,7 +529,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 					AutoRepair:  o.AutoRepair,
 					UpgradeType: hyperv1.UpgradeTypeReplace,
 				},
-				NodeCount:   &o.NodePoolReplicas,
+				Replicas:    &o.NodePoolReplicas,
 				ClusterName: o.Name,
 				Release: hyperv1.Release{
 					Image: o.ReleaseImage,

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -51,10 +51,10 @@ func init() {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
-// +kubebuilder:subresource:scale:specpath=.spec.nodeCount,statuspath=.status.nodeCount
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".spec.clusterName",description="Cluster"
-// +kubebuilder:printcolumn:name="Desired Nodes",type="integer",JSONPath=".spec.nodeCount",description="Desired Nodes"
-// +kubebuilder:printcolumn:name="Current Nodes",type="integer",JSONPath=".status.nodeCount",description="Available Nodes"
+// +kubebuilder:printcolumn:name="Desired Nodes",type="integer",JSONPath=".spec.replicas",description="Desired Nodes"
+// +kubebuilder:printcolumn:name="Current Nodes",type="integer",JSONPath=".status.replicas",description="Available Nodes"
 // +kubebuilder:printcolumn:name="Autoscaling",type="string",JSONPath=".status.conditions[?(@.type==\"AutoscalingEnabled\")].status",description="Autoscaling Enabled"
 // +kubebuilder:printcolumn:name="Autorepair",type="string",JSONPath=".status.conditions[?(@.type==\"AutorepairEnabled\")].status",description="Node Autorepair Enabled"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="Current version"
@@ -92,11 +92,17 @@ type NodePoolSpec struct {
 	// +immutable
 	Platform NodePoolPlatform `json:"platform"`
 
-	// NodeCount is the desired number of nodes the pool should maintain. If
+	// Deprecated: Use Replicas instead. NodeCount will be dropped in the next
+	// api release.
+	//
+	// +optional
+	NodeCount *int32 `json:"nodeCount,omitempty"`
+
+	// Replicas is the desired number of nodes the pool should maintain. If
 	// unset, the default value is 0.
 	//
 	// +optional
-	NodeCount *int32 `json:"nodeCount"`
+	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Management specifies behavior for managing nodes in the pool, such as
 	// upgrade strategies and auto-repair behaviors.
@@ -130,10 +136,10 @@ type NodePoolSpec struct {
 
 // NodePoolStatus is the latest observed status of a NodePool.
 type NodePoolStatus struct {
-	// NodeCount is the latest observed number of nodes in the pool.
+	// Replicas is the latest observed number of nodes in the pool.
 	//
 	// +optional
-	NodeCount int32 `json:"nodeCount"`
+	Replicas int32 `json:"replicas"`
 
 	// Version is the semantic version of the latest applied release specified by
 	// the NodePool.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1435,6 +1435,11 @@ func (in *NodePoolSpec) DeepCopyInto(out *NodePoolSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.Management.DeepCopyInto(&out.Management)
 	if in.AutoScaling != nil {
 		in, out := &in.AutoScaling, &out.AutoScaling

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -25,11 +25,11 @@ spec:
       name: Cluster
       type: string
     - description: Desired Nodes
-      jsonPath: .spec.nodeCount
+      jsonPath: .spec.replicas
       name: Desired Nodes
       type: integer
     - description: Available Nodes
-      jsonPath: .status.nodeCount
+      jsonPath: .status.replicas
       name: Current Nodes
       type: integer
     - description: Autoscaling Enabled
@@ -197,8 +197,8 @@ spec:
                 - upgradeType
                 type: object
               nodeCount:
-                description: NodeCount is the desired number of nodes the pool should
-                  maintain. If unset, the default value is 0.
+                description: 'Deprecated: Use Replicas instead. NodeCount will be
+                  dropped in the next api release.'
                 format: int32
                 type: integer
               nodeDrainTimeout:
@@ -4909,6 +4909,11 @@ spec:
                 required:
                 - image
                 type: object
+              replicas:
+                description: Replicas is the desired number of nodes the pool should
+                  maintain. If unset, the default value is 0.
+                format: int32
+                type: integer
             required:
             - clusterName
             - management
@@ -4970,8 +4975,8 @@ spec:
                   - type
                   type: object
                 type: array
-              nodeCount:
-                description: NodeCount is the latest observed number of nodes in the
+              replicas:
+                description: Replicas is the latest observed number of nodes in the
                   pool.
                 format: int32
                 type: integer
@@ -4987,8 +4992,8 @@ spec:
     storage: true
     subresources:
       scale:
-        specReplicasPath: .spec.nodeCount
-        statusReplicasPath: .status.nodeCount
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}
 status:
   acceptedNames:

--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -84,7 +84,7 @@ func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts
 				UpgradeType: hyperv1.UpgradeTypeReplace,
 			},
 			ClusterName: o.ClusterName,
-			NodeCount:   &o.NodeCount,
+			Replicas:    &o.NodeCount,
 			Release: hyperv1.Release{
 				Image: releaseImage,
 			},

--- a/docs/content/how-to/agent/create-agent-cluster.md
+++ b/docs/content/how-to/agent/create-agent-cluster.md
@@ -36,7 +36,7 @@ Upon scaling down a NodePool, Agents will be unbound from the corresponding clus
 
 > **NOTE**: Instead of deploying Assisted Service and Hive, RHACM can be deployed (as those are part of RHACM) but at the time of writting this document, there were some issues if using RHACM that's why only the required bits are used.
 
-We will leverage [`tasty`](https://github.com/karmab/tasty) to deploy the required operators easily. 
+We will leverage [`tasty`](https://github.com/karmab/tasty) to deploy the required operators easily.
 
 * Install tasty:
 
@@ -111,7 +111,7 @@ RHEL8 doesn't include go1.17 officially but it can be installed via `gvm` by fol
 sudo dnf install -y curl git make bison gcc glibc-devel
 git clone https://github.com/openshift/hypershift.git
 pushd hypershift
- 
+
 # Install gvm to install go 1.17
 bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
 source ${HOME}/.gvm/scripts/gvm
@@ -156,7 +156,7 @@ podman login -u ${QUAY_ACCOUNT} -p testpassword quay.io
 sudo dnf install -y curl git make bison gcc glibc-devel
 git clone https://github.com/openshift/hypershift.git
 pushd hypershift
- 
+
 # Install gvm to install go 1.17
 bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
 source ${HOME}/.gvm/scripts/gvm
@@ -261,7 +261,7 @@ metadata:
  namespace: ${CLUSTERS_NAMESPACE}
 type: kubernetes.io/dockerconfigjson
 EOF
- 
+
 envsubst <<"EOF" | oc apply -f -
 apiVersion: v1
 kind: Secret
@@ -336,7 +336,7 @@ metadata:
   namespace: ${CLUSTERS_NAMESPACE}
 spec:
   clusterName: ${HOSTED}
-  nodeCount: 0
+  replicas: 0
   management:
     autoRepair: false
     upgradeType: Replace
@@ -540,7 +540,7 @@ oc patch ${AGENT} -n ${HOSTED_CLUSTER_NS} -p '{"spec":{"installation_disk_id":"/
 * Finally, scaling up the nodepool will trigger the installation:
 
 ~~~sh
-oc patch nodepool/${HOSTED}-workers -n ${CLUSTERS_NAMESPACE} -p '{"spec":{"nodeCount": 1}}' --type merge
+oc patch nodepool/${HOSTED}-workers -n ${CLUSTERS_NAMESPACE} -p '{"spec":{"replicas": 1}}' --type merge
 ~~~
 
 * Then the worker is added to the cluster:
@@ -553,25 +553,25 @@ ocp-worker-0.hosted0.krnl.es   Ready    worker   63m   v1.22.3+fdba464
 oc get co --kubeconfig=${HOSTED}-kubeconfig
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
 console                                    4.9.21    False       False         False      62m     RouteHealthAvailable: failed to GET route (https://console-openshift-console.apps.hosted0.krnl.es): Get "https://console-openshift-console.apps.hosted0.krnl.es": x509: certificate is valid for *.apps.ocp.krnl.es, not console-openshift-console.apps.hosted0.krnl.es
-csi-snapshot-controller                    4.9.21    True        False         False      61m     
-dns                                        4.9.21    True        False         False      61m     
-image-registry                             4.9.21    True        False         False      61m     
+csi-snapshot-controller                    4.9.21    True        False         False      61m
+dns                                        4.9.21    True        False         False      61m
+image-registry                             4.9.21    True        False         False      61m
 ingress                                    4.9.21    True        False         True       51m     The "default" ingress controller reports Degraded=True: DegradedConditions: One or more other status conditions indicate a degraded state: PodsScheduled=False (PodsNotScheduled: Some pods are not scheduled: Pod "router-default-7f9dc784cb-mlg9m" cannot be scheduled: 0/1 nodes are available: 1 node(s) didn't have free ports for the requested pod ports. Make sure you have sufficient worker nodes.), CanaryChecksSucceeding=False (CanaryChecksRepetitiveFailures: Canary route checks for the default ingress controller are failing)
-kube-apiserver                             4.9.21    True        False         False      4h27m   
-kube-controller-manager                    4.9.21    True        False         False      4h27m   
-kube-scheduler                             4.9.21    True        False         False      4h27m   
-kube-storage-version-migrator              4.9.21    True        False         False      61m     
+kube-apiserver                             4.9.21    True        False         False      4h27m
+kube-controller-manager                    4.9.21    True        False         False      4h27m
+kube-scheduler                             4.9.21    True        False         False      4h27m
+kube-storage-version-migrator              4.9.21    True        False         False      61m
 monitoring                                           False       True          True       45m     Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error.
-network                                    4.9.21    True        False         False      63m     
-node-tuning                                4.9.21    True        False         False      61m     
-openshift-apiserver                        4.9.21    True        False         False      4h27m   
-openshift-controller-manager               4.9.21    True        False         False      4h27m   
-openshift-samples                          4.9.21    True        False         False      60m     
-operator-lifecycle-manager                 4.9.21    True        False         False      4h26m   
-operator-lifecycle-manager-catalog         4.9.21    True        False         False      4h26m   
-operator-lifecycle-manager-packageserver   4.9.21    True        False         False      4h27m   
-service-ca                                 4.9.21    True        False         False      62m     
-storage                                    4.9.21    True        False         False      62m    
+network                                    4.9.21    True        False         False      63m
+node-tuning                                4.9.21    True        False         False      61m
+openshift-apiserver                        4.9.21    True        False         False      4h27m
+openshift-controller-manager               4.9.21    True        False         False      4h27m
+openshift-samples                          4.9.21    True        False         False      60m
+operator-lifecycle-manager                 4.9.21    True        False         False      4h26m
+operator-lifecycle-manager-catalog         4.9.21    True        False         False      4h26m
+operator-lifecycle-manager-packageserver   4.9.21    True        False         False      4h27m
+service-ca                                 4.9.21    True        False         False      62m
+storage                                    4.9.21    True        False         False      62m
 
 oc get clusterversion --kubeconfig=${HOSTED}-kubeconfig
 NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
@@ -630,11 +630,11 @@ export AGENT=$(oc get agent -n ${HOSTED_CLUSTER_NS} ${UUID} -o name)
 
 oc patch ${AGENT} -n ${HOSTED_CLUSTER_NS} -p '{"spec":{"installation_disk_id":"/dev/sda","approved":true,"hostname":"ocp-worker-1.hosted0.krnl.es","role":"worker"}}' --type merge
 
-oc patch nodepool/${HOSTED}-workers -n ${CLUSTERS_NAMESPACE} -p '{"spec":{"nodeCount": 2}}' --type merge
+oc patch nodepool/${HOSTED}-workers -n ${CLUSTERS_NAMESPACE} -p '{"spec":{"replicas": 2}}' --type merge
 ~~~
 
 ~~~sh
-oc get nodes --kubeconfig=hosted0-kubeconfig  
+oc get nodes --kubeconfig=hosted0-kubeconfig
 NAME                           STATUS   ROLES    AGE    VERSION
 ocp-worker-0.hosted0.krnl.es   Ready    worker   19h    v1.22.3+fdba464
 ocp-worker-1.hosted0.krnl.es   Ready    worker   2m2s   v1.22.3+fdba464
@@ -643,30 +643,30 @@ oc get hostedcluster -n clusters hosted0
 NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   REASON
 hosted0   4.9.21    hosted0-admin-kubeconfig   Completed   True        HostedClusterAsExpected
 
-oc get co --kubeconfig=hosted0-kubeconfig  
+oc get co --kubeconfig=hosted0-kubeconfig
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-console                                    4.9.21    True        False         False      68s     
-csi-snapshot-controller                    4.9.21    True        False         False      19h     
-dns                                        4.9.21    True        False         False      19h     
-image-registry                             4.9.21    True        False         False      19h     
-ingress                                    4.9.21    True        False         False      19h     
-kube-apiserver                             4.9.21    True        False         False      22h     
-kube-controller-manager                    4.9.21    True        False         False      22h     
-kube-scheduler                             4.9.21    True        False         False      22h     
-kube-storage-version-migrator              4.9.21    True        False         False      19h     
-monitoring                                 4.9.21    True        False         False      6m26s   
-network                                    4.9.21    True        False         False      19h     
-node-tuning                                4.9.21    True        False         False      19h     
-openshift-apiserver                        4.9.21    True        False         False      22h     
-openshift-controller-manager               4.9.21    True        False         False      22h     
-openshift-samples                          4.9.21    True        False         False      19h     
-operator-lifecycle-manager                 4.9.21    True        False         False      22h     
-operator-lifecycle-manager-catalog         4.9.21    True        False         False      22h     
-operator-lifecycle-manager-packageserver   4.9.21    True        False         False      22h     
-service-ca                                 4.9.21    True        False         False      19h     
+console                                    4.9.21    True        False         False      68s
+csi-snapshot-controller                    4.9.21    True        False         False      19h
+dns                                        4.9.21    True        False         False      19h
+image-registry                             4.9.21    True        False         False      19h
+ingress                                    4.9.21    True        False         False      19h
+kube-apiserver                             4.9.21    True        False         False      22h
+kube-controller-manager                    4.9.21    True        False         False      22h
+kube-scheduler                             4.9.21    True        False         False      22h
+kube-storage-version-migrator              4.9.21    True        False         False      19h
+monitoring                                 4.9.21    True        False         False      6m26s
+network                                    4.9.21    True        False         False      19h
+node-tuning                                4.9.21    True        False         False      19h
+openshift-apiserver                        4.9.21    True        False         False      22h
+openshift-controller-manager               4.9.21    True        False         False      22h
+openshift-samples                          4.9.21    True        False         False      19h
+operator-lifecycle-manager                 4.9.21    True        False         False      22h
+operator-lifecycle-manager-catalog         4.9.21    True        False         False      22h
+operator-lifecycle-manager-packageserver   4.9.21    True        False         False      22h
+service-ca                                 4.9.21    True        False         False      19h
 storage                                    4.9.21    True        False         False      19h
 
-oc get clusterversion --kubeconfig=hosted0-kubeconfig  
+oc get clusterversion --kubeconfig=hosted0-kubeconfig
 NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
 version   4.9.21    True        False         94s     Cluster version is 4.9.21
 ~~~

--- a/docs/content/how-to/none/create-none-cluster.md
+++ b/docs/content/how-to/none/create-none-cluster.md
@@ -22,7 +22,7 @@ RHEL8 doesn't include go1.17 officially but it can be installed via `gvm` by fol
 sudo dnf install -y curl git make bison gcc glibc-devel
 git clone https://github.com/openshift/hypershift.git
 pushd hypershift
- 
+
 # Install gvm to install go 1.17
 bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
 source ${HOME}/.gvm/scripts/gvm
@@ -67,7 +67,7 @@ podman login -u ${QUAY_ACCOUNT} -p testpassword quay.io
 sudo dnf install -y curl git make bison gcc glibc-devel
 git clone https://github.com/openshift/hypershift.git
 pushd hypershift
- 
+
 # Install gvm to install go 1.17
 bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
 source ${HOME}/.gvm/scripts/gvm
@@ -174,7 +174,7 @@ metadata:
  namespace: ${CLUSTERS_NAMESPACE}
 type: kubernetes.io/dockerconfigjson
 EOF
- 
+
 envsubst <<"EOF" | oc apply -f -
 apiVersion: v1
 kind: Secret
@@ -247,7 +247,7 @@ metadata:
   namespace: ${CLUSTERS_NAMESPACE}
 spec:
   clusterName: ${HOSTED}
-  nodeCount: 0
+  replicas: 0
   management:
     autoRepair: false
     upgradeType: Replace
@@ -373,26 +373,26 @@ kni1-worker-0.cloud.lab.eng.bos.redhat.com   Ready    worker   28m   v1.22.3+e79
 
 oc get co --kubeconfig=${HOSTED}-kubeconfig
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-console                                    4.9.17    True        False         False      17m     
-csi-snapshot-controller                    4.9.17    True        False         False      24m     
-dns                                        4.9.17    True        False         False      24m     
+console                                    4.9.17    True        False         False      17m
+csi-snapshot-controller                    4.9.17    True        False         False      24m
+dns                                        4.9.17    True        False         False      24m
 image-registry                             4.9.17    False       False         False      4m49s   NodeCADaemonAvailable: The daemon set node-ca does not have available replicas...
-ingress                                    4.9.17    True        False         False      14m     
-kube-apiserver                             4.9.17    True        False         False      3h45m   
-kube-controller-manager                    4.9.17    True        False         False      3h45m   
-kube-scheduler                             4.9.17    True        False         False      3h45m   
-kube-storage-version-migrator              4.9.17    True        False         False      24m     
+ingress                                    4.9.17    True        False         False      14m
+kube-apiserver                             4.9.17    True        False         False      3h45m
+kube-controller-manager                    4.9.17    True        False         False      3h45m
+kube-scheduler                             4.9.17    True        False         False      3h45m
+kube-storage-version-migrator              4.9.17    True        False         False      24m
 monitoring                                           False       True          True       9m      Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error.
-network                                    4.9.17    True        False         False      25m     
-node-tuning                                4.9.17    True        False         False      24m     
-openshift-apiserver                        4.9.17    True        False         False      3h45m   
-openshift-controller-manager               4.9.17    True        False         False      3h45m   
-openshift-samples                          4.9.17    True        False         False      23m     
-operator-lifecycle-manager                 4.9.17    True        False         False      3h45m   
-operator-lifecycle-manager-catalog         4.9.17    True        False         False      3h45m   
-operator-lifecycle-manager-packageserver   4.9.17    True        False         False      3h45m   
-service-ca                                 4.9.17    True        False         False      25m     
-storage                                    4.9.17    True        False         False      25m     
+network                                    4.9.17    True        False         False      25m
+node-tuning                                4.9.17    True        False         False      24m
+openshift-apiserver                        4.9.17    True        False         False      3h45m
+openshift-controller-manager               4.9.17    True        False         False      3h45m
+openshift-samples                          4.9.17    True        False         False      23m
+operator-lifecycle-manager                 4.9.17    True        False         False      3h45m
+operator-lifecycle-manager-catalog         4.9.17    True        False         False      3h45m
+operator-lifecycle-manager-packageserver   4.9.17    True        False         False      3h45m
+service-ca                                 4.9.17    True        False         False      25m
+storage                                    4.9.17    True        False         False      25m
 
 oc get clusterversion --kubeconfig=${HOSTED}-kubeconfig
 NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
@@ -410,25 +410,25 @@ hosted0   4.9.17    hosted0-admin-kubeconfig   Completed   True        HostedClu
 
 KUBECONFIG=./hosted0-kubeconfig oc get co
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-console                                    4.9.17    True        False         False      64m     
-csi-snapshot-controller                    4.9.17    True        False         False      71m     
-dns                                        4.9.17    True        False         False      71m     
-image-registry                             4.9.17    True        False         False      11m     
-ingress                                    4.9.17    True        False         False      61m     
-kube-apiserver                             4.9.17    True        False         False      4h32m   
-kube-controller-manager                    4.9.17    True        False         False      4h32m   
-kube-scheduler                             4.9.17    True        False         False      4h32m   
-kube-storage-version-migrator              4.9.17    True        False         False      71m     
-monitoring                                 4.9.17    True        False         False      6m51s   
-network                                    4.9.17    True        False         False      72m     
-node-tuning                                4.9.17    True        False         False      71m     
-openshift-apiserver                        4.9.17    True        False         False      4h32m   
-openshift-controller-manager               4.9.17    True        False         False      4h32m   
-openshift-samples                          4.9.17    True        False         False      70m     
-operator-lifecycle-manager                 4.9.17    True        False         False      4h32m   
-operator-lifecycle-manager-catalog         4.9.17    True        False         False      4h32m   
-operator-lifecycle-manager-packageserver   4.9.17    True        False         False      4h32m   
-service-ca                                 4.9.17    True        False         False      72m     
+console                                    4.9.17    True        False         False      64m
+csi-snapshot-controller                    4.9.17    True        False         False      71m
+dns                                        4.9.17    True        False         False      71m
+image-registry                             4.9.17    True        False         False      11m
+ingress                                    4.9.17    True        False         False      61m
+kube-apiserver                             4.9.17    True        False         False      4h32m
+kube-controller-manager                    4.9.17    True        False         False      4h32m
+kube-scheduler                             4.9.17    True        False         False      4h32m
+kube-storage-version-migrator              4.9.17    True        False         False      71m
+monitoring                                 4.9.17    True        False         False      6m51s
+network                                    4.9.17    True        False         False      72m
+node-tuning                                4.9.17    True        False         False      71m
+openshift-apiserver                        4.9.17    True        False         False      4h32m
+openshift-controller-manager               4.9.17    True        False         False      4h32m
+openshift-samples                          4.9.17    True        False         False      70m
+operator-lifecycle-manager                 4.9.17    True        False         False      4h32m
+operator-lifecycle-manager-catalog         4.9.17    True        False         False      4h32m
+operator-lifecycle-manager-packageserver   4.9.17    True        False         False      4h32m
+service-ca                                 4.9.17    True        False         False      72m
 storage                                    4.9.17    True        False         False      72m
 
 KUBECONFIG=./hosted0-kubeconfig oc get clusterversion

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -581,7 +581,20 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>NodeCount is the desired number of nodes the pool should maintain. If
+<p>Deprecated: Use Replicas instead. NodeCount will be dropped in the next
+api release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Replicas is the desired number of nodes the pool should maintain. If
 unset, the default value is 0.</p>
 </td>
 </tr>
@@ -4398,7 +4411,20 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>NodeCount is the desired number of nodes the pool should maintain. If
+<p>Deprecated: Use Replicas instead. NodeCount will be dropped in the next
+api release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Replicas is the desired number of nodes the pool should maintain. If
 unset, the default value is 0.</p>
 </td>
 </tr>
@@ -4487,14 +4513,14 @@ the purpose of the change. In future we plan to propagate this field in-place.
 <tbody>
 <tr>
 <td>
-<code>nodeCount</code></br>
+<code>replicas</code></br>
 <em>
 int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>NodeCount is the latest observed number of nodes in the pool.</p>
+<p>Replicas is the latest observed number of nodes in the pool.</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -22508,11 +22508,11 @@ objects:
         name: Cluster
         type: string
       - description: Desired Nodes
-        jsonPath: .spec.nodeCount
+        jsonPath: .spec.replicas
         name: Desired Nodes
         type: integer
       - description: Available Nodes
-        jsonPath: .status.nodeCount
+        jsonPath: .status.replicas
         name: Current Nodes
         type: integer
       - description: Autoscaling Enabled
@@ -22684,8 +22684,8 @@ objects:
                   - upgradeType
                   type: object
                 nodeCount:
-                  description: NodeCount is the desired number of nodes the pool should
-                    maintain. If unset, the default value is 0.
+                  description: 'Deprecated: Use Replicas instead. NodeCount will be
+                    dropped in the next api release.'
                   format: int32
                   type: integer
                 nodeDrainTimeout:
@@ -27584,6 +27584,11 @@ objects:
                   required:
                   - image
                   type: object
+                replicas:
+                  description: Replicas is the desired number of nodes the pool should
+                    maintain. If unset, the default value is 0.
+                  format: int32
+                  type: integer
               required:
               - clusterName
               - management
@@ -27646,8 +27651,8 @@ objects:
                     - type
                     type: object
                   type: array
-                nodeCount:
-                  description: NodeCount is the latest observed number of nodes in
+                replicas:
+                  description: Replicas is the latest observed number of nodes in
                     the pool.
                   format: int32
                   type: integer
@@ -27663,8 +27668,8 @@ objects:
       storage: true
       subresources:
         scale:
-          specReplicasPath: .spec.nodeCount
-          statusReplicasPath: .status.nodeCount
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
         status: {}
   status:
     acceptedNames:

--- a/hypershift-operator/controllers/nodepool/aws_test.go
+++ b/hypershift-operator/controllers/nodepool/aws_test.go
@@ -29,7 +29,7 @@ func TestAWSMachineTemplate(t *testing.T) {
 			name: "ebs size",
 			nodePool: hyperv1.NodePoolSpec{
 				ClusterName: "",
-				NodeCount:   nil,
+				Replicas:    nil,
 				Config:      nil,
 				Management:  hyperv1.NodePoolManagement{},
 				AutoScaling: nil,

--- a/hypershift-operator/controllers/nodepool/inplace.go
+++ b/hypershift-operator/controllers/nodepool/inplace.go
@@ -710,7 +710,7 @@ func (r *NodePoolReconciler) reconcileMachineSet(ctx context.Context,
 		// Before persisting, if the NodePool is brand new we want to make sure the replica number is set so the MachineSet controller
 		// does not panic.
 		if machineSet.Spec.Replicas == nil {
-			machineSet.Spec.Replicas = k8sutilspointer.Int32Ptr(k8sutilspointer.Int32PtrDerefOr(nodePool.Spec.NodeCount, 0))
+			machineSet.Spec.Replicas = k8sutilspointer.Int32Ptr(k8sutilspointer.Int32PtrDerefOr(nodePool.Spec.Replicas, 0))
 		}
 		return nil
 	}
@@ -718,7 +718,7 @@ func (r *NodePoolReconciler) reconcileMachineSet(ctx context.Context,
 	setMachineSetReplicas(nodePool, machineSet)
 
 	// Bubble up AvailableReplicas and Ready condition from MachineSet.
-	nodePool.Status.NodeCount = machineSet.Status.AvailableReplicas
+	nodePool.Status.Replicas = machineSet.Status.AvailableReplicas
 	for _, c := range machineSet.Status.Conditions {
 		// This condition should aggregate and summarise readiness from underlying MachineSets and Machines
 		// https://github.com/kubernetes-sigs/cluster-api/issues/3486.
@@ -765,6 +765,6 @@ func setMachineSetReplicas(nodePool *hyperv1.NodePool, machineSet *capiv1.Machin
 	if !isAutoscalingEnabled(nodePool) {
 		machineSet.Annotations[autoscalerMaxAnnotation] = "0"
 		machineSet.Annotations[autoscalerMinAnnotation] = "0"
-		machineSet.Spec.Replicas = k8sutilspointer.Int32Ptr(k8sutilspointer.Int32PtrDerefOr(nodePool.Spec.NodeCount, 0))
+		machineSet.Spec.Replicas = k8sutilspointer.Int32Ptr(k8sutilspointer.Int32PtrDerefOr(nodePool.Spec.Replicas, 0))
 	}
 }

--- a/hypershift-operator/controllers/nodepool/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt_test.go
@@ -27,7 +27,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 				},
 				Spec: hyperv1.NodePoolSpec{
 					ClusterName: "",
-					NodeCount:   nil,
+					Replicas:    nil,
 					Config:      nil,
 					Management:  hyperv1.NodePoolManagement{},
 					AutoScaling: nil,

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -157,7 +157,7 @@ func TestValidateAutoscaling(t *testing.T) {
 			name: "fails when both nodeCount and autoscaling are set",
 			nodePool: &hyperv1.NodePool{
 				Spec: hyperv1.NodePoolSpec{
-					NodeCount: k8sutilspointer.Int32Ptr(1),
+					Replicas: k8sutilspointer.Int32Ptr(1),
 					AutoScaling: &hyperv1.NodePoolAutoScaling{
 						Min: 1,
 						Max: 2,
@@ -572,7 +572,7 @@ func TestSetMachineDeploymentReplicas(t *testing.T) {
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: hyperv1.NodePoolSpec{
-					NodeCount: k8sutilspointer.Int32Ptr(5),
+					Replicas: k8sutilspointer.Int32Ptr(5),
 				},
 			},
 			machineDeployment: &capiv1.MachineDeployment{

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -69,8 +69,8 @@ func TestAutoscaling(t *testing.T) {
 		Min: min,
 		Max: max,
 	}
-	nodepool.Spec.NodeCount = nil
-	err = client.Update(ctx, nodepool)
+	nodepool.Spec.Replicas = nil
+	err = client.Update(testContext, nodepool)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to update NodePool")
 	t.Logf("Enabled autoscaling. Namespace: %s, name: %s, min: %v, max: %v", nodepool.Namespace, nodepool.Name, min, max)
 

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -106,7 +106,7 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 	t.Logf("Created nodepool. Namespace: %s, name: %s", nodepool.Namespace, nodepool.Name)
 
 	t.Logf("Waiting for KubeVirtMachines to be marked as ready")
-	e2eutil.WaitForKubeVirtMachines(t, ctx, client, hostedCluster, *nodepool.Spec.NodeCount)
+	e2eutil.WaitForKubeVirtMachines(t, ctx, client, hostedCluster, *nodepool.Spec.Replicas)
 
 	// Wait for kubevirt cluster to be marked as available
 	t.Logf("Waiting for KubeVirtCluster to be marked as ready")
@@ -118,7 +118,7 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 
 	// Using the guest client, introspect that the nodes for the tenant cluster become ready
 	t.Logf("Waiting for nodes to become ready")
-	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, *nodepool.Spec.NodeCount)
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, *nodepool.Spec.Replicas)
 
 	// Setup wildcard *.apps route for nested kubevirt cluster
 	t.Logf("Setting up wildcard *.apps route for nested kubevirt tenant cluster")

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -314,9 +314,9 @@ func EnsureNodeCountMatchesNodePoolReplicas(t *testing.T, ctx context.Context, h
 		if err := hostClient.List(ctx, &nodePoolList, &crclient.ListOptions{Namespace: nodePoolNamespace}); err != nil {
 			t.Fatalf("failed to list nodepools: %v", err)
 		}
-		nodeCount := 0
+		replicas := 0
 		for _, nodePool := range nodePoolList.Items {
-			nodeCount = nodeCount + int(*nodePool.Spec.NodeCount)
+			replicas = replicas + int(*nodePool.Spec.Replicas)
 		}
 
 		var nodes corev1.NodeList
@@ -324,8 +324,8 @@ func EnsureNodeCountMatchesNodePoolReplicas(t *testing.T, ctx context.Context, h
 			t.Fatalf("failed to list nodes in guest cluster: %v", err)
 		}
 
-		if nodeCount != len(nodes.Items) {
-			t.Errorf("nodepool replicas %d does not match number of nodes in cluster %d", nodeCount, len(nodes.Items))
+		if replicas != len(nodes.Items) {
+			t.Errorf("nodepool replicas %d does not match number of nodes in cluster %d", replicas, len(nodes.Items))
 		}
 	})
 }


### PR DESCRIPTION
Every other kube api that manages identical things uses a field named
replicas to denote the number of replicas, rather than $thingCount.
Stick to that convention.

This change is limited to the Hypershift operator, so it won't break
compatibility with an older CPO.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.