### PR TITLE
Unique OpenShift vxlan port for KubeVirt Platform

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
@@ -1,0 +1,49 @@
+package network
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+func NetworkOperator() *operatorv1.Network {
+	return &operatorv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	}
+}
+
+// The default vxlan port registered by IANA is 4789. We need to avoid that for
+// kubernetes which runs nested.
+// 9879 is a currently unassigned IANA port in the user port range.
+const kubevirtDefaultVXLANPort = uint32(9879)
+
+func ReconcileNetworkOperator(network *operatorv1.Network, networkType hyperv1.NetworkType, platformType hyperv1.PlatformType) error {
+	switch platformType {
+	case hyperv1.KubevirtPlatform:
+		// Modify vxlan port to avoid collisions with management cluster's default vxlan port.
+		if networkType == hyperv1.OpenShiftSDN {
+			port := kubevirtDefaultVXLANPort
+			if network.Spec.DefaultNetwork.OpenShiftSDNConfig == nil {
+				network.Spec.DefaultNetwork.OpenShiftSDNConfig = &operatorv1.OpenShiftSDNConfig{}
+			}
+			if network.Spec.DefaultNetwork.OpenShiftSDNConfig.VXLANPort == nil {
+				network.Spec.DefaultNetwork.OpenShiftSDNConfig.VXLANPort = &port
+			}
+		}
+
+	default:
+		// do nothing
+	}
+
+	// Setting the management state is required in order to create
+	// this object. We need to create this object before the cno starts
+	// because mutating many of the values (like vxlanport) is not premitted
+	// after the cno reconciles this operator CR
+	if network.Spec.ManagementState == "" {
+		network.Spec.ManagementState = "Managed"
+	}
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile_test.go
@@ -1,0 +1,164 @@
+package network
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+func TestReconcileDefaultIngressController(t *testing.T) {
+	port := kubevirtDefaultVXLANPort
+	fakePort := uint32(11111)
+	testsCases := []struct {
+		name              string
+		inputNetwork      *operatorv1.Network
+		inputNetworkType  hyperv1.NetworkType
+		inputPlatformType hyperv1.PlatformType
+		expectedNetwork   *operatorv1.Network
+	}{
+		{
+			name:              "KubeVirt with OpenshiftSDN uses unique default vxlan port",
+			inputNetwork:      NetworkOperator(),
+			inputNetworkType:  hyperv1.OpenShiftSDN,
+			inputPlatformType: hyperv1.KubevirtPlatform,
+			expectedNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+					DefaultNetwork: operatorv1.DefaultNetworkDefinition{
+						OpenShiftSDNConfig: &operatorv1.OpenShiftSDNConfig{
+							VXLANPort: &port,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "KubeVirt with OpenshiftSDN does not set port when vxlan port already exists",
+			inputNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+					DefaultNetwork: operatorv1.DefaultNetworkDefinition{
+						OpenShiftSDNConfig: &operatorv1.OpenShiftSDNConfig{
+							VXLANPort: &fakePort,
+						},
+					},
+				},
+			},
+			inputNetworkType:  hyperv1.OpenShiftSDN,
+			inputPlatformType: hyperv1.KubevirtPlatform,
+			expectedNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+					DefaultNetwork: operatorv1.DefaultNetworkDefinition{
+						OpenShiftSDNConfig: &operatorv1.OpenShiftSDNConfig{
+							VXLANPort: &fakePort,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:              "KubeVirt with non SDN network does not set unique vxlan port",
+			inputNetwork:      NetworkOperator(),
+			inputNetworkType:  "fake",
+			inputPlatformType: hyperv1.KubevirtPlatform,
+			expectedNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+				},
+			},
+		},
+		{
+			name:              "AWS with SDN does not set unique vxlan port",
+			inputNetwork:      NetworkOperator(),
+			inputNetworkType:  hyperv1.OpenShiftSDN,
+			inputPlatformType: hyperv1.AWSPlatform,
+			expectedNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+				},
+			},
+		},
+		{
+			name:              "None with SDN does not set unique vxlan port",
+			inputNetwork:      NetworkOperator(),
+			inputNetworkType:  hyperv1.OpenShiftSDN,
+			inputPlatformType: hyperv1.NonePlatform,
+			expectedNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+				},
+			},
+		},
+		{
+			name:              "IBM with SDN does not set unique vxlan port",
+			inputNetwork:      NetworkOperator(),
+			inputNetworkType:  hyperv1.OpenShiftSDN,
+			inputPlatformType: hyperv1.IBMCloudPlatform,
+			expectedNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+				},
+			},
+		},
+		{
+			name:              "Azure with SDN does not set unique vxlan port",
+			inputNetwork:      NetworkOperator(),
+			inputNetworkType:  hyperv1.OpenShiftSDN,
+			inputPlatformType: hyperv1.AzurePlatform,
+			expectedNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+				},
+			},
+		},
+		{
+			name:              "Agent with SDN does not set unique vxlan port",
+			inputNetwork:      NetworkOperator(),
+			inputNetworkType:  hyperv1.OpenShiftSDN,
+			inputPlatformType: hyperv1.AgentPlatform,
+			expectedNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			err := ReconcileNetworkOperator(tc.inputNetwork, tc.inputNetworkType, tc.inputPlatformType)
+			g.Expect(err).To(BeNil())
+			g.Expect(tc.inputNetwork).To(BeEquivalentTo(tc.expectedNetwork))
+		})
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -33,6 +34,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/monitoring"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/namespaces"
+	networkoperator "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/oapi"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/oauth"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm"
@@ -123,6 +125,7 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 		&configv1.ClusterOperator{},
 		&configv1.ClusterVersion{},
 		&apiregistrationv1.APIService{},
+		&operatorv1.Network{},
 	}
 	for _, r := range resourcesToWatch {
 		if err := c.Watch(&source.Kind{Type: r}, eventHandler()); err != nil {
@@ -301,6 +304,15 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		errs = append(errs, fmt.Errorf("failed to reconcile kubeadmin password hash secret: %w", err))
 	}
 
+	log.Info("reconciling network operator")
+	networkOperator := networkoperator.NetworkOperator()
+	if _, err := r.CreateOrUpdate(ctx, r.client, networkOperator, func() error {
+		networkoperator.ReconcileNetworkOperator(networkOperator, hcp.Spec.NetworkType, hcp.Spec.Platform.Type)
+		return nil
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile network operator: %w", err))
+	}
+
 	log.Info("reconciling monitoring configuration")
 	monitoringConfig := manifests.MonitoringConfig()
 	if _, err := r.CreateOrUpdate(ctx, r.client, monitoringConfig, func() error {
@@ -428,9 +440,9 @@ func (r *reconciler) reconcileConfig(ctx context.Context, hcp *hyperv1.HostedCon
 		errs = append(errs, fmt.Errorf("failed to reconcile ingress config: %w", err))
 	}
 
-	network := globalconfig.NetworkConfig()
-	if _, err := r.CreateOrUpdate(ctx, r.client, network, func() error {
-		globalconfig.ReconcileNetworkConfig(network, hcp, globalConfig)
+	networkConfig := globalconfig.NetworkConfig()
+	if _, err := r.CreateOrUpdate(ctx, r.client, networkConfig, func() error {
+		globalconfig.ReconcileNetworkConfig(networkConfig, hcp, globalConfig)
 		return nil
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile network config: %w", err))

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	"github.com/openshift/hypershift/support/releaseinfo"
@@ -103,6 +104,7 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 				&configv1.Infrastructure{}: allSelector,
 				&configv1.DNS{}:            allSelector,
 				&configv1.Ingress{}:        allSelector,
+				&operatorv1.Network{}:      allSelector,
 				&configv1.Network{}:        allSelector,
 				&configv1.Proxy{}:          allSelector,
 				&configv1.Build{}:          allSelector,


### PR DESCRIPTION
This solves an issue we've been seeing in our e2e tests where the KubeVirt platform's console ingress occasionally fails.

Nested OpenShiftSDN requires unique vxlan ports for the nested layers or else connectivity breaks at the nested layer. This impacts the KubeVirt Hypershift platform because the KubeVirt VMs are running in OpenShiftSDN in the management cluster, and there's another layer of OpenShiftSDN running within the KubeVirt VM worker nodes themselves.

To work around this, when the KubeVirt platform is in use and the OpenShiftSDN network type is being used, we set a unique vxlan port that's different than the default 4789. I picked 9879 for the nested vxlan because it's an unregistered port in the IANA user range. In the future we can consider making this port configurable if we want, but I'm not sure it's worth adding that tuning until we're sure we need it.

Once we transition to OVNKubernetes for the tenant clusters, we'll have a similar issue for the genevePort where we'll need to set a unique genevePort that differs from the one that the management cluster uses.