### PR TITLE
[WIP] Load apiserver-network-proxy image from ocp payload

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -19,12 +19,6 @@ const (
 	DisablePKIReconciliationAnnotation        = "hypershift.openshift.io/disable-pki-reconciliation"
 	IdentityProviderOverridesAnnotationPrefix = "idpoverrides.hypershift.openshift.io/"
 	OauthLoginURLOverrideAnnotation           = "oauth.hypershift.openshift.io/login-url-override"
-	// KonnectivityServerImageAnnotation is a temporary annotation that allows the specification of the konnectivity server image.
-	// This will be removed when Konnectivity is added to the Openshift release payload
-	KonnectivityServerImageAnnotation = "hypershift.openshift.io/konnectivity-server-image"
-	// KonnectivityAgentImageAnnotation is a temporary annotation that allows the specification of the konnectivity agent image.
-	// This will be removed when Konnectivity is added to the Openshift release payload
-	KonnectivityAgentImageAnnotation = "hypershift.openshift.io/konnectivity-agent-image"
 	// ControlPlaneOperatorImageAnnotation is a annotation that allows the specification of the control plane operator image.
 	// This is used for development and e2e workflows
 	ControlPlaneOperatorImageAnnotation = "hypershift.openshift.io/control-plane-operator-image"

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -148,13 +148,10 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	p.AgentDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	p.ServerDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
-	if hcp.Annotations != nil {
-		if _, ok := hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]; ok {
-			p.KonnectivityServerImage = hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]
-		}
-		if _, ok := hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]; ok {
-			p.KonnectivityAgentImage = hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]
-		}
+	// check apiserver-network-proxy image in ocp payload and use it
+	if _, ok := images["apiserver-network-proxy"]; ok {
+		p.KonnectivityServerImage = images["apiserver-network-proxy"]
+		p.KonnectivityAgentImage = images["apiserver-network-proxy"]
 	}
 	return p
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/params.go
@@ -54,8 +54,9 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 			SuccessThreshold:    1,
 		},
 	}
-	if _, ok := hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]; ok {
-		p.Image = hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]
+	// check apiserver-network-proxy image in ocp payload and use it
+	if _, ok := images["apiserver-network-proxy"]; ok {
+		p.Image = images["apiserver-network-proxy"]
 	}
 	p.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1109,8 +1109,6 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	mirroredAnnotations := []string{
 		hyperv1.DisablePKIReconciliationAnnotation,
 		hyperv1.OauthLoginURLOverrideAnnotation,
-		hyperv1.KonnectivityAgentImageAnnotation,
-		hyperv1.KonnectivityServerImageAnnotation,
 		hyperv1.RestartDateAnnotation,
 		hyperv1.IBMCloudKMSProviderImage,
 		hyperv1.AWSKMSProviderImage,


### PR DESCRIPTION
This PR enables to load apiserver-network-proxy image from OCP release payload only if its available. if image is not available in the OCP release image, its uses default override method.  

**What this PR does / why we need it**:
apiserver-network-proxy image is available in ocp 4.11 payload. we can read it from payload. 

fixes # https://issues.redhat.com/browse/HOSTEDCP-301
