### PR TITLE
Use forked processes instead of pods to generate ignition payload

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedapicache"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator"
-	ignitionserver "github.com/openshift/hypershift/ignition-server"
+	ignitionserver "github.com/openshift/hypershift/ignition-server/cmd"
 	konnectivitysocks5proxy "github.com/openshift/hypershift/konnectivity-socks5-proxy"
 	kubernetesdefaultproxy "github.com/openshift/hypershift/kubernetes-default-proxy"
 	"github.com/openshift/hypershift/support/capabilities"

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1104,7 +1104,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile the Ignition server
-	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, utilitiesImage, defaultIngressDomain); err != nil {
+	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, utilitiesImage, hcp, defaultIngressDomain); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile ignition server: %w", err)
 	}
 
@@ -1612,8 +1612,7 @@ func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.Servi
 	return nil
 }
 
-func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, utilitiesImage, defaultIngressDomain string) error {
-
+func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, utilitiesImage string, hcp *hyperv1.HostedControlPlane, defaultIngressDomain string) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
@@ -1766,7 +1765,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 	}
 
 	role := ignitionserver.Role(controlPlaneNamespace.Name)
-	if _, err := createOrUpdate(ctx, r.Client, role, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, role, func() error {
 		role.Rules = []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
@@ -1788,18 +1787,22 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition role: %w", err)
+	} else {
+		log.Info("Reconciled ignition role", "result", result)
 	}
 
 	sa := ignitionserver.ServiceAccount(controlPlaneNamespace.Name)
-	if _, err := createOrUpdate(ctx, r.Client, sa, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, sa, func() error {
 		util.EnsurePullSecret(sa, controlplaneoperator.PullSecret("").Name)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator service account: %w", err)
+	} else {
+		log.Info("Reconciled ignition server service account", "result", result)
 	}
 
 	roleBinding := ignitionserver.RoleBinding(controlPlaneNamespace.Name)
-	if _, err := createOrUpdate(ctx, r.Client, roleBinding, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, roleBinding, func() error {
 		roleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
@@ -1816,11 +1819,13 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition RoleBinding: %w", err)
+	} else {
+		log.Info("Reconciled ignition server rolebinding", "result", result)
 	}
 
 	// Reconcile deployment
 	ignitionServerDeployment := ignitionserver.Deployment(controlPlaneNamespace.Name)
-	if _, err := createOrUpdate(ctx, r.Client, ignitionServerDeployment, func() error {
+	if result, err := createOrUpdate(ctx, r.Client, ignitionServerDeployment, func() error {
 		if ignitionServerDeployment.Annotations == nil {
 			ignitionServerDeployment.Annotations = map[string]string{}
 		}
@@ -1853,6 +1858,12 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 								Secret: &corev1.SecretVolumeSource{
 									SecretName: servingCertSecret.Name,
 								},
+							},
+						},
+						{
+							Name: "payloads",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -1908,6 +1919,10 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 									Name:          "https",
 									ContainerPort: 9090,
 								},
+								{
+									Name:          "metrics",
+									ContainerPort: 8080,
+								},
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
@@ -1919,6 +1934,10 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 								{
 									Name:      "serving-cert",
 									MountPath: "/var/run/secrets/ignition/serving-cert",
+								},
+								{
+									Name:      "payloads",
+									MountPath: "/payloads",
 								},
 							},
 						},
@@ -1961,6 +1980,34 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition deployment: %w", err)
+	} else {
+		log.Info("Reconciled ignition server deployment", "result", result)
+	}
+
+	// Reconcile PodMonitor
+	podMonitor := ignitionserver.PodMonitor(controlPlaneNamespace.Name)
+	if result, err := createOrUpdate(ctx, r.Client, podMonitor, func() error {
+		podMonitor.Spec.Selector = *ignitionServerDeployment.Spec.Selector
+		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
+			Interval: "15s",
+			Port:     "metrics",
+		}}
+		podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{controlPlaneNamespace.Name}}
+		podMonitor.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: hyperv1.GroupVersion.String(),
+			Kind:       "HostedControlPlane",
+			Name:       hcp.Name,
+			UID:        hcp.UID,
+		}})
+		if podMonitor.Annotations == nil {
+			podMonitor.Annotations = map[string]string{}
+		}
+		podMonitor.Annotations[hostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ignition server pod monitor: %w", err)
+	} else {
+		log.Info("Reconciled ignition server podmonitor", "result", result)
 	}
 
 	return nil

--- a/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
+++ b/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
@@ -2,6 +2,7 @@ package ignitionserver
 
 import (
 	routev1 "github.com/openshift/api/route/v1"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -29,6 +30,15 @@ func Service(namespace string) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      ResourceName,
+		},
+	}
+}
+
+func PodMonitor(controlPlaneNamespace string) *prometheusoperatorv1.PodMonitor {
+	return &prometheusoperatorv1.PodMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      "ignition-server",
 		},
 	}
 }

--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	hyperapi "github.com/openshift/hypershift/api"
+	"github.com/openshift/hypershift/ignition-server/controllers"
+	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+type RunLocalIgnitionProviderOptions struct {
+	Namespace   string
+	Image       string
+	TokenSecret string
+	WorkDir     string
+}
+
+func NewRunLocalIgnitionProviderCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run-local-ign-provider",
+		Short: "Executes payload generation once for debugging and exits",
+	}
+
+	opts := RunLocalIgnitionProviderOptions{}
+
+	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "Namespace")
+	cmd.Flags().StringVar(&opts.Image, "image", opts.Image, "Release image")
+	cmd.Flags().StringVar(&opts.TokenSecret, "token-secret", opts.TokenSecret, "Token secret name")
+	cmd.Flags().StringVar(&opts.WorkDir, "dir", opts.WorkDir, "Working directory (default: temporary dir)")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+		ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+			o.EncodeTime = zapcore.RFC3339TimeEncoder
+		})))
+		return opts.Run(ctx)
+	}
+
+	return cmd
+}
+
+func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
+	start := time.Now()
+	log := ctrl.Log.WithName("local-ign-provider")
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return err
+	}
+	cfg.QPS = 100
+	cfg.Burst = 100
+	cl, err := client.New(cfg, client.Options{Scheme: hyperapi.Scheme})
+	if err != nil {
+		return fmt.Errorf("unable to get kubernetes client: %w", err)
+	}
+	if err != nil {
+		return err
+	}
+	token := &corev1.Secret{}
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: o.Namespace, Name: o.TokenSecret}, token); err != nil {
+		return err
+	}
+	compressedConfig := token.Data[controllers.TokenSecretConfigKey]
+	config, err := controllers.Decompress(compressedConfig)
+	if err != nil {
+		return nil
+	}
+	p := &controllers.LocalIgnitionProvider{
+		Client:          cl,
+		ReleaseProvider: &releaseinfo.RegistryClientProvider{},
+		CloudProvider:   "",
+		Namespace:       o.Namespace,
+		WorkDir:         o.WorkDir,
+		PreserveOutput:  true,
+	}
+
+	payload, err := p.GetPayload(ctx, o.Image, string(config))
+	if err != nil {
+		return err
+	}
+
+	payloadFile, err := os.CreateTemp(o.WorkDir, "payload-")
+	if err != nil {
+		return err
+	}
+	defer payloadFile.Close()
+	if err := os.WriteFile(payloadFile.Name(), payload, 0644); err != nil {
+		return fmt.Errorf("failed to write payload file: %w", err)
+	}
+
+	log.Info("Wrote payload", "duration", time.Since(start).Round(time.Second).String(), "output", payloadFile.Name())
+	return nil
+}

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"regexp"
+	"syscall"
+	"time"
+
+	hyperapi "github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/ignition-server/controllers"
+	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const namespaceEnvVariableName = "MY_NAMESPACE"
+
+// We only match /ignition
+var ignPathPattern = regexp.MustCompile("^/ignition[^/ ]*$")
+var payloadStore = controllers.NewPayloadStore()
+
+type Options struct {
+	Addr              string
+	CertFile          string
+	KeyFile           string
+	RegistryOverrides map[string]string
+	Platform          string
+	WorkDir           string
+	MetricsAddr       string
+}
+
+// This is an https server that enable us to satisfy
+// 1 - 1 relation between clusters and ign endpoints.
+// It runs a token Secret controller.
+// The token Secret controller uses an IgnitionProvider provider implementation
+// (e.g machineConfigServerIgnitionProvider) to keep up to date a payload store in memory.
+// The payload store has the structure "NodePool token": "payload".
+// A token represents a given cluster version (and in the future also a machine Config) at any given point in time.
+// For a request to succeed a token needs to be passed in the Header.
+func NewStartCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ignition-server",
+		Short: "Starts the ignition server",
+	}
+
+	opts := Options{
+		Addr:              "0.0.0.0:9090",
+		MetricsAddr:       "0.0.0.0:8080",
+		CertFile:          "/var/run/secrets/ignition/serving-cert/tls.crt",
+		KeyFile:           "/var/run/secrets/ignition/serving-cert/tls.key",
+		WorkDir:           "/payloads",
+		RegistryOverrides: map[string]string{},
+	}
+
+	cmd.Flags().StringVar(&opts.Addr, "addr", opts.Addr, "Listen address")
+	cmd.Flags().StringVar(&opts.CertFile, "cert-file", opts.CertFile, "Path to the serving cert")
+	cmd.Flags().StringVar(&opts.KeyFile, "key-file", opts.KeyFile, "Path to the serving key")
+	cmd.Flags().StringToStringVar(&opts.RegistryOverrides, "registry-overrides", map[string]string{}, "registry-overrides contains the source registry string as a key and the destination registry string as value. Images before being applied are scanned for the source registry string and if found the string is replaced with the destination registry string. Format is: sr1=dr1,sr2=dr2")
+	cmd.Flags().StringVar(&opts.Platform, "platform", "", "The cloud provider platform name")
+	cmd.Flags().StringVar(&opts.WorkDir, "work-dir", "", "Directory in which to store transient working data")
+	cmd.Flags().StringVar(&opts.MetricsAddr, "metrics-addr", opts.MetricsAddr, "The address the metric endpoint binds to.")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		// TODO: Add an fsnotify watcher to cancel the context and trigger a restart
+		// if any of the secret data has changed.
+		if err := run(ctx, opts); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	return cmd
+}
+
+// setUpPayloadStoreReconciler sets up manager with a TokenSecretReconciler controller
+// to keep the PayloadStore up to date.
+func setUpPayloadStoreReconciler(ctx context.Context, registryOverrides map[string]string, cloudProvider hyperv1.PlatformType, cacheDir string, metricsAddr string) (ctrl.Manager, error) {
+	if os.Getenv(namespaceEnvVariableName) == "" {
+		return nil, fmt.Errorf("environment variable %s is empty, this is not supported", namespaceEnvVariableName)
+	}
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+		o.EncodeTime = zapcore.RFC3339TimeEncoder
+	})))
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.UserAgent = "ignition-server-manager"
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+		Scheme:             hyperapi.Scheme,
+		Port:               9443,
+		MetricsBindAddress: metricsAddr,
+		// LeaderElection:     opts.EnableLeaderElection,
+		Namespace: os.Getenv(namespaceEnvVariableName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to start manager: %w", err)
+	}
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return nil, fmt.Errorf("unable to set up health check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return nil, fmt.Errorf("unable to set up ready check: %w", err)
+	}
+	if err = (&controllers.TokenSecretReconciler{
+		Client:       mgr.GetClient(),
+		PayloadStore: payloadStore,
+		IgnitionProvider: &controllers.LocalIgnitionProvider{
+			ReleaseProvider: &releaseinfo.RegistryMirrorProviderDecorator{
+				Delegate: &releaseinfo.CachedProvider{
+					Inner: &releaseinfo.RegistryClientProvider{},
+					Cache: map[string]*releaseinfo.ReleaseImage{},
+				},
+				RegistryOverrides: registryOverrides,
+			},
+			Client:        mgr.GetClient(),
+			Namespace:     os.Getenv(namespaceEnvVariableName),
+			CloudProvider: cloudProvider,
+			WorkDir:       cacheDir,
+		},
+	}).SetupWithManager(ctx, mgr); err != nil {
+		return nil, fmt.Errorf("unable to create controller: %w", err)
+	}
+
+	return mgr, nil
+}
+
+func run(ctx context.Context, opts Options) error {
+	certWatcher, err := certwatcher.New(opts.CertFile, opts.KeyFile)
+	if err != nil {
+		return fmt.Errorf("failed to load serving cert: %w", err)
+	}
+
+	mgr, err := setUpPayloadStoreReconciler(ctx, opts.RegistryOverrides, hyperv1.PlatformType(opts.Platform), opts.WorkDir, opts.MetricsAddr)
+	if err != nil {
+		return fmt.Errorf("error setting up manager: %w", err)
+	}
+	if err := mgr.Add(certWatcher); err != nil {
+		return fmt.Errorf("failed to add certWatcher to manager: %w", err)
+	}
+	go mgr.Start(ctx)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("User Agent: %s. Requested: %s", r.Header.Get("User-Agent"), r.URL.Path)
+
+		if !ignPathPattern.MatchString(r.URL.Path) {
+			// No pattern matched; send 404 response.
+			log.Printf("Path not found: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+
+		// Authorize the request against the token
+		const bearerPrefix = "Bearer "
+		auth := r.Header.Get("Authorization")
+		n := len(bearerPrefix)
+		if len(auth) < n || auth[:n] != bearerPrefix {
+			log.Printf("Invalid Authorization header value prefix")
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		encodedToken := auth[n:]
+		decodedToken, err := base64.StdEncoding.DecodeString(encodedToken)
+		if err != nil {
+			log.Printf("Invalid token value")
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		value, ok := payloadStore.Get(string(decodedToken))
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(value.Payload)
+	})
+
+	server := http.Server{
+		Addr:         opts.Addr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		TLSConfig:    &tls.Config{GetCertificate: certWatcher.GetCertificate},
+	}
+
+	go func() {
+		<-ctx.Done()
+		if err := server.Shutdown(ctx); err != nil {
+			log.Printf("error shutting down server: %s", err)
+		}
+	}()
+
+	log.Printf("Listening on %s", opts.Addr)
+	if err := server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -1,0 +1,443 @@
+package controllers
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sync"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// LocalIgnitionProvider is an IgnitionProvider that executes MCO binaries
+// directly to build ignition payload contents out of a given release image and
+// a config string containing 0..N MachineConfig YAML definitions.
+//
+// To do this, MCO binaries and other static input files are extracted from a
+// release image into WorkDir. These contents are cleaned up after each
+// execution and are not currently cached between executions for a given release
+// image because the effort of managing the cache is not yet justified by any
+// performance measurements.
+//
+// Currently, all GetPayload executions are performed serially, enforced by a
+// mutex. Enabling concurrent executions requires more work because of the of
+// MCS, which is an HTTP server process, implying work to allocate
+// non-conflicting ports. This effort is not yet justified by any performance
+// measurements.
+type LocalIgnitionProvider struct {
+	Client          client.Client
+	ReleaseProvider releaseinfo.Provider
+	CloudProvider   hyperv1.PlatformType
+	Namespace       string
+
+	// WorkDir is the base working directory for contents extracted from a
+	// release payload. Usually this would map to a volume mount.
+	WorkDir string
+
+	// PreserveOutput indicates whether the temporary working directory created
+	// under WorkDir should be preserved. If false, the temporary directory is
+	// deleted after use.
+	PreserveOutput bool
+
+	lock sync.Mutex
+}
+
+var _ IgnitionProvider = (*LocalIgnitionProvider)(nil)
+
+func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage string, customConfig string) ([]byte, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	log := ctrl.Log.WithName("get-payload")
+
+	// Fetch the pull secret contents
+	pullSecret, err := func() ([]byte, error) {
+		secret := &corev1.Secret{}
+		if err := p.Client.Get(ctx, client.ObjectKey{Namespace: p.Namespace, Name: pullSecretName}, secret); err != nil {
+			return nil, fmt.Errorf("failed to get pull secret: %w", err)
+		}
+		data, exists := secret.Data[corev1.DockerConfigJsonKey]
+		if !exists {
+			return nil, fmt.Errorf("pull secret missing %q key", corev1.DockerConfigJsonKey)
+		}
+		return data, nil
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pull secret: %w", err)
+	}
+
+	// Fetch the bootstrap kubeconfig contents
+	bootstrapKubeConfig, err := func() ([]byte, error) {
+		secret := &corev1.Secret{}
+		if err := p.Client.Get(ctx, client.ObjectKey{Namespace: p.Namespace, Name: "bootstrap-kubeconfig"}, secret); err != nil {
+			return nil, fmt.Errorf("failed to get bootstrap kubeconfig secret: %w", err)
+		}
+		data, exists := secret.Data["kubeconfig"]
+		if !exists {
+			return nil, fmt.Errorf("bootstrap kubeconfig secret missing kubeconfig key")
+		}
+		return data, nil
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get bootstrap kubeconfig: %w", err)
+	}
+
+	// Fetch the MCS config
+	mcsConfig := &corev1.ConfigMap{}
+	if err := p.Client.Get(ctx, client.ObjectKey{Namespace: p.Namespace, Name: "machine-config-server"}, mcsConfig); err != nil {
+		return nil, fmt.Errorf("failed to get machine-config-server configmap: %w", err)
+	}
+
+	// Look up the release image metadata
+	images, err := func() (map[string]string, error) {
+		img, err := p.ReleaseProvider.Lookup(ctx, releaseImage, pullSecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up release image metadata: %w", err)
+		}
+		return img.ComponentImages(), nil
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get component images: %v", err)
+	}
+
+	mcoImage, hasMcoImage := images["machine-config-operator"]
+	if !hasMcoImage {
+		return nil, fmt.Errorf("release image does not contain machine-config-operator (images: %v)", images)
+	}
+	log.Info("discovered mco image", "image", mcoImage)
+
+	// Set up the base working directory
+	workDir, err := ioutil.TempDir(p.WorkDir, "get-payload")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create working directory: %w", err)
+	}
+	if !p.PreserveOutput {
+		defer func() {
+			if err := os.RemoveAll(workDir); err != nil {
+				log.Error(err, "failed to delete working directory", "dir", workDir)
+			}
+		}()
+	}
+	log.Info("created working directory", "dir", workDir)
+
+	// Prepare all the working subdirectories
+	binDir := filepath.Join(workDir, "bin")
+	mcoBaseDir := filepath.Join(workDir, "mco")
+	mccBaseDir := filepath.Join(workDir, "mcc")
+	mcsBaseDir := filepath.Join(workDir, "mcs")
+	configDir := filepath.Join(workDir, "config")
+	for _, dir := range []string{binDir, mcoBaseDir, mccBaseDir, mcsBaseDir, configDir} {
+		if err := os.Mkdir(dir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to make directory %s: %w", dir, err)
+		}
+	}
+
+	// Write out the custom config to the MCC directory
+	if err := os.WriteFile(filepath.Join(mccBaseDir, "custom.yaml"), []byte(customConfig), 0644); err != nil {
+		return nil, fmt.Errorf("failed to write mcc config: %w", err)
+	}
+	// Write out the bootstrap kubeconfig to the MCS directory
+	if err := os.WriteFile(filepath.Join(mcsBaseDir, "kubeconfig"), bootstrapKubeConfig, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write bootstrap kubeconfig: %w", err)
+	}
+	// Extract MCS config files into the config directory
+	for name, contents := range mcsConfig.Data {
+		if err := os.WriteFile(filepath.Join(configDir, name), []byte(contents), 0644); err != nil {
+			return nil, fmt.Errorf("failed to write MCS config file %q: %w", name, err)
+		}
+	}
+	// For Azure, extract the cloud provider config file as MCO input
+	if p.CloudProvider == hyperv1.AzurePlatform {
+		cloudConfigMap := &corev1.ConfigMap{}
+		if err := p.Client.Get(ctx, client.ObjectKey{Namespace: p.Namespace, Name: manifests.AzureProviderConfig("").Name}, cloudConfigMap); err != nil {
+			return nil, fmt.Errorf("failed to get cloud provider configmap: %w", err)
+		}
+		cloudConfYaml, err := yaml.Marshal(cloudConfigMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal cloud config: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(mcoBaseDir, "cloud.conf.configmap.yaml"), cloudConfYaml, 0644); err != nil {
+			return nil, fmt.Errorf("failed to write bootstrap kubeconfig: %w", err)
+		}
+	}
+
+	// Extract template files from the MCO image to the MCC input directory
+	err = func() error {
+		start := time.Now()
+		if err := registryclient.ExtractImageFilesToDir(ctx, mcoImage, pullSecret, "etc/mcc/templates/*", mccBaseDir); err != nil {
+			return fmt.Errorf("failed to extract mcc templates: %w", err)
+		}
+		log.Info("extracted templates", "time", time.Since(start).Round(time.Second).String())
+		return nil
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract templates from image: %w", err)
+	}
+
+	// Extract binaries from the MCO image into the bin directory
+	err = func() error {
+		start := time.Now()
+		binaries := []string{"machine-config-operator", "machine-config-controller", "machine-config-server"}
+		for _, name := range binaries {
+			file, err := os.Create(filepath.Join(binDir, name))
+			if err != nil {
+				return fmt.Errorf("failed to create file: %w", err)
+			}
+			if err := file.Chmod(0777); err != nil {
+				return fmt.Errorf("failed to chmod file: %w", err)
+			}
+			if err := registryclient.ExtractImageFile(ctx, mcoImage, pullSecret, filepath.Join("usr/bin/", name), file); err != nil {
+				return fmt.Errorf("failed to extract image file: %w", err)
+			}
+			if err := file.Close(); err != nil {
+				return fmt.Errorf("failed to close file: %w", err)
+			}
+		}
+		log.Info("downloaded binaries", "time", time.Since(start).Round(time.Second).String())
+		return nil
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to download binaries: %w", err)
+	}
+
+	// First, run the MCO using templates and image refs as input. This generates
+	// output for the MCC.
+	err = func() error {
+		destDir := filepath.Join(workDir, "mco")
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return fmt.Errorf("failed to make dir: %w", err)
+		}
+
+		args := []string{
+			"bootstrap",
+			fmt.Sprintf("--machine-config-operator-image=%s", images["machine-config-operator"]),
+			fmt.Sprintf("--machine-config-oscontent-image=%s", images["machine-os-content"]),
+			fmt.Sprintf("--infra-image=%s", images["pod"]),
+			fmt.Sprintf("--keepalived-image=%s", images["keepalived-ipfailover"]),
+			fmt.Sprintf("--coredns-image=%s", images["codedns"]),
+			fmt.Sprintf("--haproxy-image=%s", images["haproxy"]),
+			fmt.Sprintf("--baremetal-runtimecfg-image=%s", images["baremetal-runtimecfg"]),
+			fmt.Sprintf("--root-ca=%s/root-ca.crt", configDir),
+			fmt.Sprintf("--kube-ca=%s/combined-ca.crt", configDir),
+			fmt.Sprintf("--infra-config-file=%s/cluster-infrastructure-02-config.yaml", configDir),
+			fmt.Sprintf("--network-config-file=%s/cluster-network-02-config.yaml", configDir),
+			fmt.Sprintf("--proxy-config-file=%s/cluster-proxy-01-config.yaml", configDir),
+			fmt.Sprintf("--config-file=%s/install-config.yaml", configDir),
+			fmt.Sprintf("--dns-config-file=%s/cluster-dns-02-config.yaml", configDir),
+			fmt.Sprintf("--pull-secret=%s/pull-secret.yaml", configDir),
+			fmt.Sprintf("--dest-dir=%s", destDir),
+		}
+		if image, exists := images["mdns-publisher"]; exists {
+			args = append(args, fmt.Sprintf("--mdns-publisher-image=%s", image))
+		}
+		if p.CloudProvider == hyperv1.AzurePlatform {
+			args = append(args, fmt.Sprintf("--cloud-config-file=%s/cloud.conf.configmap.yaml", mcoBaseDir))
+		}
+
+		start := time.Now()
+		cmd := exec.CommandContext(ctx, filepath.Join(binDir, "machine-config-operator"), args...)
+		out, err := cmd.CombinedOutput()
+		log.Info("machine-config-operator process completed", "time", time.Since(start).Round(time.Second).String(), "output", string(out))
+		if err != nil {
+			return fmt.Errorf("machine-config-operator process failed: %w", err)
+		}
+
+		// Copy output to the MCC base directory
+		bootstrapManifestsDir := filepath.Join(destDir, "bootstrap", "manifests")
+		manifests, err := ioutil.ReadDir(bootstrapManifestsDir)
+		if err != nil {
+			return fmt.Errorf("failed to read dir: %w", err)
+		}
+		for _, fd := range manifests {
+			src := path.Join(bootstrapManifestsDir, fd.Name())
+			dst := path.Join(mccBaseDir, fd.Name())
+			if fd.IsDir() {
+				continue
+			}
+			if err := copyFile(src, dst); err != nil {
+				return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+			}
+		}
+
+		// Copy machineconfigpool config data to the MCC input directory. This is
+		// important to override the pools with the ones generated by the CPO.
+		err = func() error {
+			matches, err := filepath.Glob(filepath.Join(configDir, "*.machineconfigpool.yaml"))
+			if err != nil {
+				return fmt.Errorf("failed to list dir %s: %w", configDir, err)
+			}
+			for _, src := range matches {
+				dst := filepath.Join(mccBaseDir, filepath.Base(src))
+				if err := copyFile(src, dst); err != nil {
+					return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+				}
+			}
+			return nil
+		}()
+		if err != nil {
+			return fmt.Errorf("failed to copy mcs config to mcc directory: %w", err)
+		}
+		return nil
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute machine-config-operator: %w", err)
+	}
+
+	// Next, run the MCC using templates and MCO output as input, producing output
+	// for the MCS.
+	err = func() error {
+		start := time.Now()
+		cmd := exec.CommandContext(ctx, filepath.Join(binDir, "machine-config-controller"), "bootstrap",
+			fmt.Sprintf("--manifest-dir=%s", mccBaseDir),
+			fmt.Sprintf("--templates=%s", filepath.Join(mccBaseDir, "etc", "mcc", "templates")),
+			fmt.Sprintf("--pull-secret=%s/machineconfigcontroller-pull-secret", mccBaseDir),
+			fmt.Sprintf("--dest-dir=%s", mcsBaseDir),
+		)
+		out, err := cmd.CombinedOutput()
+		log.Info("machine-config-controller process completed", "time", time.Since(start).Round(time.Second).String(), "output", string(out))
+		if err != nil {
+			return fmt.Errorf("machine-config-controller process failed: %w", err)
+		}
+		return nil
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute machine-config-controller: %w", err)
+	}
+
+	// Finally, run the MCS to generate a payload.
+	payload, err := func() ([]byte, error) {
+		start := time.Now()
+
+		// Generate certificates. The MCS is hard-coded to expose a TLS listener
+		// and requires both a certificate and a key.
+		// TODO: This could be generated once up-front and cached for all processes
+		err = func() error {
+			cfg := &certs.CertCfg{
+				Subject:   pkix.Name{CommonName: "machine-config-server", OrganizationalUnit: []string{"openshift"}},
+				KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+				Validity:  certs.ValidityOneDay,
+				IsCA:      true,
+			}
+			key, crt, err := certs.GenerateSelfSignedCertificate(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to generate cert: %w", err)
+			}
+			if err := os.WriteFile(filepath.Join(mcsBaseDir, "tls.crt"), certs.CertToPem(crt), 0644); err != nil {
+				return fmt.Errorf("failed to write mcs cert: %w", err)
+			}
+			if err := os.WriteFile(filepath.Join(mcsBaseDir, "tls.key"), certs.PrivateKeyToPem(key), 0644); err != nil {
+				return fmt.Errorf("failed to write mcs cert: %w", err)
+			}
+			return nil
+		}()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate certificates: %w", err)
+		}
+
+		// Spin up the MCS process and ensure it's signaled to terminate when
+		// the function returns
+		mcsCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		cmd := exec.CommandContext(mcsCtx, filepath.Join(binDir, "machine-config-server"), "bootstrap",
+			fmt.Sprintf("--server-basedir=%s", mcsBaseDir),
+			fmt.Sprintf("--bootstrap-kubeconfig=%s/kubeconfig", mcsBaseDir),
+			fmt.Sprintf("--cert=%s/tls.crt", mcsBaseDir),
+			fmt.Sprintf("--key=%s/tls.key", mcsBaseDir),
+			"--secure-port=22623",
+			"--insecure-port=22624",
+		)
+		go func() {
+			out, err := cmd.CombinedOutput()
+			log.Info("machine-config-server process exited", "output", string(out), "error", err)
+		}()
+
+		// Try connecting to the server until we get a response or the context is
+		// closed
+		httpclient := &http.Client{
+			Timeout: 5 * time.Second,
+		}
+		var payload []byte
+		err = wait.PollUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+			req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost:22624/config/master", nil)
+			if err != nil {
+				return false, fmt.Errorf("error building http request: %w", err)
+			}
+			// We pass expected Headers to return the right config version.
+			// https://www.iana.org/assignments/media-types/application/vnd.coreos.ignition+json
+			// https://github.com/coreos/ignition/blob/0cbe33fee45d012515479a88f0fe94ef58d5102b/internal/resource/url.go#L61-L64
+			// https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/server/api.go#L269
+			req.Header.Add("Accept", "application/vnd.coreos.ignition+json;version=3.2.0, */*;q=0.1")
+			res, err := httpclient.Do(req)
+			if err != nil {
+				log.Error(err, "mcs request failed")
+				return false, nil
+			}
+			if res.StatusCode != http.StatusOK {
+				log.Error(err, "mcs returned unexpected response code", "code", res.StatusCode)
+				return false, nil
+			}
+
+			defer func() {
+				if err := res.Body.Close(); err != nil {
+					log.Error(err, "failed to close mcs response body")
+				}
+			}()
+			p, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				log.Error(err, "failed to read mcs response body")
+				return false, nil
+			}
+			payload = p
+			log.Info("got mcs payload", "time", time.Since(start).Round(time.Second).String())
+			return true, nil
+		})
+		return payload, err
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get payload from mcs: %w", err)
+	}
+
+	return payload, nil
+}
+
+// copyFile copies a file named src to dst, preserving attributes.
+func copyFile(src, dst string) error {
+	srcfd, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcfd.Close()
+
+	dstfd, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstfd.Close()
+
+	if _, err = io.Copy(dstfd, srcfd); err != nil {
+		return err
+	}
+	srcinfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dst, srcinfo.Mode())
+}

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -14,11 +14,13 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -35,6 +37,29 @@ const (
 	// https://github.com/kubernetes-sigs/controller-runtime/blob/1e4d87c9f9e15e4a58bb81909dd787f30ede7693/pkg/cache/cache.go#L118
 	ttl = time.Hour * 11
 )
+
+var (
+	TokenRotationTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ign_server_token_rotation_total",
+	})
+
+	PayloadCacheMissTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ign_server_payload_cache_miss_total",
+	})
+
+	PayloadGenerationSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "ign_server_payload_generation_seconds",
+		Buckets: []float64{5, 15, 30, 45, 60},
+	})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		TokenRotationTotal,
+		PayloadCacheMissTotal,
+		PayloadGenerationSeconds,
+	)
+}
 
 func NewPayloadStore() *ExpiringCache {
 	return &ExpiringCache{
@@ -199,20 +224,32 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			if err := r.rotateToken(ctx, tokenSecret, value, now); err != nil {
 				return ctrl.Result{}, err
 			}
+			TokenRotationTotal.Inc()
 		}
 		return ctrl.Result{RequeueAfter: ttl/2 - durationDeref(timeLived)}, nil
 	}
 
 	releaseImage := string(tokenSecret.Data[TokenSecretReleaseKey])
 	compressedConfig := tokenSecret.Data[TokenSecretConfigKey]
-	config, err := decompress(compressedConfig)
+	config, err := Decompress(compressedConfig)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	payload, err := r.IgnitionProvider.GetPayload(ctx, releaseImage, string(config))
+	PayloadCacheMissTotal.Inc()
+	payload, err := func() ([]byte, error) {
+		start := time.Now()
+		payload, err := r.IgnitionProvider.GetPayload(ctx, releaseImage, string(config))
+		if err != nil {
+			return nil, fmt.Errorf("error getting ignition payload: %v", err)
+		}
+		duration := time.Since(start).Round(time.Second).Seconds()
+		log.Info("got ignition payload", "duration", duration)
+		PayloadGenerationSeconds.Observe(duration)
+		return payload, err
+	}()
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("error getting ignition payload: %v", err)
+		return ctrl.Result{}, err
 	}
 
 	log.Info("IgnitionProvider generated payload")
@@ -226,7 +263,7 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{RequeueAfter: ttl/2 - durationDeref(timeLived)}, nil
 }
 
-func decompress(content []byte) ([]byte, error) {
+func Decompress(content []byte) ([]byte, error) {
 	if len(content) == 0 {
 		return nil, nil
 	}

--- a/ignition-server/main.go
+++ b/ignition-server/main.go
@@ -1,206 +1,32 @@
-package ignitionserver
+package main
 
 import (
-	"context"
-	"crypto/tls"
-	"encoding/base64"
 	"fmt"
-	"log"
-	"net/http"
 	"os"
-	"os/signal"
-	"regexp"
-	"syscall"
-	"time"
 
-	hyperapi "github.com/openshift/hypershift/api"
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/ignition-server/controllers"
-	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/openshift/hypershift/ignition-server/cmd"
 )
 
-const namespaceEnvVariableName = "MY_NAMESPACE"
-
-// We only match /ignition
-var ignPathPattern = regexp.MustCompile("^/ignition[^/ ]*$")
-var payloadStore = controllers.NewPayloadStore()
-
-type Options struct {
-	Addr              string
-	CertFile          string
-	KeyFile           string
-	RegistryOverrides map[string]string
-	Platform          string
-}
-
-// This is an https server that enable us to satisfy
-// 1 - 1 relation between clusters and ign endpoints.
-// It runs a token Secret controller.
-// The token Secret controller uses an IgnitionProvider provider implementation
-// (e.g machineConfigServerIgnitionProvider) to keep up to date a payload store in memory.
-// The payload store has the structure "NodePool token": "payload".
-// A token represents a given cluster version (and in the future also a machine Config) at any given point in time.
-// For a request to succeed a token needs to be passed in the Header.
-// TODO (alberto): Metrics.
-func NewStartCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "ignition-server",
-		Short: "Starts the ignition server",
-	}
-
-	opts := Options{
-		Addr:              "0.0.0.0:9090",
-		CertFile:          "/var/run/secrets/ignition/serving-cert/tls.crt",
-		KeyFile:           "/var/run/secrets/ignition/serving-cert/tls.key",
-		RegistryOverrides: map[string]string{},
-	}
-
-	cmd.Flags().StringVar(&opts.Addr, "addr", opts.Addr, "Listen address")
-	cmd.Flags().StringVar(&opts.CertFile, "cert-file", opts.CertFile, "Path to the serving cert")
-	cmd.Flags().StringVar(&opts.KeyFile, "key-file", opts.KeyFile, "Path to the serving key")
-	cmd.Flags().StringToStringVar(&opts.RegistryOverrides, "registry-overrides", map[string]string{}, "registry-overrides contains the source registry string as a key and the destination registry string as value. Images before being applied are scanned for the source registry string and if found the string is replaced with the destination registry string. Format is: sr1=dr1,sr2=dr2")
-	cmd.Flags().StringVar(&opts.Platform, "platform", "", "The cloud provider platform name")
-
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
-
-		// TODO: Add an fsnotify watcher to cancel the context and trigger a restart
-		// if any of the secret data has changed.
-		if err := run(ctx, opts); err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	return cmd
-}
-
-// setUpPayloadStoreReconciler sets up manager with a TokenSecretReconciler controller
-// to keep the PayloadStore up to date.
-func setUpPayloadStoreReconciler(ctx context.Context, registryOverrides map[string]string, cloudProvider hyperv1.PlatformType) (ctrl.Manager, error) {
-	if os.Getenv(namespaceEnvVariableName) == "" {
-		return nil, fmt.Errorf("environment variable %s is empty, this is not supported", namespaceEnvVariableName)
-	}
-
+func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	})))
-	restConfig := ctrl.GetConfigOrDie()
-	restConfig.UserAgent = "ignition-server-manager"
-	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme: hyperapi.Scheme,
-		Port:   9443,
-		// TODO (alberto): expose this flags?
-		// MetricsBindAddress: opts.MetricsAddr,
-		// LeaderElection:     opts.EnableLeaderElection,
-		Namespace: os.Getenv(namespaceEnvVariableName),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to start manager: %w", err)
-	}
-	if err = (&controllers.TokenSecretReconciler{
-		Client:       mgr.GetClient(),
-		PayloadStore: payloadStore,
-		IgnitionProvider: &controllers.MCSIgnitionProvider{
-			ReleaseProvider: &releaseinfo.RegistryMirrorProviderDecorator{
-				Delegate: &releaseinfo.CachedProvider{
-					Inner: &releaseinfo.RegistryClientProvider{},
-					Cache: map[string]*releaseinfo.ReleaseImage{},
-				},
-				RegistryOverrides: registryOverrides,
-			},
-			Client:        mgr.GetClient(),
-			Namespace:     os.Getenv(namespaceEnvVariableName),
-			CloudProvider: cloudProvider,
-		},
-	}).SetupWithManager(ctx, mgr); err != nil {
-		return nil, fmt.Errorf("unable to create controller: %w", err)
+
+	root := &cobra.Command{
+		Use:   "debug",
+		Short: "A program for debugging the ignition server",
 	}
 
-	return mgr, nil
-}
+	root.AddCommand(cmd.NewStartCommand())
+	root.AddCommand(cmd.NewRunLocalIgnitionProviderCommand())
 
-func run(ctx context.Context, opts Options) error {
-	certWatcher, err := certwatcher.New(opts.CertFile, opts.KeyFile)
-	if err != nil {
-		return fmt.Errorf("failed to load serving cert: %w", err)
+	if err := root.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
 	}
-
-	mgr, err := setUpPayloadStoreReconciler(ctx, opts.RegistryOverrides, hyperv1.PlatformType(opts.Platform))
-	if err != nil {
-		return fmt.Errorf("error setting up manager: %w", err)
-	}
-	if err := mgr.Add(certWatcher); err != nil {
-		return fmt.Errorf("failed to add certWatcher to manager: %w", err)
-	}
-	go mgr.Start(ctx)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("User Agent: %s. Requested: %s", r.Header.Get("User-Agent"), r.URL.Path)
-
-		if !ignPathPattern.MatchString(r.URL.Path) {
-			// No pattern matched; send 404 response.
-			log.Printf("Path not found: %s", r.URL.Path)
-			http.NotFound(w, r)
-			return
-		}
-
-		// Authorize the request against the token
-		const bearerPrefix = "Bearer "
-		auth := r.Header.Get("Authorization")
-		n := len(bearerPrefix)
-		if len(auth) < n || auth[:n] != bearerPrefix {
-			log.Printf("Invalid Authorization header value prefix")
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		encodedToken := auth[n:]
-		decodedToken, err := base64.StdEncoding.DecodeString(encodedToken)
-		if err != nil {
-			log.Printf("Invalid token value")
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		value, ok := payloadStore.Get(string(decodedToken))
-		if !ok {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		w.Write(value.Payload)
-	})
-
-	server := http.Server{
-		Addr:         opts.Addr,
-		Handler:      mux,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		TLSConfig:    &tls.Config{GetCertificate: certWatcher.GetCertificate},
-	}
-
-	go func() {
-		<-ctx.Done()
-		if err := server.Shutdown(ctx); err != nil {
-			log.Printf("error shutting down server: %s", err)
-		}
-	}()
-
-	log.Printf("Listening on %s", opts.Addr)
-	if err := server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
-		return err
-	}
-	return nil
 }

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -7,7 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
 
+	"github.com/docker/distribution"
 	"github.com/docker/distribution/registry/client/transport"
 	"k8s.io/client-go/rest"
 
@@ -21,36 +25,9 @@ import (
 // ExtractImageFiles extracts a list of files from a registry image given the image reference, pull secret and the
 // list of files to extract. It returns a map with file contents or an error.
 func ExtractImageFiles(ctx context.Context, imageRef string, pullSecret []byte, files ...string) (map[string][]byte, error) {
-	rt, err := rest.TransportFor(&rest.Config{})
+	layers, fromBlobs, err := getMetadata(ctx, imageRef, pullSecret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create secure transport: %w", err)
-	}
-	insecureRT, err := rest.TransportFor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create insecure transport: %w", err)
-	}
-	credStore, err := dockercredentials.NewFromBytes(pullSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse docker credentials: %w", err)
-	}
-	registryContext := registryclient.NewContext(rt, insecureRT).WithCredentials(credStore).
-		WithRequestModifiers(transport.NewHeaderRequestModifier(http.Header{http.CanonicalHeaderKey("User-Agent"): []string{rest.DefaultKubernetesUserAgent()}}))
-
-	ref, err := reference.Parse(imageRef)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
-	}
-	repo, err := registryContext.Repository(ctx, ref.DockerClientDefaults().RegistryURL(), ref.RepositoryName(), false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create repository client for %s: %w", ref.DockerClientDefaults().RegistryURL(), err)
-	}
-	firstManifest, location, err := manifest.FirstManifest(ctx, ref, repo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to obtain root manifest for %s: %w", imageRef, err)
-	}
-	_, layers, err := manifest.ManifestToImageConfig(ctx, firstManifest, repo.Blobs(ctx), location)
-	if err != nil {
-		return nil, fmt.Errorf("failed to obtain image layers for %s: %w", imageRef, err)
+		return nil, err
 	}
 
 	fileContents := map[string][]byte{}
@@ -60,7 +37,7 @@ func ExtractImageFiles(ctx context.Context, imageRef string, pullSecret []byte, 
 	if len(fileContents) == 0 {
 		return fileContents, nil
 	}
-	fromBlobs := repo.Blobs(ctx)
+
 	// Iterate over layers in reverse order to find the most recent version of files
 	for i := len(layers) - 1; i >= 0; i-- {
 		layer := layers[i]
@@ -122,4 +99,160 @@ func allFound(content map[string][]byte) bool {
 		}
 	}
 	return true
+}
+
+func ExtractImageFile(ctx context.Context, imageRef string, pullSecret []byte, file string, out io.Writer) error {
+	layers, fromBlobs, err := getMetadata(ctx, imageRef, pullSecret)
+	if err != nil {
+		return err
+	}
+
+	// Iterate over layers in reverse order to find the most recent version of files
+	found := false
+	for i := len(layers) - 1; i >= 0; i-- {
+		layer := layers[i]
+		err := func() error {
+			r, err := fromBlobs.Open(ctx, layer.Digest)
+			if err != nil {
+				return fmt.Errorf("unable to access the source layer %s: %v", layer.Digest, err)
+			}
+			defer r.Close()
+			rc, err := dockerarchive.DecompressStream(r)
+			if err != nil {
+				return err
+			}
+			defer rc.Close()
+			tr := tar.NewReader(rc)
+			for {
+				hdr, err := tr.Next()
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					return err
+				}
+				if hdr.Typeflag == tar.TypeReg {
+					if hdr.Name != file {
+						continue
+					}
+					found = true
+					if _, err := io.Copy(out, tr); err != nil {
+						return err
+					}
+					return nil
+				}
+			}
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+		if found {
+			return nil
+		}
+	}
+	return fmt.Errorf("file not found")
+}
+
+func ExtractImageFilesToDir(ctx context.Context, imageRef string, pullSecret []byte, pattern string, outputDir string) error {
+	regex, err := regexp.Compile(pattern)
+	if err != nil {
+		return fmt.Errorf("invalid pattern: %w", err)
+	}
+
+	layers, fromBlobs, err := getMetadata(ctx, imageRef, pullSecret)
+	if err != nil {
+		return err
+	}
+
+	// Iterate over layers in reverse order to find the most recent version of files
+	written := map[string]struct{}{}
+	for i := len(layers) - 1; i >= 0; i-- {
+		layer := layers[i]
+		err := func() error {
+			r, err := fromBlobs.Open(ctx, layer.Digest)
+			if err != nil {
+				return fmt.Errorf("unable to access the source layer %s: %v", layer.Digest, err)
+			}
+			defer r.Close()
+			rc, err := dockerarchive.DecompressStream(r)
+			if err != nil {
+				return err
+			}
+			defer rc.Close()
+			tr := tar.NewReader(rc)
+			for {
+				hdr, err := tr.Next()
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					return err
+				}
+				if hdr.Typeflag == tar.TypeReg {
+					// Only copy the file once from the most recent layer
+					if _, exists := written[hdr.Name]; exists {
+						continue
+					}
+					if !regex.MatchString(hdr.Name) {
+						continue
+					}
+					dst := filepath.Join(outputDir, hdr.Name)
+					if err := os.MkdirAll(filepath.Clean(filepath.Dir(dst)), 0755); err != nil {
+						return fmt.Errorf("failed to make dir: %w", err)
+					}
+					dstfd, err := os.Create(dst)
+					if err != nil {
+						return err
+					}
+					if _, err = io.Copy(dstfd, tr); err != nil {
+						dstfd.Close()
+						return err
+					}
+					dstfd.Close()
+					written[hdr.Name] = struct{}{}
+				}
+			}
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getMetadata(ctx context.Context, imageRef string, pullSecret []byte) ([]distribution.Descriptor, distribution.BlobStore, error) {
+	rt, err := rest.TransportFor(&rest.Config{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create secure transport: %w", err)
+	}
+	insecureRT, err := rest.TransportFor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create insecure transport: %w", err)
+	}
+	credStore, err := dockercredentials.NewFromBytes(pullSecret)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse docker credentials: %w", err)
+	}
+	registryContext := registryclient.NewContext(rt, insecureRT).WithCredentials(credStore).
+		WithRequestModifiers(transport.NewHeaderRequestModifier(http.Header{http.CanonicalHeaderKey("User-Agent"): []string{rest.DefaultKubernetesUserAgent()}}))
+
+	ref, err := reference.Parse(imageRef)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
+	}
+	repo, err := registryContext.Repository(ctx, ref.DockerClientDefaults().RegistryURL(), ref.RepositoryName(), false)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create repository client for %s: %w", ref.DockerClientDefaults().RegistryURL(), err)
+	}
+	firstManifest, location, err := manifest.FirstManifest(ctx, ref, repo)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to obtain root manifest for %s: %w", imageRef, err)
+	}
+	_, layers, err := manifest.ManifestToImageConfig(ctx, firstManifest, repo.Blobs(ctx), location)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to obtain image layers for %s: %w", imageRef, err)
+	}
+	return layers, repo.Blobs(ctx), nil
 }

--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -42,14 +42,14 @@ func TestAutoRepair(t *testing.T) {
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
 
 	// Perform some very basic assertions about the guest cluster
-	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
+	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
 	// TODO (alberto): have ability to label and get Nodes by NodePool. NodePool.Status.Nodes?
 	numNodes := clusterOpts.NodePoolReplicas * numZones
-	nodes := e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
+	nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
 
 	// Wait for the rollout to be reported complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
-	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
+	e2eutil.WaitForImageRollout(t, ctx, client, hostedCluster, globalOpts.LatestReleaseImage)
 
 	// Terminate one of the machines belonging to the cluster
 	nodeToReplace := nodes[0].Name
@@ -66,14 +66,14 @@ func TestAutoRepair(t *testing.T) {
 	// Wait for nodes to be ready again, without the node that was terminated
 	t.Logf("Waiting for %d available nodes without %s", numNodes, nodeToReplace)
 	err = wait.PollUntil(30*time.Second, func() (done bool, err error) {
-		nodes := e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
+		nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
 		for _, node := range nodes {
 			if node.Name == nodeToReplace {
 				return false, nil
 			}
 		}
 		return true, nil
-	}, testContext.Done())
+	}, ctx.Done())
 	g.Expect(err).NotTo(HaveOccurred(), "failed to wait for new node to become available")
 
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -82,7 +82,7 @@ func testKillRandomMembers(parentCtx context.Context, client crclient.Client, cl
 
 		// Get a client for the cluster
 		t.Logf("Waiting for guest client to become available")
-		guestClient := e2eutil.WaitForGuestClient(t, testContext, client, cluster)
+		guestClient := e2eutil.WaitForGuestClient(t, ctx, client, cluster)
 
 		// Create data in the cluster which should survive the ensuring chaos
 		value, _ := time.Now().MarshalText()
@@ -170,7 +170,7 @@ func testKillAllMembers(parentCtx context.Context, client crclient.Client, clust
 
 		// Get a client for the cluster
 		t.Logf("Waiting for guest client to become available")
-		guestClient := e2eutil.WaitForGuestClient(t, testContext, client, cluster)
+		guestClient := e2eutil.WaitForGuestClient(t, ctx, client, cluster)
 
 		// Create data in the cluster which should survive the ensuring chaos
 		value, _ := time.Now().MarshalText()

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -33,33 +33,33 @@ func TestUpgradeControlPlane(t *testing.T) {
 
 	// Sanity check the cluster by waiting for the nodes to report ready
 	t.Logf("Waiting for guest client to become available")
-	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
+	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
 
 	// Wait for Nodes to be Ready
 	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
 
 	// Wait for the first rollout to be complete
 	t.Logf("Waiting for initial cluster rollout. Image: %s", globalOpts.PreviousReleaseImage)
-	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.PreviousReleaseImage)
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	e2eutil.WaitForImageRollout(t, ctx, client, hostedCluster, globalOpts.PreviousReleaseImage)
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
 	// Update the cluster image
 	t.Logf("Updating cluster image. Image: %s", globalOpts.LatestReleaseImage)
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 	hostedCluster.Spec.Release.Image = globalOpts.LatestReleaseImage
-	err = client.Update(testContext, hostedCluster)
+	err = client.Update(ctx, hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
 
 	// Wait for the new rollout to be complete
 	t.Logf("waiting for updated cluster image rollout. Image: %s", globalOpts.LatestReleaseImage)
-	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	e2eutil.WaitForImageRollout(t, ctx, client, hostedCluster, globalOpts.LatestReleaseImage)
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
-	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, client, hostedCluster)
 	e2eutil.EnsureNoPodsWithTooHighPriority(t, ctx, client, hostedCluster)

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -148,7 +148,7 @@ func TestNoneCreateCluster(t *testing.T) {
 	// Since the None platform has no workers, CVO will not have expectations set,
 	// which in turn means that the ClusterVersion object will never be populated.
 	// Therefore only test if the control plane comes up (etc, apiserver, ...)
-	e2eutil.WaitForConditionsOnHostedControlPlane(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
+	e2eutil.WaitForConditionsOnHostedControlPlane(t, ctx, client, hostedCluster, globalOpts.LatestReleaseImage)
 
 	// etcd restarts for me once always and apiserver two times before running stable
 	// e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this commit, ignition payloads for nodepools were generated by
orchestrating MCO components using pods. This was a performance problem because
ignition server restarts (e.g. during upgrades) resulted in thundering herds of
ignition payload generation pods, limiting overall cluster capacity.

This commit refactors ignition payload generation away from pods and to a
mechanism that extracts MCO binaries (and supporting files) from release
payloads so they can be forked as subprocesses of the ignition server
controller, removing all pod scheduling overhead. This change should be
completely transparent to the end user and is a drop-in replacement for the old
implementation.

The current implementation has the following limitations:

* Extracted payload contents are not cached across executions per release image.
  This is possible, but not worth doing unless subsequent performance analysis
  justifies it.

* All payload generation executions are serial. Concurrent executions are
  possible, but not worth doing unless subsequent performance analysis justifies
  it.

This commit also enables metrics collection for the ignition server component and
adds the following metrics:

* ign_server_token_rotation_total
* ign_server_payload_cache_miss_total
* ign_server_payload_generation_seconds
* ign_server_payload_cache_total

TODO:
- [x] Fix Azure support
- [x] Fix mDNS support

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.