### PR TITLE
read apiserver-network-proxy image from ocp payload

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -147,6 +147,11 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	p.AgentDeamonSetConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	p.AgentDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	p.ServerDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+	// check apiserver-network-proxy image in ocp payload and use it
+	if _, ok := images["apiserver-network-proxy"]; ok {
+		p.KonnectivityServerImage = images["apiserver-network-proxy"]
+		p.KonnectivityAgentImage = images["apiserver-network-proxy"]
+	}
 
 	if hcp.Annotations != nil {
 		if _, ok := hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]; ok {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/params.go
@@ -54,6 +54,10 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 			SuccessThreshold:    1,
 		},
 	}
+	// check apiserver-network-proxy image in ocp payload and use it
+	if _, ok := images["apiserver-network-proxy"]; ok {
+		p.Image = images["apiserver-network-proxy"]
+	}
 	if _, ok := hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]; ok {
 		p.Image = hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]
 	}


### PR DESCRIPTION

This PR enables to load apiserver-network-proxy image from OCP release payload only if its available. if image is not available in the OCP release image, its uses default override method.

What this PR does / why we need it:
apiserver-network-proxy image is available in ocp 4.11 reelase iamge. so we can read it from payload.

fixes # https://issues.redhat.com/browse/HOSTEDCP-301
