### PR TITLE
AntiAffinity rules to spread KubeVirt VMs across mgmt nodes

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt.go
@@ -2,14 +2,54 @@ package nodepool
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 )
 
 func kubevirtMachineTemplateSpec(nodePool *hyperv1.NodePool) *capikubevirt.KubevirtMachineTemplateSpec {
+	nodePoolNameLabelKey := "hypershift.kubevirt.io/node-pool-name"
+
+	vmTemplate := nodePool.Spec.Platform.Kubevirt.NodeTemplate
+
+	if vmTemplate.Spec.Template.Spec.Affinity == nil {
+		vmTemplate.Spec.Template.Spec.Affinity = &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+					{
+						Weight: int32(100),
+						PodAffinityTerm: corev1.PodAffinityTerm{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      nodePoolNameLabelKey,
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{nodePool.Name},
+									},
+								},
+							},
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	if vmTemplate.ObjectMeta.Labels == nil {
+		vmTemplate.ObjectMeta.Labels = map[string]string{}
+	}
+	if vmTemplate.Spec.Template.ObjectMeta.Labels == nil {
+		vmTemplate.Spec.Template.ObjectMeta.Labels = map[string]string{}
+	}
+
+	vmTemplate.Spec.Template.ObjectMeta.Labels[nodePoolNameLabelKey] = nodePool.Name
+	vmTemplate.ObjectMeta.Labels[nodePoolNameLabelKey] = nodePool.Name
+
 	return &capikubevirt.KubevirtMachineTemplateSpec{
 		Template: capikubevirt.KubevirtMachineTemplateResource{
 			Spec: capikubevirt.KubevirtMachineSpec{
-				VirtualMachineTemplate: *nodePool.Spec.Platform.Kubevirt.NodeTemplate,
+				VirtualMachineTemplate: *vmTemplate,
 			},
 		},
 	}

--- a/hypershift-operator/controllers/nodepool/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt_test.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 )
@@ -20,6 +22,9 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 		{
 			name: "happy flow",
 			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-pool",
+				},
 				Spec: hyperv1.NodePoolSpec{
 					ClusterName: "",
 					NodeCount:   nil,
@@ -58,11 +63,45 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 func generateNodeTemplate(memory string, cpu uint32, image string) *capikubevirt.VirtualMachineTemplateSpec {
 	runAlways := kubevirtv1.RunStrategyAlways
 	guestQuantity := apiresource.MustParse(memory)
+	nodePoolNameLabelKey := "hypershift.kubevirt.io/node-pool-name"
 	return &capikubevirt.VirtualMachineTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				nodePoolNameLabelKey: "my-pool",
+			},
+		},
 		Spec: kubevirtv1.VirtualMachineSpec{
 			RunStrategy: &runAlways,
 			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						nodePoolNameLabelKey: "my-pool",
+					},
+				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight: int32(100),
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      nodePoolNameLabelKey,
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"my-pool"},
+												},
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
+					},
+
 					Domain: kubevirtv1.DomainSpec{
 						CPU:    &kubevirtv1.CPU{Cores: cpu},
 						Memory: &kubevirtv1.Memory{Guest: &guestQuantity},


### PR DESCRIPTION
One of the challenges we have with the KubeVirt platform is that mgmt node disruption (such as an RHCOS update) has the potential to impact multiple tenant clusters with workers running as KubeVirt VMs on the mgmt cluster.

In order to minimize the disruption per a tenant cluster in these situations, we set an anti affinity rule that prefers that VMs for a single cluster are spread across multiple mgmt nodes. This helps ensure that we don't take down all worker node VMs for a tenant cluster when a single mgmt node goes down.

This default anti-affinity rule is only added to the KubeVirttMachine when the user does not explicitly specify their own affinity rules on the nodepool's kubevirt platform spec.
