### PR TITLE
Create valid route names with long namespace names

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -107,6 +107,7 @@ type HostedControlPlaneReconciler struct {
 	upsert.CreateOrUpdateProvider
 	EnableCIDebugOutput   bool
 	OperateOnReleaseImage string
+	DefaultIngressDomain  string
 }
 
 func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -771,9 +772,9 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivityServerService(ctx co
 	if serviceStrategy.Type != hyperv1.Route {
 		return nil
 	}
-	kasRoute := manifests.KonnectivityServerRoute(hcp.Namespace)
-	if _, err := r.CreateOrUpdate(ctx, r.Client, kasRoute, func() error {
-		return konnectivity.ReconcileRoute(kasRoute, p.OwnerRef, util.IsPrivateHCP(hcp), serviceStrategy)
+	konnectivityRoute := manifests.KonnectivityServerRoute(hcp.Namespace)
+	if _, err := r.CreateOrUpdate(ctx, r.Client, konnectivityRoute, func() error {
+		return konnectivity.ReconcileRoute(konnectivityRoute, p.OwnerRef, util.IsPrivateHCP(hcp), serviceStrategy, r.DefaultIngressDomain)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile Konnectivity server route: %w", err)
 	}
@@ -797,7 +798,7 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServerService(ctx context.C
 	}
 	oauthRoute := manifests.OauthServerRoute(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r.Client, oauthRoute, func() error {
-		return oauth.ReconcileRoute(oauthRoute, p.OwnerRef, serviceStrategy)
+		return oauth.ReconcileRoute(oauthRoute, p.OwnerRef, serviceStrategy, r.DefaultIngressDomain)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile OAuth route: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -6,9 +6,10 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
 )
 
-func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy) error {
+func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy, defaultIngressDomain string) error {
 	ownerRef.ApplyTo(route)
 	if strategy.Route != nil && strategy.Route.Hostname != "" {
 		if route.Annotations == nil {
@@ -16,6 +17,8 @@ func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, strategy *hy
 		}
 		route.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.Route.Hostname
 		route.Spec.Host = strategy.Route.Hostname
+	} else {
+		route.Spec.Host = util.ShortenRouteHostnameIfNeeded(route.Name, route.Namespace, defaultIngressDomain)
 	}
 	route.Spec.To = routev1.RouteTargetReference{
 		Kind: "Service",

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -14,6 +14,7 @@ import (
 	ignitionserver "github.com/openshift/hypershift/ignition-server"
 	konnectivitysocks5proxy "github.com/openshift/hypershift/konnectivity-socks5-proxy"
 	"github.com/openshift/hypershift/support/capabilities"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/util"
@@ -271,6 +272,8 @@ func NewStartCommand() *cobra.Command {
 			os.Exit(1)
 		}
 
+		defaultIngressDomain := os.Getenv(config.DefaultIngressDomainEnvVar)
+
 		if err := (&hostedcontrolplane.HostedControlPlaneReconciler{
 			Client:                        mgr.GetClient(),
 			ManagementClusterCapabilities: mgmtClusterCaps,
@@ -279,6 +282,7 @@ func NewStartCommand() *cobra.Command {
 			CreateOrUpdateProvider:        upsert.New(enableCIDebugOutput),
 			EnableCIDebugOutput:           enableCIDebugOutput,
 			OperateOnReleaseImage:         os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
+			DefaultIngressDomain:          defaultIngressDomain,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")
 			os.Exit(1)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -209,6 +209,9 @@ func (r *HostedClusterReconciler) managedResources() []client.Object {
 	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityRoute) {
 		managedResources = append(managedResources, &routev1.Route{})
 	}
+	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityConfigOpenshiftIO) {
+		managedResources = append(managedResources, &configv1.Ingress{})
+	}
 	return managedResources
 }
 
@@ -1064,14 +1067,18 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile machine approver: %w", err)
 	}
 
+	defaultIngressDomain, err := r.defaultIngressDomain(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to determine default ingress domain: %w", err)
+	}
 	// Reconcile the control plane operator
-	err = r.reconcileControlPlaneOperator(ctx, createOrUpdate, hcluster, hcp, controlPlaneOperatorImage)
+	err = r.reconcileControlPlaneOperator(ctx, createOrUpdate, hcluster, hcp, controlPlaneOperatorImage, defaultIngressDomain)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile control plane operator: %w", err)
 	}
 
 	// Reconcile the Ignition server
-	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, controlPlaneOperatorImage); err != nil {
+	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, controlPlaneOperatorImage, defaultIngressDomain); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile ignition server: %w", err)
 	}
 
@@ -1421,7 +1428,7 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, cre
 
 // reconcileControlPlaneOperator orchestrates reconciliation of the control plane
 // operator components.
-func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane, controlPlaneOperatorImage string) error {
+func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane, controlPlaneOperatorImage, defaultIngressDomain string) error {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
@@ -1494,7 +1501,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	// Reconcile operator deployment
 	controlPlaneOperatorDeployment := controlplaneoperator.OperatorDeployment(controlPlaneNamespace.Name)
 	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
-		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, r.SetDefaultSecurityContext, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()))
+		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, r.SetDefaultSecurityContext, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()), defaultIngressDomain)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator deployment: %w", err)
@@ -1578,7 +1585,7 @@ func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.Servi
 	return nil
 }
 
-func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, controlPlaneOperatorImage string) error {
+func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, controlPlaneOperatorImage, defaultIngressDomain string) error {
 
 	log := ctrl.LoggerFrom(ctx)
 
@@ -1619,6 +1626,8 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 			} else if serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
 				ignitionServerRoute.ObjectMeta.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = serviceStrategy.Route.Hostname
 				ignitionServerRoute.Spec.Host = serviceStrategy.Route.Hostname
+			} else {
+				ignitionServerRoute.Spec.Host = util.ShortenRouteHostnameIfNeeded(ignitionServerRoute.Name, ignitionServerRoute.Namespace, defaultIngressDomain)
 			}
 			ignitionServerRoute.Annotations[hostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
 			ignitionServerRoute.Spec.TLS = &routev1.TLSConfig{
@@ -2026,7 +2035,7 @@ func getControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 	return hypershiftOperatorImage, nil
 }
 
-func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, cpoImage string, setDefaultSecurityContext bool, sa *corev1.ServiceAccount, enableCIDebugOutput bool, registryOverrideCommandLine string) error {
+func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, cpoImage string, setDefaultSecurityContext bool, sa *corev1.ServiceAccount, enableCIDebugOutput bool, registryOverrideCommandLine, defaultIngressDomain string) error {
 	cpoResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("44Mi"),
@@ -2138,6 +2147,15 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 			},
 		)
 	}
+	if len(defaultIngressDomain) > 0 {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  config.DefaultIngressDomainEnvVar,
+				Value: defaultIngressDomain,
+			},
+		)
+	}
+
 	mainContainer = util.FindContainer("control-plane-operator", deployment.Spec.Template.Spec.Containers)
 	proxy.SetEnvVars(&mainContainer.Env)
 
@@ -4143,6 +4161,21 @@ func (r *HostedClusterReconciler) defaultAPIPortIfNeeded(ctx context.Context, hc
 	}
 
 	return nil
+}
+
+func (r *HostedClusterReconciler) defaultIngressDomain(ctx context.Context) (string, error) {
+	if !r.ManagementClusterCapabilities.Has(capabilities.CapabilityConfigOpenshiftIO) {
+		return "", nil
+	}
+	ingress := &configv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(ingress), ingress); err != nil {
+		return "", fmt.Errorf("failed to retrieve ingress: %w", err)
+	}
+	return ingress.Spec.Domain, nil
 }
 
 func (r *HostedClusterReconciler) defaultClusterIDsIfNeeded(ctx context.Context, hcluster *hyperv1.HostedCluster) error {

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -20,4 +20,6 @@ const (
 	DefaultAPIServerPort         = 6443
 	DefaultServiceNodePortRange  = "30000-32767"
 	DefaultSecurityContextUser   = 1001
+
+	DefaultIngressDomainEnvVar = "DEFAULT_INGRESS_DOMAIN"
 )

--- a/support/util/route.go
+++ b/support/util/route.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// ShortenRouteHostnameIfNeeded will return a shortened hostname if the route hostname will exceed
+// the allowed DNS name size. If the hostname is not too long, an empty string is returned so that
+// the default can be used.
+func ShortenRouteHostnameIfNeeded(name, namespace string, baseDomain string) string {
+	if baseDomain == "" {
+		return ""
+	}
+	if len(name)+len(namespace)+1 < validation.DNS1123LabelMaxLength {
+		return ""
+	} else {
+		return fmt.Sprintf("%s.%s", strings.TrimSuffix(shortenName(name+"-"+namespace, "", validation.DNS1123LabelMaxLength), "-"), baseDomain)
+	}
+}
+
+// shortenName returns a name given a base ("deployment-5") and a suffix ("deploy")
+// It will first attempt to join them with a dash. If the resulting name is longer
+// than maxLength: if the suffix is too long, it will truncate the base name and add
+// an 8-character hash of the [base]-[suffix] string.  If the suffix is not too long,
+// it will truncate the base, add the hash of the base and return [base]-[hash]-[suffix]
+// Source: openshift/origin v3.9.0 pkg/api/apihelpers/namer.go
+func shortenName(base, suffix string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
+	name := fmt.Sprintf("%s-%s", base, suffix)
+	if len(name) <= maxLength {
+		return name
+	}
+
+	baseLength := maxLength - 10 /*length of -hash-*/ - len(suffix)
+
+	// if the suffix is too long, ignore it
+	if baseLength < 0 {
+		prefix := base[0:min(len(base), max(0, maxLength-9))]
+		// Calculate hash on initial base-suffix string
+		shortName := fmt.Sprintf("%s-%s", prefix, hash(name))
+		return shortName[:min(maxLength, len(shortName))]
+	}
+
+	prefix := base[0:baseLength]
+	// Calculate hash on initial base-suffix string
+	return fmt.Sprintf("%s-%s-%s", prefix, hash(base), suffix)
+}
+
+// max returns the greater of its 2 inputs
+func max(a, b int) int {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// min returns the lesser of its 2 inputs
+func min(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+// hash calculates the hexadecimal representation (8-chars)
+// of the hash of the passed in string using the FNV-a algorithm
+func hash(s string) string {
+	hash := fnv.New32a()
+	hash.Write([]byte(s))
+	intHash := hash.Sum32()
+	result := fmt.Sprintf("%08x", intHash)
+	return result
+}

--- a/support/util/route_test.go
+++ b/support/util/route_test.go
@@ -1,0 +1,104 @@
+package util
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestShortenName(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		shortName := randSeq(rand.Intn(kvalidation.DNS1123SubdomainMaxLength-10) + 1)
+		longName := randSeq(kvalidation.DNS1123SubdomainMaxLength + rand.Intn(100))
+
+		tests := []struct {
+			base, suffix, expected string
+		}{
+			{
+				base:     shortName,
+				suffix:   "deploy",
+				expected: shortName + "-deploy",
+			},
+			{
+				base:     longName,
+				suffix:   "deploy",
+				expected: longName[:kvalidation.DNS1123SubdomainMaxLength-16] + "-" + hash(longName) + "-deploy",
+			},
+			{
+				base:     shortName,
+				suffix:   longName,
+				expected: shortName + "-" + hash(shortName+"-"+longName),
+			},
+			{
+				base:     "",
+				suffix:   shortName,
+				expected: "-" + shortName,
+			},
+			{
+				base:     "",
+				suffix:   longName,
+				expected: "-" + hash("-"+longName),
+			},
+			{
+				base:     shortName,
+				suffix:   "",
+				expected: shortName + "-",
+			},
+			{
+				base:     longName,
+				suffix:   "",
+				expected: longName[:kvalidation.DNS1123SubdomainMaxLength-10] + "-" + hash(longName) + "-",
+			},
+		}
+
+		for j, test := range tests {
+			t.Run(fmt.Sprintf("test-%d-%d", i, j), func(t *testing.T) {
+				result := shortenName(test.base, test.suffix, kvalidation.DNS1123SubdomainMaxLength)
+				if result != test.expected {
+					t.Errorf("Got unexpected result. Expected: %s Got: %s", test.expected, result)
+				}
+			})
+		}
+	}
+}
+
+func TestShortenNameIsDifferent(t *testing.T) {
+	shortName := randSeq(32)
+	deployerName := shortenName(shortName, "deploy", kvalidation.DNS1123SubdomainMaxLength)
+	builderName := shortenName(shortName, "build", kvalidation.DNS1123SubdomainMaxLength)
+	if deployerName == builderName {
+		t.Errorf("Expecting names to be different: %s\n", deployerName)
+	}
+	longName := randSeq(kvalidation.DNS1123SubdomainMaxLength + 10)
+	deployerName = shortenName(longName, "deploy", kvalidation.DNS1123SubdomainMaxLength)
+	builderName = shortenName(longName, "build", kvalidation.DNS1123SubdomainMaxLength)
+	if deployerName == builderName {
+		t.Errorf("Expecting names to be different: %s\n", deployerName)
+	}
+}
+
+func TestShortenNameReturnShortNames(t *testing.T) {
+	base := randSeq(32)
+	for maxLength := 0; maxLength < len(base)+2; maxLength++ {
+		for suffixLen := 0; suffixLen <= maxLength+1; suffixLen++ {
+			suffix := randSeq(suffixLen)
+			got := shortenName(base, suffix, maxLength)
+			if len(got) > maxLength {
+				t.Fatalf("len(GetName(%[1]q, %[2]q, %[3]d)) = len(%[4]q) = %[5]d; want %[3]d", base, suffix, maxLength, got, len(got))
+			}
+		}
+	}
+}
+
+// From k8s.io/kubernetes/pkg/api/generator.go
+var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789-")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When using a long name for a cluster namespace, the routes that the
control plane operator creates is invalid because a segment of the
domain name has a length > 63 chars.

This commit sets the host name for routes to ensure that the resulting
host name is valid. Modification of the route hostname only happens when
the resulting hostname will be invalid. The name is shortened by
trimming the original name and appending a hash of the entire name,
resulting in repeatable and distinct names every time the name is
shortened.

**Which issue(s) this PR fixes** 
Fixes # [HOSTEDCP-371](https://issues.redhat.com/browse/HOSTEDCP-371)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.