### PR TITLE
Fix priority class for olm cronjob and verify priorityclasses in e2e

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
@@ -9,7 +9,7 @@ spec:
       template:
         spec:
           serviceAccountName: olm-collect-profiles
-          priorityClassName: openshift-user-critical
+          priorityClassName: hypershift-control-plane
           containers:
             - name: collect-profiles
               image: OLM_OPERATOR_IMAGE

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -62,4 +62,5 @@ func TestUpgradeControlPlane(t *testing.T) {
 	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, client, hostedCluster)
+	e2eutil.EnsureNoPodsWithTooHighPriority(t, ctx, client, hostedCluster)
 }


### PR DESCRIPTION
The olm cronjob had a prioryClass of openshift-user-critical which has a
priority that is above all other controlplane components in the
management cluster. Downgrade it to the standard
hypershift-control-plane and add an e2e test that verifies that no pod
has a priority higher than the etcd priority.

Fixes https://github.com/openshift/hypershift/issues/1223
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.