### PR TITLE
e2e: Don't fail test on transient recoverable API lookup

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -207,7 +207,7 @@ func WaitForConditionsOnHostedControlPlane(t *testing.T, ctx context.Context, cl
 		cp := &hyperv1.HostedControlPlane{}
 		err = client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: hostedCluster.Name}, cp)
 		if err != nil {
-			t.Errorf("Failed to get hostedcontrolplane: %v", err)
+			t.Logf("Failed to get hostedcontrolplane: %v", err)
 			return false, nil
 		}
 
@@ -229,9 +229,9 @@ func WaitForConditionsOnHostedControlPlane(t *testing.T, ctx context.Context, cl
 		}
 
 		if isAvailable {
-			t.Logf("Waiting for all conditions to be ready: Image: %s, conditions: %v", image, conditions)
 			return true, nil
 		}
+		t.Logf("Waiting for all conditions to be ready: Image: %s, conditions: %v", image, conditions)
 		return false, nil
 	}, ctx.Done())
 	g.Expect(err).NotTo(HaveOccurred(), "failed waiting for image rollout")


### PR DESCRIPTION
Before this commit, calls to `WaitForConditionsOnHostedControlPlane()` could
fail a test if an API lookup fails even though that lookup is recoverable and
retried automatically. This made the test flaky.

This commit fixes the code so that these retriable errors are logged but do
not fail the test.

This commit also moves a log message which was intended to emit during retries
but was instead placed at the exit point.
