### PR TITLE
Add support to set up a http proxy for guest clusters

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -44,6 +44,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.AWSPlatform.AdditionalTags, "additional-tags", opts.AWSPlatform.AdditionalTags, "Additional tags to set on AWS resources")
 	cmd.Flags().StringVar(&opts.AWSPlatform.EndpointAccess, "endpoint-access", opts.AWSPlatform.EndpointAccess, "Access for control plane endpoints (Public, PublicAndPrivate, Private)")
 	cmd.Flags().StringVar(&opts.AWSPlatform.EtcdKMSKeyARN, "kms-key-arn", opts.AWSPlatform.EtcdKMSKeyARN, "The ARN of the KMS key to use for Etcd encryption. If not supplied, etcd encryption will default to using a generated AESCBC key.")
+	cmd.Flags().BoolVar(&opts.AWSPlatform.EnableProxy, "enable-proxy", opts.AWSPlatform.EnableProxy, "If a proxy should be set up, rather than allowing direct internet access from the nodes")
 
 	cmd.MarkFlagRequired("aws-creds")
 
@@ -110,6 +111,8 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			BaseDomain:         opts.BaseDomain,
 			AdditionalTags:     opts.AWSPlatform.AdditionalTags,
 			Zones:              opts.AWSPlatform.Zones,
+			EnableProxy:        opts.AWSPlatform.EnableProxy,
+			SSHKeyFile:         opts.SSHKeyFile,
 		}
 		infra, err = opt.CreateInfra(ctx)
 		if err != nil {
@@ -186,6 +189,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		RootVolumeIOPS:              opts.AWSPlatform.RootVolumeIOPS,
 		ResourceTags:                tags,
 		EndpointAccess:              opts.AWSPlatform.EndpointAccess,
+		ProxyAddress:                infra.ProxyAddr,
 	}
 	return nil
 }

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -97,6 +97,7 @@ type AWSPlatformOptions struct {
 	EndpointAccess     string
 	Zones              []string
 	EtcdKMSKeyARN      string
+	EnableProxy        bool
 }
 
 type AzurePlatformOptions struct {

--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -91,7 +91,7 @@ func (o *DestroyInfraOptions) DestroyInfra(ctx context.Context) error {
 	route53Client := route53.New(awsSession, awsutil.NewAWSRoute53Config())
 	s3Client := s3.New(awsSession, awsConfig)
 
-	var errs []error
+	errs := o.destroyInstances(ctx, ec2Client)
 	errs = append(errs, o.DestroyInternetGateways(ctx, ec2Client)...)
 	errs = append(errs, o.DestroyDHCPOptions(ctx, ec2Client)...)
 	errs = append(errs, o.DestroyEIPs(ctx, ec2Client)...)
@@ -372,6 +372,29 @@ func (o *DestroyInfraOptions) DestroyNATGateways(ctx context.Context, client ec2
 	if err != nil {
 		errs = append(errs, err)
 	}
+	return errs
+}
+
+func (o *DestroyInfraOptions) destroyInstances(ctx context.Context, client ec2iface.EC2API) []error {
+	var errs []error
+	deleteInstances := func(out *ec2.DescribeInstancesOutput, _ bool) bool {
+		var instanceIDs []*string
+		for _, reservation := range out.Reservations {
+			for _, instance := range reservation.Instances {
+				instanceIDs = append(instanceIDs, aws.String(*instance.InstanceId))
+			}
+		}
+		if _, err := client.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: instanceIDs}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to terminate instances: %w", err))
+		}
+
+		return true
+	}
+
+	if err := client.DescribeInstancesPagesWithContext(ctx, &ec2.DescribeInstancesInput{Filters: o.ec2Filters()}, deleteInstances); err != nil {
+		errs = append(errs, fmt.Errorf("failed to describe instances: %w", err))
+	}
+
 	return errs
 }
 

--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -386,6 +386,12 @@ func (o *CreateInfraOptions) CreatePrivateRouteTable(client ec2iface.EC2API, vpc
 			return "", err
 		}
 	}
+
+	// Everything below this is only needed if direct internet access is used
+	if o.EnableProxy {
+		return aws.StringValue(routeTable.RouteTableId), nil
+	}
+
 	if !o.hasNATGatewayRoute(routeTable, natGatewayID) {
 		isRetriable := func(err error) bool {
 			if awsErr, ok := err.(awserr.Error); ok {

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
@@ -33,7 +33,7 @@ func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Se
 	globalconfig.ReconcileNetworkConfig(network, hcp, globalConfig)
 
 	proxy := globalconfig.ProxyConfig()
-	globalconfig.ReconcileProxyConfig(proxy, hcp, globalConfig)
+	globalconfig.ReconcileProxyConfigWithStatus(proxy, hcp, globalConfig)
 
 	return &MCSParams{
 		OwnerRef:       config.OwnerRefFrom(hcp),

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -451,7 +451,7 @@ func (r *reconciler) reconcileConfig(ctx context.Context, hcp *hyperv1.HostedCon
 
 	proxy := globalconfig.ProxyConfig()
 	if _, err := r.CreateOrUpdate(ctx, r.client, proxy, func() error {
-		globalconfig.ReconcileProxyConfig(proxy, hcp, globalConfig)
+		globalconfig.ReconcileProxyConfig(proxy, globalConfig)
 		return nil
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile proxy config: %w", err))

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	hyperutil "github.com/openshift/hypershift/hypershift-operator/controllers/util"
+	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -480,7 +481,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), targetConfigVersionHash)
 	if result, err := r.CreateOrUpdate(ctx, r.Client, userDataSecret, func() error {
-		return reconcileUserDataSecret(userDataSecret, nodePool, caCertBytes, tokenBytes, ignEndpoint)
+		return reconcileUserDataSecret(ctx, userDataSecret, nodePool, caCertBytes, tokenBytes, ignEndpoint, hcluster)
 	}); err != nil {
 		return ctrl.Result{}, err
 	} else {
@@ -648,7 +649,7 @@ func (r *NodePoolReconciler) delete(ctx context.Context, nodePool *hyperv1.NodeP
 	return nil
 }
 
-func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.NodePool, CA, token []byte, ignEndpoint string) error {
+func reconcileUserDataSecret(ctx context.Context, userDataSecret *corev1.Secret, nodePool *hyperv1.NodePool, CA, token []byte, ignEndpoint string, hc *hyperv1.HostedCluster) error {
 	// The token secret controller deletes expired token Secrets.
 	// When that happens the NodePool controller reconciles and create a new one.
 	// Then it reconciles the userData Secret with the new generated token.
@@ -660,9 +661,16 @@ func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.No
 	}
 	userDataSecret.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
 
+	globalConfig, err := globalconfig.ParseGlobalConfig(ctx, hc.Spec.Configuration)
+	if err != nil {
+		return fmt.Errorf("failed to parse global config: %w", err)
+	}
+	proxy := globalconfig.ProxyConfig()
+	globalconfig.ReconcileProxyConfigWithStatusFromHostedCluster(proxy, hc, globalConfig)
+
 	encodedCACert := base64.StdEncoding.EncodeToString(CA)
 	encodedToken := base64.StdEncoding.EncodeToString(token)
-	ignConfig := ignConfig(encodedCACert, encodedToken, ignEndpoint)
+	ignConfig := ignConfig(encodedCACert, encodedToken, ignEndpoint, proxy)
 	userDataValue, err := json.Marshal(ignConfig)
 	if err != nil {
 		return fmt.Errorf("failed to marshal ignition config: %w", err)
@@ -911,8 +919,8 @@ func setMachineDeploymentReplicas(nodePool *hyperv1.NodePool, machineDeployment 
 	}
 }
 
-func ignConfig(encodedCACert, encodedToken, endpoint string) ignitionapi.Config {
-	return ignitionapi.Config{
+func ignConfig(encodedCACert, encodedToken, endpoint string, proxy *configv1.Proxy) ignitionapi.Config {
+	cfg := ignitionapi.Config{
 		Ignition: ignitionapi.Ignition{
 			Version: "3.2.0",
 			Security: ignitionapi.Security{
@@ -939,6 +947,18 @@ func ignConfig(encodedCACert, encodedToken, endpoint string) ignitionapi.Config 
 			},
 		},
 	}
+	if proxy.Status.HTTPProxy != "" {
+		cfg.Ignition.Proxy.HTTPProxy = k8sutilspointer.String(proxy.Status.HTTPProxy)
+	}
+	if proxy.Status.HTTPSProxy != "" {
+		cfg.Ignition.Proxy.HTTPSProxy = k8sutilspointer.String(proxy.Status.HTTPSProxy)
+	}
+	if proxy.Status.NoProxy != "" {
+		for _, item := range strings.Split(proxy.Status.NoProxy, ",") {
+			cfg.Ignition.Proxy.NoProxy = append(cfg.Ignition.Proxy.NoProxy, ignitionapi.NoProxyItem(item))
+		}
+	}
+	return cfg
 }
 
 func (r *NodePoolReconciler) getConfig(ctx context.Context, nodePool *hyperv1.NodePool, expectedCoreConfigResources int, controlPlaneResource string) (configsRaw string, missingConfigs bool, err error) {

--- a/support/globalconfig/proxy.go
+++ b/support/globalconfig/proxy.go
@@ -1,9 +1,13 @@
 package globalconfig
 
 import (
+	"fmt"
+	"strings"
+
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func ProxyConfig() *configv1.Proxy {
@@ -14,8 +18,71 @@ func ProxyConfig() *configv1.Proxy {
 	}
 }
 
-func ReconcileProxyConfig(cfg *configv1.Proxy, hcp *hyperv1.HostedControlPlane, globalConfig GlobalConfig) {
+func ReconcileProxyConfig(cfg *configv1.Proxy, globalConfig GlobalConfig) {
+	spec := configv1.ProxySpec{}
 	if globalConfig.Proxy != nil {
-		cfg.Spec = globalConfig.Proxy.Spec
+		spec = globalConfig.Proxy.Spec
 	}
+
+	cfg.Spec = spec
+}
+
+func ReconcileProxyConfigWithStatus(cfg *configv1.Proxy, hcp *hyperv1.HostedControlPlane, globalConfig GlobalConfig) {
+	ReconcileProxyConfig(cfg, globalConfig)
+	defaultProxyStatus(cfg, hcp.Spec.MachineCIDR, hcp.Spec.PodCIDR, hcp.Spec.ServiceCIDR, hcp.Spec.Platform)
+}
+
+func ReconcileProxyConfigWithStatusFromHostedCluster(cfg *configv1.Proxy, hc *hyperv1.HostedCluster, globalConfig GlobalConfig) {
+	ReconcileProxyConfig(cfg, globalConfig)
+	defaultProxyStatus(cfg, hc.Spec.Networking.MachineCIDR, hc.Spec.Networking.PodCIDR, hc.Spec.Networking.ServiceCIDR, hc.Spec.Platform)
+}
+
+// defaultProxyStatus does what the name suggests. It is needed to fill in no_proxy sensibly and because the ignition rendering will ignore the proxy
+// config if the status is empty: https://github.com/openshift/machine-config-operator/blob/5f21537c5743d9a834936ea4eacd4691404a4958/pkg/operator/render.go#L174
+// This code effectifely duplicates logic from the CNO because we need this data before the controlplane is up and from the hypershift operator which shouldn't
+// access guest cluster apiservers. CNO code: https://github.com/openshift/cluster-network-operator/blob/a0e506ca7d323493afd1ff32f8366e06fd1f1c59/pkg/util/proxyconfig/no_proxy.go#L22
+// We might consider updating the CNO proxy controller to manage this.
+func defaultProxyStatus(p *configv1.Proxy, machineCIDR, podCIDR, serviceCIDR string, platform hyperv1.PlatformSpec) {
+	p.Status.HTTPProxy = p.Spec.HTTPProxy
+	p.Status.HTTPSProxy = p.Spec.HTTPSProxy
+	if p.Spec.HTTPProxy == "" && p.Spec.HTTPSProxy == "" {
+		return
+	}
+
+	set := sets.NewString(
+		"127.0.0.1",
+		"localhost",
+		".svc",
+		".cluster.local",
+		// This is hypershift specific, we need it for private clusters
+		".local",
+		podCIDR,
+		serviceCIDR,
+	)
+	if machineCIDR != "" {
+		set.Insert(machineCIDR)
+	}
+
+	if platform.Type == hyperv1.AWSPlatform || platform.Type == hyperv1.AzurePlatform {
+		set.Insert("169.254.169.254")
+	}
+
+	if platform.Type == hyperv1.AWSPlatform {
+		region := platform.AWS.Region
+		if region == "us-east-1" {
+			set.Insert(".ec2.internal")
+		} else {
+			set.Insert(fmt.Sprintf(".%s.compute.internal", region))
+		}
+	}
+
+	if len(p.Spec.NoProxy) > 0 {
+		for _, userValue := range strings.Split(p.Spec.NoProxy, ",") {
+			if userValue != "" {
+				set.Insert(userValue)
+			}
+		}
+	}
+
+	p.Status.NoProxy = strings.Join(set.List(), ",")
 }


### PR DESCRIPTION
This change:
* Adds a new --enable-proxy flag to the create aws infra command
  which will create a http proxy instance if set
* It will also cause a proxy config pointing to said instance to be
  added to the HostedCluster
* Extends the globalconfig package to optionally be able to set the
  status of a proxy config, including additional no_proxy hosts
* Makes the nodepool controllers userdata secret generation consider a
  proxy config if preset
* Makes the ignition config rendering use a proxy config with status
  set, as otherwise the proxy config will be ignored
* Makes the aws infra destroy command also  clean up instances to not
  get blocked by the proxy instance

Ref https://issues.redhat.com/browse/HOSTEDCP-333

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.