### PR TITLE
Do not wait on capi clusterrolebinding delete

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3169,13 +3169,9 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		}
 	}
 
-	exists, err = hyperutil.DeleteIfNeeded(ctx, r.Client, clusterapi.CAPIManagerClusterRoleBinding(controlPlaneNamespace))
+	_, err = hyperutil.DeleteIfNeeded(ctx, r.Client, clusterapi.CAPIManagerClusterRoleBinding(controlPlaneNamespace))
 	if err != nil {
 		return false, err
-	}
-	if exists {
-		log.Info("Waiting for Cluster API ClusterRoleBinding deletion", "controlPlaneNamespace", controlPlaneNamespace)
-		return false, nil
 	}
 
 	// There are scenarios where CAPI might not be operational e.g None Platform.


### PR DESCRIPTION
**What this PR does / why we need it**:

We are getting 404 delete on this `ClusterRoleBinding` because of rapid reconciliation of HostedClusters during their deletion.

I think that this will fix it in a hacky way, plus there is no need to wait for the deletion of this resource.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.