### PR TITLE
Signal parsing config failure in a condition

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	NodePoolValidHostedClusterConditionType      = "ValidHostedCluster"
 	NodePoolValidReleaseImageConditionType       = "ValidReleaseImage"
 	NodePoolValidAMIConditionType                = "ValidAMI"
 	NodePoolValidMachineConfigConditionType      = "ValidMachineConfig"

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -31,6 +31,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/hypershift/support/globalconfig"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -3462,6 +3464,11 @@ func (r *HostedClusterReconciler) validateConfigAndClusterCapabilities(ctx conte
 
 	if err := validateClusterID(hc); err != nil {
 		errs = append(errs, err)
+	}
+
+	_, err := globalconfig.ParseGlobalConfig(ctx, hc.Spec.Configuration)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to parse cluster configuration: %w", err))
 	}
 
 	return utilerrors.NewAggregate(errs)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR signal invalid cluster config in a HC condition. It also do the same for NodePools and refactors to narrow down the reconcileUserdata signature and let it only use what it takes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
ref https://issues.redhat.com/browse/HOSTEDCP-380

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.