### PR TITLE
Add validating webhook for HostedClusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,7 @@ ci-install-hypershift-private:
 		--oidc-storage-provider-s3-credentials=/etc/hypershift-pool-aws-credentials/credentials \
 		--oidc-storage-provider-s3-bucket-name=hypershift-ci-oidc \
 		--oidc-storage-provider-s3-region=us-east-1 \
+		--enable-webhook \
 		--private-platform=AWS \
 		--aws-private-creds=/etc/hypershift-pool-aws-credentials/credentials \
 		--aws-private-region=us-east-1 \

--- a/api/v1alpha1/hostedcluster_webhook.go
+++ b/api/v1alpha1/hostedcluster_webhook.go
@@ -1,0 +1,49 @@
+package v1alpha1
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var log = ctrl.Log.WithName("hostedcluster")
+
+func (r *HostedCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+var _ webhook.Validator = &HostedCluster{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// NOTE: add CREATE in the ValidatingWebhookConfiguration for this to work
+func (r *HostedCluster) ValidateCreate() error {
+	log.Info("HostedCluster validate create", "name", r.Name)
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *HostedCluster) ValidateUpdate(old runtime.Object) error {
+	log.Info("HostedCluster validate update", "name", r.Name)
+	var allErrs field.ErrorList
+
+	// TODO: Do immutablity enforcement here
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: GroupVersion.Group, Kind: "HostedCluster"},
+		r.Name, allErrs)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// NOTE: add DELETE in the ValidatingWebhookConfiguration for this to work
+func (r *HostedCluster) ValidateDelete() error {
+	log.Info("HostedCluster validate delete", "name", r.Name)
+	return nil
+}

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -283,6 +283,16 @@ objects:
           hypershift.openshift.io/operator-component: operator
           name: operator
       spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: name
+                  operator: In
+                  values:
+                  - operator
+              topologyKey: kubernetes.io/hostname
         containers:
         - args:
           - run
@@ -319,6 +329,9 @@ objects:
           - containerPort: 9000
             name: metrics
             protocol: TCP
+          - containerPort: 9443
+            name: manager
+            protocol: TCP
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -348,6 +361,8 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      service.beta.openshift.io/serving-cert-secret-name: manager-serving-cert
     creationTimestamp: null
     labels:
       name: operator
@@ -359,6 +374,10 @@ objects:
       port: 9393
       protocol: TCP
       targetPort: metrics
+    - name: manager
+      port: 443
+      protocol: TCP
+      targetPort: manager
     selector:
       name: operator
     type: ClusterIP

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -70,6 +70,7 @@ type StartOptions struct {
 	Namespace                        string
 	DeploymentName                   string
 	MetricsAddr                      string
+	CertDir                          string
 	EnableOCPClusterMonitoring       bool
 	EnableCIDebugOutput              bool
 	ControlPlaneOperatorImage        string
@@ -94,6 +95,7 @@ func NewStartCommand() *cobra.Command {
 		Namespace:                        "hypershift",
 		DeploymentName:                   "operator",
 		MetricsAddr:                      "0",
+		CertDir:                          "",
 		ControlPlaneOperatorImage:        "",
 		RegistryOverrides:                map[string]string{},
 		PrivatePlatform:                  string(hyperv1.NonePlatform),
@@ -104,6 +106,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace this operator lives in")
 	cmd.Flags().StringVar(&opts.DeploymentName, "deployment-name", opts.DeploymentName, "The name of the deployment of this operator")
 	cmd.Flags().StringVar(&opts.MetricsAddr, "metrics-addr", opts.MetricsAddr, "The address the metric endpoint binds to.")
+	cmd.Flags().StringVar(&opts.CertDir, "cert-dir", opts.CertDir, "Path to the serving key and cert for manager")
 	cmd.Flags().StringVar(&opts.ControlPlaneOperatorImage, "control-plane-operator-image", opts.ControlPlaneOperatorImage, "A control plane operator image to use (defaults to match this operator if running in a deployment)")
 	cmd.Flags().BoolVar(&opts.EnableOCPClusterMonitoring, "enable-ocp-cluster-monitoring", opts.EnableOCPClusterMonitoring, "Development-only option that will make your OCP cluster unsupported: If the cluster Prometheus should be configured to scrape metrics")
 	cmd.Flags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", false, "If extra CI debug output should be enabled")
@@ -135,6 +138,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		Scheme:                        hyperapi.Scheme,
 		MetricsBindAddress:            opts.MetricsAddr,
 		Port:                          9443,
+		CertDir:                       opts.CertDir,
 		LeaderElection:                true,
 		LeaderElectionID:              "hypershift-operator-leader-elect",
 		LeaderElectionResourceLock:    "leases",
@@ -216,6 +220,11 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	}
 	if err := hostedClusterReconciler.SetupWithManager(mgr, createOrUpdate); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
+	}
+	if opts.CertDir != "" {
+		if err = (&hyperv1.HostedCluster{}).SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create controller: %w", err)
+		}
 	}
 
 	if err := (&nodepool.NodePoolReconciler{


### PR DESCRIPTION
This PR adds a validating webhook to the `hypershift-operator` for the `HostedCluster` type

This allows enforcement of immutable fields on the `HostedCluster` spec.

Creation of the `ValidatingWebhookConfiguration` can be disabled on the `hypershift install` CLI with the `--disable-webhook` flag.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.