### PR TITLE
Make HyperShift operator compatible with previous CPOs without utilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,11 @@ COPY --from=builder /hypershift/bin/hypershift \
                     /hypershift/bin/control-plane-operator \
      /usr/bin/
 
+RUN cd /usr/bin && \
+    ln -s control-plane-operator ignition-server && \
+    ln -s control-plane-operator konnectivity-socks5-proxy && \
+    ln -s control-plane-operator availability-prober && \
+    ln -s control-plane-operator token-minter
+
 ENTRYPOINT /usr/bin/hypershift
+LABEL io.openshift.hypershift.control-plane-operator-subcommands=true

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -12,3 +12,4 @@ COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plan
 ENTRYPOINT /usr/bin/control-plane-operator
 
 LABEL io.openshift.release.operator=true
+LABEL io.openshift.hypershift.control-plane-operator-subcommands=true

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/go-logr/logr v1.2.1
 	github.com/go-logr/zapr v1.2.0
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/go-cmp v0.5.6
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.3.0
@@ -85,7 +86,6 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -105,6 +105,8 @@ const (
 	imageCAPI                              = "registry.ci.openshift.org/hypershift/cluster-api:v1.0.0"
 	ImageStreamAutoscalerImage             = "cluster-autoscaler"
 	ImageStreamClusterMachineApproverImage = "cluster-machine-approver"
+
+	controlPlaneOperatorSubcommandsLabel = "io.openshift.hypershift.control-plane-operator-subcommands"
 )
 
 // NoopReconcile is just a default mutation function that does nothing.
@@ -141,6 +143,8 @@ type HostedClusterReconciler struct {
 
 	OIDCStorageProviderS3BucketName string
 	S3Client                        s3iface.S3API
+
+	ImageMetadataProvider util.ImageMetadataProvider
 }
 
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters,verbs=get;list;watch;create;update;patch;delete
@@ -645,9 +649,21 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get controlPlaneOperatorImage: %w", err)
 	}
+	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to look up image metadata for %s: %w", controlPlaneOperatorImage, err)
+	}
+	cpoHasUtilities := false
+	if _, hasLabel := util.ImageLabels(controlPlaneOperatorImageMetadata)[controlPlaneOperatorSubcommandsLabel]; hasLabel {
+		cpoHasUtilities = true
+	}
+	utilitiesImage := controlPlaneOperatorImage
+	if !cpoHasUtilities {
+		utilitiesImage = r.HypershiftOperatorImage
+	}
 
 	// Reconcile Platform specifics.
-	p, err := platform.GetPlatform(hcluster, controlPlaneOperatorImage)
+	p, err := platform.GetPlatform(hcluster, utilitiesImage)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -1057,13 +1073,13 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile the autoscaler
-	err = r.reconcileAutoscaler(ctx, createOrUpdate, hcluster, hcp, controlPlaneOperatorImage)
+	err = r.reconcileAutoscaler(ctx, createOrUpdate, hcluster, hcp, utilitiesImage)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile autoscaler: %w", err)
 	}
 
 	// Reconcile the machine approver
-	if err = r.reconcileMachineApprover(ctx, createOrUpdate, hcluster, hcp, controlPlaneOperatorImage); err != nil {
+	if err = r.reconcileMachineApprover(ctx, createOrUpdate, hcluster, hcp, utilitiesImage); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile machine approver: %w", err)
 	}
 
@@ -1071,14 +1087,15 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to determine default ingress domain: %w", err)
 	}
+
 	// Reconcile the control plane operator
-	err = r.reconcileControlPlaneOperator(ctx, createOrUpdate, hcluster, hcp, controlPlaneOperatorImage, defaultIngressDomain)
+	err = r.reconcileControlPlaneOperator(ctx, createOrUpdate, hcluster, hcp, controlPlaneOperatorImage, utilitiesImage, defaultIngressDomain, cpoHasUtilities)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile control plane operator: %w", err)
 	}
 
 	// Reconcile the Ignition server
-	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, controlPlaneOperatorImage, defaultIngressDomain); err != nil {
+	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, utilitiesImage, defaultIngressDomain); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile ignition server: %w", err)
 	}
 
@@ -1428,7 +1445,7 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, cre
 
 // reconcileControlPlaneOperator orchestrates reconciliation of the control plane
 // operator components.
-func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane, controlPlaneOperatorImage, defaultIngressDomain string) error {
+func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane, controlPlaneOperatorImage, utilitiesImage, defaultIngressDomain string, cpoHasUtilities bool) error {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
@@ -1501,7 +1518,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	// Reconcile operator deployment
 	controlPlaneOperatorDeployment := controlplaneoperator.OperatorDeployment(controlPlaneNamespace.Name)
 	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
-		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, r.SetDefaultSecurityContext, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()), defaultIngressDomain)
+		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, controlPlaneOperatorImage, utilitiesImage, r.SetDefaultSecurityContext, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()), defaultIngressDomain, cpoHasUtilities)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator deployment: %w", err)
@@ -1585,7 +1602,7 @@ func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.Servi
 	return nil
 }
 
-func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, controlPlaneOperatorImage, defaultIngressDomain string) error {
+func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, utilitiesImage, defaultIngressDomain string) error {
 
 	log := ctrl.LoggerFrom(ctx)
 
@@ -1821,7 +1838,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 					Containers: []corev1.Container{
 						{
 							Name:            ignitionserver.ResourceName,
-							Image:           controlPlaneOperatorImage,
+							Image:           utilitiesImage,
 							ImagePullPolicy: corev1.PullAlways,
 							Env: []corev1.EnvVar{
 								{
@@ -1931,7 +1948,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 // reconcileAutoscaler orchestrates reconciliation of autoscaler components using
 // both the HostedCluster and the HostedControlPlane which the autoscaler takes
 // inputs from.
-func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, controlPlaneOperatorImage string) error {
+func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, utilitiesImage string) error {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
@@ -1989,7 +2006,7 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, creat
 
 		autoScalerDeployment := autoscaler.AutoScalerDeployment(controlPlaneNamespace.Name)
 		_, err = createOrUpdate(ctx, r.Client, autoScalerDeployment, func() error {
-			return reconcileAutoScalerDeployment(autoScalerDeployment, hcluster, autoScalerServiceAccount, capiKubeConfigSecret, hcluster.Spec.Autoscaling, clusterAutoscalerImage, controlPlaneOperatorImage, r.SetDefaultSecurityContext)
+			return reconcileAutoScalerDeployment(autoScalerDeployment, hcluster, autoScalerServiceAccount, capiKubeConfigSecret, hcluster.Spec.Autoscaling, clusterAutoscalerImage, utilitiesImage, r.SetDefaultSecurityContext)
 		})
 		if err != nil {
 			return fmt.Errorf("failed to reconcile autoscaler deployment: %w", err)
@@ -2035,7 +2052,7 @@ func getControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 	return hypershiftOperatorImage, nil
 }
 
-func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, cpoImage string, setDefaultSecurityContext bool, sa *corev1.ServiceAccount, enableCIDebugOutput bool, registryOverrideCommandLine, defaultIngressDomain string) error {
+func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, cpoImage, utilitiesImage string, setDefaultSecurityContext bool, sa *corev1.ServiceAccount, enableCIDebugOutput bool, registryOverrideCommandLine, defaultIngressDomain string, cpoHasUtilities bool) error {
 	cpoResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("44Mi"),
@@ -2048,6 +2065,22 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 		if len(mainContainer.Resources.Requests) > 0 || len(mainContainer.Resources.Limits) > 0 {
 			cpoResources = mainContainer.Resources
 		}
+	}
+
+	args := []string{
+		"run",
+		"--namespace", "$(MY_NAMESPACE)",
+		"--deployment-name", "control-plane-operator",
+		"--metrics-addr", "0.0.0.0:8080",
+		fmt.Sprintf("--enable-ci-debug-output=%t", enableCIDebugOutput),
+		fmt.Sprintf("--registry-overrides=%s", registryOverrideCommandLine),
+	}
+	if !cpoHasUtilities {
+		args = append(args,
+			"--socks5-proxy-image", utilitiesImage,
+			"--availability-prober-image", utilitiesImage,
+			"--token-minter-image", utilitiesImage,
+		)
 	}
 
 	deployment.Spec = appsv1.DeploymentSpec{
@@ -2091,11 +2124,8 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 							},
 						},
 						Command: []string{"/usr/bin/control-plane-operator"},
-						Args: []string{"run", "--namespace", "$(MY_NAMESPACE)", "--deployment-name", "control-plane-operator",
-							"--metrics-addr", "0.0.0.0:8080", fmt.Sprintf("--enable-ci-debug-output=%t", enableCIDebugOutput),
-							fmt.Sprintf("--registry-overrides=%s", registryOverrideCommandLine),
-						},
-						Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 8080}},
+						Args:    args,
+						Ports:   []corev1.ContainerPort{{Name: "metrics", ContainerPort: 8080}},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{
@@ -2205,7 +2235,7 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 			})
 		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, corev1.Container{
 			Name:            "token-minter",
-			Image:           cpoImage,
+			Image:           utilitiesImage,
 			ImagePullPolicy: corev1.PullAlways,
 			Command:         []string{"/usr/bin/control-plane-operator", "token-minter"},
 			Args: []string{
@@ -3315,7 +3345,7 @@ func (r *HostedClusterReconciler) reconcileClusterPrometheusRBAC(ctx context.Con
 	return nil
 }
 
-func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, controlPlaneOperatorImage string) error {
+func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, utilitiesImage string) error {
 	controlPlaneNamespaceName := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
 
 	// Reconcile machine-approver role
@@ -3362,7 +3392,7 @@ func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, 
 
 		deployment := machineapprover.Deployment(controlPlaneNamespaceName)
 		if _, err := createOrUpdate(ctx, r.Client, deployment, func() error {
-			return reconcileMachineApproverDeployment(deployment, hcluster, sa, kubeconfigSecretName, config, machineApproverImage, controlPlaneOperatorImage, r.SetDefaultSecurityContext)
+			return reconcileMachineApproverDeployment(deployment, hcluster, sa, kubeconfigSecretName, config, machineApproverImage, utilitiesImage, r.SetDefaultSecurityContext)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile machine-approver deployment: %w", err)
 		}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/hypershift/support/capabilities"
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/upsert"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -1125,6 +1126,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 		ManagementClusterCapabilities: fakecapabilities.NewSupportAllExcept(capabilities.CapabilityConfigOpenshiftIO),
 		createOrUpdate:                func(reconcile.Request) upsert.CreateOrUpdateFN { return ctrl.CreateOrUpdate },
 		ReleaseProvider:               &fakereleaseprovider.FakeReleaseProvider{},
+		ImageMetadataProvider:         &fakeImageMetadataProvider{},
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
@@ -1452,4 +1454,10 @@ func TestDefaultClusterIDsIfNeeded(t *testing.T) {
 			}
 		})
 	}
+}
+
+type fakeImageMetadataProvider struct{}
+
+func (*fakeImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
+	return &dockerv1client.DockerImageConfig{}, nil
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -29,14 +29,14 @@ const (
 	imageCAPA = "registry.ci.openshift.org/hypershift/cluster-api-aws-controller:v1.1.0"
 )
 
-func New(controlPlaneOperatorImage string) *AWS {
+func New(utilitiesImage string) *AWS {
 	return &AWS{
-		controlPlaneOperatorImage: controlPlaneOperatorImage,
+		utilitiesImage: utilitiesImage,
 	}
 }
 
 type AWS struct {
-	controlPlaneOperatorImage string
+	utilitiesImage string
 }
 
 func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
@@ -192,7 +192,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 					},
 					{
 						Name:            "token-minter",
-						Image:           p.controlPlaneOperatorImage,
+						Image:           p.utilitiesImage,
 						ImagePullPolicy: corev1.PullAlways,
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -223,7 +223,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 			},
 		},
 	}
-	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Namespace, hcp.Spec.APIPort), p.controlPlaneOperatorImage, &deploymentSpec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Namespace, hcp.Spec.APIPort), p.utilitiesImage, &deploymentSpec.Template.Spec)
 	return deploymentSpec, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -56,11 +56,11 @@ type Platform interface {
 	DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error
 }
 
-func GetPlatform(hcluster *hyperv1.HostedCluster, controlplaneOperatorImage string) (Platform, error) {
+func GetPlatform(hcluster *hyperv1.HostedCluster, utilitiesImage string) (Platform, error) {
 	var platform Platform
 	switch hcluster.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
-		platform = aws.New(controlplaneOperatorImage)
+		platform = aws.New(utilitiesImage)
 	case hyperv1.IBMCloudPlatform:
 		platform = &ibmcloud.IBMCloud{}
 	case hyperv1.NonePlatform:

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
+	"github.com/openshift/hypershift/support/util"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -206,6 +207,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		},
 		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
 		EnableCIDebugOutput:        opts.EnableCIDebugOutput,
+		ImageMetadataProvider:      &util.RegistryClientImageMetadataProvider{},
 	}
 	if opts.OIDCStorageProviderS3BucketName != "" {
 		awsSession := awsutil.NewSession("hypershift-operator-oidc-bucket", opts.OIDCStorageProviderS3Credentials, "", "", opts.OIDCStorageProviderS3Region)

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -1,0 +1,94 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/docker/distribution/registry/client/transport"
+	"github.com/golang/groupcache/lru"
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/registryclient"
+	"github.com/openshift/hypershift/support/thirdparty/oc/pkg/cli/image/manifest"
+	"github.com/openshift/hypershift/support/thirdparty/oc/pkg/cli/image/manifest/dockercredentials"
+)
+
+var (
+	imageMetadataCache = lru.New(1000)
+)
+
+type ImageMetadataProvider interface {
+	ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error)
+}
+
+type RegistryClientImageMetadataProvider struct{}
+
+// ImageMetadata returns metadata for a given image using the given pull secret
+// to authenticate. This lookup uses a cache based on the image digest. If the
+// reference of the image contains a digest (which is the mainline case for images in a release payload),
+// the digest is parsed from the image reference and then used to lookup image metadata in the
+// cache. When the image reference does not contain a digest, a lookup is made to the registry to
+// fetch the digest of the image that the tag refers to. This is because the actual image that the
+// tag is referring to could have changed. Once a digest is obtained, the cache is checked so that
+// no further fetching occurs. Only if both cache lookups fail, the image metadata is fetched and
+// stored in the cache.
+func (*RegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
+
+	ref, err := reference.Parse(imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
+	}
+
+	// If the image reference contains a digest, immediately look it up in the cache
+	if ref.ID != "" {
+		if imageConfigObject, exists := imageMetadataCache.Get(string(ref.ID)); exists {
+			return imageConfigObject.(*dockerv1client.DockerImageConfig), nil
+		}
+	}
+
+	credStore, err := dockercredentials.NewFromBytes(pullSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse docker credentials: %w", err)
+	}
+	rt, err := rest.TransportFor(&rest.Config{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secure transport: %w", err)
+	}
+	registryContext := registryclient.NewContext(rt, nil).WithCredentials(credStore).
+		WithRequestModifiers(transport.NewHeaderRequestModifier(http.Header{http.CanonicalHeaderKey("User-Agent"): []string{rest.DefaultKubernetesUserAgent()}}))
+
+	repo, err := registryContext.Repository(ctx, ref.DockerClientDefaults().RegistryURL(), ref.RepositoryName(), false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create repository client for %s: %w", ref.DockerClientDefaults().RegistryURL(), err)
+	}
+	firstManifest, location, err := manifest.FirstManifest(ctx, ref, repo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain root manifest for %s: %w", imageRef, err)
+	}
+	// If the image ref did not contain a digest, attempt looking it up by digest after we've fetched the digest
+	if ref.ID == "" {
+		if imageConfigObject, exists := imageMetadataCache.Get(string(location.Manifest)); exists {
+			return imageConfigObject.(*dockerv1client.DockerImageConfig), nil
+		}
+	}
+
+	config, _, err := manifest.ManifestToImageConfig(ctx, firstManifest, repo.Blobs(ctx), location)
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain image configuration for %s: %w", imageRef, err)
+	}
+	imageMetadataCache.Add(string(location.Manifest), config)
+
+	return config, nil
+}
+
+// ImageLabels returns labels on a given image metadata
+func ImageLabels(metadata *dockerv1client.DockerImageConfig) map[string]string {
+	if metadata.Config != nil {
+		return metadata.Config.Labels
+	} else {
+		return metadata.ContainerConfig.Labels
+	}
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
Adds symlinks in HyperShift operator image for previously standalone
utilities and enables the control plane operator to invoke the right
command based on the symlink it was invoked with.

Checks whether the CPO for a given cluster includes subcommands for
utilities by checking the labels on the CPO image, and only uses the
CPO image for utilities if it does include the labels.


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.