### PR TITLE
AWS infra destroy, handle empty instanceIDs

### DIFF
--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -384,8 +384,10 @@ func (o *DestroyInfraOptions) destroyInstances(ctx context.Context, client ec2if
 				instanceIDs = append(instanceIDs, aws.String(*instance.InstanceId))
 			}
 		}
-		if _, err := client.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: instanceIDs}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to terminate instances: %w", err))
+		if len(instanceIDs) > 0 {
+			if _, err := client.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: instanceIDs}); err != nil {
+				errs = append(errs, fmt.Errorf("failed to terminate instances: %w", err))
+			}
 		}
 
 		return true


### PR DESCRIPTION
In the case where the nodepool didn't create any instances this
list can be empty on destroy, which causes an error like:

missing required field, TerminateInstancesInput.InstanceIds

This causes the destroy to get stuck, so instead handle the
case where the list is empty.

