### PR TITLE
destroy cluster: check whether there are instances to terminate

### DIFF
--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -384,8 +384,10 @@ func (o *DestroyInfraOptions) destroyInstances(ctx context.Context, client ec2if
 				instanceIDs = append(instanceIDs, aws.String(*instance.InstanceId))
 			}
 		}
-		if _, err := client.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: instanceIDs}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to terminate instances: %w", err))
+		if len(instanceIDs) > 0 {
+			if _, err := client.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: instanceIDs}); err != nil {
+				errs = append(errs, fmt.Errorf("failed to terminate instances: %w", err))
+			}
 		}
 
 		return true


### PR DESCRIPTION
**What this PR does / why we need it**:

Calling `hypershift aws destroy cluster` on the CLI was resulting in
the following error message:

```
{"error": "failed to terminate instances: InvalidParameter: 1 validation
 error(s) found.\n- missing required field,
 TerminateInstancesInput.InstanceIds.\n", "type": "errors.aggregate,
 failed to terminate instances: InvalidParameter: 1 validation error(s)
 found.\n- missing required field, TerminateInstancesInput.InstanceIds.
 \n}
```

This adds a check to avoid calling terminate instances if there are no
instances to destroy.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.