### PR TITLE
continue to allow support for specification of clusterAutoscalerImage…

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2016,6 +2016,10 @@ func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, creat
 		if err != nil {
 			return fmt.Errorf("failed to get image for cluster autoscaler: %w", err)
 		}
+		// TODO: can remove this override when all IBM production clusters upgraded to a version that uses the release image
+		if imageVal, ok := hcluster.Annotations[hyperv1.ClusterAutoscalerImage]; ok {
+			clusterAutoscalerImage = imageVal
+		}
 
 		autoScalerDeployment := autoscaler.AutoScalerDeployment(controlPlaneNamespace.Name)
 		_, err = createOrUpdate(ctx, r.Client, autoScalerDeployment, func() error {
@@ -3401,6 +3405,10 @@ func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, 
 		machineApproverImage, err := r.getPayloadImage(ctx, hcluster, ImageStreamClusterMachineApproverImage)
 		if err != nil {
 			return fmt.Errorf("failed to get image for machine approver: %w", err)
+		}
+		// TODO: can remove this override when all IBM production clusters upgraded to a version that uses the release image
+		if imageVal, ok := hcluster.Annotations[hyperv1.MachineApproverImage]; ok {
+			machineApproverImage = imageVal
 		}
 
 		deployment := machineapprover.Deployment(controlPlaneNamespaceName)


### PR DESCRIPTION
… and machineApprover image until no longer necessary

IBM's production release candidate still relies on this behavior to deploy the images specified in the BOM. We will need to have this support in place until we can confirm we have successfully upgraded all production clusters to a later BOM version that no longer needs this behavior and instead uses the release image

**What this PR does / why we need it**:
Fixes a removal of behavior that cannot be removed until all existing production clusters no longer need it.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.