### PR TITLE
ensure release image annotation added to deployment template metadata  to enable proper detection in IBM Cloud deployment process

### DIFF
--- a/hypershift-operator/controllers/util/deployment.go
+++ b/hypershift-operator/controllers/util/deployment.go
@@ -27,6 +27,10 @@ func SetReleaseImageAnnotation(deployment *appsv1.Deployment, releaseImage strin
 		deployment.Annotations = make(map[string]string)
 	}
 	deployment.Annotations[hyperv1.ReleaseImageAnnotation] = releaseImage
+	if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+	}
+	deployment.Spec.Template.ObjectMeta.Annotations[hyperv1.ReleaseImageAnnotation] = releaseImage
 }
 
 func SetDefaultPriorityClass(deployment *appsv1.Deployment) {

--- a/hypershift-operator/controllers/util/deployment_test.go
+++ b/hypershift-operator/controllers/util/deployment_test.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetRestartAnnotation(t *testing.T) {
+	fakeReleaseImage := "registry.com/namespace/image:1"
+	testsCases := []struct {
+		name               string
+		inputDeployment    *appsv1.Deployment
+		expectedDeployment *appsv1.Deployment
+	}{
+		{
+			name: "when release image is specified it is populated on the deployment",
+			inputDeployment: &appsv1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "deploy1",
+					Namespace: "master",
+				},
+			},
+			expectedDeployment: &appsv1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "deploy1",
+					Namespace: "master",
+					Annotations: map[string]string{
+						hyperv1.ReleaseImageAnnotation: fakeReleaseImage,
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: v12.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Annotations: map[string]string{
+								hyperv1.ReleaseImageAnnotation: fakeReleaseImage,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			SetReleaseImageAnnotation(tc.inputDeployment, fakeReleaseImage)
+			g.Expect(tc.inputDeployment).To(BeEquivalentTo(tc.expectedDeployment))
+		})
+	}
+}


### PR DESCRIPTION
The release image annotation should also be added to the pod template annotation so it is reflected on the pods that are scheduled from the deployment. This is necessary from a monitoring perspective and for detection in IBM Cloud's deployment process to ensure rollouts complete on a release image update

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.