### PR TITLE
reconcile oauth serving cert rbac to allow oauth proxies in the openshift-monitoring namespace to work

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/oauth.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/oauth.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 func OAuthCABundle() *corev1.ConfigMap {
@@ -37,6 +38,24 @@ func OAuthServerBrowserClient() *oauthv1.OAuthClient {
 	return &oauthv1.OAuthClient{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "openshift-browser-client",
+		},
+	}
+}
+
+func OAuthServingCertRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "system:openshift:oauth-servercert-trust",
+			Namespace: "openshift-config-managed",
+		},
+	}
+}
+
+func OAuthServingCertRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "system:openshift:oauth-servercert-trust",
+			Namespace: "openshift-config-managed",
 		},
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/oauth/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/oauth/reconcile_test.go
@@ -1,0 +1,79 @@
+package oauth
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestReconcileOauthServingCertRole(t *testing.T) {
+	testsCases := []struct {
+		name         string
+		inputRole    *rbacv1.Role
+		expectedRole *rbacv1.Role
+	}{
+		{
+			name:      "when empty role specified the rules are populated",
+			inputRole: manifests.OAuthServingCertRole(),
+			expectedRole: &rbacv1.Role{
+				ObjectMeta: manifests.OAuthServingCertRole().ObjectMeta,
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{""},
+						ResourceNames: []string{"oauth-serving-cert"},
+						Resources:     []string{"configmaps"},
+						Verbs:         []string{"get", "list", "watch"},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			err := ReconcileOauthServingCertRole(tc.inputRole)
+			g.Expect(err).To(Not(HaveOccurred()))
+			g.Expect(tc.inputRole).To(BeEquivalentTo(tc.expectedRole))
+		})
+	}
+}
+
+func TestReconcileOauthServingCertRoleBinding(t *testing.T) {
+	testsCases := []struct {
+		name                string
+		inputRoleBinding    *rbacv1.RoleBinding
+		expectedRoleBinding *rbacv1.RoleBinding
+	}{
+		{
+			name:             "when empty role binding specified the roleref and subjects are populated",
+			inputRoleBinding: manifests.OAuthServingCertRoleBinding(),
+			expectedRoleBinding: &rbacv1.RoleBinding{
+				ObjectMeta: manifests.OAuthServingCertRoleBinding().ObjectMeta,
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     manifests.OAuthServingCertRole().Name,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "Group",
+						Name:     "system:authenticated",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			err := ReconcileOauthServingCertRoleBinding(tc.inputRoleBinding)
+			g.Expect(err).To(Not(HaveOccurred()))
+			g.Expect(tc.inputRoleBinding).To(BeEquivalentTo(tc.expectedRoleBinding))
+		})
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -355,6 +355,21 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		errs = append(errs, fmt.Errorf("failed to reconcile oauth challenging client: %w", err))
 	}
 
+	log.Info("reconciling oauth serving cert rbac")
+	oauthServingCertRole := manifests.OAuthServingCertRole()
+	if _, err := r.CreateOrUpdate(ctx, r.client, oauthServingCertRole, func() error {
+		return oauth.ReconcileOauthServingCertRole(oauthServingCertRole)
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile oauth serving cert role: %w", err))
+	}
+
+	oauthServingCertRoleBinding := manifests.OAuthServingCertRoleBinding()
+	if _, err := r.CreateOrUpdate(ctx, r.client, oauthServingCertRoleBinding, func() error {
+		return oauth.ReconcileOauthServingCertRoleBinding(oauthServingCertRoleBinding)
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile oauth serving cert rolebinding: %w", err))
+	}
+
 	log.Info("reconciling cloud credential secrets")
 	errs = append(errs, r.reconcileCloudCredentialSecrets(ctx, hcp, log)...)
 


### PR DESCRIPTION
This adds rbac that allows authenticated users to fetch the oauth-serving-cert configmap. This is necessary for the oauth proxies in the openshift-monitoring namespace to work and allow users access to the prometheus/grafana/alertmanager dashboards.

Without it accessing prometheus dashboard directly fails with
![Screen Shot 2022-04-11 at 10 40 43 AM](https://user-images.githubusercontent.com/7716924/162815836-4a2efd0c-8d37-4a0e-8b8e-fe2db78f11d5.png)

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.