### PR TITLE
Expose a service account signing key in the API

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -44,6 +44,14 @@ type HostedControlPlaneSpec struct {
 	Platform  PlatformSpec `json:"platform"`
 	DNS       DNSSpec      `json:"dns"`
 
+	// ServiceAccountSigningKey is a reference to a secret containing the private key
+	// used by the service account token issuer. The secret is expected to contain
+	// a single key named "key". If not specified, a service account signing key will
+	// be generated automatically for the cluster.
+	//
+	// +optional
+	ServiceAccountSigningKey *corev1.LocalObjectReference `json:"serviceAccountSigningKey,omitempty"`
+
 	// APIPort is the port at which the APIServer listens inside a worker
 	// +optional
 	APIPort *int32 `json:"apiPort,omitempty"`

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -89,6 +89,10 @@ const (
 
 	// ExternalDNSHostnameAnnotation is the annotation external-dns uses to register DNS name for different HCP services.
 	ExternalDNSHostnameAnnotation = "external-dns.alpha.kubernetes.io/hostname"
+
+	// ServiceAccountSigningKeySecretKey is the name of the secret key that should contain the service account signing
+	// key if specified.
+	ServiceAccountSigningKeySecretKey = "key"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.
@@ -197,6 +201,17 @@ type HostedClusterSpec struct {
 	// +immutable
 	// +optional
 	IssuerURL string `json:"issuerURL,omitempty"`
+
+	// ServiceAccountSigningKey is a reference to a secret containing the private key
+	// used by the service account token issuer. The secret is expected to contain
+	// a single key named "key". If not specified, a service account signing key will
+	// be generated automatically for the cluster. When specifying a service account
+	// signing key, a IssuerURL must also be specified.
+	//
+	// +immutable
+	// +kubebuilder:validation:Optional
+	// +optional
+	ServiceAccountSigningKey *corev1.LocalObjectReference `json:"serviceAccountSigningKey,omitempty"`
 
 	// Configuration specifies configuration for individual OCP components in the
 	// cluster, represented as embedded resources that correspond to the openshift

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -746,6 +746,11 @@ func (in *HostedClusterSpec) DeepCopyInto(out *HostedClusterSpec) {
 	}
 	out.PullSecret = in.PullSecret
 	out.SSHKey = in.SSHKey
+	if in.ServiceAccountSigningKey != nil {
+		in, out := &in.ServiceAccountSigningKey, &out.ServiceAccountSigningKey
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	if in.Configuration != nil {
 		in, out := &in.Configuration, &out.Configuration
 		*out = new(ClusterConfiguration)
@@ -893,6 +898,11 @@ func (in *HostedControlPlaneSpec) DeepCopyInto(out *HostedControlPlaneSpec) {
 	out.SSHKey = in.SSHKey
 	in.Platform.DeepCopyInto(&out.Platform)
 	out.DNS = in.DNS
+	if in.ServiceAccountSigningKey != nil {
+		in, out := &in.ServiceAccountSigningKey, &out.ServiceAccountSigningKey
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	if in.APIPort != nil {
 		in, out := &in.APIPort, &out.APIPort
 		*out = new(int32)

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -893,6 +893,19 @@ spec:
                 required:
                 - type
                 type: object
+              serviceAccountSigningKey:
+                description: ServiceAccountSigningKey is a reference to a secret containing
+                  the private key used by the service account token issuer. The secret
+                  is expected to contain a single key named "key". If not specified,
+                  a service account signing key will be generated automatically for
+                  the cluster. When specifying a service account signing key, a IssuerURL
+                  must also be specified.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
               services:
                 description: "Services specifies how individual control plane services
                   are published from the hosting cluster of the control plane. \n

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -790,6 +790,18 @@ spec:
                 required:
                 - type
                 type: object
+              serviceAccountSigningKey:
+                description: ServiceAccountSigningKey is a reference to a secret containing
+                  the private key used by the service account token issuer. The secret
+                  is expected to contain a single key named "key". If not specified,
+                  a service account signing key will be generated automatically for
+                  the cluster.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
               serviceCIDR:
                 type: string
               services:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -306,6 +306,24 @@ validation.</p>
 </tr>
 <tr>
 <td>
+<code>serviceAccountSigningKey</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountSigningKey is a reference to a secret containing the private key
+used by the service account token issuer. The secret is expected to contain
+a single key named &ldquo;key&rdquo;. If not specified, a service account signing key will
+be generated automatically for the cluster. When specifying a service account
+signing key, a IssuerURL must also be specified.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>configuration</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1alpha1.ClusterConfiguration">
@@ -2544,6 +2562,24 @@ validation.</p>
 </tr>
 <tr>
 <td>
+<code>serviceAccountSigningKey</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountSigningKey is a reference to a secret containing the private key
+used by the service account token issuer. The secret is expected to contain
+a single key named &ldquo;key&rdquo;. If not specified, a service account signing key will
+be generated automatically for the cluster. When specifying a service account
+signing key, a IssuerURL must also be specified.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>configuration</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1alpha1.ClusterConfiguration">
@@ -2917,6 +2953,23 @@ DNSSpec
 </em>
 </td>
 <td>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountSigningKey</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountSigningKey is a reference to a secret containing the private key
+used by the service account token issuer. The secret is expected to contain
+a single key named &ldquo;key&rdquo;. If not specified, a service account signing key will
+be generated automatically for the cluster.</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -20556,6 +20556,19 @@ objects:
                   required:
                   - type
                   type: object
+                serviceAccountSigningKey:
+                  description: ServiceAccountSigningKey is a reference to a secret
+                    containing the private key used by the service account token issuer.
+                    The secret is expected to contain a single key named "key". If
+                    not specified, a service account signing key will be generated
+                    automatically for the cluster. When specifying a service account
+                    signing key, a IssuerURL must also be specified.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
                 services:
                   description: "Services specifies how individual control plane services
                     are published from the hosting cluster of the control plane. \n
@@ -21661,6 +21674,18 @@ objects:
                       type: string
                   required:
                   - type
+                  type: object
+                serviceAccountSigningKey:
+                  description: ServiceAccountSigningKey is a reference to a secret
+                    containing the private key used by the service account token issuer.
+                    The secret is expected to contain a single key named "key". If
+                    not specified, a service account signing key will be generated
+                    automatically for the cluster.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
                   type: object
                 serviceCIDR:
                   type: string

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -867,6 +867,13 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	// Reconcile the service account signing key if set
+	if hcluster.Spec.ServiceAccountSigningKey != nil {
+		if err := r.reconcileServiceAccountSigningKey(ctx, hcluster, controlPlaneNamespace.Name, createOrUpdate); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile service account signing key: %w", err)
+		}
+	}
+
 	// Reconcile etcd client MTLS secret if the control plane is using an unmanaged etcd cluster
 	if hcluster.Spec.Etcd.ManagementType == hyperv1.Unmanaged {
 		unmanagedEtcdTLSClientSecret := &corev1.Secret{
@@ -1187,6 +1194,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	}
 	hcp.Spec.FIPS = hcluster.Spec.FIPS
 	hcp.Spec.IssuerURL = hcluster.Spec.IssuerURL
+	hcp.Spec.ServiceAccountSigningKey = hcluster.Spec.ServiceAccountSigningKey
 	hcp.Spec.ServiceCIDR = hcluster.Spec.Networking.ServiceCIDR
 	hcp.Spec.PodCIDR = hcluster.Spec.Networking.PodCIDR
 	hcp.Spec.MachineCIDR = hcluster.Spec.Networking.MachineCIDR
@@ -3503,6 +3511,10 @@ func (r *HostedClusterReconciler) validateConfigAndClusterCapabilities(ctx conte
 		}
 	}
 
+	if err := r.validateServiceAccountSigningKey(ctx, hc); err != nil {
+		errs = append(errs, fmt.Errorf("invalid service account signing key: %w", err))
+	}
+
 	if err := r.validateAzureConfig(ctx, hc); err != nil {
 		errs = append(errs, err)
 	}
@@ -4014,6 +4026,13 @@ func (r *HostedClusterReconciler) reconcileAWSOIDCDocuments(ctx context.Context,
 		return nil
 	}
 
+	// Skip creating documents if a service account signer key was set. Although technically it is possible for us
+	// to use a specified service account signing key and still create discovery documents, the presence of the
+	// signing key is what will indicate that the documents are generated and stored elsewhere.
+	if hcluster.Spec.ServiceAccountSigningKey != nil && hcluster.Spec.ServiceAccountSigningKey.Name != "" {
+		return nil
+	}
+
 	// We use the presence of the finalizer to short-circuit the document upload to avoid
 	// constantly re-uploading it.
 	if controllerutil.ContainsFinalizer(hcluster, oidcDocumentsFinalizer) {
@@ -4263,7 +4282,7 @@ func validateClusterID(hc *hyperv1.HostedCluster) error {
 }
 
 // getPayloadImage get an image from the payload for a particular component.
-func (r HostedClusterReconciler) getPayloadImage(ctx context.Context, hc *hyperv1.HostedCluster, component string) (string, error) {
+func (r *HostedClusterReconciler) getPayloadImage(ctx context.Context, hc *hyperv1.HostedCluster, component string) (string, error) {
 	var pullSecret corev1.Secret
 	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hc.Spec.PullSecret.Name}, &pullSecret); err != nil {
 		return "", fmt.Errorf("failed to get pull secret: %w", err)
@@ -4281,4 +4300,78 @@ func (r HostedClusterReconciler) getPayloadImage(ctx context.Context, hc *hyperv
 		return "", fmt.Errorf("image does not exist for release: %q", image)
 	}
 	return image, nil
+}
+
+func (r *HostedClusterReconciler) reconcileServiceAccountSigningKey(ctx context.Context, hc *hyperv1.HostedCluster, targetNamespace string, createOrUpdate upsert.CreateOrUpdateFN) error {
+	privateBytes, publicBytes, err := r.serviceAccountSigningKeyBytes(ctx, hc)
+	if err != nil {
+		return err
+	}
+	cpSigningKeySecret := controlplaneoperator.ServiceAccountSigningKeySecret(targetNamespace)
+	_, err = createOrUpdate(ctx, r.Client, cpSigningKeySecret, func() error {
+		// Only set the signing key when the key does not already exist
+		if _, hasKey := cpSigningKeySecret.Data[controlplaneoperator.ServiceSignerPrivateKey]; hasKey {
+			return nil
+		}
+		if cpSigningKeySecret.Data == nil {
+			cpSigningKeySecret.Data = map[string][]byte{}
+		}
+		cpSigningKeySecret.Data[controlplaneoperator.ServiceSignerPrivateKey] = privateBytes
+		cpSigningKeySecret.Data[controlplaneoperator.ServiceSignerPublicKey] = publicBytes
+		return nil
+	})
+	return err
+}
+
+func (r *HostedClusterReconciler) validateServiceAccountSigningKey(ctx context.Context, hc *hyperv1.HostedCluster) error {
+	// Skip if service account signing key is not set
+	if hc.Spec.ServiceAccountSigningKey == nil || hc.Spec.ServiceAccountSigningKey.Name == "" {
+		return nil
+	}
+	if hc.Spec.IssuerURL == "" {
+		return fmt.Errorf("the IssuerURL must be set when specifying a service account signing key")
+	}
+
+	privateBytes, _, err := r.serviceAccountSigningKeyBytes(ctx, hc)
+	if err != nil {
+		return err
+	}
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name
+	cpSigningKeySecret := controlplaneoperator.ServiceAccountSigningKeySecret(controlPlaneNamespace)
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(cpSigningKeySecret), cpSigningKeySecret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("cannot get control plane signing key secret %s/%s: %w", cpSigningKeySecret.Namespace, cpSigningKeySecret.Name, err)
+		}
+		return nil
+	}
+	if cpSigningKeySecret.Data != nil {
+		existingKeyBytes, hasKey := cpSigningKeySecret.Data[controlplaneoperator.ServiceSignerPrivateKey]
+		if !hasKey {
+			return nil
+		}
+		if !bytes.Equal(existingKeyBytes, privateBytes) {
+			return fmt.Errorf("existing control plane service account signing key does not match private key")
+		}
+	}
+	return nil
+}
+
+func (r *HostedClusterReconciler) serviceAccountSigningKeyBytes(ctx context.Context, hc *hyperv1.HostedCluster) ([]byte, []byte, error) {
+	signingKeySecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: hc.Namespace, Name: hc.Spec.ServiceAccountSigningKey.Name}, signingKeySecret); err != nil {
+		return nil, nil, fmt.Errorf("failed to get hostedcluster ServiceAccountSigningKey secret %s: %w", hc.Spec.ServiceAccountSigningKey.Name, err)
+	}
+	privateKeyPEMBytes, hasKey := signingKeySecret.Data[hyperv1.ServiceAccountSigningKeySecretKey]
+	if !hasKey {
+		return nil, nil, fmt.Errorf("cannot find service account key %q in secret %s", hyperv1.ServiceAccountSigningKeySecretKey, signingKeySecret.Name)
+	}
+	privateKey, err := certs.PemToPrivateKey(privateKeyPEMBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot decode private key in secret %s: %w", signingKeySecret.Name, err)
+	}
+	publicKeyPEMBytes, err := certs.PublicKeyToPem(&privateKey.PublicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot serialize public key from private key %s: %w", signingKeySecret.Name, err)
+	}
+	return privateKeyPEMBytes, publicKeyPEMBytes, nil
 }

--- a/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
@@ -10,6 +10,11 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+const (
+	ServiceSignerPrivateKey = "service-account.key"
+	ServiceSignerPublicKey  = "service-account.pub"
+)
+
 func OperatorDeployment(controlPlaneOperatorNamespace string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -132,6 +137,15 @@ func PodMonitor(controlPlaneNamespace string) *prometheusoperatorv1.PodMonitor {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
 			Name:      "controlplane-operator",
+		},
+	}
+}
+
+func ServiceAccountSigningKeySecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sa-signing-key",
+			Namespace: ns,
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a service account signing key to the HostedCluster spec. If specified,
we skip reconciling discovery documents to an S3 bucket.

This allows consumers of our API to generate their own signing key and
place OIDC discovery documents wherever they like.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-374](https://issues.redhat.com//browse/HOSTEDCP-374)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.