### PR TITLE
exclude InfraID from immutability check

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -359,6 +359,7 @@ func validateHostedClusterCreate(hc *hyperv1.HostedCluster) admission.Response {
 func filterMutableHostedClusterSpecFields(spec *hyperv1.HostedClusterSpec) {
 	spec.Release.Image = ""
 	spec.ClusterID = ""
+	spec.InfraID = ""
 	spec.Configuration = nil
 	spec.AdditionalTrustBundle = nil
 	spec.SecretEncryption = nil


### PR DESCRIPTION
**What this PR does / why we need it**:

HostedCluster `spec.infraID` can be defaulted by the HO if not set at create time.

Also incorporated feedback from https://github.com/openshift/hypershift/pull/1262#issuecomment-1097136978

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.