### PR TITLE
e2e: fix early exit on destroy infra aws

### DIFF
--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -100,7 +100,7 @@ func (o *DestroyInfraOptions) DestroyInfra(ctx context.Context) error {
 	errs = append(errs, o.DestroyS3Buckets(ctx, s3Client)...)
 	errs = append(errs, o.DestroyVPCEndpointServices(ctx, ec2Client)...)
 	errs = append(errs, o.DestroyVPCs(ctx, ec2Client, elbClient, elbv2Client, route53Client)...)
-	if len(errs) > 0 {
+	if err := utilerrors.NewAggregate(errs); err != nil {
 		return utilerrors.NewAggregate(errs)
 	}
 	errs = append(errs, o.DestroyEIPs(ctx, ec2Client)...)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes issue introduced in https://github.com/openshift/hypershift/pull/1263 that is leaving DHCPOptions and EIPs uncleaned

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.