### PR TITLE
Use '--' for flags in kms token minter container

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/aws_kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/aws_kms.go
@@ -211,8 +211,8 @@ func buildKASContainerAWSKMSTokenMinter(image string) func(*corev1.Container) {
 			"--service-account-namespace=kube-system",
 			"--service-account-name=kms-provider",
 			"--token-audience=openshift",
-			fmt.Sprintf("-token-file=%s", path.Join(awsKMSVolumeMounts.Path(c.Name, kasVolumeAWSKMSCloudProviderToken().Name), "token")),
-			fmt.Sprintf("-kubeconfig=%s", path.Join(awsKMSVolumeMounts.Path(c.Name, kasVolumeLocalhostKubeconfig().Name), KubeconfigKey)),
+			fmt.Sprintf("--token-file=%s", path.Join(awsKMSVolumeMounts.Path(c.Name, kasVolumeAWSKMSCloudProviderToken().Name), "token")),
+			fmt.Sprintf("--kubeconfig=%s", path.Join(awsKMSVolumeMounts.Path(c.Name, kasVolumeLocalhostKubeconfig().Name), KubeconfigKey)),
 		}
 		c.VolumeMounts = awsKMSVolumeMounts.ContainerMounts(c.Name)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When we switched utilities to be subcommands of control-plane-operator
the flag format changed to require `--` instead of `-`. We missed
changing the token minter container that gets added when using AWS KMS
etcd encryption. This change fixes that.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-385](https://issues.redhat.com//browse/HOSTEDCP-385)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
