### PR TITLE
e2e: update HO budgets

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -432,15 +432,19 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 			// significantly under budget for all but the last test(s) to complete on
 			// a particular test cluster These budgets will also need to scale up with
 			// additional tests that create HostedClusters
+			//
+			// Current HCs per periodic job: 9
+			// Read per HC: 300
+			// Mutate per HC: 400
 			{
 				name:   "hypershift-operator read",
 				query:  `sum(hypershift:operator:component_api_requests_total{method="GET"})`,
-				budget: 1500,
+				budget: 2700,
 			},
 			{
 				name:   "hypershift-operator mutate",
 				query:  `sum(hypershift:operator:component_api_requests_total{method!="GET"})`,
-				budget: 3000,
+				budget: 3600,
 			},
 			{
 				name:   "hypershift-operator no 404 deletes",


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/openshift/hypershift/pull/1257 and https://github.com/openshift/hypershift/pull/1260, we need to update the e2e budgets for the shared hypershift-operator across tests.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.