### PR TITLE
Update KubeVirt platform to work with OVNKubernetes

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
@@ -20,6 +20,10 @@ func NetworkOperator() *operatorv1.Network {
 // 9879 is a currently unassigned IANA port in the user port range.
 const kubevirtDefaultVXLANPort = uint32(9879)
 
+// The default OVN geneve port is 6081. We need to avoid that for kubernetes which runs nested.
+// 9880 is a currently unassigned IANA port in the user port range.
+const kubevirtDefaultGenevePort = uint32(9880)
+
 func ReconcileNetworkOperator(network *operatorv1.Network, networkType hyperv1.NetworkType, platformType hyperv1.PlatformType) error {
 	switch platformType {
 	case hyperv1.KubevirtPlatform:
@@ -31,6 +35,14 @@ func ReconcileNetworkOperator(network *operatorv1.Network, networkType hyperv1.N
 			}
 			if network.Spec.DefaultNetwork.OpenShiftSDNConfig.VXLANPort == nil {
 				network.Spec.DefaultNetwork.OpenShiftSDNConfig.VXLANPort = &port
+			}
+		} else if networkType == hyperv1.OVNKubernetes {
+			port := kubevirtDefaultGenevePort
+			if network.Spec.DefaultNetwork.OVNKubernetesConfig == nil {
+				network.Spec.DefaultNetwork.OVNKubernetesConfig = &operatorv1.OVNKubernetesConfig{}
+			}
+			if network.Spec.DefaultNetwork.OVNKubernetesConfig.GenevePort == nil {
+				network.Spec.DefaultNetwork.OVNKubernetesConfig.GenevePort = &port
 			}
 		}
 

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -89,6 +89,7 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	clusterOpts.BaseDomain = defaultIngressOperator.Status.Domain
+	clusterOpts.NetworkType = string(hyperv1.OVNKubernetes)
 
 	t.Logf("Using base domain %s", clusterOpts.BaseDomain)
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.KubevirtPlatform, globalOpts.ArtifactDir)


### PR DESCRIPTION
The KubeVirt Hypershift platform is running worker nodes as VMs hosted in an infra OCP cluster. When both the infra and tenant OCP clusters use OVNKubernetes, we have an environment where an OVN network is "nested" inside an OVN network.

By default, the geneve port used for the nested tenant cluster's OVN network will collide with the same port used by the infra cluster's OVN network. This collision causes traffic issues within the tenant clusters.

To account for this, we use a different geneve port for KubeVirt platform hosted clusters. This is similar in concept to what we had to do for vxlan ports when OpenshiftSDN is in use.