### PR TITLE
Begin using KubeVirt as the infrastructure platform instead of None

### DIFF
--- a/support/globalconfig/infrastructure.go
+++ b/support/globalconfig/infrastructure.go
@@ -22,12 +22,6 @@ func InfrastructureConfig() *configv1.Infrastructure {
 func ReconcileInfrastructure(infra *configv1.Infrastructure, hcp *hyperv1.HostedControlPlane) {
 
 	platformType := hcp.Spec.Platform.Type
-	switch hcp.Spec.Platform.Type {
-	// In case of KubeVirtPlatform, set the Infrastructure to NonePlatform
-	// This is done in order to prevent error in machine-config-server
-	case hyperv1.KubevirtPlatform:
-		platformType = hyperv1.NonePlatform
-	}
 
 	apiServerAddress := hcp.Status.ControlPlaneEndpoint.Host
 	apiServerPort := hcp.Status.ControlPlaneEndpoint.Port


### PR DESCRIPTION
The machine-config-operator had some left over logic from the old KubeVirt IPI effort that broke the KubeVirt Hypershift platform. This caused us to have to temporarily report the `None` platform on the infrastructure object. Otherwise we'd get a bunch of coredns and other networking related changes layered in that are no longer relevant for kubevirt+hypershift.

I updated the mco [here](https://github.com/openshift/machine-config-operator/pull/3084) to strip out the old KubeVirt IPI logic but leave the KubeVirt platform intact. Now we can remove the weird workaround where we used `none`. This is important because it's needed for us to begin integrating logic into the cso for the kubevirt-csi driver install. 