### PR TITLE
Configure the CNO to proxy the apiserver for public clusters

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
@@ -1,0 +1,52 @@
+package cno
+
+import (
+	"strconv"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestReconcileDeployment(t *testing.T) {
+	tcs := []struct {
+		name                        string
+		params                      Params
+		expectProxyAPIServerAddress bool
+	}{
+		{
+			name:                        "No private apiserver connectivity, proxy apiserver address is set",
+			params:                      Params{ConnectsThroughInternetToControlplane: true},
+			expectProxyAPIServerAddress: true,
+		},
+		{
+			name: "Private apiserver connectivity, proxy apiserver address is unset",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.params.ReleaseVersion == "" {
+				tc.params.ReleaseVersion = "4.11.0"
+			}
+
+			dep := &appsv1.Deployment{}
+			if err := ReconcileDeployment(dep, tc.params, nil); err != nil {
+				t.Fatalf("ReconcileDeployment: %v", err)
+			}
+
+			var hasProxyAPIServerAddress bool
+			for _, envVar := range dep.Spec.Template.Spec.Containers[0].Env {
+				if envVar.Name == "PROXY_INTERNAL_APISERVER_ADDRESS" {
+					hasProxyAPIServerAddress = envVar.Value == "true"
+					break
+				}
+			}
+
+			if hasProxyAPIServerAddress != tc.expectProxyAPIServerAddress {
+				t.Errorf("expected 'PROXY_INTERNAL_APISERVER_ADDRESS' env var to be %s, was %s",
+					strconv.FormatBool(tc.expectProxyAPIServerAddress),
+					strconv.FormatBool(hasProxyAPIServerAddress))
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2236,7 +2236,7 @@ func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.C
 	}
 
 	var apiserverProxy string
-	if globalConfig.Proxy != nil && globalConfig.Proxy.Spec.HTTPSProxy != "" && (hcp.Spec.Platform.AWS == nil || hcp.Spec.Platform.AWS.EndpointAccess == hyperv1.Public) {
+	if globalConfig.Proxy != nil && globalConfig.Proxy.Spec.HTTPSProxy != "" && util.ConnectsThroughInternetToControlplane(hcp.Spec.Platform) {
 		apiserverProxy = globalConfig.Proxy.Spec.HTTPSProxy
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1643,9 +1643,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 			// and ignore updates.
 			if ignitionServerRoute.CreationTimestamp.IsZero() {
 				switch {
-				case hcluster.Spec.Platform.Type == hyperv1.AWSPlatform &&
-					(hcluster.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate ||
-						hcluster.Spec.Platform.AWS.EndpointAccess == hyperv1.Private):
+				case !util.ConnectsThroughInternetToControlplane(hcluster.Spec.Platform):
 					ignitionServerRoute.Spec.Host = fmt.Sprintf("%s.apps.%s.hypershift.local", ignitionServerRoute.Name, hcluster.Name)
 				case serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "":
 					ignitionServerRoute.Spec.Host = serviceStrategy.Route.Hostname

--- a/support/util/public.go
+++ b/support/util/public.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+// HasPrivateAPIServerConnectivity determines if workloads running inside the guest cluster can access
+// the apiserver without using the Internet.
+func ConnectsThroughInternetToControlplane(platform hyperv1.PlatformSpec) bool {
+	return platform.AWS == nil || platform.AWS.EndpointAccess == hyperv1.Public
+}

--- a/support/util/public_test.go
+++ b/support/util/public_test.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+func TestConnectsThroughInternetToControlplane(t *testing.T) {
+	testCases := []struct {
+		name     string
+		platform hyperv1.PlatformSpec
+		expected bool
+	}{
+		{
+			name:     "Not aws always uses internet",
+			expected: true,
+		},
+		{
+			name: "AWS public uses internet",
+			platform: hyperv1.PlatformSpec{
+				AWS: &hyperv1.AWSPlatformSpec{EndpointAccess: hyperv1.Public},
+			},
+			expected: true,
+		},
+		{
+			name: "AWS public/private doesn't use internet",
+			platform: hyperv1.PlatformSpec{
+				AWS: &hyperv1.AWSPlatformSpec{EndpointAccess: hyperv1.PublicAndPrivate},
+			},
+		},
+		{
+			name: "AWS private doesn't use internet",
+			platform: hyperv1.PlatformSpec{
+				AWS: &hyperv1.AWSPlatformSpec{EndpointAccess: hyperv1.Private},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ConnectsThroughInternetToControlplane(tc.platform)
+			if actual != tc.expected {
+				t.Errorf("expected %t, got %t", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The CNO currently never proxies the apisever address. In case of public
Hypershift clusters it needs to do that though, so configure it
accordingly.

Basically integrates https://github.com/openshift/cluster-network-operator/pull/1381

Ref https://issues.redhat.com/browse/HOSTEDCP-333

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.