### PR TITLE
Revert default network type back to SDN in CLI

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/cluster/agent"
 	"github.com/openshift/hypershift/cmd/cluster/aws"
 	"github.com/openshift/hypershift/cmd/cluster/azure"
@@ -29,6 +30,7 @@ func NewCreateCommands() *cobra.Command {
 		Timeout:                        0,
 		ExternalDNSDomain:              "",
 		AdditionalTrustBundle:          "",
+		NetworkType:                    string(hyperv1.OpenShiftSDN),
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",


### PR DESCRIPTION
HostNetwork -> ServiceIP traffic doesn't work with ovn-k yet, which
makes us unable to even run the conformance tests as the
clusteroperators never get ready. Revert the default back for the time
being so we have at least some signal.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.