### PR TITLE
Drop outdated TODO for machine configs

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -114,12 +114,6 @@ type NodePoolSpec struct {
 	//
 	// Each ConfigMap must have a single key named "config" whose value is the
 	// JSON or YAML of a serialized MachineConfig.
-	//
-	// TODO (alberto): this ConfigMaps are meant to contain MachineConfig,
-	// KubeletConfig and ContainerRuntimeConfig but MCO only supports
-	// MachineConfig in bootstrap mode atm. See:
-	// https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119
-	//
 	// +kubebuilder:validation:Optional
 	Config []corev1.LocalObjectReference `json:"config,omitempty"`
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -107,10 +107,7 @@ spec:
                   configurations of nodes in the NodePool. The MachineConfig API schema
                   is defined here: \n https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172
                   \n Each ConfigMap must have a single key named \"config\" whose
-                  value is the JSON or YAML of a serialized MachineConfig. \n TODO
-                  (alberto): this ConfigMaps are meant to contain MachineConfig, KubeletConfig
-                  and ContainerRuntimeConfig but MCO only supports MachineConfig in
-                  bootstrap mode atm. See: https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119"
+                  value is the JSON or YAML of a serialized MachineConfig."
                 items:
                   description: LocalObjectReference contains enough information to
                     let you locate the referenced object inside the same namespace.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -629,10 +629,6 @@ nodes in the NodePool. The MachineConfig API schema is defined here:</p>
 <p><a href="https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172">https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172</a></p>
 <p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the
 JSON or YAML of a serialized MachineConfig.</p>
-<p>TODO (alberto): this ConfigMaps are meant to contain MachineConfig,
-KubeletConfig and ContainerRuntimeConfig but MCO only supports
-MachineConfig in bootstrap mode atm. See:
-<a href="https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119">https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119</a></p>
 </td>
 </tr>
 <tr>
@@ -4450,10 +4446,6 @@ nodes in the NodePool. The MachineConfig API schema is defined here:</p>
 <p><a href="https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172">https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172</a></p>
 <p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the
 JSON or YAML of a serialized MachineConfig.</p>
-<p>TODO (alberto): this ConfigMaps are meant to contain MachineConfig,
-KubeletConfig and ContainerRuntimeConfig but MCO only supports
-MachineConfig in bootstrap mode atm. See:
-<a href="https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119">https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119</a></p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -22584,10 +22584,7 @@ objects:
                     configurations of nodes in the NodePool. The MachineConfig API
                     schema is defined here: \n https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172
                     \n Each ConfigMap must have a single key named \"config\" whose
-                    value is the JSON or YAML of a serialized MachineConfig. \n TODO
-                    (alberto): this ConfigMaps are meant to contain MachineConfig,
-                    KubeletConfig and ContainerRuntimeConfig but MCO only supports
-                    MachineConfig in bootstrap mode atm. See: https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/controller/bootstrap/bootstrap.go#L104-L119"
+                    value is the JSON or YAML of a serialized MachineConfig."
                   items:
                     description: LocalObjectReference contains enough information
                       to let you locate the referenced object inside the same namespace.


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop TODO for supporting container runtime and kubelet config in NodePool MachineConfigs since This is supported now https://github.com/openshift/machine-config-operator/blob/1af0a6f96fc7c0f44230293ac026a96acb0da512/pkg/controller/bootstrap/bootstrap.go\#L117-L119.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.