### PR TITLE
feat(cpo): Disable PodSecurity for 4.10

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -131,7 +131,8 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 	}
 	args.Set("egress-selector-config-file", cpath(kasVolumeEgressSelectorConfig().Name, EgressSelectorConfigMapKey))
 	args.Set("enable-admission-plugins", admissionPlugins()...)
-	if version.Minor == 11 {
+	if version.Minor == 10 || version.Minor == 11 {
+		// This is explicitly disabled in OCP 4.10
 		// This is enabled by default in 4.11 but currently disabled by OCP. It is planned to get re-enabled but currently
 		// breaks conformance testing, ref: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1262
 		args.Set("disable-admission-plugins", "PodSecurity")


### PR DESCRIPTION
**What this PR does / why we need it**:
Explicitly disable PodSecurity for 4.10 to be inline with OCP KAS config.
https://github.com/openshift/cluster-kube-apiserver-operator/blob/release-4.10/bindata/assets/config/defaultconfig.yaml#L46

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
N/A

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.