### PR TITLE
Add test for NodePools in place upgrades

### DIFF
--- a/hypershift-operator/controllers/nodepool/inplace_test.go
+++ b/hypershift-operator/controllers/nodepool/inplace_test.go
@@ -236,10 +236,11 @@ func TestInPlaceUpgradeComplete(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node1",
 						Annotations: map[string]string{
-							CurrentMachineConfigAnnotationKey: desiredConfigHash,
-							DesiredMachineConfigAnnotationKey: desiredConfigHash,
-							DesiredDrainerAnnotationKey:       uncordonRequest,
-							LastAppliedDrainerAnnotationKey:   uncordonRequest,
+							CurrentMachineConfigAnnotationKey:     desiredConfigHash,
+							DesiredMachineConfigAnnotationKey:     desiredConfigHash,
+							DesiredDrainerAnnotationKey:           uncordonRequest,
+							LastAppliedDrainerAnnotationKey:       uncordonRequest,
+							MachineConfigDaemonStateAnnotationKey: MachineConfigDaemonStateDone,
 						},
 					},
 				},
@@ -247,10 +248,11 @@ func TestInPlaceUpgradeComplete(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Annotations: map[string]string{
-							CurrentMachineConfigAnnotationKey: desiredConfigHash,
-							DesiredMachineConfigAnnotationKey: desiredConfigHash,
-							DesiredDrainerAnnotationKey:       uncordonRequest,
-							LastAppliedDrainerAnnotationKey:   uncordonRequest,
+							CurrentMachineConfigAnnotationKey:     desiredConfigHash,
+							DesiredMachineConfigAnnotationKey:     desiredConfigHash,
+							DesiredDrainerAnnotationKey:           uncordonRequest,
+							LastAppliedDrainerAnnotationKey:       uncordonRequest,
+							MachineConfigDaemonStateAnnotationKey: MachineConfigDaemonStateDone,
 						},
 					},
 				},

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -607,7 +607,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			log.Info("Reconciled MachineSet", "result", result)
 		}
 
-		if err := r.reconcileInPlaceUpgrade(ctx, hcluster, nodePool, ms, targetConfigHash, targetVersion, targetConfigVersionHash, ignEndpoint, caCertBytes, tokenBytes); err != nil {
+		if err := r.reconcileInPlaceUpgrade(ctx, hcluster, nodePool, ms, targetConfigHash, targetVersion, targetConfigVersionHash, tokenSecret); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -8,6 +8,10 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
@@ -17,14 +21,14 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestUpgradeNodePool(t *testing.T) {
+func TestReplaceUpgradeNodePool(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	t.Logf("Starting nodepool upgrade test from %s to %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
+	t.Logf("Starting NodePool replace upgrade test from %s to %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
 
 	client, err := e2eutil.GetClient()
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
@@ -44,6 +48,116 @@ func TestUpgradeNodePool(t *testing.T) {
 					MaxSurge:       func(v intstr.IntOrString) *intstr.IntOrString { return &v }(intstr.FromInt(3)),
 				},
 			}
+		}
+	}
+
+	// Look up metadata about the release images so that we can extract the version
+	// information for later assertions.
+	releaseInfoProvider := &releaseinfo.RegistryClientProvider{}
+	pullSecretFile, err := os.Open(clusterOpts.PullSecretFile)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to open pull secret file")
+	defer pullSecretFile.Close()
+	pullSecret, err := ioutil.ReadAll(pullSecretFile)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to read pull secret file")
+	previousReleaseInfo, err := releaseInfoProvider.Lookup(ctx, globalOpts.PreviousReleaseImage, pullSecret)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get release info for previous image")
+	latestReleaseInfo, err := releaseInfoProvider.Lookup(ctx, globalOpts.LatestReleaseImage, pullSecret)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get release info for latest image")
+
+	// Create the test cluster.
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
+
+	// Wait for connectivity to the cluster.
+	t.Logf("Waiting for guest client to become available")
+	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
+
+	// Wait for Nodes to be Ready.
+	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+
+	// Wait for the first rollout to be complete and refresh the HostedCluster.
+	t.Logf("Waiting for initial cluster rollout. Image: %s", hostedCluster.Spec.Release.Image)
+	e2eutil.WaitForImageRollout(t, ctx, client, hostedCluster, hostedCluster.Spec.Release.Image)
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+
+	// Find NodePools.
+	var nodePools hyperv1.NodePoolList
+	err = client.List(ctx, &nodePools, &crclient.ListOptions{Namespace: hostedCluster.Namespace})
+	g.Expect(err).NotTo(HaveOccurred(), "failed to list NodePools")
+
+	// Wait for NodePools to roll out the initial version.
+	// TODO: Consider doing this in parallel
+	for _, nodePool := range nodePools.Items {
+		e2eutil.WaitForNodePoolVersion(t, ctx, client, &nodePool, previousReleaseInfo.Version())
+	}
+
+	// Update NodePool images to the latest.
+	for _, nodePool := range nodePools.Items {
+		err = client.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get NodePool")
+		t.Logf("Updating NodePool image. Image: %s", globalOpts.LatestReleaseImage)
+		nodePool.Spec.Release.Image = globalOpts.LatestReleaseImage
+		err = client.Update(ctx, &nodePool)
+		g.Expect(err).NotTo(HaveOccurred(), "failed update NodePool image")
+	}
+
+	// Check the upgrade is signalled in a condition.
+	for _, nodePool := range nodePools.Items {
+		err := wait.PollUntil(5*time.Second, func() (done bool, err error) {
+			err = client.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get NodePool")
+
+			for _, condition := range nodePool.Status.Conditions {
+				if condition.Type == hyperv1.NodePoolUpdatingVersionConditionType && condition.Status == corev1.ConditionTrue {
+					return true, nil
+				}
+			}
+			return false, nil
+		}, ctx.Done())
+		g.Expect(err).NotTo(HaveOccurred(), "failed to find UpdatingVersionCondition condition")
+		t.Log("NodePool have UpdatingVersionCondition condition")
+	}
+
+	// Wait for at least 1 Node to be unready, so we know the process is started.
+	e2eutil.WaitForNUnReadyNodes(t, ctx, guestClient, 1)
+	t.Log("Upgrade has stated as at least 1 Node to is unready")
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+
+	// Wait for NodePools to roll out the latest version
+	// TODO: Consider doing this in parallel
+	for _, nodePool := range nodePools.Items {
+		e2eutil.WaitForNodePoolVersion(t, ctx, client, &nodePool, latestReleaseInfo.Version())
+		e2eutil.WaitForNodePoolConditionsNotToBePresent(t, ctx, client, &nodePool, hyperv1.NodePoolUpdatingVersionConditionType)
+	}
+
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
+	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, client, hostedCluster)
+	e2eutil.EnsureNoPodsWithTooHighPriority(t, ctx, client, hostedCluster)
+}
+
+func TestInPlaceUpgradeNodePool(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	t.Logf("Starting NodePool in place upgrade test from %s to %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
+
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
+
+	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts.ReleaseImage = globalOpts.LatestReleaseImage
+	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
+
+	clusterOpts.BeforeApply = func(o crclient.Object) {
+		switch v := o.(type) {
+		case *hyperv1.NodePool:
+			v.Spec.Release.Image = globalOpts.PreviousReleaseImage
+			v.Spec.Management.UpgradeType = hyperv1.UpgradeTypeInPlace
 		}
 	}
 
@@ -80,7 +194,7 @@ func TestUpgradeNodePool(t *testing.T) {
 	// Find nodepools
 	var nodePools hyperv1.NodePoolList
 	err = client.List(ctx, &nodePools, &crclient.ListOptions{Namespace: hostedCluster.Namespace})
-	g.Expect(err).NotTo(HaveOccurred(), "failed to list nodepools")
+	g.Expect(err).NotTo(HaveOccurred(), "failed to list NodePools")
 
 	// Wait for nodepools to roll out the initial version
 	// TODO: Consider doing this in parallel
@@ -88,20 +202,39 @@ func TestUpgradeNodePool(t *testing.T) {
 		e2eutil.WaitForNodePoolVersion(t, ctx, client, &nodePool, previousReleaseInfo.Version())
 	}
 
-	// Update nodepool images to the latest
+	// Update NodePool images to the latest
 	for _, nodePool := range nodePools.Items {
 		err = client.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
-		g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
-		t.Logf("Updating nodepool image. Image: %s", globalOpts.LatestReleaseImage)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get NodePool")
+		t.Logf("Updating NodePool image. Image: %s", globalOpts.LatestReleaseImage)
 		nodePool.Spec.Release.Image = globalOpts.LatestReleaseImage
 		err = client.Update(ctx, &nodePool)
 		g.Expect(err).NotTo(HaveOccurred(), "failed update nodePool image")
 	}
 
-	// Wait for Nodes to be Ready
+	// Check the upgrade is signalled in a condition.
+	for _, nodePool := range nodePools.Items {
+		err := wait.PollUntil(5*time.Second, func() (done bool, err error) {
+			err = client.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get NodePool")
+
+			for _, condition := range nodePool.Status.Conditions {
+				if condition.Type == hyperv1.NodePoolUpdatingVersionConditionType && condition.Status == corev1.ConditionTrue {
+					return true, nil
+				}
+			}
+			return false, nil
+		}, ctx.Done())
+		g.Expect(err).NotTo(HaveOccurred(), "failed to find UpdatingVersionCondition condition")
+		t.Log("NodePool have UpdatingVersionCondition condition")
+	}
+
+	// Wait for at least 1 Node to be unready, so we know the process is started.
+	e2eutil.WaitForNUnReadyNodes(t, ctx, guestClient, 1)
+	t.Log("Upgrade has started as at least 1 Node to is unready")
 	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
 
-	// Wait for nodepools to roll out the latest version
+	// Wait for NodePools to roll out the latest version.
 	// TODO: Consider doing this in parallel
 	for _, nodePool := range nodePools.Items {
 		e2eutil.WaitForNodePoolVersion(t, ctx, client, &nodePool, latestReleaseInfo.Version())

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -167,6 +167,41 @@ func WaitForNReadyNodes(t *testing.T, ctx context.Context, client crclient.Clien
 	return nodes.Items
 }
 
+func WaitForNUnReadyNodes(t *testing.T, ctx context.Context, client crclient.Client, n int32) []corev1.Node {
+	g := NewWithT(t)
+
+	t.Logf("Waiting for Nodes to become unready. Want: %v", n)
+	nodes := &corev1.NodeList{}
+	readyNodeCount := 0
+	err := wait.PollUntil(5*time.Second, func() (done bool, err error) {
+		// TODO (alberto): have ability to filter nodes by NodePool. NodePool.Status.Nodes?
+		err = client.List(ctx, nodes)
+		if err != nil {
+			return false, nil
+		}
+		if len(nodes.Items) == 0 {
+			return false, nil
+		}
+		var readyNodes []string
+		for _, node := range nodes.Items {
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == corev1.NodeReady && cond.Status != corev1.ConditionTrue {
+					readyNodes = append(readyNodes, node.Name)
+				}
+			}
+		}
+		if len(readyNodes) != int(n) {
+			readyNodeCount = len(readyNodes)
+			return false, nil
+		}
+		return true, nil
+	}, ctx.Done())
+	g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to ensure guest nodes became ready, ready: (%d/%d): ", readyNodeCount, n))
+
+	t.Logf("Wanted Nodes are unready. Count: %v", n)
+	return nodes.Items
+}
+
 func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, image string) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables e2e test for in place upgrades https://github.com/openshift/hypershift/pull/1258 so any follow up will be test driven.
As part of getting the test green this PR moves from querying the ign server to store the payload in the secret token so it can be consumed by the in place upgrade process. Otherwiswe the ign server is not reachable form the NodePool controller in private topologies.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

ref https://issues.redhat.com/browse/HOSTEDCP-402

Follow ups:
https://issues.redhat.com/browse/HOSTEDCP-417
https://issues.redhat.com/browse/HOSTEDCP-403
https://issues.redhat.com/browse/HOSTEDCP-405
https://issues.redhat.com/browse/HOSTEDCP-404

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.