### PR TITLE
Reduce no-op API server calls from hypershift-operator

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -248,7 +248,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	}
 
 	if mgmtClusterCaps.Has(capabilities.CapabilityConfigOpenshiftIO) {
-		if err := proxy.Setup(mgr, opts.Namespace, opts.DeploymentName); err != nil {
+		if err := proxy.Setup(mgr, createOrUpdate, opts.Namespace, opts.DeploymentName); err != nil {
 			return fmt.Errorf("failed to set up the proxy controller: %w", err)
 		}
 	}


### PR DESCRIPTION
Before this commit, controllers in the hypershift-operator used a mixture of
`CreateOrUpdateProvider` and direct `client.Update()` calls; the latter case
results in many no-op API server calls.

This commit replaces all direct calls to `client.Update()` with
`CreateOrUpdateProvider` calls to ensure no-op updates don't cause API server
spamming.

Status updates may still result in no-op API server calls and should be
addressed in a followup.
