### PR TITLE
Add ValidReleaseImage condition to HostedCluster

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1239,6 +1239,12 @@ const (
 	// OIDCConfigurationInvalid indicates if an AWS cluster's OIDC condition is
 	// detected as invalid.
 	OIDCConfigurationInvalid ConditionType = "OIDCConfigurationInvalid"
+
+	// ValidReleaseImage indicates if the release image set in the spec is valid
+	// for the HostedCluster. For example, this can be set false if the
+	// HostedCluster itself attempts an unsupported version before 4.9 or an
+	// unsupported upgrade e.g y-stream upgrade before 4.11.
+	ValidReleaseImage ConditionType = "ValidReleaseImage"
 )
 
 const (
@@ -1275,6 +1281,8 @@ const (
 	InsufficientClusterCapabilitiesReason = "InsufficientClusterCapabilities"
 
 	OIDCConfigurationInvalidReason = "OIDCConfigurationInvalid"
+
+	InvalidImageReason = "InvalidImage"
 )
 
 // HostedClusterStatus is the latest observed status of a HostedCluster.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2131,6 +2131,12 @@ ClusterConfiguration specified for the HostedCluster is valid.</p>
 </td>
 </tr><tr><td><p>&#34;ValidHostedControlPlaneConfiguration&#34;</p></td>
 <td></td>
+</tr><tr><td><p>&#34;ValidReleaseImage&#34;</p></td>
+<td><p>ValidReleaseImage indicates if the release image set in the spec is valid
+for the HostedCluster. For example, this can be set false if the
+HostedCluster itself attempts an unsupported version before 4.9 or an
+unsupported upgrade e.g y-stream upgrade before 4.11.</p>
+</td>
 </tr></tbody>
 </table>
 ###DNSSpec { #hypershift.openshift.io/v1alpha1.DNSSpec }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -584,6 +584,31 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	meta.SetStatusCondition(&hcluster.Status.Conditions, util.GenerateReconciliationPausedCondition(hcluster.Spec.PausedUntil, hcluster.Generation))
 
+	// Set ValidReleaseImage condition
+	{
+		condition := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.ValidReleaseImage))
+
+		// This check can be expensive looking up release image versions
+		// (hopefully they are cached).  Skip if we have already observed for
+		// this generation.
+		if condition == nil || condition.ObservedGeneration != hcluster.Generation {
+			condition := metav1.Condition{
+				Type:               string(hyperv1.ValidReleaseImage),
+				ObservedGeneration: hcluster.Generation,
+			}
+			if err := r.validateReleaseImage(ctx, hcluster); err != nil {
+				condition.Status = metav1.ConditionFalse
+				condition.Message = err.Error()
+				condition.Reason = hyperv1.InvalidImageReason
+			} else {
+				condition.Status = metav1.ConditionTrue
+				condition.Message = "Release image is valid"
+				condition.Reason = hyperv1.AsExpectedReason
+			}
+			meta.SetStatusCondition(&hcluster.Status.Conditions, condition)
+		}
+	}
+
 	// Persist status updates
 	if err := r.Client.Status().Update(ctx, hcluster); err != nil {
 		if apierrors.IsConflict(err) {
@@ -633,12 +658,17 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	{
 		validConfig := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.ValidHostedClusterConfiguration))
 		if validConfig != nil && validConfig.Status == metav1.ConditionFalse {
-			log.Info("Configuration is invalid, reconciliation is blocked", "message", validConfig.Message)
+			log.Error(fmt.Errorf("configuration is invalid"), "reconciliation is blocked", "message", validConfig.Message)
 			return ctrl.Result{}, nil
 		}
 		supportedHostedCluster := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.SupportedHostedCluster))
 		if supportedHostedCluster != nil && supportedHostedCluster.Status == metav1.ConditionFalse {
-			log.Info("Hosted Cluster is not supported by operator configuration, reconciliation is blocked", "message", supportedHostedCluster.Message)
+			log.Error(fmt.Errorf("not supported by operator configuration"), "reconciliation is blocked", "message", supportedHostedCluster.Message)
+			return ctrl.Result{}, nil
+		}
+		validReleaseImage := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.ValidReleaseImage))
+		if validReleaseImage != nil && validReleaseImage.Status == metav1.ConditionFalse {
+			log.Error(fmt.Errorf("release image is invalid"), "reconciliation is blocked", "message", validReleaseImage.Message)
 			return ctrl.Result{}, nil
 		}
 	}
@@ -3235,6 +3265,54 @@ func (r *HostedClusterReconciler) validateConfigAndClusterCapabilities(ctx conte
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+func (r *HostedClusterReconciler) validateReleaseImage(ctx context.Context, hc *hyperv1.HostedCluster) error {
+	var pullSecret corev1.Secret
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hc.Spec.PullSecret.Name}, &pullSecret); err != nil {
+		return fmt.Errorf("failed to get pull secret: %w", err)
+	}
+	pullSecretBytes, ok := pullSecret.Data[corev1.DockerConfigJsonKey]
+	if !ok {
+		return fmt.Errorf("expected %s key in pull secret", corev1.DockerConfigJsonKey)
+	}
+
+	releaseInfo, err := r.ReleaseProvider.Lookup(ctx, hc.Spec.Release.Image, pullSecretBytes)
+	if err != nil {
+		return fmt.Errorf("failed to lookup release image: %w", err)
+	}
+	version, err := semver.Parse(releaseInfo.Version())
+	if err != nil {
+		return err
+	}
+
+	var currentVersion *semver.Version
+	if hc.Status.Version != nil && hc.Status.Version.Desired.Image != hc.Spec.Release.Image {
+		releaseInfo, err := r.ReleaseProvider.Lookup(ctx, hc.Status.Version.Desired.Image, pullSecretBytes)
+		if err != nil {
+			return fmt.Errorf("failed to lookup release image: %w", err)
+		}
+		version, err := semver.Parse(releaseInfo.Version())
+		if err != nil {
+			return err
+		}
+		currentVersion = &version
+	}
+
+	return isValidReleaseVersion(version, currentVersion, hc.Spec.Networking.NetworkType)
+}
+
+func isValidReleaseVersion(version semver.Version, currentVersion *semver.Version, networkType hyperv1.NetworkType) error {
+	if version.LT(semver.MustParse("4.8.0")) {
+		return fmt.Errorf("releases before 4.8 are not supported")
+	}
+	if currentVersion != nil && currentVersion.Minor > version.Minor {
+		return fmt.Errorf("y-stream downgrade is not supported")
+	}
+	if networkType == hyperv1.OpenShiftSDN && currentVersion != nil && currentVersion.Minor < version.Minor {
+		return fmt.Errorf("y-stream upgrade is not for OpenShiftSDN")
+	}
+	return nil
 }
 
 func (r *HostedClusterReconciler) validateAzureConfig(ctx context.Context, hc *hyperv1.HostedCluster) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

We need validation for changes to `spec.release.image` on the `HostedCluster`.  This is an attempt to implement basic checks and block reconciliation when a user sets the release image to something unsupported.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
https://issues.redhat.com/browse/HOSTEDCP-389

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.