### PR TITLE
Transition KubeVirt platform to using persistent storage for root volume

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -14,9 +14,6 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 
 	configv1 "github.com/openshift/api/config/v1"
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
-	kubevirtv1 "kubevirt.io/api/core/v1"
-	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -96,6 +93,8 @@ type ExampleKubevirtOptions struct {
 	Memory                    string
 	Cores                     uint32
 	Image                     string
+	RootVolumeSize            uint32
+	RootVolumeStorageClass    string
 }
 
 type ExampleAWSOptionsZones struct {
@@ -567,61 +566,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 		}
 	case hyperv1.KubevirtPlatform:
 		nodePool := defaultNodePool(cluster.Name)
-		runAlways := kubevirtv1.RunStrategyAlways
-		guestQuantity := apiresource.MustParse(o.Kubevirt.Memory)
-		nodePool.Spec.Platform.Kubevirt = &hyperv1.KubevirtNodePoolPlatform{
-			NodeTemplate: &capikubevirt.VirtualMachineTemplateSpec{
-				Spec: kubevirtv1.VirtualMachineSpec{
-					RunStrategy: &runAlways,
-					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-						Spec: kubevirtv1.VirtualMachineInstanceSpec{
-							Domain: kubevirtv1.DomainSpec{
-								CPU:    &kubevirtv1.CPU{Cores: o.Kubevirt.Cores},
-								Memory: &kubevirtv1.Memory{Guest: &guestQuantity},
-								Devices: kubevirtv1.Devices{
-									Disks: []kubevirtv1.Disk{
-										{
-											Name: "containervolume",
-											DiskDevice: kubevirtv1.DiskDevice{
-												Disk: &kubevirtv1.DiskTarget{
-													Bus: "virtio",
-												},
-											},
-										},
-									},
-									Interfaces: []kubevirtv1.Interface{
-										{
-											Name: "default",
-											InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
-												Bridge: &kubevirtv1.InterfaceBridge{},
-											},
-										},
-									},
-								},
-							},
-							Volumes: []kubevirtv1.Volume{
-								{
-									Name: "containervolume",
-									VolumeSource: kubevirtv1.VolumeSource{
-										ContainerDisk: &kubevirtv1.ContainerDiskSource{
-											Image: o.Kubevirt.Image,
-										},
-									},
-								},
-							},
-							Networks: []kubevirtv1.Network{
-								{
-									Name: "default",
-									NetworkSource: kubevirtv1.NetworkSource{
-										Pod: &kubevirtv1.PodNetwork{},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
+		nodePool.Spec.Platform.Kubevirt = ExampleKubeVirtTemplate(o.Kubevirt)
 		nodePools = append(nodePools, nodePool)
 	case hyperv1.NonePlatform, hyperv1.AgentPlatform:
 		nodePools = append(nodePools, defaultNodePool(cluster.Name))

--- a/api/fixtures/example_kubevirt.go
+++ b/api/fixtures/example_kubevirt.go
@@ -1,0 +1,105 @@
+package fixtures
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+)
+
+func ExampleKubeVirtTemplate(o *ExampleKubevirtOptions) *hyperv1.KubevirtNodePoolPlatform {
+	runAlways := kubevirtv1.RunStrategyAlways
+	guestQuantity := apiresource.MustParse(o.Memory)
+
+	rootVolumeName := "rhcos"
+	volumeSize := apiresource.MustParse(fmt.Sprintf("%vGi", o.RootVolumeSize))
+	imageContainerURL := fmt.Sprintf("docker://%s", o.Image)
+
+	exampleTemplate := &hyperv1.KubevirtNodePoolPlatform{
+		NodeTemplate: &capikubevirt.VirtualMachineTemplateSpec{
+			Spec: kubevirtv1.VirtualMachineSpec{
+				RunStrategy: &runAlways,
+				Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							CPU:    &kubevirtv1.CPU{Cores: o.Cores},
+							Memory: &kubevirtv1.Memory{Guest: &guestQuantity},
+							Devices: kubevirtv1.Devices{
+								Interfaces: []kubevirtv1.Interface{
+									{
+										Name: "default",
+										InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+											Bridge: &kubevirtv1.InterfaceBridge{},
+										},
+									},
+								},
+							},
+						},
+						Networks: []kubevirtv1.Network{
+							{
+								Name: "default",
+								NetworkSource: kubevirtv1.NetworkSource{
+									Pod: &kubevirtv1.PodNetwork{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	exampleTemplate.NodeTemplate.Spec.Template.Spec.Domain.Devices.Disks = []kubevirtv1.Disk{
+		{
+			Name: rootVolumeName,
+			DiskDevice: kubevirtv1.DiskDevice{
+				Disk: &kubevirtv1.DiskTarget{
+					Bus: "virtio",
+				},
+			},
+		},
+	}
+
+	exampleTemplate.NodeTemplate.Spec.Template.Spec.Volumes = []kubevirtv1.Volume{
+		{
+			Name: rootVolumeName,
+			VolumeSource: kubevirtv1.VolumeSource{
+				DataVolume: &kubevirtv1.DataVolumeSource{
+					Name: rootVolumeName,
+				},
+			},
+		},
+	}
+
+	dataVolume := kubevirtv1.DataVolumeTemplateSpec{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rootVolumeName,
+		},
+		Spec: v1beta1.DataVolumeSpec{
+			Source: &v1beta1.DataVolumeSource{
+				Registry: &v1beta1.DataVolumeSourceRegistry{URL: &imageContainerURL},
+			},
+		},
+	}
+
+	dataVolume.Spec.Storage = &v1beta1.StorageSpec{
+		Resources: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]apiresource.Quantity{
+				corev1.ResourceStorage: volumeSize,
+			},
+		},
+	}
+
+	if o.RootVolumeStorageClass != "" {
+		dataVolume.Spec.Storage.StorageClassName = &o.RootVolumeStorageClass
+	}
+
+	exampleTemplate.NodeTemplate.Spec.DataVolumeTemplates = []kubevirtv1.DataVolumeTemplateSpec{dataVolume}
+
+	return exampleTemplate
+}

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -87,6 +87,8 @@ type KubevirtPlatformCreateOptions struct {
 	Memory                    string
 	Cores                     uint32
 	ContainerDiskImage        string
+	RootVolumeSize            uint32
+	RootVolumeStorageClass    string
 }
 
 type AWSPlatformOptions struct {

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -29,10 +29,13 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		Memory:                    "4Gi",
 		Cores:                     2,
 		ContainerDiskImage:        "",
+		RootVolumeSize:            16,
 	}
 
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.Memory, "memory", opts.KubevirtPlatform.Memory, "The amount of memory which is visible inside the Guest OS (type BinarySI, e.g. 5Gi, 100Mi)")
 	cmd.Flags().Uint32Var(&opts.KubevirtPlatform.Cores, "cores", opts.KubevirtPlatform.Cores, "The number of cores inside the vmi, Must be a value greater or equal 1")
+	cmd.Flags().StringVar(&opts.KubevirtPlatform.RootVolumeStorageClass, "root-volume-storage-class", opts.KubevirtPlatform.RootVolumeStorageClass, "The storage class to use for machines in the NodePool")
+	cmd.Flags().Uint32Var(&opts.KubevirtPlatform.RootVolumeSize, "root-volume-size", opts.KubevirtPlatform.RootVolumeSize, "The size of the root volume for machines in the NodePool in Gi")
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.ContainerDiskImage, "containerdisk", opts.KubevirtPlatform.ContainerDiskImage, "A reference to docker image with the embedded disk to be used to create the machines")
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.ServicePublishingStrategy, "service-publishing-strategy", opts.KubevirtPlatform.ServicePublishingStrategy, fmt.Sprintf("Define how to expose the cluster services. Supported options: %s (Use LoadBalancer and Route to expose services), %s (Select a random node to expose service access through)", IngressServicePublishingStrategy, NodePortServicePublishingStrategy))
 
@@ -85,6 +88,10 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		return errors.New("the number of cores inside the machine must be a value greater or equal 1")
 	}
 
+	if opts.KubevirtPlatform.RootVolumeSize < 8 {
+		return fmt.Errorf("the root volume size [%d] must be greater than or equal to 8", opts.KubevirtPlatform.RootVolumeSize)
+	}
+
 	infraID := opts.InfraID
 	exampleOptions.InfraID = infraID
 
@@ -100,6 +107,8 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		Memory:                    opts.KubevirtPlatform.Memory,
 		Cores:                     opts.KubevirtPlatform.Cores,
 		Image:                     opts.KubevirtPlatform.ContainerDiskImage,
+		RootVolumeSize:            opts.KubevirtPlatform.RootVolumeSize,
+		RootVolumeStorageClass:    opts.KubevirtPlatform.RootVolumeStorageClass,
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	k8s.io/pod-security-admission v0.23.5
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 	kubevirt.io/api v0.0.0-20211117075245-c94ce62baf5a
+	kubevirt.io/containerized-data-importer-api v1.41.0
 	sigs.k8s.io/apiserver-network-proxy v0.0.24
 	sigs.k8s.io/cluster-api v1.1.3
 	sigs.k8s.io/cluster-api-provider-aws v1.1.0
@@ -120,7 +121,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
-	kubevirt.io/containerized-data-importer-api v1.41.0 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk v0.2.1 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -69,7 +69,7 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 		t.Skip("Skipping testing because environment doesn't support KubeVirt")
 	}
 
-	ctx, cancel := context.WithTimeout(testContext, 35*time.Minute)
+	ctx, cancel := context.WithTimeout(testContext, 45*time.Minute)
 	defer cancel()
 
 	t.Parallel()
@@ -90,6 +90,7 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	clusterOpts.BaseDomain = defaultIngressOperator.Status.Domain
 	clusterOpts.NetworkType = string(hyperv1.OVNKubernetes)
+	clusterOpts.KubevirtPlatform.RootVolumeSize = 16
 
 	t.Logf("Using base domain %s", clusterOpts.BaseDomain)
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.KubevirtPlatform, globalOpts.ArtifactDir)


### PR DESCRIPTION
This PR transitions the KubeVirt platform away from using ephemeral storage and towards using persistent storage. Persistent storage allows the nodes hosted in KubeVirt VMs to be restarted/recovered without losing state.