### PR TITLE
disable reconcile of registry config in IBMCloud deployments

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -204,11 +204,15 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 
 	log.Info("reconciling registry config")
 	registryConfig := manifests.Registry()
-	if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
-		registry.ReconcileRegistryConfig(registryConfig, r.platformType, hcp.Spec.InfrastructureAvailabilityPolicy)
-		return nil
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile imageregistry config: %w", err))
+	// IBM Cloud platform allows managed service automation to initialize the registry config and then afterwards
+	// the client is in full control of the updates
+	if r.platformType != hyperv1.IBMCloudPlatform {
+		if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
+			registry.ReconcileRegistryConfig(registryConfig, r.platformType, hcp.Spec.InfrastructureAvailabilityPolicy)
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile imageregistry config: %w", err))
+		}
 	}
 
 	log.Info("reconciling ingress controller")


### PR DESCRIPTION
Currently there is a race condition in IBMCloud deployments where if hypershift initializes the registry config before the managed service operation has a chance to properly initialize the registry config: It will result in a bad initial config that will cause the cluster-image-registry operator to crash and lead to tickets. For IBMCloud deployments: the initialization of this config should be delegated to the managed service to do the initalization so this does not occur. From there: the user can edit however they like in line with upstream openshift

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.