### PR TITLE
Fix webhook to allow apiserver port defaulting and add tests

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -378,6 +378,14 @@ func filterMutableHostedClusterSpecFields(spec *hyperv1.HostedClusterSpec) {
 func validateHostedClusterUpdate(new *hyperv1.HostedCluster, old *hyperv1.HostedCluster) admission.Response {
 	filterMutableHostedClusterSpecFields(&new.Spec)
 	filterMutableHostedClusterSpecFields(&old.Spec)
+
+	// We default the port in Azure management cluster  so we allow setting it from being unset, but no updates.
+	if new.Spec.Networking.APIServer != nil && (old.Spec.Networking.APIServer == nil || old.Spec.Networking.APIServer.Port == nil) {
+		if old.Spec.Networking.APIServer == nil {
+			old.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{}
+		}
+		old.Spec.Networking.APIServer.Port = new.Spec.Networking.APIServer.Port
+	}
 	if !reflect.DeepEqual(new.Spec, old.Spec) {
 		return admission.Denied("attempted change to immutable field(s)")
 	}

--- a/hypershift-operator/main_test.go
+++ b/hypershift-operator/main_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	configv1 "github.com/openshift/api/config/v1"
+	hyperapi "github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
+	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
+	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
+	"github.com/openshift/hypershift/support/upsert"
+	"go.uber.org/zap/zaptest"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	utilpointer "k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestWebhookAllowsHostedClusterReconcilerUpdates(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name              string
+		hostedCluster     *hyperv1.HostedCluster
+		additionalObjects []crclient.Object
+	}{
+		{
+			name: "None cluster on azure management cluster",
+			hostedCluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "none-cluster",
+					Namespace: "some-ns",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.Ignition,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+							},
+						},
+					},
+				},
+			},
+			additionalObjects: []crclient.Object{
+				&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec:       configv1.InfrastructureSpec{PlatformSpec: configv1.PlatformSpec{Type: configv1.AzurePlatformType}},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns"},
+					Data:       map[string][]byte{".dockerconfigjson": []byte("something")},
+				},
+				&configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.hostedCluster.Annotations = map[string]string{
+				hyperv1.ControlPlaneOperatorImageAnnotation: "some-image",
+			}
+
+			mgr, err := ctrl.NewManager(&rest.Config{}, ctrl.Options{
+				MetricsBindAddress: "0",
+				MapperProvider: func(*rest.Config) (meta.RESTMapper, error) {
+					return restmapper.NewDiscoveryRESTMapper(nil), nil
+				},
+				NewClient: func(cache.Cache, *rest.Config, client.Options, ...client.Object) (client.Client, error) {
+					return &hostedClusterUpdateValidatingClient{
+						Client: fake.NewClientBuilder().
+							WithScheme(hyperapi.Scheme).
+							WithObjects(append(tc.additionalObjects, tc.hostedCluster)...).
+							Build(),
+					}, nil
+				},
+				NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+					return &informertest.FakeInformers{}, nil
+				},
+				Scheme: hyperapi.Scheme,
+			})
+			if err != nil {
+				t.Fatalf("failed to construct manager: %v", err)
+			}
+			hostedClusterReconciler := &hostedcluster.HostedClusterReconciler{
+				Client:                        mgr.GetClient(),
+				ManagementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
+				ImageMetadataProvider: imageMetadataProviderFunc(func(context.Context, string, []byte) (*dockerv1client.DockerImageConfig, error) {
+					return &dockerv1client.DockerImageConfig{}, nil
+				}),
+				ReleaseProvider: &fakereleaseprovider.FakeReleaseProvider{},
+			}
+			if err := hostedClusterReconciler.SetupWithManager(mgr, upsert.New(true)); err != nil {
+				t.Fatalf("failed to set up hostedClusterReconciler: %v", err)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx = log.IntoContext(ctx, zapr.NewLogger(zaptest.NewLogger(t)))
+
+			if _, err := hostedClusterReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: crclient.ObjectKeyFromObject(tc.hostedCluster)}); err != nil {
+				t.Errorf("failed to reconcile cluster: %v", err)
+			}
+		})
+	}
+}
+
+type hostedClusterUpdateValidatingClient struct {
+	crclient.Client
+}
+
+func (h *hostedClusterUpdateValidatingClient) Update(ctx context.Context, obj crclient.Object, opts ...crclient.UpdateOption) error {
+	hcluster, isHcluster := obj.(*hyperv1.HostedCluster)
+	if !isHcluster {
+		return h.Client.Update(ctx, obj, opts...)
+	}
+
+	oldCluster := &hyperv1.HostedCluster{}
+	if err := h.Client.Get(ctx, crclient.ObjectKeyFromObject(hcluster), oldCluster); err != nil {
+		return fmt.Errorf("failed to validate hostedcluster update: failed to get old hosted cluster: %w", err)
+	}
+
+	result := validateHostedClusterUpdate(hcluster.DeepCopy(), oldCluster.DeepCopy())
+	if !result.Allowed {
+		return fmt.Errorf("update rejected by admission: %s", result.AdmissionResponse.Result.Reason)
+	}
+
+	return h.Client.Update(ctx, obj, opts...)
+}
+
+type imageMetadataProviderFunc func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error)
+
+func (f imageMetadataProviderFunc) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
+	return f(ctx, imageRef, pullSecret)
+}
+
+func TestValidateHostedClusterUpdate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name string
+		old  *hyperv1.HostedCluster
+		new  *hyperv1.HostedCluster
+
+		expectAllowed bool
+	}{
+		{
+			name: "APIServer port was unset and gets set, allowed",
+			old:  &hyperv1.HostedCluster{},
+			new: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{Networking: hyperv1.ClusterNetworking{APIServer: &hyperv1.APIServerNetworking{Port: utilpointer.Int32(7443)}}},
+			},
+			expectAllowed: true,
+		},
+		{
+			name: "APIServer port remains unchanged, allowed",
+			old: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{Networking: hyperv1.ClusterNetworking{APIServer: &hyperv1.APIServerNetworking{Port: utilpointer.Int32(7443)}}},
+			},
+			new: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{Networking: hyperv1.ClusterNetworking{APIServer: &hyperv1.APIServerNetworking{Port: utilpointer.Int32(7443)}}},
+			},
+			expectAllowed: true,
+		},
+		{
+			name: "APIServer port gets updated, not allowed",
+			old: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{Networking: hyperv1.ClusterNetworking{APIServer: &hyperv1.APIServerNetworking{Port: utilpointer.Int32(7443)}}},
+			},
+			new: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{Networking: hyperv1.ClusterNetworking{APIServer: &hyperv1.APIServerNetworking{Port: utilpointer.Int32(8443)}}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := validateHostedClusterUpdate(tc.new, tc.old)
+			if result.Allowed != tc.expectAllowed {
+				t.Errorf("expected allowd to be %t, was %t", tc.expectAllowed, result.Allowed)
+			}
+		})
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -956,6 +956,7 @@ sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
 sigs.k8s.io/controller-runtime/pkg/cache
+sigs.k8s.io/controller-runtime/pkg/cache/informertest
 sigs.k8s.io/controller-runtime/pkg/cache/internal
 sigs.k8s.io/controller-runtime/pkg/certwatcher
 sigs.k8s.io/controller-runtime/pkg/client
@@ -966,6 +967,7 @@ sigs.k8s.io/controller-runtime/pkg/cluster
 sigs.k8s.io/controller-runtime/pkg/config
 sigs.k8s.io/controller-runtime/pkg/config/v1alpha1
 sigs.k8s.io/controller-runtime/pkg/controller
+sigs.k8s.io/controller-runtime/pkg/controller/controllertest
 sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
 sigs.k8s.io/controller-runtime/pkg/conversion
 sigs.k8s.io/controller-runtime/pkg/event

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/cache/informertest/fake_cache.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/cache/informertest/fake_cache.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informertest
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+)
+
+var _ cache.Cache = &FakeInformers{}
+
+// FakeInformers is a fake implementation of Informers.
+type FakeInformers struct {
+	InformersByGVK map[schema.GroupVersionKind]toolscache.SharedIndexInformer
+	Scheme         *runtime.Scheme
+	Error          error
+	Synced         *bool
+}
+
+// GetInformerForKind implements Informers.
+func (c *FakeInformers) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (cache.Informer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	obj, err := c.Scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+	return c.informerFor(gvk, obj)
+}
+
+// FakeInformerForKind implements Informers.
+func (c *FakeInformers) FakeInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (*controllertest.FakeInformer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	obj, err := c.Scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+	i, err := c.informerFor(gvk, obj)
+	if err != nil {
+		return nil, err
+	}
+	return i.(*controllertest.FakeInformer), nil
+}
+
+// GetInformer implements Informers.
+func (c *FakeInformers) GetInformer(ctx context.Context, obj client.Object) (cache.Informer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	gvks, _, err := c.Scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, err
+	}
+	gvk := gvks[0]
+	return c.informerFor(gvk, obj)
+}
+
+// WaitForCacheSync implements Informers.
+func (c *FakeInformers) WaitForCacheSync(ctx context.Context) bool {
+	if c.Synced == nil {
+		return true
+	}
+	return *c.Synced
+}
+
+// FakeInformerFor implements Informers.
+func (c *FakeInformers) FakeInformerFor(obj runtime.Object) (*controllertest.FakeInformer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	gvks, _, err := c.Scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, err
+	}
+	gvk := gvks[0]
+	i, err := c.informerFor(gvk, obj)
+	if err != nil {
+		return nil, err
+	}
+	return i.(*controllertest.FakeInformer), nil
+}
+
+func (c *FakeInformers) informerFor(gvk schema.GroupVersionKind, _ runtime.Object) (toolscache.SharedIndexInformer, error) {
+	if c.Error != nil {
+		return nil, c.Error
+	}
+	if c.InformersByGVK == nil {
+		c.InformersByGVK = map[schema.GroupVersionKind]toolscache.SharedIndexInformer{}
+	}
+	informer, ok := c.InformersByGVK[gvk]
+	if ok {
+		return informer, nil
+	}
+
+	c.InformersByGVK[gvk] = &controllertest.FakeInformer{}
+	return c.InformersByGVK[gvk], nil
+}
+
+// Start implements Informers.
+func (c *FakeInformers) Start(ctx context.Context) error {
+	return c.Error
+}
+
+// IndexField implements Cache.
+func (c *FakeInformers) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	return nil
+}
+
+// Get implements Cache.
+func (c *FakeInformers) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	return nil
+}
+
+// List implements Cache.
+func (c *FakeInformers) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllertest contains fake informers for testing controllers
+// When in doubt, it's almost always better to test against a real API server
+// using envtest.Environment.
+package controllertest

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/testing.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/testing.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllertest
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
+)
+
+var _ runtime.Object = &ErrorType{}
+
+// ErrorType implements runtime.Object but isn't registered in any scheme and should cause errors in tests as a result.
+type ErrorType struct{}
+
+// GetObjectKind implements runtime.Object.
+func (ErrorType) GetObjectKind() schema.ObjectKind { return nil }
+
+// DeepCopyObject implements runtime.Object.
+func (ErrorType) DeepCopyObject() runtime.Object { return nil }
+
+var _ workqueue.RateLimitingInterface = Queue{}
+
+// Queue implements a RateLimiting queue as a non-ratelimited queue for testing.
+// This helps testing by having functions that use a RateLimiting queue synchronously add items to the queue.
+type Queue struct {
+	workqueue.Interface
+}
+
+// AddAfter implements RateLimitingInterface.
+func (q Queue) AddAfter(item interface{}, duration time.Duration) {
+	q.Add(item)
+}
+
+// AddRateLimited implements RateLimitingInterface.  TODO(community): Implement this.
+func (q Queue) AddRateLimited(item interface{}) {
+	q.Add(item)
+}
+
+// Forget implements RateLimitingInterface.  TODO(community): Implement this.
+func (q Queue) Forget(item interface{}) {}
+
+// NumRequeues implements RateLimitingInterface.  TODO(community): Implement this.
+func (q Queue) NumRequeues(item interface{}) int {
+	return 0
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/unconventionallisttypecrd.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/unconventionallisttypecrd.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllertest
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ runtime.Object = &UnconventionalListType{}
+var _ runtime.Object = &UnconventionalListTypeList{}
+
+// UnconventionalListType is used to test CRDs with List types that
+// have a slice of pointers rather than a slice of literals.
+type UnconventionalListType struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              string `json:"spec,omitempty"`
+}
+
+// DeepCopyObject implements runtime.Object
+// Handwritten for simplicity.
+func (u *UnconventionalListType) DeepCopyObject() runtime.Object {
+	return u.DeepCopy()
+}
+
+// DeepCopy implements *UnconventionalListType
+// Handwritten for simplicity.
+func (u *UnconventionalListType) DeepCopy() *UnconventionalListType {
+	return &UnconventionalListType{
+		TypeMeta:   u.TypeMeta,
+		ObjectMeta: *u.ObjectMeta.DeepCopy(),
+		Spec:       u.Spec,
+	}
+}
+
+// UnconventionalListTypeList is used to test CRDs with List types that
+// have a slice of pointers rather than a slice of literals.
+type UnconventionalListTypeList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []*UnconventionalListType `json:"items"`
+}
+
+// DeepCopyObject implements runtime.Object
+// Handwritten for simplicity.
+func (u *UnconventionalListTypeList) DeepCopyObject() runtime.Object {
+	return u.DeepCopy()
+}
+
+// DeepCopy implements *UnconventionalListTypeListt
+// Handwritten for simplicity.
+func (u *UnconventionalListTypeList) DeepCopy() *UnconventionalListTypeList {
+	out := &UnconventionalListTypeList{
+		TypeMeta: u.TypeMeta,
+		ListMeta: *u.ListMeta.DeepCopy(),
+	}
+	for _, item := range u.Items {
+		out.Items = append(out.Items, item.DeepCopy())
+	}
+	return out
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/util.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/util.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllertest
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.SharedIndexInformer = &FakeInformer{}
+
+// FakeInformer provides fake Informer functionality for testing.
+type FakeInformer struct {
+	// Synced is returned by the HasSynced functions to implement the Informer interface
+	Synced bool
+
+	// RunCount is incremented each time RunInformersAndControllers is called
+	RunCount int
+
+	handlers []cache.ResourceEventHandler
+}
+
+// AddIndexers does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) AddIndexers(indexers cache.Indexers) error {
+	return nil
+}
+
+// GetIndexer does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) GetIndexer() cache.Indexer {
+	return nil
+}
+
+// Informer returns the fake Informer.
+func (f *FakeInformer) Informer() cache.SharedIndexInformer {
+	return f
+}
+
+// HasSynced implements the Informer interface.  Returns f.Synced.
+func (f *FakeInformer) HasSynced() bool {
+	return f.Synced
+}
+
+// AddEventHandler implements the Informer interface.  Adds an EventHandler to the fake Informers.
+func (f *FakeInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+	f.handlers = append(f.handlers, handler)
+}
+
+// Run implements the Informer interface.  Increments f.RunCount.
+func (f *FakeInformer) Run(<-chan struct{}) {
+	f.RunCount++
+}
+
+// Add fakes an Add event for obj.
+func (f *FakeInformer) Add(obj metav1.Object) {
+	for _, h := range f.handlers {
+		h.OnAdd(obj)
+	}
+}
+
+// Update fakes an Update event for obj.
+func (f *FakeInformer) Update(oldObj, newObj metav1.Object) {
+	for _, h := range f.handlers {
+		h.OnUpdate(oldObj, newObj)
+	}
+}
+
+// Delete fakes an Delete event for obj.
+func (f *FakeInformer) Delete(obj metav1.Object) {
+	for _, h := range f.handlers {
+		h.OnDelete(obj)
+	}
+}
+
+// AddEventHandlerWithResyncPeriod does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+
+}
+
+// GetStore does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) GetStore() cache.Store {
+	return nil
+}
+
+// GetController does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) GetController() cache.Controller {
+	return nil
+}
+
+// LastSyncResourceVersion does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) LastSyncResourceVersion() string {
+	return ""
+}
+
+// SetWatchErrorHandler does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) SetWatchErrorHandler(cache.WatchErrorHandler) error {
+	return nil
+}


### PR DESCRIPTION
Currently, tests on an Azure management cluster always fail when the
webhook is enabled, because it rejects the apiserver port defaulting
request.

/assign @sjenning 

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.