### PR TITLE
Export `ign_server_payload_generation_seconds` metric and add e2e budget

### DIFF
--- a/cmd/install/assets/recordingrules/hypershift.yaml
+++ b/cmd/install/assets/recordingrules/hypershift.yaml
@@ -16,6 +16,9 @@ groups:
             label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""}, "app", "$1", "label_app", "(.*)")
           )
 
+  - record: hypershift:controlplane:ign_payload_generation_seconds_p90
+    expr: histogram_quantile(0.9, sum by (namespace, le) (rate(ign_server_payload_generation_seconds_bucket{container="ignition-server"}[3m])))
+
   - record: hypershift:controlplane:component_cpu_usage_seconds
     expr: avg by (app, namespace, pod) (
             sum(

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -451,6 +451,8 @@ objects:
           by (pod, namespace) * on (pod, namespace) group_left(app) label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""},
           "app", "$1", "label_app", "(.*)") )
         record: hypershift:controlplane:component_memory_usage
+      - expr: histogram_quantile(0.9, sum by (namespace, le) (rate(ign_server_payload_generation_seconds_bucket{container="ignition-server"}[3m])))
+        record: hypershift:controlplane:ign_payload_generation_seconds_p90
       - expr: avg by (app, namespace, pod) ( sum( rate( container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
           ) ) by (pod, namespace) * on (pod, namespace) group_left(app) label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""},
           "app", "$1", "label_app", "(.*)") ) / count by (app, namespace, pod) ( sum(

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -455,6 +455,11 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 				query:  fmt.Sprintf(`sum by (pod) (max_over_time(hypershift:controlplane:component_api_requests_total{app="control-plane-operator", method="DELETE", code="404", namespace=~"%s"}[%dm]))`, namespace, clusterAgeMinutes),
 				budget: 5,
 			},
+			{
+				name:   "ignition-server p90 payload generation time",
+				query:  fmt.Sprintf(`sum by (namespace) (max_over_time(hypershift:controlplane:ign_payload_generation_seconds_p90{namespace="%s"}[%dm]))`, namespace, clusterAgeMinutes),
+				budget: 45,
+			},
 			// hypershift-operator budget can not be per HC so metric will be
 			// significantly under budget for all but the last test(s) to complete on
 			// a particular test cluster These budgets will also need to scale up with


### PR DESCRIPTION
Before this commit, the `ign_server_payload_generation_seconds` metric was not
being accounted for in the e2e metrics budget assertions, which led to us
failing to detect a possible performance regression on AWS with the new ignition
payload generation implementation.

This commit adds a recording rule for `ign_server_payload_generation_seconds`
(to ensure the metric is exported), and also implements a budget check in the
e2e fixture. For now, the budget is a p90 expectation of 45 seconds for payload
generation, which is very probably conservative. We've observed an intermittent
8 minute value in one known e2e test case that hasn't yet been reproduced. We
should adjust the histogram bucket and budget once we have more data around the
implementation's real world performance.

Hopefully this budget will help us detect problems and narrow down a reproducer
for the anomaly.
