### PR TITLE
e2e: log the error when failing to connect to the guest KAS

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -117,9 +117,11 @@ func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Clien
 	var guestClient crclient.Client
 	waitForGuestClientCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
-	err = wait.PollUntil(5*time.Second, func() (done bool, err error) {
+	// SOA TTL is 60s. If DNS lookup fails on the api-* name, it is unlikely to succeed in less than 60s.
+	err = wait.PollUntil(35*time.Second, func() (done bool, err error) {
 		kubeClient, err := crclient.New(guestConfig, crclient.Options{Scheme: scheme})
 		if err != nil {
+			t.Logf("attempt to connect failed: %s", err)
 			return false, nil
 		}
 		guestClient = kubeClient


### PR DESCRIPTION
**What this PR does / why we need it**:

This should help find issues in kubeconfig generation and name resolution failures/delays

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.