### PR TITLE
Add OAuthURL to HostedCluster status

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -195,6 +195,13 @@ type HostedControlPlaneStatus struct {
 	// +kubebuilder:validation:Optional
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint,omitempty"`
 
+	// OAuthCallbackURLTemplate contains a template for the URL to use as a callback
+	// for identity providers. The [identity-provider-name] placeholder must be replaced
+	// with the name of an identity provider defined on the HostedCluster.
+	// This is populated after the infrastructure is ready.
+	// +kubebuilder:validation:Optional
+	OAuthCallbackURLTemplate string `json:"oauthCallbackURLTemplate,omitempty"`
+
 	// Version is the semantic version of the release applied by
 	// the hosted control plane operator
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1287,7 +1287,14 @@ type HostedClusterStatus struct {
 	// IgnitionEndpoint is the endpoint injected in the ign config userdata.
 	// It exposes the config for instances to become kubernetes nodes.
 	// +optional
-	IgnitionEndpoint string `json:"ignitionEndpoint"`
+	IgnitionEndpoint string `json:"ignitionEndpoint,omitempty"`
+
+	// OAuthCallbackURLTemplate contains a template for the URL to use as a callback
+	// for identity providers. The [identity-provider-name] placeholder must be replaced
+	// with the name of an identity provider defined on the HostedCluster.
+	// This is populated after the infrastructure is ready.
+	// +kubebuilder:validation:Optional
+	OAuthCallbackURLTemplate string `json:"oauthCallbackURLTemplate,omitempty"`
 
 	// Conditions represents the latest available observations of a control
 	// plane's current state.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -1225,6 +1225,13 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              oauthCallbackURLTemplate:
+                description: OAuthCallbackURLTemplate contains a template for the
+                  URL to use as a callback for identity providers. The [identity-provider-name]
+                  placeholder must be replaced with the name of an identity provider
+                  defined on the HostedCluster. This is populated after the infrastructure
+                  is ready.
+                type: string
               version:
                 description: Version is the status of the release version applied
                   to the HostedCluster.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -1159,6 +1159,13 @@ spec:
                   update to the current releaseImage property.
                 format: date-time
                 type: string
+              oauthCallbackURLTemplate:
+                description: OAuthCallbackURLTemplate contains a template for the
+                  URL to use as a callback for identity providers. The [identity-provider-name]
+                  placeholder must be replaced with the name of an identity provider
+                  defined on the HostedCluster. This is populated after the infrastructure
+                  is ready.
+                type: string
               ready:
                 default: false
                 description: Ready denotes that the HostedControlPlane API Server

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -319,6 +319,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 					Status: metav1.ConditionTrue,
 					Reason: hyperv1.AsExpectedReason,
 				}
+				hostedControlPlane.Status.OAuthCallbackURLTemplate = fmt.Sprintf("https://%s:%d/oauthcallback/[identity-provider-name]", infraStatus.OAuthHost, infraStatus.OAuthPort)
 			} else {
 				message := "Cluster infrastructure is still provisioning"
 				if len(infraStatus.Message) > 0 {

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2786,6 +2786,20 @@ It exposes the config for instances to become kubernetes nodes.</p>
 </tr>
 <tr>
 <td>
+<code>oauthCallbackURLTemplate</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OAuthCallbackURLTemplate contains a template for the URL to use as a callback
+for identity providers. The [identity-provider-name] placeholder must be replaced
+with the name of an identity provider defined on the HostedCluster.
+This is populated after the infrastructure is ready.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>conditions</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#condition-v1-meta">
@@ -3273,6 +3287,20 @@ APIEndpoint
 <p>ControlPlaneEndpoint contains the endpoint information by which
 external clients can access the control plane.  This is populated
 after the infrastructure is ready.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>oauthCallbackURLTemplate</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OAuthCallbackURLTemplate contains a template for the URL to use as a callback
+for identity providers. The [identity-provider-name] placeholder must be replaced
+with the name of an identity provider defined on the HostedCluster.
+This is populated after the infrastructure is ready.</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -21164,6 +21164,13 @@ objects:
                         TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
+                oauthCallbackURLTemplate:
+                  description: OAuthCallbackURLTemplate contains a template for the
+                    URL to use as a callback for identity providers. The [identity-provider-name]
+                    placeholder must be replaced with the name of an identity provider
+                    defined on the HostedCluster. This is populated after the infrastructure
+                    is ready.
+                  type: string
                 version:
                   description: Version is the status of the release version applied
                     to the HostedCluster.
@@ -22453,6 +22460,13 @@ objects:
                   description: lastReleaseImageTransitionTime is the time of the last
                     update to the current releaseImage property.
                   format: date-time
+                  type: string
+                oauthCallbackURLTemplate:
+                  description: OAuthCallbackURLTemplate contains a template for the
+                    URL to use as a callback for identity providers. The [identity-provider-name]
+                    placeholder must be replaced with the name of an identity provider
+                    defined on the HostedCluster. This is populated after the infrastructure
+                    is ready.
                   type: string
                 ready:
                   default: false

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -518,6 +518,23 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	// Set the OAuth URL
+	{
+		controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
+		hcp := controlplaneoperator.HostedControlPlane(controlPlaneNamespace.Name, hcluster.Name)
+		err := r.Client.Get(ctx, client.ObjectKeyFromObject(hcp), hcp)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				hcp = nil
+			} else {
+				return ctrl.Result{}, fmt.Errorf("failed to get hostedcontrolplane: %w", err)
+			}
+		}
+		if hcp != nil {
+			hcluster.Status.OAuthCallbackURLTemplate = hcp.Status.OAuthCallbackURLTemplate
+		}
+	}
+
 	// Set the ignition server availability condition by checking its deployment.
 	{
 		// Assume the server is unavailable unless proven otherwise.


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes the OAuth URL to clients of the HostedCluster API. This URL
is used in configuring identity providers such as Github that require
an OAuth callback URL.


**Checklist**
- [x] Subject and description added to both, commit and PR.