### PR TITLE
Reduce KubeVirt e2e test flakiness

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -90,7 +90,6 @@ func TestKubeVirtCreateCluster(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions()
 	clusterOpts.BaseDomain = defaultIngressOperator.Status.Domain
-	clusterOpts.NetworkType = string(hyperv1.OVNKubernetes)
 
 	t.Logf("Using base domain %s", clusterOpts.BaseDomain)
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.KubevirtPlatform, globalOpts.ArtifactDir)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -61,6 +61,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.AWSEndpointAccess, "e2e.aws-endpoint-access", "", "endpoint access profile for the cluster")
 	flag.StringVar(&globalOpts.configurableClusterOptions.ExternalDNSDomain, "e2e.external-dns-domain", "", "domain that external-dns will use to create DNS records for HCP endpoints")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "container disk image to use for kubevirt nodes")
+	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtNodeMemory, "e2e.kubevirt-node-memory", "4Gi", "the amount of memory to provide to each workload node")
 	flag.IntVar(&globalOpts.configurableClusterOptions.NodePoolReplicas, "e2e.node-pool-replicas", 2, "the number of replicas for each node pool in the cluster")
 	flag.StringVar(&globalOpts.LatestReleaseImage, "e2e.latest-release-image", "", "The latest OCP release image for use by tests")
 	flag.StringVar(&globalOpts.PreviousReleaseImage, "e2e.previous-release-image", "", "The previous OCP release image relative to the latest")
@@ -212,6 +213,7 @@ type configurableClusterOptions struct {
 	AWSEndpointAccess          string
 	ExternalDNSDomain          string
 	KubeVirtContainerDiskImage string
+	KubeVirtNodeMemory         string
 	NodePoolReplicas           int
 }
 
@@ -238,7 +240,7 @@ func (o *options) DefaultClusterOptions() core.CreateOptions {
 			ServicePublishingStrategy: kubevirt.IngressServicePublishingStrategy,
 			ContainerDiskImage:        o.configurableClusterOptions.KubeVirtContainerDiskImage,
 			Cores:                     2,
-			Memory:                    "4Gi",
+			Memory:                    o.configurableClusterOptions.KubeVirtNodeMemory,
 		},
 		AzurePlatform: core.AzurePlatformOptions{
 			CredentialsFile: o.configurableClusterOptions.AzureCredentialsFile,


### PR DESCRIPTION
We're encountering some issues with flaky tests on the kubevirt platform. There are two issues here that this PR addresses.

1. We need the ability to alter the guest memory used for the worker nodes in the prow configs. We're seeing in 4.11 that some of the default OCP components can't start on the worker nodes due to lack of memory. This is addressed by the new `e2e.kubevirt-node-memory` e2e test cli option
2. Running OVNKubernetes as the network overlay in the worker nodes is flaky at the moment. I'm investigating this, but for now I think we should switch back to the e2e default which uses the SDN.
