### PR TITLE
feat(cpo): adhere to upgrade order from kube version skew policy

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -608,6 +608,17 @@ func (r *HostedControlPlaneReconciler) update(ctx context.Context, hostedControl
 		return fmt.Errorf("failed to reconcile kube apiserver: %w", err)
 	}
 
+	// Block until kube apiserver is fully ready to enforce upgrade order of version skew policy
+	// https://kubernetes.io/releases/version-skew-policy/#supported-component-upgrade-order
+	ready, err := util.IsDeploymentReady(ctx, r, manifests.KASDeployment(hostedControlPlane.Namespace))
+	if err != nil {
+		return fmt.Errorf("failed to check kube apiserver availability: %w", err)
+	}
+	if !ready {
+		r.Log.Info("Waiting for kube apiserver deployment to become ready")
+		return nil
+	}
+
 	// Reconcile kube controller manager
 	r.Log.Info("Reconciling Kube Controller Manager")
 	if err := r.reconcileKubeControllerManager(ctx, hostedControlPlane, globalConfig, releaseImage); err != nil {
@@ -624,6 +635,17 @@ func (r *HostedControlPlaneReconciler) update(ctx context.Context, hostedControl
 	r.Log.Info("Reconciling OpenShift API Server")
 	if err := r.reconcileOpenShiftAPIServer(ctx, hostedControlPlane, globalConfig, releaseImage, infraStatus.OpenShiftAPIHost); err != nil {
 		return fmt.Errorf("failed to reconcile openshift apiserver: %w", err)
+	}
+
+	// Block until openshift apiserver is fully ready to enforce upgrade order of version skew policy
+	// https://github.com/openshift/enhancements/blob/master/enhancements/update/eus-upgrades-mvp.md
+	ready, err = util.IsDeploymentReady(ctx, r, manifests.OpenShiftAPIServerDeployment(hostedControlPlane.Namespace))
+	if err != nil {
+		return fmt.Errorf("failed to check openshift apiserver availability: %w", err)
+	}
+	if !ready {
+		r.Log.Info("Waiting for openshift apiserver deployment to become ready")
+		return nil
 	}
 
 	// Reconcile openshift oauth apiserver
@@ -1632,6 +1654,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile api server deployment: %w", err)
 	}
+
 	return nil
 }
 
@@ -1741,6 +1764,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.C
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift apiserver deployment: %w", err)
 	}
+
 	return nil
 }
 

--- a/support/util/deployment.go
+++ b/support/util/deployment.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsDeploymentReady(ctx context.Context, c crclient.Client, deployment *appsv1.Deployment) (bool, error) {
+	if err := c.Get(ctx, crclient.ObjectKeyFromObject(deployment), deployment); err != nil {
+		return false, fmt.Errorf("failed to fetch %s deployment: %w", deployment.Name, err)
+	}
+
+	if *deployment.Spec.Replicas != deployment.Status.AvailableReplicas ||
+		*deployment.Spec.Replicas != deployment.Status.ReadyReplicas ||
+		*deployment.Spec.Replicas != deployment.Status.UpdatedReplicas ||
+		deployment.ObjectMeta.Generation > deployment.Status.ObservedGeneration {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/support/util/deployment_test.go
+++ b/support/util/deployment_test.go
@@ -1,0 +1,110 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestIsDeploymentReady(t *testing.T) {
+	client := fake.NewClientBuilder().WithRuntimeObjects(
+		// Positive path - all replicas updated, available, ready
+		&appsv1.Deployment{
+			ObjectMeta: v1.ObjectMeta{
+				Name:       "positive-path",
+				Generation: 1,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32Ptr(3),
+			},
+			Status: appsv1.DeploymentStatus{
+				UpdatedReplicas:    3,
+				AvailableReplicas:  3,
+				ReadyReplicas:      3,
+				ObservedGeneration: 1,
+			},
+		},
+		// Negative path - replicas not yet updated
+		&appsv1.Deployment{
+			ObjectMeta: v1.ObjectMeta{
+				Name:       "negative-path-1",
+				Generation: 1,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32Ptr(3),
+			},
+			Status: appsv1.DeploymentStatus{
+				UpdatedReplicas:    2,
+				AvailableReplicas:  3,
+				ReadyReplicas:      3,
+				ObservedGeneration: 1,
+			},
+		},
+		// Negative path - replicas not yet available
+		&appsv1.Deployment{
+			ObjectMeta: v1.ObjectMeta{
+				Name:       "negative-path-2",
+				Generation: 1,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32Ptr(3),
+			},
+			Status: appsv1.DeploymentStatus{
+				UpdatedReplicas:    3,
+				AvailableReplicas:  2,
+				ReadyReplicas:      3,
+				ObservedGeneration: 1,
+			},
+		},
+		// Negative path - generation mismatch
+		&appsv1.Deployment{
+			ObjectMeta: v1.ObjectMeta{
+				Name:       "negative-path-3",
+				Generation: 2,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32Ptr(3),
+			},
+			Status: appsv1.DeploymentStatus{
+				UpdatedReplicas:    3,
+				AvailableReplicas:  3,
+				ReadyReplicas:      3,
+				ObservedGeneration: 1,
+			},
+		},
+	).Build()
+
+	// Positive path - all replicas updated, available, ready
+	result, err := IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "positive-path"}})
+	if !result || err != nil {
+		t.Errorf("expected result %t, got %t: %v", true, result, err)
+	}
+
+	// Negative path - replicas not yet updated
+	result, err = IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "negative-path-1"}})
+	if result || err != nil {
+		t.Errorf("expected result %t, got %t: %v", false, result, err)
+	}
+
+	// Negative path - replicas not yet available
+	result, err = IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "negative-path-2"}})
+	if result || err != nil {
+		t.Errorf("expected result %t, got %t: %v", false, result, err)
+	}
+
+	// Negative path - generation mismatch
+	result, err = IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "negative-path-3"}})
+	if result || err != nil {
+		t.Errorf("expected result %t, got %t: %v", false, result, err)
+	}
+
+	// Negative path - deployment not found
+	result, err = IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "does-not-exist"}})
+	if result || err == nil {
+		t.Errorf("expected result %t, got %t: %v", false, result, err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This CPO change ensures `kube-apiserver` and `openshift-apiserver` deployments to roll out all updated replicas before proceeding with reconciliation. This makes it so that hypershift control planes adheres to the supported upgrade order as described in kube version skew policy.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #1222 

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.