### PR TITLE
install: enable user provided AWS credentials secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ app-sre-saas-template: hypershift
 		--enable-ocp-cluster-monitoring=false \
 		--enable-ci-debug-output=false \
 		--enable-admin-rbac-generation=true \
+		--private-platform=AWS \
+		--aws-private-region=eu-east-1 \
+		--aws-private-secret=aws-credentials \
+		--aws-private-secret-key=credentials \
 		render --template --format yaml > $(DIR)/hack/app-sre/saas_template.yaml
 
 # Run tests

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -2,11 +2,12 @@ package assets
 
 import (
 	"fmt"
+	"testing"
+
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
@@ -110,7 +111,14 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 				},
 				Replicas:         3,
 				PrivatePlatform:  string(hyperv1.AWSPlatform),
-				OIDCBucketRegion: "us-east-1",
+				AWSPrivateRegion: "us-east-1",
+				AWSPrivateSecret: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: awsCredsSecretName,
+					},
+				},
+				AWSPrivateSecretKey: "mykey",
+				OIDCBucketRegion:    "us-east-1",
 				OIDCStorageProviderS3Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "oidc-s3-secret",

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -110,6 +110,59 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 					},
 				},
 				Replicas:         3,
+				PrivatePlatform:  string(hyperv1.NonePlatform),
+				OIDCBucketRegion: "us-east-1",
+				OIDCStorageProviderS3Secret: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "oidc-s3-secret",
+					},
+				},
+				OIDCBucketName:                 "oidc-bucket",
+				OIDCStorageProviderS3SecretKey: "mykey",
+			},
+			expectedArgs: []string{
+				"run",
+				"--namespace=$(MY_NAMESPACE)",
+				"--deployment-name=operator",
+				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
+				fmt.Sprintf("--enable-ci-debug-output=%t", false),
+				fmt.Sprintf("--private-platform=%s", string(hyperv1.NonePlatform)),
+				"--oidc-storage-provider-s3-bucket-name=" + "oidc-bucket",
+				"--oidc-storage-provider-s3-region=" + "us-east-1",
+				"--oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/" + "mykey",
+			},
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "oidc-storage-provider-s3-creds",
+					MountPath: "/etc/oidc-storage-provider-s3-creds",
+				},
+			},
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "oidc-storage-provider-s3-creds",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "oidc-s3-secret",
+						},
+					},
+				},
+			},
+		},
+		"specify aws private creds and oidc parameters result in appropriate volumes and volumeMounts": {
+			inputBuildParameters: HyperShiftOperatorDeployment{
+				Namespace: &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNamespace,
+					},
+				},
+				OperatorImage: testOperatorImage,
+				ServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hypershift",
+					},
+				},
+				Replicas:         3,
 				PrivatePlatform:  string(hyperv1.AWSPlatform),
 				AWSPrivateRegion: "us-east-1",
 				AWSPrivateSecret: &corev1.Secret{

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -76,7 +76,7 @@ func (o *Options) Validate() error {
 
 	switch hyperv1.PlatformType(o.PrivatePlatform) {
 	case hyperv1.AWSPlatform:
-		if (o.AWSPrivateCreds == "" && o.AWSPrivateCredentialsSecret == "") || o.AWSPrivateRegion == "" {
+		if (len(o.AWSPrivateCreds) == 0 && len(o.AWSPrivateCredentialsSecret) == 0) || len(o.AWSPrivateRegion) == 0 {
 			errs = append(errs, fmt.Errorf("--aws-private-region and --aws-private-creds or --aws-private-secret are required with --private-platform=%s", hyperv1.AWSPlatform))
 		}
 	case hyperv1.NonePlatform:

--- a/cmd/install/install_render.go
+++ b/cmd/install/install_render.go
@@ -16,14 +16,17 @@ var (
 	RenderFormatYaml = "yaml"
 	RenderFormatJson = "json"
 
-	TemplateParamHyperShiftImage      = "OPERATOR_IMG"
-	TemplateParamHyperShiftImageTag   = "IMAGE_TAG"
-	TemplateParamNamespace            = "NAMESPACE"
-	TemplateParamOIDCS3Name           = "OIDC_S3_NAME"
-	TemplateParamOIDCS3Region         = "OIDC_S3_REGION"
-	TemplateParamOIDCS3CredsSecret    = "OIDC_S3_CREDS_SECRET"
-	TemplateParamOIDCS3CredsSecretKey = "OIDC_S3_CREDS_SECRET_KEY"
-	TemplateParamOperatorReplicas     = "OPERATOR_REPLICAS"
+	TemplateParamHyperShiftImage          = "OPERATOR_IMG"
+	TemplateParamHyperShiftImageTag       = "IMAGE_TAG"
+	TemplateParamNamespace                = "NAMESPACE"
+	TemplateParamOIDCS3Name               = "OIDC_S3_NAME"
+	TemplateParamOIDCS3Region             = "OIDC_S3_REGION"
+	TemplateParamOIDCS3CredsSecret        = "OIDC_S3_CREDS_SECRET"
+	TemplateParamOIDCS3CredsSecretKey     = "OIDC_S3_CREDS_SECRET_KEY"
+	TemplateParamAWSPrivateRegion         = "AWS_PRIVATE_REGION"
+	TemplateParamAWSPrivateCredsSecret    = "AWS_PRIVATE_CREDS_SECRET"
+	TemplateParamAWSPrivateCredsSecretKey = "AWS_PRIVATE_CREDS_SECRET_KEY"
+	TemplateParamOperatorReplicas         = "OPERATOR_REPLICAS"
 )
 
 func NewRenderCommand(opts *Options) *cobra.Command {
@@ -112,6 +115,19 @@ func hyperShiftOperatorTemplateManifest(opts *Options) (crclient.Object, error) 
 		opts.OIDCStorageProviderS3Region = fmt.Sprintf("${%s}", TemplateParamOIDCS3Region)
 		opts.OIDCStorageProviderS3CredentialsSecret = fmt.Sprintf("${%s}", TemplateParamOIDCS3CredsSecret)
 		opts.OIDCStorageProviderS3CredentialsSecretKey = fmt.Sprintf("${%s}", TemplateParamOIDCS3CredsSecretKey)
+	}
+
+	// aws private credentials
+	if opts.AWSPrivateCredentialsSecret != "" {
+		templateParameters = append(
+			templateParameters,
+			map[string]string{"name": TemplateParamAWSPrivateRegion, "value": opts.AWSPrivateRegion},
+			map[string]string{"name": TemplateParamAWSPrivateCredsSecret, "value": opts.AWSPrivateCredentialsSecret},
+			map[string]string{"name": TemplateParamAWSPrivateCredsSecretKey, "value": opts.AWSPrivateCredentialsSecretKey},
+		)
+		opts.AWSPrivateRegion = fmt.Sprintf("${%s}", TemplateParamAWSPrivateCredsSecret)
+		opts.AWSPrivateCredentialsSecret = fmt.Sprintf("${%s}", TemplateParamAWSPrivateCredsSecret)
+		opts.AWSPrivateCredentialsSecretKey = fmt.Sprintf("${%s}", TemplateParamAWSPrivateCredsSecretKey)
 	}
 
 	// create manifests

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -12,11 +12,27 @@ func TestOptions_Validate(t *testing.T) {
 		inputOptions Options
 		expectError  bool
 	}{
-		"when aws private platform without private creds and region it errors": {
+		"when aws private platform without private creds or secret reference and region it errors": {
 			inputOptions: Options{
 				PrivatePlatform: string(hyperv1.AWSPlatform),
 			},
 			expectError: true,
+		},
+		"when aws private platform with private creds and region there is no error": {
+			inputOptions: Options{
+				PrivatePlatform:  string(hyperv1.AWSPlatform),
+				AWSPrivateCreds:  "/path/to/credentials",
+				AWSPrivateRegion: "us-east-1",
+			},
+			expectError: false,
+		},
+		"when aws private platform with secret and region there is no error": {
+			inputOptions: Options{
+				PrivatePlatform:             string(hyperv1.AWSPlatform),
+				AWSPrivateCredentialsSecret: "my-secret",
+				AWSPrivateRegion:            "us-east-1",
+			},
+			expectError: false,
 		},
 		"when empty private platform is specified it errors": {
 			inputOptions: Options{},

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -301,7 +301,7 @@ objects:
           - --metrics-addr=:9000
           - --enable-ocp-cluster-monitoring=false
           - --enable-ci-debug-output=false
-          - --private-platform=None
+          - --private-platform=AWS
           - --oidc-storage-provider-s3-bucket-name=${OIDC_S3_NAME}
           - --oidc-storage-provider-s3-region=${OIDC_S3_REGION}
           - --oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/${OIDC_S3_CREDS_SECRET_KEY}
@@ -312,6 +312,12 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: AWS_SHARED_CREDENTIALS_FILE
+            value: /etc/provider/${AWS_PRIVATE_CREDS_SECRET_KEY}
+          - name: AWS_REGION
+            value: ${AWS_PRIVATE_CREDS_SECRET}
+          - name: AWS_SDK_LOAD_CONFIG
+            value: "1"
           image: ${OPERATOR_IMG}:${IMAGE_TAG}
           imagePullPolicy: Always
           livenessProbe:
@@ -351,12 +357,25 @@ objects:
           volumeMounts:
           - mountPath: /etc/oidc-storage-provider-s3-creds
             name: oidc-storage-provider-s3-creds
+          - mountPath: /etc/provider
+            name: credentials
+          - mountPath: /var/run/secrets/openshift/serviceaccount
+            name: token
         priorityClassName: hypershift-operator
         serviceAccountName: operator
         volumes:
         - name: oidc-storage-provider-s3-creds
           secret:
             secretName: ${OIDC_S3_CREDS_SECRET}
+        - name: credentials
+          secret:
+            secretName: ${AWS_PRIVATE_CREDS_SECRET}
+        - name: token
+          projected:
+            sources:
+            - serviceAccountToken:
+                audience: openshift
+                path: token
   status: {}
 - apiVersion: v1
   kind: Service
@@ -27881,6 +27900,12 @@ parameters:
 - name: OIDC_S3_CREDS_SECRET
   value: oidc-s3-creds
 - name: OIDC_S3_CREDS_SECRET_KEY
+  value: credentials
+- name: AWS_PRIVATE_REGION
+  value: eu-east-1
+- name: AWS_PRIVATE_CREDS_SECRET
+  value: aws-credentials
+- name: AWS_PRIVATE_CREDS_SECRET_KEY
   value: credentials
 - name: OPERATOR_REPLICAS
   value: "1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `hypershift install` options `--aws-private-secret` and `--aws-private-secret-key` to specify an existing Kubernetes secret and key name for the AWS shared credentials file. The existing `--aws-private-creds` flag (which creates the secret on the user's behalf) is unaffected. These options are helpful in scenarios when the secret is provided by other means. Also, when the installation template is rendered to a file, it should not contain secrets.

The template generated by `hypershift install render --template` was changed to provide parameters for those CLI options, namely `AWS_PRIVATE_REGION`, `AWS_PRIVATE_CREDS_SECRET` and `AWS_PRIVATE_CREDS_SECRET_KEY`.

A similar change has been implemented for the OIDC bucket credentials secret in https://github.com/openshift/hypershift/pull/949

Part of https://issues.redhat.com/browse/HOSTEDCP-415