### PR TITLE
Use pod based ign payload generator on AWS

### DIFF
--- a/test/e2e/util/dump/journals.go
+++ b/test/e2e/util/dump/journals.go
@@ -133,6 +133,8 @@ func DumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 	outputDir := filepath.Join(artifactDir, "machine-journals")
 	scriptCmd := exec.Command(copyJournalFile.Name(), outputDir)
 	env := os.Environ()
+	env = append(env, fmt.Sprintf("AWS_SHARED_CREDENTIALS_FILE=%s", awsCreds))
+	env = append(env, fmt.Sprintf("INFRAID=%s", hc.Spec.InfraID))
 	env = append(env, fmt.Sprintf("BASTION_IP=%s", bastionIP))
 	env = append(env, fmt.Sprintf("INSTANCE_IPS=%s", strings.Join(machineIPs, " ")))
 	env = append(env, fmt.Sprintf("SSH_PRIVATE_KEY=%s", privateKeyFile))


### PR DESCRIPTION
Commit 7712095 introduced a new ignition payload provider which has some
performance regression on AWS that has not yet been identified and fixed,
causing CI instability.

This commit reverts the provider implementation on AWS back to the old
implementation until the problem is solved.
