### PR TITLE
E2E: Add TestNodepoolMachineconfigGetsRolledout

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -119,7 +119,7 @@ type NodePoolSpec struct {
 	// MachineConfig resources to be injected into the ignition configurations of
 	// nodes in the NodePool. The MachineConfig API schema is defined here:
 	//
-	// https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172
+	// https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
 	//
 	// Each ConfigMap must have a single key named "config" whose value is the
 	// JSON or YAML of a serialized MachineConfig.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -105,7 +105,7 @@ spec:
                 description: "Config is a list of references to ConfigMaps containing
                   serialized MachineConfig resources to be injected into the ignition
                   configurations of nodes in the NodePool. The MachineConfig API schema
-                  is defined here: \n https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172
+                  is defined here: \n https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
                   \n Each ConfigMap must have a single key named \"config\" whose
                   value is the JSON or YAML of a serialized MachineConfig."
                 items:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -639,7 +639,7 @@ NodePoolAutoScaling
 <p>Config is a list of references to ConfigMaps containing serialized
 MachineConfig resources to be injected into the ignition configurations of
 nodes in the NodePool. The MachineConfig API schema is defined here:</p>
-<p><a href="https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172">https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172</a></p>
+<p><a href="https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185">https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185</a></p>
 <p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the
 JSON or YAML of a serialized MachineConfig.</p>
 </td>
@@ -4751,7 +4751,7 @@ NodePoolAutoScaling
 <p>Config is a list of references to ConfigMaps containing serialized
 MachineConfig resources to be injected into the ignition configurations of
 nodes in the NodePool. The MachineConfig API schema is defined here:</p>
-<p><a href="https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172">https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172</a></p>
+<p><a href="https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185">https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185</a></p>
 <p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the
 JSON or YAML of a serialized MachineConfig.</p>
 </td>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -22625,7 +22625,7 @@ objects:
                   description: "Config is a list of references to ConfigMaps containing
                     serialized MachineConfig resources to be injected into the ignition
                     configurations of nodes in the NodePool. The MachineConfig API
-                    schema is defined here: \n https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L172
+                    schema is defined here: \n https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
                     \n Each ConfigMap must have a single key named \"config\" whose
                     value is the JSON or YAML of a serialized MachineConfig."
                   items:

--- a/support/api/scheme.go
+++ b/support/api/scheme.go
@@ -10,6 +10,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -62,4 +63,5 @@ func init() {
 	v1alpha1.AddToScheme(Scheme)
 	apiserverconfigv1.AddToScheme(Scheme)
 	prometheusoperatorv1.AddToScheme(Scheme)
+	mcfgv1.AddToScheme(Scheme)
 }

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -1,0 +1,204 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	hyperapi "github.com/openshift/hypershift/support/api"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilpointer "k8s.io/utils/pointer"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/yaml"
+)
+
+func TestNodepoolMachineconfigGetsRolledout(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
+
+	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
+	clusterOpts.BeforeApply = func(o crclient.Object) {
+		nodePool, isNodepool := o.(*hyperv1.NodePool)
+		if !isNodepool {
+			return
+		}
+		nodePool.Spec.Management.Replace = &hyperv1.ReplaceUpgrade{
+			Strategy: hyperv1.UpgradeStrategyRollingUpdate,
+			RollingUpdate: &hyperv1.RollingUpdate{
+				MaxUnavailable: func(v intstr.IntOrString) *intstr.IntOrString { return &v }(intstr.FromInt(0)),
+				MaxSurge:       func(v intstr.IntOrString) *intstr.IntOrString { return &v }(intstr.FromInt(int(*nodePool.Spec.Replicas))),
+			},
+		}
+	}
+
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+
+	// Sanity check the cluster by waiting for the nodes to report ready
+	t.Logf("Waiting for guest client to become available")
+	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
+
+	// Wait for Nodes to be Ready
+	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
+
+	// Wait for the rollout to be complete
+	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
+	e2eutil.WaitForImageRollout(t, testContext, client, guestClient, hostedCluster, globalOpts.LatestReleaseImage)
+	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+
+	ignitionConfig := ignitionapi.Config{
+		Ignition: ignitionapi.Ignition{
+			Version: "3.2.0",
+		},
+		Storage: ignitionapi.Storage{
+			Files: []ignitionapi.File{{
+				Node:          ignitionapi.Node{Path: "/etc/custom-config"},
+				FileEmbedded1: ignitionapi.FileEmbedded1{Contents: ignitionapi.Resource{Source: utilpointer.String("data:,content%0A")}},
+			}},
+		},
+	}
+	serializedIgnitionConfig, err := json.Marshal(ignitionConfig)
+	if err != nil {
+		t.Fatalf("failed to serialize ignition config: %v", err)
+	}
+	machineConfig := &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "custom",
+			Labels: map[string]string{"machineconfiguration.openshift.io/role": "worker"},
+		},
+		Spec: mcfgv1.MachineConfigSpec{Config: runtime.RawExtension{Raw: serializedIgnitionConfig}},
+	}
+	gvk, err := apiutil.GVKForObject(machineConfig, hyperapi.Scheme)
+	if err != nil {
+		t.Fatalf("failed to get typeinfo for %T from scheme: %v", machineConfig, err)
+	}
+	machineConfig.SetGroupVersionKind(gvk)
+	serializedMachineConfig, err := yaml.Marshal(machineConfig)
+	if err != nil {
+		t.Fatalf("failed to serialize machineConfig: %v", err)
+	}
+	machineConfigConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "custom-machine-config",
+			Namespace: hostedCluster.Namespace,
+		},
+		Data: map[string]string{"config": string(serializedMachineConfig)},
+	}
+	if err := client.Create(ctx, machineConfigConfigMap); err != nil {
+		t.Fatalf("failed to create configmap for custom machineconfig: %v", err)
+	}
+
+	nodepools := &hyperv1.NodePoolList{}
+	if err := client.List(ctx, nodepools, crclient.InNamespace(hostedCluster.Namespace)); err != nil {
+		t.Fatalf("failed to list nodepools in namespace %s: %v", hostedCluster.Namespace, err)
+	}
+
+	for _, nodepool := range nodepools.Items {
+		if !ownedBy(hostedCluster.UID, nodepool.OwnerReferences) {
+			continue
+		}
+		nodepool.Spec.Config = append(nodepool.Spec.Config, corev1.LocalObjectReference{Name: machineConfigConfigMap.Name})
+		if err := client.Update(ctx, &nodepool); err != nil {
+			t.Fatalf("failed to update nodepool %s after adding machineconfig: %v", nodepool.Name, err)
+		}
+	}
+
+	ds := machineConfigUpdatedVerificationDS.DeepCopy()
+	if err := guestClient.Create(ctx, ds); err != nil {
+		t.Fatalf("failed to create %s DaemonSet in guestcluster: %v", ds.Name, err)
+	}
+
+	t.Logf("waiting for rollout of updated nodepools")
+	err = wait.PollImmediateWithContext(ctx, 5*time.Second, 15*time.Minute, func(ctx context.Context) (bool, error) {
+		if ctx.Err() != nil {
+			return false, err
+		}
+		pods := &corev1.PodList{}
+		if err := guestClient.List(ctx, pods, crclient.InNamespace(ds.Namespace), crclient.MatchingLabels(ds.Spec.Selector.MatchLabels)); err != nil {
+			t.Logf("WARNING: failed to list pods, will retry: %v", err)
+			return false, nil
+		}
+		nodes := &corev1.NodeList{}
+		if err := guestClient.List(ctx, nodes); err != nil {
+			t.Logf("WARNING: failed to list nodes, will retry: %v", err)
+			return false, nil
+		}
+		if len(pods.Items) != len(nodes.Items) {
+			return false, nil
+		}
+
+		for _, pod := range pods.Items {
+			if !isPodReady(&pod) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed waiting for all pods in the machine config update verification DS to be ready: %v", err)
+	}
+
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
+	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+	e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, ctx, client, hostedCluster)
+	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, client, hostedCluster)
+	e2eutil.EnsureNoPodsWithTooHighPriority(t, ctx, client, hostedCluster)
+}
+
+func ownedBy(uid types.UID, ownerRefs []metav1.OwnerReference) bool {
+	for _, ownerRef := range ownerRefs {
+		if ownerRef.UID == uid {
+			return true
+		}
+	}
+
+	return false
+}
+
+//go:embed nodepool_machineconfig_verification_ds.yaml
+var machineConfigUpdatedVerificationDSRaw []byte
+
+var machineConfigUpdatedVerificationDS = func() *appsv1.DaemonSet {
+	ds := &appsv1.DaemonSet{}
+	if err := yaml.Unmarshal(machineConfigUpdatedVerificationDSRaw, &ds); err != nil {
+		panic(err)
+	}
+	return ds
+}()
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}

--- a/test/e2e/nodepool_machineconfig_verification_ds.yaml
+++ b/test/e2e/nodepool_machineconfig_verification_ds.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: machineconfig-update-checker
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: machineconfig-update-checker
+  template:
+    metadata:
+      labels:
+        name: machineconfig-update-checker
+    spec:
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: machineconfig-update-checker
+        image: alpine
+        command:
+        - /bin/sleep
+        - 24h
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        readinessProbe:
+          exec:
+            command:
+            - /bin/cat
+            - /host/etc/custom-config
+        volumeMounts:
+        - name: host
+          mountPath: /host
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: host
+        hostPath:
+          path: /


### PR DESCRIPTION
This adds a new test that checks if a nodepool rolls out additional
machine configs. It works by:
* Creating a cluster inclusive nodes and waiting for everything to be
  ready
* Adding an additional machineconfig to all nodepools of the cluster
  that specifies to create a file /etc/custom-config
* Deploying a daemonset whose readyness probe does an exec to cat this
  new file
* Waiting until the daemonset has as many pods as there are nodes and
  for all those pods to be ready

Ref https://issues.redhat.com/browse/HOSTEDCP-412

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.