### PR TITLE
Change webhook to implement webhook.CustomValidator

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -1,0 +1,91 @@
+package hostedcluster
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// Webhook implements a validating webhook for HostedCluster.
+type Webhook struct{}
+
+// SetupWebhookWithManager sets up HostedCluster webhooks.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&hyperv1.HostedCluster{}).
+		WithValidator(&Webhook{}).
+		Complete()
+}
+
+var _ webhook.CustomValidator = &Webhook{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *Webhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	newHC, ok := newObj.(*hyperv1.HostedCluster)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a HostedCluster but got a %T", newObj))
+	}
+
+	oldHC, ok := oldObj.(*hyperv1.HostedCluster)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a HostedCluster but got a %T", oldObj))
+	}
+
+	return validateHostedClusterUpdate(newHC, oldHC)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *Webhook) ValidateDelete(_ context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func filterMutableHostedClusterSpecFields(spec *hyperv1.HostedClusterSpec) {
+	spec.Release.Image = ""
+	spec.ClusterID = ""
+	spec.InfraID = ""
+	spec.Configuration = nil
+	spec.AdditionalTrustBundle = nil
+	spec.SecretEncryption = nil
+	spec.PausedUntil = nil
+	for i, svc := range spec.Services {
+		if svc.Type == hyperv1.NodePort && svc.NodePort != nil {
+			spec.Services[i].NodePort.Address = ""
+			spec.Services[i].NodePort.Port = 0
+		}
+	}
+	if spec.Platform.Type == hyperv1.AWSPlatform && spec.Platform.AWS != nil {
+		spec.Platform.AWS.ResourceTags = nil
+	}
+}
+
+func validateHostedClusterUpdate(new *hyperv1.HostedCluster, old *hyperv1.HostedCluster) error {
+	filterMutableHostedClusterSpecFields(&new.Spec)
+	filterMutableHostedClusterSpecFields(&old.Spec)
+
+	// We default the port in Azure management cluster, so we allow setting it from being unset, but no updates.
+	if new.Spec.Networking.APIServer != nil && (old.Spec.Networking.APIServer == nil || old.Spec.Networking.APIServer.Port == nil) {
+		if old.Spec.Networking.APIServer == nil {
+			old.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{}
+		}
+		old.Spec.Networking.APIServer.Port = new.Spec.Networking.APIServer.Port
+	}
+	// TODO (alberto): use equality semantic
+	if !reflect.DeepEqual(new.Spec, old.Spec) {
+		// TODO (alberto): leverage k8s.io/apimachinery/pkg/api/errors and k8s.io/apimachinery/pkg/util/validation/field
+		// to return granular and meaningful output per field.
+		return fmt.Errorf("attempted change to immutable field(s)")
+	}
+
+	return nil
+}

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -19,9 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
-	"reflect"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -41,7 +39,6 @@ import (
 	"github.com/openshift/hypershift/support/util"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
-	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
@@ -52,8 +49,6 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func main() {
@@ -229,8 +224,9 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}
 	if opts.CertDir != "" {
-		hookServer := mgr.GetWebhookServer()
-		hookServer.Register("/validate-hypershift-openshift-io-v1alpha1-hostedcluster", &webhook.Admission{Handler: &hostedClusterValidator{}})
+		if err := hostedcluster.SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create webhook: %w", err)
+		}
 	}
 
 	if err := (&nodepool.NodePoolReconciler{
@@ -314,84 +310,4 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	// Start the controllers
 	log.Info("starting manager")
 	return mgr.Start(ctx)
-}
-
-type hostedClusterValidator struct {
-	decoder *admission.Decoder
-}
-
-var _ admission.Handler = &hostedClusterValidator{}
-
-func (v *hostedClusterValidator) Handle(_ context.Context, req admission.Request) admission.Response {
-	new := &hyperv1.HostedCluster{}
-	err := v.decoder.DecodeRaw(req.Object, new)
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-	old := &hyperv1.HostedCluster{}
-	err = v.decoder.DecodeRaw(req.OldObject, old)
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-	switch req.Operation {
-	case admissionv1.Create:
-		return validateHostedClusterCreate(new.DeepCopy())
-	case admissionv1.Update:
-		return validateHostedClusterUpdate(old.DeepCopy(), new.DeepCopy())
-	case admissionv1.Delete:
-		return validateHostedClusterDelete(old.DeepCopy())
-	default:
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("bad operation"))
-	}
-}
-
-var _ admission.DecoderInjector = &hostedClusterValidator{}
-
-func (v *hostedClusterValidator) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
-	return nil
-}
-
-func validateHostedClusterCreate(hc *hyperv1.HostedCluster) admission.Response {
-	return admission.Allowed("")
-}
-
-func filterMutableHostedClusterSpecFields(spec *hyperv1.HostedClusterSpec) {
-	spec.Release.Image = ""
-	spec.ClusterID = ""
-	spec.InfraID = ""
-	spec.Configuration = nil
-	spec.AdditionalTrustBundle = nil
-	spec.SecretEncryption = nil
-	spec.PausedUntil = nil
-	for i, svc := range spec.Services {
-		if svc.Type == hyperv1.NodePort && svc.NodePort != nil {
-			spec.Services[i].NodePort.Address = ""
-			spec.Services[i].NodePort.Port = 0
-		}
-	}
-	if spec.Platform.Type == hyperv1.AWSPlatform && spec.Platform.AWS != nil {
-		spec.Platform.AWS.ResourceTags = nil
-	}
-}
-
-func validateHostedClusterUpdate(new *hyperv1.HostedCluster, old *hyperv1.HostedCluster) admission.Response {
-	filterMutableHostedClusterSpecFields(&new.Spec)
-	filterMutableHostedClusterSpecFields(&old.Spec)
-
-	// We default the port in Azure management cluster  so we allow setting it from being unset, but no updates.
-	if new.Spec.Networking.APIServer != nil && (old.Spec.Networking.APIServer == nil || old.Spec.Networking.APIServer.Port == nil) {
-		if old.Spec.Networking.APIServer == nil {
-			old.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{}
-		}
-		old.Spec.Networking.APIServer.Port = new.Spec.Networking.APIServer.Port
-	}
-	if !reflect.DeepEqual(new.Spec, old.Spec) {
-		return admission.Denied("attempted change to immutable field(s)")
-	}
-	return admission.Allowed("")
-}
-
-func validateHostedClusterDelete(hc *hyperv1.HostedCluster) admission.Response {
-	return admission.Allowed("")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This give us the ability to:
Scope different webhooks to packages/files so the main does not grow indefinitely.
Reusing controller runtime interface.
Drop unnecessary existing logic in main.
Give a consistent way to share validation logic from controllers which does not necessarily need to be exported.
i.e Sustainable code structure.

Since we want to implement the CR outside the the API package we create a mock Webhook struct for HostedCluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.