### PR TITLE
fix panic due to race on hosted API cache start

### DIFF
--- a/control-plane-operator/controllers/hostedapicache/cache.go
+++ b/control-plane-operator/controllers/hostedapicache/cache.go
@@ -189,13 +189,13 @@ func (h *hostedAPICache) update(requestCtx context.Context, triggerObj client.Ob
 	h.kubeConfig = newKubeConfig
 
 	// Start the new cache
-	go func() {
-		if err := h.cache.Start(newCacheCtx); err != nil {
+	go func(cache cache.Cache) {
+		if err := cache.Start(newCacheCtx); err != nil {
 			h.log.Error(err, "failed to start hosted api cache")
 		} else {
 			h.log.Info("hosted api cache gracefully stopped")
 		}
-	}()
+	}(h.cache)
 
 	h.log.Info("rebuilt api cache")
 	return nil


### PR DESCRIPTION


**What this PR does / why we need it**:

Fixes panic at https://github.com/openshift/hypershift/blob/aa2c387cc511ca83b6c7b4af120928b32f5eb654/control-plane-operator/controllers/hostedapicache/cache.go#L193

`h.cache` is nil because `destroy()` was called on it from `controller.secret`

CPO logs
```
{"level":"info","ts":"2022-05-05T09:58:23-05:00","logger":"hosted-api-cache","msg":"rebuilt api cache"}
{"level":"info","ts":"2022-05-05T09:58:23-05:00","logger":"controller.secret","msg":"destroying hosted API cache because kubeconfig secret is missing","reconciler group":"","reconciler kind":"Secret","name":"admin-kubeconfig","namespace":"clusters-sjenning-example"}
```

Passing `h.cache` to the goroutine while still holding the lock fixes this.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.