### PR TITLE
AWS: Deploy Pod Identity Webhook

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -35,6 +35,12 @@ func ReconcileIngressOperatorKubeconfigSecret(secret, ca *corev1.Secret, ownerRe
 	return reconcileKubeconfig(secret, secret, ca, svcURL, "", "ingress-operator", ownerRef)
 }
 
+func ReconcileAWSPodIdentityWebhookKubeconfigSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, apiServerPort int32) error {
+	svcURL := InClusterKASURL(secret.Namespace, apiServerPort)
+	// The secret that holds the kubeconfig and the one that holds the certs are the same
+	return reconcileKubeconfig(secret, secret, ca, svcURL, "", "aws-pod-identity-webhook", ownerRef)
+}
+
 func InClusterKASURL(namespace string, apiServerPort int32) string {
 	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, apiServerPort)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -19,13 +19,14 @@ import (
 )
 
 type KubeAPIServerImages struct {
-	ClusterConfigOperator string `json:"clusterConfigOperator"`
-	CLI                   string `json:"cli"`
-	HyperKube             string `json:"hyperKube"`
-	IBMCloudKMS           string `json:"ibmcloudKMS"`
-	AWSKMS                string `json:"awsKMS"`
-	Portieris             string `json:"portieris"`
-	TokenMinterImage      string
+	ClusterConfigOperator      string `json:"clusterConfigOperator"`
+	CLI                        string `json:"cli"`
+	HyperKube                  string `json:"hyperKube"`
+	IBMCloudKMS                string `json:"ibmcloudKMS"`
+	AWSKMS                     string `json:"awsKMS"`
+	Portieris                  string `json:"portieris"`
+	TokenMinterImage           string
+	AWSPodIdentityWebhookImage string
 }
 
 type KubeAPIServerParams struct {
@@ -88,11 +89,12 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		ConsolePublicURL:     fmt.Sprintf("https://console-openshift-console.%s", dns.Spec.BaseDomain),
 
 		Images: KubeAPIServerImages{
-			HyperKube:             images["hyperkube"],
-			CLI:                   images["cli"],
-			ClusterConfigOperator: images["cluster-config-operator"],
-			TokenMinterImage:      images["token-minter"],
-			AWSKMS:                images["aws-kms-provider"],
+			HyperKube:                  images["hyperkube"],
+			CLI:                        images["cli"],
+			ClusterConfigOperator:      images["cluster-config-operator"],
+			TokenMinterImage:           images["token-minter"],
+			AWSKMS:                     images["aws-kms-provider"],
+			AWSPodIdentityWebhookImage: images["aws-pod-identity-webhook"],
 		},
 	}
 	if hcp.Spec.APIAdvertiseAddress != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/aws.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/aws.go
@@ -13,3 +13,12 @@ func AWSProviderConfig(ns string) *corev1.ConfigMap {
 		},
 	}
 }
+
+func AWSPodIdentityWebhookKubeconfig(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-pod-identity-webhook-kubeconfig",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -301,3 +301,12 @@ func ClusterVersionOperatorServerCertSecret(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func AWSPodIdentityWebhookServingCert(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-pod-identity-webhook-serving-cert",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/aws_pod_identity_webhook.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/aws_pod_identity_webhook.go
@@ -1,0 +1,10 @@
+package pki
+
+import (
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ReconcileAWSPodIdentityWebhookServingCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "127.0.0.1", nil, X509UsageClientServerAuth, nil, []string{"127.0.0.1"})
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -70,6 +70,10 @@ func ReconcileIngressOperatorClientCertSecret(secret, ca *corev1.Secret, ownerRe
 	return reconcileSignedCert(secret, ca, ownerRef, "system:serviceaccount:openshift-ingress-operator:ingress-operator", []string{"system:serviceaccounts"}, X509UsageClientServerAuth)
 }
 
+func ReconcileAWSPodIdentityWebhookClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSignedCert(secret, ca, ownerRef, "system:serviceaccount:openshift-authentication:aws-pod-identity-webhook", []string{"system:serviceaccounts"}, X509UsageClientServerAuth)
+}
+
 func nextIP(ip net.IP) net.IP {
 	nextIP := net.IP(make([]byte, len(ip)))
 	copy(nextIP, ip)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/aws_pod_identity_webhook.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/aws_pod_identity_webhook.go
@@ -1,0 +1,31 @@
+package manifests
+
+import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func AWSPodIdentityWebhook() *admissionregistrationv1.MutatingWebhookConfiguration {
+	return &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aws-pod-identity",
+		},
+	}
+}
+
+func AWSPodIdentityWebhookClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aws-pod-identity-webhook",
+		},
+	}
+}
+
+func AWSPodIdentityWebhookClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aws-pod-identity-webhook",
+		},
+	}
+}


### PR DESCRIPTION
This change makes us deploy the AWS Pod Identity Webhook in the
management cluster for AWS clusters. It is comprised of:

* Deploying the webhook as sidecar to the KAS for AWS clusters: Why
  sidecar? Because that is both the easiest and fastest, as we avoid a
  bunch of network hops
* Minting a serving cert for the webhook
* Minging a kubeconfig for the webhook
* Setting up rbac for the kubeconfig
* Setting up the MutatignWebhookconfiguration

Sample usage:

Create a ServiceAccount with sts annotations:

```yaml
apiVersion: v1
imagePullSecrets:
- name: default-dockercfg-64n54
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/s3-reader
    eks.amazonaws.com/token-expiration: "86400"
  creationTimestamp: "2022-05-05T17:19:03Z"
  name: default
  namespace: default
  resourceVersion: "46637"
  uid: 4802aef9-a7c6-4daf-9d36-c4c923ef73d1
secrets:
- name: default-token-7p5sc
- name: default-dockercfg-64n54
```

Notice how pods that use that SA get env vars and a token volume:

```
$ k get pod nginx-85b98978db-8ts7w -ojson|jq '{"env": .spec.containers[0].env, "volumeMounts": .spec.containers[0].volumeMounts, "volume": .spec.volumes[0]}'|json2yaml
env:
- name: AWS_DEFAULT_REGION
  value: ca-central-1
- name: AWS_REGION
  value: ca-central-1
- name: AWS_ROLE_ARN
  value: arn:aws:iam::111122223333:role/s3-reader
- name: AWS_WEB_IDENTITY_TOKEN_FILE
  value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
volume:
  name: aws-iam-token
  projected:
    defaultMode: 420
    sources:
    - serviceAccountToken:
        audience: openshift
        expirationSeconds: 86400
        path: token
volumeMounts:
- mountPath: /var/run/secrets/kubernetes.io/serviceaccount
  name: kube-api-access-426sh
  readOnly: true
- mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
  name: aws-iam-token
  readOnly: true

```

Ref https://issues.redhat.com/browse/HOSTEDCP-205

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.