### PR TITLE
Autodetect KubeVirt disk image using release payload

### DIFF
--- a/api/fixtures/example_kubevirt.go
+++ b/api/fixtures/example_kubevirt.go
@@ -17,9 +17,6 @@ func ExampleKubeVirtTemplate(o *ExampleKubevirtOptions) *hyperv1.KubevirtNodePoo
 
 	exampleTemplate := &hyperv1.KubevirtNodePoolPlatform{
 		RootVolume: &hyperv1.KubevirtRootVolume{
-			Image: &hyperv1.KubevirtDiskImage{
-				ContainerDiskImage: &o.Image,
-			},
 			KubevirtVolume: hyperv1.KubevirtVolume{
 				Type: hyperv1.KubevirtVolumeTypePersistent,
 				Persistent: &hyperv1.KubevirtPersistentVolume{
@@ -37,6 +34,12 @@ func ExampleKubeVirtTemplate(o *ExampleKubevirtOptions) *hyperv1.KubevirtNodePoo
 	}
 	if o.Cores != 0 {
 		exampleTemplate.Compute.Cores = &o.Cores
+	}
+
+	if o.Image != "" {
+		exampleTemplate.RootVolume.Image = &hyperv1.KubevirtDiskImage{
+			ContainerDiskImage: &o.Image,
+		}
 	}
 
 	return exampleTemplate

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -12,6 +12,7 @@ const (
 	NodePoolValidReleaseImageConditionType       = "ValidReleaseImage"
 	NodePoolValidAMIConditionType                = "ValidAMI"
 	NodePoolValidPowerVSImageConditionType       = "ValidPowerVSImage"
+	NodePoolValidKubeVirtImageConditionType      = "ValidKubeVirtImage"
 	NodePoolValidMachineConfigConditionType      = "ValidMachineConfig"
 	NodePoolValidKubevirtConfigConditionType     = "ValidKubevirtConfig"
 	NodePoolUpdateManagementEnabledConditionType = "UpdateManagementEnabled"
@@ -451,7 +452,9 @@ type KubevirtPersistentVolume struct {
 // KubevirtRootVolume represents the volume that the rhcos disk will be stored and run from.
 type KubevirtRootVolume struct {
 	// Image represents what rhcos image to use for the node pool
-	Image *KubevirtDiskImage `json:"diskImage"`
+	//
+	// +optional
+	Image *KubevirtDiskImage `json:"diskImage,omitempty"`
 
 	// KubevirtVolume represents of type of storage to run the image on
 	KubevirtVolume `json:",inline"`
@@ -487,7 +490,9 @@ type KubevirtVolume struct {
 // KubevirtDiskImage contains values representing where the rhcos image is located
 type KubevirtDiskImage struct {
 	// ContainerDiskImage is a string representing the container image that holds the root disk
-	ContainerDiskImage *string `json:"containerDiskImage"`
+	//
+	// +optional
+	ContainerDiskImage *string `json:"containerDiskImage,omitempty"`
 }
 
 // KubevirtNodePoolPlatform specifies the configuration of a NodePool when operating

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -74,16 +74,6 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		}
 	}
 
-	if opts.NodePoolReplicas > -1 {
-		// TODO (nargaman): replace with official container image, after RFE-2501 is completed
-		// As long as there is no official container image
-		// The image must be provided by user
-		// Otherwise it must fail
-		if opts.KubevirtPlatform.ContainerDiskImage == "" {
-			return errors.New("the container disk image for the Kubevirt machine must be provided by user (\"--containerdisk\" flag)")
-		}
-	}
-
 	if opts.KubevirtPlatform.Cores < 1 {
 		return errors.New("the number of cores inside the machine must be a value greater or equal 1")
 	}

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -485,8 +485,6 @@ spec:
                                 description: ContainerDiskImage is a string representing
                                   the container image that holds the root disk
                                 type: string
-                            required:
-                            - containerDiskImage
                             type: object
                           persistent:
                             description: Persistent volume type means the VM's storage
@@ -516,8 +514,6 @@ spec:
                             enum:
                             - Persistent
                             type: string
-                        required:
-                        - diskImage
                         type: object
                     required:
                     - rootVolume

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3896,6 +3896,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ContainerDiskImage is a string representing the container image that holds the root disk</p>
 </td>
 </tr>
@@ -4017,6 +4018,7 @@ KubevirtDiskImage
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Image represents what rhcos image to use for the node pool</p>
 </td>
 </tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -23011,8 +23011,6 @@ objects:
                                   description: ContainerDiskImage is a string representing
                                     the container image that holds the root disk
                                   type: string
-                              required:
-                              - containerDiskImage
                               type: object
                             persistent:
                               description: Persistent volume type means the VM's storage
@@ -23042,8 +23040,6 @@ objects:
                               enum:
                               - Persistent
                               type: string
-                          required:
-                          - diskImage
                           type: object
                       required:
                       - rootVolume

--- a/hypershift-operator/controllers/nodepool/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt_test.go
@@ -1,7 +1,6 @@
 package nodepool
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -45,7 +44,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 			expected: &capikubevirt.KubevirtMachineTemplateSpec{
 				Template: capikubevirt.KubevirtMachineTemplateResource{
 					Spec: capikubevirt.KubevirtMachineSpec{
-						VirtualMachineTemplate: *generateNodeTemplate("5Gi", 4, "testimage", "32Gi"),
+						VirtualMachineTemplate: *generateNodeTemplate("5Gi", 4, "docker://testimage", "32Gi"),
 					},
 				},
 			},
@@ -58,7 +57,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 			err := kubevirtPlatformValidation(tc.nodePool)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			result := kubevirtMachineTemplateSpec(tc.nodePool)
+			result := kubevirtMachineTemplateSpec("", tc.nodePool)
 			if !equality.Semantic.DeepEqual(tc.expected, result) {
 				t.Errorf(cmp.Diff(tc.expected, result))
 			}
@@ -95,7 +94,6 @@ func generateKubevirtPlatform(memory string, cores uint32, image string, volumeS
 func generateNodeTemplate(memory string, cpu uint32, image string, volumeSize string) *capikubevirt.VirtualMachineTemplateSpec {
 	runAlways := kubevirtv1.RunStrategyAlways
 	guestQuantity := apiresource.MustParse(memory)
-	imageContainerURL := fmt.Sprintf("docker://%s", image)
 	volumeSizeQuantity := apiresource.MustParse(volumeSize)
 	nodePoolNameLabelKey := "hypershift.kubevirt.io/node-pool-name"
 	pullMethod := v1beta1.RegistryPullNode
@@ -117,7 +115,7 @@ func generateNodeTemplate(memory string, cpu uint32, image string, volumeSize st
 					Spec: v1beta1.DataVolumeSpec{
 						Source: &v1beta1.DataVolumeSource{
 							Registry: &v1beta1.DataVolumeSourceRegistry{
-								URL:        &imageContainerURL,
+								URL:        &image,
 								PullMethod: &pullMethod,
 							},
 						},

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -424,6 +424,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	// Validate KubeVirt platform specific format
+	var kubevirtBootImage string
 	if nodePool.Spec.Platform.Type == hyperv1.KubevirtPlatform {
 		if err := kubevirtPlatformValidation(nodePool); err != nil {
 			setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
@@ -436,6 +437,25 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			return ctrl.Result{}, fmt.Errorf("validation of NodePool KubeVirt platform failed: %w", err)
 		}
 		removeStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolValidKubevirtConfigConditionType)
+
+		kubevirtBootImage, err = getKubeVirtImage(nodePool, releaseImage)
+		if err != nil {
+			setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+				Type:               hyperv1.NodePoolValidKubeVirtImageConditionType,
+				Status:             corev1.ConditionFalse,
+				Reason:             hyperv1.NodePoolValidationFailedConditionReason,
+				Message:            fmt.Sprintf("Couldn't discover an KubeVirt Image for release image %q: %s", nodePool.Spec.Release.Image, err.Error()),
+				ObservedGeneration: nodePool.Generation,
+			})
+			return ctrl.Result{}, fmt.Errorf("couldn't discover an KubeVirt disk image in release payload image: %w", err)
+		}
+		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolValidKubeVirtImageConditionType,
+			Status:             corev1.ConditionTrue,
+			Reason:             hyperv1.NodePoolAsExpectedConditionReason,
+			Message:            fmt.Sprintf("Bootstrap KubeVirt Image is %q", kubevirtBootImage),
+			ObservedGeneration: nodePool.Generation,
+		})
 	}
 
 	// Validate config input.
@@ -600,7 +620,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	// Reconcile (Platform)MachineTemplate.
-	template, mutateTemplate, machineTemplateSpecJSON, err := machineTemplateBuilders(hcluster, nodePool, infraID, ami, powervsBootImage)
+	template, mutateTemplate, machineTemplateSpecJSON, err := machineTemplateBuilders(hcluster, nodePool, infraID, ami, powervsBootImage, kubevirtBootImage)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -1280,6 +1300,27 @@ func defaultNodePoolAMI(region string, releaseImage *releaseinfo.ReleaseImage) (
 	return regionData.Image, nil
 }
 
+func defaultKubeVirtImage(releaseImage *releaseinfo.ReleaseImage) (string, error) {
+	arch, foundArch := releaseImage.StreamMetadata.Architectures["x86_64"]
+	if !foundArch {
+		return "", fmt.Errorf("couldn't find OS metadata for architecture %q", "x64_64")
+	}
+	openStack, exists := arch.Artifacts["openstack"]
+	if !exists {
+		return "", fmt.Errorf("couldn't find OS metadata for openstack")
+	}
+	artifact, exists := openStack.Formats["qcow2.gz"]
+	if !exists {
+		return "", fmt.Errorf("couldn't find OS metadata for openstack qcow2.gz")
+	}
+	disk, exists := artifact["disk"]
+	if !exists {
+		return "", fmt.Errorf("couldn't find OS metadata for the openstack qcow2.gz disk")
+	}
+
+	return disk.Location, nil
+}
+
 // MachineDeploymentComplete considers a MachineDeployment to be complete once all of its desired replicas
 // are updated and available, and no old machines are running.
 func MachineDeploymentComplete(deployment *capiv1.MachineDeployment) bool {
@@ -1543,7 +1584,7 @@ func isPlatformNone(nodePool *hyperv1.NodePool) bool {
 // a func to mutate the (platform)MachineTemplate.spec, a json string representation for (platform)MachineTemplate.spec
 // and an error.
 func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.NodePool,
-	infraID, ami, powervsBootImage string) (client.Object, func(object client.Object) error, string, error) {
+	infraID, ami, powervsBootImage, kubevirtBootImage string) (client.Object, func(object client.Object) error, string, error) {
 	var mutateTemplate func(object client.Object) error
 	var template client.Object
 	var machineTemplateSpec interface{}
@@ -1576,7 +1617,7 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 		}
 	case hyperv1.KubevirtPlatform:
 		template = &capikubevirt.KubevirtMachineTemplate{}
-		machineTemplateSpec = kubevirtMachineTemplateSpec(nodePool)
+		machineTemplateSpec = kubevirtMachineTemplateSpec(kubevirtBootImage, nodePool)
 		mutateTemplate = func(object client.Object) error {
 			o, _ := object.(*capikubevirt.KubevirtMachineTemplate)
 			o.Spec = *machineTemplateSpec.(*capikubevirt.KubevirtMachineTemplateSpec)

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -919,7 +919,7 @@ func RunTestMachineTemplateBuilders(t *testing.T, preCreateMachineTemplate bool)
 	expectedMachineTemplateSpecJSON, err := json.Marshal(expectedMachineTemplate.Spec)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	template, mutateTemplate, machineTemplateSpecJSON, err := machineTemplateBuilders(hcluster, nodePool, infraID, ami, "")
+	template, mutateTemplate, machineTemplateSpecJSON, err := machineTemplateBuilders(hcluster, nodePool, infraID, ami, "", "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(machineTemplateSpecJSON).To(BeIdenticalTo(string(expectedMachineTemplateSpecJSON)))
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.PullSecretFile, "e2e.pull-secret-file", "", "path to pull secret")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AWSEndpointAccess, "e2e.aws-endpoint-access", "", "endpoint access profile for the cluster")
 	flag.StringVar(&globalOpts.configurableClusterOptions.ExternalDNSDomain, "e2e.external-dns-domain", "", "domain that external-dns will use to create DNS records for HCP endpoints")
-	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "container disk image to use for kubevirt nodes")
+	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "DEPRECATED (ignored will be removed soon)")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtNodeMemory, "e2e.kubevirt-node-memory", "4Gi", "the amount of memory to provide to each workload node")
 	flag.IntVar(&globalOpts.configurableClusterOptions.NodePoolReplicas, "e2e.node-pool-replicas", 2, "the number of replicas for each node pool in the cluster")
 	flag.StringVar(&globalOpts.LatestReleaseImage, "e2e.latest-release-image", "", "The latest OCP release image for use by tests")
@@ -238,7 +238,6 @@ func (o *options) DefaultClusterOptions() core.CreateOptions {
 		},
 		KubevirtPlatform: core.KubevirtPlatformCreateOptions{
 			ServicePublishingStrategy: kubevirt.IngressServicePublishingStrategy,
-			ContainerDiskImage:        o.configurableClusterOptions.KubeVirtContainerDiskImage,
 			Cores:                     2,
 			Memory:                    o.configurableClusterOptions.KubeVirtNodeMemory,
 		},


### PR DESCRIPTION
This PR makes the KubeVirt `ContainerDisk` value on the NodePool optional. When no disk is explicitly defined on the nodepool the nodepool controller will automatically detect a disk for KubeVirt using the x86 OpenStack qcow2 image found in the release payload.

The OpenStack image is compatible with KubeVirt, however in the future we plan to ship our own KubeVirt specific image. Once that new KubeVirt image is introduced into the payload, we'll transition this logic to attempt to detect the kubevirt image first, then fall back to the openstack image if necessary.  