### PR TITLE
DNM: disable NodePool upgrade e2es

### DIFF
--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestReplaceUpgradeNodePool(t *testing.T) {
+	t.SkipNow()
 	t.Parallel()
 	g := NewWithT(t)
 
@@ -138,6 +139,7 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 }
 
 func TestInPlaceUpgradeNodePool(t *testing.T) {
+	t.SkipNow()
 	t.Parallel()
 	g := NewWithT(t)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Trying to isolate dramatically high GET rates as reported by the hypershift-operator

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.