### PR TITLE
Add image-content-sources option to create cluster CLI

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -59,6 +59,7 @@ type ExampleOptions struct {
 	SSHPublicKey                     []byte
 	SSHPrivateKey                    []byte
 	NodePoolReplicas                 int32
+	ImageContentSources              []hyperv1.ImageContentSource
 	InfraID                          string
 	ComputeCIDR                      string
 	ServiceCIDR                      string
@@ -500,6 +501,10 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 			},
 		}
 		cluster.Spec.AdditionalTrustBundle = &corev1.LocalObjectReference{Name: userCABundleCM.Name}
+	}
+
+	if len(o.ImageContentSources) > 0 {
+		cluster.Spec.ImageContentSources = o.ImageContentSources
 	}
 
 	if o.NodePoolReplicas <= -1 {

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -29,6 +29,7 @@ func NewCreateCommands() *cobra.Command {
 		Timeout:                        0,
 		ExternalDNSDomain:              "",
 		AdditionalTrustBundle:          "",
+		ImageContentSources:            "",
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -48,6 +49,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ControlPlaneOperatorImage, "control-plane-operator-image", opts.ControlPlaneOperatorImage, "Override the default image used to deploy the control plane operator")
 	cmd.PersistentFlags().StringVar(&opts.SSHKeyFile, "ssh-key", opts.SSHKeyFile, "Path to an SSH key file")
 	cmd.PersistentFlags().StringVar(&opts.AdditionalTrustBundle, "additional-trust-bundle", opts.AdditionalTrustBundle, "Path to a file with user CA bundle")
+	cmd.PersistentFlags().StringVar(&opts.ImageContentSources, "image-content-sources", opts.ImageContentSources, "Path to a file with image content sources")
 	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If >-1, create a default NodePool with this many replicas")
 	cmd.PersistentFlags().StringArrayVar(&opts.Annotations, "annotations", opts.Annotations, "Annotations to apply to the hostedcluster (key=value). Can be specified multiple times.")
 	cmd.PersistentFlags().BoolVar(&opts.FIPS, "fips", opts.FIPS, "Enables FIPS mode for nodes in the cluster")


### PR DESCRIPTION
This allows us to specify the imageContentSources for the HostedCluster
on the CLI via a yaml file.

**What this PR does / why we need it**:

When testing disconnected/ipv6 it's necessary to specify imageContentSources that map registries to a local mirror.

Currently this is possible, but means you have to `--render` then modify the HostedCluster resource

Instead add a CLI arg which reads a yaml file with contents like 

```
    - mirrors:
      - virthost.ostest.test.metalkube.org:5000/localimages/local-release-image
      source: registry.ci.openshift.org/ocp/4.11-2022-05-06-101304
    - mirrors:
      - virthost.ostest.test.metalkube.org:5000/localimages/local-release-image
      source: registry.ci.openshift.org/ocp/release
```

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.