### PR TITLE
fix the region parameter in app-sre templates

### DIFF
--- a/cmd/install/install_render.go
+++ b/cmd/install/install_render.go
@@ -125,7 +125,7 @@ func hyperShiftOperatorTemplateManifest(opts *Options) (crclient.Object, error) 
 			map[string]string{"name": TemplateParamAWSPrivateCredsSecret, "value": opts.AWSPrivateCredentialsSecret},
 			map[string]string{"name": TemplateParamAWSPrivateCredsSecretKey, "value": opts.AWSPrivateCredentialsSecretKey},
 		)
-		opts.AWSPrivateRegion = fmt.Sprintf("${%s}", TemplateParamAWSPrivateCredsSecret)
+		opts.AWSPrivateRegion = fmt.Sprintf("${%s}", TemplateParamAWSPrivateRegion)
 		opts.AWSPrivateCredentialsSecret = fmt.Sprintf("${%s}", TemplateParamAWSPrivateCredsSecret)
 		opts.AWSPrivateCredentialsSecretKey = fmt.Sprintf("${%s}", TemplateParamAWSPrivateCredsSecretKey)
 	}

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -317,7 +317,7 @@ objects:
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: /etc/provider/${AWS_PRIVATE_CREDS_SECRET_KEY}
           - name: AWS_REGION
-            value: ${AWS_PRIVATE_CREDS_SECRET}
+            value: ${AWS_PRIVATE_REGION}
           - name: AWS_SDK_LOAD_CONFIG
             value: "1"
           image: ${OPERATOR_IMG}:${IMAGE_TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:
The app-sre template is currently mixing the AWS region and the credential secret name

**Which issue(s) this PR fixes**
N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.