### PR TITLE
Nodepool in-place upgrade: Reduce api requests

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/cmca"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
+	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/spf13/cobra"
@@ -210,7 +211,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		},
 	}
 	operatorConfig := &operator.HostedClusterConfigOperatorConfig{
-		TargetCreateOrUpdateProvider: &operator.LabelEnforcingUpsertProvider{
+		TargetCreateOrUpdateProvider: &labelenforcingclient.LabelEnforcingUpsertProvider{
 			Upstream:  upsert.New(o.enableCIDebugOutput),
 			APIReader: mgr.GetAPIReader(),
 		},

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -23,6 +23,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 )
@@ -93,10 +94,10 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 			if err != nil {
 				return nil, err
 			}
-			return &labelEnforcingClient{
-				Client: client,
-				labels: map[string]string{cacheLabelSelectorKey: cacheLabelSelectorValue},
-			}, nil
+			return labelenforcingclient.New(
+				client,
+				map[string]string{cacheLabelSelectorKey: cacheLabelSelectorValue},
+			), nil
 		},
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{

--- a/support/labelenforcingclient/labelenforcer_test.go
+++ b/support/labelenforcingclient/labelenforcer_test.go
@@ -1,4 +1,4 @@
-package operator
+package labelenforcingclient
 
 import (
 	"context"
@@ -30,7 +30,7 @@ func TestLabelEnforcingClientEnforcesLabel(t *testing.T) {
 			name: "Label set with wrong value gets overriden",
 			in: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 				Name:   "foo",
-				Labels: map[string]string{cacheLabelSelectorKey: "invalid"},
+				Labels: map[string]string{CacheLabelSelectorKey: "invalid"},
 			}},
 		},
 	}
@@ -38,9 +38,9 @@ func TestLabelEnforcingClientEnforcesLabel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			client := &labelEnforcingClient{
+			client := &LabelEnforcingClient{
 				Client: fake.NewClientBuilder().Build(),
-				labels: map[string]string{cacheLabelSelectorKey: cacheLabelSelectorValue},
+				labels: map[string]string{CacheLabelSelectorKey: CacheLabelSelectorValue},
 			}
 
 			if err := client.Create(ctx, tc.in.DeepCopyObject().(crclient.Object)); err != nil {
@@ -51,8 +51,8 @@ func TestLabelEnforcingClientEnforcesLabel(t *testing.T) {
 			if err := client.Get(ctx, crclient.ObjectKeyFromObject(retrieved), retrieved); err != nil {
 				t.Fatalf("failed to get object after creating it: %v", err)
 			}
-			if val := retrieved.GetLabels()[cacheLabelSelectorKey]; val != cacheLabelSelectorValue {
-				t.Errorf("expected label %s to have value %s, found %q", cacheLabelSelectorKey, cacheLabelSelectorValue, val)
+			if val := retrieved.GetLabels()[CacheLabelSelectorKey]; val != CacheLabelSelectorValue {
+				t.Errorf("expected label %s to have value %s, found %q", CacheLabelSelectorKey, CacheLabelSelectorValue, val)
 			}
 
 			if err := client.Update(ctx, tc.in.DeepCopyObject().(crclient.Object)); err != nil {
@@ -63,8 +63,8 @@ func TestLabelEnforcingClientEnforcesLabel(t *testing.T) {
 			if err := client.Get(ctx, crclient.ObjectKeyFromObject(retrieved), retrieved); err != nil {
 				t.Fatalf("failed to get object after creating it: %v", err)
 			}
-			if val := retrieved.GetLabels()[cacheLabelSelectorKey]; val != cacheLabelSelectorValue {
-				t.Errorf("expected label %s to have value %s, found %q", cacheLabelSelectorKey, cacheLabelSelectorValue, val)
+			if val := retrieved.GetLabels()[CacheLabelSelectorKey]; val != CacheLabelSelectorValue {
+				t.Errorf("expected label %s to have value %s, found %q", CacheLabelSelectorKey, CacheLabelSelectorValue, val)
 			}
 		})
 	}
@@ -99,7 +99,7 @@ func TestLabelEnforcingUpsertProvider(t *testing.T) {
 	client := fake.NewClientBuilder().WithObjects(obj).Build()
 	clientWithSelector := labelselectingReadClient{
 		Client:   client,
-		selector: labels.SelectorFromSet(labels.Set{cacheLabelSelectorKey: cacheLabelSelectorValue}),
+		selector: labels.SelectorFromSet(labels.Set{CacheLabelSelectorKey: CacheLabelSelectorValue}),
 	}
 
 	// Adding it to the fakeclient sets the ResourceVersion which will


### PR DESCRIPTION
This drastically reduces the api requests the nodepool in-place
upgrading does to the guest cluster KAS by:

* Reading from a cache instead of the api. This caused the follow-up
  problem that it results in a cache for pods and configmaps being
  created, as we request those through the client. To not cache
  everything there, we use the same approach as in the HCCO: We enforce
  a label on create/update at the client level and use a label selector
  on the cache. The only exception for this are Nodes, as we don't
  create those
* Cache the client together with the cache: Client creation results in
  api discovery, which does a good ~50 api requests. Cache the client to
  avoid this
* Key the cache by hostedcluster instead of nodepool: Currently, the
  cache is keyed and lifecycled by nodepool, resulting in nodePoolCount
  cache entries being created rather than one per hostedcluster. Fix
  this.

This change makes the TestInPlaceUpgradeNodePool test pass.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Ref https://issues.redhat.com/browse/HOSTEDCP-405

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.