### PR TITLE
Make CI master nodes schedulable for cnv VMs

### DIFF
--- a/hack/ci/install-cnv.sh
+++ b/hack/ci/install-cnv.sh
@@ -5,6 +5,9 @@ set -ex
 # The kubevirt tests require wildcard routes to be allowed
 oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
 
+# Make the masters schedulable so we have more capacity to run VMs
+oc patch scheduler cluster --type=json -p '[{ "op": "replace", "path": "/spec/mastersSchedulable", "value": true }]'
+
 oc apply -f - <<EOF
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
As we're exercising more advanced scenarios for the KubeVirt platform, we're needing more capacity in our CI clusters. One easy way for us to gain capacity without increasing the number or size of the CI machines themselves is to utilize the master nodes for KubeVirt VMs.