### PR TITLE
Make CPO image configurable in `ci-test-e2e` Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,4 +236,5 @@ ci-test-e2e:
 		--e2e.previous-release-image=${OCP_IMAGE_PREVIOUS} \
 		--e2e.additional-tags="expirationDate=$(shell date -d '4 hours' --iso=minutes --utc)" \
 		--e2e.aws-endpoint-access=PublicAndPrivate \
-		--e2e.external-dns-domain=service.ci.hypershift.devcluster.openshift.com
+		--e2e.external-dns-domain=service.ci.hypershift.devcluster.openshift.com \
+		--e2e.control-plane-operator-image=${CONTROL_PLANE_OPERATOR_IMAGE}


### PR DESCRIPTION
This commit makes the CPO image configurable within the `ci-test-e2e`
make target via the `CONTROL_PLANE_OPERATOR_IMAGE` environment variable.

If the value is an empty string, the CPO image won't be overridden, which
makes this change compatible with the existing usage in the periodics while
providing the override for presubmits.
