### PR TITLE
test: adjust HO mutate budget

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -504,7 +504,7 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 			//
 			// Current HCs per periodic job: 10
 			// Read per HC: 300
-			// Mutate per HC: 500
+			// Mutate per HC: 600  TODO: need to tighten this when HO stop communicating with guest KAS for in-place upgrade
 			{
 				name:   "hypershift-operator read",
 				query:  `sum(hypershift:operator:component_api_requests_total{method="GET"})`,
@@ -513,7 +513,7 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 			{
 				name:   "hypershift-operator mutate",
 				query:  `sum(hypershift:operator:component_api_requests_total{method!="GET"})`,
-				budget: 5000,
+				budget: 6000,
 			},
 			{
 				name:   "hypershift-operator no 404 deletes",


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that periodic are running to completion again (HO is operating for longer), we are running right up against the HO mutate limit.  This temporarily raises the HO mutate budget and should be readjusted after the in-place node upgrade refactor lands and we aren't talking to the guest KAS anymore.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.