### PR TITLE
Fix(cpo): Propagate TLS security profile config to kube-controller-manager and kube-scheduler

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1725,7 +1725,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeScheduler(ctx context.Contex
 
 	schedulerDeployment := manifests.SchedulerDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, schedulerDeployment, func() error {
-		return scheduler.ReconcileDeployment(schedulerDeployment, p.OwnerRef, p.DeploymentConfig, p.HyperkubeImage, p.FeatureGates(), p.SchedulerPolicy(), p.AvailabilityProberImage, hcp.Spec.APIPort)
+		return scheduler.ReconcileDeployment(schedulerDeployment, p.OwnerRef, p.DeploymentConfig, p.HyperkubeImage, p.FeatureGates(), p.SchedulerPolicy(), p.AvailabilityProberImage, hcp.Spec.APIPort, p.CipherSuites(), p.MinTLSVersion())
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile scheduler deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -3,6 +3,7 @@ package kcm
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -301,6 +302,12 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 	}
 	if p.CloudProvider != "" {
 		args = append(args, fmt.Sprintf("--cloud-provider=%s", p.CloudProvider))
+	}
+	if p.MinTLSVersion() != "" {
+		args = append(args, fmt.Sprintf("--tls-min-version=%s", p.MinTLSVersion()))
+	}
+	if len(p.CipherSuites()) != 0 {
+		args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(p.CipherSuites(), ",")))
 	}
 	args = append(args, []string{
 		fmt.Sprintf("--cert-dir=%s", cpath(kcmVolumeCertDir().Name, "")),

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -26,6 +26,7 @@ type KubeControllerManagerParams struct {
 	Port                int32                        `json:"port"`
 	ServiceCIDR         string
 	PodCIDR             string
+	APIServer           *configv1.APIServer `json:"apiServer"`
 
 	config.DeploymentConfig
 	config.OwnerRef
@@ -49,6 +50,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 		ServiceCIDR:             hcp.Spec.ServiceCIDR,
 		PodCIDR:                 hcp.Spec.PodCIDR,
 		AvailabilityProberImage: images[util.AvailabilityProberImageName],
+		APIServer:               globalConfig.APIServer,
 	}
 	params.Scheduling = config.Scheduling{
 		PriorityClass: config.DefaultPriorityClass,
@@ -129,4 +131,18 @@ func (p *KubeControllerManagerParams) FeatureGates() []string {
 			FeatureSet: configv1.Default,
 		})
 	}
+}
+
+func (p *KubeControllerManagerParams) CipherSuites() []string {
+	if p.APIServer != nil {
+		return config.CipherSuites(p.APIServer.Spec.TLSSecurityProfile)
+	}
+	return config.CipherSuites(nil)
+}
+
+func (p *KubeControllerManagerParams) MinTLSVersion() string {
+	if p.APIServer != nil {
+		return config.MinTLSVersion(p.APIServer.Spec.TLSSecurityProfile)
+	}
+	return config.MinTLSVersion(nil)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,7 +35,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, featureGates []string, policy configv1.ConfigMapNameReference, availabilityProberImage string, apiPort *int32) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, featureGates []string, policy configv1.ConfigMapNameReference, availabilityProberImage string, apiPort *int32, ciphers []string, tlsVersion string) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main scheduler container
@@ -63,7 +64,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.BoolPtr(false),
 				Containers: []corev1.Container{
-					util.BuildContainer(schedulerContainerMain(), buildSchedulerContainerMain(image, deployment.Namespace, featureGates, policy)),
+					util.BuildContainer(schedulerContainerMain(), buildSchedulerContainerMain(image, deployment.Namespace, featureGates, policy, ciphers, tlsVersion)),
 				},
 				Volumes: []corev1.Volume{
 					util.BuildVolume(schedulerVolumeConfig(), buildSchedulerVolumeConfig),
@@ -84,7 +85,7 @@ func schedulerContainerMain() *corev1.Container {
 	}
 }
 
-func buildSchedulerContainerMain(image, namespace string, featureGates []string, policy configv1.ConfigMapNameReference) func(*corev1.Container) {
+func buildSchedulerContainerMain(image, namespace string, featureGates []string, policy configv1.ConfigMapNameReference, cipherSuites []string, tlsVersion string) func(*corev1.Container) {
 	return func(c *corev1.Container) {
 		kubeConfigPath := path.Join(volumeMounts.Path(schedulerContainerMain().Name, schedulerVolumeKubeconfig().Name), kas.KubeconfigKey)
 		configPath := path.Join(volumeMounts.Path(schedulerContainerMain().Name, schedulerVolumeConfig().Name), KubeSchedulerConfigKey)
@@ -108,6 +109,12 @@ func buildSchedulerContainerMain(image, namespace string, featureGates []string,
 		if len(policy.Name) > 0 {
 			c.Args = append(c.Args, fmt.Sprintf("--policy-config-map=%s", policy.Name))
 			c.Args = append(c.Args, fmt.Sprintf("--policy-config-namespace=%s", namespace))
+		}
+		if len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+		if tlsVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsVersion))
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Currently, the TLS Security Profile config isn't propagated to the kube-scheduler and kube-controller-manager like it is for other control plane components. This PR ensures the components are configured accordingly with the MinTLSVersion and CipherSuites. 

**Which issue(s) this PR fixes** https://github.com/openshift/hypershift/issues/1371

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.