### PR TITLE
Ignition server: Use https health check if possible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,7 @@ RUN cd /usr/bin && \
     ln -s control-plane-operator token-minter
 
 ENTRYPOINT /usr/bin/hypershift
+
 LABEL io.openshift.hypershift.control-plane-operator-subcommands=true
 LABEL io.openshift.hypershift.control-plane-operator-skips-haproxy=true
+LABEL io.openshift.hypershift.ignition-server-healthz-handler=true

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -14,3 +14,4 @@ ENTRYPOINT /usr/bin/control-plane-operator
 LABEL io.openshift.release.operator=true
 LABEL io.openshift.hypershift.control-plane-operator-subcommands=true
 LABEL io.openshift.hypershift.control-plane-operator-skips-haproxy=true
+LABEL io.openshift.hypershift.ignition-server-healthz-handler=true

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -1,5 +1,14 @@
 FROM quay.io/openshift/origin-base:4.10
 
 LABEL io.openshift.hypershift.control-plane-operator-skips-haproxy=true
+LABEL io.openshift.hypershift.control-plane-operator-subcommands=true
+LABEL io.openshift.hypershift.ignition-server-healthz-handler=true
+
+RUN cd /usr/bin && \
+    ln -s control-plane-operator ignition-server && \
+    ln -s control-plane-operator konnectivity-socks5-proxy && \
+    ln -s control-plane-operator availability-prober && \
+    ln -s control-plane-operator token-minter
+
 COPY bin/* /usr/bin/
 ENTRYPOINT /usr/bin/hypershift

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -110,6 +110,7 @@ const (
 	ImageStreamClusterMachineApproverImage = "cluster-machine-approver"
 
 	controlPlaneOperatorSubcommandsLabel = "io.openshift.hypershift.control-plane-operator-subcommands"
+	ignitionServerHealthzHandlerLabel    = "io.openshift.hypershift.ignition-server-healthz-handler"
 )
 
 // NoopReconcile is just a default mutation function that does nothing.
@@ -683,6 +684,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if !cpoHasUtilities {
 		utilitiesImage = r.HypershiftOperatorImage
 	}
+	_, ignitionServerHasHealthzHandler := util.ImageLabels(controlPlaneOperatorImageMetadata)[ignitionServerHealthzHandlerLabel]
 
 	// Reconcile Platform specifics.
 	p, err := platform.GetPlatform(hcluster, utilitiesImage)
@@ -1124,7 +1126,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile the Ignition server
-	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, utilitiesImage, hcp, defaultIngressDomain); err != nil {
+	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, utilitiesImage, hcp, defaultIngressDomain, ignitionServerHasHealthzHandler); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile ignition server: %w", err)
 	}
 
@@ -1638,7 +1640,7 @@ func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.Servi
 	return nil
 }
 
-func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, utilitiesImage string, hcp *hyperv1.HostedControlPlane, defaultIngressDomain string) error {
+func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, utilitiesImage string, hcp *hyperv1.HostedControlPlane, defaultIngressDomain string, hasHealthzHandler bool) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
@@ -1847,6 +1849,19 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 		log.Info("Reconciled ignition server rolebinding", "result", result)
 	}
 
+	var probeHandler corev1.ProbeHandler
+	if hasHealthzHandler {
+		probeHandler.HTTPGet = &corev1.HTTPGetAction{
+			Path:   "/healthz",
+			Port:   intstr.FromInt(9090),
+			Scheme: corev1.URISchemeHTTPS,
+		}
+	} else {
+		probeHandler.TCPSocket = &corev1.TCPSocketAction{
+			Port: intstr.FromInt(9090),
+		}
+	}
+
 	// Reconcile deployment
 	ignitionServerDeployment := ignitionserver.Deployment(controlPlaneNamespace.Name)
 	if result, err := createOrUpdate(ctx, r.Client, ignitionServerDeployment, func() error {
@@ -1915,11 +1930,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 								"--platform", string(hcluster.Spec.Platform.Type),
 							},
 							LivenessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(9090),
-									},
-								},
+								ProbeHandler:        probeHandler,
 								InitialDelaySeconds: 120,
 								TimeoutSeconds:      5,
 								PeriodSeconds:       60,
@@ -1927,11 +1938,7 @@ func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, c
 								SuccessThreshold:    1,
 							},
 							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(9090),
-									},
-								},
+								ProbeHandler:        probeHandler,
 								InitialDelaySeconds: 5,
 								TimeoutSeconds:      5,
 								PeriodSeconds:       60,

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -201,6 +201,7 @@ func run(ctx context.Context, opts Options) error {
 		w.WriteHeader(http.StatusOK)
 		w.Write(value.Payload)
 	})
+	mux.HandleFunc("/healthz", func(http.ResponseWriter, *http.Request) {})
 
 	server := http.Server{
 		Addr:         opts.Addr,


### PR DESCRIPTION
Currently, the tcp health checking spams the ignition server log with
error. This change adds a simple http healthz endpoint and uses that for
healthchecking if the docker image has a specific label that is also
added. Featuregating this is needed, because the new healthcheck will
never succeed on older ignition servers that do not have this new
handler.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.