### PR TITLE
Add sane defaults for InfrastructureAvailabilityPolicy and ControllerAvailabilityPolicy

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -135,6 +135,7 @@ type HostedClusterSpec struct {
 	// critical control plane components. The default value is SingleReplica.
 	//
 	// +optional
+	// +kubebuilder:default:="SingleReplica"
 	// +immutable
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
 
@@ -143,6 +144,7 @@ type HostedClusterSpec struct {
 	// HighlyAvailable.
 	//
 	// +optional
+	// +kubebuilder:default:="HighlyAvailable"
 	// +immutable
 	InfrastructureAvailabilityPolicy AvailabilityPolicy `json:"infrastructureAvailabilityPolicy,omitempty"`
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -177,6 +177,7 @@ spec:
                     type: array
                 type: object
               controllerAvailabilityPolicy:
+                default: SingleReplica
                 description: ControllerAvailabilityPolicy specifies the availability
                   policy applied to critical control plane components. The default
                   value is SingleReplica.
@@ -327,6 +328,7 @@ spec:
                   with the HostedCluster and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
+                default: HighlyAvailable
                 description: InfrastructureAvailabilityPolicy specifies the availability
                   policy applied to infrastructure services which run on cluster nodes.
                   The default value is HighlyAvailable.

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -20103,6 +20103,7 @@ objects:
                       type: array
                   type: object
                 controllerAvailabilityPolicy:
+                  default: SingleReplica
                   description: ControllerAvailabilityPolicy specifies the availability
                     policy applied to critical control plane components. The default
                     value is SingleReplica.
@@ -20255,6 +20256,7 @@ objects:
                     with the HostedCluster and its associated NodePools.
                   type: string
                 infrastructureAvailabilityPolicy:
+                  default: HighlyAvailable
                   description: InfrastructureAvailabilityPolicy specifies the availability
                     policy applied to infrastructure services which run on cluster
                     nodes. The default value is HighlyAvailable.


### PR DESCRIPTION
**What this PR does / why we need it**:
This fields are propagated to the HCP and its backend defaults behaviour when they are empty.
Default behaviour should explicit signaled by the API so we provide a consistent UX and we avoid the posibility of breaking the API policy transparently by chaging backend behaviour.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.