### PR TITLE
Add support to ignore the HostedCluster and Nodepool resource.

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -269,6 +269,12 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to get cluster %q: %w", req.NamespacedName, err)
 	}
 
+	// Check if the HostedCluster CR should be ignored
+	if hcluster.Annotations != nil && strings.ToLower(hcluster.Annotations[hyperutil.HypershiftIgnoreAnnotation]) == "true" {
+		log.Info("Skip reconcile, found ignore annotation")
+		return ctrl.Result{}, nil
+	}
+
 	// If deleted, clean up and return early.
 	if !hcluster.DeletionTimestamp.IsZero() {
 		// Keep trying to delete until we know it's safe to finalize.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1457,6 +1457,30 @@ func TestDefaultClusterIDsIfNeeded(t *testing.T) {
 	}
 }
 
+func TestIgnoreHostedCluster(t *testing.T) {
+	testHC := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-cluster",
+			Namespace: "fake-namespace",
+			Annotations: map[string]string{
+				"hypershift.openshift.io/ignore": "True",
+			},
+		},
+	}
+	r := &HostedClusterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(testHC).Build(),
+	}
+	g := NewGomegaWithT(t)
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testHC.Namespace,
+			Name:      testHC.Name,
+		},
+	}
+	_, err := r.Reconcile(context.Background(), req)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
 type fakeImageMetadataProvider struct{}
 
 func (*fakeImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -145,6 +145,15 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Check if the NodePool CR should be ignored
+	if (hcluster.Annotations != nil &&
+		strings.ToLower(hcluster.Annotations[hyperutil.HypershiftIgnoreAnnotation]) == "true") ||
+		(nodePool.Annotations != nil &&
+			strings.ToLower(nodePool.Annotations[hyperutil.HypershiftIgnoreAnnotation]) == "true") {
+		log.Info("Skip reconcile, found ignore annotation")
+		return ctrl.Result{}, nil
+	}
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
 
 	// If deleted, clean up and return early.

--- a/hypershift-operator/controllers/util/util.go
+++ b/hypershift-operator/controllers/util/util.go
@@ -2,8 +2,9 @@ package util
 
 import (
 	"context"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -33,7 +34,8 @@ func ParseNamespacedName(name string) types.NamespacedName {
 }
 
 const (
-	UserDataKey = "data"
+	UserDataKey                = "data"
+	HypershiftIgnoreAnnotation = "hypershift.openshift.io/ignore"
 )
 
 func ReconcileWorkerManifest(cm *corev1.ConfigMap, resource client.Object) error {


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
* We are using an ObjectRef in ACM to point to HostedCluster and NodePool CR's for certain deployment scenarios. To make sure the CR's are not reconciled by the controller, we are looking to put an early escape in the reconcile loop.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Related to https://github.com/stolostron/hypershift-deployment-controller/pull/86

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.