### PR TITLE
Change ignition server http code if token not found.

### DIFF
--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -190,7 +190,11 @@ func run(ctx context.Context, opts Options) error {
 
 		value, ok := payloadStore.Get(string(decodedToken))
 		if !ok {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			// We return a 5xx here to give ignition the chance to backoff and retry if the machine request happens
+			// before the content is cached for this token.
+			// https://coreos.github.io/ignition/operator-notes/#http-backoff-and-retry
+			log.Printf("Token not found")
+			http.Error(w, "Token not found", http.StatusNetworkAuthenticationRequired)
 			return
 		}
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -287,7 +287,7 @@ func WaitForNodePoolVersion(t *testing.T, ctx context.Context, client crclient.C
 	start := time.Now()
 
 	t.Logf("Waiting for nodepool %s/%s to report version %s (currently %s)", nodePool.Namespace, nodePool.Name, version, nodePool.Status.Version)
-	err := wait.PollImmediateUntil(10*time.Second, func() (done bool, err error) {
+	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
 		latest := nodePool.DeepCopy()
 		err = client.Get(ctx, crclient.ObjectKeyFromObject(nodePool), latest)
 		if err != nil {
@@ -295,7 +295,7 @@ func WaitForNodePoolVersion(t *testing.T, ctx context.Context, client crclient.C
 			return false, nil
 		}
 		return latest.Status.Version == version, nil
-	}, ctx.Done())
+	})
 	g.Expect(err).NotTo(HaveOccurred(), "failed waiting for nodepool version")
 
 	t.Logf("Observed nodepool %s/%s to report version %s in %s", nodePool.Namespace, nodePool.Name, version, time.Since(start).Round(time.Second))


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a racing issue between the payload being available in the ign-server and any machine requesting it and being able to boot.
Let's follow the path of *-7b2b7-us-east-1b-e731d66e which is the token secret referenced by a MachinSet which Machine was unable to boot.

The payload is generated at 2022-05-18T12:39:39Z","msg":"got ignition payload
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_hypershift/1399/pull-ci-openshift-hypershift-main-e2e-aws-all/1526895205024796672/artifacts/e2e-aws-all/test-e2e/artifacts/TestReplaceUpgradeNodePool_PreTeardownClusterDump/namespaces/e2e-clusters-9v26f-example-7b2b7/core/pods/logs/ignition-server-74bd6bd554-qr7z6-ignition-server.log

The above happens right after multiple machines send http request to the ign-server
2022/05/18 12:39:33 User Agent: Ignition/2.13.0. Requested: /ignition
2022/05/18 12:39:33 User Agent: Ignition/2.13.0. Requested: /ignition
2022/05/18 12:39:34 User Agent: Ignition/2.13.0. Requested: /ignition

Including the one failing to boot
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_hypershift/1399/pull-ci-openshift-hypershift-main-e2e-aws-all/1526895205024796672/artifacts/e2e-aws-all/test-e2e/artifacts/TestReplaceUpgradeNodePool_PreTeardownClusterDump/machine-console-logs/example-7b2b7-us-east-1b-fk9g6.log

Because the ign-server is return a 4xx if the token required does not exist Ignition considers the process unsuccessful but complete without retrying and backoff https://coreos.github.io/ignition/operator-notes/#http-backoff-and-retry

This also sets a test function time out to avoid hitting the core CI platform global timeout, thi let us fail earlier  and dump the artifacts for the test.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.