### PR TITLE
Nodepool render: Avoid including a logline

### DIFF
--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -103,7 +103,7 @@ func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("NodePool %s was rendered to yaml output file\n", o.Name)
+		fmt.Fprintf(os.Stderr, "NodePool %s was rendered to yaml output file\n", o.Name)
 		return nil
 	}
 


### PR DESCRIPTION
The log gets currently printed to stdout, resulting in it being included
when redirecting that. Print to stderr instead to avoid that.

Ref https://issues.redhat.com/browse/HOSTEDCP-431

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.