### PR TITLE
adopt existing immutable selectors to prevent errors reconciling components from roks toolkit clusters

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
@@ -44,8 +44,10 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		MaxSurge:       &maxSurge,
 		MaxUnavailable: &maxUnavailable,
 	}
-	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: clusterPolicyControllerLabels,
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: clusterPolicyControllerLabels,
+		}
 	}
 	deployment.Spec.Template.ObjectMeta.Labels = clusterPolicyControllerLabels
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -83,7 +83,9 @@ var (
 
 func cvoLabels() map[string]string {
 	return map[string]string{
-		"app":                         "cluster-version-operator",
+		"app": "cluster-version-operator",
+		// value for compatibility with roks-toolkit clusters
+		"k8s-app":                     "cluster-version-operator",
 		hyperv1.ControlPlaneComponent: "cluster-version-operator",
 	}
 }
@@ -98,11 +100,14 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	if mainContainer != nil {
 		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
 	}
-
-	deployment.Spec = appsv1.DeploymentSpec{
-		Selector: &metav1.LabelSelector{
+	selector := deployment.Spec.Selector
+	if selector == nil {
+		selector = &metav1.LabelSelector{
 			MatchLabels: cvoLabels(),
-		},
+		}
+	}
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: selector,
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: cvoLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -115,9 +115,10 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	if mainContainer != nil {
 		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
 	}
-
-	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: kasLabels(),
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: kasLabels(),
+		}
 	}
 	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
 		Type: appsv1.RollingUpdateDeploymentStrategyType,

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -17,8 +17,9 @@ import (
 
 func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy, owner *metav1.OwnerReference, apiServerPort int, isPublic bool) error {
 	util.EnsureOwnerRef(svc, owner)
-	svc.Spec.Selector = kasLabels()
-
+	if svc.Spec.Selector == nil {
+		svc.Spec.Selector = kasLabels()
+	}
 	// Ensure labels propagate to endpoints so service
 	// monitors can select them
 	if svc.Labels == nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -64,8 +64,10 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev
 		p.DeploymentConfig.SetContainerResourcesIfPresent(mainContainer)
 	}
 
-	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: kcmLabels(),
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: kcmLabels(),
+		}
 	}
 	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 	maxSurge := intstr.FromInt(3)

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -88,8 +88,10 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 			MaxSurge:       &maxSurge,
 		},
 	}
-	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: openShiftAPIServerLabels(),
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: openShiftAPIServerLabels(),
+		}
 	}
 	deployment.Spec.Template.ObjectMeta.Labels = openShiftAPIServerLabels()
 	etcdUrlData, err := url.Parse(etcdURL)

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -62,8 +62,10 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 			MaxSurge:       &maxSurge,
 		},
 	}
-	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: openShiftOAuthAPIServerLabels(),
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: openShiftOAuthAPIServerLabels(),
+		}
 	}
 	deployment.Spec.Template.ObjectMeta.Labels = openShiftOAuthAPIServerLabels()
 	deployment.Spec.Template.Spec = corev1.PodSpec{

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/service.go
@@ -39,7 +39,9 @@ func ReconcileOLMPackageServerService(svc *corev1.Service, ownerRef config.Owner
 func reconcileAPIService(svc *corev1.Service, ownerRef config.OwnerRef, labels map[string]string, targetPort int) error {
 	ownerRef.ApplyTo(svc)
 	svc.Labels = openshiftAPIServerLabels()
-	svc.Spec.Selector = labels
+	if svc.Spec.Selector == nil {
+		svc.Spec.Selector = labels
+	}
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -56,9 +56,10 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 	if mainContainer != nil {
 		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
 	}
-
-	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: oauthLabels(),
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: oauthLabels(),
+		}
 	}
 	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 	maxSurge := intstr.FromInt(3)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -27,7 +27,9 @@ var (
 
 func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy) error {
 	ownerRef.ApplyTo(svc)
-	svc.Spec.Selector = oauthServerLabels
+	if svc.Spec.Selector == nil {
+		svc.Spec.Selector = oauthServerLabels
+	}
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
@@ -59,8 +59,10 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		MaxSurge:       &maxSurge,
 		MaxUnavailable: &maxUnavailable,
 	}
-	deployment.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: openShiftControllerManagerLabels(),
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: openShiftControllerManagerLabels(),
+		}
 	}
 	deployment.Spec.Template.ObjectMeta.Labels = openShiftControllerManagerLabels()
 	deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -45,10 +45,14 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 
 	maxSurge := intstr.FromInt(3)
 	maxUnavailable := intstr.FromInt(1)
-	deployment.Spec = appsv1.DeploymentSpec{
-		Selector: &metav1.LabelSelector{
+	selector := deployment.Spec.Selector
+	if deployment.Spec.Selector == nil {
+		selector = &metav1.LabelSelector{
 			MatchLabels: schedulerLabels,
-		},
+		}
+	}
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: selector,
 		Strategy: appsv1.DeploymentStrategy{
 			Type: appsv1.RollingUpdateDeploymentStrategyType,
 			RollingUpdate: &appsv1.RollingUpdateDeployment{

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -184,7 +184,7 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 	// in order to progress the rollout. However, you do not want to set that in the single replica case because it will
 	// result in downtime.
 	if c.Replicas > 1 {
-		maxSurge := intstr.FromInt(3)
+		maxSurge := intstr.FromInt(0)
 		maxUnavailable := intstr.FromInt(1)
 		if deployment.Spec.Strategy.RollingUpdate == nil {
 			deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{}


### PR DESCRIPTION
This fixes an error in the control plane operator where it will fail to reconcile and properly adopt deployments based on roks toolkit clusters. This is due to the fact that the selectors has changed and that is an immutable field. Specifically, hypershift selectors add a duplicate selector hypershit.component that is not contained in roks toolkit clusters. Even with the single app selector: deployment rollout behavior is unchanged. This allows for zero downtime adoption of roks toolkit clusters. Associated issue: https://github.com/openshift/hypershift/issues/1042

Key Changes:
1) Need to preserve label selector on services to ensure network connectivity isn't cutoff on adoption 
2) Need to adopt deployment immutable  selector on deployments in order to be able to successfully adopt deployments
3) Need to adjust the rollout policy to properly ensure a rolling update after adoption. In addition maxSurge has no value with the hard affinity rules unless someone happened to be in a environment with 4+ zones which is not supported today. The pending pods actually enter a scheduling backoff loop until an existing pod in the deployment is deleted (and frees up a zone)

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #  https://github.com/openshift/hypershift/issues/1042

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.