### PR TITLE
Change infrastructureAvailabilityPolicy default to single replica

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -60,15 +60,19 @@ type HostedControlPlaneSpec struct {
 	// +optional
 	APIAdvertiseAddress *string `json:"apiAdvertiseAddress,omitempty"`
 
-	// ControllerAvailabilityPolicy specifies whether to run control plane controllers in HA mode
-	// Defaults to SingleReplica when not set
+	// ControllerAvailabilityPolicy specifies the availability policy applied to
+	// critical control plane components. The default value is SingleReplica.
+	//
 	// +optional
+	// +kubebuilder:default:="SingleReplica"
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
 
-	// InfrastructureAvailabilityPolicy specifies whether to run infrastructure services that
-	// run on the guest cluster nodes in HA mode
-	// Defaults to HighlyAvailable when not set
+	// InfrastructureAvailabilityPolicy specifies the availability policy applied
+	// to infrastructure services which run on cluster nodes. The default value is
+	// SingleReplica.
+	//
 	// +optional
+	// +kubebuilder:default:="SingleReplica"
 	InfrastructureAvailabilityPolicy AvailabilityPolicy `json:"infrastructureAvailabilityPolicy,omitempty"`
 
 	// FIPS specifies if the nodes for the cluster will be running in FIPS mode

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -141,10 +141,10 @@ type HostedClusterSpec struct {
 
 	// InfrastructureAvailabilityPolicy specifies the availability policy applied
 	// to infrastructure services which run on cluster nodes. The default value is
-	// HighlyAvailable.
+	// SingleReplica.
 	//
 	// +optional
-	// +kubebuilder:default:="HighlyAvailable"
+	// +kubebuilder:default:="SingleReplica"
 	// +immutable
 	InfrastructureAvailabilityPolicy AvailabilityPolicy `json:"infrastructureAvailabilityPolicy,omitempty"`
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -328,10 +328,10 @@ spec:
                   with the HostedCluster and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: HighlyAvailable
+                default: SingleReplica
                 description: InfrastructureAvailabilityPolicy specifies the availability
                   policy applied to infrastructure services which run on cluster nodes.
-                  The default value is HighlyAvailable.
+                  The default value is SingleReplica.
                 type: string
               issuerURL:
                 default: https://kubernetes.default.svc

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -120,9 +120,10 @@ spec:
                     type: array
                 type: object
               controllerAvailabilityPolicy:
-                description: ControllerAvailabilityPolicy specifies whether to run
-                  control plane controllers in HA mode Defaults to SingleReplica when
-                  not set
+                default: SingleReplica
+                description: ControllerAvailabilityPolicy specifies the availability
+                  policy applied to critical control plane components. The default
+                  value is SingleReplica.
                 type: string
               dns:
                 description: DNSSpec specifies the DNS configuration in the cluster.
@@ -262,9 +263,10 @@ spec:
               infraID:
                 type: string
               infrastructureAvailabilityPolicy:
-                description: InfrastructureAvailabilityPolicy specifies whether to
-                  run infrastructure services that run on the guest cluster nodes
-                  in HA mode Defaults to HighlyAvailable when not set
+                default: SingleReplica
+                description: InfrastructureAvailabilityPolicy specifies the availability
+                  policy applied to infrastructure services which run on cluster nodes.
+                  The default value is SingleReplica.
                 type: string
               issuerURL:
                 type: string

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
@@ -12,9 +12,9 @@ type IngressParams struct {
 }
 
 func NewIngressParams(hcp *hyperv1.HostedControlPlane, globalConfig globalconfig.GlobalConfig) *IngressParams {
-	var replicas int32 = 2
-	if hcp.Spec.InfrastructureAvailabilityPolicy == hyperv1.SingleReplica {
-		replicas = 1
+	var replicas int32 = 1
+	if hcp.Spec.InfrastructureAvailabilityPolicy == hyperv1.HighlyAvailable {
+		replicas = 2
 	}
 	return &IngressParams{
 		IngressSubdomain: globalconfig.IngressDomain(hcp, globalConfig.Ingress),

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
@@ -13,10 +13,10 @@ func ReconcileRegistryConfig(cfg *imageregistryv1.Config, platform hyperv1.Platf
 	// Only initialize number of replicas if creating the config
 	if cfg.ResourceVersion == "" {
 		switch availabilityPolicy {
-		case hyperv1.SingleReplica:
-			cfg.Spec.Replicas = 1
-		default:
+		case hyperv1.HighlyAvailable:
 			cfg.Spec.Replicas = 2
+		default:
+			cfg.Spec.Replicas = 1
 		}
 	}
 	if cfg.Spec.ManagementState == "" {

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -179,7 +179,7 @@ AvailabilityPolicy
 <em>(Optional)</em>
 <p>InfrastructureAvailabilityPolicy specifies the availability policy applied
 to infrastructure services which run on cluster nodes. The default value is
-HighlyAvailable.</p>
+SingleReplica.</p>
 <p>
 Value must be one of:
 &#34;HighlyAvailable&#34;, 
@@ -2446,7 +2446,7 @@ AvailabilityPolicy
 <em>(Optional)</em>
 <p>InfrastructureAvailabilityPolicy specifies the availability policy applied
 to infrastructure services which run on cluster nodes. The default value is
-HighlyAvailable.</p>
+SingleReplica.</p>
 <p>
 Value must be one of:
 &#34;HighlyAvailable&#34;, 
@@ -3035,8 +3035,8 @@ AvailabilityPolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>ControllerAvailabilityPolicy specifies whether to run control plane controllers in HA mode
-Defaults to SingleReplica when not set</p>
+<p>ControllerAvailabilityPolicy specifies the availability policy applied to
+critical control plane components. The default value is SingleReplica.</p>
 <p>
 Value must be one of:
 &#34;HighlyAvailable&#34;, 
@@ -3055,9 +3055,9 @@ AvailabilityPolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>InfrastructureAvailabilityPolicy specifies whether to run infrastructure services that
-run on the guest cluster nodes in HA mode
-Defaults to HighlyAvailable when not set</p>
+<p>InfrastructureAvailabilityPolicy specifies the availability policy applied
+to infrastructure services which run on cluster nodes. The default value is
+SingleReplica.</p>
 <p>
 Value must be one of:
 &#34;HighlyAvailable&#34;, 

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -20263,10 +20263,10 @@ objects:
                     with the HostedCluster and its associated NodePools.
                   type: string
                 infrastructureAvailabilityPolicy:
-                  default: HighlyAvailable
+                  default: SingleReplica
                   description: InfrastructureAvailabilityPolicy specifies the availability
                     policy applied to infrastructure services which run on cluster
-                    nodes. The default value is HighlyAvailable.
+                    nodes. The default value is SingleReplica.
                   type: string
                 issuerURL:
                   default: https://kubernetes.default.svc
@@ -21418,9 +21418,10 @@ objects:
                       type: array
                   type: object
                 controllerAvailabilityPolicy:
-                  description: ControllerAvailabilityPolicy specifies whether to run
-                    control plane controllers in HA mode Defaults to SingleReplica
-                    when not set
+                  default: SingleReplica
+                  description: ControllerAvailabilityPolicy specifies the availability
+                    policy applied to critical control plane components. The default
+                    value is SingleReplica.
                   type: string
                 dns:
                   description: DNSSpec specifies the DNS configuration in the cluster.
@@ -21562,9 +21563,10 @@ objects:
                 infraID:
                   type: string
                 infrastructureAvailabilityPolicy:
-                  description: InfrastructureAvailabilityPolicy specifies whether
-                    to run infrastructure services that run on the guest cluster nodes
-                    in HA mode Defaults to HighlyAvailable when not set
+                  default: SingleReplica
+                  description: InfrastructureAvailabilityPolicy specifies the availability
+                    policy applied to infrastructure services which run on cluster
+                    nodes. The default value is SingleReplica.
                   type: string
                 issuerURL:
                   type: string

--- a/support/globalconfig/infrastructure.go
+++ b/support/globalconfig/infrastructure.go
@@ -38,10 +38,10 @@ func ReconcileInfrastructure(infra *configv1.Infrastructure, hcp *hyperv1.Hosted
 	}
 
 	switch hcp.Spec.InfrastructureAvailabilityPolicy {
-	case hyperv1.SingleReplica:
-		infra.Status.InfrastructureTopology = configv1.SingleReplicaTopologyMode
-	default:
+	case hyperv1.HighlyAvailable:
 		infra.Status.InfrastructureTopology = configv1.HighlyAvailableTopologyMode
+	default:
+		infra.Status.InfrastructureTopology = configv1.SingleReplicaTopologyMode
 	}
 
 	switch platformType {


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes the InfrastructureAvailabilityPolicy to SingleReplica to be consistent with the ControllerAvailabilityPolicy default..

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.