### PR TITLE
Add missing control plane prometheus rules

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/alerts/assets/apiusage.yaml
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/alerts/assets/apiusage.yaml
@@ -1,0 +1,38 @@
+# The canonical source of the rule is https://github.com/openshift/cluster-kube-apiserver-operator/blob/release-4.10/bindata/assets/alerts/api-usage.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: api-usage
+  namespace: openshift-kube-apiserver
+spec:
+  groups:
+    - name: pre-release-lifecycle
+      rules:
+        - alert: APIRemovedInNextReleaseInUse
+          annotations:
+            summary: Deprecated API that will be removed in the next version is being used.
+            description: >-
+              Deprecated API that will be removed in the next version is being used. Removing the workload that is using
+              the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
+              a successful upgrade to the next cluster version.
+              Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
+          expr: |
+            group(apiserver_requested_deprecated_apis{removed_release="1.24"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
+          for: 1h
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: info
+        - alert: APIRemovedInNextEUSReleaseInUse
+          annotations:
+            summary: Deprecated API that will be removed in the next EUS version is being used.
+            description: >-
+              Deprecated API that will be removed in the next EUS version is being used. Removing the workload that is using
+              the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
+              a successful upgrade to the next EUS cluster version.
+              Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
+          expr: |
+            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[45]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
+          for: 1h
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: info

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/alerts/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/alerts/reconcile.go
@@ -1,0 +1,38 @@
+package crd
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	//go:embed assets/apiusage.yaml
+	apiUsageYaml []byte
+
+	apiUsage = createRule(apiUsageYaml)
+)
+
+func ReconcileApiUsageRule(rule *prometheusoperatorv1.PrometheusRule) error {
+	rule.Spec = apiUsage.Spec
+	return nil
+}
+
+func createRule(content []byte) *prometheusoperatorv1.PrometheusRule {
+	rule := &prometheusoperatorv1.PrometheusRule{}
+	deserializeResource(content, rule)
+	return rule
+}
+
+func deserializeResource(data []byte, obj runtime.Object) {
+	gvks, _, err := api.Scheme.ObjectKinds(obj)
+	if err != nil || len(gvks) == 0 {
+		panic(fmt.Sprintf("cannot determine gvk of resource: %v", err))
+	}
+	if _, _, err = api.YamlSerializer.Decode(data, &gvks[0], obj); err != nil {
+		panic(fmt.Sprintf("cannot decode resource: %v", err))
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/alerts.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/alerts.go
@@ -1,0 +1,15 @@
+package manifests
+
+import (
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ApiUsageRule() *prometheusoperatorv1.PrometheusRule {
+	return &prometheusoperatorv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api-usage",
+			Namespace: "openshift-kube-apiserver",
+		},
+	}
+}


### PR DESCRIPTION
This PR adds "api-usage" Prometheus alert rules (APIRemovedInNextReleaseInUse and APIRemovedInNextEUSReleaseInUse https://github.com/openshift/cluster-kube-apiserver-operator/blob/release-4.9/bindata/assets/alerts/api-usage.yaml) to Hypershift-hosted clusters . The rules are missing because the component that normally creates them ([cluster-kube-apiserver-operator](https://github.com/openshift/cluster-kube-apiserver-operator)) does not exist Hypershift-hosted clusters.

GitHub issue: https://github.com/openshift/hypershift/issues/1201

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.