### PR TITLE
Allow nodepool deletion when hcluster is gone

### DIFF
--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -14,17 +14,16 @@ const (
 	EC2VolumeDefaultType string = "gp3"
 )
 
-func machineDeployment(nodePool *hyperv1.NodePool, clusterName string, controlPlaneNamespace string) *capiv1.MachineDeployment {
-	resourcesName := generateName(clusterName, nodePool.Spec.ClusterName, nodePool.GetName())
+func machineDeployment(nodePool *hyperv1.NodePool, controlPlaneNamespace string) *capiv1.MachineDeployment {
 	return &capiv1.MachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourcesName,
+			Name:      nodePool.GetName(),
 			Namespace: controlPlaneNamespace,
 		},
 	}
 }
 
-func machineSet(nodePool *hyperv1.NodePool, clusterName string, controlPlaneNamespace string) *capiv1.MachineSet {
+func machineSet(nodePool *hyperv1.NodePool, controlPlaneNamespace string) *capiv1.MachineSet {
 	return &capiv1.MachineSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodePool.GetName(),


### PR DESCRIPTION
Currently, nodepool deletion will fail if the hostedcluster doesn't
exist anymore which means that if nodepool deletion is too slow, we will
deadlock. This fixes that.

Note that this introduces an backwards-incompatible change to how
machinedeployments are named. This means that the hypershift operator
will create a new machinedeployment for existing nodepools when
upgraded. The same goes for cleanup, the machinedeployment will be
deleted transiently by the garbage collector controller, however the
same goes for the capi pods, hence cleanup might not work automatically.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.