### PR TITLE
Tests: Enable junit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,17 +224,4 @@ ci-install-hypershift-private:
 
 .PHONY: ci-test-e2e
 ci-test-e2e:
-	bin/test-e2e \
-		-test.v \
-		-test.timeout=0 \
-		-test.parallel=20 \
-		--e2e.aws-credentials-file=/etc/hypershift-pool-aws-credentials/credentials \
-		--e2e.aws-zones=us-east-1a,us-east-1b,us-east-1c \
-		--e2e.node-pool-replicas=1 \
-		--e2e.pull-secret-file=/etc/ci-pull-credentials/.dockerconfigjson \
-		--e2e.base-domain=ci.hypershift.devcluster.openshift.com \
-		--e2e.latest-release-image=${OCP_IMAGE_LATEST} \
-		--e2e.previous-release-image=${OCP_IMAGE_PREVIOUS} \
-		--e2e.additional-tags="expirationDate=$(shell date -d '4 hours' --iso=minutes --utc)" \
-		--e2e.aws-endpoint-access=PublicAndPrivate \
-		--e2e.external-dns-domain=service.ci.hypershift.devcluster.openshift.com
+	./hack/ci-test-e2e.sh

--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+set -o monitor
+
+set -x
+
+generate_junit() {
+  cat  /tmp/test_out | go tool test2json -t > /tmp/test_out.json
+  gotestsum --raw-command --junitfile="${ARTIFACT_DIR}/junit.xml" --format=standard-verbose -- cat /tmp/test_out.json
+}
+trap generate_junit EXIT
+
+bin/test-e2e \
+  -test.v \
+  -test.timeout=2h10m \
+  -test.parallel=20 \
+  --e2e.aws-credentials-file=/etc/hypershift-pool-aws-credentials/credentials \
+  --e2e.aws-zones=us-east-1a,us-east-1b,us-east-1c \
+  --e2e.node-pool-replicas=1 \
+  --e2e.pull-secret-file=/etc/ci-pull-credentials/.dockerconfigjson \
+  --e2e.base-domain=ci.hypershift.devcluster.openshift.com \
+  --e2e.latest-release-image="${OCP_IMAGE_LATEST}" \
+  --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" \
+  --e2e.additional-tags="expirationDate=$(date -d '4 hours' --iso=minutes --utc)" \
+  --e2e.aws-endpoint-access=PublicAndPrivate \
+  --e2e.external-dns-domain=service.ci.hypershift.devcluster.openshift.com | tee /tmp/test_out


### PR DESCRIPTION
This enables junit for the ci-test-e2e maketarget. It uses a Bash exit
trap to ensure that failure of the test command get properly propagated.
/hold
/test e2e-aws-all

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.