### PR TITLE
Loopdetector: Give some more leeway

### DIFF
--- a/support/upsert/loopdetector.go
+++ b/support/upsert/loopdetector.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -37,12 +36,8 @@ const LoopDetectorWarningMessage = "WARNING: Object got updated more than one ti
 // Once we did a no-op update, we will ignore the object because we assume that if we have
 // a bug in the defaulting, we will end up always updating.
 func updateLoopThreshold(o runtime.Object) int {
-	// Nodes in in-place upgrade scenario to through through three updates
-	// in a row.
-	if _, isNode := o.(*corev1.Node); isNode {
-		return 3
-	}
-	return 2
+	// Give some leeway, if we actually revert defaults we will do a lot more than this
+	return 5
 }
 
 type updateLoopDetector struct {


### PR DESCRIPTION
The current treshold causes flakes, presumably because changes do not
get back into the cache in time. Give some leeway, if we actually revert
defaults we will likely end up with a very high number of updates and
still detect that.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.