### PR TITLE
Ensure that the private router pod uses the HC's pull secret

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2312,8 +2312,7 @@ func (r *HostedControlPlaneReconciler) reconcilePrivateIngressController(ctx con
 func (r *HostedControlPlaneReconciler) reconcilePrivateRouter(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseInfo *releaseinfo.ReleaseImage) error {
 	sa := manifests.PrivateRouterServiceAccount(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r.Client, sa, func() error {
-		config.OwnerRefFrom(hcp).ApplyTo(sa)
-		return nil
+		return ingress.ReconcilePrivateRouterServiceAccount(sa, config.OwnerRefFrom(hcp))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile private router service account: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
@@ -299,6 +300,12 @@ func ReconcilePrivateRouterRoleBinding(rb *rbacv1.RoleBinding, ownerRef config.O
 		Kind:     "Role",
 		Name:     manifests.PrivateRouterRole("").Name,
 	}
+	return nil
+}
+
+func ReconcilePrivateRouterServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sa)
+	util.EnsurePullSecret(sa, common.PullSecret("").Name)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The service account for the private router pod doesn't specify any
image pull secrets. This means that the pull secret specified for the
hosted cluster is not used in pulling the router image.

This change ensures that the private-router service account uses the
pull secret for the hosted cluster.

**Checklist**
- [x] Subject and description added to both, commit and PR.