### PR TITLE
hack/publish-ocp.sh fix cut syntax

### DIFF
--- a/hack/publish-ocp.sh
+++ b/hack/publish-ocp.sh
@@ -16,5 +16,5 @@ PROJECT="$1"
 export KO_DOCKER_REPO="$(oc registry info --public)/hypershift"
 EXTERNAL_PULLSPEC=$(ko publish --insecure-registry "$PROJECT")
 
-INTERNAL_PULLSPEC="$INTERNAL_REPO/$(echo $EXTERNAL_PULLSPEC | cut -d'/' -f2 -f3)"
+INTERNAL_PULLSPEC="$INTERNAL_REPO/$(echo $EXTERNAL_PULLSPEC | cut -d'/' -f2-3)"
 echo $INTERNAL_PULLSPEC


### PR DESCRIPTION
The current syntax doesn't work, at least on coreutils 8.32 that's
shipped with Fedora 35
