### PR TITLE
Scrape all KAS metrics inside guest cluster

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/monitoring/servicemonitor.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/monitoring/servicemonitor.go
@@ -3,6 +3,7 @@ package monitoring
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift/hypershift/support/metrics"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
@@ -24,19 +25,11 @@ func ReconcileKubeAPIServerServiceMonitor(serviceMonitor *prometheusoperatorv1.S
 				},
 				CAFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 			},
-			Interval: "30s",
-			Scheme:   "https",
-			Port:     "https",
-			Path:     "/metrics",
-			MetricRelabelConfigs: []*prometheusoperatorv1.RelabelConfig{
-				{
-					Action: "keep",
-					Regex:  "etcd_object_counts.*",
-					SourceLabels: []string{
-						"__name__",
-					},
-				},
-			},
+			Interval:             "30s",
+			Scheme:               "https",
+			Port:                 "https",
+			Path:                 "/metrics",
+			MetricRelabelConfigs: metrics.KASRelabelConfigs(metrics.MetricsSetAll),
 		},
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently sync a servicemonitor into the guest cluster so that KAS
metrics are scraped by the guest CMO. However, the current
servicemonitor only scrapes a single metric from the KAS.

This commit modifies the servicemonitor so it includes all metrics that
are typically scraped in a standalone OCP cluster.

**Checklist**
- [x] Subject and description added to both, commit and PR.