### PR TITLE
Set autoscaler CAPI group explicitely

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2980,6 +2980,10 @@ func reconcileAutoScalerDeployment(deployment *appsv1.Deployment, hc *hyperv1.Ho
 									},
 								},
 							},
+							{
+								Name:  "CAPI_GROUP",
+								Value: "cluster.x-k8s.io",
+							},
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{


### PR DESCRIPTION
**What this PR does / why we need it**:
We were relying on the autoscaler default machine api group which if changed by accident as in https://github.com/openshift/kubernetes-autoscaler/commit/8a93f4e3b065e9b2c8c3329707c52ee9053f36bf would automatically break usas we don't grant rbac for machine.openshift.io https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_hypershift/1424/pull-ci-openshift-hypershift-main-e2e-aws-all/1531259053521506304/artifacts/e2e-aws-all/test-e2e/artifacts/TestAutoscaling_PreTeardownClusterDump/namespaces/e2e-clusters-hzlnb-example-wrtvk/core/pods/logs/cluster-autoscaler-59858bdf6d-qst7w-cluster-autoscaler.log

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.