### PR TITLE
Use git commit as version in HyperShift binaries

### DIFF
--- a/availability-prober/availability_prober.go
+++ b/availability-prober/availability_prober.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/openshift/hypershift/pkg/version"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +43,7 @@ func NewStartCommand() *cobra.Command {
 	}))
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
+		log.Info("Starting availability-prober", "version", version.String())
 		url, err := url.Parse(opts.target)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("failed to parse %q as url", opts.target))

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/pkg/version"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/util"
@@ -269,6 +270,7 @@ type HyperShiftOperatorDeployment struct {
 	OIDCStorageProviderS3Secret    *corev1.Secret
 	OIDCStorageProviderS3SecretKey string
 	MetricsSet                     metrics.MetricsSet
+	IncludeVersion                 bool
 }
 
 func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
@@ -522,6 +524,12 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 				},
 			},
 		},
+	}
+
+	if o.IncludeVersion {
+		deployment.Annotations = map[string]string{
+			"hypershift.openshift.io/install-cli-version": version.String(),
+		}
 	}
 
 	if o.AdditionalTrustBundle != nil {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -426,6 +426,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 		OIDCStorageProviderS3SecretKey: opts.OIDCStorageProviderS3CredentialsSecretKey,
 		Images:                         images,
 		MetricsSet:                     opts.MetricsSet,
+		IncludeVersion:                 !opts.Template,
 	}.Build()
 	objects = append(objects, operatorDeployment)
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/openshift/hypershift/pkg/version"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -38,4 +41,22 @@ func LookupDefaultOCPVersion() (OCPVersion, error) {
 		return version, err
 	}
 	return version, nil
+}
+
+func NewVersionCommand() *cobra.Command {
+	var commitOnly bool
+	cmd := &cobra.Command{
+		Use:          "version",
+		Short:        "Prints HyperShift CLI version",
+		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			if commitOnly {
+				fmt.Printf("%s\n", version.GetRevision())
+				return
+			}
+			fmt.Printf("%s\n", version.String())
+		},
+	}
+	cmd.Flags().BoolVar(&commitOnly, "commit-only", commitOnly, "Output only the code commit")
+	return cmd
 }

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
+	"github.com/openshift/hypershift/pkg/version"
 	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
@@ -193,6 +194,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 	cfg := operator.CfgFromFile(o.TargetKubeconfig)
 	cpConfig := ctrl.GetConfigOrDie()
 	mgr := operator.Mgr(cfg, cpConfig, o.Namespace)
+	mgr.GetLogger().Info("Starting hosted-cluster-config-operator", "version", version.String())
 	cpCluster, err := cluster.New(cpConfig, func(opt *cluster.Options) {
 		opt.Namespace = o.Namespace
 		opt.Scheme = api.Scheme

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -174,6 +174,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringToStringVar(&registryOverrides, "registry-overrides", map[string]string{}, "registry-overrides contains the source registry string as a key and the destination registry string as value. Images before being applied are scanned for the source registry string and if found the string is replaced with the destination registry string. Format is: sr1=dr1,sr2=dr2")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
+		setupLog.Info("Starting hypershift-controlplane-manager", "version", version.String())
 		ctx := ctrl.SetupSignalHandler()
 
 		restConfig := ctrl.GetConfigOrDie()

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -136,6 +136,8 @@ func NewStartCommand() *cobra.Command {
 }
 
 func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
+	log.Info("Starting hypershift-operator-manager", "version", version.String())
+
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.UserAgent = "hypershift-operator-manager"
 	leaseDuration := time.Second * 60

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -16,6 +16,7 @@ import (
 	hyperapi "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/ignition-server/controllers"
+	"github.com/openshift/hypershift/pkg/version"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
@@ -140,9 +141,11 @@ func setUpPayloadStoreReconciler(ctx context.Context, registryOverrides map[stri
 }
 
 func run(ctx context.Context, opts Options) error {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	logger := zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
-	})))
+	}))
+	ctrl.SetLogger(logger)
+	logger.Info("Starting ignition-server", "version", version.String())
 
 	certWatcher, err := certwatcher.New(opts.CertFile, opts.KeyFile)
 	if err != nil {

--- a/konnectivity-socks5-proxy/main.go
+++ b/konnectivity-socks5-proxy/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	socks5 "github.com/armon/go-socks5"
+	"github.com/openshift/hypershift/pkg/version"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/proxy"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,7 +49,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&clientKeyPath, "tls-key-path", "/etc/konnectivity-proxy-tls/tls.key", "The path to the konnectivity client's private key.")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		fmt.Println("Starting proxy...")
+		fmt.Printf("Starting proxy. Version %s\n", version.String())
 		client, err := client.New(ctrl.GetConfigOrDie(), client.Options{})
 		if err != nil {
 			panic(err)

--- a/kubernetes-default-proxy/kubernetes_default_proxy.go
+++ b/kubernetes-default-proxy/kubernetes_default_proxy.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/openshift/hypershift/pkg/version"
 	"github.com/spf13/cobra"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -67,7 +68,7 @@ func (s *server) run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to listen on tcp:%s: %w", s.listenAddr, err)
 	}
-	s.log.Info("Starting to listen", "listen-address", s.listenAddr)
+	s.log.Info("Starting to listen", "listen-address", s.listenAddr, "version", version.String())
 
 	for {
 		if ctx.Err() != nil {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	destroycmd "github.com/openshift/hypershift/cmd/destroy"
 	dumpcmd "github.com/openshift/hypershift/cmd/dump"
 	installcmd "github.com/openshift/hypershift/cmd/install"
+	cliversion "github.com/openshift/hypershift/cmd/version"
 	"github.com/openshift/hypershift/pkg/version"
 )
 
@@ -56,6 +57,7 @@ func main() {
 	cmd.AddCommand(destroycmd.NewCommand())
 	cmd.AddCommand(dumpcmd.NewCommand())
 	cmd.AddCommand(consolelogs.NewCommand())
+	cmd.AddCommand(cliversion.NewVersionCommand())
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"fmt"
 	"runtime/debug"
 )
 
@@ -18,4 +19,8 @@ func GetRevision() string {
 		}
 	}
 	return "<unknown>"
+}
+
+func String() string {
+	return fmt.Sprintf("openshift/hypershift %s", GetRevision())
 }

--- a/token-minter/tokenminter.go
+++ b/token-minter/tokenminter.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/hypershift/pkg/version"
 	"github.com/spf13/cobra"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -52,6 +53,8 @@ func NewStartCommand() *cobra.Command {
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(cmd.Context())
+
+		log.Printf("Starting token minter. Version = %s\n", version.String())
 
 		c := make(chan os.Signal, 2)
 		signal.Notify(c, os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds git commit, tree state and build date as ldflags to hypershift
binaries. It then includes the version in output logs.
It also adds a command `version` that outputs the version from the CLI
and also includes that version as an annotation in the HyperShift
deployment to indicate which version of the CLI was used to generate it.

This enables us to better debug errors and understand which version of
the code is running in a particular installation.

**Checklist**
- [x] Subject and description added to both, commit and PR.