### PR TITLE
CNO operands use private APIServer address when HCP is private

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -96,8 +96,13 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
 	p.DeploymentConfig.Replicas = 1
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
-	p.APIServerAddress = hcp.Status.ControlPlaneEndpoint.Host
-	p.APIServerPort = hcp.Status.ControlPlaneEndpoint.Port
+	if util.IsPrivateHCP(hcp) {
+		p.APIServerAddress = fmt.Sprintf("api.%s.hypershift.local", hcp.Name)
+		p.APIServerPort = 6443
+	} else {
+		p.APIServerAddress = hcp.Status.ControlPlaneEndpoint.Host
+		p.APIServerPort = hcp.Status.ControlPlaneEndpoint.Port
+	}
 	p.HostedClusterName = hcp.Name
 	p.TokenAudience = hcp.Spec.IssuerURL
 


### PR DESCRIPTION
**What this PR does / why we need it**:

CNO operands in the guest cluster should use the private API server address when the HC is private.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.