### PR TITLE
Increase MHC nodeStartupTimeout

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1050,7 +1050,7 @@ func (r *NodePoolReconciler) reconcileMachineHealthCheck(mhc *capiv1.MachineHeal
 		},
 		MaxUnhealthy: &maxUnhealthy,
 		NodeStartupTimeout: &metav1.Duration{
-			Duration: 10 * time.Minute,
+			Duration: 20 * time.Minute,
 		},
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to try to mitigate and isolate CI flakiness https://github.com/openshift/hypershift/pull/1430#issuecomment-1144666152 where ocassionaly cluster creation with autorepair enabled has failed to get healthy Nodes. In these failures Machines are being deleted when the NodeStartupTimeout is met. If there's a legit reason why the Nodes are not being created this won't help, however it will help to make more clear the former is true.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.