### PR TITLE
Adjust memory requests to align with PerfScale recommendations

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -33,7 +33,7 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, globalCon
 		Resources: map[string]corev1.ResourceRequirements{
 			cpcContainerMain().Name: {
 				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("100Mi"),
+					corev1.ResourceMemory: resource.MustParse("200Mi"),
 					corev1.ResourceCPU:    resource.MustParse("10m"),
 				},
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
@@ -38,7 +38,7 @@ func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.Host
 	params.Resources = map[string]corev1.ResourceRequirements{
 		hccContainerMain().Name: {
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("10Mi"),
+				corev1.ResourceMemory: resource.MustParse("80Mi"),
 				corev1.ResourceCPU:    resource.MustParse("60m"),
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -247,7 +247,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		},
 		kasContainerMain().Name: {
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("1500Mi"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
 				corev1.ResourceCPU:    resource.MustParse("350m"),
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -90,7 +90,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	params.Resources = map[string]corev1.ResourceRequirements{
 		kcmContainerMain().Name: {
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("200Mi"),
+				corev1.ResourceMemory: resource.MustParse("400Mi"),
 				corev1.ResourceCPU:    resource.MustParse("60m"),
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -143,7 +143,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, globalConfig g
 		Resources: map[string]corev1.ResourceRequirements{
 			oauthContainerMain().Name: {
 				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("200Mi"),
+					corev1.ResourceMemory: resource.MustParse("80Mi"),
 					corev1.ResourceCPU:    resource.MustParse("150m"),
 				},
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -90,7 +90,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, globalConfig globalco
 	p.Resources = map[string]corev1.ResourceRequirements{
 		oauthContainerMain().Name: {
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("150Mi"),
+				corev1.ResourceMemory: resource.MustParse("40Mi"),
 				corev1.ResourceCPU:    resource.MustParse("25m"),
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
@@ -49,4 +49,4 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 60Mi
+              memory: 160Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
@@ -68,7 +68,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 70Mi
+            memory: 250Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2987,7 +2987,7 @@ func reconcileAutoScalerDeployment(deployment *appsv1.Deployment, hc *hyperv1.Ho
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("35Mi"),
+								corev1.ResourceMemory: resource.MustParse("120Mi"),
 								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},


### PR DESCRIPTION
This aligns memory requests for components under our direct management with recommendations from PerfScale.

Net impact is total HCP memory request increases by 1005Mi for SingleReplica and 1905Mi for HA.  Total HCP memory request after this change is 7.3Gi for SR and 18Gi for HA.

A follow-on to this PR is adjusting `ovnkube-master` pod from 1500Mi total request to more like ~400Mi.  This will save 1.1Gi of requests on SR and 3.3Gi on HA making total HCP request 6.2Gi for SR and ~14.7Gi for HA.

Currently, HCPs actually _use_ 5Gi for SR and 10Gi for HA in CI.  CI clusters are largely idle though and generally represent a lower bound on usage.

`etcd` pods are not adjusted in this PR as we are currently aligned with standalone OCP at `600Mi` memory request.  However, real world usage seems to higher and somewhat unbounded.  There is a significant deviation from standalone OCP `kube-apiserver` request of 1Gi vs hypershift 1.5Gi (current) and 2Gi after this PR.  `etcd` might warrant the same deviation in our situation but the variance is significant for `etcd` between the idle case at ~600Mi and P75 load measured at ~2.2Gi.  So leaving that for a future PR.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
https://issues.redhat.com/browse/HOSTEDCP-481

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.