### PR TITLE
Manage ignition server from CPO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,4 @@ ENTRYPOINT /usr/bin/hypershift
 LABEL io.openshift.hypershift.control-plane-operator-subcommands=true
 LABEL io.openshift.hypershift.control-plane-operator-skips-haproxy=true
 LABEL io.openshift.hypershift.ignition-server-healthz-handler=true
+LABEL io.openshift.hypershift.control-plane-operator-manages-ignition-server=true

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -15,3 +15,4 @@ LABEL io.openshift.release.operator=true
 LABEL io.openshift.hypershift.control-plane-operator-subcommands=true
 LABEL io.openshift.hypershift.control-plane-operator-skips-haproxy=true
 LABEL io.openshift.hypershift.ignition-server-healthz-handler=true
+LABEL io.openshift.hypershift.control-plane-operator-manages-ignition-server=true

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -3,6 +3,7 @@ FROM quay.io/openshift/origin-base:4.10
 LABEL io.openshift.hypershift.control-plane-operator-skips-haproxy=true
 LABEL io.openshift.hypershift.control-plane-operator-subcommands=true
 LABEL io.openshift.hypershift.ignition-server-healthz-handler=true
+LABEL io.openshift.hypershift.control-plane-operator-manages-ignition-server=true
 
 RUN cd /usr/bin && \
     ln -s control-plane-operator ignition-server && \

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -1,0 +1,487 @@
+package ignitionserver
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"net"
+	"strings"
+
+	routev1 "github.com/openshift/api/route/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
+	hyperutil "github.com/openshift/hypershift/hypershift-operator/controllers/util"
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/proxy"
+	"github.com/openshift/hypershift/support/upsert"
+	"github.com/openshift/hypershift/support/util"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilpointer "k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ReconcileIgnitionServer(ctx context.Context,
+	c client.Client,
+	createOrUpdate upsert.CreateOrUpdateFN,
+	utilitiesImage string,
+	hcp *hyperv1.HostedControlPlane,
+	defaultIngressDomain string,
+	hasHealthzHandler bool,
+	registryOverrides map[string]string,
+	managementClusterHasCapabilitySecurityContextConstraint bool,
+) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	controlPlaneNamespace := hcp.Namespace
+	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.Ignition)
+	if serviceStrategy == nil {
+		//lint:ignore ST1005 Ignition is proper name
+		return fmt.Errorf("Ignition service strategy not specified")
+	}
+	// Reconcile service
+	ignitionServerService := ignitionserver.Service(controlPlaneNamespace)
+	if _, err := createOrUpdate(ctx, c, ignitionServerService, func() error {
+		return reconcileIgnitionServerService(ignitionServerService, serviceStrategy)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ignition service: %w", err)
+	}
+	var ignitionServerAddress string
+	switch serviceStrategy.Type {
+	case hyperv1.Route:
+		// Reconcile route
+		ignitionServerRoute := ignitionserver.Route(controlPlaneNamespace)
+		if _, err := createOrUpdate(ctx, c, ignitionServerRoute, func() error {
+			// The route host is considered immutable, so set it only once upon creation
+			// and ignore updates.
+			if ignitionServerRoute.CreationTimestamp.IsZero() {
+				switch {
+				case !util.ConnectsThroughInternetToControlplane(hcp.Spec.Platform):
+					ignitionServerRoute.Spec.Host = fmt.Sprintf("%s.apps.%s.hypershift.local", ignitionServerRoute.Name, hcp.Name)
+				case serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "":
+					ignitionServerRoute.Spec.Host = serviceStrategy.Route.Hostname
+				default:
+					ignitionServerRoute.Spec.Host = util.ShortenRouteHostnameIfNeeded(ignitionServerRoute.Name, ignitionServerRoute.Namespace, defaultIngressDomain)
+				}
+			}
+
+			if ignitionServerRoute.Annotations == nil {
+				ignitionServerRoute.Annotations = map[string]string{}
+			}
+			if hcp.Spec.Platform.Type == hyperv1.AWSPlatform &&
+				(hcp.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate ||
+					hcp.Spec.Platform.AWS.EndpointAccess == hyperv1.Private) {
+				if ignitionServerRoute.Labels == nil {
+					ignitionServerRoute.Labels = map[string]string{}
+				}
+				ignitionServerRoute.Labels[hyperutil.HypershiftRouteLabel] = controlPlaneNamespace
+			} else if serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
+				ignitionServerRoute.ObjectMeta.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = serviceStrategy.Route.Hostname
+			}
+			ignitionServerRoute.Spec.TLS = &routev1.TLSConfig{
+				Termination: routev1.TLSTerminationPassthrough,
+			}
+			ignitionServerRoute.Spec.To = routev1.RouteTargetReference{
+				Kind:   "Service",
+				Name:   ignitionserver.ResourceName,
+				Weight: utilpointer.Int32Ptr(100),
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ignition route: %w", err)
+		}
+
+		// The route must be admitted and assigned a host before we can generate certs
+		if len(ignitionServerRoute.Status.Ingress) == 0 || len(ignitionServerRoute.Status.Ingress[0].Host) == 0 {
+			log.Info("ignition server reconciliation waiting for ignition server route to be assigned a host value")
+			return nil
+		}
+		ignitionServerAddress = ignitionServerRoute.Status.Ingress[0].Host
+	case hyperv1.NodePort:
+		if serviceStrategy.NodePort == nil {
+			return fmt.Errorf("nodeport metadata not specified for ignition service")
+		}
+		ignitionServerAddress = serviceStrategy.NodePort.Address
+	default:
+		return fmt.Errorf("unknown service strategy type for ignition service: %s", serviceStrategy.Type)
+	}
+
+	// Reconcile a root CA for ignition serving certificates. We only create this
+	// and don't update it for now.
+	caCertSecret := ignitionserver.IgnitionCACertSecret(controlPlaneNamespace)
+	if result, err := createOrUpdate(ctx, c, caCertSecret, func() error {
+		if caCertSecret.CreationTimestamp.IsZero() {
+			cfg := &certs.CertCfg{
+				Subject:   pkix.Name{CommonName: "ignition-root-ca", OrganizationalUnit: []string{"openshift"}},
+				KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+				Validity:  certs.ValidityTenYears,
+				IsCA:      true,
+			}
+			key, crt, err := certs.GenerateSelfSignedCertificate(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to generate CA: %w", err)
+			}
+			caCertSecret.Type = corev1.SecretTypeTLS
+			caCertSecret.Data = map[string][]byte{
+				corev1.TLSCertKey:       certs.CertToPem(crt),
+				corev1.TLSPrivateKeyKey: certs.PrivateKeyToPem(key),
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ignition ca cert: %w", err)
+	} else {
+		log.Info("reconciled ignition CA cert secret", "result", result)
+	}
+
+	// Reconcile a ignition serving certificate issued by the generated root CA. We
+	// only create this and don't update it for now.
+	servingCertSecret := ignitionserver.IgnitionServingCertSecret(controlPlaneNamespace)
+	if result, err := createOrUpdate(ctx, c, servingCertSecret, func() error {
+		if servingCertSecret.CreationTimestamp.IsZero() {
+			caCert, err := certs.PemToCertificate(caCertSecret.Data[corev1.TLSCertKey])
+			if err != nil {
+				return fmt.Errorf("couldn't get ca cert: %w", err)
+			}
+			caKey, err := certs.PemToPrivateKey(caCertSecret.Data[corev1.TLSPrivateKeyKey])
+			if err != nil {
+				return fmt.Errorf("couldn't get ca key: %w", err)
+			}
+			cfg := &certs.CertCfg{
+				Subject:   pkix.Name{CommonName: "ignition-server", Organization: []string{"openshift"}},
+				KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+				Validity:  certs.ValidityOneYear,
+			}
+			numericIP := net.ParseIP(ignitionServerAddress)
+			if numericIP == nil {
+				cfg.DNSNames = []string{ignitionServerAddress}
+			} else {
+				cfg.IPAddresses = []net.IP{numericIP}
+			}
+			key, crt, err := certs.GenerateSignedCertificate(caKey, caCert, cfg)
+			if err != nil {
+				return fmt.Errorf("failed to generate ignition serving cert: %w", err)
+			}
+			servingCertSecret.Type = corev1.SecretTypeTLS
+			servingCertSecret.Data = map[string][]byte{
+				corev1.TLSCertKey:       certs.CertToPem(crt),
+				corev1.TLSPrivateKeyKey: certs.PrivateKeyToPem(key),
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ignition serving cert: %w", err)
+	} else {
+		log.Info("reconciled ignition serving cert secret", "result", result)
+	}
+
+	role := ignitionserver.Role(controlPlaneNamespace)
+	if result, err := createOrUpdate(ctx, c, role, func() error {
+		role.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{
+					"events",
+					// This is needed by the tokeSecret controller to watch secrets.
+					"secrets",
+					// This is needed by the MCS ignitionProvider to lookup the release image and create the MCS.
+					"pods/log",
+					"serviceaccounts",
+					"pods",
+					// This is needed by the MCS ignitionProvider to create an ephemeral ConfigMap
+					// with the machine config to mount it into the MCS Pod that generates the final payload.
+					"configmaps",
+				},
+				Verbs: []string{"*"},
+			},
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ignition role: %w", err)
+	} else {
+		log.Info("Reconciled ignition role", "result", result)
+	}
+
+	sa := ignitionserver.ServiceAccount(controlPlaneNamespace)
+	if result, err := createOrUpdate(ctx, c, sa, func() error {
+		util.EnsurePullSecret(sa, controlplaneoperator.PullSecret("").Name)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile controlplane operator service account: %w", err)
+	} else {
+		log.Info("Reconciled ignition server service account", "result", result)
+	}
+
+	roleBinding := ignitionserver.RoleBinding(controlPlaneNamespace)
+	if result, err := createOrUpdate(ctx, c, roleBinding, func() error {
+		roleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		}
+
+		roleBinding.Subjects = []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ignition RoleBinding: %w", err)
+	} else {
+		log.Info("Reconciled ignition server rolebinding", "result", result)
+	}
+
+	var probeHandler corev1.ProbeHandler
+	if hasHealthzHandler {
+		probeHandler.HTTPGet = &corev1.HTTPGetAction{
+			Path:   "/healthz",
+			Port:   intstr.FromInt(9090),
+			Scheme: corev1.URISchemeHTTPS,
+		}
+	} else {
+		probeHandler.TCPSocket = &corev1.TCPSocketAction{
+			Port: intstr.FromInt(9090),
+		}
+	}
+
+	// Reconcile deployment
+	ignitionServerDeployment := ignitionserver.Deployment(controlPlaneNamespace)
+	if result, err := createOrUpdate(ctx, c, ignitionServerDeployment, func() error {
+		if ignitionServerDeployment.Annotations == nil {
+			ignitionServerDeployment.Annotations = map[string]string{}
+		}
+		ignitionServerLabels := map[string]string{
+			"app":                         ignitionserver.ResourceName,
+			hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
+		}
+		ignitionServerDeployment.Spec = appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: ignitionServerLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: ignitionServerLabels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName:            sa.Name,
+					TerminationGracePeriodSeconds: utilpointer.Int64Ptr(10),
+					Tolerations: []corev1.Toleration{
+						{
+							Key:    "node-role.kubernetes.io/master",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "serving-cert",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: servingCertSecret.Name,
+								},
+							},
+						},
+						{
+							Name: "payloads",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            ignitionserver.ResourceName,
+							Image:           utilitiesImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env: []corev1.EnvVar{
+								{
+									Name: "MY_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+							Command: []string{
+								"/usr/bin/control-plane-operator",
+								"ignition-server",
+								"--cert-file", "/var/run/secrets/ignition/serving-cert/tls.crt",
+								"--key-file", "/var/run/secrets/ignition/serving-cert/tls.key",
+								"--registry-overrides", convertRegistryOverridesToCommandLineFlag(registryOverrides),
+								"--platform", string(hcp.Spec.Platform.Type),
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler:        probeHandler,
+								InitialDelaySeconds: 120,
+								TimeoutSeconds:      5,
+								PeriodSeconds:       60,
+								FailureThreshold:    6,
+								SuccessThreshold:    1,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler:        probeHandler,
+								InitialDelaySeconds: 5,
+								TimeoutSeconds:      5,
+								PeriodSeconds:       60,
+								FailureThreshold:    3,
+								SuccessThreshold:    1,
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "https",
+									ContainerPort: 9090,
+								},
+								{
+									Name:          "metrics",
+									ContainerPort: 8080,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("40Mi"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "serving-cert",
+									MountPath: "/var/run/secrets/ignition/serving-cert",
+								},
+								{
+									Name:      "payloads",
+									MountPath: "/payloads",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		proxy.SetEnvVars(&ignitionServerDeployment.Spec.Template.Spec.Containers[0].Env)
+
+		if hcp.Spec.AdditionalTrustBundle != nil {
+			// Add trusted-ca mount with optional configmap
+			util.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, ignitionServerDeployment)
+		}
+
+		// set security context
+		if !managementClusterHasCapabilitySecurityContextConstraint {
+			ignitionServerDeployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsUser: utilpointer.Int64Ptr(config.DefaultSecurityContextUser),
+			}
+		}
+		hyperutil.SetRestartAnnotation(hcp.ObjectMeta, ignitionServerDeployment)
+		hyperutil.SetColocation(hcp.ObjectMeta, ignitionServerDeployment)
+		hyperutil.SetControlPlaneIsolation(hcp.ObjectMeta, ignitionServerDeployment)
+		hyperutil.SetDefaultPriorityClass(ignitionServerDeployment)
+		switch hcp.Spec.ControllerAvailabilityPolicy {
+		case hyperv1.HighlyAvailable:
+			maxSurge := intstr.FromInt(1)
+			maxUnavailable := intstr.FromInt(1)
+			ignitionServerDeployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
+			ignitionServerDeployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge:       &maxSurge,
+				MaxUnavailable: &maxUnavailable,
+			}
+			ignitionServerDeployment.Spec.Replicas = utilpointer.Int32Ptr(3)
+			hyperutil.SetMultizoneSpread(ignitionServerLabels, ignitionServerDeployment)
+		default:
+			ignitionServerDeployment.Spec.Replicas = utilpointer.Int32(1)
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ignition deployment: %w", err)
+	} else {
+		log.Info("Reconciled ignition server deployment", "result", result)
+	}
+
+	// Reconcile PodMonitor
+	podMonitor := ignitionserver.PodMonitor(controlPlaneNamespace)
+	if result, err := createOrUpdate(ctx, c, podMonitor, func() error {
+		podMonitor.Spec.Selector = *ignitionServerDeployment.Spec.Selector
+		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
+			Interval: "15s",
+			Port:     "metrics",
+		}}
+		podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{controlPlaneNamespace}}
+		podMonitor.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: hyperv1.GroupVersion.String(),
+			Kind:       "HostedControlPlane",
+			Name:       hcp.Name,
+			UID:        hcp.UID,
+		}})
+		if podMonitor.Annotations == nil {
+			podMonitor.Annotations = map[string]string{}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ignition server pod monitor: %w", err)
+	} else {
+		log.Info("Reconciled ignition server podmonitor", "result", result)
+	}
+
+	return nil
+}
+
+func servicePublishingStrategyByType(hcp *hyperv1.HostedControlPlane, svcType hyperv1.ServiceType) *hyperv1.ServicePublishingStrategy {
+	for _, mapping := range hcp.Spec.Services {
+		if mapping.Service == svcType {
+			return &mapping.ServicePublishingStrategy
+		}
+	}
+	return nil
+}
+
+func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy) error {
+	svc.Spec.Selector = map[string]string{
+		"app": ignitionserver.ResourceName,
+	}
+	var portSpec corev1.ServicePort
+	if len(svc.Spec.Ports) > 0 {
+		portSpec = svc.Spec.Ports[0]
+	} else {
+		svc.Spec.Ports = []corev1.ServicePort{portSpec}
+	}
+	portSpec.Port = int32(443)
+	portSpec.Name = "https"
+	portSpec.Protocol = corev1.ProtocolTCP
+	portSpec.TargetPort = intstr.FromInt(9090)
+	switch strategy.Type {
+	case hyperv1.NodePort:
+		svc.Spec.Type = corev1.ServiceTypeNodePort
+		if portSpec.NodePort == 0 && strategy.NodePort != nil {
+			portSpec.NodePort = strategy.NodePort.Port
+		}
+	case hyperv1.Route:
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+	default:
+		return fmt.Errorf("invalid publishing strategy for Ignition service: %s", strategy.Type)
+	}
+	svc.Spec.Ports[0] = portSpec
+	return nil
+}
+
+func convertRegistryOverridesToCommandLineFlag(registryOverrides map[string]string) string {
+	commandLineFlagArray := []string{}
+	for registrySource, registryReplacement := range registryOverrides {
+		commandLineFlagArray = append(commandLineFlagArray, fmt.Sprintf("%s=%s", registrySource, registryReplacement))
+	}
+	if len(commandLineFlagArray) > 0 {
+		return strings.Join(commandLineFlagArray, ",")
+	}
+	// this is the equivalent of null on a StringToString command line variable.
+	return "="
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver_test.go
@@ -1,0 +1,142 @@
+package ignitionserver
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestReconcileIgnitionServerServiceNodePortFreshInitialization(t *testing.T) {
+	tests := []struct {
+		name                           string
+		inputIgnitionServerService     *corev1.Service
+		inputServicePublishingStrategy *hyperv1.ServicePublishingStrategy
+	}{
+		{
+			name:                       "fresh service initialization",
+			inputIgnitionServerService: ignitionserver.Service("default"),
+			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.NodePort,
+			},
+		},
+		{
+			name:                       "fresh service with node port specified",
+			inputIgnitionServerService: ignitionserver.Service("default"),
+			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.NodePort,
+				NodePort: &hyperv1.NodePortPublishingStrategy{
+					Port: int32(30000),
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reconcileIgnitionServerService(test.inputIgnitionServerService, test.inputServicePublishingStrategy)
+			g := NewGomegaWithT(t)
+			g.Expect(len(test.inputIgnitionServerService.Spec.Ports)).To(Equal(1))
+			g.Expect(test.inputIgnitionServerService.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt(9090)))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Port).To(Equal(int32(443)))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Name).To(Equal("https"))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+			if test.inputServicePublishingStrategy.NodePort != nil && test.inputServicePublishingStrategy.NodePort.Port > 0 {
+				g.Expect(test.inputIgnitionServerService.Spec.Ports[0].NodePort).To(Equal(test.inputServicePublishingStrategy.NodePort.Port))
+			}
+		})
+	}
+}
+
+func TestReconcileIgnitionServerServiceNodePortExistingService(t *testing.T) {
+	tests := []struct {
+		name                           string
+		inputIgnitionServerService     *corev1.Service
+		inputServicePublishingStrategy *hyperv1.ServicePublishingStrategy
+	}{
+		{
+			name: "existing service keeps nodeport",
+			inputIgnitionServerService: &corev1.Service{
+				ObjectMeta: ignitionserver.Service("default").ObjectMeta,
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "https",
+							Port:       443,
+							TargetPort: intstr.FromInt(9090),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   int32(30000),
+						},
+					},
+				},
+			},
+			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.NodePort,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			initialNodePort := test.inputIgnitionServerService.Spec.Ports[0].NodePort
+			reconcileIgnitionServerService(test.inputIgnitionServerService, test.inputServicePublishingStrategy)
+			g := NewGomegaWithT(t)
+			g.Expect(len(test.inputIgnitionServerService.Spec.Ports)).To(Equal(1))
+			g.Expect(test.inputIgnitionServerService.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt(9090)))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Port).To(Equal(int32(443)))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Name).To(Equal("https"))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].NodePort).To(Equal(initialNodePort))
+		})
+	}
+}
+
+func TestReconcileIgnitionServerServiceRoute(t *testing.T) {
+	tests := []struct {
+		name                           string
+		inputIgnitionServerService     *corev1.Service
+		inputServicePublishingStrategy *hyperv1.ServicePublishingStrategy
+	}{
+		{
+			name:                       "fresh service initialization",
+			inputIgnitionServerService: ignitionserver.Service("default"),
+			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+			},
+		},
+		{
+			name: "existing service",
+			inputIgnitionServerService: &corev1.Service{
+				ObjectMeta: ignitionserver.Service("default").ObjectMeta,
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "https",
+							Port:       443,
+							TargetPort: intstr.FromInt(9090),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reconcileIgnitionServerService(test.inputIgnitionServerService, test.inputServicePublishingStrategy)
+			g := NewGomegaWithT(t)
+			g.Expect(len(test.inputIgnitionServerService.Spec.Ports)).To(Equal(1))
+			g.Expect(test.inputIgnitionServerService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt(9090)))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Port).To(Equal(int32(443)))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Name).To(Equal("https"))
+			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+		})
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"sort"
 	"strings"
@@ -46,6 +45,7 @@ import (
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
 	"github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	ignitionserverreconciliation "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ignitionserver"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -109,8 +109,9 @@ const (
 	ImageStreamAutoscalerImage             = "cluster-autoscaler"
 	ImageStreamClusterMachineApproverImage = "cluster-machine-approver"
 
-	controlPlaneOperatorSubcommandsLabel = "io.openshift.hypershift.control-plane-operator-subcommands"
-	ignitionServerHealthzHandlerLabel    = "io.openshift.hypershift.ignition-server-healthz-handler"
+	controlPlaneOperatorSubcommandsLabel           = "io.openshift.hypershift.control-plane-operator-subcommands"
+	ignitionServerHealthzHandlerLabel              = "io.openshift.hypershift.ignition-server-healthz-handler"
+	controlplaneOperatorManagesIgnitionServerLabel = "io.openshift.hypershift.control-plane-operator-manages-ignition-server"
 )
 
 // NoopReconcile is just a default mutation function that does nothing.
@@ -685,6 +686,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		utilitiesImage = r.HypershiftOperatorImage
 	}
 	_, ignitionServerHasHealthzHandler := util.ImageLabels(controlPlaneOperatorImageMetadata)[ignitionServerHealthzHandlerLabel]
+	_, controlplaneOperatorManagesIgnitionServer := util.ImageLabels(controlPlaneOperatorImageMetadata)[controlplaneOperatorManagesIgnitionServerLabel]
 
 	// Reconcile Platform specifics.
 	p, err := platform.GetPlatform(hcluster, utilitiesImage)
@@ -1126,8 +1128,19 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile the Ignition server
-	if err = r.reconcileIgnitionServer(ctx, createOrUpdate, hcluster, utilitiesImage, hcp, defaultIngressDomain, ignitionServerHasHealthzHandler); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reconcile ignition server: %w", err)
+	if !controlplaneOperatorManagesIgnitionServer {
+		if err := ignitionserverreconciliation.ReconcileIgnitionServer(ctx,
+			r.Client,
+			createOrUpdate,
+			utilitiesImage,
+			hcp,
+			defaultIngressDomain,
+			ignitionServerHasHealthzHandler,
+			r.ReleaseProvider.GetRegistryOverrides(),
+			r.ManagementClusterCapabilities.Has(capabilities.CapabilitySecurityContextConstraint),
+		); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile ignition server: %w", err)
+		}
 	}
 
 	// Reconcile the machine config server
@@ -1450,11 +1463,11 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, cre
 			}
 		}
 
-		hyperutil.SetColocation(hcluster, deployment)
+		hyperutil.SetColocation(hcluster.ObjectMeta, deployment)
 		// TODO (alberto): Reconsider enable this back when we face a real need
 		// with no better solution.
 		// hyperutil.SetRestartAnnotation(hc, deployment)
-		hyperutil.SetControlPlaneIsolation(hcluster, deployment)
+		hyperutil.SetControlPlaneIsolation(hcluster.ObjectMeta, deployment)
 		hyperutil.SetDefaultPriorityClass(deployment)
 
 		switch hcluster.Spec.ControllerAvailabilityPolicy {
@@ -1609,439 +1622,6 @@ func servicePublishingStrategyByType(hcp *hyperv1.HostedCluster, svcType hyperv1
 			return &mapping.ServicePublishingStrategy
 		}
 	}
-	return nil
-}
-
-func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy) error {
-	svc.Spec.Selector = map[string]string{
-		"app": ignitionserver.ResourceName,
-	}
-	var portSpec corev1.ServicePort
-	if len(svc.Spec.Ports) > 0 {
-		portSpec = svc.Spec.Ports[0]
-	} else {
-		svc.Spec.Ports = []corev1.ServicePort{portSpec}
-	}
-	portSpec.Port = int32(443)
-	portSpec.Name = "https"
-	portSpec.Protocol = corev1.ProtocolTCP
-	portSpec.TargetPort = intstr.FromInt(9090)
-	switch strategy.Type {
-	case hyperv1.NodePort:
-		svc.Spec.Type = corev1.ServiceTypeNodePort
-		if portSpec.NodePort == 0 && strategy.NodePort != nil {
-			portSpec.NodePort = strategy.NodePort.Port
-		}
-	case hyperv1.Route:
-		svc.Spec.Type = corev1.ServiceTypeClusterIP
-	default:
-		return fmt.Errorf("invalid publishing strategy for Ignition service: %s", strategy.Type)
-	}
-	svc.Spec.Ports[0] = portSpec
-	return nil
-}
-
-func (r *HostedClusterReconciler) reconcileIgnitionServer(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, utilitiesImage string, hcp *hyperv1.HostedControlPlane, defaultIngressDomain string, hasHealthzHandler bool) error {
-	log := ctrl.LoggerFrom(ctx)
-
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace); err != nil {
-		return fmt.Errorf("failed to get control plane namespace: %w", err)
-	}
-
-	serviceStrategy := servicePublishingStrategyByType(hcluster, hyperv1.Ignition)
-	if serviceStrategy == nil {
-		//lint:ignore ST1005 Ignition is proper name
-		return fmt.Errorf("Ignition service strategy not specified")
-	}
-	// Reconcile service
-	ignitionServerService := ignitionserver.Service(controlPlaneNamespace.Name)
-	if _, err := createOrUpdate(ctx, r.Client, ignitionServerService, func() error {
-		return reconcileIgnitionServerService(ignitionServerService, serviceStrategy)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition service: %w", err)
-	}
-	var ignitionServerAddress string
-	switch serviceStrategy.Type {
-	case hyperv1.Route:
-		// Reconcile route
-		ignitionServerRoute := ignitionserver.Route(controlPlaneNamespace.Name)
-		if _, err := createOrUpdate(ctx, r.Client, ignitionServerRoute, func() error {
-			// The route host is considered immutable, so set it only once upon creation
-			// and ignore updates.
-			if ignitionServerRoute.CreationTimestamp.IsZero() {
-				switch {
-				case !util.ConnectsThroughInternetToControlplane(hcluster.Spec.Platform):
-					ignitionServerRoute.Spec.Host = fmt.Sprintf("%s.apps.%s.hypershift.local", ignitionServerRoute.Name, hcluster.Name)
-				case serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "":
-					ignitionServerRoute.Spec.Host = serviceStrategy.Route.Hostname
-				default:
-					ignitionServerRoute.Spec.Host = util.ShortenRouteHostnameIfNeeded(ignitionServerRoute.Name, ignitionServerRoute.Namespace, defaultIngressDomain)
-				}
-			}
-
-			if ignitionServerRoute.Annotations == nil {
-				ignitionServerRoute.Annotations = map[string]string{}
-			}
-			if hcluster.Spec.Platform.Type == hyperv1.AWSPlatform &&
-				(hcluster.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate ||
-					hcluster.Spec.Platform.AWS.EndpointAccess == hyperv1.Private) {
-				if ignitionServerRoute.Labels == nil {
-					ignitionServerRoute.Labels = map[string]string{}
-				}
-				ignitionServerRoute.Labels[hyperutil.HypershiftRouteLabel] = controlPlaneNamespace.Name
-			} else if serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
-				ignitionServerRoute.ObjectMeta.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = serviceStrategy.Route.Hostname
-			}
-			ignitionServerRoute.Annotations[HostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
-			ignitionServerRoute.Spec.TLS = &routev1.TLSConfig{
-				Termination: routev1.TLSTerminationPassthrough,
-			}
-			ignitionServerRoute.Spec.To = routev1.RouteTargetReference{
-				Kind:   "Service",
-				Name:   ignitionserver.ResourceName,
-				Weight: k8sutilspointer.Int32Ptr(100),
-			}
-			return nil
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile ignition route: %w", err)
-		}
-
-		// The route must be admitted and assigned a host before we can generate certs
-		if len(ignitionServerRoute.Status.Ingress) == 0 || len(ignitionServerRoute.Status.Ingress[0].Host) == 0 {
-			log.Info("ignition server reconciliation waiting for ignition server route to be assigned a host value")
-			return nil
-		}
-		ignitionServerAddress = ignitionServerRoute.Status.Ingress[0].Host
-	case hyperv1.NodePort:
-		if serviceStrategy.NodePort == nil {
-			return fmt.Errorf("nodeport metadata not specified for ignition service")
-		}
-		ignitionServerAddress = serviceStrategy.NodePort.Address
-	default:
-		return fmt.Errorf("unknown service strategy type for ignition service: %s", serviceStrategy.Type)
-	}
-
-	// Reconcile a root CA for ignition serving certificates. We only create this
-	// and don't update it for now.
-	caCertSecret := ignitionserver.IgnitionCACertSecret(controlPlaneNamespace.Name)
-	if result, err := createOrUpdate(ctx, r.Client, caCertSecret, func() error {
-		if caCertSecret.CreationTimestamp.IsZero() {
-			cfg := &certs.CertCfg{
-				Subject:   pkix.Name{CommonName: "ignition-root-ca", OrganizationalUnit: []string{"openshift"}},
-				KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-				Validity:  certs.ValidityTenYears,
-				IsCA:      true,
-			}
-			key, crt, err := certs.GenerateSelfSignedCertificate(cfg)
-			if err != nil {
-				return fmt.Errorf("failed to generate CA: %w", err)
-			}
-			caCertSecret.Type = corev1.SecretTypeTLS
-			caCertSecret.Data = map[string][]byte{
-				corev1.TLSCertKey:       certs.CertToPem(crt),
-				corev1.TLSPrivateKeyKey: certs.PrivateKeyToPem(key),
-			}
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition ca cert: %w", err)
-	} else {
-		log.Info("reconciled ignition CA cert secret", "result", result)
-	}
-
-	// Reconcile a ignition serving certificate issued by the generated root CA. We
-	// only create this and don't update it for now.
-	servingCertSecret := ignitionserver.IgnitionServingCertSecret(controlPlaneNamespace.Name)
-	if result, err := createOrUpdate(ctx, r.Client, servingCertSecret, func() error {
-		if servingCertSecret.CreationTimestamp.IsZero() {
-			caCert, err := certs.PemToCertificate(caCertSecret.Data[corev1.TLSCertKey])
-			if err != nil {
-				return fmt.Errorf("couldn't get ca cert: %w", err)
-			}
-			caKey, err := certs.PemToPrivateKey(caCertSecret.Data[corev1.TLSPrivateKeyKey])
-			if err != nil {
-				return fmt.Errorf("couldn't get ca key: %w", err)
-			}
-			cfg := &certs.CertCfg{
-				Subject:   pkix.Name{CommonName: "ignition-server", Organization: []string{"openshift"}},
-				KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-				Validity:  certs.ValidityOneYear,
-			}
-			numericIP := net.ParseIP(ignitionServerAddress)
-			if numericIP == nil {
-				cfg.DNSNames = []string{ignitionServerAddress}
-			} else {
-				cfg.IPAddresses = []net.IP{numericIP}
-			}
-			key, crt, err := certs.GenerateSignedCertificate(caKey, caCert, cfg)
-			if err != nil {
-				return fmt.Errorf("failed to generate ignition serving cert: %w", err)
-			}
-			servingCertSecret.Type = corev1.SecretTypeTLS
-			servingCertSecret.Data = map[string][]byte{
-				corev1.TLSCertKey:       certs.CertToPem(crt),
-				corev1.TLSPrivateKeyKey: certs.PrivateKeyToPem(key),
-			}
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition serving cert: %w", err)
-	} else {
-		log.Info("reconciled ignition serving cert secret", "result", result)
-	}
-
-	role := ignitionserver.Role(controlPlaneNamespace.Name)
-	if result, err := createOrUpdate(ctx, r.Client, role, func() error {
-		role.Rules = []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{
-					"events",
-					// This is needed by the tokeSecret controller to watch secrets.
-					"secrets",
-					// This is needed by the MCS ignitionProvider to lookup the release image and create the MCS.
-					"pods/log",
-					"serviceaccounts",
-					"pods",
-					// This is needed by the MCS ignitionProvider to create an ephemeral ConfigMap
-					// with the machine config to mount it into the MCS Pod that generates the final payload.
-					"configmaps",
-				},
-				Verbs: []string{"*"},
-			},
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition role: %w", err)
-	} else {
-		log.Info("Reconciled ignition role", "result", result)
-	}
-
-	sa := ignitionserver.ServiceAccount(controlPlaneNamespace.Name)
-	if result, err := createOrUpdate(ctx, r.Client, sa, func() error {
-		util.EnsurePullSecret(sa, controlplaneoperator.PullSecret("").Name)
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile controlplane operator service account: %w", err)
-	} else {
-		log.Info("Reconciled ignition server service account", "result", result)
-	}
-
-	roleBinding := ignitionserver.RoleBinding(controlPlaneNamespace.Name)
-	if result, err := createOrUpdate(ctx, r.Client, roleBinding, func() error {
-		roleBinding.RoleRef = rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     role.Name,
-		}
-
-		roleBinding.Subjects = []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      sa.Name,
-				Namespace: sa.Namespace,
-			},
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition RoleBinding: %w", err)
-	} else {
-		log.Info("Reconciled ignition server rolebinding", "result", result)
-	}
-
-	var probeHandler corev1.ProbeHandler
-	if hasHealthzHandler {
-		probeHandler.HTTPGet = &corev1.HTTPGetAction{
-			Path:   "/healthz",
-			Port:   intstr.FromInt(9090),
-			Scheme: corev1.URISchemeHTTPS,
-		}
-	} else {
-		probeHandler.TCPSocket = &corev1.TCPSocketAction{
-			Port: intstr.FromInt(9090),
-		}
-	}
-
-	// Reconcile deployment
-	ignitionServerDeployment := ignitionserver.Deployment(controlPlaneNamespace.Name)
-	if result, err := createOrUpdate(ctx, r.Client, ignitionServerDeployment, func() error {
-		if ignitionServerDeployment.Annotations == nil {
-			ignitionServerDeployment.Annotations = map[string]string{}
-		}
-		ignitionServerLabels := map[string]string{
-			"app":                         ignitionserver.ResourceName,
-			hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
-		}
-		ignitionServerDeployment.Annotations[HostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
-		ignitionServerDeployment.Spec = appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: ignitionServerLabels,
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: ignitionServerLabels,
-				},
-				Spec: corev1.PodSpec{
-					ServiceAccountName:            sa.Name,
-					TerminationGracePeriodSeconds: k8sutilspointer.Int64Ptr(10),
-					Tolerations: []corev1.Toleration{
-						{
-							Key:    "node-role.kubernetes.io/master",
-							Effect: corev1.TaintEffectNoSchedule,
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "serving-cert",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: servingCertSecret.Name,
-								},
-							},
-						},
-						{
-							Name: "payloads",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name:            ignitionserver.ResourceName,
-							Image:           utilitiesImage,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Env: []corev1.EnvVar{
-								{
-									Name: "MY_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-							},
-							Command: []string{
-								"/usr/bin/control-plane-operator",
-								"ignition-server",
-								"--cert-file", "/var/run/secrets/ignition/serving-cert/tls.crt",
-								"--key-file", "/var/run/secrets/ignition/serving-cert/tls.key",
-								"--registry-overrides", convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()),
-								"--platform", string(hcluster.Spec.Platform.Type),
-							},
-							LivenessProbe: &corev1.Probe{
-								ProbeHandler:        probeHandler,
-								InitialDelaySeconds: 120,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       60,
-								FailureThreshold:    6,
-								SuccessThreshold:    1,
-							},
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler:        probeHandler,
-								InitialDelaySeconds: 5,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       60,
-								FailureThreshold:    3,
-								SuccessThreshold:    1,
-							},
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "https",
-									ContainerPort: 9090,
-								},
-								{
-									Name:          "metrics",
-									ContainerPort: 8080,
-								},
-							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("40Mi"),
-									corev1.ResourceCPU:    resource.MustParse("10m"),
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "serving-cert",
-									MountPath: "/var/run/secrets/ignition/serving-cert",
-								},
-								{
-									Name:      "payloads",
-									MountPath: "/payloads",
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		proxy.SetEnvVars(&ignitionServerDeployment.Spec.Template.Spec.Containers[0].Env)
-
-		if hcluster.Spec.AdditionalTrustBundle != nil {
-			// Add trusted-ca mount with optional configmap
-			util.DeploymentAddTrustBundleVolume(hcluster.Spec.AdditionalTrustBundle, ignitionServerDeployment)
-		}
-
-		// set security context
-		if r.SetDefaultSecurityContext {
-			ignitionServerDeployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-				RunAsUser: k8sutilspointer.Int64Ptr(config.DefaultSecurityContextUser),
-			}
-		}
-		hyperutil.SetRestartAnnotation(hcluster, ignitionServerDeployment)
-		hyperutil.SetColocation(hcluster, ignitionServerDeployment)
-		hyperutil.SetControlPlaneIsolation(hcluster, ignitionServerDeployment)
-		hyperutil.SetDefaultPriorityClass(ignitionServerDeployment)
-		switch hcluster.Spec.ControllerAvailabilityPolicy {
-		case hyperv1.HighlyAvailable:
-			maxSurge := intstr.FromInt(1)
-			maxUnavailable := intstr.FromInt(1)
-			ignitionServerDeployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
-			ignitionServerDeployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-				MaxSurge:       &maxSurge,
-				MaxUnavailable: &maxUnavailable,
-			}
-			hyperutil.SetDeploymentReplicas(hcluster, ignitionServerDeployment, 3)
-			hyperutil.SetMultizoneSpread(ignitionServerLabels, ignitionServerDeployment)
-		default:
-			hyperutil.SetDeploymentReplicas(hcluster, ignitionServerDeployment, 1)
-		}
-
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition deployment: %w", err)
-	} else {
-		log.Info("Reconciled ignition server deployment", "result", result)
-	}
-
-	// Reconcile PodMonitor
-	podMonitor := ignitionserver.PodMonitor(controlPlaneNamespace.Name)
-	if result, err := createOrUpdate(ctx, r.Client, podMonitor, func() error {
-		podMonitor.Spec.Selector = *ignitionServerDeployment.Spec.Selector
-		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
-			Interval: "15s",
-			Port:     "metrics",
-		}}
-		podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{controlPlaneNamespace.Name}}
-		podMonitor.SetOwnerReferences([]metav1.OwnerReference{{
-			APIVersion: hyperv1.GroupVersion.String(),
-			Kind:       "HostedControlPlane",
-			Name:       hcp.Name,
-			UID:        hcp.UID,
-		}})
-		if podMonitor.Annotations == nil {
-			podMonitor.Annotations = map[string]string{}
-		}
-		podMonitor.Annotations[HostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition server pod monitor: %w", err)
-	} else {
-		log.Info("Reconciled ignition server podmonitor", "result", result)
-	}
-
 	return nil
 }
 
@@ -2386,9 +1966,9 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 		}
 	}
 
-	hyperutil.SetColocation(hc, deployment)
-	hyperutil.SetRestartAnnotation(hc, deployment)
-	hyperutil.SetControlPlaneIsolation(hc, deployment)
+	hyperutil.SetColocation(hc.ObjectMeta, deployment)
+	hyperutil.SetRestartAnnotation(hc.ObjectMeta, deployment)
+	hyperutil.SetControlPlaneIsolation(hc.ObjectMeta, deployment)
 	hyperutil.SetDefaultPriorityClass(deployment)
 	return nil
 }
@@ -2700,9 +2280,9 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 		}
 	}
 
-	hyperutil.SetColocation(hc, deployment)
-	hyperutil.SetRestartAnnotation(hc, deployment)
-	hyperutil.SetControlPlaneIsolation(hc, deployment)
+	hyperutil.SetColocation(hc.ObjectMeta, deployment)
+	hyperutil.SetRestartAnnotation(hc.ObjectMeta, deployment)
+	hyperutil.SetControlPlaneIsolation(hc.ObjectMeta, deployment)
 	hyperutil.SetDefaultPriorityClass(deployment)
 	switch hc.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
@@ -3041,9 +2621,9 @@ func reconcileAutoScalerDeployment(deployment *appsv1.Deployment, hc *hyperv1.Ho
 	}
 
 	hyperutil.SetReleaseImageAnnotation(deployment, hc.Spec.Release.Image)
-	hyperutil.SetColocation(hc, deployment)
-	hyperutil.SetRestartAnnotation(hc, deployment)
-	hyperutil.SetControlPlaneIsolation(hc, deployment)
+	hyperutil.SetColocation(hc.ObjectMeta, deployment)
+	hyperutil.SetRestartAnnotation(hc.ObjectMeta, deployment)
+	hyperutil.SetControlPlaneIsolation(hc.ObjectMeta, deployment)
 	hyperutil.SetDefaultPriorityClass(deployment)
 	return nil
 }
@@ -3904,9 +3484,9 @@ func reconcileMachineApproverDeployment(deployment *appsv1.Deployment, hc *hyper
 	}
 
 	hyperutil.SetReleaseImageAnnotation(deployment, hc.Spec.Release.Image)
-	hyperutil.SetColocation(hc, deployment)
-	hyperutil.SetRestartAnnotation(hc, deployment)
-	hyperutil.SetControlPlaneIsolation(hc, deployment)
+	hyperutil.SetColocation(hc.ObjectMeta, deployment)
+	hyperutil.SetRestartAnnotation(hc.ObjectMeta, deployment)
+	hyperutil.SetControlPlaneIsolation(hc.ObjectMeta, deployment)
 	hyperutil.SetDefaultPriorityClass(deployment)
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/autoscaler"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
-	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/capabilities"
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
@@ -606,137 +605,6 @@ func TestServicePublishingStrategyByType(t *testing.T) {
 	}
 }
 
-func TestReconcileIgnitionServerServiceNodePortFreshInitialization(t *testing.T) {
-	tests := []struct {
-		name                           string
-		inputIgnitionServerService     *corev1.Service
-		inputServicePublishingStrategy *hyperv1.ServicePublishingStrategy
-	}{
-		{
-			name:                       "fresh service initialization",
-			inputIgnitionServerService: ignitionserver.Service("default"),
-			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
-				Type: hyperv1.NodePort,
-			},
-		},
-		{
-			name:                       "fresh service with node port specified",
-			inputIgnitionServerService: ignitionserver.Service("default"),
-			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
-				Type: hyperv1.NodePort,
-				NodePort: &hyperv1.NodePortPublishingStrategy{
-					Port: int32(30000),
-				},
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			reconcileIgnitionServerService(test.inputIgnitionServerService, test.inputServicePublishingStrategy)
-			g := NewGomegaWithT(t)
-			g.Expect(len(test.inputIgnitionServerService.Spec.Ports)).To(Equal(1))
-			g.Expect(test.inputIgnitionServerService.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt(9090)))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Port).To(Equal(int32(443)))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Name).To(Equal("https"))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
-			if test.inputServicePublishingStrategy.NodePort != nil && test.inputServicePublishingStrategy.NodePort.Port > 0 {
-				g.Expect(test.inputIgnitionServerService.Spec.Ports[0].NodePort).To(Equal(test.inputServicePublishingStrategy.NodePort.Port))
-			}
-		})
-	}
-}
-
-func TestReconcileIgnitionServerServiceNodePortExistingService(t *testing.T) {
-	tests := []struct {
-		name                           string
-		inputIgnitionServerService     *corev1.Service
-		inputServicePublishingStrategy *hyperv1.ServicePublishingStrategy
-	}{
-		{
-			name: "existing service keeps nodeport",
-			inputIgnitionServerService: &corev1.Service{
-				ObjectMeta: ignitionserver.Service("default").ObjectMeta,
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{
-						{
-							Name:       "https",
-							Port:       443,
-							TargetPort: intstr.FromInt(9090),
-							Protocol:   corev1.ProtocolTCP,
-							NodePort:   int32(30000),
-						},
-					},
-				},
-			},
-			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
-				Type: hyperv1.NodePort,
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			initialNodePort := test.inputIgnitionServerService.Spec.Ports[0].NodePort
-			reconcileIgnitionServerService(test.inputIgnitionServerService, test.inputServicePublishingStrategy)
-			g := NewGomegaWithT(t)
-			g.Expect(len(test.inputIgnitionServerService.Spec.Ports)).To(Equal(1))
-			g.Expect(test.inputIgnitionServerService.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt(9090)))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Port).To(Equal(int32(443)))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Name).To(Equal("https"))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].NodePort).To(Equal(initialNodePort))
-		})
-	}
-}
-
-func TestReconcileIgnitionServerServiceRoute(t *testing.T) {
-	tests := []struct {
-		name                           string
-		inputIgnitionServerService     *corev1.Service
-		inputServicePublishingStrategy *hyperv1.ServicePublishingStrategy
-	}{
-		{
-			name:                       "fresh service initialization",
-			inputIgnitionServerService: ignitionserver.Service("default"),
-			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
-				Type: hyperv1.Route,
-			},
-		},
-		{
-			name: "existing service",
-			inputIgnitionServerService: &corev1.Service{
-				ObjectMeta: ignitionserver.Service("default").ObjectMeta,
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{
-						{
-							Name:       "https",
-							Port:       443,
-							TargetPort: intstr.FromInt(9090),
-							Protocol:   corev1.ProtocolTCP,
-						},
-					},
-				},
-			},
-			inputServicePublishingStrategy: &hyperv1.ServicePublishingStrategy{
-				Type: hyperv1.Route,
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			reconcileIgnitionServerService(test.inputIgnitionServerService, test.inputServicePublishingStrategy)
-			g := NewGomegaWithT(t)
-			g.Expect(len(test.inputIgnitionServerService.Spec.Ports)).To(Equal(1))
-			g.Expect(test.inputIgnitionServerService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt(9090)))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Port).To(Equal(int32(443)))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Name).To(Equal("https"))
-			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
-		})
-	}
-}
-
 func TestReconcileCAPICluster(t *testing.T) {
 	testCases := []struct {
 		name               string
@@ -1102,11 +970,12 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 				".dockerconfigjson": []byte("{}"),
 			},
 		},
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "agent-namespace",
-			},
-		},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "agent-namespace"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "agent"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "aws"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "none"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ibm"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kubevirt"}},
 	}
 	for _, cluster := range hostedClusters {
 		cluster.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
@@ -66,6 +66,7 @@ func TestWebhookAllowsHostedClusterReconcilerUpdates(t *testing.T) {
 					Data:       map[string][]byte{".dockerconfigjson": []byte("something")},
 				},
 				&configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "none-cluster"}},
 			},
 		},
 	}


### PR DESCRIPTION
This changes moves the ignition server management from the HO into the
CPO. In order to stay backwards compatible, the HO will still reconcile
the ignition server if the CPO isn't opted into doing that through a
Docker image label.

Ref https://issues.redhat.com/browse/HOSTEDCP-411

/cc @enxebre 

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.