### PR TITLE
set snapshot-count on etcd to limit memory usage variability

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -104,6 +104,7 @@ func buildEtcdContainer(p *EtcdParams, namespace string) func(c *corev1.Containe
 --initial-cluster=${INITIAL_CLUSTER} \
 --initial-cluster-state=new \
 --quota-backend-bytes=${QUOTA_BACKEND_BYTES} \
+--snapshot-count=10000 \
 --peer-client-cert-auth=true \
 --peer-cert-file=/etc/etcd/tls/peer/peer.crt \
 --peer-key-file=/etc/etcd/tls/peer/peer.key \


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/etcd-io/etcd/issues/13889

tl;dr in etcd v3.2, upstream etcd increased the snapshot count from 10k to 100k with very little rationale https://github.com/etcd-io/etcd/pull/7160

This allows a lot more time for the etcd memory usage to rise before the snapshot is taken and memory can be released.

10k is the old default and this reverts to that old behavior in an effort to moderate the large memory usage swings we observe and allow for more a appropriate container memory request  to be set.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.