### PR TITLE
feat(cpo): disable CP profiling for IBMCloud Platform

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1742,7 +1742,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeScheduler(ctx context.Contex
 
 	schedulerDeployment := manifests.SchedulerDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, schedulerDeployment, func() error {
-		return scheduler.ReconcileDeployment(schedulerDeployment, p.OwnerRef, p.DeploymentConfig, p.HyperkubeImage, p.FeatureGates(), p.SchedulerPolicy(), p.AvailabilityProberImage, hcp.Spec.APIPort, p.CipherSuites(), p.MinTLSVersion())
+		return scheduler.ReconcileDeployment(schedulerDeployment, p.OwnerRef, p.DeploymentConfig, p.HyperkubeImage, p.FeatureGates(), p.SchedulerPolicy(), p.AvailabilityProberImage, hcp.Spec.APIPort, p.CipherSuites(), p.MinTLSVersion(), hcp.Spec.Platform.Type)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile scheduler deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -177,6 +177,9 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 	args.Set("max-mutating-requests-inflight", "1000")
 	args.Set("max-requests-inflight", "3000")
 	args.Set("min-request-timeout", "3600")
+	if p.PlatformType == hyperv1.IBMCloudPlatform {
+		args.Set("profiling", "false")
+	}
 	args.Set("proxy-client-cert-file", cpath(kasVolumeAggregatorCert().Name, corev1.TLSCertKey))
 	args.Set("proxy-client-key-file", cpath(kasVolumeAggregatorCert().Name, corev1.TLSPrivateKeyKey))
 	args.Set("requestheader-allowed-names", requestHeaderAllowedNames()...)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -38,6 +38,7 @@ type KubeAPIServerParams struct {
 	CloudProvider       string                       `json:"cloudProvider"`
 	CloudProviderConfig *corev1.LocalObjectReference `json:"cloudProviderConfig"`
 	CloudProviderCreds  *corev1.LocalObjectReference `json:"cloudProviderCreds"`
+	PlatformType        hyperv1.PlatformType         `json:"platformType"`
 
 	ServiceAccountIssuer string                       `json:"serviceAccountIssuer"`
 	ServiceCIDR          string                       `json:"serviceCIDR"`
@@ -280,6 +281,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
+	params.PlatformType = hcp.Spec.Platform.Type
 
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
@@ -383,6 +385,7 @@ func (p *KubeAPIServerParams) ConfigParams() KubeAPIServerConfigParams {
 		NodePortRange:                p.ServiceNodePortRange(),
 		AuditWebhookEnabled:          p.AuditWebhookRef != nil,
 		ConsolePublicURL:             p.ConsolePublicURL,
+		PlatformType:                 p.PlatformType,
 	}
 }
 
@@ -400,6 +403,7 @@ type KubeAPIServerConfigParams struct {
 	AdvertiseAddress             string
 	ServiceAccountIssuerURL      string
 	CloudProvider                string
+	PlatformType                 hyperv1.PlatformType
 	CloudProviderConfigRef       *corev1.LocalObjectReference
 	EtcdURL                      string
 	FeatureGates                 []string

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -311,6 +311,9 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 	if len(p.CipherSuites()) != 0 {
 		args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(p.CipherSuites(), ",")))
 	}
+	if p.PlatformType == hyperv1.IBMCloudPlatform {
+		args = append(args, "--profiling=false")
+	}
 	args = append(args, []string{
 		fmt.Sprintf("--cert-dir=%s", cpath(kcmVolumeCertDir().Name, "")),
 		fmt.Sprintf("--cluster-cidr=%s", p.PodCIDR),

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -24,9 +24,10 @@ type KubeControllerManagerParams struct {
 	CloudProviderConfig *corev1.LocalObjectReference `json:"cloudProviderConfig"`
 	CloudProviderCreds  *corev1.LocalObjectReference `json:"cloudProviderCreds"`
 	Port                int32                        `json:"port"`
+	APIServer           *configv1.APIServer          `json:"apiServer"`
+	PlatformType        hyperv1.PlatformType         `json:"platformType"`
 	ServiceCIDR         string
 	PodCIDR             string
-	APIServer           *configv1.APIServer `json:"apiServer"`
 
 	config.DeploymentConfig
 	config.OwnerRef
@@ -99,6 +100,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
+	params.PlatformType = hcp.Spec.Platform.Type
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		params.CloudProvider = aws.Provider

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -21,7 +21,8 @@ type KubeSchedulerParams struct {
 	HyperkubeImage          string                `json:"hyperkubeImage"`
 	AvailabilityProberImage string                `json:"availabilityProberImage"`
 	config.DeploymentConfig `json:",inline"`
-	APIServer               *configv1.APIServer `json:"apiServer"`
+	APIServer               *configv1.APIServer  `json:"apiServer"`
+	PlatformType            hyperv1.PlatformType `json:"platformType"`
 }
 
 func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, images map[string]string, globalConfig globalconfig.GlobalConfig, setDefaultSecurityContext bool) *KubeSchedulerParams {
@@ -79,6 +80,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	params.DeploymentConfig.SetControlPlaneIsolation(hcp)
+	params.PlatformType = hcp.Spec.Platform.Type
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.Replicas = 3


### PR DESCRIPTION
**What this PR does / why we need it**: Disabling CP profiling to follow best practices highlighted in [CIS benchmark for Kubernetes](https://www.cisecurity.org/benchmark/kubernetes). Disabling profiling is limited to the IBMCloud platform type. 

**Which issue(s) this PR fixes**: [Disable Kubernetes control plane profiling for IBM Cloud platform](https://github.com/openshift/hypershift/issues/1438)


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.