### PR TITLE
Fix the private router to work on a 4.11 mgmt cluster

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1244,7 +1244,7 @@ func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"security.openshift.io"},
 				Resources: []string{"securitycontextconstraints"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     []string{"get", "list", "watch", "use"},
 			},
 			{
 				APIGroups: []string{"rbac.authorization.k8s.io"},

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -23393,6 +23393,7 @@ objects:
     - get
     - list
     - watch
+    - use
   - apiGroups:
     - rbac.authorization.k8s.io
     resources:

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2063,6 +2063,12 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 				"watch",
 			},
 		},
+		{
+			APIGroups:     []string{"security.openshift.io"},
+			ResourceNames: []string{"hostnetwork"},
+			Resources:     []string{"securitycontextconstraints"},
+			Verbs:         []string{"use"},
+		},
 	}
 	return nil
 }


### PR DESCRIPTION
4.11 management clusters have a different default SCC which breaks the
router pods. Update the deployment and role to match what the
cluster-ingress-operator does to fix it.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.