### PR TITLE
nat gateway: check for invalid eip

### DIFF
--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -347,7 +347,8 @@ func (o *CreateInfraOptions) CreateNATGateway(client ec2iface.EC2API, publicSubn
 
 	isNATGatewayRetriable := func(err error) bool {
 		if awsErr, ok := err.(awserr.Error); ok {
-			return strings.EqualFold(awsErr.Code(), invalidSubnet)
+			return strings.EqualFold(awsErr.Code(), invalidSubnet) ||
+				strings.EqualFold(awsErr.Code(), invalidElasticIPNotFound)
 		}
 		return false
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We are currently only checking whether there is an invalid subnet when retrying nat gateway creation, but we also need to check for an invalid eip error

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.