### PR TITLE
Ensure cache is set during token rotation before reconciling

### DIFF
--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -322,19 +322,29 @@ func (r *TokenSecretReconciler) rotateToken(ctx context.Context, tokenSecret *co
 		patch.Annotations = make(map[string]string)
 	}
 
-	if _, ok := tokenSecret.Data[TokenSecretOldTokenKey]; ok {
-		r.PayloadStore.Delete(string(tokenSecret.Data[TokenSecretOldTokenKey]))
+	oldtoken, ok := tokenSecret.Data[TokenSecretOldTokenKey]
+	if ok {
+		r.PayloadStore.Delete(string(oldtoken))
+
 	}
 
 	patch.Annotations[TokenSecretTokenGenerationTime] = rotationTime.Format(time.RFC3339Nano)
 	patch.Data[TokenSecretOldTokenKey] = tokenSecret.Data[TokenSecretTokenKey]
 	patch.Data[TokenSecretTokenKey] = []byte(newToken)
 
+	// Set the new token before patching the object. Otherwise, there is a race: if the secret is reconciled
+	// before the value is set in the cache the new token would require a new payload generation in that reconciliation.
+	r.PayloadStore.Set(newToken, value)
+
 	if err := r.Client.Patch(ctx, patch, client.MergeFrom(tokenSecret)); err != nil {
+		// If token patch operation fails, consistently restore the cache.
+		// Otherwise, the next reconciliation the token would require a new payload generation because
+		// it wouldn't be in the cache anymore.
+		r.PayloadStore.Delete(newToken)
+		r.PayloadStore.Set(string(oldtoken), value)
 		return err
 	}
 
-	r.PayloadStore.Set(newToken, value)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We are observing unexpected cache regeneration in IBM, this attempt to prevent those from happening.

Set the new token before patching the object. Otherwise, there is a race: if the secret is reconciled before the value is set in the cache the new token would require a new payload generation in that reconciliation.

If token patch operation fails, consistently restore the cache.
Otherwise, the next reconciliation the token would require a new payload generation because it wouldn't be in the cache anymore.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.