### PR TITLE
Drop kas call in agent ReconcileCAPIInfraCR and fail if no ign

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -918,6 +918,9 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 					Agent: &hyperv1.AgentPlatformSpec{AgentNamespace: "agent-namespace"},
 				},
 			},
+			Status: hyperv1.HostedClusterStatus{
+				IgnitionEndpoint: "ign",
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "aws"},


### PR DESCRIPTION
**What this PR does / why we need it**:
This add unit tests and fixes the ReconcileCAPIInfraCR agent implementation to avoid an unncesesary kas call to fetch the HCP, since all needed info is available already.

Aditionally it returns early if there's no ign endpoint to ensure we create the agentCluster only after ignition endpoint exists so AgentClusterInstall is only created with the right ign to boot machines.
https://bugzilla.redhat.com/show_bug.cgi?id=2097895
https://github.com/openshift/assisted-service/blob/241ad46db74add5f16e153f5f7ba0a5496fb06ba/pkg/validating-webhooks/hiveextension/v1beta1/agentclusterinstall_admission_hook.go#L185
https://github.com/openshift/cluster-api-provider-agent/blob/master/controllers/agentcluster_controller.go#L126
This change honours the following statement:
For AgentClusterInstall/ClusterDeployment if the input is empty, the value is defaulted so the field is optional and immutable. For CAPI is effectively required and immutable.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.