### PR TITLE
The ValidateReleaseImage was returning an error stating it could not find the pull-secret and blocked HC

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -591,7 +591,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// This check can be expensive looking up release image versions
 		// (hopefully they are cached).  Skip if we have already observed for
 		// this generation.
-		if condition == nil || condition.ObservedGeneration != hcluster.Generation {
+		if condition == nil || condition.ObservedGeneration != hcluster.Generation || condition.Status != metav1.ConditionTrue {
 			condition := metav1.Condition{
 				Type:               string(hyperv1.ValidReleaseImage),
 				ObservedGeneration: hcluster.Generation,


### PR DESCRIPTION
### Description
* If the pull-secret is created after the hostedCluster resource,  the generation check that is done, would block access to trying the validation again if the first attempt failed.
* ACM creates the HostedCluster resource and secrets with ManifestWork the creation order of resources is not guaranteed.

Signed-off-by: Joshua Packer <jpacker@redhat.com>

**What this PR does / why we need it**:
  Provisioning with ACM/MCE was blocked after [Merge pull request](https://github.com/openshift/hypershift/commit/069d7d1f4e7908d68ece987257e5a0e6b4f0ffa6) https://github.com/openshift/hypershift/pull/1296

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
NA

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] ~Relevant issues have been referenced.~
- [ ] This change includes docs. 
- [ ] This change includes unit tests.