### PR TITLE
install: add operator-only option for OCP metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ app-sre-saas-template: hypershift
 		--oidc-storage-provider-s3-secret=oidc-s3-creds \
 		--oidc-storage-provider-s3-region=us-east-1 \
 		--oidc-storage-provider-s3-secret-key=credentials \
-		--enable-ocp-cluster-monitoring=false \
+		--platform-monitoring=None \
 		--enable-ci-debug-output=false \
 		--enable-admin-rbac-generation=true \
 		--private-platform=AWS \

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -53,7 +53,7 @@ type Options struct {
 	Template                                  bool
 	Format                                    string
 	ExcludeEtcdManifests                      bool
-	EnableOCPClusterMonitoring                bool
+	PlatformMonitoring                        metrics.PlatformMonitoring
 	EnableCIDebugOutput                       bool
 	PrivatePlatform                           string
 	AWSPrivateCreds                           string
@@ -134,7 +134,7 @@ func NewCommand() *cobra.Command {
 
 	var opts Options
 	if os.Getenv("CI") == "true" {
-		opts.EnableOCPClusterMonitoring = true
+		opts.PlatformMonitoring = metrics.PlatformMonitoringAll
 		opts.EnableCIDebugOutput = true
 	}
 	opts.PrivatePlatform = string(hyperv1.NonePlatform)
@@ -145,7 +145,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Development, "development", false, "Enable tweaks to facilitate local development")
 	cmd.PersistentFlags().BoolVar(&opts.EnableWebhook, "enable-webhook", false, "Enable webhook for hypershift API types")
 	cmd.PersistentFlags().BoolVar(&opts.ExcludeEtcdManifests, "exclude-etcd", false, "Leave out etcd manifests")
-	cmd.PersistentFlags().BoolVar(&opts.EnableOCPClusterMonitoring, "enable-ocp-cluster-monitoring", opts.EnableOCPClusterMonitoring, "Development-only option that will make your OCP cluster unsupported: If the cluster Prometheus should be configured to scrape metrics")
+	cmd.PersistentFlags().Var(&opts.PlatformMonitoring, "platform-monitoring", "Select an option for enabling platform cluster monitoring. Valid values are: None, OperatorOnly, All")
 	cmd.PersistentFlags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", opts.EnableCIDebugOutput, "If extra CI debug output should be enabled")
 	cmd.PersistentFlags().StringVar(&opts.PrivatePlatform, "private-platform", opts.PrivatePlatform, "Platform on which private clusters are supported by this operator (supports \"AWS\" or \"None\")")
 	cmd.PersistentFlags().StringVar(&opts.AWSPrivateCreds, "aws-private-creds", opts.AWSPrivateCreds, "Path to an AWS credentials file with privileges sufficient to manage private cluster resources")
@@ -258,7 +258,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 
 	operatorNamespace := assets.HyperShiftNamespace{
 		Name:                       opts.Namespace,
-		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
+		EnableOCPClusterMonitoring: opts.PlatformMonitoring.IsEnabled(),
 	}.Build()
 	objects = append(objects, operatorNamespace)
 
@@ -413,7 +413,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 		OperatorImage:                  opts.HyperShiftImage,
 		ServiceAccount:                 operatorServiceAccount,
 		Replicas:                       opts.HyperShiftOperatorReplicas,
-		EnableOCPClusterMonitoring:     opts.EnableOCPClusterMonitoring,
+		EnableOCPClusterMonitoring:     opts.PlatformMonitoring == metrics.PlatformMonitoringAll,
 		EnableCIDebugOutput:            opts.EnableCIDebugOutput,
 		EnableWebhook:                  opts.EnableWebhook,
 		PrivatePlatform:                opts.PrivatePlatform,
@@ -443,7 +443,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	prometheusRoleBinding := assets.HyperShiftOperatorPrometheusRoleBinding{
 		Namespace:                  operatorNamespace,
 		Role:                       prometheusRole,
-		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
+		EnableOCPClusterMonitoring: opts.PlatformMonitoring.IsEnabled(),
 	}.Build()
 	objects = append(objects, prometheusRoleBinding)
 

--- a/support/metrics/platform_monitoring.go
+++ b/support/metrics/platform_monitoring.go
@@ -1,0 +1,45 @@
+package metrics
+
+import "fmt"
+
+// PlatformMonitoring is used to indicate which metrics will be scraped by the
+// management cluster's platform monitoring stack:
+// - OperatorOnly indicates that only the hypershift operator will be scraped
+// - All indicates that the hypershift operator and any control planes created by it will be scraped
+// - None indicates that neither operator nor control planes will be scraped
+type PlatformMonitoring string
+
+var (
+	PlatformMonitoringOperatorOnly PlatformMonitoring = "OperatorOnly"
+	PlatformMonitoringAll          PlatformMonitoring = "All"
+	PlatformMonitoringNone         PlatformMonitoring = "None"
+)
+
+func (o *PlatformMonitoring) String() string {
+	if o == nil {
+		return ""
+	}
+	return string(*o)
+}
+
+func (o *PlatformMonitoring) Set(value string) error {
+	switch value {
+	case string(PlatformMonitoringOperatorOnly):
+		*o = PlatformMonitoringOperatorOnly
+	case string(PlatformMonitoringAll):
+		*o = PlatformMonitoringAll
+	case string(PlatformMonitoringNone):
+		*o = PlatformMonitoringNone
+	default:
+		return fmt.Errorf("invalid OCP monitoring option: %s, valid values are: %s, %s, %s", value, string(PlatformMonitoringOperatorOnly), string(PlatformMonitoringAll), string(PlatformMonitoringNone))
+	}
+	return nil
+}
+
+func (o *PlatformMonitoring) Type() string {
+	return "PlatformMonitoringOption"
+}
+
+func (o *PlatformMonitoring) IsEnabled() bool {
+	return o != nil && (*o != PlatformMonitoringNone)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of providing a simple boolean for enabling OCP monitoring for
the HyperShift operator and all control plane namespaces, this commit
introduces an option to enable OCP monitoring only for the HyperShift
operator and not control plane namespaces.

This additional option is needed for the MCE standalone use case in
which we want to use OCP monitoring to collect metrics from the
HyperShift operator to send to telemetry. For control plane namespaces
we want to use User Workload Monitoring to remote write telemetry of the
individual hosted clusters.

**Checklist**
- [x] Subject and description added to both, commit and PR.