### PR TITLE
feat(cpo): Support disable profiling annotation

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -93,6 +93,11 @@ const (
 	// ServiceAccountSigningKeySecretKey is the name of the secret key that should contain the service account signing
 	// key if specified.
 	ServiceAccountSigningKeySecretKey = "key"
+
+	// DisableProfilingAnnotation is the annotation that allows disabling profiling for control plane components.
+	// Any components specified in this list will have profiling disabled. Profiling is disabled by default for etcd and konnectivity.
+	// Components this annotation can apply to: kube-scheduler, kube-controller-manager, kube-apiserver.
+	DisableProfilingAnnotation = "hypershift.openshift.io/disable-profiling"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1743,7 +1743,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeScheduler(ctx context.Contex
 
 	schedulerDeployment := manifests.SchedulerDeployment(hcp.Namespace)
 	if _, err := r.CreateOrUpdate(ctx, r, schedulerDeployment, func() error {
-		return scheduler.ReconcileDeployment(schedulerDeployment, p.OwnerRef, p.DeploymentConfig, p.HyperkubeImage, p.FeatureGates(), p.SchedulerPolicy(), p.AvailabilityProberImage, hcp.Spec.APIPort, p.CipherSuites(), p.MinTLSVersion())
+		return scheduler.ReconcileDeployment(schedulerDeployment, p.OwnerRef, p.DeploymentConfig, p.HyperkubeImage, p.FeatureGates(), p.SchedulerPolicy(), p.AvailabilityProberImage, hcp.Spec.APIPort, p.CipherSuites(), p.MinTLSVersion(), p.DisableProfiling)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile scheduler deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -148,6 +148,9 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 		args.Set("audit-webhook-config-file", auditWebhookConfigFile())
 		args.Set("audit-webhook-mode", "batch")
 	}
+	if p.DisableProfiling {
+		args.Set("profiling", "false")
+	}
 	args.Set("egress-selector-config-file", cpath(kasVolumeEgressSelectorConfig().Name, EgressSelectorConfigMapKey))
 	args.Set("enable-admission-plugins", admissionPlugins()...)
 	if version.Minor == 10 {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
+	"github.com/openshift/hypershift/support/util"
 )
 
 type KubeAPIServerImages struct {
@@ -54,6 +55,7 @@ type KubeAPIServerParams struct {
 	KubeConfigRef        *hyperv1.KubeconfigSecretRef `json:"kubeConfigRef"`
 	AuditWebhookRef      *corev1.LocalObjectReference `json:"auditWebhookRef"`
 	ConsolePublicURL     string                       `json:"consolePublicURL"`
+	DisableProfiling     bool                         `json:"disableProfiling"`
 	config.DeploymentConfig
 	config.OwnerRef
 
@@ -83,6 +85,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		PodCIDR:              hcp.Spec.PodCIDR,
 		Availability:         hcp.Spec.ControllerAvailabilityPolicy,
 		ConsolePublicURL:     fmt.Sprintf("https://console-openshift-console.%s", dns.Spec.BaseDomain),
+		DisableProfiling:     util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], manifests.KASDeployment("").Name),
 
 		Images: KubeAPIServerImages{
 			HyperKube:                  images["hyperkube"],
@@ -409,6 +412,7 @@ type KubeAPIServerConfigParams struct {
 	NodePortRange                string
 	AuditWebhookEnabled          bool
 	ConsolePublicURL             string
+	DisableProfiling             bool
 }
 
 func (p *KubeAPIServerParams) TLSSecurityProfile() *configv1.TLSSecurityProfile {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -311,6 +311,9 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 	if len(p.CipherSuites()) != 0 {
 		args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(p.CipherSuites(), ",")))
 	}
+	if p.DisableProfiling {
+		args = append(args, "--profiling=false")
+	}
 	args = append(args, []string{
 		fmt.Sprintf("--cert-dir=%s", cpath(kcmVolumeCertDir().Name, "")),
 		fmt.Sprintf("--cluster-cidr=%s", p.PodCIDR),

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -26,6 +26,7 @@ type KubeControllerManagerParams struct {
 	ServiceCIDR         string
 	PodCIDR             string
 	APIServer           *configv1.APIServerSpec `json:"apiServer"`
+	DisableProfiling    bool                    `json:"disableProfiling"`
 
 	config.DeploymentConfig
 	config.OwnerRef
@@ -57,6 +58,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	params.Scheduling = config.Scheduling{
 		PriorityClass: config.DefaultPriorityClass,
 	}
+	params.DisableProfiling = util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], manifests.KCMDeployment("").Name)
 	params.LivenessProbes = config.LivenessProbes{
 		kcmContainerMain().Name: {
 			ProbeHandler: corev1.ProbeHandler{

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -35,7 +35,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, featureGates []string, policy configv1.ConfigMapNameReference, availabilityProberImage string, apiPort *int32, ciphers []string, tlsVersion string) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, featureGates []string, policy configv1.ConfigMapNameReference, availabilityProberImage string, apiPort *int32, ciphers []string, tlsVersion string, disableProfiling bool) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main scheduler container
@@ -68,7 +68,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.BoolPtr(false),
 				Containers: []corev1.Container{
-					util.BuildContainer(schedulerContainerMain(), buildSchedulerContainerMain(image, deployment.Namespace, featureGates, policy, ciphers, tlsVersion)),
+					util.BuildContainer(schedulerContainerMain(), buildSchedulerContainerMain(image, deployment.Namespace, featureGates, policy, ciphers, tlsVersion, disableProfiling)),
 				},
 				Volumes: []corev1.Volume{
 					util.BuildVolume(schedulerVolumeConfig(), buildSchedulerVolumeConfig),
@@ -89,7 +89,7 @@ func schedulerContainerMain() *corev1.Container {
 	}
 }
 
-func buildSchedulerContainerMain(image, namespace string, featureGates []string, policy configv1.ConfigMapNameReference, cipherSuites []string, tlsVersion string) func(*corev1.Container) {
+func buildSchedulerContainerMain(image, namespace string, featureGates []string, policy configv1.ConfigMapNameReference, cipherSuites []string, tlsVersion string, disableProfiling bool) func(*corev1.Container) {
 	return func(c *corev1.Container) {
 		kubeConfigPath := path.Join(volumeMounts.Path(schedulerContainerMain().Name, schedulerVolumeKubeconfig().Name), kas.KubeconfigKey)
 		configPath := path.Join(volumeMounts.Path(schedulerContainerMain().Name, schedulerVolumeConfig().Name), KubeSchedulerConfigKey)
@@ -119,6 +119,9 @@ func buildSchedulerContainerMain(image, namespace string, featureGates []string,
 		}
 		if tlsVersion != "" {
 			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsVersion))
+		}
+		if disableProfiling {
+			c.Args = append(c.Args, "--profiling=false")
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -9,6 +9,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 )
@@ -21,6 +22,7 @@ type KubeSchedulerParams struct {
 	AvailabilityProberImage string                    `json:"availabilityProberImage"`
 	config.DeploymentConfig `json:",inline"`
 	APIServer               *configv1.APIServerSpec `json:"apiServer"`
+	DisableProfiling        bool                    `json:"disableProfiling"`
 }
 
 func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, images map[string]string, setDefaultSecurityContext bool) *KubeSchedulerParams {
@@ -89,6 +91,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 
 	params.SetDefaultSecurityContext = setDefaultSecurityContext
+	params.DisableProfiling = util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], manifests.SchedulerDeployment("").Name)
 
 	params.OwnerRef = config.OwnerRefFrom(hcp)
 	return params

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1243,6 +1243,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.AWSKMSProviderImage,
 		hyperv1.PortierisImageAnnotation,
 		hyperutil.DebugDeploymentsAnnotation,
+		hyperv1.DisableProfilingAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/support/util/strings.go
+++ b/support/util/strings.go
@@ -1,0 +1,14 @@
+package util
+
+import "strings"
+
+// Contains checks if a comma-delimited string contains a specific string.
+func StringListContains(list string, s string) bool {
+	slice := strings.Split(list, ",")
+	for _, a := range slice {
+		if strings.Trim(a, " ") == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Add annotation to support disabling profiling for control plane components. 

**Which issue(s) this PR fixes** 
Fixes #1438

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.