### PR TITLE
docs: agent: AgentServiceConfig script used fixed version instead of latest

### DIFF
--- a/docs/content/how-to/agent/create-agent-cluster.md
+++ b/docs/content/how-to/agent/create-agent-cluster.md
@@ -56,11 +56,12 @@ Create the `AgentServiceConfig` resource
 ~~~sh
 export DB_VOLUME_SIZE="10Gi"
 export FS_VOLUME_SIZE="10Gi"
-export OCP_VERSION="4.10"
+export OCP_VERSION="4.10.16"
+export OCP_MAJMIN=${OCP_VERSION%.*}
 export ARCH="x86_64"
-export OCP_RELEASE_VERSION=$(curl -s https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest-${OCP_VERSION}/release.txt | awk '/machine-os / { print $2 }')
-export ISO_URL="https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/${OCP_VERSION}/latest/rhcos-live.${ARCH}.iso"
-export ROOT_FS_URL="https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/${OCP_VERSION}/latest/rhcos-live-rootfs.${ARCH}.img"
+export OCP_RELEASE_VERSION=$(curl -s https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${OCP_VERSION}/release.txt | awk '/machine-os / { print $2 }')
+export ISO_URL="https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/${OCP_MAJMIN}/${OCP_VERSION}/rhcos-${OCP_VERSION}-${ARCH}-live.${ARCH}.iso"
+export ROOT_FS_URL="https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/${OCP_MAJMIN}/${OCP_VERSION}/rhcos-${OCP_VERSION}-${ARCH}-live-rootfs.${ARCH}.img"
 
 envsubst <<"EOF" | oc apply -f -
 apiVersion: agent-install.openshift.io/v1beta1


### PR DESCRIPTION
In #1466 I simplied the agent docs.  As part of that, I switched the `AgentServiceConfig` script to reference the moving target `latest` rather than a specific version, which is likely to lag behind in the future.

However, assisted-service stores a hash of the referenced resources at the time the `AgentServiceConfig` is created/modified.  When `latest` is changed, the hash check fails and hosts booted with the discovery ISO are unable to join as Agents.

This reverts the script to pointing to a particular RHCOS build to avoid breaking when `latest` changes.

@avishayt @eranco74 @csrwng 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.