### PR TITLE
nodepool controller: remove right condition type

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -322,7 +322,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		log.Info("CA Secret is missing tls.crt key")
 		return ctrl.Result{}, nil
 	}
-	removeStatusCondition(&nodePool.Status.Conditions, hyperv1.IgnitionCACertMissingReason)
+	removeStatusCondition(&nodePool.Status.Conditions, string(hyperv1.IgnitionEndpointAvailable))
 
 	// Validate and get releaseImage.
 	releaseImage, err := r.getReleaseImage(ctx, hcluster, nodePool.Spec.Release.Image)


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a minor fix to nodepool controller to remove the right condition type when not missing CA cert

**Checklist**
- [x] Subject and description added to both, commit and PR.