### PR TITLE
[WIP] Kubevirt Platform: Add kubevirt-cloud-provider controller

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/deployment.go
@@ -1,0 +1,57 @@
+package ccm
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/platform"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, ccmPlatform platform.Platform) error {
+	p := NewCloudProviderParams(hcp)
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: ccmLabels(),
+		},
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: ccmLabels(),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					util.BuildContainer(manifests.CCMContainer(), buildCCMContainer(ccmPlatform)),
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+	}
+
+	ccmPlatform.AddPlatfomVolumes(deployment)
+
+	p.OwnerRef.ApplyTo(deployment)
+	p.DeploymentConfig.ApplyTo(deployment)
+	return nil
+}
+
+func buildCCMContainer(ccmPlatform platform.Platform) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = ccmPlatform.GetContainerImage()
+		c.ImagePullPolicy = corev1.PullIfNotPresent
+		c.Command = ccmPlatform.GetContainerCommand()
+		c.Args = ccmPlatform.GetContainerArgs()
+		c.VolumeMounts = ccmPlatform.GetPodVolumeMounts().ContainerMounts(c.Name)
+		c.Ports = []corev1.ContainerPort{
+			{
+				Name:          "https",
+				Protocol:      "TCP",
+				ContainerPort: 10258,
+			},
+		}
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/params.go
@@ -1,0 +1,63 @@
+package ccm
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type CloudProviderParams struct {
+	OwnerRef         config.OwnerRef `json:"ownerRef"`
+	DeploymentConfig config.DeploymentConfig
+}
+
+func NewCloudProviderParams(hcp *hyperv1.HostedControlPlane) *CloudProviderParams {
+	p := &CloudProviderParams{
+		OwnerRef: config.OwnerRefFrom(hcp),
+	}
+	p.DeploymentConfig.Resources = config.ResourcesSpec{
+		manifests.CCMContainer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+				corev1.ResourceCPU:    resource.MustParse("75m"),
+			},
+		},
+	}
+	p.DeploymentConfig.LivenessProbes = config.LivenessProbes{
+		manifests.CCMContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(10258)),
+					Path:   "healthz",
+				},
+			},
+			InitialDelaySeconds: 120,
+			TimeoutSeconds:      5,
+			PeriodSeconds:       60,
+		},
+	}
+	p.DeploymentConfig.AdditionalLabels = additionalLabels()
+	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.SetControlPlaneIsolation(hcp)
+	p.DeploymentConfig.SetColocationAnchor(hcp)
+
+	p.DeploymentConfig.Replicas = 1
+
+	return p
+}
+
+func ccmLabels() map[string]string {
+	return map[string]string{
+		"app": "cloud-controller-manager",
+	}
+}
+
+func additionalLabels() map[string]string {
+	return map[string]string{
+		hyperv1.ControlPlaneComponent: "cloud-controller-manager",
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/platform/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/platform/kubevirt/kubevirt.go
@@ -1,0 +1,124 @@
+package kubevirt
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+var (
+	// TODO nargaman need to add to images
+	image = "quay.io/nargaman/kubevirt-cloud-controller-manager:v0.1.0"
+)
+
+type Kubevirt struct {
+	hcp *hyperv1.HostedControlPlane
+}
+
+func NewKubevirtPlatform(hcp *hyperv1.HostedControlPlane) *Kubevirt {
+	return &Kubevirt{
+		hcp: hcp,
+	}
+}
+
+func (k *Kubevirt) GetContainerImage() string {
+	return image
+}
+
+func (k *Kubevirt) GetContainerCommand() []string {
+	return []string{"/bin/kubevirt-cloud-controller-manager"}
+}
+
+func (k *Kubevirt) GetContainerArgs() []string {
+	return []string{
+		"--cloud-provider=kubevirt",
+		"--cloud-config=/etc/cloud/cloud-config",
+		// "--use-service-account-credentials=true",
+		"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+		"--cluster-name", k.hcp.Name,
+	}
+}
+
+func (k *Kubevirt) GetPodVolumeMounts() util.PodVolumeMounts {
+	return util.PodVolumeMounts{
+		manifests.CCMContainer().Name: util.ContainerVolumeMounts{
+			ccmVolumeKubeconfig().Name:      "/etc/kubernetes/kubeconfig",
+			ccmVolumeCombinedCA().Name:      "/etc/kubernetes/combined-ca",
+			ccmVolumeClusterSignerCA().Name: "/etc/kubernetes/cluster-signer-ca",
+			ccmCloudConfig().Name:           "/etc/cloud",
+		},
+	}
+}
+
+func (k *Kubevirt) AddPlatfomVolumes(deployment *appsv1.Deployment) {
+
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmVolumeKubeconfig(), buildCCMVolumeKubeconfig),
+	)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmVolumeCombinedCA(), buildCCMVolumeCombinedCA),
+	)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmVolumeClusterSignerCA(), buildCCMClusterSignerCA),
+	)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmCloudConfig(), buildCCMCloudConfig),
+	)
+}
+
+func ccmVolumeKubeconfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "kubeconfig",
+	}
+}
+
+func ccmVolumeCombinedCA() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "combined-ca",
+	}
+}
+
+func ccmVolumeClusterSignerCA() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cluster-signer-ca",
+	}
+}
+
+func ccmCloudConfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cloud-config",
+	}
+}
+
+func buildCCMVolumeKubeconfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+	}
+}
+
+func buildCCMVolumeCombinedCA(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+	v.ConfigMap.DefaultMode = pointer.Int32Ptr(420)
+	v.ConfigMap.Name = manifests.CombinedCAConfigMap("").Name
+}
+
+func buildCCMClusterSignerCA(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.ClusterSignerCASecret("").Name,
+	}
+}
+
+func buildCCMCloudConfig(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: manifests.CCMConfigMap("").Name,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/platform/platform.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/platform/platform.go
@@ -1,0 +1,25 @@
+package platform
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/ccm/platform/kubevirt"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type Platform interface {
+	AddPlatfomVolumes(deployment *appsv1.Deployment)
+	GetContainerImage() string
+	GetContainerCommand() []string
+	GetContainerArgs() []string
+	GetPodVolumeMounts() util.PodVolumeMounts
+}
+
+func GetPlatform(hcp *hyperv1.HostedControlPlane) Platform {
+	var platform Platform
+	switch hcp.Spec.Platform.Type {
+	case hyperv1.KubevirtPlatform:
+		platform = kubevirt.NewKubevirtPlatform(hcp)
+	}
+	return platform
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/credentials.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/credentials.go
@@ -1,0 +1,135 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/upsert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+func createServiceAccount(ctx context.Context, hcp *hyperv1.HostedControlPlane, c client.Client, createOrUpdate upsert.CreateOrUpdateFN) (*corev1.ServiceAccount, error) {
+	ownerRef := config.OwnerRefFrom(hcp)
+	sa := ccmServiceAccount(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, c, sa, func() error {
+		return reconcileCCMServiceAccount(sa, ownerRef)
+	}); err != nil {
+		return nil, fmt.Errorf("failed to reconcile Kubevirt cloud provider service account: %w", err)
+	}
+	role := ccmRole(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, c, role, func() error {
+		return reconcileCCMRole(role, ownerRef)
+	}); err != nil {
+		return nil, fmt.Errorf("failed to reconcile Kubevirt cloud provider role: %w", err)
+	}
+	roleBinding := ccmRoleBinding(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, c, roleBinding, func() error {
+		return reconcileCCMRoleBinding(roleBinding, ownerRef, sa, role)
+	}); err != nil {
+		return nil, fmt.Errorf("failed to reconcile Kubevirt cloud provider rolebinding: %w", err)
+	}
+
+	// clusterRole := ccmClusterRole()
+	// if _, err := r.CreateOrUpdate(ctx, r, clusterRole, func() error {
+	// 	return kubevirt.reconcileCCMClusterRole(clusterRole)
+	// }); err != nil {
+	// 	return nil, fmt.Errorf("failed to reconcile Kubevirt cloud provider cluster role: %w", err)
+	// }
+	// clusterRoleBinding := ccmClusterRoleBinding()
+	// if _, err := r.CreateOrUpdate(ctx, r, clusterRoleBinding, func() error {
+	// 	return kubevirt.reconcileCCMClusterRoleBinding(clusterRoleBinding, sa, clusterRole)
+	// }); err != nil {
+	// 	return nil, fmt.Errorf("failed to reconcile Kubevirt cloud provider cluster rolebinding: %w", err)
+	// }
+	return sa, nil
+}
+
+func CreateInClusterConfig(ctx context.Context, hcp *hyperv1.HostedControlPlane, c client.Client, createOrUpdate upsert.CreateOrUpdateFN) ([]byte, error) {
+	sa, err := createServiceAccount(ctx, hcp, c, createOrUpdate)
+	if err != nil {
+		return nil, err
+	}
+
+	token, caCert, err := getTokenData(ctx, c, sa)
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	clusters := make(map[string]*clientcmdapi.Cluster)
+	clusters["infra-cluster"] = &clientcmdapi.Cluster{
+		Server:                   restConfig.Host,
+		CertificateAuthorityData: caCert,
+	}
+
+	contexts := make(map[string]*clientcmdapi.Context)
+	contexts["default-context"] = &clientcmdapi.Context{
+		Cluster:   "infra-cluster",
+		Namespace: sa.Namespace,
+		AuthInfo:  sa.Namespace,
+	}
+
+	authinfos := make(map[string]*clientcmdapi.AuthInfo)
+	authinfos[sa.Namespace] = &clientcmdapi.AuthInfo{
+		Token: string(token),
+	}
+
+	config := &clientcmdapi.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       clusters,
+		Contexts:       contexts,
+		CurrentContext: "default-context",
+		AuthInfos:      authinfos,
+	}
+
+	json, err := runtime.Encode(clientcmdlatest.Codec, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode the configuration: %w", err)
+	}
+	output, err := yaml.JSONToYAML(json)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create yaml configuration: %w", err)
+	}
+
+	return output, nil
+}
+
+func getTokenData(ctx context.Context, c client.Client, sa *corev1.ServiceAccount) ([]byte, []byte, error) {
+	requestedSecretName := sa.Name + "-token"
+	secretList := &corev1.SecretList{}
+	opts := []client.ListOption{
+		client.InNamespace(sa.Namespace),
+	}
+	if err := c.List(ctx, secretList, opts...); err != nil {
+		return nil, nil, fmt.Errorf("can't get the token secret list in namespace %s, %w", sa.Namespace, err)
+	}
+	for _, secret := range secretList.Items {
+		if strings.HasPrefix(secret.Name, requestedSecretName) {
+			token, ok := secret.Data["token"]
+			if !ok {
+				return nil, nil, fmt.Errorf("can't find the koken in the secret")
+			}
+			caCert, ok := secret.Data["ca.crt"]
+			if !ok {
+				return nil, nil, fmt.Errorf("can't find the ca.crt in the secret")
+			}
+			return token, caCert, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("can't find secret %s", requestedSecretName)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/providerconfig.go
@@ -1,0 +1,49 @@
+package kubevirt
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	CloudConfigKey = "cloud-config"
+)
+
+// Cloud Config is a copy of the relevant subset of the upstream type
+// at https://github.com/kubevirt/cloud-provider-kubevirt/blob/main/pkg/provider/cloud.go
+type CloudConfig struct {
+	Kubeconfig   string             `yaml:"kubeconfig"`
+	LoadBalancer LoadBalancerConfig `yaml:"loadBalancer"`
+	InstancesV2  InstancesV2Config  `yaml:"instancesV2"`
+}
+
+type LoadBalancerConfig struct {
+	// Enabled activates the load balancer interface of the CCM
+	Enabled bool `yaml:"enabled"`
+	// CreationPollInterval determines how many seconds to wait for the load balancer creation
+	CreationPollInterval int `yaml:"creationPollInterval"`
+}
+
+type InstancesV2Config struct {
+	// Enabled activates the instances interface of the CCM
+	Enabled bool `yaml:"enabled"`
+}
+
+func (c *CloudConfig) String() (string, error) {
+	out, err := yaml.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func cloudConfig(kubeconfig []byte) CloudConfig {
+	return CloudConfig{
+		Kubeconfig: string(kubeconfig),
+		LoadBalancer: LoadBalancerConfig{
+			Enabled: true,
+		},
+		InstancesV2: InstancesV2Config{
+			Enabled: true,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
@@ -1,0 +1,154 @@
+package kubevirt
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ccmServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func ccmRole(ns string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func ccmRoleBinding(ns string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+// func ccmClusterRole() *rbacv1.ClusterRole {
+// 	return &rbacv1.ClusterRole{
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name: "kubevirt-cloud-controller-manager-clusterrole",
+// 		},
+// 	}
+// }
+//
+// func ccmClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+// 	return &rbacv1.ClusterRoleBinding{
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name: "kubevirt-cloud-controller-manager-clusterrole",
+// 		},
+// 	}
+// }
+
+func ReconcileCloudConfig(cm *corev1.ConfigMap, hcp *hyperv1.HostedControlPlane, kubeconfig []byte) error {
+	cfg := cloudConfig(kubeconfig)
+	serializedCfg, err := cfg.String()
+	if err != nil {
+		return fmt.Errorf("failed to serialize cloudconfig: %w", err)
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data[CloudConfigKey] = string(serializedCfg)
+
+	return nil
+}
+
+func reconcileCCMServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sa)
+	return nil
+}
+
+func reconcileCCMRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(role)
+	role.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"kubevirt.io"},
+			Resources: []string{"virtualmachines"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{"kubevirt.io"},
+			Resources: []string{"virtualmachineinstances"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"update",
+			},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{rbacv1.VerbAll},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"services"},
+			Verbs:     []string{rbacv1.VerbAll},
+		},
+	}
+	return nil
+}
+
+func reconcileCCMRoleBinding(roleBinding *rbacv1.RoleBinding, ownerRef config.OwnerRef, sa *corev1.ServiceAccount, role *rbacv1.Role) error {
+	ownerRef.ApplyTo(roleBinding)
+	roleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "Role",
+		Name:     role.Name,
+	}
+	roleBinding.Subjects = []rbacv1.Subject{
+		{
+			Namespace: sa.Namespace,
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      sa.Name,
+		},
+	}
+	return nil
+}
+
+// func reconcileCCMClusterRole(clusterRole *rbacv1.ClusterRole) error {
+// 	clusterRole.Rules = []rbacv1.PolicyRule{
+// 		{
+// 			APIGroups: []string{""},
+// 			Resources: []string{"nodes"},
+// 			Verbs:     []string{"get"},
+// 		},
+// 	}
+// 	return nil
+// }
+//
+// func reconcileCCMClusterRoleBinding(clusterRoleBinding *rbacv1.ClusterRoleBinding, sa *corev1.ServiceAccount, clusterRole *rbacv1.ClusterRole) error {
+// 	clusterRoleBinding.RoleRef = rbacv1.RoleRef{
+// 		APIGroup: rbacv1.GroupName,
+// 		Kind:     "ClusterRole",
+// 		Name:     clusterRole.Name,
+// 	}
+// 	clusterRoleBinding.Subjects = []rbacv1.Subject{
+// 		{
+// 			Namespace: sa.Namespace,
+// 			Kind:      rbacv1.ServiceAccountKind,
+// 			Name:      sa.Name,
+// 		},
+// 	}
+// 	return nil
+// }

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/ccm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/ccm.go
@@ -1,0 +1,31 @@
+package manifests
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CCMDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cloud-config",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMContainer() *corev1.Container {
+	return &corev1.Container{
+		Name: "cloud-controller-manager",
+	}
+}

--- a/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
@@ -51,6 +51,22 @@ func OperatorRoleBinding(controlPlaneOperatorNamespace string) *rbacv1.RoleBindi
 	}
 }
 
+func OperatorClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "control-plane-operator",
+		},
+	}
+}
+
+func OperatorClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "control-plane-operator",
+		},
+	}
+}
+
 func OperatorIngressRole(ingressNamespace string, controlPlaneOperatorNamespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduce new cloud-controller-manager controller for
kubevirt platform.

This PR include some changes which I would like to discuss about:

1. CCM code structure suggestion:
The cloud-config code was added under `control-plane-operator/controllers/hostedcontrolplane/cloud` package, like all previous platforms
For the deployment code, as this is one of the first platforms using external cloud-provider, I created new package (`ccm`) in which all the controller code was added
The reconcileDeployment was created in Generic way, and all platform specific parameters are added with the platform interface.
I'm aware to the PowerVS cloud-controller-manager that was added (#1422), in case my suggestion would be accepted, I would add another commit changing the PoweVS code to use the same pattern
2. CCM RBAC permissions in the management cluster:
The cloud-controller-manager's cloud infrastructure is actually the management cluster, therefore I added code creates kubeconfig with limited RBAC permissions (the Kubeconfig is created from Service Account)
Because the operator which responsible to create this Kubeconfig is control-plane-operator, I had to make sure also this operator has the permissions.

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.