### PR TITLE
cache registry files

### DIFF
--- a/ignition-server/controllers/image_file_cache.go
+++ b/ignition-server/controllers/image_file_cache.go
@@ -1,0 +1,157 @@
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var log = ctrl.Log.WithName("image-cache")
+
+func NewImageFileCache(workDir string) (*imageFileCache, error) {
+	cacheDir, err := os.MkdirTemp(workDir, "cache-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	return &imageFileCache{
+		cacheMap:  make(map[cacheKey]cacheValue),
+		cacheDir:  cacheDir,
+		regClient: registryclient.ExtractImageFile,
+		mutex:     sync.RWMutex{},
+	}, nil
+}
+
+// Caching wrapper around the registry client function "regClient".
+// All files returned by the function are cached as files in a sub-directory of "cacheDir".
+// The cached files never expire, but can be automatically re-downloaded if they become corrupted.
+type imageFileCache struct {
+	cacheMap  map[cacheKey]cacheValue
+	cacheDir  string
+	regClient regClient // wrapped registryclient function
+	mutex     sync.RWMutex
+}
+
+type checksum []byte
+type regClient func(ctx context.Context, imageRef string, pullSecret []byte, file string, out io.Writer) error
+
+type cacheKey struct {
+	imageRef  string
+	imageFile string
+}
+
+type cacheValue struct {
+	fileName string
+	fileSha  checksum
+}
+
+func (c *imageFileCache) extractImageFile(ctx context.Context, imageRef string, pullSecret []byte, imageFile string, out io.Writer) error {
+	key := cacheKey{imageRef: imageRef, imageFile: imageFile}
+
+	c.mutex.RLock()
+	file, ok := c.cacheMap[key]
+	c.mutex.RUnlock()
+
+	if ok && cacheFileIsValid(file) {
+		log.Info("retrieved cached file", "imageRef", imageRef, "file", imageFile)
+		return returnCacheFile(file.fileName, out)
+	}
+
+	// Image file does not seem to be in the cache, begin critical section to add it...
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// Another thread could have added the file to cache while we were waiting for exclusive lock, check again...
+	if file, ok := c.cacheMap[key]; ok && cacheFileIsValid(file) {
+		log.Info("retrieved cached file", "imageRef", imageRef, "file", imageFile)
+		return returnCacheFile(file.fileName, out)
+	}
+
+	// No, image file really is not in the cache or checksum test failed - download from the registry...
+	newFileName, err := downloadImageFile(ctx, c.regClient, imageRef, pullSecret, imageFile, c.cacheDir)
+	if err != nil {
+		return err
+	}
+
+	newFileSha, err := calcFileChecksum(newFileName)
+	if err != nil {
+		return err
+	}
+
+	c.cacheMap[key] = cacheValue{newFileName, newFileSha}
+	log.Info("downloaded and cached file", "imageRef", imageRef, "file", imageFile)
+
+	return returnCacheFile(newFileName, out)
+}
+
+func cacheFileIsValid(file cacheValue) bool {
+	checksum, err := calcFileChecksum(file.fileName)
+	if err != nil {
+		log.Error(err, "failed to calculate checksum of cached file", "file", file.fileName)
+		return false
+	}
+
+	if !bytes.Equal(checksum, file.fileSha) {
+		log.Error(err, "cache file is corrupted", "file", file.fileName)
+		return false
+	}
+	return true
+}
+
+func calcFileChecksum(file string) (checksum, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		log.Error(err, "failed to open file", "file", file)
+		return nil, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		log.Error(err, "failed to calculate checksum of file", "file", file)
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
+}
+
+func returnCacheFile(fullCacheFileName string, out io.Writer) error {
+	file, err := os.Open(fullCacheFileName)
+	if err != nil {
+		return fmt.Errorf("failed to open cache file: %w", err)
+	}
+	defer file.Close()
+	if _, err := io.Copy(out, file); err != nil {
+		return fmt.Errorf("failed to copy cache file: %w", err)
+	}
+	return nil
+}
+
+func downloadImageFile(ctx context.Context, regClient regClient, imageRef string, pullSecret []byte, imageFile string, cacheDir string) (_ string, err error) {
+	newFile, err := ioutil.TempFile(cacheDir, filepath.Base(imageFile)+"-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create cache file: %w", err)
+	}
+
+	defer func() {
+		closeErr := newFile.Close()
+		if closeErr != nil && err == nil {
+			err = fmt.Errorf("failed to close cache file: %w", closeErr)
+		}
+	}()
+
+	if err = regClient(ctx, imageRef, pullSecret, imageFile, newFile); err != nil {
+		return "", fmt.Errorf("failed to extract image file: %w", err)
+	}
+
+	return newFile.Name(), nil
+}

--- a/ignition-server/controllers/image_file_cache_test.go
+++ b/ignition-server/controllers/image_file_cache_test.go
@@ -1,0 +1,106 @@
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestImageFileCache(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var content string // image file content registryClientMock returns
+	var called int     // number of times registryClientMock called
+	var fail bool      // registryClientMock responds with failure
+
+	regClientFuncMock := func(ctx context.Context, imageRef string, pullSecret []byte, imageFile string, out io.Writer) error {
+		out.Write([]byte(content))
+		called++
+		if fail {
+			return errors.New("mocked failure")
+		}
+		return nil
+	}
+
+	cacheDir := t.TempDir()
+
+	sut := &imageFileCache{
+		cacheMap:  make(map[cacheKey]cacheValue),
+		cacheDir:  cacheDir,
+		regClient: regClientFuncMock,
+		mutex:     sync.RWMutex{},
+	}
+
+	// first file should miss the cache
+	content = "test1"
+	response1, err1 := getImageFile(t, sut, "ref1", "dir/file1")
+	g.Expect(err1).Should(Succeed())
+	g.Expect(called).To(Equal(1)) // incremented
+	g.Expect(response1).To(Equal(content))
+
+	// next call should hit the cache
+	response2, err2 := getImageFile(t, sut, "ref1", "dir/file1")
+	g.Expect(err2).Should(Succeed())
+	g.Expect(called).To(Equal(1)) // not incremented
+	g.Expect(response2).To(Equal(content))
+
+	// corrupted files should be re-downloaded
+	simulateFileCorruption(t, cacheDir)
+	response2bis, err2bis := getImageFile(t, sut, "ref1", "dir/file1")
+	g.Expect(err2bis).Should(Succeed())
+	g.Expect(called).To(Equal(2)) // incremented
+	g.Expect(response2bis).To(Equal(content))
+
+	// call with different imageRef should miss the cache
+	content = "test2"
+	response3, err3 := getImageFile(t, sut, "ref2", "dir/file1")
+	g.Expect(err3).Should(Succeed())
+	g.Expect(called).To(Equal(3)) // incremented
+	g.Expect(response3).To(Equal(content))
+
+	// next call to get the same image file should hit the cache
+	response4, err4 := getImageFile(t, sut, "ref2", "dir/file1")
+	g.Expect(err4).Should(Succeed())
+	g.Expect(called).To(Equal(3)) // not incremented
+	g.Expect(response4).To(Equal(content))
+
+	// registry client failure should be propagated back to the caller
+	fail = true
+	_, err5 := getImageFile(t, sut, "ref2", "dir/file2")
+	g.Expect(called).To(Equal(4)) // incremented
+	g.Expect(err5).Should(HaveOccurred())
+	g.Expect(err5.Error()).Should(ContainSubstring("mocked failure"))
+	t.Log("failure message returned:", err5)
+}
+
+func getImageFile(t *testing.T, sut *imageFileCache, imageRef string, imageFile string) (string, error) {
+	var buff bytes.Buffer
+	sutErr := sut.extractImageFile(context.Background(), imageRef, []byte("pull-secret"), imageFile, &buff)
+	return buff.String(), sutErr
+}
+
+func simulateFileCorruption(t *testing.T, cacheDir string) {
+	files, err := ioutil.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatal("failed to open cache directory", err)
+	}
+	fileInfo := files[0] // only one file is supposed to be in the directory
+	cachedFileName := filepath.Join(cacheDir, fileInfo.Name())
+	t.Log("adding some garbage into file:", cachedFileName)
+	cachedFile, err := os.OpenFile(cachedFileName, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal("failed to open cache file", err)
+	}
+	defer cachedFile.Close()
+	if _, err := cachedFile.WriteString("世界"); err != nil {
+		t.Fatal("failed to add data to a cache file", err)
+	}
+}

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -57,6 +57,8 @@ type LocalIgnitionProvider struct {
 	// deleted after use.
 	PreserveOutput bool
 
+	ImageFileCache *imageFileCache
+
 	lock sync.Mutex
 }
 
@@ -204,7 +206,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 			if err := file.Chmod(0777); err != nil {
 				return fmt.Errorf("failed to chmod file: %w", err)
 			}
-			if err := registryclient.ExtractImageFile(ctx, mcoImage, pullSecret, filepath.Join("usr/bin/", name), file); err != nil {
+			if err := p.ImageFileCache.extractImageFile(ctx, mcoImage, pullSecret, filepath.Join("usr/bin/", name), file); err != nil {
 				return fmt.Errorf("failed to extract image file: %w", err)
 			}
 			if err := file.Close(); err != nil {


### PR DESCRIPTION
This PR adds caching capability to the registry client function registryclient.ExtractImageFile() to prevent it from re-downloading big binary image files multiple times so that load on the back-end registry is reduced.

Please see issue https://github.com/openshift/hypershift/issues/1437

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.