### PR TITLE
PowerVS : CIS Domain nextUrl usage fixed

### DIFF
--- a/cmd/infra/powervs/create.go
+++ b/cmd/infra/powervs/create.go
@@ -386,7 +386,7 @@ func (infra *Infra) setupBaseDomain(options *CreateInfraOptions) (err error) {
 		}
 
 		// For paging over next set of resources getting the start token
-		if resourceList.NextURL != nil || *resourceList.NextURL != "" {
+		if resourceList.NextURL != nil && *resourceList.NextURL != "" {
 			nextUrl = *resourceList.NextURL
 			return
 		}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Resource instance's nextUrl accessed without validating nil condition due to incorrect usage of OR condition instead of AND.
Fixed it by replacing it with AND condition.
https://issues.redhat.com/browse/MULTIARCH-2574

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.