### PR TITLE
kube-apiserver-proxy use privatelink for private clusters

### DIFF
--- a/support/util/visibility.go
+++ b/support/util/visibility.go
@@ -17,3 +17,9 @@ func IsPublicHCP(hcp *hyperv1.HostedControlPlane) bool {
 	return hcp.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate ||
 		hcp.Spec.Platform.AWS.EndpointAccess == hyperv1.Public
 }
+
+func IsPrivateHC(hc *hyperv1.HostedCluster) bool {
+	return hc.Spec.Platform.Type == hyperv1.AWSPlatform &&
+		(hc.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate ||
+			hc.Spec.Platform.AWS.EndpointAccess == hyperv1.Private)
+}


### PR DESCRIPTION
Fix issue where guest cluster components do not communicate over privatelink when connecting to the KAS over the service network.  This causes guest cluster components to be blocked when using `apiAllowedCIDRBlocks`.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.