### PR TITLE
Add PlatformCredentialsFound condition to report missing platform creds

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1271,6 +1271,10 @@ const (
 	// HostedCluster itself attempts an unsupported version before 4.9 or an
 	// unsupported upgrade e.g y-stream upgrade before 4.11.
 	ValidReleaseImage ConditionType = "ValidReleaseImage"
+
+	// PlatformCredentialsFound indicates that credentials required for the
+	// desired platform are valid.
+	PlatformCredentialsFound ConditionType = "PlatformCredentialsFound"
 )
 
 const (
@@ -1306,7 +1310,8 @@ const (
 
 	InsufficientClusterCapabilitiesReason = "InsufficientClusterCapabilities"
 
-	OIDCConfigurationInvalidReason = "OIDCConfigurationInvalid"
+	OIDCConfigurationInvalidReason    = "OIDCConfigurationInvalid"
+	PlatformCredentialsNotFoundReason = "PlatformCredentialsNotFound"
 
 	InvalidImageReason = "InvalidImage"
 )

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2263,6 +2263,10 @@ HostedCluster is available to handle ignition requests.</p>
 <td><p>OIDCConfigurationInvalid indicates if an AWS cluster&rsquo;s OIDC condition is
 detected as invalid.</p>
 </td>
+</tr><tr><td><p>&#34;PlatformCredentialsFound&#34;</p></td>
+<td><p>PlatformCredentialsFound indicates that credentials required for the
+desired platform are valid.</p>
+</td>
 </tr><tr><td><p>&#34;ReconciliationPaused&#34;</p></td>
 <td><p>ReconciliationPaused indicates if reconciliation of the hostedcluster is
 paused.</p>


### PR DESCRIPTION
https://issues.redhat.com/browse/HOSTEDCP-493

**What this PR does / why we need it**:

Example condition on the HC if CPO cred is missing for platform AWS
```
    - lastTransitionTime: "2022-06-30T16:43:38Z"
      message: 'failed to get control plane operator provider creds example-cpo-creds:
        Secret "example-cpo-creds" not found'
      observedGeneration: 3
      reason: PlatformCredentialsInvalid
      status: "False"
      type: PlatformCredentialsValid   
```

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.