### PR TITLE
E2E dump: Do not require platform opt-in for dump to work

### DIFF
--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -279,14 +279,12 @@ func newClusterDumper(hc *hyperv1.HostedCluster, opts *core.CreateOptions, artif
 				t.Logf("Failed to dump machine journals; this is nonfatal: %v", err)
 			}
 			return utilerrors.NewAggregate(dumpErrors)
-		case hyperv1.NonePlatform, hyperv1.KubevirtPlatform:
+		default:
 			err := dump.DumpHostedCluster(ctx, hc, dumpGuestCluster, dumpDir)
 			if err != nil {
 				return fmt.Errorf("failed to dump hosted cluster: %w", err)
 			}
 			return nil
-		default:
-			return fmt.Errorf("unsupported cluster platform")
 		}
 	}
 }


### PR DESCRIPTION
We have a default dumping mechanism that works and provides value for
all platforms. Rather than failing by default and require each platform
to opt in, despite most using the default logic, we should just use the
default logic and only use the platform-level switching to allow adding
platform-specific logic if wanted.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.