### PR TITLE
HO: Add a reconciliation success condition

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1611,6 +1611,10 @@ const (
 	// active or paused.
 	ReconciliationActive ConditionType = "ReconciliationActive"
 
+	// ReconciliationSucceeded indicates if the hostedcluster reconciliation
+	// succeeded.
+	ReconciliationSucceeded ConditionType = "ReconciliationSucceeded"
+
 	// ValidOIDCConfiguration indicates if an AWS cluster's OIDC condition is
 	// detected as invalid.
 	ValidOIDCConfiguration ConditionType = "ValidOIDCConfiguration"

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2673,6 +2673,10 @@ desired platform are valid.</p>
 <td><p>ReconciliationActive indicates if reconciliation of the hostedcluster is
 active or paused.</p>
 </td>
+</tr><tr><td><p>&#34;ReconciliationSucceeded&#34;</p></td>
+<td><p>ReconciliationSucceeded indicates if the hostedcluster reconciliation
+succeeded.</p>
+</td>
 </tr><tr><td><p>&#34;SupportedHostedCluster&#34;</p></td>
 <td><p>SupportedHostedCluster indicates whether a HostedCluster is supported by
 the current configuration of the hypershift-operator.


### PR DESCRIPTION
This adds a catch-all condition to hostedclusters that indicate the
success of a reconciliation and will surface errors, if any.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.