### PR TITLE
Added changes for serviceID API Key to access resources

### DIFF
--- a/cmd/infra/powervs/destroy.go
+++ b/cmd/infra/powervs/destroy.go
@@ -121,7 +121,12 @@ func (options *DestroyInfraOptions) DestroyInfra(infra *Infra) (err error) {
 		return fmt.Errorf("IBMCLOUD_API_KEY not set")
 	}
 
-	resourceGroupID, err := getResourceGroupID(options.ResourceGroup)
+	accountID, err := getAccount(getIAMAuth())
+	if err != nil {
+		return fmt.Errorf("error retrieving account ID %w", err)
+	}
+
+	resourceGroupID, err := getResourceGroupID(options.ResourceGroup, accountID)
 	if err != nil {
 		return err
 	}
@@ -160,7 +165,7 @@ func (options *DestroyInfraOptions) DestroyInfra(infra *Infra) (err error) {
 
 	var session *ibmpisession.IBMPISession
 	if !skipPowerVs {
-		session, err = createPowerVSSession(options.PowerVSRegion, options.PowerVSZone, options.Debug)
+		session, err = createPowerVSSession(accountID, options.PowerVSRegion, options.PowerVSZone, options.Debug)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
If API Key created under a specific service ID, getResourceGroup method requires to pass accountID explicitly.
With the changes submitted, both generic API key and service ID API key can be handled.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.