### PR TITLE
docs: fix getting-started.md typo

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -5,7 +5,7 @@ title: Getting started
 # Getting started
 
 HyperShift is middleware for hosting OpenShift control planes at scale that
-solves for cost and time to provision, as well as portability cross cloud with
+solves for cost and time to provision, as well as portability across cloud service providers with
 strong separation of concerns between management and workloads. Clusters are
 fully compliant OpenShift Container Platform (OCP) clusters and are compatible
 with standard OCP and Kubernetes toolchains.


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes typos in docs (getting-started.md): Highlighted in red 👇
<img width="1440" alt="fix getting-started md typo" src="https://user-images.githubusercontent.com/96339995/178063342-0286d3d7-eaf9-4cc4-831b-65e704ddee4c.png">
�