### PR TITLE
NE-1043: Move the DNS operator into the management cluster

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -66,6 +66,7 @@ var (
 		"0000_50_operator-marketplace_09_operator.yaml",
 		"0000_50_operator-marketplace_10_clusteroperator.yaml",
 		"0000_50_operator-marketplace_11_service_monitor.yaml",
+		"0000_70_dns-operator_02-deployment-ibm-cloud-managed.yaml",
 		"0000_50_cluster-ingress-operator_02-deployment-ibm-cloud-managed.yaml",
 		"0000_70_cluster-network-operator_02_rbac.yaml",
 		"0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml",

--- a/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
@@ -1,0 +1,162 @@
+package dnsoperator
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+const (
+	// dnsOperatorContainerName is the name of the operator container.
+	dnsOperatorContainerName = "dns-operator"
+)
+
+// Images stores the image pullspecs for the images that the DNS operator
+// deployment references.
+type Images struct {
+	DNSOperator   string
+	CoreDNS       string
+	KubeRBACProxy string
+	CLI           string
+}
+
+// Params stores the parameters that are required to configure the DNS operator
+// deployment on HyperShift, as well as some additional information about the
+// deployment.
+type Params struct {
+	// ReleaseVersion is the HyperShift release version.
+	ReleaseVersion string
+	// AvailabilityProberImage is the image for the prober, which runs on
+	// the management cluster and probes the DNS operator.
+	AvailabilityProberImage string
+	// Images has the image pullspecs that the DNS operator deployment
+	// references.
+	Images Images
+	// DeploymentConfig has information about the DNS operator deployment.
+	DeploymentConfig config.DeploymentConfig
+}
+
+// NewParams creates a new Params object for a DNS operator deployment.
+func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[string]string, setDefaultSecurityContext bool) Params {
+	p := Params{
+		Images: Images{
+			DNSOperator:   images["cluster-dns-operator"],
+			CoreDNS:       images["coredns"],
+			KubeRBACProxy: images["kube-rbac-proxy"],
+			CLI:           images["cli"],
+		},
+		ReleaseVersion:          version,
+		AvailabilityProberImage: images[util.AvailabilityProberImageName],
+	}
+
+	p.DeploymentConfig.AdditionalAnnotations = map[string]string{
+		"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+	}
+	p.DeploymentConfig.AdditionalLabels = map[string]string{
+		"name":                        "dns-operator",
+		hyperv1.ControlPlaneComponent: "dns-operator",
+	}
+	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+
+	return p
+}
+
+// ReconcileDeployment reconciles a deployment of the DNS operator, which runs
+// in the management cluster and manages operands in a hosted cluster.  For
+// non-HyperShift clusters, the DNS operator is deployed by
+// cluster-version-operator with the following manifest:
+// <https://github.com/openshift/cluster-dns-operator/blob/master/manifests/0000_70_dns-operator_02-deployment.yaml>.
+// For HyperShift, the deployment differs from non-HyperShift clusters in the
+// following ways:
+//
+// * The operator is configured with a kubeconfig for the managed cluster.
+//
+// * The operator metrics are exposed using cleartext rather than being
+//   protected using kube-rbac-proxy.  (However, CoreDNS's metrics are still
+//   protected using kube-rbac-proxy on the hosted cluster.)
+//
+// * The operator has HyperShift-specific annotations, labels, owner reference,
+//   and affinity rules and omits the node selector for control-plane nodes.
+//
+// * The operator has an init container that probes the hosted cluster's
+//   kube-apiserver to verify that the dnses.operator.openshift.io API is
+//   available.
+//
+// The DNS operator does not require access to the cloud platform API,
+// hosted-cluster services, or external services, so the operator does not
+// require any special proxy configuration or permissions in the management
+// cluster.
+func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) {
+	dep.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"name": "dns-operator"},
+	}
+	dep.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)
+	dep.Spec.Template.Spec.Containers = []corev1.Container{{
+		Command: []string{"dns-operator"},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "RELEASE_VERSION",
+				Value: params.ReleaseVersion,
+			}, {
+				Name:  "IMAGE",
+				Value: params.Images.CoreDNS,
+			}, {
+				Name:  "OPENSHIFT_CLI_IMAGE",
+				Value: params.Images.CLI,
+			}, {
+				Name:  "KUBE_RBAC_PROXY_IMAGE",
+				Value: params.Images.KubeRBACProxy,
+			}, {
+				Name:  "KUBECONFIG",
+				Value: "/etc/kubernetes/kubeconfig",
+			},
+		},
+		Image: params.Images.DNSOperator,
+		Name:  dnsOperatorContainerName,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("29Mi"),
+			},
+		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      manifests.DNSOperatorKubeconfig("").Name,
+			MountPath: "/etc/kubernetes",
+		}},
+	}}
+	dep.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
+	dep.Spec.Template.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(2)
+	dep.Spec.Template.Spec.Volumes = []corev1.Volume{{
+		Name: "dns-operator-kubeconfig",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  "dns-operator-kubeconfig",
+				DefaultMode: utilpointer.Int32Ptr(416),
+			},
+		},
+	}}
+	util.AvailabilityProber(
+		kas.InClusterKASReadyURL(dep.Namespace, apiPort),
+		params.AvailabilityProberImage,
+		&dep.Spec.Template.Spec,
+		func(o *util.AvailabilityProberOpts) {
+			o.KubeconfigVolumeName = "dns-operator-kubeconfig"
+			o.RequiredAPIs = []schema.GroupVersionKind{
+				{Group: "operator.openshift.io", Version: "v1", Kind: "DNS"},
+			}
+		},
+	)
+	params.DeploymentConfig.ApplyTo(dep)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/dnsoperator.go
@@ -1,0 +1,29 @@
+package manifests
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DNSOperatorKubeconfig returns a stub secret, with name and namespace, for the
+// DNS operator's kubeconfig.
+func DNSOperatorKubeconfig(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dns-operator-kubeconfig",
+			Namespace: ns,
+		},
+	}
+}
+
+// DNSOperatorDeployment returns a stub deployment, with name and namespace, for
+// the DNS operator.
+func DNSOperatorDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dns-operator",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/dns.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/dns.go
@@ -1,0 +1,17 @@
+package manifests
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DNSOperatorDeployment returns a stub deployment, with name and namespace, for
+// the DNS operator.
+func DNSOperatorDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dns-operator",
+			Namespace: "openshift-dns-operator",
+		},
+	}
+}


### PR DESCRIPTION
Move the DNS operator into the management cluster so that the operator doesn't require that the hosted cluster have control-plane nodes.

* `control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go` (`manifestsToOmit`): Add "0000_70_dns-operator_02-deployment-ibm-cloud-managed.yaml".
* `control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go`: New file.
(`dnsOperatorContainerName`): New const.
(`Images`, `Params`): New types to describe the configuration of the DNS operator deployment in the management cluster.
(`NewParams`): New function.  Return a `Params` object for a DNS operator deployment.
(`ReconcileDeployment`): New function.  Reconcile a DNS operator deployment.
* `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` (`update`): Call `reconcileDNSOperator`.
(`reconcileDNSOperator`): New method.  Ensure that a kubeconfig and deployment exist for the DNS operator, using the new `ReconcileDeployment` function.
* `control-plane-operator/controllers/hostedcontrolplane/manifests/dnsoperator.go`: New file.
(`DNSOperatorKubeconfig`): New function.  Return the metadata for the secret for the kubeconfig for a DNS operator.
(`DNSOperatorDeployment`): New function.  Return the metadata for a DNS operator deployment.
* `control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/dns.go`: New file.
(`DNSOperatorDeployment`): New function.  Return the metadata for a DNS operator deployment.
* `control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go` (`deleteDNSOperatorDeploymentOnce`): New `sync.Once`.
(`Reconcile`): Delete the DNS operator deployment in the hosted cluster in case a deployment is present there after upgrading from an older version of HyperShift.  Use the uncached client because the cached client has a label selector that makes it unusable for this purpose, and guard with `deleteDNSOperatorDeploymentOnce` to prevent excessive API calls with the uncached client.
* `control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go` (`TestReconcileErrorHandling`): Add a comment explaining how the test works.  Define a fake uncached client to prevent `Reconcile` from causing a nil pointer panic.



-------

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.