### PR TITLE
Drop --control-plane-operator-image flag

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -47,7 +47,6 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Path to a pull secret (required)")
 	cmd.PersistentFlags().StringVar(&opts.ControlPlaneAvailabilityPolicy, "control-plane-availability-policy", opts.ControlPlaneAvailabilityPolicy, "Availability policy for hosted cluster components. Supported options: SingleReplica, HighlyAvailable")
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", opts.Render, "Render output as YAML to stdout instead of applying")
-	cmd.PersistentFlags().StringVar(&opts.ControlPlaneOperatorImage, "control-plane-operator-image", opts.ControlPlaneOperatorImage, "Override the default image used to deploy the control plane operator")
 	cmd.PersistentFlags().StringVar(&opts.SSHKeyFile, "ssh-key", opts.SSHKeyFile, "Path to an SSH key file")
 	cmd.PersistentFlags().StringVar(&opts.AdditionalTrustBundle, "additional-trust-bundle", opts.AdditionalTrustBundle, "Path to a file with user CA bundle")
 	cmd.PersistentFlags().StringVar(&opts.ImageContentSources, "image-content-sources", opts.ImageContentSources, "Path to a file with image content sources")

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -40,7 +40,6 @@ type CreateOptions struct {
 	Annotations                      []string
 	AutoRepair                       bool
 	ControlPlaneAvailabilityPolicy   string
-	ControlPlaneOperatorImage        string
 	EtcdStorageClass                 string
 	FIPS                             bool
 	GenerateSSH                      bool
@@ -158,10 +157,6 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		}
 		k, v := pair[0], pair[1]
 		annotations[k] = v
-	}
-
-	if len(opts.ControlPlaneOperatorImage) > 0 {
-		annotations[hyperv1.ControlPlaneOperatorImageAnnotation] = opts.ControlPlaneOperatorImage
 	}
 
 	pullSecret, err := ioutil.ReadFile(opts.PullSecretFile)


### PR DESCRIPTION
**What this PR does / why we need it**:
This sets an annotation which is only meant for dev purposes. The annotation can be set without the CLI flag and having it here get users confused and prone to setup unsupported versions


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.