### PR TITLE
PowerVS Infra bug fix on DHCP error return and removed a debug log

### DIFF
--- a/cmd/infra/powervs/create_test.go
+++ b/cmd/infra/powervs/create_test.go
@@ -1,0 +1,50 @@
+package powervs
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/IBM-Cloud/power-go-client/power/models"
+)
+
+func TestUseExistingDHCP(t *testing.T) {
+	id1 := "id1"
+	id2 := "id2"
+
+	type expected struct {
+		dhcpServerID string
+		err          error
+		errExpected  bool
+	}
+
+	tests := map[string]struct {
+		input    models.DHCPServers
+		expected expected
+	}{
+		"DHCPServerDetail returned with no error": {
+			input:    models.DHCPServers{{ID: &id1}},
+			expected: expected{dhcpServerID: id1, err: nil, errExpected: false},
+		},
+		"Error expected when more than one DHCPServer exist": {
+			input:    models.DHCPServers{{ID: &id1}, {ID: &id2}},
+			expected: expected{"", dhcpServerLimitExceeds(2), true},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			dhcpServerID, err := useExistingDHCP(test.input)
+
+			g.Expect(dhcpServerID).To(BeEquivalentTo(test.expected.dhcpServerID))
+
+			if test.expected.errExpected {
+				g.Expect(err).To(BeEquivalentTo(test.expected.err))
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}

--- a/cmd/infra/powervs/destroy.go
+++ b/cmd/infra/powervs/destroy.go
@@ -297,8 +297,6 @@ func destroyPowerVsCloudInstance(options *DestroyInfraOptions, infra *Infra, clo
 					return
 				}
 
-				log(options.InfraID).Info("resp", "code", resp.StatusCode, "message", resp.String())
-
 				if resp.StatusCode >= 400 {
 					err = fmt.Errorf("retrying due to resp code is %d and message is %s", resp.StatusCode, resp.String())
 					return


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

This PR trying to address two issues reported here https://issues.redhat.com/browse/MULTIARCH-2703 and https://issues.redhat.com/browse/MULTIARCH-2695.

 [MULTIARCH-2703](https://issues.redhat.com//browse/MULTIARCH-2703): Due to an internal error, DHCP private network is not returned and it should have been captured in setting up DHCP block itself, before proceeding to the infra creation. Refactored the code to handle this. Refactored the code generally too.

 [MULTIARCH-2695](https://issues.redhat.com//browse/MULTIARCH-2695): Removed the log added for debug purpose.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.