### PR TITLE
Add label to oauth route

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -9,6 +9,12 @@ import (
 	"github.com/openshift/hypershift/support/util"
 )
 
+const (
+	// hyperShiftOAuthRouteLabel is a label added to OAuth routes so that they
+	// can be selected via label selector in a dedicated router shard.
+	hyperShiftOAuthRouteLabel = "hypershift.openshift.io/oauth"
+)
+
 func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy, defaultIngressDomain string) error {
 	ownerRef.ApplyTo(route)
 
@@ -22,6 +28,11 @@ func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, strategy *hy
 			route.Spec.Host = util.ShortenRouteHostnameIfNeeded(route.Name, route.Namespace, defaultIngressDomain)
 		}
 	}
+
+	if route.Labels == nil {
+		route.Labels = map[string]string{}
+	}
+	route.Labels[hyperShiftOAuthRouteLabel] = "true"
 
 	if strategy.Route != nil && strategy.Route.Hostname != "" {
 		if route.Annotations == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
In the managed scenario (Service Delivery), a separate router shard
(IngressController) can be created to make control plane routes public,
making it possible to keep most routes in the cluster private.
In a PublicAndPrivate use case, the only route in a HyperShift control
plane that needs to be public is the OAuth route.

This commit adds a label to oauth routes so that if you have a dedicated
router shard for them, you are able to use a selector in your router
shard to only select oauth routes.

**Checklist**
- [x] Subject and description added to both, commit and PR.