### PR TITLE
E2E: Use zaptest logger for cluster creation

### DIFF
--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -11,7 +11,6 @@ import (
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/cmd/util"
 )
 
@@ -40,7 +39,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		}
 
 		if err := CreateCluster(ctx, opts); err != nil {
-			log.Log.Error(err, "Failed to create cluster")
+			opts.Log.Error(err, "Failed to create cluster")
 			return err
 		}
 		return nil
@@ -55,7 +54,7 @@ func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
 
 func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
 	if opts.AgentPlatform.APIServerAddress == "" {
-		opts.AgentPlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx)
+		opts.AgentPlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx, opts.Log)
 		if err != nil {
 			return err
 		}

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -10,7 +10,6 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
-	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/infraid"
 	"github.com/spf13/cobra"
@@ -57,7 +56,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		}
 
 		if err := CreateCluster(ctx, opts); err != nil {
-			log.Log.Error(err, "Failed to create cluster")
+			opts.Log.Error(err, "Failed to create cluster")
 			return err
 		}
 		return nil
@@ -114,7 +113,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			EnableProxy:        opts.AWSPlatform.EnableProxy,
 			SSHKeyFile:         opts.SSHKeyFile,
 		}
-		infra, err = opt.CreateInfra(ctx)
+		infra, err = opt.CreateInfra(ctx, opts.Log)
 		if err != nil {
 			return fmt.Errorf("failed to create infra: %w", err)
 		}

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -11,7 +11,6 @@ import (
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	azureinfra "github.com/openshift/hypershift/cmd/infra/azure"
-	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/support/infraid"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -50,7 +49,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		}()
 
 		if err := CreateCluster(ctx, opts); err != nil {
-			log.Log.Error(err, "Failed to create cluster")
+			opts.Log.Error(err, "Failed to create cluster")
 			os.Exit(1)
 		}
 	}
@@ -84,7 +83,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			InfraID:         infraID,
 			CredentialsFile: opts.AzurePlatform.CredentialsFile,
 			BaseDomain:      opts.BaseDomain,
-		}).Run(ctx)
+		}).Run(ctx, opts.Log)
 		if err != nil {
 			return fmt.Errorf("failed to create infra: %w", err)
 		}

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/cluster/none"
 	"github.com/openshift/hypershift/cmd/cluster/powervs"
+	"github.com/openshift/hypershift/cmd/log"
 )
 
 func NewCreateCommands() *cobra.Command {
@@ -31,6 +32,7 @@ func NewCreateCommands() *cobra.Command {
 		ExternalDNSDomain:              "",
 		AdditionalTrustBundle:          "",
 		ImageContentSources:            "",
+		Log:                            log.Log,
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -9,7 +9,6 @@ import (
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/log"
 )
 
 const (
@@ -50,7 +49,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		}
 
 		if err := CreateCluster(ctx, opts); err != nil {
-			log.Log.Error(err, "Failed to create cluster")
+			opts.Log.Error(err, "Failed to create cluster")
 			return err
 		}
 		return nil
@@ -71,7 +70,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		return fmt.Errorf("external-api-server-address is supported only for NodePort service publishing strategy, service publishing strategy %s is used", opts.KubevirtPlatform.ServicePublishingStrategy)
 	}
 	if opts.KubevirtPlatform.APIServerAddress == "" && opts.KubevirtPlatform.ServicePublishingStrategy == NodePortServicePublishingStrategy && !opts.Render {
-		if opts.KubevirtPlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx); err != nil {
+		if opts.KubevirtPlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx, opts.Log); err != nil {
 			return err
 		}
 	}

--- a/cmd/cluster/none/create.go
+++ b/cmd/cluster/none/create.go
@@ -7,7 +7,6 @@ import (
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/log"
 )
 
 func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
@@ -32,7 +31,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		}
 
 		if err := CreateCluster(ctx, opts); err != nil {
-			log.Log.Error(err, "Failed to create cluster")
+			opts.Log.Error(err, "Failed to create cluster")
 			return err
 		}
 		return nil
@@ -50,7 +49,7 @@ func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
 
 func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
 	if opts.NonePlatform.APIServerAddress == "" {
-		if opts.NonePlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx); err != nil {
+		if opts.NonePlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx, opts.Log); err != nil {
 			return err
 		}
 	}

--- a/cmd/cluster/powervs/create.go
+++ b/cmd/cluster/powervs/create.go
@@ -12,7 +12,6 @@ import (
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	powervsinfra "github.com/openshift/hypershift/cmd/infra/powervs"
-	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/support/infraid"
 	"github.com/spf13/cobra"
 )
@@ -75,7 +74,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		}()
 
 		if err := CreateCluster(ctx, opts); err != nil {
-			log.Log.Error(err, "Failed to create cluster")
+			opts.Log.Error(err, "Failed to create cluster")
 			os.Exit(1)
 		}
 	}

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
@@ -96,20 +97,21 @@ func NewCreateCommand() *cobra.Command {
 	cmd.MarkFlagRequired("aws-creds")
 	cmd.MarkFlagRequired("base-domain")
 
+	l := log.Log
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := opts.Run(cmd.Context()); err != nil {
-			log.Log.Error(err, "Failed to create infrastructure")
+		if err := opts.Run(cmd.Context(), l); err != nil {
+			l.Error(err, "Failed to create infrastructure")
 			return err
 		}
-		log.Log.Info("Successfully created infrastructure")
+		l.Info("Successfully created infrastructure")
 		return nil
 	}
 
 	return cmd
 }
 
-func (o *CreateInfraOptions) Run(ctx context.Context) error {
-	result, err := o.CreateInfra(ctx)
+func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) error {
+	result, err := o.CreateInfra(ctx, l)
 	if err != nil {
 		return err
 	}
@@ -133,8 +135,8 @@ func (o *CreateInfraOptions) Run(ctx context.Context) error {
 	return nil
 }
 
-func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutput, error) {
-	log.Log.Info("Creating infrastructure", "id", o.InfraID)
+func (o *CreateInfraOptions) CreateInfra(ctx context.Context, l logr.Logger) (*CreateInfraOutput, error) {
+	l.Info("Creating infrastructure", "id", o.InfraID)
 
 	awsSession := awsutil.NewSession("cli-create-infra", o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey, o.Region)
 	ec2Client := ec2.New(awsSession, awsutil.NewConfig())
@@ -152,7 +154,7 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 		BaseDomain:  o.BaseDomain,
 	}
 	if len(o.Zones) == 0 {
-		zone, err := o.firstZone(ec2Client)
+		zone, err := o.firstZone(l, ec2Client)
 		if err != nil {
 			return nil, err
 		}
@@ -160,14 +162,14 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 	}
 
 	// VPC resources
-	result.VPCID, err = o.createVPC(ec2Client)
+	result.VPCID, err = o.createVPC(l, ec2Client)
 	if err != nil {
 		return nil, err
 	}
-	if err = o.CreateDHCPOptions(ec2Client, result.VPCID); err != nil {
+	if err = o.CreateDHCPOptions(l, ec2Client, result.VPCID); err != nil {
 		return nil, err
 	}
-	igwID, err := o.CreateInternetGateway(ec2Client, result.VPCID)
+	igwID, err := o.CreateInternetGateway(l, ec2Client, result.VPCID)
 	if err != nil {
 		return nil, err
 	}
@@ -188,23 +190,23 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 		return nil, err
 	}
 	for _, zone := range o.Zones {
-		privateSubnetID, err := o.CreatePrivateSubnet(ec2Client, result.VPCID, zone, privateNetwork.String())
+		privateSubnetID, err := o.CreatePrivateSubnet(l, ec2Client, result.VPCID, zone, privateNetwork.String())
 		if err != nil {
 			return nil, err
 		}
-		publicSubnetID, err := o.CreatePublicSubnet(ec2Client, result.VPCID, zone, publicNetwork.String())
+		publicSubnetID, err := o.CreatePublicSubnet(l, ec2Client, result.VPCID, zone, publicNetwork.String())
 		if err != nil {
 			return nil, err
 		}
 		var natGatewayID string
 		publicSubnetIDs = append(publicSubnetIDs, publicSubnetID)
 		if !o.EnableProxy {
-			natGatewayID, err = o.CreateNATGateway(ec2Client, publicSubnetID, zone)
+			natGatewayID, err = o.CreateNATGateway(l, ec2Client, publicSubnetID, zone)
 			if err != nil {
 				return nil, err
 			}
 		}
-		privateRouteTable, err := o.CreatePrivateRouteTable(ec2Client, result.VPCID, natGatewayID, privateSubnetID, zone)
+		privateRouteTable, err := o.CreatePrivateRouteTable(l, ec2Client, result.VPCID, natGatewayID, privateSubnetID, zone)
 		if err != nil {
 			return nil, err
 		}
@@ -217,12 +219,12 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 		privateNetwork.IP[2] = privateNetwork.IP[2] + 16
 		publicNetwork.IP[2] = publicNetwork.IP[2] + 16
 	}
-	publicRouteTable, err := o.CreatePublicRouteTable(ec2Client, result.VPCID, igwID, publicSubnetIDs)
+	publicRouteTable, err := o.CreatePublicRouteTable(l, ec2Client, result.VPCID, igwID, publicSubnetIDs)
 	if err != nil {
 		return nil, err
 	}
 	endpointRouteTableIds = append(endpointRouteTableIds, aws.String(publicRouteTable))
-	err = o.CreateVPCS3Endpoint(ec2Client, result.VPCID, endpointRouteTableIds)
+	err = o.CreateVPCS3Endpoint(l, ec2Client, result.VPCID, endpointRouteTableIds)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +249,7 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 				return nil, fmt.Errorf("failed to read ssh-key-file from %s: %w", o.SSHKeyFile, err)
 			}
 		}
-		result.ProxyAddr, err = o.createProxyHost(ctx, ec2Client, result.Zones[0].SubnetID, result.VPCID, string(sshKeyFile))
+		result.ProxyAddr, err = o.createProxyHost(ctx, l, ec2Client, result.Zones[0].SubnetID, result.VPCID, string(sshKeyFile))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create proxy host: %w", err)
 		}
@@ -256,7 +258,7 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context) (*CreateInfraOutpu
 	return result, nil
 }
 
-func (o *CreateInfraOptions) createProxyHost(ctx context.Context, client ec2iface.EC2API, subnetID, vpcID string, sshKeys string) (string, error) {
+func (o *CreateInfraOptions) createProxyHost(ctx context.Context, l logr.Logger, client ec2iface.EC2API, subnetID, vpcID string, sshKeys string) (string, error) {
 	const securityGroupName = "proxy-sg"
 	sgCreateResult, err := client.CreateSecurityGroupWithContext(ctx, &ec2.CreateSecurityGroupInput{
 		GroupName:         aws.String(securityGroupName),
@@ -283,7 +285,7 @@ func (o *CreateInfraOptions) createProxyHost(ctx context.Context, client ec2ifac
 		return "", fmt.Errorf("cannot find security group that was just created (%s)", aws.StringValue(sgCreateResult.GroupId))
 	}
 	sg := sgResult.SecurityGroups[0]
-	log.Log.Info("Created security group", "name", securityGroupName, "id", aws.StringValue(sg.GroupId))
+	l.Info("Created security group", "name", securityGroupName, "id", aws.StringValue(sg.GroupId))
 
 	permissions := []*ec2.IpPermission{
 		{
@@ -310,7 +312,7 @@ func (o *CreateInfraOptions) createProxyHost(ctx context.Context, client ec2ifac
 	if err != nil {
 		return "", fmt.Errorf("failed to authorize security group: %w", err)
 	}
-	log.Log.Info("Authorized security group for proxy")
+	l.Info("Authorized security group for proxy")
 
 	result, err := client.RunInstancesWithContext(ctx, &ec2.RunInstancesInput{
 		ImageId:      aws.String("resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"),
@@ -331,7 +333,7 @@ func (o *CreateInfraOptions) createProxyHost(ctx context.Context, client ec2ifac
 	if err != nil {
 		return "", fmt.Errorf("failed to launch proxy host: %w", err)
 	}
-	log.Log.Info("Created proxy host")
+	l.Info("Created proxy host")
 
 	return fmt.Sprintf("http://%s:3128", *result.Instances[0].PrivateIpAddress), nil
 }

--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -27,7 +27,7 @@ func TestAutoRepair(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	numZones := int32(len(clusterOpts.AWSPlatform.Zones))
 	if numZones <= 1 {
 		clusterOpts.NodePoolReplicas = 3

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -29,12 +29,16 @@ func TestAutoscaling(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	if len(globalOpts.configurableClusterOptions.Zone) == 0 {
+		t.Fatal("TestAutoscaling requires multiple zones")
+	}
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
 
 	// Get one of the newly created NodePools
-	zone := clusterOpts.AWSPlatform.Zones[0]
+	zone := globalOpts.configurableClusterOptions.Zone[0]
 	nodepool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedCluster.Namespace,

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -37,7 +37,7 @@ func TestHAEtcdChaos(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	// Create a cluster
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.NodePoolReplicas = 0
 
@@ -60,7 +60,7 @@ func TestEtcdChaos(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	// Create a cluster
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.NodePoolReplicas = 0
 

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -25,7 +25,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 
 	t.Logf("Starting control plane upgrade test. FromImage: %s, toImage: %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
 
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -26,7 +26,7 @@ func TestCreateCluster(t *testing.T) {
 	client, err := e2eutil.GetClient()
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
@@ -59,7 +59,7 @@ func TestNoneCreateCluster(t *testing.T) {
 	client, err := e2eutil.GetClient()
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ControlPlaneAvailabilityPolicy = "SingleReplica"
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir)

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -40,7 +40,7 @@ func TestNodepoolMachineconfigGetsRolledout(t *testing.T) {
 	client, err := e2eutil.GetClient()
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.BeforeApply = func(o crclient.Object) {
 		nodePool, isNodepool := o.(*hyperv1.NodePool)

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -33,7 +33,7 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 	client, err := e2eutil.GetClient()
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ReleaseImage = globalOpts.LatestReleaseImage
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 
@@ -146,7 +146,7 @@ func TestInPlaceUpgradeNodePool(t *testing.T) {
 	client, err := e2eutil.GetClient()
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ReleaseImage = globalOpts.LatestReleaseImage
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -45,7 +45,7 @@ func TestOLM(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	// Create a cluster
-	clusterOpts := globalOpts.DefaultClusterOptions()
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.NodePoolReplicas = 1
 	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.AWSPlatform, globalOpts.ArtifactDir)
 


### PR DESCRIPTION
This change makes us use the zaptest logger for cluster creation in E2E
tests. The zaptest logger scopes its output to the current testcase,
which should help a lot with legibility of E2E output. In order for this
change to be useful, all providers need to use the passed logger for
their cluster creation log, this change only does that for AWS and
Azure.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.