### PR TITLE
E2E: Use zaptest logger for dumping and AWS/Azure destroy

### DIFF
--- a/cmd/cluster/aws/destroy.go
+++ b/cmd/cluster/aws/destroy.go
@@ -49,24 +49,26 @@ func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error
 	baseDomain := o.AWSPlatform.BaseDomain
 	region := o.AWSPlatform.Region
 
-	log.Log.Info("Destroying infrastructure", "infraID", infraID)
+	o.Log.Info("Destroying infrastructure", "infraID", infraID)
 	destroyInfraOpts := awsinfra.DestroyInfraOptions{
 		Region:             region,
 		InfraID:            infraID,
 		AWSCredentialsFile: o.AWSPlatform.AWSCredentialsFile,
 		Name:               o.Name,
 		BaseDomain:         baseDomain,
+		Log:                o.Log,
 	}
 	if err := destroyInfraOpts.Run(ctx); err != nil {
 		return fmt.Errorf("failed to destroy infrastructure: %w", err)
 	}
 
 	if !o.AWSPlatform.PreserveIAM {
-		log.Log.Info("Destroying IAM", "infraID", infraID)
+		o.Log.Info("Destroying IAM", "infraID", infraID)
 		destroyOpts := awsinfra.DestroyIAMOptions{
 			Region:             region,
 			AWSCredentialsFile: o.AWSPlatform.AWSCredentialsFile,
 			InfraID:            infraID,
+			Log:                o.Log,
 		}
 		if err := destroyOpts.Run(ctx); err != nil {
 			return fmt.Errorf("failed to destroy IAM: %w", err)

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -85,6 +85,7 @@ func NewDestroyCommands() *cobra.Command {
 		Namespace:          "clusters",
 		Name:               "",
 		ClusterGracePeriod: 10 * time.Minute,
+		Log:                log.Log,
 	}
 
 	cmd := &cobra.Command{

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/cmd/util"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +32,7 @@ type DestroyOptions struct {
 	AzurePlatform      AzurePlatformDestroyOptions
 	PowerVSPlatform    PowerVSPlatformDestroyOptions
 	InfraID            string
+	Log                logr.Logger
 }
 
 type AWSPlatformDestroyOptions struct {
@@ -62,13 +63,13 @@ func GetCluster(ctx context.Context, o *DestroyOptions) (*hyperv1.HostedCluster,
 	var hostedCluster hyperv1.HostedCluster
 	if err := c.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, &hostedCluster); err != nil {
 		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-			log.Log.Info("Hosted cluster not found, destroying infrastructure from user input", "namespace", o.Namespace, "name", o.Name, "infraID", o.InfraID)
+			o.Log.Info("Hosted cluster not found, destroying infrastructure from user input", "namespace", o.Namespace, "name", o.Name, "infraID", o.InfraID)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get hostedcluster: %w", err)
 	}
 
-	log.Log.Info("Found hosted cluster", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name)
+	o.Log.Info("Found hosted cluster", "namespace", hostedCluster.Namespace, "name", hostedCluster.Name)
 	return &hostedCluster, nil
 }
 
@@ -85,17 +86,17 @@ func DestroyCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster, o
 		controllerutil.AddFinalizer(hostedCluster, destroyFinalizer)
 		if err := c.Update(ctx, hostedCluster); err != nil {
 			if apierrors.IsNotFound(err) {
-				log.Log.Info("Hosted cluster not found, skipping finalizer update", "namespace", o.Namespace, "name", o.Name)
+				o.Log.Info("Hosted cluster not found, skipping finalizer update", "namespace", o.Namespace, "name", o.Name)
 			} else {
 				return fmt.Errorf("failed to add finalizer to hosted cluster: %w", err)
 			}
 		} else {
-			log.Log.Info("Updated finalizer for hosted cluster", "namespace", o.Namespace, "name", o.Name)
+			o.Log.Info("Updated finalizer for hosted cluster", "namespace", o.Namespace, "name", o.Name)
 		}
-		log.Log.Info("Deleting hosted cluster", "namespace", o.Namespace, "name", o.Name)
+		o.Log.Info("Deleting hosted cluster", "namespace", o.Namespace, "name", o.Name)
 		if err := c.Delete(ctx, hostedCluster); err != nil {
 			if apierrors.IsNotFound(err) {
-				log.Log.Info("Hosted not found, skipping delete", "namespace", o.Namespace, "name", o.Name)
+				o.Log.Info("Hosted not found, skipping delete", "namespace", o.Namespace, "name", o.Name)
 			} else {
 				return fmt.Errorf("failed to delete hostedcluster: %w", err)
 			}
@@ -109,7 +110,7 @@ func DestroyCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster, o
 				if apierrors.IsNotFound(err) {
 					return true, nil
 				}
-				log.Log.Error(err, "Failed to get hosted cluster", "namespace", o.Namespace, "name", o.Name)
+				o.Log.Error(err, "Failed to get hosted cluster", "namespace", o.Namespace, "name", o.Name)
 				return false, nil
 			}
 			done := len(hostedCluster.Finalizers) == 1 && hostedCluster.Finalizers[0] == destroyFinalizer
@@ -126,15 +127,15 @@ func DestroyCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster, o
 	}
 
 	// clean up CLI generated secrets
-	log.Log.Info("Deleting Secrets", "namespace", o.Namespace)
+	o.Log.Info("Deleting Secrets", "namespace", o.Namespace)
 	if err := c.DeleteAllOf(ctx, &v1.Secret{}, client.InNamespace(o.Namespace), client.MatchingLabels{util.AutoInfraLabelName: o.InfraID}); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Log.Info("Secrets not found based on labels, skipping delete", "namespace", o.Namespace, "labels", util.AutoInfraLabelName+":"+o.InfraID)
+			o.Log.Info("Secrets not found based on labels, skipping delete", "namespace", o.Namespace, "labels", util.AutoInfraLabelName+":"+o.InfraID)
 		} else {
 			return fmt.Errorf("failed to clean up secrets in %s namespace: %w", o.Namespace, err)
 		}
 	} else {
-		log.Log.Info("Deleted CLI generated secrets")
+		o.Log.Info("Deleted CLI generated secrets")
 	}
 
 	if hostedClusterExists {
@@ -144,11 +145,11 @@ func DestroyCluster(ctx context.Context, hostedCluster *hyperv1.HostedCluster, o
 				return fmt.Errorf("failed to remove finalizer: %w", err)
 			}
 		} else {
-			log.Log.Info("Finalized hosted cluster", "namespace", o.Namespace, "name", o.Name)
+			o.Log.Info("Finalized hosted cluster", "namespace", o.Namespace, "name", o.Name)
 		}
 	}
 
-	log.Log.Info("Successfully destroyed cluster and infrastructure", "namespace", o.Namespace, "name", o.Name, "infraID", o.InfraID)
+	o.Log.Info("Successfully destroyed cluster and infrastructure", "namespace", o.Namespace, "name", o.Name, "infraID", o.InfraID)
 	return nil
 }
 

--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -36,6 +37,7 @@ type DestroyInfraOptions struct {
 	AWSSecretKey       string
 	Name               string
 	BaseDomain         string
+	Log                logr.Logger
 }
 
 func NewDestroyCommand() *cobra.Command {
@@ -48,6 +50,7 @@ func NewDestroyCommand() *cobra.Command {
 	opts := DestroyInfraOptions{
 		Region: "us-east-1",
 		Name:   "example",
+		Log:    log.Log,
 	}
 
 	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Cluster ID with which to tag AWS resources (required)")
@@ -62,10 +65,10 @@ func NewDestroyCommand() *cobra.Command {
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := opts.Run(cmd.Context()); err != nil {
-			log.Log.Error(err, "Failed to destroy infrastructure")
+			opts.Log.Error(err, "Failed to destroy infrastructure")
 			return err
 		}
-		log.Log.Info("Successfully destroyed infrastructure")
+		opts.Log.Info("Successfully destroyed infrastructure")
 		return nil
 	}
 
@@ -79,7 +82,7 @@ func (o *DestroyInfraOptions) Run(ctx context.Context) error {
 			if !awsutil.IsErrorRetryable(err) {
 				return false, err
 			}
-			log.Log.Info("WARNING: error during destroy, will retry", "error", err.Error())
+			o.Log.Info("WARNING: error during destroy, will retry", "error", err.Error())
 			return false, nil
 		}
 		return true, nil
@@ -102,7 +105,7 @@ func (o *DestroyInfraOptions) DestroyInfra(ctx context.Context) error {
 	errs = append(errs, o.DestroyVPCEndpointServices(ctx, ec2Client)...)
 	errs = append(errs, o.DestroyVPCs(ctx, ec2Client, elbClient, elbv2Client, route53Client)...)
 	if err := utilerrors.NewAggregate(errs); err != nil {
-		return utilerrors.NewAggregate(errs)
+		return err
 	}
 	errs = append(errs, o.DestroyEIPs(ctx, ec2Client)...)
 	errs = append(errs, o.DestroyDHCPOptions(ctx, ec2Client)...)
@@ -128,13 +131,13 @@ func (o *DestroyInfraOptions) DestroyS3Buckets(ctx context.Context, client s3ifa
 			})
 			if err != nil {
 				if aerr, ok := err.(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchBucket {
-					log.Log.Info("S3 Bucket already deleted", "name", *bucket.Name)
+					o.Log.Info("S3 Bucket already deleted", "name", *bucket.Name)
 					err = nil
 				} else {
 					errs = append(errs, err)
 				}
 			} else {
-				log.Log.Info("Deleted S3 Bucket", "name", *bucket.Name)
+				o.Log.Info("Deleted S3 Bucket", "name", *bucket.Name)
 			}
 		}
 	}
@@ -168,7 +171,7 @@ func (o *DestroyInfraOptions) DestroyV1ELBs(ctx context.Context, client elbiface
 			if err != nil {
 				errs = append(errs, err)
 			} else {
-				log.Log.Info("Deleted ELB", "name", lb.LoadBalancerName)
+				o.Log.Info("Deleted ELB", "name", lb.LoadBalancerName)
 			}
 		}
 		return true
@@ -195,7 +198,7 @@ func (o *DestroyInfraOptions) DestroyV2ELBs(ctx context.Context, client elbv2ifa
 			if err != nil {
 				errs = append(errs, err)
 			} else {
-				log.Log.Info("Deleted ELB", "name", lb.LoadBalancerName)
+				o.Log.Info("Deleted ELB", "name", lb.LoadBalancerName)
 			}
 		}
 		return true
@@ -227,7 +230,7 @@ func (o *DestroyInfraOptions) DestroyVPCEndpoints(ctx context.Context, client ec
 				for _, id := range ids {
 					epIDs = append(epIDs, aws.StringValue(id))
 				}
-				log.Log.Info("Deleted VPC endpoints", "IDs", strings.Join(epIDs, " "))
+				o.Log.Info("Deleted VPC endpoints", "IDs", strings.Join(epIDs, " "))
 			}
 		}
 		return true
@@ -266,7 +269,7 @@ func (o *DestroyInfraOptions) DestroyVPCEndpointServices(ctx context.Context, cl
 				errs = append(errs, fmt.Errorf("failed to reject endpoint connections for service %s endpoints %v", aws.StringValue(service), aws.StringValueSlice(endpoints)))
 				return false
 			}
-			log.Log.Info("Deleted endpoint connections", "serviceID", aws.StringValue(service), "endpoints", fmt.Sprintf("%v", aws.StringValueSlice(endpoints)))
+			o.Log.Info("Deleted endpoint connections", "serviceID", aws.StringValue(service), "endpoints", fmt.Sprintf("%v", aws.StringValueSlice(endpoints)))
 		}
 
 		if _, err := client.DeleteVpcEndpointServiceConfigurationsWithContext(ctx, &ec2.DeleteVpcEndpointServiceConfigurationsInput{
@@ -274,7 +277,7 @@ func (o *DestroyInfraOptions) DestroyVPCEndpointServices(ctx context.Context, cl
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete vpc endpoint services with ids %v: %w", ids, err))
 		} else {
-			log.Log.Info("Deleted VPC endpoint services", "IDs", ids)
+			o.Log.Info("Deleted VPC endpoint services", "IDs", ids)
 		}
 
 		return true
@@ -306,7 +309,7 @@ func (o *DestroyInfraOptions) DestroyRouteTables(ctx context.Context, client ec2
 					if err != nil {
 						routeErrs = append(routeErrs, err)
 					} else {
-						log.Log.Info("Deleted route from route table", "table", aws.StringValue(routeTable.RouteTableId), "destination", aws.StringValue(route.DestinationCidrBlock))
+						o.Log.Info("Deleted route from route table", "table", aws.StringValue(routeTable.RouteTableId), "destination", aws.StringValue(route.DestinationCidrBlock))
 					}
 				}
 			}
@@ -327,7 +330,7 @@ func (o *DestroyInfraOptions) DestroyRouteTables(ctx context.Context, client ec2
 				if err != nil {
 					assocErrs = append(assocErrs, err)
 				} else {
-					log.Log.Info("Removed route table association", "table", aws.StringValue(routeTable.RouteTableId), "association", aws.StringValue(assoc.RouteTableId))
+					o.Log.Info("Removed route table association", "table", aws.StringValue(routeTable.RouteTableId), "association", aws.StringValue(assoc.RouteTableId))
 				}
 			}
 			if len(assocErrs) > 0 {
@@ -343,7 +346,7 @@ func (o *DestroyInfraOptions) DestroyRouteTables(ctx context.Context, client ec2
 			if err != nil {
 				errs = append(errs, err)
 			} else {
-				log.Log.Info("Deleted route table", "table", aws.StringValue(routeTable.RouteTableId))
+				o.Log.Info("Deleted route table", "table", aws.StringValue(routeTable.RouteTableId))
 			}
 		}
 		return false
@@ -371,7 +374,7 @@ func (o *DestroyInfraOptions) DestroySecurityGroups(ctx context.Context, client 
 				if err != nil {
 					permissionErrs = append(permissionErrs, err)
 				} else {
-					log.Log.Info("Revoked security group ingress permissions", "group", aws.StringValue(sg.GroupId))
+					o.Log.Info("Revoked security group ingress permissions", "group", aws.StringValue(sg.GroupId))
 				}
 			}
 
@@ -383,7 +386,7 @@ func (o *DestroyInfraOptions) DestroySecurityGroups(ctx context.Context, client 
 				if err != nil {
 					permissionErrs = append(permissionErrs, err)
 				} else {
-					log.Log.Info("Revoked security group egress permissions", "group", aws.StringValue(sg.GroupId))
+					o.Log.Info("Revoked security group egress permissions", "group", aws.StringValue(sg.GroupId))
 				}
 			}
 			if len(permissionErrs) > 0 {
@@ -399,7 +402,7 @@ func (o *DestroyInfraOptions) DestroySecurityGroups(ctx context.Context, client 
 			if err != nil {
 				errs = append(errs, err)
 			} else {
-				log.Log.Info("Deleted security group", "group", aws.StringValue(sg.GroupId))
+				o.Log.Info("Deleted security group", "group", aws.StringValue(sg.GroupId))
 			}
 		}
 
@@ -484,7 +487,7 @@ func (o *DestroyInfraOptions) DestroyInternetGateways(ctx context.Context, clien
 				if err != nil {
 					detachErrs = append(detachErrs, err)
 				} else {
-					log.Log.Info("Detached internet gateway from VPC", "gateway id", aws.StringValue(igw.InternetGatewayId), "vpc", aws.StringValue(attachment.VpcId))
+					o.Log.Info("Detached internet gateway from VPC", "gateway id", aws.StringValue(igw.InternetGatewayId), "vpc", aws.StringValue(attachment.VpcId))
 				}
 			}
 			if len(detachErrs) > 0 {
@@ -497,7 +500,7 @@ func (o *DestroyInfraOptions) DestroyInternetGateways(ctx context.Context, clien
 			if err != nil {
 				errs = append(errs, err)
 			} else {
-				log.Log.Info("Deleted internet gateway", "id", aws.StringValue(igw.InternetGatewayId))
+				o.Log.Info("Deleted internet gateway", "id", aws.StringValue(igw.InternetGatewayId))
 			}
 		}
 		return true
@@ -522,7 +525,7 @@ func (o *DestroyInfraOptions) DestroySubnets(ctx context.Context, client ec2ifac
 			if err != nil {
 				errs = append(errs, err)
 			} else {
-				log.Log.Info("Deleted subnet", "id", aws.StringValue(subnet.SubnetId))
+				o.Log.Info("Deleted subnet", "id", aws.StringValue(subnet.SubnetId))
 			}
 		}
 		return true
@@ -563,7 +566,7 @@ func (o *DestroyInfraOptions) DestroyVPCs(ctx context.Context, ec2client ec2ifac
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to delete vpc with id %s: %w", *vpc.VpcId, err))
 			} else {
-				log.Log.Info("Deleted VPC", "id", aws.StringValue(vpc.VpcId))
+				o.Log.Info("Deleted VPC", "id", aws.StringValue(vpc.VpcId))
 			}
 		}
 		return true
@@ -588,7 +591,7 @@ func (o *DestroyInfraOptions) DestroyDHCPOptions(ctx context.Context, client ec2
 			if err != nil {
 				errs = append(errs, err)
 			} else {
-				log.Log.Info("Deleted DHCP options", "id", aws.StringValue(dhcpOpt.DhcpOptionsId))
+				o.Log.Info("Deleted DHCP options", "id", aws.StringValue(dhcpOpt.DhcpOptionsId))
 			}
 		}
 		return true
@@ -619,7 +622,7 @@ func (o *DestroyInfraOptions) DestroyEIPs(ctx context.Context, client ec2iface.E
 		if err != nil {
 			errs = append(errs, err)
 		} else {
-			log.Log.Info("Deleted EIP", "id", aws.StringValue(addr.AllocationId))
+			o.Log.Info("Deleted EIP", "id", aws.StringValue(addr.AllocationId))
 		}
 	}
 	return errs

--- a/cmd/infra/aws/route53.go
+++ b/cmd/infra/aws/route53.go
@@ -139,7 +139,7 @@ func (o *DestroyInfraOptions) CleanupPublicZone(ctx context.Context, client rout
 			return fmt.Errorf("failed to delete wildcard record from public zone %s: %w", id, err)
 		}
 	} else {
-		log.Log.Info("Deleted wildcard record from public hosted zone", "id", id, "name", recordName)
+		o.Log.Info("Deleted wildcard record from public hosted zone", "id", id, "name", recordName)
 	}
 	return nil
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,16 +19,15 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/version"
 	"github.com/openshift/hypershift/test/e2e/podtimingcontroller"
+	"github.com/openshift/hypershift/test/e2e/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -254,7 +253,7 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		ServiceCIDR: "172.31.0.0/16",
 		PodCIDR:     "10.132.0.0/14",
 		BeforeApply: o.BeforeApply,
-		Log:         zapr.NewLogger(zaptest.NewLogger(t)),
+		Log:         util.NewLogr(t),
 	}
 	createOption.AWSPlatform.AdditionalTags = append(createOption.AWSPlatform.AdditionalTags, o.additionalTags...)
 	if len(o.configurableClusterOptions.Zone) == 0 {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -14,6 +16,7 @@ import (
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	promconfig "github.com/prometheus/common/config"
 	prommodel "github.com/prometheus/common/model"
+	"go.uber.org/zap/zaptest"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -708,4 +711,8 @@ func createK8sClient() (*k8s.Clientset, error) {
 	}
 
 	return cli, nil
+}
+
+func NewLogr(t *testing.T) logr.Logger {
+	return zapr.NewLogger(zaptest.NewLogger(t))
 }


### PR DESCRIPTION
This ensures that the logging in the tests get scoped to the specific test, making the E2E output more legible.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.