### PR TITLE
add Degraded condition to HCP

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -172,6 +172,7 @@ type ConditionType string
 
 const (
 	HostedControlPlaneAvailable          ConditionType = "Available"
+	HostedControlPlaneDegraded           ConditionType = "Degraded"
 	EtcdAvailable                        ConditionType = "EtcdAvailable"
 	EtcdSnapshotRestored                 ConditionType = "EtcdSnapshotRestored"
 	KubeAPIServerAvailable               ConditionType = "KubeAPIServerAvailable"

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2661,6 +2661,8 @@ an initial deployment or upgrade.</p>
 </td>
 </tr><tr><td><p>&#34;Available&#34;</p></td>
 <td></td>
+</tr><tr><td><p>&#34;Degraded&#34;</p></td>
+<td></td>
 </tr><tr><td><p>&#34;IgnitionEndpointAvailable&#34;</p></td>
 <td><p>IgnitionEndpointAvailable indicates whether the ignition server for the
 HostedCluster is available to handle ignition requests.</p>

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var (
-	managedByLabel = "hypershift.openshift.io/managed-by"
+const (
+	ManagedByLabel = "hypershift.openshift.io/managed-by"
 )
 
 type DeploymentConfig struct {
@@ -208,7 +208,7 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 	if deployment.Labels == nil {
 		deployment.Labels = map[string]string{}
 	}
-	deployment.Labels[managedByLabel] = "control-plane-operator"
+	deployment.Labels[ManagedByLabel] = "control-plane-operator"
 
 	c.Scheduling.ApplyTo(&deployment.Spec.Template.Spec)
 	c.AdditionalLabels.ApplyTo(&deployment.Spec.Template.ObjectMeta)


### PR DESCRIPTION
**What this PR does / why we need it**:
Requires https://github.com/openshift/hypershift/pull/1554
https://issues.redhat.com/browse/HOSTEDCP-495

Adds a `Degraded` condition on the HCP with Reason `UnavailableReplicas` if any of the CPO managed deployments has a `status.unavailableReplicas` > 0.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.