### PR TITLE
E2E: Stop retrying destroy if inputs are missing

### DIFF
--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -126,6 +126,9 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 		err := wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 			err := destroyCluster(ctx, hc, opts)
 			if err != nil {
+				if strings.Contains(err.Error(), "required inputs are missing") {
+					return false, err
+				}
 				t.Logf("Failed to destroy cluster, will retry: %v", err)
 				err := dumpCluster(ctx, t, false)
 				if err != nil {


### PR DESCRIPTION
In situations where we don't create anything, e.G. because an invalid
release image was specified, the e2e destroy code loops forever withot
any chance of success. Avoid this.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.