### PR TITLE
Azure: Make disk type configurable and default to SSD instead of HDD

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -621,6 +621,19 @@ type AzureNodePoolPlatform struct {
 	// +kubebuilder:validation:Minimum=16
 	// +optional
 	DiskSizeGB int32 `json:"diskSizeGB,omitempty"`
+	// DiskStorageAccountType is the disk storage account type to use. Valid values are:
+	// * Standard_LRS: HDD
+	// * StandardSSD_LRS: Standard SSD
+	// * Premium_LRS: Premium SDD
+	// * UltraSSD_LRS: Ultra SDD
+	//
+	// Defaults to Premium_LRS. For more details, visit the Azure documentation:
+	// https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison
+	//
+	// +kubebuilder:default:=Premium_LRS
+	// +kubebuilder:validation:Enum=Standard_LRS;StandardSSD_LRS;Premium_LRS;UltraSSD_LRS
+	// +optional
+	DiskStorageAccountType string `json:"diskStorageAccountType,omitempty"`
 	// AvailabilityZone of the nodepool. Must not be specified for clusters
 	// in a location that does not support AvailabilityZone.
 	// +optional

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -428,6 +428,19 @@ spec:
                         format: int32
                         minimum: 16
                         type: integer
+                      diskStorageAccountType:
+                        default: Premium_LRS
+                        description: "DiskStorageAccountType is the disk storage account
+                          type to use. Valid values are: * Standard_LRS: HDD * StandardSSD_LRS:
+                          Standard SSD * Premium_LRS: Premium SDD * UltraSSD_LRS:
+                          Ultra SDD \n Defaults to Premium_LRS. For more details,
+                          visit the Azure documentation: https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison"
+                        enum:
+                        - Standard_LRS
+                        - StandardSSD_LRS
+                        - Premium_LRS
+                        - UltraSSD_LRS
+                        type: string
                       imageID:
                         description: 'ImageID is the id of the image to boot from.
                           If unset, the default image at the location below will be

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2042,6 +2042,24 @@ int32
 </tr>
 <tr>
 <td>
+<code>diskStorageAccountType</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DiskStorageAccountType is the disk storage account type to use. Valid values are:
+* Standard_LRS: HDD
+* StandardSSD_LRS: Standard SSD
+* Premium_LRS: Premium SDD
+* UltraSSD_LRS: Ultra SDD</p>
+<p>Defaults to Premium_LRS. For more details, visit the Azure documentation:
+<a href="https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison">https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison</a></p>
+</td>
+</tr>
+<tr>
+<td>
 <code>availabilityZone</code></br>
 <em>
 string

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -26808,6 +26808,19 @@ objects:
                           format: int32
                           minimum: 16
                           type: integer
+                        diskStorageAccountType:
+                          default: Premium_LRS
+                          description: "DiskStorageAccountType is the disk storage
+                            account type to use. Valid values are: * Standard_LRS:
+                            HDD * StandardSSD_LRS: Standard SSD * Premium_LRS: Premium
+                            SDD * UltraSSD_LRS: Ultra SDD \n Defaults to Premium_LRS.
+                            For more details, visit the Azure documentation: https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison"
+                          enum:
+                          - Standard_LRS
+                          - StandardSSD_LRS
+                          - Premium_LRS
+                          - UltraSSD_LRS
+                          type: string
                         imageID:
                           description: 'ImageID is the id of the image to boot from.
                             If unset, the default image at the location below will

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -29,6 +29,9 @@ func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1
 		Image:  &capiazure.Image{ID: utilpointer.String(bootImage(hcluster, nodePool))},
 		OSDisk: capiazure.OSDisk{
 			DiskSizeGB: utilpointer.Int32Ptr(nodePool.Spec.Platform.Azure.DiskSizeGB),
+			ManagedDisk: &capiazure.ManagedDiskParameters{
+				StorageAccountType: nodePool.Spec.Platform.Azure.DiskStorageAccountType,
+			},
 		},
 		SubnetName:             hcluster.Spec.Platform.Azure.SubnetName,
 		Identity:               capiazure.VMIdentityUserAssigned,


### PR DESCRIPTION
This makes the disk type on Azure configurable and defaults it to SSD
disks, instead of hdd in order to speed things up. Comparison of join
times, the nodepools were created at the same time:

```
hdd-qpghq   Ready    worker   4m10s   v1.24.0+b5932d4
hdd-rv576   Ready    worker   3m41s   v1.24.0+b5932d4
hdd-vxnhr   Ready    worker   5m4s    v1.24.0+b5932d4
ssd-n27qp   Ready    worker   6m21s   v1.24.0+b5932d4
ssd-q4s5f   Ready    worker   6m13s   v1.24.0+b5932d4
ssd-tqlmh   Ready    worker   6m24s   v1.24.0+b5932d4
```

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.