### PR TITLE
add Degraded condition to HostedCluster

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1584,6 +1584,10 @@ const (
 	// an initial deployment or upgrade.
 	HostedClusterProgressing ConditionType = "Progressing"
 
+	// HostedClusterDegraded indicates whether the HostedCluster is encountering
+	// an error that may require user intervention to resolve.
+	HostedClusterDegraded ConditionType = "Degraded"
+
 	// IgnitionEndpointAvailable indicates whether the ignition server for the
 	// HostedCluster is available to handle ignition requests.
 	IgnitionEndpointAvailable ConditionType = "IgnitionEndpointAvailable"

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2675,6 +2675,10 @@ underlying cluster&rsquo;s ClusterVersion.</p>
 <td><p>HostedClusterAvailable indicates whether the HostedCluster has a healthy
 control plane.</p>
 </td>
+</tr><tr><td><p>&#34;Degraded&#34;</p></td>
+<td><p>HostedClusterDegraded indicates whether the HostedCluster is encountering
+an error that may require user intervention to resolve.</p>
+</td>
 </tr><tr><td><p>&#34;Progressing&#34;</p></td>
 <td><p>HostedClusterProgressing indicates whether the HostedCluster is attempting
 an initial deployment or upgrade.</p>


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up to #1560 
https://issues.redhat.com/browse/HOSTEDCP-495

Copies the Degraded condition on the HCP up to the user-facing HC.

As of this PR, the HC controller does not have any additional logic to observe degraded conditions within its management domain but that is in the plan e.g. deployment availability checks on CAPI and the CPO, etc

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.