### PR TITLE
Add configmap containing supported versions to hypershift namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go v1.40.56
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/clarketm/json v1.14.1
+	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/ignition/v2 v2.10.1
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/go-logr/logr v1.2.1
@@ -83,7 +84,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/coreos/vcontext v0.0.0-20210407161507-4ee6c745c8bd // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/hypershift-operator/controllers/manifests/supportedversion/configmap.go
+++ b/hypershift-operator/controllers/manifests/supportedversion/configmap.go
@@ -1,0 +1,15 @@
+package supportedversion
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      "supported-versions",
+		},
+	}
+}

--- a/hypershift-operator/controllers/supportedversion/reconciler.go
+++ b/hypershift-operator/controllers/supportedversion/reconciler.go
@@ -1,0 +1,89 @@
+package supportedversion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	manifests "github.com/openshift/hypershift/hypershift-operator/controllers/manifests/supportedversion"
+	"github.com/openshift/hypershift/support/supportedversion"
+	"github.com/openshift/hypershift/support/upsert"
+)
+
+const (
+	configMapKey = "supported-versions"
+)
+
+type Reconciler struct {
+	client.Client
+	upsert.CreateOrUpdateProvider
+	namespace string
+}
+
+func New(c client.Client, createOrUpdateProvider upsert.CreateOrUpdateProvider, namespace string) *Reconciler {
+	return &Reconciler{
+		Client:                 c,
+		CreateOrUpdateProvider: createOrUpdateProvider,
+		namespace:              namespace,
+	}
+}
+func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
+	// A channel is used to generate an initial sync event.
+	// Afterwards, the controller syncs on the ConfigMap.
+	initialSync := make(chan event.GenericEvent)
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}, builder.WithPredicates(predicate.NewPredicateFuncs(r.selectSupportedVersionsConfigMap))).
+		Watches(&source.Channel{Source: initialSync}, &handler.EnqueueRequestForObject{}).
+		Complete(r)
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+	go func() {
+		initialSync <- event.GenericEvent{Object: manifests.ConfigMap(r.namespace)}
+	}()
+	return nil
+}
+
+type supportedVersions struct {
+	Versions []string `json:"versions"`
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, r.ensureSupportedVersionConfigMap(ctx)
+}
+
+func (r *Reconciler) ensureSupportedVersionConfigMap(ctx context.Context) error {
+	cm := manifests.ConfigMap(r.namespace)
+	if _, err := r.CreateOrUpdate(ctx, r, cm, func() error {
+		content := &supportedVersions{
+			Versions: supportedversion.Supported(),
+		}
+		contentBytes, err := json.Marshal(content)
+		if err != nil {
+			return fmt.Errorf("cannot marshal content: %w", err)
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[configMapKey] = string(contentBytes)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to update supported version configmap: %w", err)
+	}
+	return nil
+}
+
+func (r *Reconciler) selectSupportedVersionsConfigMap(obj client.Object) bool {
+	return obj.GetNamespace() == r.namespace && obj.GetName() == manifests.ConfigMap(r.namespace).Name
+}

--- a/hypershift-operator/controllers/supportedversion/reconciler_test.go
+++ b/hypershift-operator/controllers/supportedversion/reconciler_test.go
@@ -1,0 +1,36 @@
+package supportedversion
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	manifests "github.com/openshift/hypershift/hypershift-operator/controllers/manifests/supportedversion"
+	"github.com/openshift/hypershift/support/supportedversion"
+	"github.com/openshift/hypershift/support/upsert"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestEnsureSupportedVersionConfigMap(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+	reconciler := &Reconciler{
+		Client:                 c,
+		CreateOrUpdateProvider: upsert.New(true),
+		namespace:              "hypershift",
+	}
+	g := NewGomegaWithT(t)
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{})
+	g.Expect(err).To(BeNil())
+	cfgMap := manifests.ConfigMap("hypershift")
+	err = c.Get(context.Background(), client.ObjectKeyFromObject(cfgMap), cfgMap)
+	g.Expect(err).To(BeNil())
+	g.Expect(cfgMap.Data[configMapKey]).ToNot(BeEmpty())
+	data := &supportedVersions{}
+	err = json.Unmarshal([]byte(cfgMap.Data[configMapKey]), data)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(data.Versions)).To(Equal(supportedversion.SupportedPreviousMinorVersions + 1))
+}

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/platform/aws"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/proxy"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/supportedversion"
 	hyperutil "github.com/openshift/hypershift/hypershift-operator/controllers/util"
 	"github.com/openshift/hypershift/pkg/version"
 	"github.com/openshift/hypershift/support/capabilities"
@@ -268,6 +269,12 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		}).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller: %w", err)
 		}
+	}
+
+	// Start controller to manage supported versions configmap
+	if err := (supportedversion.New(mgr.GetClient(), createOrUpdate, opts.Namespace).
+		SetupWithManager(mgr)); err != nil {
+		return fmt.Errorf("unable to create supported version controller: %w", err)
 	}
 
 	// The mgr and therefore the cache is not started yet, thus we have to construct a client that

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -1,0 +1,42 @@
+package supportedversion
+
+import (
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+// LatestSupportedVersion is the latest minor OCP version supported by the
+// HyperShift operator.
+// NOTE: The .0 (z release) should be ignored. It's only here to support
+// semver parsing.
+var LatestSupportedVersion = semver.New("4.12.0")
+
+// SupportedPreviousMinorVersions is the number of minor versions prior to current
+// version that are supported.
+const SupportedPreviousMinorVersions = 2
+
+func Supported() []string {
+	versions := []string{trimVersion(LatestSupportedVersion.String())}
+	for i := 0; i < SupportedPreviousMinorVersions; i++ {
+		versions = append(versions, trimVersion(subtractMinor(LatestSupportedVersion, int64(i+1)).String()))
+	}
+	return versions
+}
+
+func trimVersion(version string) string {
+	return strings.TrimSuffix(version, ".0")
+}
+
+func subtractMinor(version *semver.Version, count int64) *semver.Version {
+	result := *version
+	result.Minor = maxInt64(0, result.Minor-count)
+	return &result
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -1,0 +1,12 @@
+package supportedversion
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSupportedVersions(t *testing.T) {
+	g := NewGomegaWithT(t)
+	g.Expect(Supported()).To(Equal([]string{"4.12", "4.11", "4.10"}))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a controller that maintains a configmap in the `hypershift`
namespace that contains a list of supported minor versions by the
current controller.

This is done by a controller and not laid down by the installer because
the operator itself is the source of truth for what it supports, and not
the CLI.

The ConfigMap will be used by the MCE UI to filter the versions that can
be used when creating a HostedCluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-496](https://issues.redhat.com//browse/HOSTEDCP-496)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.