### PR TITLE
Add control plane operator component template label to components missing it

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -198,7 +198,12 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 	if dep.Spec.Template.Labels == nil {
 		dep.Spec.Template.Labels = map[string]string{}
 	}
-	dep.Spec.Template.Labels["name"] = operatorName
+	dep.Spec.Template.Labels = map[string]string{
+		"name":                        operatorName,
+		"app":                         operatorName,
+		hyperv1.ControlPlaneComponent: operatorName,
+	}
+
 	cnoArgs := []string{"start",
 		"--listen=0.0.0.0:9104",
 		"--kubeconfig=/etc/hosted-kubernetes/kubeconfig",

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -91,8 +91,9 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 }
 
 func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) {
+	operatorName := "ingress-operator"
 	dep.Spec.Replicas = utilpointer.Int32(1)
-	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": "ingress-operator"}}
+	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": operatorName}}
 	dep.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
 	if dep.Spec.Template.Annotations == nil {
 		dep.Spec.Template.Annotations = map[string]string{}
@@ -101,7 +102,12 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 	if dep.Spec.Template.Labels == nil {
 		dep.Spec.Template.Labels = map[string]string{}
 	}
-	dep.Spec.Template.Labels["name"] = "ingress-operator"
+	dep.Spec.Template.Labels = map[string]string{
+		"name":                        operatorName,
+		"app":                         operatorName,
+		hyperv1.ControlPlaneComponent: operatorName,
+	}
+
 	dep.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)
 	dep.Spec.Template.Spec.Containers = []corev1.Container{{
 		Command: []string{

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -85,7 +85,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	switch hcp.Spec.ControllerAvailabilityPolicy {
 	case hyperv1.HighlyAvailable:
 		params.Replicas = 3
-		params.DeploymentConfig.SetMultizoneSpread(schedulerLabels)
+		params.DeploymentConfig.SetMultizoneSpread(labels)
 	default:
 		params.Replicas = 1
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `hyperv1.ControlPlaneComponent` to components that are missing it:
network operator, ingress operator, scheduler.

```kubectl get pods -l hypershift.openshift.io/control-plane-component -nclusters-agl```

Might follow up with some refactor to the deployment config library.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.