### PR TITLE
Add check for AWS ARNs

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -935,6 +935,15 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 					Type: hyperv1.AWSPlatform,
 					AWS: &hyperv1.AWSPlatformSpec{
 						EndpointAccess: hyperv1.Public,
+						RolesRef: hyperv1.AWSRolesRef{
+							IngressARN:              "ingress-arn",
+							ImageRegistryARN:        "image-registry-arn",
+							StorageARN:              "storage-arn",
+							NetworkARN:              "network-arn",
+							KubeCloudControllerARN:  " kube-cloud-controller-arn",
+							NodePoolManagementARN:   "node-pool-management-arn",
+							ControlPlaneOperatorARN: "control-plane-operator-arn",
+						},
 					},
 				},
 			},

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -241,6 +241,9 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 	// this is not trivial as the CPO deployment itself needs the secret with the ControlPlaneOperatorARN
 	var errs []error
 	syncSecret := func(secret *corev1.Secret, arn string) error {
+		if arn == "" {
+			return fmt.Errorf("ARN is not provided for cloud credential secret %s/%s", secret.Namespace, secret.Name)
+		}
 		if _, err := createOrUpdate(ctx, c, secret, func() error {
 			credentials := fmt.Sprintf(awsCredentialsTemplate, arn)
 			secret.Data = map[string][]byte{"credentials": []byte(credentials)}


### PR DESCRIPTION
**What this PR does / why we need it**:
Small fix for https://github.com/openshift/hypershift/pull/1516

If ARNs are not provided in the HC, either through the new or old fields, we just render a credentials file that looks like
```
[default]
role_arn = 
web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
```

This results in an error in the underlying component that is hard to detect without looking at the logs.

Instead, return a HC-level reconciliation error and report that on the `PlatformCredentialsFound` condition.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.