### PR TITLE
Optional RestoreSnapshotURL should have omitempty

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1373,7 +1373,7 @@ type ManagedEtcdStorageSpec struct {
 	//
 	// +optional
 	// +immutable
-	RestoreSnapshotURL []string `json:"restoreSnapshotURL"`
+	RestoreSnapshotURL []string `json:"restoreSnapshotURL,omitempty"`
 }
 
 // PersistentVolumeEtcdStorageSpec is the configuration for PersistentVolume


### PR DESCRIPTION

**What this PR does / why we need it**:
The optional field RestoreSnapshotURL does not have `json omitempty`. When the HypershiftDeployment controller tries to update a HostedCluster CR, the following error occurs because of missing `omitempty`.

```
spec.hostedClusterSpec.etcd.managed.storage.restoreSnapshotURL: Invalid value: "null": spec.hostedClusterSpec.etcd.managed.storage.restoreSnapshotURL in body must be of type array: "null"
```

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.