### PR TITLE
Add e2e changes for PowerVS

### DIFF
--- a/cmd/cluster/powervs/create.go
+++ b/cmd/cluster/powervs/create.go
@@ -28,7 +28,6 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	}
 
 	opts.PowerVSPlatform = core.PowerVSPlatformOptions{
-		APIKey:     os.Getenv("IBMCLOUD_API_KEY"),
 		Region:     "us-south",
 		Zone:       "us-south",
 		VpcRegion:  "us-south",
@@ -83,6 +82,12 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 }
 
 func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
+	var err error
+	opts.PowerVSPlatform.APIKey, err = powervsinfra.GetAPIKey()
+	if err != nil {
+		return fmt.Errorf("error retrieving IBM Cloud API Key %w", err)
+	}
+
 	if err := validate(opts); err != nil {
 		return err
 	}
@@ -98,8 +103,9 @@ func validate(opts *core.CreateOptions) error {
 	}
 
 	if opts.PowerVSPlatform.APIKey == "" {
-		return fmt.Errorf("IBMCLOUD_API_KEY not set")
+		return fmt.Errorf("cloud API Key not set. Set it with IBMCLOUD_API_KEY env var or set file path containing API Key credential in IBMCLOUD_CREDENTIALS")
 	}
+
 	return nil
 }
 

--- a/docs/content/how-to/powervs/prerequisites-and-env-guide.md
+++ b/docs/content/how-to/powervs/prerequisites-and-env-guide.md
@@ -8,7 +8,10 @@ PowerVS and VPC region zone's possible values can be found [here](https://cluste
 If you want to set up custom endpoints, please see this [section](#setting-custom-endpoints-for-ibm-cloud-services)
 
 ### Setting up IBM Cloud Authentication
-Authenticate IBM Cloud Clients by setting the `IBMCLOUD_API_KEY` environment var to your API Key.
+There are two ways to set up authentication
+- Authenticate IBM Cloud Clients by setting the `IBMCLOUD_API_KEY` environment var to your API Key.
+- Authenticate IBM Cloud Clients by setting the `IBMCLOUD_CREDENTIALS` environment var pointing to a file containing your API Key.
+
 
 ### Setting custom endpoints for IBM Cloud services
 Set the following environment var to set the custom endpoint.

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
@@ -7,6 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sutilspointer "k8s.io/utils/pointer"
@@ -99,6 +100,12 @@ func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *
 						Name:            "manager",
 						Image:           imageCAPIBM,
 						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+							},
+						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      "credentials",

--- a/test/e2e/autorepair_test.go
+++ b/test/e2e/autorepair_test.go
@@ -44,7 +44,7 @@ func TestAutoRepair(t *testing.T) {
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
 	// TODO (alberto): have ability to label and get Nodes by NodePool. NodePool.Status.Nodes?
 	numNodes := clusterOpts.NodePoolReplicas * numZones
-	nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the rollout to be reported complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
@@ -65,7 +65,7 @@ func TestAutoRepair(t *testing.T) {
 	// Wait for nodes to be ready again, without the node that was terminated
 	t.Logf("Waiting for %d available nodes without %s", numNodes, nodeToReplace)
 	err = wait.PollUntil(30*time.Second, func() (done bool, err error) {
-		nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+		nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 		for _, node := range nodes {
 			if node.Name == nodeToReplace {
 				return false, nil

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -64,7 +64,7 @@ func TestAutoscaling(t *testing.T) {
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
 	// TODO (alberto): have ability to label and get Nodes by NodePool. NodePool.Status.Nodes?
 	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// find the zone value. This might not be identical to the zone value passed
 	// in during node creation, e.G. in azure this is $region-$zone, on AWS it is
@@ -126,7 +126,7 @@ func TestAutoscaling(t *testing.T) {
 	// Wait for one more node.
 	// TODO (alberto): have ability for NodePool to label Nodes and let workload target specific Nodes.
 	numNodes = numNodes + 1
-	_ = e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	_ = e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Delete workload.
 	cascadeDelete := metav1.DeletePropagationForeground
@@ -138,7 +138,7 @@ func TestAutoscaling(t *testing.T) {
 
 	// Wait for one less node.
 	numNodes = numNodes - 1
-	_ = e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	_ = e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 }
 
 func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, image string, zone string) *batchv1.Job {

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -37,7 +37,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 
 	// Wait for Nodes to be Ready
 	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the first rollout to be complete
 	t.Logf("Waiting for initial cluster rollout. Image: %s", globalOpts.PreviousReleaseImage)

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -37,7 +37,7 @@ func TestCreateCluster(t *testing.T) {
 
 	// Wait for Nodes to be Ready
 	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
+	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the rollout to be complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -76,6 +76,10 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.SSHKeyFile, "e2e.ssh-key-file", "", "Path to a ssh public key")
 	flag.StringVar(&globalOpts.platformRaw, "e2e.platform", string(hyperv1.AWSPlatform), "The platform to use for the tests")
 	flag.StringVar(&globalOpts.configurableClusterOptions.NetworkType, "network-type", "", "The network type to use. If unset, will default based on the OCP version.")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSResourceGroup, "e2e.powervs-resource-group", "", "IBM Cloud Resource group")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSRegion, "e2e.powervs-region", "us-south", "IBM Cloud region. Default is us-south")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSZone, "e2e.powervs-zone", "us-south", "IBM Cloud zone. Default is us-sout")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSVpcRegion, "e2e.powervs-vpc-region", "us-south", "IBM Cloud VPC Region for VPC resources. Default is us-south")
 
 	flag.Parse()
 
@@ -221,6 +225,10 @@ type configurableClusterOptions struct {
 	NodePoolReplicas           int
 	SSHKeyFile                 string
 	NetworkType                string
+	PowerVSResourceGroup       string
+	PowerVSRegion              string
+	PowerVSZone                string
+	PowerVSVpcRegion           string
 }
 
 func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
@@ -250,6 +258,16 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 			Location:        o.configurableClusterOptions.AzureLocation,
 			InstanceType:    "Standard_D4s_v4",
 			DiskSizeGB:      120,
+		},
+		PowerVSPlatform: core.PowerVSPlatformOptions{
+			ResourceGroup: o.configurableClusterOptions.PowerVSResourceGroup,
+			Region:        o.configurableClusterOptions.PowerVSRegion,
+			Zone:          o.configurableClusterOptions.PowerVSZone,
+			VpcRegion:     o.configurableClusterOptions.PowerVSVpcRegion,
+			SysType:       "s922",
+			ProcType:      "shared",
+			Processors:    "0.5",
+			Memory:        32,
 		},
 		ServiceCIDR: "172.31.0.0/16",
 		PodCIDR:     "10.132.0.0/14",

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -64,7 +64,7 @@ func TestNodepoolMachineconfigGetsRolledout(t *testing.T) {
 
 	// Wait for Nodes to be Ready
 	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes)
+	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the rollout to be complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -73,7 +73,7 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 
 	// Wait for Nodes to be Ready.
 	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the first rollout to be complete and refresh the HostedCluster.
 	t.Logf("Waiting for initial cluster rollout. Image: %s", hostedCluster.Spec.Release.Image)
@@ -122,7 +122,7 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 	// Wait for at least 1 Node to be unready, so we know the process is started.
 	e2eutil.WaitForNUnReadyNodes(t, ctx, guestClient, 1)
 	t.Log("Upgrade has stated as at least 1 Node to is unready")
-	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for NodePools to roll out the latest version
 	// TODO: Consider doing this in parallel
@@ -180,7 +180,7 @@ func TestInPlaceUpgradeNodePool(t *testing.T) {
 
 	// Wait for Nodes to be Ready
 	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the first rollout to be complete and refresh the hostedcluster
 	t.Logf("Waiting for initial cluster rollout. Image: %s", hostedCluster.Spec.Release.Image)
@@ -229,7 +229,7 @@ func TestInPlaceUpgradeNodePool(t *testing.T) {
 	// Wait for at least 1 Node to be unready, so we know the process is started.
 	e2eutil.WaitForNUnReadyNodes(t, ctx, guestClient, 1)
 	t.Log("Upgrade has started as at least 1 Node to is unready")
-	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for NodePools to roll out the latest version.
 	// TODO: Consider doing this in parallel

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -54,7 +54,7 @@ func TestOLM(t *testing.T) {
 
 	// Wait for guest cluster nodes to become available
 	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
-	util.WaitForNReadyNodes(t, ctx, guestClient, numNodes)
+	util.WaitForNReadyNodes(t, ctx, guestClient, numNodes, cluster.Spec.Platform.Type)
 
 	guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name
 	t.Logf("Hosted control plane namespace is %s", guestNamespace)

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/cluster/none"
+	"github.com/openshift/hypershift/cmd/cluster/powervs"
 	"github.com/openshift/hypershift/test/e2e/util/dump"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -221,6 +222,8 @@ func createCluster(ctx context.Context, hc *hyperv1.HostedCluster, opts *core.Cr
 		return kubevirt.CreateCluster(ctx, opts)
 	case hyperv1.AzurePlatform:
 		return azure.CreateCluster(ctx, opts)
+	case hyperv1.PowerVSPlatform:
+		return powervs.CreateCluster(ctx, opts)
 	default:
 		return fmt.Errorf("unsupported platform %s", hc.Spec.Platform.Type)
 	}
@@ -253,6 +256,18 @@ func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster
 			Location:        createOpts.AzurePlatform.Location,
 		}
 		return azure.DestroyCluster(ctx, opts)
+	case hyperv1.PowerVSPlatform:
+		opts.PowerVSPlatform = core.PowerVSPlatformDestroyOptions{
+			BaseDomain:    hc.Spec.DNS.BaseDomain,
+			CISCRN:        hc.Spec.Platform.PowerVS.CISInstanceCRN,
+			CISDomainID:   hc.Spec.DNS.PrivateZoneID,
+			ResourceGroup: createOpts.PowerVSPlatform.ResourceGroup,
+			Region:        createOpts.PowerVSPlatform.Region,
+			Zone:          createOpts.PowerVSPlatform.Zone,
+			VPCRegion:     createOpts.PowerVSPlatform.VpcRegion,
+		}
+		return powervs.DestroyCluster(ctx, opts)
+
 	default:
 		return fmt.Errorf("unsupported cluster platform %s", hc.Spec.Platform.Type)
 	}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Add e2e changes for PowerVS cloud platform.
Changes added are:
- Added env var `IBMCLOUD_CREDENTIALS` to pass cred file containing API key for auth purpose, since prow job follows secrets to be passed as files for e2e job authentication, added this change.
- Added changes in `test/e2e` for handling PowerVS platform.
- Handled timeout in `WaitForNReadyNodes` func respective to cloud platform, since PowerVS requires some extra time for nodes to get ready. 
- Added resource request for CAPI, since `EnsureHCPContainersHaveResourceRequests` test is validating the resource requests for HC containers.
- Returned nil when ever no resources are available to delete instead of an error in infra deletion. This is required, during tearDown, if there is any internal error occurs and some resources might not get deleted and some might get deleted. In next iteration since part of the resources are deleted and currently it throws error when its not available to delete. It goes on an infinite loop until destroy returns nil error. So, with this change, if the resource not available to delete, will log and return nil.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.