### PR TITLE
Use non-default path for user CA certs

### DIFF
--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -72,7 +72,7 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 				{
 					Name:      "trusted-ca",
 					ReadOnly:  true,
-					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					MountPath: "/etc/pki/tls/certs",
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -81,7 +81,7 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "user-ca-bundle"},
-							Items:                []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"}},
+							Items:                []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "user-ca-bundle.pem"}},
 						},
 					},
 				},

--- a/support/util/volumes.go
+++ b/support/util/volumes.go
@@ -13,7 +13,7 @@ func BuildVolume(volume *corev1.Volume, buildFn func(*corev1.Volume)) corev1.Vol
 func DeploymentAddTrustBundleVolume(trustBundleConfigMap *corev1.LocalObjectReference, deployment *appsv1.Deployment) {
 	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:      "trusted-ca",
-		MountPath: "/etc/pki/ca-trust/extracted/pem",
+		MountPath: "/etc/pki/tls/certs",
 		ReadOnly:  true,
 	})
 	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
@@ -21,7 +21,7 @@ func DeploymentAddTrustBundleVolume(trustBundleConfigMap *corev1.LocalObjectRefe
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: *trustBundleConfigMap,
-				Items:                []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"}},
+				Items:                []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "user-ca-bundle.pem"}},
 			},
 		},
 	})


### PR DESCRIPTION
We need to ensure the default certs aren't overwritten when a user
provides additional certs - looking at
https://go.dev/src/crypto/x509/root_linux.go it seems we should be
able to use a non-default filename in /etc/pki/tls/certs instead

**What this PR does / why we need it**:

Aims to fix reported issues testing with additionalTrustBundle on AWS (I only tested with `none` platform when developing #972)

Leaving this WIP until we can confirm it fixes the reported issue, but also that the new cert location is correctly read in the case where user additional CA certs are provided.