### PR TITLE
ARMOCP-412: Add ARM nodepool to AWS x86 Hosted Cluster

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -74,6 +74,7 @@ type ExampleOptions struct {
 	AutoRepair                       bool
 	EtcdStorageClass                 string
 	ExternalDNSDomain                string
+	Arch                             string
 	AWS                              *ExampleAWSOptions
 	None                             *ExampleNoneOptions
 	Agent                            *ExampleAgentOptions
@@ -518,6 +519,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				Platform: hyperv1.NodePoolPlatform{
 					Type: cluster.Spec.Platform.Type,
 				},
+				Arch:             o.Arch,
 				NodeDrainTimeout: &metav1.Duration{Duration: o.NodeDrainTimeout},
 			},
 		}

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -28,6 +28,7 @@ const (
 	NodePoolInplaceUpgradeFailedConditionReason  = "InplaceUpgradeFailed"
 	NodePoolNotFoundReason                       = "NotFound"
 	NodePoolFailedToGetReason                    = "FailedToGet"
+	NodePoolValidArchPlatform                    = "ValidArchPlatform"
 	// NodePoolLabel is used to label Nodes.
 	NodePoolLabel = "hypershift.openshift.io/nodePool"
 )
@@ -42,6 +43,21 @@ const (
 	// IgnitionServerTokenExpirationTimestampAnnotation holds the time that a ignition token expires and should be
 	// removed from the cluster.
 	IgnitionServerTokenExpirationTimestampAnnotation = "hypershift.openshift.io/ignition-token-expiration-timestamp"
+)
+
+const (
+	ArchitectureAMD64   = "amd64"
+	ArchitectureS390X   = "s390x"
+	ArchitecturePPC64LE = "ppc64le"
+	ArchitectureARM64   = "arm64"
+)
+
+var (
+	// ArchAliases contains the RHCOS release metadata aliases for the different architectures supported as API input.
+	ArchAliases = map[string]string{
+		ArchitectureAMD64: "x86_64",
+		ArchitectureARM64: "aarch64",
+	}
 )
 
 func init() {
@@ -169,6 +185,16 @@ type NodePoolSpec struct {
 	// JSON or YAML of a serialized Tuned.
 	// +kubebuilder:validation:Optional
 	TuningConfig []corev1.LocalObjectReference `json:"tuningConfig,omitempty"`
+
+	// Arch is the preferred processor architecture for the NodePool (currently only supported on AWS)
+	// NOTE: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
+	//	https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
+	// TODO Add ppc64le and s390x to enum validation once the architectures are supported
+	//
+	// +kubebuilder:default:=amd64
+	// +kubebuilder:validation:Enum=arm64;amd64
+	// +optional
+	Arch string `json:"arch,omitempty"`
 }
 
 // NodePoolStatus is the latest observed status of a NodePool.

--- a/api/v1beta1/nodepool_conditions.go
+++ b/api/v1beta1/nodepool_conditions.go
@@ -72,4 +72,5 @@ const (
 	IgnitionCACertMissingReason           = "IgnitionCACertMissing"
 	IgnitionNotReached                    = "ignitionNotReached"
 	DefaultAWSSecurityGroupNotReadyReason = "DefaultSGNotReady"
+	NodePoolValidArchPlatform             = "ValidArchPlatform"
 )

--- a/api/v1beta1/nodepool_types.go
+++ b/api/v1beta1/nodepool_types.go
@@ -11,12 +11,25 @@ import (
 )
 
 const (
+	ArchitectureAMD64   = "amd64"
+	ArchitectureS390X   = "s390x"
+	ArchitecturePPC64LE = "ppc64le"
+	ArchitectureARM64   = "arm64"
+
 	// NodePoolLabel is used to label Nodes.
 	NodePoolLabel = "hypershift.openshift.io/nodePool"
 
 	// IgnitionServerTokenExpirationTimestampAnnotation holds the time that a ignition token expires and should be
 	// removed from the cluster.
 	IgnitionServerTokenExpirationTimestampAnnotation = "hypershift.openshift.io/ignition-token-expiration-timestamp"
+)
+
+var (
+	// ArchAliases contains the RHCOS release metadata aliases for the different architectures supported as API input.
+	ArchAliases = map[string]string{
+		ArchitectureAMD64: "x86_64",
+		ArchitectureARM64: "aarch64",
+	}
 )
 
 func init() {
@@ -143,6 +156,16 @@ type NodePoolSpec struct {
 	// JSON or YAML of a serialized Tuned.
 	// +kubebuilder:validation:Optional
 	TuningConfig []corev1.LocalObjectReference `json:"tuningConfig,omitempty"`
+
+	// Arch is the preferred processor architecture for the NodePool (currently only supported on AWS)
+	// NOTE: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
+	//	https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
+	// TODO Add ppc64le and s390x to enum validation once the architectures are supported
+	//
+	// +kubebuilder:default:=amd64
+	// +kubebuilder:validation:Enum=arm64;amd64
+	// +optional
+	Arch string `json:"arch,omitempty"`
 }
 
 // NodePoolStatus is the latest observed status of a NodePool.

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -25,7 +25,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	opts.AWSPlatform = core.AWSPlatformOptions{
 		AWSCredentialsFile: "",
 		Region:             "us-east-1",
-		InstanceType:       "m5.large",
+		InstanceType:       "",
 		RootVolumeType:     "gp3",
 		RootVolumeSize:     120,
 		RootVolumeIOPS:     0,
@@ -195,6 +195,19 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		tags = append(tags, hyperv1.AWSResourceTag{Key: k, Value: v})
 	}
 
+	var instanceType string
+	if opts.AWSPlatform.InstanceType != "" {
+		instanceType = opts.AWSPlatform.InstanceType
+	} else {
+		// Aligning with AWS IPI instance type defaults
+		switch opts.Arch {
+		case hyperv1.ArchitectureAMD64:
+			instanceType = "m5.large"
+		case hyperv1.ArchitectureARM64:
+			instanceType = "m6g.large"
+		}
+	}
+
 	exampleOptions.BaseDomain = infra.BaseDomain
 	exampleOptions.BaseDomainPrefix = infra.BaseDomainPrefix
 	exampleOptions.MachineCIDR = infra.MachineCIDR
@@ -220,7 +233,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		VPCID:                   infra.VPCID,
 		SecurityGroupID:         infra.SecurityGroupID,
 		InstanceProfile:         iamInfo.ProfileName,
-		InstanceType:            opts.AWSPlatform.InstanceType,
+		InstanceType:            instanceType,
 		Roles:                   iamInfo.Roles,
 		KMSProviderRoleARN:      iamInfo.KMSProviderRoleARN,
 		KMSKeyARN:               iamInfo.KMSKeyARN,

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -37,6 +37,7 @@ func NewCreateCommands() *cobra.Command {
 		Log:                            log.Log,
 		NodeDrainTimeout:               0,
 		NodeUpgradeType:                v1beta1.UpgradeTypeReplace,
+		Arch:                           "amd64",
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -74,6 +75,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
+	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The default processor architecture for the NodePool (e.g. arm64, amd64)")
 
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(none.NewCreateCommand(opts))

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -61,6 +61,7 @@ type CreateOptions struct {
 	ServiceCIDR                      string
 	ClusterCIDR                      string
 	ExternalDNSDomain                string
+	Arch                             string
 	NodeSelector                     map[string]string
 	NonePlatform                     NonePlatformCreateOptions
 	KubevirtPlatform                 KubevirtPlatformCreateOptions
@@ -267,6 +268,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		EtcdStorageClass:                 opts.EtcdStorageClass,
 		ServiceCIDR:                      opts.ServiceCIDR,
 		ClusterCIDR:                      opts.ClusterCIDR,
+		Arch:                             opts.Arch,
 		NodeSelector:                     opts.NodeSelector,
 		UpgradeType:                      opts.NodeUpgradeType,
 	}, nil

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -79,6 +79,18 @@ spec:
           spec:
             description: Spec is the desired behavior of the NodePool.
             properties:
+              arch:
+                default: amd64
+                description: 'Arch is the preferred processor architecture for the
+                  NodePool (currently only supported on AWS) NOTE: This is set as
+                  optional to prevent validation from failing due to a limitation
+                  on client side validation with open API machinery: https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
+                  TODO Add ppc64le and s390x to enum validation once the architectures
+                  are supported'
+                enum:
+                - arm64
+                - amd64
+                type: string
               autoScaling:
                 description: Autoscaling specifies auto-scaling behavior for the NodePool.
                 properties:
@@ -918,6 +930,18 @@ spec:
           spec:
             description: Spec is the desired behavior of the NodePool.
             properties:
+              arch:
+                default: amd64
+                description: 'Arch is the preferred processor architecture for the
+                  NodePool (currently only supported on AWS) NOTE: This is set as
+                  optional to prevent validation from failing due to a limitation
+                  on client side validation with open API machinery: https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
+                  TODO Add ppc64le and s390x to enum validation once the architectures
+                  are supported'
+                enum:
+                - arm64
+                - amd64
+                type: string
               autoScaling:
                 description: Autoscaling specifies auto-scaling behavior for the NodePool.
                 properties:

--- a/cmd/nodepool/aws/create.go
+++ b/cmd/nodepool/aws/create.go
@@ -23,7 +23,7 @@ type AWSPlatformCreateOptions struct {
 
 func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	platformOpts := &AWSPlatformCreateOptions{
-		InstanceType:   "m5.large",
+		InstanceType:   "",
 		RootVolumeType: "gp3",
 		RootVolumeSize: 120,
 		RootVolumeIOPS: 0,
@@ -80,8 +80,22 @@ func (o *AWSPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool 
 		}
 		o.SecurityGroupID = *defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID
 	}
+
+	var instanceType string
+	if o.InstanceType != "" {
+		instanceType = o.InstanceType
+	} else {
+		// Aligning with AWS IPI instance type defaults
+		switch nodePool.Spec.Arch {
+		case "amd64":
+			instanceType = "m5.large"
+		case "arm64":
+			instanceType = "m6g.large"
+		}
+	}
+
 	nodePool.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
-		InstanceType:    o.InstanceType,
+		InstanceType:    instanceType,
 		InstanceProfile: o.InstanceProfile,
 		Subnet: &hyperv1.AWSResourceReference{
 			ID: &o.SubnetID,

--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -23,6 +23,7 @@ type CreateNodePoolOptions struct {
 	ReleaseImage    string
 	Render          bool
 	NodeUpgradeType hyperv1.UpgradeType
+	Arch            string
 }
 
 type PlatformOptions interface {
@@ -92,6 +93,7 @@ func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts
 			Platform: hyperv1.NodePoolPlatform{
 				Type: hcluster.Spec.Platform.Type,
 			},
+			Arch: o.Arch,
 		},
 	}
 

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -31,6 +31,7 @@ func NewCreateCommand() *cobra.Command {
 		NodeCount:       2,
 		ReleaseImage:    "",
 		NodeUpgradeType: hyperv1.UpgradeTypeReplace,
+		Arch:            "amd64",
 	}
 
 	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The name of the NodePool")
@@ -39,6 +40,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ClusterName, "cluster-name", opts.ClusterName, "The name of the HostedCluster nodes in this pool will join")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes. If empty, defaults to the same release image as the HostedCluster.")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
+	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The processor architecture for the NodePool (e.g. arm64, amd64)")
 
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying")
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -17,7 +17,9 @@ var (
 )
 
 // https://docs.ci.openshift.org/docs/getting-started/useful-links/#services
-const releaseURL = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest"
+const (
+	releaseURL = "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-multi/latest"
+)
 
 type OCPVersion struct {
 	Name        string `json:"name"`

--- a/docs/content/how-to/aws/create-aws-hosted-cluster-arm-workers.md
+++ b/docs/content/how-to/aws/create-aws-hosted-cluster-arm-workers.md
@@ -1,0 +1,56 @@
+---
+title: Create ARM NodePools on AWS Hosted Cluster
+---
+
+# Create ARM NodePools on AWS Hosted Cluster
+
+## Creating a Hosted Cluster with ARM NodePool
+
+Create a new cluster, specifying the `RELEASE_IMAGE` and `ARCH`:
+
+```shell linenums="1"
+REGION=us-east-1
+CLUSTER_NAME=example
+BASE_DOMAIN=example.com
+AWS_CREDS="$HOME/.aws/credentials"
+PULL_SECRET="$HOME/pull-secret"
+RELEASE_IMAGE="quay.io/openshift-release-dev/ocp-release@sha256:1a101ef5215da468cea8bd2eb47114e85b2b64a6b230d5882f845701f55d057f"
+ARCH="arm64"
+
+hypershift create cluster aws \
+--name $CLUSTER_NAME \
+--node-pool-replicas=3 \
+--base-domain $BASE_DOMAIN \
+--pull-secret $PULL_SECRET \
+--aws-creds $AWS_CREDS \
+--region $REGION \
+--release-image $RELEASE_IMAGE \
+--arch $ARCH \
+--generate-ssh
+```
+
+!!! important
+
+    The release image used needs to be a manifest listed image.
+
+!!! note
+
+    Currently, the only valid values for '--arch' are 'arm64' and 'amd64'. 'amd64' is the default when '--arch' isn't used.
+
+The hosted cluster will spin up with an ARM NodePool. The default AWS ARM instance type is `m6g.large`.
+
+## Creating ARM NodePools on Existing Hosted Cluster
+
+As long as a hosted cluster was created with a manifest listed image in the `--release-image`, ARM NodePools can be added to the hosted cluster:
+
+```shell linenums="1"
+CLUSTER_NAME=example
+NODE_POOLNAME=example-worker
+ARCH="arm64"
+
+hypershift create nodepool aws \
+--cluster-name $CLUSTER_NAME \
+--name $NODE_POOLNAME \
+--node-count=3 \
+--arch $ARCH \
+```

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -725,6 +725,21 @@ nodes in the NodePool. The Tuned API is defined here:</p>
 JSON or YAML of a serialized Tuned.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>arch</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arch is the preferred processor architecture for the NodePool (currently only supported on AWS)
+NOTE: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
+<a href="https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215">https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215</a>
+TODO Add ppc64le and s390x to enum validation once the architectures are supported</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -5889,6 +5904,21 @@ nodes in the NodePool. The Tuned API is defined here:</p>
 <p><a href="https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go">https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go</a></p>
 <p>Each ConfigMap must have a single key named &ldquo;tuned&rdquo; whose value is the
 JSON or YAML of a serialized Tuned.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>arch</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arch is the preferred processor architecture for the NodePool (currently only supported on AWS)
+NOTE: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
+<a href="https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215">https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215</a>
+TODO Add ppc64le and s390x to enum validation once the architectures are supported</p>
 </td>
 </tr>
 </tbody>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -68,6 +68,8 @@ nav:
     - how-to/aws/etc-backup-restore.md
     - how-to/aws/disaster-recovery.md
     - how-to/aws/troubleshooting.md
+    - how-to/aws/create-aws-hosted-cluster-arm-workers.md
+    - how-to/aws/migrate-hosted-cluster.md
   - 'Azure':
     - how-to/azure/create-azure-cluster.md
   - 'Agent':

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -42393,6 +42393,18 @@ objects:
             spec:
               description: Spec is the desired behavior of the NodePool.
               properties:
+                arch:
+                  default: amd64
+                  description: 'Arch is the preferred processor architecture for the
+                    NodePool (currently only supported on AWS) NOTE: This is set as
+                    optional to prevent validation from failing due to a limitation
+                    on client side validation with open API machinery: https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
+                    TODO Add ppc64le and s390x to enum validation once the architectures
+                    are supported'
+                  enum:
+                  - arm64
+                  - amd64
+                  type: string
                 autoScaling:
                   description: Autoscaling specifies auto-scaling behavior for the
                     NodePool.
@@ -43241,6 +43253,18 @@ objects:
             spec:
               description: Spec is the desired behavior of the NodePool.
               properties:
+                arch:
+                  default: amd64
+                  description: 'Arch is the preferred processor architecture for the
+                    NodePool (currently only supported on AWS) NOTE: This is set as
+                    optional to prevent validation from failing due to a limitation
+                    on client side validation with open API machinery: https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
+                    TODO Add ppc64le and s390x to enum validation once the architectures
+                    are supported'
+                  enum:
+                  - arm64
+                  - amd64
+                  type: string
                 autoScaling:
                   description: Autoscaling specifies auto-scaling behavior for the
                     NodePool.

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -367,6 +367,17 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		ObservedGeneration: nodePool.Generation,
 	})
 
+	// Validate arch platform support
+	if (nodePool.Spec.Arch != "") && (nodePool.Spec.Platform.Type != hyperv1.AWSPlatform) {
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolValidArchPlatform,
+			Status:             corev1.ConditionFalse,
+			Reason:             hyperv1.NodePoolValidationFailedReason,
+			Message:            fmt.Sprintf("Arch flag is not supported for platform: %s", nodePool.Spec.Platform.Type),
+			ObservedGeneration: nodePool.Generation,
+		})
+	}
+
 	// Validate AWS platform specific input
 	var ami string
 	if nodePool.Spec.Platform.Type == hyperv1.AWSPlatform {
@@ -379,7 +390,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			removeStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolValidPlatformImageType)
 		} else {
 			// TODO: Should the region be included in the NodePool platform information?
-			ami, err = defaultNodePoolAMI(hcluster.Spec.Platform.AWS.Region, releaseImage)
+			ami, err = defaultNodePoolAMI(hcluster.Spec.Platform.AWS.Region, nodePool.Spec.Arch, releaseImage)
 			if err != nil {
 				SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 					Type:               hyperv1.NodePoolValidPlatformImageType,
@@ -1933,11 +1944,10 @@ func validateAutoscaling(nodePool *hyperv1.NodePool) error {
 	return nil
 }
 
-func defaultNodePoolAMI(region string, releaseImage *releaseinfo.ReleaseImage) (string, error) {
-	// TODO: The architecture should be specified from the API
-	arch, foundArch := releaseImage.StreamMetadata.Architectures["x86_64"]
+func defaultNodePoolAMI(region string, specifiedArch string, releaseImage *releaseinfo.ReleaseImage) (string, error) {
+	arch, foundArch := releaseImage.StreamMetadata.Architectures[hyperv1.ArchAliases[specifiedArch]]
 	if !foundArch {
-		return "", fmt.Errorf("couldn't find OS metadata for architecture %q", "x64_64")
+		return "", fmt.Errorf("couldn't find OS metadata for architecture %q", specifiedArch)
 	}
 
 	regionData, hasRegionData := arch.Images.AWS.Regions[region]

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	ignserver "github.com/openshift/hypershift/ignition-server/controllers"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
@@ -1993,6 +1995,107 @@ func TestTaintsToJSON(t *testing.T) {
 			node := &corev1.Node{}
 			node.Spec.Taints = append(node.Spec.Taints, coreTaints...)
 			g.Expect(node.Spec.Taints).To(ContainElements(coreTaints))
+		})
+	}
+}
+
+func TestDefaultNodePoolAMI(t *testing.T) {
+	testCases := []struct {
+		name          string
+		region        string
+		specifiedArch string
+		releaseImage  *releaseinfo.ReleaseImage
+		image         string
+		err           error
+		expectedImage string
+	}{
+		{
+			name:          "successfully pull amd64 AMI",
+			region:        "us-east-1",
+			specifiedArch: "amd64",
+			expectedImage: "us-east-1-x86_64-image",
+		},
+		{
+			name:          "successfully pull arm64 AMI",
+			region:        "us-east-1",
+			specifiedArch: "arm64",
+			expectedImage: "us-east-1-aarch64-image",
+		},
+		{
+			name:          "fail to pull amd64 AMI because region can't be found",
+			region:        "us-east-2",
+			specifiedArch: "amd64",
+			expectedImage: "",
+		},
+		{
+			name:          "fail to pull arm64 AMI because region can't be found",
+			region:        "us-east-2",
+			specifiedArch: "arm64",
+			expectedImage: "",
+		},
+		{
+			name:          "fail because architecture can't be found",
+			region:        "us-east-2",
+			specifiedArch: "arm644",
+			expectedImage: "",
+		},
+		{
+			name:          "fail because architecture can't be found",
+			region:        "us-east-2",
+			specifiedArch: "s390x",
+			expectedImage: "",
+		},
+		{
+			name:          "fail because no image data is defined",
+			region:        "us-west-1",
+			specifiedArch: "arm64",
+			expectedImage: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			other := []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"},
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: nil,
+					},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithObjects(other...).Build()
+			releaseProvider := &fakereleaseprovider.FakeReleaseProvider{}
+			hc := &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					PullSecret: corev1.LocalObjectReference{
+						Name: "pull-secret",
+					},
+					Release: hyperv1.Release{
+						Image: "image-4.12.0",
+					},
+				},
+			}
+
+			ctx := context.Background()
+			tc.releaseImage = fakereleaseprovider.GetReleaseImage(ctx, hc, client, releaseProvider)
+
+			tc.image, tc.err = defaultNodePoolAMI(tc.region, tc.specifiedArch, tc.releaseImage)
+			if strings.Contains(tc.name, "successfully") {
+				g.Expect(tc.image).To(Equal(tc.expectedImage))
+				g.Expect(tc.err).To(BeNil())
+			} else if strings.Contains(tc.name, "fail to pull") {
+				g.Expect(tc.image).To(BeEmpty())
+				g.Expect(tc.err.Error()).To(Equal("couldn't find AWS image for region \"" + tc.region + "\""))
+			} else if strings.Contains(tc.name, "fail because architecture") {
+				g.Expect(tc.image).To(BeEmpty())
+				g.Expect(tc.err.Error()).To(Equal("couldn't find OS metadata for architecture \"" + tc.specifiedArch + "\""))
+			} else {
+				g.Expect(tc.image).To(BeEmpty())
+				g.Expect(tc.err.Error()).To(Equal("release image metadata has no image for region \"" + tc.region + "\""))
+			}
 		})
 	}
 }

--- a/support/releaseinfo/fake/fake.go
+++ b/support/releaseinfo/fake/fake.go
@@ -9,8 +9,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	imagev1 "github.com/openshift/api/image/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ releaseinfo.ProviderWithRegistryOverrides = &FakeReleaseProvider{}
@@ -51,6 +54,38 @@ func (f *FakeReleaseProvider) Lookup(ctx context.Context, image string, pullSecr
 				},
 			},
 		},
+		StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+			Architectures: map[string]releaseinfo.CoreOSArchitecture{
+				"x86_64": {
+					Images: releaseinfo.CoreOSImages{
+						AWS: releaseinfo.CoreOSAWSImages{
+							Regions: map[string]releaseinfo.CoreOSAWSImage{
+								"us-east-1": {
+									Release: "us-east-1-x86_64-release",
+									Image:   "us-east-1-x86_64-image",
+								},
+							},
+						},
+					},
+				},
+				"aarch64": {
+					Images: releaseinfo.CoreOSImages{
+						AWS: releaseinfo.CoreOSAWSImages{
+							Regions: map[string]releaseinfo.CoreOSAWSImage{
+								"us-east-1": {
+									Release: "us-east-1-aarch64-release",
+									Image:   "us-east-1-aarch64-image",
+								},
+								"us-west-1": {
+									Release: "us-west-1-aarch64-release",
+									Image:   "",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	if len(f.ImageVersion) == 0 {
 		if f.Version != "" {
@@ -68,4 +103,21 @@ func (f *FakeReleaseProvider) Lookup(ctx context.Context, image string, pullSecr
 
 func (*FakeReleaseProvider) GetRegistryOverrides() map[string]string {
 	return nil
+}
+
+func GetReleaseImage(ctx context.Context, hc *hyperv1.HostedCluster, client crclient.WithWatch, releaseProvider *FakeReleaseProvider) *releaseinfo.ReleaseImage {
+	var pullSecret corev1.Secret
+	if err := client.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hc.Spec.PullSecret.Name}, &pullSecret); err != nil {
+		return nil
+	}
+	pullSecretBytes, ok := pullSecret.Data[corev1.DockerConfigJsonKey]
+	if !ok {
+		return nil
+	}
+	releaseInfo, err := releaseProvider.Lookup(ctx, hc.Spec.Release.Image, pullSecretBytes)
+	if err != nil {
+		return nil
+	}
+
+	return releaseInfo
 }

--- a/test/e2e/arm_nodepool_test.go
+++ b/test/e2e/arm_nodepool_test.go
@@ -1,0 +1,57 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	_ "embed"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/version"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCreateClusterWithArmNodePool(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts.Arch = "arm64"
+
+	defaultVersion, err := version.LookupDefaultOCPVersion()
+	if err != nil {
+		t.Fail()
+	}
+	clusterOpts.ReleaseImage = defaultVersion.PullSpec
+	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
+
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
+
+	// Sanity check the cluster by waiting for the nodes to report ready
+	t.Logf("Waiting for guest client to become available")
+	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
+
+	// Wait for Nodes to be Ready
+	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
+
+	// Wait for the rollout to be complete
+	t.Logf("Waiting for cluster rollout. Image: %s", clusterOpts.ReleaseImage)
+	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, clusterOpts.ReleaseImage)
+	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
+	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -396,8 +396,8 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		ControlPlaneOperatorImage:        o.configurableClusterOptions.ControlPlaneOperatorImage,
 		ExternalDNSDomain:                o.configurableClusterOptions.ExternalDNSDomain,
 		NodeUpgradeType:                  hyperv1.UpgradeTypeReplace,
+		Arch:                             "amd64",
 		AWSPlatform: core.AWSPlatformOptions{
-			InstanceType:       "m5.large",
 			RootVolumeSize:     64,
 			RootVolumeType:     "gp3",
 			AWSCredentialsFile: o.configurableClusterOptions.AWSCredentialsFile,


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows a User to add an ARM AWS instance type in a nodepool

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/ARMOCP-412

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.


@enxebre, @bryan-cox and I have been working on this and need some help.

Initially, we wanted the hypershift operator to intake an `instancetype`, and select the right AMI based on its `arch`. Unfortunately, this wouldn't work because the hypershift controller doesn't have enough AWS access to make that validation. Instead, we choose to put this logic in the hypershift cli.  While this works, I'm not sure if the hypershift cli is the only code that creates nodepools/hostedcontrolplanes. I'm afraid that we may have made an assumption that could break things like ACM/MCE, but we don't know enough about those to say for sure. 