### PR TITLE
Sort deployments for Degraded condition check

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 	"strings"
 	"time"
 
@@ -319,6 +320,9 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 		}
 		var errs []error
+		sort.SliceStable(cpoManagedDeploymentList.Items, func(i, j int) bool {
+			return cpoManagedDeploymentList.Items[i].Name < cpoManagedDeploymentList.Items[j].Name
+		})
 		for _, deployment := range cpoManagedDeploymentList.Items {
 			if deployment.Status.UnavailableReplicas > 0 {
 				errs = append(errs, fmt.Errorf("%s deployment has %d unavailable replicas", deployment.Name, deployment.Status.UnavailableReplicas))


### PR DESCRIPTION
**What this PR does / why we need it**:
Shuffling of the deployment list is resulting in unnecessary status updates.  Sort the list so the condition message is stable for a given set of deployments. 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.