### PR TITLE
Ingress endpoint

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -52,6 +52,11 @@ const (
 	// PortierisImageAnnotation is an annotation that allows the specification of the portieries component
 	// (performs container image verification).
 	PortierisImageAnnotation = "hypershift.openshift.io/portieris-image"
+	// Configure ingress controller with endpoint publishing strategy as Private.
+	// This overrides any opinionated strategy set by platform in ReconcileDefaultIngressController.
+	// It's used by IBM cloud to support ingress endpoint publishing strategy scope
+	// NOTE: We'll expose this in the API if the use case gets generalised.
+	PrivateIngressControllerAnnotation = "hypershift.openshift.io/private-ingress-controller"
 
 	// ClusterAPIProviderAWSImage overrides the CAPI AWS provider image to use for
 	// a HostedControlPlane.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
@@ -1,6 +1,7 @@
 package ingress
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/support/globalconfig"
 )
@@ -9,16 +10,30 @@ type IngressParams struct {
 	IngressSubdomain string
 	Replicas         int32
 	PlatformType     hyperv1.PlatformType
+	IsPrivate        bool
+	IBMCloudUPI      bool
 }
 
 func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 	var replicas int32 = 1
+	isPrivate := false
+	ibmCloudUPI := false
+	if hcp.Spec.Platform.IBMCloud != nil && hcp.Spec.Platform.IBMCloud.ProviderType == configv1.IBMCloudProviderTypeUPI {
+		ibmCloudUPI = true
+	}
+	if hcp.Annotations[hyperv1.PrivateIngressControllerAnnotation] == "true" {
+		isPrivate = true
+	}
 	if hcp.Spec.InfrastructureAvailabilityPolicy == hyperv1.HighlyAvailable {
 		replicas = 2
 	}
+
 	return &IngressParams{
 		IngressSubdomain: globalconfig.IngressDomain(hcp),
 		Replicas:         replicas,
 		PlatformType:     hcp.Spec.Platform.Type,
+		IsPrivate:        isPrivate,
+		IBMCloudUPI:      ibmCloudUPI,
 	}
+
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 )
 
-func ReconcileDefaultIngressController(ingressController *operatorv1.IngressController, ingressSubdomain string, platformType hyperv1.PlatformType, replicas int32, isIBMCloudUPI bool) error {
+func ReconcileDefaultIngressController(ingressController *operatorv1.IngressController, ingressSubdomain string, platformType hyperv1.PlatformType, replicas int32, isIBMCloudUPI bool, isPrivate bool) error {
 	ingressController.Spec.Domain = ingressSubdomain
 	ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
 		Type: operatorv1.LoadBalancerServiceStrategyType,
@@ -63,6 +63,12 @@ func ReconcileDefaultIngressController(ingressController *operatorv1.IngressCont
 		}
 		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
 			Name: manifests.IngressDefaultIngressControllerCert().Name,
+		}
+	}
+	if isPrivate {
+		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+			Type:    operatorv1.PrivateStrategyType,
+			Private: &operatorv1.PrivateStrategy{},
 		}
 	}
 	return nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -592,7 +592,7 @@ func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv
 	p := ingress.NewIngressParams(hcp)
 	ingressController := manifests.IngressDefaultIngressController()
 	if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
-		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, (hcp.Spec.Platform.IBMCloud != nil && hcp.Spec.Platform.IBMCloud.ProviderType == configv1.IBMCloudProviderTypeUPI))
+		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, p.IBMCloudUPI, p.IsPrivate)
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1384,6 +1384,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.PortierisImageAnnotation,
 		hyperutil.DebugDeploymentsAnnotation,
 		hyperv1.DisableProfilingAnnotation,
+		hyperv1.PrivateIngressControllerAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]


### PR DESCRIPTION
Configure ingress controller with endpoint publishing strategy as Private. Expose this configuration setting as an annotation on the HostedCluster/HostedControlPlane CRs. And will be generic to be applicable to any providers. Support ingress endpoint publishing strategy scope like we do today. Support for this was recently added to the IBM ROKS Toolkit and our ROKS 4 ansible code. (Focus on scoping this up to Hypershift).

Issue: https://github.com/openshift/hypershift/issues/1599


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.