### PR TITLE
Socks 5 proxy: Only use mgmt cluster for cloud apis for ingress operator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -210,7 +210,12 @@ func ingressOperatorSocks5ProxyContainer(socks5ProxyImage string) corev1.Contain
 		Name:    socks5ProxyContainerName,
 		Image:   socks5ProxyImage,
 		Command: []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy"},
-		Args:    []string{"run"},
+		Args: []string{
+			"run",
+			// Do not route cloud provider traffic through konnektivity and thus nodes to speed
+			// up cluster creation. Requires proxy env vars to be set.
+			"--connect-directly-to-cloud-apis=true",
+		},
 		Env: []corev1.EnvVar{{
 			Name:  "KUBECONFIG",
 			Value: "/etc/kubernetes/kubeconfig",


### PR DESCRIPTION
The socks5 proxy has code to avoid sending traffic destined for cloud
provider apis through konnektivity in order to not require nodes to be
up for that communication to work.

When running a management cluster with a proxy setup and not setting
proxy env vars in the socks5 proxy, that code effectively means that it
is not possible to commnicate with those apis, as the sidecar can not
route it as it has no direct Internet connectivity.

The above currently breaks imagestreamimports if the import is from a docker
registry hosted in AWS S3, as the Openshift APIServer is supposed to
route all its imports through Konnektivity, which is why its proxy
sidecar does not get the mgmt cluster proxy env vars.

The only reason for special casing cloud provider apis here is the
ingress operator, as it should be able to setup DNS before nodes exist
in order to speed up cluster creation.

As this special case is surprising and an easy footgun, hide it behind a
flag and only activate this for the Ingress Operator.

This change should stabilize the proxy conformance periodic, which has
currently a high failure rate which ultimately always boilds down to
being unable to import the `tools` image in the `openshift` namespace,
which is used by many tests.

/cc @csrwng 

Likely the longest commit message for any commit authored by me in this repo :upside_down_face: 

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.