### PR TITLE
ensure release image annotation set on control-plane-operator

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2195,6 +2195,7 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 	hyperutil.SetRestartAnnotation(hc.ObjectMeta, deployment)
 	hyperutil.SetControlPlaneIsolation(hc.ObjectMeta, deployment)
 	hyperutil.SetDefaultPriorityClass(deployment)
+	hyperutil.SetReleaseImageAnnotation(deployment, hc.Spec.Release.Image)
 	return nil
 }
 


### PR DESCRIPTION
all hosted control-plane components should have the release image annotation set to be able to easily monitor that the associated component is derived from the active release image. Control-plane-operator is missing this annotation. This pr adds that in (utilized in IBM Cloud to track rollout progress).

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.