### PR TITLE
stop clearing configMapRef and secretRef since it breaks reconciliation of existing production workload using these fields

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1468,7 +1468,23 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		if err != nil {
 			return fmt.Errorf("failed to convert configuration fields to raw extension: %w", err)
 		}
+		// TODO: cannot remove until IBM's production fleet (4.9_openshift, 4.10_openshift) of control-plane-operators
+		// are upgraded to versions that read validation information from new sections
 		hcp.Spec.Configuration.Items = items
+		secretRef := []corev1.LocalObjectReference{}
+		configMapRef := []corev1.LocalObjectReference{}
+		for _, secretName := range globalconfig.SecretRefs(hcluster.Spec.Configuration) {
+			secretRef = append(secretRef, corev1.LocalObjectReference{
+				Name: secretName,
+			})
+		}
+		for _, configMapName := range globalconfig.ConfigMapRefs(hcluster.Spec.Configuration) {
+			configMapRef = append(configMapRef, corev1.LocalObjectReference{
+				Name: configMapName,
+			})
+		}
+		hcp.Spec.Configuration.SecretRefs = secretRef
+		hcp.Spec.Configuration.ConfigMapRefs = configMapRef
 	} else {
 		hcp.Spec.Configuration = nil
 	}


### PR DESCRIPTION
These fields cannot be cleared since it breaks validation for 4.10 and 4.9 control-plane-operator images. Those images with this removed fail validation with:
APIServer: named serving certificate ibm-named-certs not included in secret references, OAuth: identity provider IAM openid client secret hypershift-ibm-iam-clientsecret is not included in referenced secrets

The reconciliation of these values needs to continue to occur until all existing production control-plane-operators are confirmed to be at a compatible version.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.