### PR TITLE
Add flags for destroy cluster powervs command

### DIFF
--- a/cmd/cluster/powervs/destroy.go
+++ b/cmd/cluster/powervs/destroy.go
@@ -22,6 +22,20 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 		Short:        "Destroys a HostedCluster and its resources on PowerVS",
 		SilenceUsage: true,
 	}
+
+	opts.PowerVSPlatform = core.PowerVSPlatformDestroyOptions{
+		Region:    "us-south",
+		Zone:      "us-south",
+		VPCRegion: "us-south",
+	}
+
+	cmd.Flags().StringVar(&opts.PowerVSPlatform.ResourceGroup, "resource-group", opts.PowerVSPlatform.ResourceGroup, "IBM Cloud Resource group")
+	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Cluster ID with which to tag IBM Cloud resources")
+	cmd.Flags().StringVar(&opts.PowerVSPlatform.BaseDomain, "base-domain", opts.PowerVSPlatform.BaseDomain, "Cluster's base domain")
+	cmd.Flags().StringVar(&opts.PowerVSPlatform.Region, "region", opts.PowerVSPlatform.Region, "IBM Cloud region. Default is us-south")
+	cmd.Flags().StringVar(&opts.PowerVSPlatform.Zone, "zone", opts.PowerVSPlatform.Zone, "IBM Cloud zone. Default is us-south")
+	cmd.Flags().StringVar(&opts.PowerVSPlatform.VPCRegion, "vpc-region", opts.PowerVSPlatform.VPCRegion, "IBM Cloud VPC Region for VPC resources. Default is us-south")
+
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

This PR trying to address this bug https://issues.redhat.com/browse/MULTIARCH-2692 for not handling the flags for destroy cluster powervs command.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.