### PR TITLE
Use non-strict mode when parsing global config

### DIFF
--- a/support/api/scheme.go
+++ b/support/api/scheme.go
@@ -39,6 +39,10 @@ var (
 		json.DefaultMetaFactory, Scheme, Scheme,
 		json.SerializerOptions{Yaml: true, Pretty: true, Strict: true},
 	)
+	TolerantYAMLSerializer = json.NewSerializerWithOptions(
+		json.DefaultMetaFactory, Scheme, Scheme,
+		json.SerializerOptions{Yaml: true, Pretty: true, Strict: false},
+	)
 )
 
 func init() {

--- a/support/globalconfig/globalconfig.go
+++ b/support/globalconfig/globalconfig.go
@@ -39,7 +39,7 @@ func ParseGlobalConfig(ctx context.Context, cfg *hyperv1.ClusterConfiguration) (
 	}
 	kinds := sets.NewString() // keeps track of which kinds have been found
 	for i, cfg := range cfg.Items {
-		cfgObject, gvk, err := api.YamlSerializer.Decode(cfg.Raw, nil, nil)
+		cfgObject, gvk, err := api.TolerantYAMLSerializer.Decode(cfg.Raw, nil, nil)
 		if err != nil {
 			return globalConfig, fmt.Errorf("cannot parse configuration at index %d: %w", i, err)
 		}

--- a/support/globalconfig/globalconfig_test.go
+++ b/support/globalconfig/globalconfig_test.go
@@ -19,6 +19,7 @@ metadata:
   name: cluster
 spec:
   featureSet: LatencySensitive
+  unknownField: example
 `
 
 func TestParseGlobalConfig(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The HyperShift operator uses the latest version of the OpenShift API to
serialize global config in the HCP (for compatibility with older CPOs).
The issue is that if there's a new field in the latest API that the
older CPO does not understand, we currently produce an error decoding
the YAML because the YAML serializer we use is using strict mode.

This commit switches to a YAML serializer that does have strict mode for
parsing of the global configuration. Making it possible for older CPOs
to parse YAML from the latest HyperShift operator.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] This change includes unit tests.