### PR TITLE
Fix additionalTrustBundle with local ignition provider

### DIFF
--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -250,6 +250,9 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 		if image, exists := images["mdns-publisher"]; exists {
 			args = append(args, fmt.Sprintf("--mdns-publisher-image=%s", image))
 		}
+		if mcsConfig.Data["user-ca-bundle-config.yaml"] != "" {
+			args = append(args, fmt.Sprintf("--additional-trust-bundle-config-file=%s/user-ca-bundle-config.yaml", configDir))
+		}
 		if p.CloudProvider == hyperv1.AzurePlatform {
 			args = append(args, fmt.Sprintf("--cloud-config-file=%s/cloud.conf.configmap.yaml", mcoBaseDir))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

In #972 I relied on the fact that MCSIgnitionProvider [mounts the MCO
ConfigMap](https://github.com/openshift/hypershift/blob/main/ignition-server/controllers/machineconfigserver_ignitionprovider.go#L265) under `/assets/manifests` - this means that the
`user-ca-bundle-config.yaml` file path matches the [default location
from the MCO bootstrap code](https://github.com/openshift/machine-config-operator/blob/master/cmd/machine-config-operator/bootstrap.go#L69), thus no explicit
`--additional-trust-bundle-config-file` argument was required.

In #1214 we introduced a new LocalIgnitionProvider, which [unpacks the
MCO config](https://github.com/openshift/hypershift/blob/main/ignition-server/controllers/local_ignitionprovider.go#L164) to a different path e.g /payloads/get-payload123/config
hence we need to explicitly pass `--additional-trust-bundle-config-file`
or the additionalTrustBundle data is ignored.

@heliubj18 found this issue while verifying https://issues.redhat.com/browse/HOSTEDCP-291

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.