### PR TITLE
set condition messsage when waiting for kas readiness

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1688,21 +1688,22 @@ const (
 	IgnitionServerDeploymentUnavailableReason   = "IgnitionServerDeploymentUnavailable"
 
 	HostedClusterAsExpectedReason          = "HostedClusterAsExpected"
-	HostedClusterUnhealthyComponentsReason = "UnhealthyControlPlaneComponents"
+	HostedClusterWaitingForAvailableReason = "HostedClusterWaitingForAvailable"
 	InvalidConfigurationReason             = "InvalidConfiguration"
 
-	DeploymentNotFoundReason      = "DeploymentNotFound"
-	DeploymentStatusUnknownReason = "DeploymentStatusUnknown"
+	DeploymentNotFoundReason            = "DeploymentNotFound"
+	DeploymentStatusUnknownReason       = "DeploymentStatusUnknown"
+	DeploymentWaitingForAvailableReason = "DeploymentWaitingForAvailable"
 
 	HostedControlPlaneComponentsUnavailableReason = "ComponentsUnavailable"
-	KubeconfigUnavailableReason                   = "KubeconfigUnavailable"
+	KubeconfigWaitingForCreateReason              = "KubeconfigWaitingForCreate"
 	ClusterVersionStatusUnknownReason             = "ClusterVersionStatusUnknown"
 
 	StatusUnknownReason = "StatusUnknown"
 	AsExpectedReason    = "AsExpected"
 
 	EtcdQuorumAvailableReason     = "QuorumAvailable"
-	EtcdQuorumUnavailableReason   = "QuorumUnavailable"
+	EtcdWaitingForQuorumReason    = "EtcdWaitingForQuorum"
 	EtcdStatusUnknownReason       = "EtcdStatusUnknown"
 	EtcdStatefulSetNotFoundReason = "StatefulSetNotFound"
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3003,8 +3003,8 @@ func computeClusterVersionStatus(clock clock.WithTickerAndDelayedExecution, hclu
 func computeHostedClusterAvailability(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) metav1.Condition {
 	// Determine whether the hosted control plane is available.
 	hcpAvailableStatus := metav1.ConditionFalse
-	hcpAvailableMessage := "The hosted control plane is unavailable"
-	hcpAvailableReason := hyperv1.HostedClusterUnhealthyComponentsReason
+	hcpAvailableMessage := "Waiting for hosted control plane to be healthy"
+	hcpAvailableReason := hyperv1.HostedClusterWaitingForAvailableReason
 	var hcpAvailableCondition *metav1.Condition
 	if hcp != nil {
 		hcpAvailableCondition = meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.HostedControlPlaneAvailable))


### PR DESCRIPTION
**What this PR does / why we need it**:
https://issues.redhat.com/browse/HOSTEDCP-492

Set condition message when waiting for KAS readiness.

It also changes the wording of some reasons and messages from "unavailable" to "waiting" for better UX, conveying that nothing is wrong (probably) and that things are likely just still progressing. 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.