### PR TITLE
E2E etcd tests: Always run on none platform

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -259,7 +259,11 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 		platformSpec = hyperv1.PlatformSpec{
 			Type: hyperv1.NonePlatform,
 		}
-		services = getServicePublishingStrategyMappingByAPIServerAddress(o.None.APIServerAddress, o.NetworkType)
+		if o.None.APIServerAddress != "" {
+			services = getServicePublishingStrategyMappingByAPIServerAddress(o.None.APIServerAddress, o.NetworkType)
+		} else {
+			services = getIngressServicePublishingStrategyMapping(o.NetworkType)
+		}
 	case o.Agent != nil:
 		platformSpec = hyperv1.PlatformSpec{
 			Type: hyperv1.AgentPlatform,

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -100,7 +100,8 @@ type AgentPlatformCreateOptions struct {
 }
 
 type NonePlatformCreateOptions struct {
-	APIServerAddress string
+	APIServerAddress          string
+	ExposeThroughLoadBalancer bool
 }
 
 type KubevirtPlatformCreateOptions struct {

--- a/cmd/cluster/none/create.go
+++ b/cmd/cluster/none/create.go
@@ -21,6 +21,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.NonePlatform.APIServerAddress, "external-api-server-address", opts.NonePlatform.APIServerAddress, "The external API Server Address when using platform none")
+	cmd.Flags().BoolVar(&opts.NonePlatform.ExposeThroughLoadBalancer, "expose-through-load-balancer", opts.NonePlatform.ExposeThroughLoadBalancer, "If the services should be exposed through LoadBalancer. If not set, nodeports will be used instead")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -48,7 +49,7 @@ func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
 }
 
 func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
-	if opts.NonePlatform.APIServerAddress == "" {
+	if opts.NonePlatform.APIServerAddress == "" && !opts.NonePlatform.ExposeThroughLoadBalancer {
 		if opts.NonePlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx, opts.Log); err != nil {
 			return err
 		}

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -41,7 +41,7 @@ func TestHAEtcdChaos(t *testing.T) {
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.NodePoolReplicas = 0
 
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir)
 
 	t.Run("KillRandomMembers", testKillRandomMembers(ctx, client, cluster))
 	t.Run("KillAllMembers", testKillAllMembers(ctx, client, cluster))
@@ -64,7 +64,7 @@ func TestEtcdChaos(t *testing.T) {
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.NodePoolReplicas = 0
 
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir)
 
 	t.Run("KillAllMembers", testKillAllMembers(ctx, client, cluster))
 }

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -184,6 +184,7 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 func createClusterOpts(ctx context.Context, client crclient.Client, hc *hyperv1.HostedCluster, opts *core.CreateOptions) (*core.CreateOptions, error) {
 	opts.Namespace = hc.Namespace
 	opts.Name = hc.Name
+	opts.NonePlatform.ExposeThroughLoadBalancer = true
 
 	switch hc.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
@@ -204,7 +205,6 @@ func createClusterOpts(ctx context.Context, client crclient.Client, hc *hyperv1.
 		}
 
 		opts.BaseDomain = defaultIngressOperator.Status.Domain
-
 	}
 
 	return opts, nil


### PR DESCRIPTION
These tests only test etcd behavior which is the same regardless of
platform. Run them on the none platform to speed things up and avoid
needlessly creating cloud provider resources.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.