### PR TITLE
Wait for LB even when hostname is specified

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -257,11 +257,6 @@ func ReconcileServerServiceStatus(svc *corev1.Service, route *routev1.Route, str
 
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:
-		if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
-			host = strategy.LoadBalancer.Hostname
-			port = int32(KonnectivityServerPort)
-			return
-		}
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
 			message = fmt.Sprintf("Konnectivity load balancer is not provisioned; %v since creation", duration.ShortHumanDuration(time.Since(svc.ObjectMeta.CreationTimestamp.Time)))
 			var messages []string
@@ -275,13 +270,14 @@ func ReconcileServerServiceStatus(svc *corev1.Service, route *routev1.Route, str
 			}
 			return
 		}
+		port = int32(KonnectivityServerPort)
 		switch {
+		case strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "":
+			host = strategy.LoadBalancer.Hostname
 		case svc.Status.LoadBalancer.Ingress[0].Hostname != "":
 			host = svc.Status.LoadBalancer.Ingress[0].Hostname
-			port = int32(KonnectivityServerPort)
 		case svc.Status.LoadBalancer.Ingress[0].IP != "":
 			host = svc.Status.LoadBalancer.Ingress[0].IP
-			port = int32(KonnectivityServerPort)
 		}
 	case hyperv1.NodePort:
 		if strategy.NodePort == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a hostname is specified we should still block infra readiness on the LB being created.  Otherwise, the guest cluster can come up before the LB and external-dns registered record are ready.

I think this is the source of a lot of our CI flakes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.