### PR TITLE
doc(how-to/aws/create-aws-multi-az): fix getting started path

### DIFF
--- a/docs/content/how-to/aws/create-aws-hosted-cluster-multiple-zones.md
+++ b/docs/content/how-to/aws/create-aws-hosted-cluster-multiple-zones.md
@@ -6,12 +6,12 @@ title: Create AWS Hosted Cluster in Multiple Zones
 
 ## Prerequisites
 
-Complete the [Prerequisites](../../getting-started/#prerequisites) and [Before you begin](../../getting-started/#before-you-begin).
+Complete the [Prerequisites](../../../getting-started/#prerequisites) and [Before you begin](../../../getting-started/#before-you-begin).
 
 ## Creating the Hosted Cluster
 
 Create a new cluster, specifying the `BASE_DOMAIN` of the public zone provided in the
-[Prerequisites](../../getting-started/#prerequisites):
+[Prerequisites](../../../getting-started/#prerequisites):
 
 ```shell linenums="1"  hl_lines="15"
 REGION=us-east-1


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the break path to getting started on the AWS documentation page.

![Screenshot from 2022-08-01 18-22-52](https://user-images.githubusercontent.com/3216894/182248993-96f30316-44dd-4026-bad8-c4c63ab56f29.png)

cc @derekwaynecarr 