### PR TITLE
Add validation for cluster ID.

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1211,7 +1211,7 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 			hostedCluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{
 				ClusterID: "foobar",
 			}},
-			expectedResult: errors.New(`cannot parse cluster ID "foobar": invalid UUID length: 6`),
+			expectedResult: errors.New(`HostedCluster.spec.clusterID: Invalid value: "foobar": Error parsing cluster ID: invalid UUID length: 6`),
 		},
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -48,7 +48,7 @@ func (webhook *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a HostedCluster but got a %T", oldObj))
 	}
 
-	return validateHostedClusterUpdate(newHC, oldHC)
+	return validateHostedClusterUpdate(ctx, newHC, oldHC)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
@@ -153,7 +153,10 @@ func validateStructEqual(x any, y any, path *field.Path) field.ErrorList {
 	return validateStructDeepEqual(v1, v2, path, errs)
 }
 
-func validateHostedClusterUpdate(new *hyperv1.HostedCluster, old *hyperv1.HostedCluster) error {
+func validateHostedClusterUpdate(ctx context.Context, new *hyperv1.HostedCluster, old *hyperv1.HostedCluster) error {
+
+	errs := validateClusterID(new)
+
 	filterMutableHostedClusterSpecFields(&new.Spec)
 	filterMutableHostedClusterSpecFields(&old.Spec)
 
@@ -165,7 +168,7 @@ func validateHostedClusterUpdate(new *hyperv1.HostedCluster, old *hyperv1.Hosted
 		old.Spec.Networking.APIServer.Port = new.Spec.Networking.APIServer.Port
 	}
 
-	errs := validateStructEqual(new.Spec, old.Spec, field.NewPath("HostedCluster.spec"))
+	errs = append(errs, validateStructEqual(new.Spec, old.Spec, field.NewPath("HostedCluster.spec"))...)
 
 	return errs.ToAggregate()
 }


### PR DESCRIPTION
Added cluster id validation.  Did a bit of refactoring to use field
errors.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.