### PR TITLE
user-data secret is created with the key "https://github.com/openshif…

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -807,7 +807,7 @@ func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.No
 	}
 	userDataSecret.Data = map[string][]byte{
 		"disableTemplating": []byte(base64.StdEncoding.EncodeToString([]byte("true"))),
-		"value":             userDataValue,
+		"userdata":          userDataValue,
 	}
 	return nil
 }


### PR DESCRIPTION

The issue explain the PR, this issue will be closed after fixes in the cluster-api-provider-kubevirt

**What this PR does / why we need it**: userdata secret is now created with the key userdata instead of value

**Which issue(s) this PR fixes** #1634

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.