### PR TITLE
Move image registry operator to control plane

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -73,6 +73,9 @@ var (
 		"0000_80_machine-config-operator_01_machineconfigpool.crd.yaml",
 		"0000_50_cluster-node-tuning-operator_50-operator-ibm-cloud-managed.yaml",
 		"0000_50_cluster-node-tuning-operator_60-clusteroperator.yaml",
+		"0000_50_cluster-image-registry-operator_07-operator-ibm-cloud-managed.yaml",
+		"0000_50_cluster-image-registry-operator_07-operator-service.yaml",
+		"0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml",
 
 		// TODO: Remove these when cluster profiles annotations are fixed
 		// for cco and auth  operators
@@ -233,6 +236,12 @@ func resourcesToRemove() []resourceDesc {
 			name:       "cluster-node-tuning-operator",
 			namespace:  "openshift-cluster-node-tuning-operator",
 		},
+		{
+			apiVersion: "apps/v1",
+			kind:       "Deployment",
+			name:       "cluster-image-registry-operator",
+			namespace:  "openshift-image-registry",
+		},
 	}
 }
 
@@ -251,7 +260,10 @@ func preparePayloadScript() string {
 	}
 	toRemove := resourcesToRemove()
 	if len(toRemove) > 0 {
-		stmts = append(stmts, fmt.Sprintf("cat > %s/release-manifests/cleanup.yaml <<EOF", payloadDir))
+		// NOTE: the name of the cleanup file indicates the CVO runlevel for the cleanup.
+		// A level of 0000_01 forces the cleanup to happen first without waiting for any cluster operators to
+		// become available.
+		stmts = append(stmts, fmt.Sprintf("cat > %s/release-manifests/0000_01_cleanup.yaml <<EOF", payloadDir))
 	}
 	for _, desc := range resourcesToRemove() {
 		stmts = append(stmts,

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/registryoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/registryoperator.go
@@ -1,0 +1,35 @@
+package manifests
+
+import (
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ImageRegistryOperatorDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-image-registry-operator",
+			Namespace: ns,
+		},
+	}
+}
+
+func ImageRegistryOperatorServingCert(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-image-registry-operator",
+			Namespace: ns,
+		},
+	}
+}
+
+func ImageRegistryOperatorPodMonitor(ns string) *prometheusoperatorv1.PodMonitor {
+	return &prometheusoperatorv1.PodMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-image-registry-operator",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/registryoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/registryoperator.go
@@ -1,0 +1,17 @@
+package pki
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/hypershift/support/config"
+)
+
+const metricsHostname = "cluster-image-registry-operator"
+
+func ReconcileRegistryOperatorServingCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	dnsNames := []string{
+		metricsHostname,
+		"localhost",
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, metricsHostname, []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -1,0 +1,449 @@
+package registryoperator
+
+import (
+	"bytes"
+	"path"
+	"text/template"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/util"
+)
+
+const (
+	operatorName         = "cluster-image-registry-operator"
+	workerNamespace      = "openshift-image-registry"
+	workerServiceAccount = "cluster-image-registry-operator"
+	metricsHostname      = "cluster-image-registry-operator"
+	tokenFile            = "token"
+	metricsPort          = 60000
+
+	startScriptTemplateStr = `#!/bin/bash
+set -euo pipefail
+
+while true; do
+   if [[ -f {{ .TokenDir }}/token ]]; then
+      break
+   fi
+   echo "Waiting for client token"
+   sleep 2
+done
+
+echo "{{ .WorkerNamespace }}" > "{{ .TokenDir }}/namespace"
+cp "{{ .CABundle }}" "{{ .TokenDir }}/ca.crt"
+export KUBERNETES_SERVICE_HOST=kube-apiserver
+export KUBERNETES_SERVICE_PORT=$KUBE_APISERVER_SERVICE_PORT
+exec /usr/bin/cluster-image-registry-operator \
+  --files="{{ .TokenDir }}/token" \
+  --files="{{ .ServingCertDir }}/tls.crt" \
+  --files="{{ .ServingCertDir }}/tls.key"
+`
+)
+
+var startScript string
+
+func init() {
+	var err error
+	startScriptTemplate := template.Must(template.New("script").Parse(startScriptTemplateStr))
+	startScript, err = operatorStartScript(startScriptTemplate)
+	if err != nil {
+		panic(err.Error())
+	}
+}
+
+func selectorLabels() map[string]string {
+	return map[string]string{
+		"name": operatorName,
+	}
+}
+
+var (
+	volumeMounts = util.PodVolumeMounts{
+		containerMain().Name: {
+			volumeClientToken().Name: "/var/run/secrets/kubernetes.io/serviceaccount",
+			volumeServingCert().Name: "/etc/secrets",
+			volumeCABundle().Name:    "/etc/certificate/ca",
+		},
+		containerClientTokenMinter().Name: {
+			volumeClientToken().Name:     "/var/client-token",
+			volumeAdminKubeconfig().Name: "/etc/kubernetes",
+		},
+		containerWebIdentityTokenMinter().Name: {
+			volumeWebIdentityToken().Name: "/var/run/secrets/openshift/serviceaccount",
+			volumeAdminKubeconfig().Name:  "/etc/kubernetes",
+		},
+	}
+)
+
+type Params struct {
+	operatorImage    string
+	tokenMinterImage string
+	platform         hyperv1.PlatformType
+	issuerURL        string
+	releaseVersion   string
+	registryImage    string
+	prunerImage      string
+	deploymentConfig config.DeploymentConfig
+}
+
+func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[string]string, setDefaultSecurityContext bool) Params {
+	params := Params{
+		operatorImage:    images["cluster-image-registry-operator"],
+		tokenMinterImage: images["token-minter"],
+		platform:         hcp.Spec.Platform.Type,
+		issuerURL:        hcp.Spec.IssuerURL,
+		releaseVersion:   version,
+		registryImage:    images["docker-registry"],
+		prunerImage:      images["cli"],
+		deploymentConfig: config.DeploymentConfig{
+			Scheduling: config.Scheduling{
+				PriorityClass: config.DefaultPriorityClass,
+			},
+			SetDefaultSecurityContext: setDefaultSecurityContext,
+			ReadinessProbes: config.ReadinessProbes{
+				containerMain().Name: {
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/metrics",
+							Port:   intstr.FromInt(metricsPort),
+							Scheme: corev1.URISchemeHTTPS,
+						},
+					},
+					InitialDelaySeconds: 15,
+					PeriodSeconds:       60,
+					SuccessThreshold:    1,
+					FailureThreshold:    3,
+					TimeoutSeconds:      5,
+				},
+			},
+			LivenessProbes: config.LivenessProbes{
+				containerMain().Name: {
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/metrics",
+							Port:   intstr.FromInt(metricsPort),
+							Scheme: corev1.URISchemeHTTPS,
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       60,
+					SuccessThreshold:    1,
+					FailureThreshold:    5,
+					TimeoutSeconds:      5,
+				},
+			},
+			Resources: config.ResourcesSpec{
+				containerMain().Name: {
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+					},
+				},
+				containerClientTokenMinter().Name: {
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+				},
+				containerWebIdentityTokenMinter().Name: {
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+				},
+			},
+		},
+	}
+	params.deploymentConfig.SetDefaults(hcp, selectorLabels(), pointer.Int(1))
+	params.deploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
+	return params
+}
+
+func ReconcileDeployment(deployment *appsv1.Deployment, params Params) error {
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: selectorLabels(),
+		},
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: selectorLabels(),
+			},
+			Spec: corev1.PodSpec{
+				AutomountServiceAccountToken: pointer.Bool(false),
+				Containers: []corev1.Container{
+					util.BuildContainer(containerMain(), buildMainContainer(params.operatorImage, params.registryImage, params.prunerImage, params.releaseVersion)),
+					util.BuildContainer(containerClientTokenMinter(), buildClientTokenMinter(params.tokenMinterImage, params.issuerURL)),
+				},
+				Volumes: []corev1.Volume{
+					util.BuildVolume(volumeClientToken(), buildVolumeClientToken),
+					util.BuildVolume(volumeServingCert(), buildVolumeServingCert),
+					util.BuildVolume(volumeAdminKubeconfig(), buildVolumeAdminKubeconfig),
+					util.BuildVolume(volumeCABundle(), buildVolumeCABundle),
+				},
+			},
+		},
+	}
+
+	switch params.platform {
+	case hyperv1.AWSPlatform:
+		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers,
+			util.BuildContainer(containerWebIdentityTokenMinter(), buildWebIdentityTokenMinter(params.tokenMinterImage)))
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes,
+			util.BuildVolume(volumeWebIdentityToken(), buildVolumeWebIdentityToken))
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      volumeWebIdentityToken().Name,
+				MountPath: "/var/run/secrets/openshift/serviceaccount",
+			},
+		)
+	}
+
+	params.deploymentConfig.ApplyTo(deployment)
+	return nil
+}
+
+func containerMain() *corev1.Container {
+	return &corev1.Container{
+		Name: "cluster-image-registry-operator",
+	}
+}
+
+func operatorStartScript(startScriptTemplate *template.Template) (string, error) {
+	out := &bytes.Buffer{}
+	params := struct {
+		WorkerNamespace string
+		TokenDir        string
+		CABundle        string
+		ServingCertDir  string
+	}{
+		WorkerNamespace: workerNamespace,
+		TokenDir:        volumeMounts.Path(containerMain().Name, volumeClientToken().Name),
+		CABundle:        path.Join(volumeMounts.Path(containerMain().Name, volumeCABundle().Name), pki.CASignerCertMapKey),
+		ServingCertDir:  volumeMounts.Path(containerMain().Name, volumeServingCert().Name),
+	}
+	if err := startScriptTemplate.Execute(out, params); err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+func buildMainContainer(image, registryImage, prunerImage, releaseVersion string) func(*corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.Command = []string{
+			"/bin/bash",
+		}
+		c.Args = []string{
+			"-c",
+			startScript,
+		}
+		c.Env = []corev1.EnvVar{
+			{
+				Name:  "RELEASE_VERSION",
+				Value: releaseVersion,
+			},
+			{
+				Name:  "WATCH_NAMESPACE",
+				Value: workerNamespace,
+			},
+			{
+				Name:  "OPERATOR_NAME",
+				Value: operatorName,
+			},
+			{
+				Name:  "IMAGE",
+				Value: registryImage,
+			},
+			{
+				Name:  "IMAGE_PRUNER",
+				Value: prunerImage,
+			},
+			{
+				Name:  "AZURE_ENVIRONMENT_FILEPATH",
+				Value: "/tmp/azurestackcloud.json",
+			},
+		}
+		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+		c.Ports = []corev1.ContainerPort{
+			{
+				ContainerPort: metricsPort,
+				Name:          "metrics",
+			},
+		}
+	}
+}
+
+func containerClientTokenMinter() *corev1.Container {
+	return &corev1.Container{
+		Name: "client-token-minter",
+	}
+}
+
+func buildClientTokenMinter(image, issuerURL string) func(*corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.Command = []string{
+			"/usr/bin/control-plane-operator",
+			"token-minter",
+		}
+		c.Args = []string{
+			"--service-account-namespace",
+			workerNamespace,
+			"--service-account-name",
+			workerServiceAccount,
+			"--token-file",
+			path.Join(volumeMounts.Path(c.Name, volumeClientToken().Name), tokenFile),
+			"--token-audience",
+			issuerURL,
+			"--kubeconfig",
+			path.Join(volumeMounts.Path(c.Name, volumeAdminKubeconfig().Name), kas.KubeconfigKey),
+		}
+		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+	}
+}
+
+func containerWebIdentityTokenMinter() *corev1.Container {
+	return &corev1.Container{
+		Name: "token-minter",
+	}
+}
+
+func buildWebIdentityTokenMinter(image string) func(*corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.Command = []string{
+			"/usr/bin/control-plane-operator",
+			"token-minter",
+		}
+		c.Args = []string{
+			"--service-account-namespace",
+			workerNamespace,
+			"--service-account-name",
+			workerServiceAccount,
+			"--token-file",
+			path.Join(volumeMounts.Path(c.Name, volumeWebIdentityToken().Name), tokenFile),
+			"--kubeconfig",
+			path.Join(volumeMounts.Path(c.Name, volumeAdminKubeconfig().Name), kas.KubeconfigKey),
+		}
+		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+	}
+}
+
+func volumeClientToken() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "client-token",
+	}
+}
+
+func buildVolumeClientToken(v *corev1.Volume) {
+	v.EmptyDir = &corev1.EmptyDirVolumeSource{}
+}
+
+func volumeServingCert() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "serving-cert",
+	}
+}
+
+func buildVolumeServingCert(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.ImageRegistryOperatorServingCert("").Name,
+	}
+}
+
+func volumeAdminKubeconfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "kubeconfig",
+	}
+}
+
+func buildVolumeAdminKubeconfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+	}
+}
+
+func volumeCABundle() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "ca-bundle",
+	}
+}
+
+func buildVolumeCABundle(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.RootCASecret("").Name,
+	}
+}
+
+func volumeWebIdentityToken() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "web-identity-token",
+	}
+}
+
+func buildVolumeWebIdentityToken(v *corev1.Volume) {
+	v.EmptyDir = &corev1.EmptyDirVolumeSource{}
+}
+
+func ReconcileService(svc *corev1.Service) {
+	svc.Spec.ClusterIP = "None"
+	var port corev1.ServicePort
+	if len(svc.Spec.Ports) > 0 {
+		port = svc.Spec.Ports[0]
+	} else {
+		svc.Spec.Ports = []corev1.ServicePort{port}
+	}
+	port.Name = "metrics"
+	port.Port = int32(metricsPort)
+	port.Protocol = corev1.ProtocolTCP
+	port.TargetPort = intstr.FromInt(metricsPort)
+	svc.Spec.Ports[0] = port
+	svc.Spec.Selector = selectorLabels()
+}
+
+func ReconcilePodMonitor(pm *prometheusoperatorv1.PodMonitor, clusterID string, metricsSet metrics.MetricsSet) {
+	pm.Spec.Selector.MatchLabels = selectorLabels()
+	pm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{pm.Namespace},
+	}
+	targetPort := intstr.FromString("metrics")
+	pm.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{
+		{
+			Interval:   "60s",
+			TargetPort: &targetPort,
+			Path:       "/metrics",
+			Scheme:     "https",
+			TLSConfig: &prometheusoperatorv1.PodMetricsEndpointTLSConfig{
+				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
+					ServerName: metricsHostname,
+					CA: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.MetricsClientCertSecret(pm.Namespace).Name,
+							},
+							Key: "ca.crt",
+						},
+					},
+				},
+			},
+			MetricRelabelConfigs: metrics.RegistryOperatorRelabelConfigs(metricsSet),
+		},
+	}
+
+	util.ApplyClusterIDLabelToPodMonitor(&pm.Spec.PodMetricsEndpoints[0], clusterID)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile_test.go
@@ -1,0 +1,55 @@
+package registryoperator
+
+import (
+	"testing"
+
+	"github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/support/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReconcileDeployment(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			ReleaseImage: "quay.io/ocp-dev/test-release-image:latest",
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AWSPlatform,
+			},
+			IssuerURL: "https://www.example.com",
+		},
+	}
+	images := map[string]string{
+		"cluster-image-registry-operator": "quay.io/openshift/cluster-image-registry-operator:latest",
+		"token-minter":                    "quay.io/openshift/token-minter:latest",
+		"docker-registry":                 "quay.io/openshift/docker-registry:latest",
+		"cli":                             "quay.io/openshift/cli:latest",
+	}
+	deployment := manifests.ImageRegistryOperatorDeployment("test-namespace")
+	params := NewParams(hcp, "1.0.0", images, true)
+	if err := ReconcileDeployment(deployment, params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	deploymentYaml, err := util.SerializeResource(deployment, api.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	testutil.CompareWithFixture(t, deploymentYaml)
+}
+
+func TestReconcilePodMonitor(t *testing.T) {
+	pm := manifests.ImageRegistryOperatorPodMonitor("test-namespace")
+	ReconcilePodMonitor(pm, "the-cluster-id", metrics.MetricsSetTelemetry)
+	pmYaml, err := util.SerializeResource(pm, api.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	testutil.CompareWithFixture(t, pmYaml)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -1,0 +1,201 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cluster-image-registry-operator
+  namespace: test-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cluster-image-registry-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: quay.io/ocp-dev/test-release-image:latest
+      creationTimestamp: null
+      labels:
+        hypershift.openshift.io/hosted-control-plane: test-namespace
+        name: cluster-image-registry-operator
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - test-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: test-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+
+          while true; do
+             if [[ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]]; then
+                break
+             fi
+             echo "Waiting for client token"
+             sleep 2
+          done
+
+          echo "openshift-image-registry" > "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+          cp "/etc/certificate/ca/ca.crt" "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+          export KUBERNETES_SERVICE_HOST=kube-apiserver
+          export KUBERNETES_SERVICE_PORT=$KUBE_APISERVER_SERVICE_PORT
+          exec /usr/bin/cluster-image-registry-operator \
+            --files="/var/run/secrets/kubernetes.io/serviceaccount/token" \
+            --files="/etc/secrets/tls.crt" \
+            --files="/etc/secrets/tls.key"
+        command:
+        - /bin/bash
+        env:
+        - name: RELEASE_VERSION
+          value: 1.0.0
+        - name: WATCH_NAMESPACE
+          value: openshift-image-registry
+        - name: OPERATOR_NAME
+          value: cluster-image-registry-operator
+        - name: IMAGE
+          value: quay.io/openshift/docker-registry:latest
+        - name: IMAGE_PRUNER
+          value: quay.io/openshift/cli:latest
+        - name: AZURE_ENVIRONMENT_FILEPATH
+          value: /tmp/azurestackcloud.json
+        image: quay.io/openshift/cluster-image-registry-operator:latest
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /metrics
+            port: 60000
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: cluster-image-registry-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 60000
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /etc/certificate/ca
+          name: ca-bundle
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: client-token
+        - mountPath: /etc/secrets
+          name: serving-cert
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: web-identity-token
+      - args:
+        - --service-account-namespace
+        - openshift-image-registry
+        - --service-account-name
+        - cluster-image-registry-operator
+        - --token-file
+        - /var/client-token/token
+        - --token-audience
+        - https://www.example.com
+        - --kubeconfig
+        - /etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        image: quay.io/openshift/token-minter:latest
+        name: client-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/client-token
+          name: client-token
+        - mountPath: /etc/kubernetes
+          name: kubeconfig
+      - args:
+        - --service-account-namespace
+        - openshift-image-registry
+        - --service-account-name
+        - cluster-image-registry-operator
+        - --token-file
+        - /var/run/secrets/openshift/serviceaccount/token
+        - --kubeconfig
+        - /etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        image: quay.io/openshift/token-minter:latest
+        name: token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: web-identity-token
+      priorityClassName: hypershift-control-plane
+      securityContext:
+        runAsUser: 1001
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: test-namespace
+      volumes:
+      - emptyDir: {}
+        name: client-token
+      - name: serving-cert
+        secret:
+          secretName: cluster-image-registry-operator
+      - name: kubeconfig
+        secret:
+          secretName: service-network-admin-kubeconfig
+      - name: ca-bundle
+        secret:
+          secretName: root-ca
+      - emptyDir: {}
+        name: web-identity-token
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcilePodMonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcilePodMonitor.yaml
@@ -1,0 +1,39 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  creationTimestamp: null
+  name: cluster-image-registry-operator
+  namespace: test-namespace
+spec:
+  namespaceSelector:
+    matchNames:
+    - test-namespace
+  podMetricsEndpoints:
+  - bearerTokenSecret:
+      key: ""
+    interval: 60s
+    metricRelabelings:
+    - action: drop
+      regex: '*'
+      sourceLabels:
+      - __name__
+    - action: replace
+      replacement: the-cluster-id
+      targetLabel: _id
+    path: /metrics
+    relabelings:
+    - action: replace
+      replacement: the-cluster-id
+      targetLabel: _id
+    scheme: https
+    targetPort: metrics
+    tlsConfig:
+      ca:
+        secret:
+          key: ca.crt
+          name: metrics-client
+      cert: {}
+      serverName: cluster-image-registry-operator
+  selector:
+    matchLabels:
+      name: cluster-image-registry-operator

--- a/support/metrics/sets.go
+++ b/support/metrics/sets.go
@@ -329,3 +329,17 @@ func ControlPlaneOperatorRelabelConfigs(set MetricsSet) []*prometheusoperatorv1.
 	// For now, no filtering will occur for the CPO
 	return nil
 }
+
+func RegistryOperatorRelabelConfigs(set MetricsSet) []*prometheusoperatorv1.RelabelConfig {
+	switch set {
+	case MetricsSetTelemetry:
+		return []*prometheusoperatorv1.RelabelConfig{
+			{
+				Action:       "drop",
+				Regex:        "*",
+				SourceLabels: []prometheusoperatorv1.LabelName{"__name__"},
+			},
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Stops CVO from reconciling the cluster image registry operator into the
guest cluster and enables the control plane operator to reconcile it on
the management cluster side.

This change is needed to make it possible to clean up resources created
by the guest cluster. Having the image registry operator on the control
plane side allows it to keep running after worker nodes have been
removed from the cluster. On the guest cluster, changing the operator
config state to "Removed" tells the operator to remove the S3 bucket
(or other cloud storage) it created when starting up.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-486](https://issues.redhat.com//browse/HOSTEDCP-486)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced. 
- [x] This change includes unit tests.