### PR TITLE
HCCO: Use cpo manifests for references

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
@@ -24,12 +24,3 @@ func IngressDefaultIngressControllerCert() *corev1.Secret {
 		},
 	}
 }
-
-func IngressCert(ns string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ingress-crt",
-			Namespace: ns,
-		},
-	}
-}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/oauth.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/oauth.go
@@ -17,15 +17,6 @@ func OAuthCABundle() *corev1.ConfigMap {
 	}
 }
 
-func OpenShiftOAuthServerCert(ns string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "oauth-server-crt",
-			Namespace: ns,
-		},
-	}
-}
-
 func OAuthServerChallengingClient() *oauthv1.OAuthClient {
 	return &oauthv1.OAuthClient{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -597,7 +597,7 @@ func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv
 		errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
 	}
 
-	sourceCert := manifests.IngressCert(hcp.Namespace)
+	sourceCert := cpomanifests.IngressCert(hcp.Namespace)
 	if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(sourceCert), sourceCert); err != nil {
 		errs = append(errs, fmt.Errorf("failed to get ingress cert (%s/%s) from control plane: %w", sourceCert.Namespace, sourceCert.Name, err))
 	} else {
@@ -761,7 +761,7 @@ func secretHash(data []byte) string {
 }
 
 func (r *reconciler) reconcileOAuthServingCertCABundle(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
-	oauthServingCert := manifests.OpenShiftOAuthServerCert(hcp.Namespace)
+	oauthServingCert := cpomanifests.OpenShiftOAuthServerCert(hcp.Namespace)
 	if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(oauthServingCert), oauthServingCert); err != nil {
 		return fmt.Errorf("cannot get oauth serving cert: %w", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 	"github.com/openshift/hypershift/support/globalconfig"
@@ -148,7 +149,7 @@ func fakeHCP() *hyperv1.HostedControlPlane {
 }
 
 func fakeIngressCert() *corev1.Secret {
-	s := manifests.IngressCert("bar")
+	s := cpomanifests.IngressCert("bar")
 	s.Data = map[string][]byte{
 		"tls.crt": []byte("12345"),
 		"tls.key": []byte("12345"),
@@ -201,7 +202,7 @@ func fakeKubeadminPasswordSecret() *corev1.Secret {
 }
 
 func fakeOAuthServingCert() *corev1.Secret {
-	s := manifests.OpenShiftOAuthServerCert("bar")
+	s := cpomanifests.OpenShiftOAuthServerCert("bar")
 	s.Data = map[string][]byte{"tls.crt": []byte("test")}
 	return s
 }


### PR DESCRIPTION
Currently, the hcco redefines some manifests owned by the CPO. The
content of the two must be the same, otherwise things won't work.

Reference the CPO manifests instead to clarify this dependency.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.