### PR TITLE
Fix e2e powervs destroy opts

### DIFF
--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -206,6 +206,8 @@ func createClusterOpts(ctx context.Context, client crclient.Client, hc *hyperv1.
 		}
 
 		opts.BaseDomain = defaultIngressOperator.Status.Domain
+	case hyperv1.PowerVSPlatform:
+		opts.InfraID = fmt.Sprintf("%s-infra", hc.Name)
 	}
 
 	return opts, nil
@@ -259,9 +261,7 @@ func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster
 		return azure.DestroyCluster(ctx, opts)
 	case hyperv1.PowerVSPlatform:
 		opts.PowerVSPlatform = core.PowerVSPlatformDestroyOptions{
-			BaseDomain:    hc.Spec.DNS.BaseDomain,
-			CISCRN:        hc.Spec.Platform.PowerVS.CISInstanceCRN,
-			CISDomainID:   hc.Spec.DNS.PrivateZoneID,
+			BaseDomain:    createOpts.BaseDomain,
 			ResourceGroup: createOpts.PowerVSPlatform.ResourceGroup,
 			Region:        createOpts.PowerVSPlatform.Region,
 			Zone:          createOpts.PowerVSPlatform.Zone,


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
fixes https://issues.redhat.com/browse/MULTIARCH-2741
- Since HostedCluster is used to access baseDomain and CIS details, in case of an error in infra creation, these values would be nil and causing a crash. Fixed it by using CreateOpts.
- InfraID is a required param for destroy PowerVS infra, so added code to set infraID explicitly in e2e CreateOpts.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.