### PR TITLE
Increase the unittest timeout to 20m from the default 10m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,8 @@ app-sre-saas-template: hypershift
 
 # Run tests
 .PHONY: test
-test: build
-	$(GO) test -race -count=25 ./... -coverprofile cover.out
+test:
+	$(GO) test -race -count=25 -timeout=20m ./... -coverprofile cover.out
 
 .PHONY: e2e
 e2e:


### PR DESCRIPTION
It regularly times out in CI. Also remove the dependency on `build`,
unittests do not need any binaries built.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.