### PR TITLE
Add a helper to create SA kubeconfigs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	clientcmd "k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
@@ -19,26 +17,14 @@ const (
 
 func ReconcileServiceKubeconfigSecret(secret, cert, ca *corev1.Secret, ownerRef config.OwnerRef, apiServerPort int32) error {
 	svcURL := InClusterKASURL(secret.Namespace, apiServerPort)
-	return reconcileKubeconfig(secret, cert, ca, svcURL, "", "service", ownerRef)
+	return pki.ReconcileKubeConfig(secret, cert, ca, svcURL, "", "service", ownerRef)
 }
 
 func ReconcileServiceCAPIKubeconfigSecret(secret, cert, ca *corev1.Secret, ownerRef config.OwnerRef, apiServerPort int32) error {
 	svcURL := InClusterKASURL(secret.Namespace, apiServerPort)
 	// The client used by CAPI machine controller expects the kubeconfig to have this key
 	// https://github.com/kubernetes-sigs/cluster-api/blob/5c85a0a01ee44ecf7c8a3c3fdc867a88af87d73c/util/secret/secret.go#L29-L33
-	return reconcileKubeconfig(secret, cert, ca, svcURL, "value", "capi", ownerRef)
-}
-
-func ReconcileIngressOperatorKubeconfigSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, apiServerPort int32) error {
-	svcURL := InClusterKASURL(secret.Namespace, apiServerPort)
-	// The secret that holds the kubeconfig and the one that holds the certs are the same
-	return reconcileKubeconfig(secret, secret, ca, svcURL, "", "ingress-operator", ownerRef)
-}
-
-func ReconcileAWSPodIdentityWebhookKubeconfigSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, apiServerPort int32) error {
-	svcURL := InClusterKASURL(secret.Namespace, apiServerPort)
-	// The secret that holds the kubeconfig and the one that holds the certs are the same
-	return reconcileKubeconfig(secret, secret, ca, svcURL, "", "aws-pod-identity-webhook", ownerRef)
+	return pki.ReconcileKubeConfig(secret, cert, ca, svcURL, "value", "capi", ownerRef)
 }
 
 func InClusterKASURL(namespace string, apiServerPort int32) string {
@@ -56,63 +42,13 @@ func InClusterKASReadyURL(namespace string, securePort *int32) string {
 
 func ReconcileLocalhostKubeconfigSecret(secret, cert, ca *corev1.Secret, ownerRef config.OwnerRef, apiServerPort int32) error {
 	localhostURL := fmt.Sprintf("https://localhost:%d", apiServerListenPort)
-	return reconcileKubeconfig(secret, cert, ca, localhostURL, "", manifests.KubeconfigScopeLocal, ownerRef)
+	return pki.ReconcileKubeConfig(secret, cert, ca, localhostURL, "", manifests.KubeconfigScopeLocal, ownerRef)
 }
 
 func ReconcileExternalKubeconfigSecret(secret, cert, ca *corev1.Secret, ownerRef config.OwnerRef, externalURL, secretKey string) error {
-	return reconcileKubeconfig(secret, cert, ca, externalURL, secretKey, manifests.KubeconfigScopeExternal, ownerRef)
+	return pki.ReconcileKubeConfig(secret, cert, ca, externalURL, secretKey, manifests.KubeconfigScopeExternal, ownerRef)
 }
 
 func ReconcileBootstrapKubeconfigSecret(secret, cert, ca *corev1.Secret, ownerRef config.OwnerRef, externalURL string) error {
-	return reconcileKubeconfig(secret, cert, ca, externalURL, "", manifests.KubeconfigScopeBootstrap, ownerRef)
-}
-
-func reconcileKubeconfig(secret, cert, ca *corev1.Secret, url string, key string, scope manifests.KubeconfigScope, ownerRef config.OwnerRef) error {
-	ownerRef.ApplyTo(secret)
-	caBytes := ca.Data[pki.CASignerCertMapKey]
-	crtBytes, keyBytes := cert.Data[corev1.TLSCertKey], cert.Data[corev1.TLSPrivateKeyKey]
-	kubeCfgBytes, err := generateKubeConfig(url, crtBytes, keyBytes, caBytes)
-	if err != nil {
-		return fmt.Errorf("failed to generate kubeconfig: %w", err)
-	}
-	if secret.Data == nil {
-		secret.Data = map[string][]byte{}
-	}
-	if key == "" {
-		key = KubeconfigKey
-	}
-	if secret.Labels == nil {
-		secret.Labels = map[string]string{}
-	}
-	secret.Labels[manifests.KubeconfigScopeLabel] = string(scope)
-	secret.Data[key] = kubeCfgBytes
-	return nil
-}
-
-func generateKubeConfig(url string, crtBytes, keyBytes, caBytes []byte) ([]byte, error) {
-	kubeCfg := clientcmdapi.Config{
-		Kind:       "Config",
-		APIVersion: "v1",
-	}
-	kubeCfg.Clusters = map[string]*clientcmdapi.Cluster{
-		"cluster": {
-			Server:                   url,
-			CertificateAuthorityData: caBytes,
-		},
-	}
-	kubeCfg.AuthInfos = map[string]*clientcmdapi.AuthInfo{
-		"admin": {
-			ClientCertificateData: crtBytes,
-			ClientKeyData:         keyBytes,
-		},
-	}
-	kubeCfg.Contexts = map[string]*clientcmdapi.Context{
-		"admin": {
-			Cluster:   "cluster",
-			AuthInfo:  "admin",
-			Namespace: "default",
-		},
-	}
-	kubeCfg.CurrentContext = "admin"
-	return clientcmd.Write(kubeCfg)
+	return pki.ReconcileKubeConfig(secret, cert, ca, externalURL, "", manifests.KubeconfigScopeBootstrap, ownerRef)
 }


### PR DESCRIPTION
We need serviceaccount kubeconfigs for a variety of use cases. Make this
simple to encourage creating distinct kubeconfigs rather than using the
admin kubeconfig everywhere and de-duplicate the existing occurences of
this.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.