### PR TITLE
ClusterID and infraID should be immutable.

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -60,8 +60,6 @@ func (webhook *Webhook) ValidateDelete(_ context.Context, obj runtime.Object) er
 // "equal" when we do the comparison below.
 func filterMutableHostedClusterSpecFields(spec *hyperv1.HostedClusterSpec) {
 	spec.Release.Image = ""
-	spec.ClusterID = ""
-	spec.InfraID = ""
 	spec.Configuration = nil
 	spec.AdditionalTrustBundle = nil
 	spec.SecretEncryption = nil
@@ -156,6 +154,14 @@ func validateStructEqual(x any, y any, path *field.Path) field.ErrorList {
 func validateHostedClusterUpdate(new *hyperv1.HostedCluster, old *hyperv1.HostedCluster) error {
 	filterMutableHostedClusterSpecFields(&new.Spec)
 	filterMutableHostedClusterSpecFields(&old.Spec)
+
+	// Only allow these to be set from empty.  Once set they should not be changed.
+	if old.Spec.InfraID == "" {
+		new.Spec.InfraID = ""
+	}
+	if old.Spec.ClusterID == "" {
+		new.Spec.ClusterID = ""
+	}
 
 	// We default the port in Azure management cluster, so we allow setting it from being unset, but no updates.
 	if new.Spec.Networking.APIServer != nil && (old.Spec.Networking.APIServer == nil || old.Spec.Networking.APIServer.Port == nil) {


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.