### PR TITLE
E2E: Consistently use Patch to avoid conflict failures

### DIFF
--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -95,12 +95,13 @@ func TestAutoscaling(t *testing.T) {
 	// that prevent the cluster from ever scaling back down to 1:
 	// aws-ebs-csi-driver-controller
 	var min int32 = 1
+	original := nodepool.DeepCopy()
 	nodepool.Spec.AutoScaling = &hyperv1.NodePoolAutoScaling{
 		Min: min,
 		Max: max,
 	}
 	nodepool.Spec.Replicas = nil
-	err = client.Update(testContext, nodepool)
+	err = client.Patch(ctx, nodepool, crclient.MergeFrom(original))
 	g.Expect(err).NotTo(HaveOccurred(), "failed to update NodePool")
 	t.Logf("Enabled autoscaling. Namespace: %s, name: %s, min: %v, max: %v", nodepool.Namespace, nodepool.Name, min, max)
 

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -70,8 +70,9 @@ func TestUpgradeControlPlane(t *testing.T) {
 	t.Logf("Updating cluster image. Image: %s", globalOpts.LatestReleaseImage)
 	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+	original := hostedCluster.DeepCopy()
 	hostedCluster.Spec.Release.Image = globalOpts.LatestReleaseImage
-	err = client.Update(ctx, hostedCluster)
+	err = client.Patch(ctx, hostedCluster, crclient.MergeFrom(original))
 	g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
 
 	// Wait for the new rollout to be complete

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -97,8 +97,9 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 		err = client.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get NodePool")
 		t.Logf("Updating NodePool image. Image: %s", globalOpts.LatestReleaseImage)
+		original := nodePool.DeepCopy()
 		nodePool.Spec.Release.Image = globalOpts.LatestReleaseImage
-		err = client.Update(ctx, &nodePool)
+		err = client.Patch(ctx, &nodePool, crclient.MergeFrom(original))
 		g.Expect(err).NotTo(HaveOccurred(), "failed update NodePool image")
 	}
 
@@ -204,8 +205,9 @@ func TestInPlaceUpgradeNodePool(t *testing.T) {
 		err = client.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get NodePool")
 		t.Logf("Updating NodePool image. Image: %s", globalOpts.LatestReleaseImage)
+		original := nodePool.DeepCopy()
 		nodePool.Spec.Release.Image = globalOpts.LatestReleaseImage
-		err = client.Update(ctx, &nodePool)
+		err = client.Patch(ctx, &nodePool, crclient.MergeFrom(original))
 		g.Expect(err).NotTo(HaveOccurred(), "failed update nodePool image")
 	}
 


### PR DESCRIPTION
In the e2e tests we always want to set specific field(s) to specific
value(s) and we don't care if the object has changed after we received
it. By using Update we allow such failures to fail the test, so replace
the Update calls with Patch calls.

Example of e2e failing due to a conflict when updating: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/31161/rehearse-31161-pull-ci-openshift-hypershift-main-e2e-aws-nested/1556732246054932480#1:build-log.txt%3A1716

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.