### PR TITLE
external-dns settings for operator install template rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,10 @@ app-sre-saas-template: hypershift
 		--aws-private-region=eu-east-1 \
 		--aws-private-secret=aws-credentials \
 		--aws-private-secret-key=credentials \
+		--external-dns-provider=aws \
+		--external-dns-secret=dns-credentials \
+		--external-dns-domain-filter=service.hypershift.example.org \
+		--external-dns-txt-owner-id=txt-owner-id \
 		--metrics-set=SRE \
 		render --template --format yaml > $(DIR)/hack/app-sre/saas_template.yaml
 

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -142,10 +142,15 @@ type ExternalDNSDeployment struct {
 	Provider          string
 	DomainFilter      string
 	CredentialsSecret *corev1.Secret
+	TxtOwnerId        string
 }
 
 func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 	replicas := int32(1)
+	txtOwnerId := o.TxtOwnerId
+	if txtOwnerId == "" {
+		txtOwnerId = uuid.NewString()
+	}
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -185,7 +190,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								fmt.Sprintf("--provider=%s", o.Provider),
 								"--registry=txt",
 								"--txt-suffix=-external-dns",
-								fmt.Sprintf("--txt-owner-id=%s", uuid.NewString()),
+								fmt.Sprintf("--txt-owner-id=%s", txtOwnerId),
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
 							LivenessProbe: &corev1.Probe{

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -69,6 +69,7 @@ type Options struct {
 	ExternalDNSCredentials                    string
 	ExternalDNSCredentialsSecret              string
 	ExternalDNSDomainFilter                   string
+	ExternalDNSTxtOwnerId                     string
 	EnableAdminRBACGeneration                 bool
 	EnableUWMTelemetryRemoteWrite             bool
 	MetricsSet                                metrics.MetricsSet
@@ -162,6 +163,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSCredentials, "external-dns-credentials", opts.OIDCStorageProviderS3Credentials, "Credentials to use for managing DNS records using external-dns")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSCredentialsSecret, "external-dns-secret", "", "Name of an existing secret containing the external-dns credentials.")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSDomainFilter, "external-dns-domain-filter", "", "Restrict external-dns to changes within the specifed domain.")
+	cmd.PersistentFlags().StringVar(&opts.ExternalDNSTxtOwnerId, "external-dns-txt-owner-id", "", "external-dns TXT registry owner ID.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableAdminRBACGeneration, "enable-admin-rbac-generation", false, "Generate RBAC manifests for hosted cluster admins")
 	cmd.PersistentFlags().StringVar(&opts.ImageRefsFile, "image-refs", opts.ImageRefsFile, "Image references to user in Hypershift installation")
 	cmd.PersistentFlags().StringVar(&opts.AdditionalTrustBundle, "additional-trust-bundle", opts.AdditionalTrustBundle, "Path to a file with user CA bundle")
@@ -405,6 +407,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 			Provider:          opts.ExternalDNSProvider,
 			DomainFilter:      opts.ExternalDNSDomainFilter,
 			CredentialsSecret: externalDNSSecret,
+			TxtOwnerId:        opts.ExternalDNSTxtOwnerId,
 		}.Build()
 		objects = append(objects, externalDNSDeployment)
 	}

--- a/cmd/install/install_render.go
+++ b/cmd/install/install_render.go
@@ -27,6 +27,10 @@ var (
 	TemplateParamAWSPrivateCredsSecret    = "AWS_PRIVATE_CREDS_SECRET"
 	TemplateParamAWSPrivateCredsSecretKey = "AWS_PRIVATE_CREDS_SECRET_KEY"
 	TemplateParamOperatorReplicas         = "OPERATOR_REPLICAS"
+	TemplateParamExternalDNSProvider      = "EXTERNAL_DNS_PROVIDER"
+	TemplateParamExternalDNSCredsSecret   = "EXTERNAL_DNS_CREDS_SECRET"
+	TemplateParamExternalDNSDomainFilter  = "EXTERNAL_DNS_DOMAIN_FILTER"
+	TemplateParamExternalDNSTxtOwnerID    = "EXTERNAL_DNS_TXT_OWNER_ID"
 )
 
 func NewRenderCommand(opts *Options) *cobra.Command {
@@ -128,6 +132,28 @@ func hyperShiftOperatorTemplateManifest(opts *Options) (crclient.Object, error) 
 		opts.AWSPrivateRegion = fmt.Sprintf("${%s}", TemplateParamAWSPrivateRegion)
 		opts.AWSPrivateCredentialsSecret = fmt.Sprintf("${%s}", TemplateParamAWSPrivateCredsSecret)
 		opts.AWSPrivateCredentialsSecretKey = fmt.Sprintf("${%s}", TemplateParamAWSPrivateCredsSecretKey)
+	}
+
+	// external DNS
+	if opts.ExternalDNSProvider != "" && opts.ExternalDNSDomainFilter != "" && opts.ExternalDNSCredentialsSecret != "" {
+		templateParameters = append(
+			templateParameters,
+			map[string]string{"name": TemplateParamExternalDNSProvider, "value": opts.ExternalDNSProvider},
+			map[string]string{"name": TemplateParamExternalDNSDomainFilter, "value": opts.ExternalDNSDomainFilter},
+			map[string]string{"name": TemplateParamExternalDNSCredsSecret, "value": opts.ExternalDNSCredentialsSecret},
+		)
+		opts.ExternalDNSProvider = fmt.Sprintf("${%s}", TemplateParamExternalDNSProvider)
+		opts.ExternalDNSDomainFilter = fmt.Sprintf("${%s}", TemplateParamExternalDNSDomainFilter)
+		opts.ExternalDNSCredentialsSecret = fmt.Sprintf("${%s}", TemplateParamExternalDNSCredsSecret)
+
+		if opts.ExternalDNSTxtOwnerId != "" {
+			templateParameters = append(
+				templateParameters,
+				map[string]string{"name": TemplateParamExternalDNSTxtOwnerID, "value": opts.ExternalDNSTxtOwnerId},
+			)
+			opts.ExternalDNSTxtOwnerId = fmt.Sprintf("${%s}", TemplateParamExternalDNSTxtOwnerID)
+		}
+
 	}
 
 	// create manifests

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -270,6 +270,110 @@ objects:
   - kind: ServiceAccount
     name: operator
     namespace: ${NAMESPACE}
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    name: external-dns
+    namespace: ${NAMESPACE}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: external-dns
+  rules:
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    - services
+    - nodes
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: external-dns
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: external-dns
+  subjects:
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: ${NAMESPACE}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    name: external-dns
+    namespace: ${NAMESPACE}
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        name: external-dns
+    strategy: {}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: external-dns
+          hypershift.openshift.io/operator-component: external-dns
+          name: external-dns
+      spec:
+        containers:
+        - args:
+          - --source=service
+          - --source=openshift-route
+          - --domain-filter=${EXTERNAL_DNS_DOMAIN_FILTER}
+          - --provider=${EXTERNAL_DNS_PROVIDER}
+          - --registry=txt
+          - --txt-suffix=-external-dns
+          - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
+          command:
+          - /external-dns
+          image: registry.redhat.io/edo/external-dns-rhel8@sha256:c1134bb46172997ef7278b6cefbb0da44e72a9f808a7cd67b3c65d464754cab9
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 7979
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: external-dns
+          ports:
+          - containerPort: 7979
+            name: metrics
+          resources:
+            requests:
+              cpu: 5m
+              memory: 20Mi
+          volumeMounts:
+          - mountPath: /etc/provider
+            name: credentials
+        serviceAccountName: external-dns
+        volumes:
+        - name: credentials
+          secret:
+            secretName: ${EXTERNAL_DNS_CREDS_SECRET}
+  status: {}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -27640,5 +27744,13 @@ parameters:
   value: aws-credentials
 - name: AWS_PRIVATE_CREDS_SECRET_KEY
   value: credentials
+- name: EXTERNAL_DNS_PROVIDER
+  value: aws
+- name: EXTERNAL_DNS_DOMAIN_FILTER
+  value: service.hypershift.example.org
+- name: EXTERNAL_DNS_CREDS_SECRET
+  value: dns-credentials
+- name: EXTERNAL_DNS_TXT_OWNER_ID
+  value: txt-owner-id
 - name: OPERATOR_REPLICAS
   value: "1"


### PR DESCRIPTION
**What this PR does / why we need it**:
allow `--external-dns-*` install flags to be used for template rendering.

additionally, a setting `--external-dns-txt-owner-id` is introduced to provide a txt registry owner id for external-dns instead of generating a new one on each install

**Which issue(s) this PR fixes**
Part of [HOSTEDCP-485](https://issues.redhat.com/browse/HOSTEDCP-485)
