### PR TITLE
Drop insecure port on router to save rules

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -219,8 +219,8 @@ func TestReconcileAPIServerService(t *testing.T) {
 				Name: manifests.KubeAPIServerService("").Name,
 			},
 			TLS: &routev1.TLSConfig{
-				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 				Termination:                   routev1.TLSTerminationPassthrough,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 			},
 		},
 	}
@@ -239,8 +239,8 @@ func TestReconcileAPIServerService(t *testing.T) {
 				Name: manifests.KubeAPIServerService("").Name,
 			},
 			TLS: &routev1.TLSConfig{
-				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 				Termination:                   routev1.TLSTerminationPassthrough,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 			},
 		},
 	}
@@ -943,7 +943,6 @@ func TestReconcileRouter(t *testing.T) {
 				Type:     corev1.ServiceTypeLoadBalancer,
 				Selector: map[string]string{"app": "private-router"},
 				Ports: []corev1.ServicePort{
-					{Name: "http", Port: 80, TargetPort: intstr.FromString("http"), Protocol: corev1.ProtocolTCP},
 					{Name: "https", Port: 443, TargetPort: intstr.FromString("https"), Protocol: corev1.ProtocolTCP},
 					{Name: "kube-apiserver", Port: 6443, TargetPort: intstr.FromString("https"), Protocol: corev1.ProtocolTCP},
 				},

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -83,7 +83,8 @@ func ReconcileIgnitionServer(ctx context.Context,
 				ignitionServerRoute.ObjectMeta.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = serviceStrategy.Route.Hostname
 			}
 			ignitionServerRoute.Spec.TLS = &routev1.TLSConfig{
-				Termination: routev1.TLSTerminationPassthrough,
+				Termination:                   routev1.TLSTerminationPassthrough,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 			}
 			ignitionServerRoute.Spec.To = routev1.RouteTargetReference{
 				Kind:   "Service",

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -354,7 +354,6 @@ func ReconcileRouterService(svc *corev1.Service, ownerRef config.OwnerRef, kasPo
 	}
 	svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 	svc.Spec.Selector = privateRouterLabels()
-	foundHTTP := false
 	foundHTTPS := false
 	foundKAS := false
 
@@ -363,11 +362,6 @@ func ReconcileRouterService(svc *corev1.Service, ownerRef config.OwnerRef, kasPo
 	}
 	for i, port := range svc.Spec.Ports {
 		switch port.Name {
-		case "http":
-			svc.Spec.Ports[i].Port = 80
-			svc.Spec.Ports[i].TargetPort = intstr.FromString("http")
-			svc.Spec.Ports[i].Protocol = corev1.ProtocolTCP
-			foundHTTP = true
 		case "https":
 			svc.Spec.Ports[i].Port = 443
 			svc.Spec.Ports[i].TargetPort = intstr.FromString("https")
@@ -379,15 +373,6 @@ func ReconcileRouterService(svc *corev1.Service, ownerRef config.OwnerRef, kasPo
 			svc.Spec.Ports[i].Protocol = corev1.ProtocolTCP
 			foundKAS = true
 		}
-	}
-	if !foundHTTP {
-		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
-
-			Name:       "http",
-			Port:       80,
-			TargetPort: intstr.FromString("http"),
-			Protocol:   corev1.ProtocolTCP,
-		})
 	}
 	if !foundHTTPS {
 		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -168,6 +168,6 @@ func ReconcileRoute(route *routev1.Route, hostname string) {
 	}
 	route.Spec.TLS = &routev1.TLSConfig{
 		Termination:                   routev1.TLSTerminationPassthrough,
-		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -247,7 +247,8 @@ func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, private bool
 		Name: manifests.KonnectivityServerRoute(route.Namespace).Name,
 	}
 	route.Spec.TLS = &routev1.TLSConfig{
-		Termination: routev1.TLSTerminationPassthrough,
+		Termination:                   routev1.TLSTerminationPassthrough,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 	}
 	route.Spec.Port = &routev1.RoutePort{
 		TargetPort: intstr.FromInt(KonnectivityServerPort),

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -43,7 +43,7 @@ func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, strategy *hy
 	}
 	route.Spec.TLS = &routev1.TLSConfig{
 		Termination:                   routev1.TLSTerminationPassthrough,
-		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
https://issues.redhat.com/browse/HOSTEDCP-531

Drops port 80 from the `private-router` and `router` services and explicitly sets `insecureEdgeTerminationPolicy` on all routes to `None`.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.