### PR TITLE
gzip and base64-encode ignition configs

### DIFF
--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -11,6 +11,7 @@ import (
 	hyperapi "github.com/openshift/hypershift/api"
 	"github.com/openshift/hypershift/ignition-server/controllers"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/util"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -77,7 +78,7 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 		return err
 	}
 	compressedConfig := token.Data[controllers.TokenSecretConfigKey]
-	config, err := controllers.Decompress(compressedConfig)
+	config, err := util.Decompress(compressedConfig)
 	if err != nil {
 		return nil
 	}
@@ -90,7 +91,7 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 		PreserveOutput:  true,
 	}
 
-	payload, err := p.GetPayload(ctx, o.Image, string(config))
+	payload, err := p.GetPayload(ctx, o.Image, config.String())
 	if err != nil {
 		return err
 	}

--- a/ignition-server/controllers/tokensecret_controller_test.go
+++ b/ignition-server/controllers/tokensecret_controller_test.go
@@ -2,10 +2,12 @@ package controllers
 
 import (
 	"context"
-	"github.com/go-logr/logr"
-	"github.com/openshift/hypershift/api/v1alpha1"
 	"testing"
 	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/util"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
@@ -29,10 +31,12 @@ func (p *fakeIgnitionProvider) GetPayload(ctx context.Context, releaseImage stri
 }
 
 func TestReconcile(t *testing.T) {
-	compressedConfig, err := compress([]byte("compressedConfig"))
+	compressedConfig, err := util.Compress([]byte("compressedConfig"))
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	compressedConfigBytes := compressedConfig.Bytes()
 
 	testCases := []struct {
 		name       string
@@ -54,7 +58,7 @@ func TestReconcile(t *testing.T) {
 				Data: map[string][]byte{
 					TokenSecretTokenKey:   []byte(uuid.New().String()),
 					TokenSecretReleaseKey: []byte("release"),
-					TokenSecretConfigKey:  compressedConfig,
+					TokenSecretConfigKey:  compressedConfigBytes,
 				},
 			},
 			validation: func(t *testing.T, secret client.Object) {
@@ -139,7 +143,7 @@ func TestReconcile(t *testing.T) {
 				Data: map[string][]byte{
 					TokenSecretTokenKey:   []byte(uuid.New().String()),
 					TokenSecretReleaseKey: []byte("release"),
-					TokenSecretConfigKey:  compressedConfig,
+					TokenSecretConfigKey:  compressedConfigBytes,
 				},
 			},
 			validation: func(t *testing.T, secret client.Object) {

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -1,8 +1,13 @@
 package util
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -52,4 +57,103 @@ func DeleteIfNeeded(ctx context.Context, c client.Client, o client.Object) (exis
 	}
 
 	return true, nil
+}
+
+// Compresses and base-64 encodes a given byte array. Ideal for loading an
+// arbitrary byte array into a ConfigMap or Secret.
+func CompressAndEncode(payload []byte) (*bytes.Buffer, error) {
+	out := bytes.NewBuffer(nil)
+
+	if len(payload) == 0 {
+		return out, nil
+	}
+
+	// We need to base64-encode our gzipped data so we can marshal it in and out
+	// of a string since ConfigMaps and Secrets expect a textual representation.
+	base64Enc := base64.NewEncoder(base64.StdEncoding, out)
+	defer base64Enc.Close()
+
+	err := compress(bytes.NewBuffer(payload), base64Enc)
+	if err != nil {
+		return nil, fmt.Errorf("could not compress and encode payload: %w", err)
+	}
+
+	err = base64Enc.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not close base64 encoder: %w", err)
+	}
+
+	return out, err
+}
+
+// Compresses a given byte array.
+func Compress(payload []byte) (*bytes.Buffer, error) {
+	in := bytes.NewBuffer(payload)
+	out := bytes.NewBuffer(nil)
+
+	if len(payload) == 0 {
+		return out, nil
+	}
+
+	err := compress(in, out)
+	return out, err
+}
+
+// Decompresses and base-64 decodes a given byte array. Ideal for consuming a
+// gzipped / base64-encoded byte array from a ConfigMap or Secret.
+func DecodeAndDecompress(payload []byte) (*bytes.Buffer, error) {
+	if len(payload) == 0 {
+		return bytes.NewBuffer(nil), nil
+	}
+
+	base64Dec := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(payload))
+
+	return decompress(base64Dec)
+}
+
+// Decompresses a given gzipped byte array.
+func Decompress(payload []byte) (*bytes.Buffer, error) {
+	if len(payload) == 0 {
+		return bytes.NewBuffer(nil), nil
+	}
+
+	return decompress(bytes.NewBuffer(payload))
+}
+
+// Compresses a given io.Reader to a given io.Writer
+func compress(r io.Reader, w io.Writer) error {
+	gz, err := gzip.NewWriterLevel(w, gzip.BestCompression)
+	if err != nil {
+		return fmt.Errorf("could not initialize gzip writer: %w", err)
+	}
+
+	defer gz.Close()
+
+	if _, err := io.Copy(gz, r); err != nil {
+		return fmt.Errorf("could not compress payload: %w", err)
+	}
+
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("could not close gzipwriter: %w", err)
+	}
+
+	return nil
+}
+
+// Decompresses a given io.Reader.
+func decompress(r io.Reader) (*bytes.Buffer, error) {
+	gz, err := gzip.NewReader(r)
+
+	if err != nil {
+		return bytes.NewBuffer(nil), fmt.Errorf("could not initialize gzip reader: %w", err)
+	}
+
+	defer gz.Close()
+
+	data, err := ioutil.ReadAll(gz)
+	if err != nil {
+		return bytes.NewBuffer(nil), fmt.Errorf("could not decompress payload: %w", err)
+	}
+
+	return bytes.NewBuffer(data), nil
 }

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -1,0 +1,97 @@
+package util
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCompressDecompress(t *testing.T) {
+	testCases := []struct {
+		name       string
+		payload    []byte
+		compressed []byte
+	}{
+		{
+			name:       "Text",
+			payload:    []byte("The quick brown fox jumps over the lazy dog."),
+			compressed: []byte("H4sIAAAAAAAC/wrJSFUoLM1MzlZIKsovz1NIy69QyCrNLShWyC9LLVIoyUhVyEmsqlRIyU/XAwQAAP//6SWQUSwAAAA="),
+		},
+		{
+			name:       "Empty",
+			payload:    []byte{},
+			compressed: []byte{},
+		},
+		{
+			name:       "Nil",
+			payload:    nil,
+			compressed: nil,
+		},
+	}
+
+	t.Parallel()
+
+	for _, tc := range testCases {
+		t.Run(tc.name+" Valid Input", func(t *testing.T) {
+			testCompressFunc(t, tc.payload, tc.compressed)
+			testDecompressFunc(t, tc.payload, tc.compressed)
+		})
+
+		// Empty or nil inputs will not produce an error, which is what this test
+		// looks for. Instead, they will produce a nil or empty result within
+		// their initialized bytes.Buffer object.
+		if len(tc.payload) != 0 {
+			t.Run(tc.name+" Invalid Input", func(t *testing.T) {
+				testDecompressFuncErr(t, tc.payload)
+			})
+		}
+	}
+}
+
+// Tests that a given input can be expected and encoded without errors.
+func testCompressFunc(t *testing.T, payload, expected []byte) {
+	t.Helper()
+
+	g := NewWithT(t)
+
+	result, err := CompressAndEncode(payload)
+	g.Expect(err).To(BeNil(), "should be no compression errors")
+	g.Expect(result).ToNot(BeNil(), "should always return an initialized bytes.Buffer")
+
+	resultBytes := result.Bytes()
+	resultString := result.String()
+
+	g.Expect(utf8.Valid(resultBytes)).To(BeTrue(), "expected output should be a valid utf-8 sequence")
+	g.Expect(resultBytes).To(Equal(expected), "expected bytes should equal expected")
+	g.Expect(resultString).To(Equal(string(expected)), "expected strings should equal expected")
+}
+
+// Tests that a given output can be decoded and decompressed without errors.
+func testDecompressFunc(t *testing.T, payload, expected []byte) {
+	t.Helper()
+
+	g := NewWithT(t)
+
+	result, err := DecodeAndDecompress(expected)
+	g.Expect(err).To(BeNil(), "should be no decompression errors")
+	g.Expect(result).ToNot(BeNil(), "should always return an initialized bytes.Buffer")
+
+	resultBytes := result.Bytes()
+	resultString := result.String()
+
+	g.Expect(resultBytes).To(Equal(payload), "deexpected bytes should equal expected")
+	g.Expect(resultString).To(Equal(string(payload)), "deexpected string should equal expected")
+}
+
+// Tests that an invalid decompression input (not gzipped and base64-encoded)
+// will produce an error.
+func testDecompressFuncErr(t *testing.T, payload []byte) {
+	out, err := DecodeAndDecompress(payload)
+
+	g := NewWithT(t)
+	g.Expect(err).ToNot(BeNil(), "should be an error")
+	g.Expect(out).ToNot(BeNil(), "should return an initialized bytes.Buffer")
+	g.Expect(out.Bytes()).To(BeNil(), "should be a nil byte slice")
+	g.Expect(out.String()).To(BeEmpty(), "should be an empty string")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR compresses and base64-encodes the Ignition configs before placing them into a K8s ConfigMap. K8s ConfigMaps (and Secrets) have a 1 MB size limitation and in practice, the Ignition config can be around 280KB. Over time, this size could grow and exceed the 1 MB limit. Gzipped, this drops to around 78 KB giving us much more headroom. We also need to base64-encode the contents since ConfigMaps cannot store binary data.

This should be merged after https://github.com/openshift/machine-config-operator/pull/3280 since that PR implements the MCO-side decompression / decoding steps.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[MCO-290](https://issues.redhat.com//browse/MCO-290)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.