### PR TITLE
Enable cleaning up of hosted cluster cloud resources on destroy

### DIFF
--- a/api/v1alpha1/hosted_controlplane.go
+++ b/api/v1alpha1/hosted_controlplane.go
@@ -217,6 +217,8 @@ const (
 	InfrastructureReady                  ConditionType = "InfrastructureReady"
 	ValidHostedControlPlaneConfiguration ConditionType = "ValidHostedControlPlaneConfiguration"
 	ClusterVersionFailing                ConditionType = "ClusterVersionFailing"
+	CVOScaledDown                        ConditionType = "CVOScaledDown"
+	CloudResourcesDestroyed              ConditionType = "CloudResourcesDestroyed"
 )
 
 // HostedControlPlaneStatus defines the observed state of HostedControlPlane

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -109,6 +109,11 @@ const (
 	// Any components specified in this list will have profiling disabled. Profiling is disabled by default for etcd and konnectivity.
 	// Components this annotation can apply to: kube-scheduler, kube-controller-manager, kube-apiserver.
 	DisableProfilingAnnotation = "hypershift.openshift.io/disable-profiling"
+
+	// CleanupCloudResourcesAnnotation is an annotation that indicates whether a guest cluster's resources should be
+	// removed when deleting the corresponding HostedCluster. If set to "true", resources created on the cloud provider during the life
+	// of the cluster will be removed, including image registry storage, ingress dns records, load balancers, and persistent storage.
+	CleanupCloudResourcesAnnotation = "hypershift.openshift.io/cleanup-cloud-resources"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -97,6 +97,7 @@ func NewDestroyCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "A cluster name (required)")
 	cmd.PersistentFlags().DurationVar(&opts.ClusterGracePeriod, "cluster-grace-period", opts.ClusterGracePeriod, "How long to wait for the cluster to be deleted before forcibly destroying its infra")
 	cmd.PersistentFlags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Infrastructure ID; inferred from the hosted cluster by default")
+	cmd.PersistentFlags().BoolVar(&opts.DestroyCloudResources, "destroy-cloud-resources", opts.DestroyCloudResources, "If true, cloud resources such as load balancers and persistent storage disks created by the cluster during its lifetime are removed")
 
 	cmd.MarkPersistentFlagRequired("name")
 

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -76,6 +76,7 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
 				"hostedcontrolplanes/status",
 			},
 			Verbs: []string{
+				"patch",
 				"update",
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -191,6 +192,15 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Return early if deleted
 	if !hostedControlPlane.DeletionTimestamp.IsZero() {
+		if shouldCleanupCloudResources(hostedControlPlane) {
+			done, err := r.removeCloudResources(ctx, hostedControlPlane)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to ensure cloud resources are removed")
+			}
+			if !done {
+				return ctrl.Result{}, nil
+			}
+		}
 		if controllerutil.ContainsFinalizer(hostedControlPlane, finalizer) {
 			originalHCP := hostedControlPlane.DeepCopy()
 			controllerutil.RemoveFinalizer(hostedControlPlane, finalizer)
@@ -2787,4 +2797,56 @@ func (r *HostedControlPlaneReconciler) reconcileMachineApprover(ctx context.Cont
 	}
 
 	return machineapprover.ReconcileMachineApprover(ctx, r.Client, hcp, machineApproverImage, availabilityProberImage, createOrUpdate, r.SetDefaultSecurityContext)
+}
+
+func shouldCleanupCloudResources(hcp *hyperv1.HostedControlPlane) bool {
+	return hcp.Annotations[hyperv1.CleanupCloudResourcesAnnotation] == "true"
+}
+
+func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context, hcp *hyperv1.HostedControlPlane) (bool, error) {
+
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Removing cloud resources")
+
+	// check if resources have been destroyed
+	if meta.IsStatusConditionTrue(hcp.Status.Conditions, string(hyperv1.CloudResourcesDestroyed)) {
+		log.Info("Guest resources have been destroyed")
+		return true, nil
+	}
+	// if CVO has been scaled down, we're just waiting for resources to be destroyed
+	if meta.IsStatusConditionTrue(hcp.Status.Conditions, string(hyperv1.CVOScaledDown)) {
+		log.Info("Waiting for guest resources to be destroyed")
+		return false, nil
+	}
+
+	// ensure CVO has been scaled down
+	cvoDeployment := manifests.ClusterVersionOperatorDeployment(hcp.Namespace)
+	err := r.Get(ctx, client.ObjectKeyFromObject(cvoDeployment), cvoDeployment)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed get CVO deployment: %w", err)
+	}
+	if err == nil && cvoDeployment.Spec.Replicas != nil && *cvoDeployment.Spec.Replicas > 0 {
+		log.Info("Scaling down cluster version operator deployment")
+		cvoDeployment.Spec.Replicas = pointer.Int32(0)
+		if err := r.Update(ctx, cvoDeployment); err != nil {
+			return false, fmt.Errorf("failed to scale down CVO deployment: %w", err)
+		}
+	}
+	if cvoDeployment.Status.Replicas > 0 {
+		log.Info("Waiting for CVO to scale down to 0")
+		return false, nil
+	}
+	cvoScaledDownCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.CVOScaledDown))
+	if cvoScaledDownCond == nil || cvoScaledDownCond.Status != metav1.ConditionTrue {
+		cvoScaledDownCond = &metav1.Condition{
+			Type:   string(hyperv1.CVOScaledDown),
+			Status: metav1.ConditionTrue,
+			Reason: "CVOScaledDown",
+		}
+		meta.SetStatusCondition(&hcp.Status.Conditions, *cvoScaledDownCond)
+		if err := r.Status().Update(ctx, hcp); err != nil {
+			return false, fmt.Errorf("failed to set CVO scaled down condition: %w", err)
+		}
+	}
+	return false, nil
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/webhookconfig.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/webhookconfig.go
@@ -1,0 +1,14 @@
+package manifests
+
+import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ResourceCreationBlockerWebhook() *admissionregistrationv1.ValidatingWebhookConfiguration {
+	return &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hosted-cluster-resource-cleanup",
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	configv1 "github.com/openshift/api/config/v1"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
@@ -114,8 +115,16 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 				&configv1.ClusterVersion{}:  allSelector,
 				&configv1.FeatureGate{}:     allSelector,
 				&configv1.ClusterOperator{}: allSelector,
+
 				// Needed for inplace upgrader.
 				&corev1.Node{}: allSelector,
+
+				// Needed for resource cleanup
+				&corev1.Service{}:               allSelector,
+				&corev1.PersistentVolume{}:      allSelector,
+				&corev1.PersistentVolumeClaim{}: allSelector,
+				&operatorv1.IngressController{}: allSelector,
+				&imageregistryv1.Config{}:       allSelector,
 			},
 			DefaultSelector: cache.ObjectSelector{Label: cacheLabelSelector()},
 		}),

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -179,3 +179,10 @@ To delete a HostedCluster:
 ```shell
 hypershift destroy cluster aws --name $CLUSTER_NAME --aws-creds $AWS_CREDS
 ```
+
+To clean up cloud resources that may have been created by the HostedCluster during its lifetime, add
+the `--destroy-cloud-resources` flag:
+
+```shell
+hypershift destroy cluster aws --name $CLUSTER_NAME --aws-creds $AWS_CREDS --destroy-cloud-resources
+```

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2759,6 +2759,10 @@ created in the guest VPC</p>
 <td><p>AWSEndpointServiceAvailable indicates whether the AWS Endpoint Service
 has been created for the specified NLB in the management VPC</p>
 </td>
+</tr><tr><td><p>&#34;CVOScaledDown&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;CloudResourcesDestroyed&#34;</p></td>
+<td></td>
 </tr><tr><td><p>&#34;ClusterVersionFailing&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;ClusterVersionSucceeding&#34;</p></td>

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -273,6 +273,9 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		ClusterCIDR: "10.132.0.0/14",
 		BeforeApply: o.BeforeApply,
 		Log:         util.NewLogr(t),
+		Annotations: []string{
+			fmt.Sprintf("%s=true", hyperv1.CleanupCloudResourcesAnnotation),
+		},
 	}
 	createOption.AWSPlatform.AdditionalTags = append(createOption.AWSPlatform.AdditionalTags, o.additionalTags...)
 	if len(o.configurableClusterOptions.Zone) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables the removal of cloud resources created during the lifetime of a
guest cluster. These include:
- registry storage
- ingress load balancer and dns records
- load balancer services
- persistent volumes

Removal of these resources will occur when the following annotation is
present:
hypershift.openshift.io/cleanup-cloud-resources: "true"

The CLI adds this annotation to a HostedCluster when invoking the
destroy command with the 'destroy-cloud-resources' flag:

  hypershift destroy cluster aws --destroy-cloud-resources

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-486](https://issues.redhat.com//browse/HOSTEDCP-486)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.