### PR TITLE
Move Cloud network config controller to the management cluster

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -108,7 +108,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 
 func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
 	ownerRef.ApplyTo(role)
-	// Required by CNO to manage ovn-kubernetes control plane components
+	// Required by CNO to manage ovn-kubernetes and cloud-network-config-controller control plane components
 	role.Rules = []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{corev1.SchemeGroupVersion.Group},
@@ -128,7 +128,7 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
 		},
 		{
 			APIGroups: []string{appsv1.SchemeGroupVersion.Group},
-			Resources: []string{"statefulsets"},
+			Resources: []string{"statefulsets", "deployments"},
 			Verbs:     []string{"*"},
 		},
 		{
@@ -331,6 +331,7 @@ kubectl --kubeconfig $kc config use-context default`,
 			{Name: "NETWORK_CHECK_TARGET_IMAGE", Value: params.Images.NetworkCheckTarget},
 			{Name: "CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE", Value: params.Images.CloudNetworkConfigController},
 			{Name: "TOKEN_MINTER_IMAGE", Value: params.Images.TokenMinter},
+			{Name: "CLI_IMAGE", Value: params.Images.CLI},
 		}...),
 		Name:            operatorName,
 		Image:           params.Images.NetworkOperator,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -888,7 +888,6 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 			hcp.Spec.Platform.AWS.RolesRef.IngressARN:       manifests.AWSIngressCloudCredsSecret(),
 			hcp.Spec.Platform.AWS.RolesRef.StorageARN:       manifests.AWSStorageCloudCredsSecret(),
 			hcp.Spec.Platform.AWS.RolesRef.ImageRegistryARN: manifests.AWSImageRegistryCloudCredsSecret(),
-			hcp.Spec.Platform.AWS.RolesRef.NetworkARN:       manifests.AWSNetworkCloudCredsSecret(),
 		} {
 			err := syncSecret(secret, arn)
 			if err != nil {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -258,6 +258,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 		hcluster.Spec.Platform.AWS.RolesRef.KubeCloudControllerARN:  KubeCloudControllerCredsSecret(controlPlaneNamespace),
 		hcluster.Spec.Platform.AWS.RolesRef.NodePoolManagementARN:   NodePoolManagementCredsSecret(controlPlaneNamespace),
 		hcluster.Spec.Platform.AWS.RolesRef.ControlPlaneOperatorARN: ControlPlaneOperatorCredsSecret(controlPlaneNamespace),
+		hcluster.Spec.Platform.AWS.RolesRef.NetworkARN:              CloudNetworkConfigControllerCredsSecret(controlPlaneNamespace),
 	} {
 		err := syncSecret(secret, arn)
 		if err != nil {
@@ -363,6 +364,15 @@ func ControlPlaneOperatorCredsSecret(controlPlaneNamespace string) *corev1.Secre
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
 			Name:      "control-plane-operator-creds",
+		},
+	}
+}
+
+func CloudNetworkConfigControllerCredsSecret(controlPlaneNamespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      "cloud-network-config-controller-creds",
 		},
 	}
 }


### PR DESCRIPTION
CNCC should be deployed in the management cluster: https://issues.redhat.com/browse/SDN-3236

This PR renders the CNCC credentials in the management cluster and allows CNO to create deployments.
CNO PR: https://github.com/openshift/cluster-network-operator/pull/1525


Signed-off-by: Patryk Diak <pdiak@redhat.com>