### PR TITLE
Route LDAP IDPs in the oauth server through guest VPC

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -143,6 +143,10 @@ func buildOAuthContainerMain(image string) func(c *corev1.Container) {
 				Value: fmt.Sprintf("socks5://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
 			},
 			{
+				Name:  "ALL_PROXY",
+				Value: fmt.Sprintf("socks5://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
+			},
+			{
 				Name:  "NO_PROXY",
 				Value: manifests.KubeAPIServerService("").Name,
 			},
@@ -246,7 +250,7 @@ func socks5ProxyContainer(socks5ProxyImage string) corev1.Container {
 	c := corev1.Container{
 		Name:    socks5ProxyContainerName,
 		Image:   socks5ProxyImage,
-		Command: []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy"},
+		Command: []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy", "--resolve-from-guest-cluster-dns=true"},
 		Args:    []string{"run"},
 		Env: []corev1.EnvVar{{
 			Name:  "KUBECONFIG",
@@ -263,5 +267,6 @@ func socks5ProxyContainer(socks5ProxyImage string) corev1.Container {
 			{Name: "konnectivity-proxy-cert", MountPath: "/etc/konnectivity-proxy-tls"},
 		},
 	}
+
 	return c
 }


### PR DESCRIPTION
This changes makes us route LDAP IDPs in the oauth server to the guest
VPC by:
* Setting the ALL_PROXY env var to the ldap dialer will use the socks5
  sidecar
* Extending the socks5 sidecar to optionally resolve everything through
  the guest clusters cluster-dns

Ref https://issues.redhat.com/browse/HOSTEDCP-421
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.