### PR TITLE
E2E: Fix flakes due to inability of finding matching nodepools

### DIFF
--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -49,7 +49,7 @@ func TestAutoscaling(t *testing.T) {
 
 	var nodepool *hyperv1.NodePool
 	for _, np := range nodepools.Items {
-		if !ownedBy(hostedCluster.UID, np.OwnerReferences) {
+		if np.Spec.ClusterName != hostedCluster.Name {
 			continue
 		}
 		nodepool = &np

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -21,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilpointer "k8s.io/utils/pointer"
@@ -120,7 +119,7 @@ func TestNodepoolMachineconfigGetsRolledout(t *testing.T) {
 	}
 
 	for _, nodepool := range nodepools.Items {
-		if !ownedBy(hostedCluster.UID, nodepool.OwnerReferences) {
+		if nodepool.Spec.ClusterName != hostedCluster.Name {
 			continue
 		}
 		np := nodepool.DeepCopy()
@@ -171,16 +170,6 @@ func TestNodepoolMachineconfigGetsRolledout(t *testing.T) {
 	e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, ctx, client, hostedCluster)
 	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, client, hostedCluster)
 	e2eutil.EnsureNoPodsWithTooHighPriority(t, ctx, client, hostedCluster)
-}
-
-func ownedBy(uid types.UID, ownerRefs []metav1.OwnerReference) bool {
-	for _, ownerRef := range ownerRefs {
-		if ownerRef.UID == uid {
-			return true
-		}
-	}
-
-	return false
 }
 
 //go:embed nodepool_machineconfig_verification_ds.yaml


### PR DESCRIPTION
The E2E tests currently try to match nodepools to a hostedcluster by
using an ownerReference on it. This ownerreference is added by the
nodepoool controller and doesn't exist initially, which makes this
approach racy and thus causes flakes.

Use the same matching logic as the nodepool controller
(`nodepool.spec.clusterName`) to avoid this.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.