### PR TITLE
remove external-dns provider variable from openshift template parameters

### DIFF
--- a/cmd/install/install_render.go
+++ b/cmd/install/install_render.go
@@ -27,7 +27,6 @@ var (
 	TemplateParamAWSPrivateCredsSecret    = "AWS_PRIVATE_CREDS_SECRET"
 	TemplateParamAWSPrivateCredsSecretKey = "AWS_PRIVATE_CREDS_SECRET_KEY"
 	TemplateParamOperatorReplicas         = "OPERATOR_REPLICAS"
-	TemplateParamExternalDNSProvider      = "EXTERNAL_DNS_PROVIDER"
 	TemplateParamExternalDNSCredsSecret   = "EXTERNAL_DNS_CREDS_SECRET"
 	TemplateParamExternalDNSDomainFilter  = "EXTERNAL_DNS_DOMAIN_FILTER"
 	TemplateParamExternalDNSTxtOwnerID    = "EXTERNAL_DNS_TXT_OWNER_ID"
@@ -138,11 +137,9 @@ func hyperShiftOperatorTemplateManifest(opts *Options) (crclient.Object, error) 
 	if opts.ExternalDNSProvider != "" && opts.ExternalDNSDomainFilter != "" && opts.ExternalDNSCredentialsSecret != "" {
 		templateParameters = append(
 			templateParameters,
-			map[string]string{"name": TemplateParamExternalDNSProvider, "value": opts.ExternalDNSProvider},
 			map[string]string{"name": TemplateParamExternalDNSDomainFilter, "value": opts.ExternalDNSDomainFilter},
 			map[string]string{"name": TemplateParamExternalDNSCredsSecret, "value": opts.ExternalDNSCredentialsSecret},
 		)
-		opts.ExternalDNSProvider = fmt.Sprintf("${%s}", TemplateParamExternalDNSProvider)
 		opts.ExternalDNSDomainFilter = fmt.Sprintf("${%s}", TemplateParamExternalDNSDomainFilter)
 		opts.ExternalDNSCredentialsSecret = fmt.Sprintf("${%s}", TemplateParamExternalDNSCredsSecret)
 

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -339,12 +339,18 @@ objects:
           - --source=service
           - --source=openshift-route
           - --domain-filter=${EXTERNAL_DNS_DOMAIN_FILTER}
-          - --provider=${EXTERNAL_DNS_PROVIDER}
+          - --provider=aws
           - --registry=txt
           - --txt-suffix=-external-dns
           - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
+          - --aws-zone-type=public
           command:
           - /external-dns
+          env:
+          - name: AWS_SHARED_CREDENTIALS_FILE
+            value: /etc/provider/credentials
+          - name: AWS_REGION
+            value: us-east-1
           image: registry.redhat.io/edo/external-dns-rhel8@sha256:c1134bb46172997ef7278b6cefbb0da44e72a9f808a7cd67b3c65d464754cab9
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -27744,8 +27750,6 @@ parameters:
   value: aws-credentials
 - name: AWS_PRIVATE_CREDS_SECRET_KEY
   value: credentials
-- name: EXTERNAL_DNS_PROVIDER
-  value: aws
 - name: EXTERNAL_DNS_DOMAIN_FILTER
   value: service.hypershift.example.org
 - name: EXTERNAL_DNS_CREDS_SECRET


### PR DESCRIPTION
the `--external-dns-provider` parameter must not be a parameter in the openshift template generated by `hypershift install render --template`. the value of `--external-dns-provider` influences parts of the generated template, e.g. the `AWS_SHARED_CREDENTIALS_FILE` env var being added to the `external-dns` deployment or not. therefore the value of the provider must be known already at template generation time (`hypershift install render --template`) and not at template instantion time (`oc process`).

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>