### PR TITLE
APIServer route expose strategy: Fix with private clusters

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.template
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.template
@@ -270,7 +270,7 @@ frontend public_ssl
   # non SNI requests should enter a default termination backend rather than the custom cert SNI backend since it
   # will not be able to match a cert to an SNI host
   #default_backend be_no_sni
-  default_backend be_tcp:<<namespace>>:kube-apiserver
+  default_backend be_tcp:<<namespace>>:kube-apiserver-internal
   # HYPERSHIFT CHANGE END
 
 ##########################################################################


### PR DESCRIPTION
Currently the route expose strategy doesn't work for private clusters
because the routers default backend is the public KAS route which
doesn't exist.

Use the internal route instead as it always exists.

Ref https://issues.redhat.com/browse/HOSTEDCP-485

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.