### PR TITLE
Validate OCP release version and SDN on initial install

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3255,6 +3255,15 @@ func isValidReleaseVersion(version, currentVersion, latestVersionSupported, minS
 		return fmt.Errorf("y-stream upgrade is not for OpenShiftSDN")
 	}
 
+	versionMinorOnly := &semver.Version{Major: version.Major, Minor: version.Minor}
+	if networkType == hyperv1.OpenShiftSDN && currentVersion == nil && versionMinorOnly.GT(semver.MustParse("4.10.0")) {
+		return fmt.Errorf("cannot use OpenShiftSDN with OCP version > 4.10")
+	}
+
+	if networkType == hyperv1.OVNKubernetes && currentVersion == nil && versionMinorOnly.LTE(semver.MustParse("4.10.0")) {
+		return fmt.Errorf("cannot use OVNKubernetes with OCP version < 4.11")
+	}
+
 	if (version.Major == latestVersionSupported.Major && version.Minor > latestVersionSupported.Minor) || version.Major > latestVersionSupported.Major {
 		return fmt.Errorf("the latest HostedCluster version supported by this Operator is: %q. Attempting to use: %q", supportedversion.LatestSupportedVersion, version)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently validate the OCP version when upgrading a HostedCluster.
However, we don't validate that it's valid with the SDN type on initial
install. This fixes the HostedCluster validation so we validate on
initial cluster creation.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] This change includes unit tests.