### PR TITLE
Reconcile spec of clusterversion resource

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -246,7 +246,7 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 	}
 
 	log.Info("reconciling clusterversion")
-	if err := r.reconcileClusterVersion(ctx); err != nil {
+	if err := r.reconcileClusterVersion(ctx, hcp); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile clusterversion: %w", err))
 	}
 
@@ -710,9 +710,11 @@ func (r *reconciler) reconcileKonnectivityAgent(ctx context.Context, hcp *hyperv
 	return errors.NewAggregate(errs)
 }
 
-func (r *reconciler) reconcileClusterVersion(ctx context.Context) error {
+func (r *reconciler) reconcileClusterVersion(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	clusterVersion := &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
 	if _, err := r.CreateOrUpdate(ctx, r.client, clusterVersion, func() error {
+		clusterVersion.Spec.ClusterID = configv1.ClusterID(hcp.Spec.ClusterID)
+		clusterVersion.Spec.Capabilities = nil
 		clusterVersion.Spec.Upstream = ""
 		clusterVersion.Spec.Channel = ""
 		clusterVersion.Spec.DesiredUpdate = nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds capabilities and clusterID to the fields we reconcile for the
ClusterVersion resource inside the guest cluster.

Only overrides should be allowed to be set by the administrator of the
guest cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] This change includes unit tests.