### PR TITLE
OVN SBDB: Use private router when possible

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
@@ -15,11 +15,11 @@ func TestReconcileDeployment(t *testing.T) {
 	}{
 		{
 			name:                        "No private apiserver connectivity, proxy apiserver address is set",
-			params:                      Params{ConnectsThroughInternetToControlplane: true},
 			expectProxyAPIServerAddress: true,
 		},
 		{
-			name: "Private apiserver connectivity, proxy apiserver address is unset",
+			name:   "Private apiserver connectivity, proxy apiserver address is unset",
+			params: Params{IsPrivate: true},
 		},
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -580,7 +580,7 @@ func (r *HostedControlPlaneReconciler) update(ctx context.Context, hostedControl
 	}
 
 	// Reconcile router
-	kasServiceStrategy := servicePublishingStrategyByType(hostedControlPlane, hyperv1.APIServer)
+	kasServiceStrategy := util.ServicePublishingStrategyByTypeForHCP(hostedControlPlane, hyperv1.APIServer)
 	if util.IsPrivateHCP(hostedControlPlane) || util.HasPublicLoadBalancerForPrivateRouter(hostedControlPlane) {
 		r.Log.Info("Reconciling router")
 		if err := r.reconcileRouter(ctx, hostedControlPlane, releaseImage, createOrUpdate, kasServiceStrategy.Type == hyperv1.Route); err != nil {
@@ -814,15 +814,6 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 	return nil
 }
 
-func servicePublishingStrategyByType(hcp *hyperv1.HostedControlPlane, svcType hyperv1.ServiceType) *hyperv1.ServicePublishingStrategy {
-	for _, mapping := range hcp.Spec.Services {
-		if mapping.Service == svcType {
-			return &mapping.ServicePublishingStrategy
-		}
-	}
-	return nil
-}
-
 func (r *HostedControlPlaneReconciler) reconcileDefaultServiceAccount(ctx context.Context, hcp *hyperv1.HostedControlPlane, createOrUpdate upsert.CreateOrUpdateFN) error {
 	defaultSA := common.DefaultServiceAccount(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, defaultSA, func() error {
@@ -835,7 +826,7 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultServiceAccount(ctx contex
 }
 
 func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Context, hcp *hyperv1.HostedControlPlane, createOrUpdate upsert.CreateOrUpdateFN) error {
-	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.APIServer)
+	serviceStrategy := util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.APIServer)
 	if serviceStrategy == nil {
 		return errors.New("APIServer service strategy not specified")
 	}
@@ -887,7 +878,7 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Con
 
 func (r *HostedControlPlaneReconciler) reconcileKonnectivityServerService(ctx context.Context, hcp *hyperv1.HostedControlPlane, createOrUpdate upsert.CreateOrUpdateFN) error {
 	p := konnectivity.NewKonnectivityServiceParams(hcp)
-	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.Konnectivity)
+	serviceStrategy := util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.Konnectivity)
 	if serviceStrategy == nil {
 		//lint:ignore ST1005 Konnectivity is proper name
 		return fmt.Errorf("Konnectivity service strategy not specified")
@@ -911,7 +902,7 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivityServerService(ctx co
 }
 
 func (r *HostedControlPlaneReconciler) reconcileOAuthServerService(ctx context.Context, hcp *hyperv1.HostedControlPlane, createOrUpdate upsert.CreateOrUpdateFN) error {
-	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.OAuthServer)
+	serviceStrategy := util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.OAuthServer)
 	if serviceStrategy == nil {
 		return fmt.Errorf("OAuthServer service strategy not specified")
 	}
@@ -1038,7 +1029,7 @@ func (r *HostedControlPlaneReconciler) defaultReconcileInfrastructureStatus(ctx 
 }
 
 func (r *HostedControlPlaneReconciler) reconcileAPIServerServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, message string, err error) {
-	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.APIServer)
+	serviceStrategy := util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.APIServer)
 	if serviceStrategy == nil {
 		return "", 0, "", errors.New("APIServer service strategy not specified")
 	}
@@ -1067,7 +1058,7 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerServiceStatus(ctx conte
 }
 
 func (r *HostedControlPlaneReconciler) reconcileKonnectivityServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, message string, err error) {
-	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.Konnectivity)
+	serviceStrategy := util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.Konnectivity)
 	if serviceStrategy == nil {
 		err = fmt.Errorf("konnectivity service strategy not specified")
 		return
@@ -1097,7 +1088,7 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivityServiceStatus(ctx co
 }
 
 func (r *HostedControlPlaneReconciler) reconcileOAuthServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, port int32, message string, err error) {
-	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.OAuthServer)
+	serviceStrategy := util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.OAuthServer)
 	if serviceStrategy == nil {
 		err = fmt.Errorf("OAuth strategy not specified")
 		return

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -610,16 +609,11 @@ func EnsureAllRoutesUseHCPRouter(t *testing.T, ctx context.Context, hostClient c
 				t.Skip("skipping test because APIServer is not exposed through a route")
 			}
 		}
-		// TODO alvaroaleman: This needs to be fixed up in the CNO
-		exceptions := sets.NewString("ovnkube-sbdb")
 		var routes routev1.RouteList
 		if err := hostClient.List(ctx, &routes, crclient.InNamespace(manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name)); err != nil {
 			t.Fatalf("failed to list routes: %v", err)
 		}
 		for _, route := range routes.Items {
-			if exceptions.Has(route.Name) {
-				continue
-			}
 			original := route.DeepCopy()
 			ingress.AddRouteLabel(&route)
 			if diff := cmp.Diff(route.GetLabels(), original.GetLabels()); diff != "" {


### PR DESCRIPTION
Currently, the OVN SBDB never uses the private router, which is wrong.
It needs to be used if the cluster is private or if the apiserver is
exposed through a route and a custom hostname has been set for OVNSBDB.

As espcially the first check is likely to change, the settings for which
hostname to use and if the private router should be used are determined
in the CPO and passed on to the CNO.

Fixes https://issues.redhat.com/browse/HOSTEDCP-517
Related to https://issues.redhat.com/browse/HOSTEDCP-485

/hold
Requires https://github.com/openshift/cluster-network-operator/pull/1531 to merge first

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.