### PR TITLE
Add recording rules for telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ vet:
 
 .PHONY: promtool
 promtool:
-	cd $(TOOLS_DIR); $(PROMTOOL) check rules ../../cmd/install/assets/recordingrules/*.yaml
+	cd $(TOOLS_DIR); $(PROMTOOL) check rules ../../cmd/install/assets/recordingrules/*.yaml ../../control-plane-operator/controllers/hostedcontrolplane/kas/assets/*.yaml
 
 # Updates Go modules
 .PHONY: deps

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/assets/recording-rules.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/assets/recording-rules.yaml
@@ -1,0 +1,31 @@
+# Promethus recording rules for HyperShift control planes. These come from the following sources:
+# https://github.com/openshift/cluster-monitoring-operator/blob/b5964de7d193cbda4db507c52e391bb56d9c081a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+# https://github.com/openshift/cluster-kube-apiserver-operator/blob/65fc794b8aaa36a881323b26618ab46b7ed7defd/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+groups:
+- name: hypershift.rules
+  rules:  
+  - expr: sum by (instance) (apiserver_storage_objects)
+    record: instance:etcd_object_counts:sum
+  - expr: sum(rate(apiserver_request_total{job="apiserver"}[10m])) BY (code)
+    record: code:apiserver_request_total:rate:sum
+  - record: cluster:apiserver_current_inflight_requests:sum:max_over_time:2m
+    expr: |
+      max_over_time(sum(apiserver_current_inflight_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver,request_kind)[2m:])
+  - expr: sum by(plugin_name, volume_mode)(pv_collector_total_pv_count)
+    record: cluster:kube_persistentvolume_plugin_type_counts:sum
+  - expr: sum by (instance) (etcd_mvcc_db_total_size_in_bytes{job="etcd"})
+    record: instance:etcd_mvcc_db_total_size_in_bytes:sum
+  - expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m])))
+    labels:
+      quantile: "0.99"
+    record: instance:etcd_disk_wal_fsync_duration_seconds:histogram_quantile
+  - expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m])))
+    labels:
+      quantile: "0.99"
+    record: instance:etcd_network_peer_round_trip_time_seconds:histogram_quantile
+  - expr: sum by (instance) (etcd_mvcc_db_total_size_in_use_in_bytes{job="etcd"})
+    record: instance:etcd_mvcc_db_total_size_in_use_in_bytes:sum
+  - expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m])))
+    labels:
+      quantile: "0.99"
+    record: instance:etcd_disk_backend_commit_duration_seconds:histogram_quantile

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor_test.go
@@ -1,0 +1,23 @@
+package kas
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+)
+
+func TestReconcileRecordingRules(t *testing.T) {
+	rules := manifests.ControlPlaneRecordingRules("test")
+	ReconcileRecordingRules(rules, "fake-id")
+	g := NewWithT(t)
+	g.Expect(rules.Spec.Groups[0].Name).To(Equal("hypershift.rules"))
+	ruleNames := sets.NewString()
+	for _, rule := range rules.Spec.Groups[0].Rules {
+		ruleNames.Insert(rule.Record)
+	}
+	g.Expect(ruleNames.Has("instance:etcd_object_counts:sum")).To(BeTrue())
+	g.Expect(rules.Spec.Groups[0].Rules[0].Labels).To(HaveKeyWithValue("_id", "fake-id"))
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -156,3 +156,12 @@ func KASServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
 		},
 	}
 }
+
+func ControlPlaneRecordingRules(ns string) *prometheusoperatorv1.PrometheusRule {
+	return &prometheusoperatorv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recording-rules",
+			Namespace: ns,
+		},
+	}
+}

--- a/support/util/metrics.go
+++ b/support/util/metrics.go
@@ -20,6 +20,13 @@ func ApplyClusterIDLabelToPodMonitor(ep *prometheusoperatorv1.PodMetricsEndpoint
 	ep.MetricRelabelConfigs = append(ep.MetricRelabelConfigs, clusterIDRelabelConfig(clusterID))
 }
 
+func ApplyClusterIDLabelToRecordingRule(rule *prometheusoperatorv1.Rule, clusterID string) {
+	if rule.Labels == nil {
+		rule.Labels = map[string]string{}
+	}
+	rule.Labels[clusterIDLabel] = clusterID
+}
+
 func clusterIDRelabelConfig(clusterID string) *prometheusoperatorv1.RelabelConfig {
 	return &prometheusoperatorv1.RelabelConfig{
 		TargetLabel: clusterIDLabel,


### PR DESCRIPTION
**What this PR does / why we need it**:
Certain metrics sent to telemetry rely on recording rules. This PR adds
code to reconcile a prometheus rule resource in the control plane
namespace with those rules.

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-400](https://issues.redhat.com//browse/HOSTEDCP-400)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.