### PR TITLE
Allow OpenShiftSDN CNI for PowerVS platform

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3216,7 +3216,7 @@ func (r *HostedClusterReconciler) validateReleaseImage(ctx context.Context, hc *
 		minSupportedVersion = semver.MustParse("4.9.0")
 	}
 
-	return isValidReleaseVersion(&version, currentVersion, &supportedversion.LatestSupportedVersion, &minSupportedVersion, hc.Spec.Networking.NetworkType)
+	return isValidReleaseVersion(&version, currentVersion, &supportedversion.LatestSupportedVersion, &minSupportedVersion, hc.Spec.Networking.NetworkType, hc.Spec.Platform.Type)
 }
 
 func isProgressing(ctx context.Context, hc *hyperv1.HostedCluster) (bool, error) {
@@ -3243,7 +3243,7 @@ func isProgressing(ctx context.Context, hc *hyperv1.HostedCluster) (bool, error)
 	return false, nil
 }
 
-func isValidReleaseVersion(version, currentVersion, latestVersionSupported, minSupportedVersion *semver.Version, networkType hyperv1.NetworkType) error {
+func isValidReleaseVersion(version, currentVersion, latestVersionSupported, minSupportedVersion *semver.Version, networkType hyperv1.NetworkType, platformType hyperv1.PlatformType) error {
 	if version.LT(semver.MustParse("4.8.0")) {
 		return fmt.Errorf("releases before 4.8 are not supported")
 	}
@@ -3257,7 +3257,7 @@ func isValidReleaseVersion(version, currentVersion, latestVersionSupported, minS
 	}
 
 	versionMinorOnly := &semver.Version{Major: version.Major, Minor: version.Minor}
-	if networkType == hyperv1.OpenShiftSDN && currentVersion == nil && versionMinorOnly.GT(semver.MustParse("4.10.0")) {
+	if networkType == hyperv1.OpenShiftSDN && currentVersion == nil && versionMinorOnly.GT(semver.MustParse("4.10.0")) && platformType != hyperv1.PowerVSPlatform {
 		return fmt.Errorf("cannot use OpenShiftSDN with OCP version > 4.10")
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -2492,6 +2492,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 		minVersionSupported    *semver.Version
 		networkType            hyperv1.NetworkType
 		expectError            bool
+		platform               hyperv1.PlatformType
 	}{
 		{
 			name:                   "Releases before 4.8 are not supported",
@@ -2500,6 +2501,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			latestVersionSupported: v("4.12.0"),
 			minVersionSupported:    v("4.10.0"),
 			expectError:            true,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "y-stream downgrade is not supported",
@@ -2508,6 +2510,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			latestVersionSupported: v("4.12.0"),
 			minVersionSupported:    v("4.10.0"),
 			expectError:            true,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "y-stream upgrade is not for OpenShiftSDN",
@@ -2517,6 +2520,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			minVersionSupported:    v("4.10.0"),
 			networkType:            hyperv1.OpenShiftSDN,
 			expectError:            true,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "the latest HostedCluster version supported by this Operator is 4.12.0",
@@ -2525,6 +2529,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			latestVersionSupported: v("4.12.0"),
 			minVersionSupported:    v("4.10.0"),
 			expectError:            true,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "the minimum HostedCluster version supported by this Operator is 4.10.0",
@@ -2533,6 +2538,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			latestVersionSupported: v("4.12.0"),
 			minVersionSupported:    v("4.10.0"),
 			expectError:            true,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "Valid",
@@ -2541,6 +2547,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			latestVersionSupported: v("4.12.0"),
 			minVersionSupported:    v("4.10.0"),
 			expectError:            false,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "When going to minimum should be valid",
@@ -2549,6 +2556,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			latestVersionSupported: v("4.12.0"),
 			minVersionSupported:    v("4.10.0"),
 			expectError:            false,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "Valid when going to minimum with a dev tag",
@@ -2557,6 +2565,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			latestVersionSupported: v("4.12.0"),
 			minVersionSupported:    v("4.10.0"),
 			expectError:            false,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "Invalid when installing with OpenShiftSDN and version > 4.10",
@@ -2566,6 +2575,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			minVersionSupported:    v("4.10.0"),
 			networkType:            hyperv1.OpenShiftSDN,
 			expectError:            true,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "Valid when installing with OpenShift SDN and version <= 4.10",
@@ -2575,6 +2585,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			minVersionSupported:    v("4.10.0"),
 			networkType:            hyperv1.OpenShiftSDN,
 			expectError:            false,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "Invalid when isntalling with OVNKubernetes and version < 4.11",
@@ -2584,6 +2595,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			minVersionSupported:    v("4.10.0"),
 			networkType:            hyperv1.OVNKubernetes,
 			expectError:            true,
+			platform:               hyperv1.NonePlatform,
 		},
 		{
 			name:                   "Valid when isntalling with OVNKubernetes and version >= 4.11",
@@ -2593,13 +2605,24 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			minVersionSupported:    v("4.10.0"),
 			networkType:            hyperv1.OVNKubernetes,
 			expectError:            false,
+			platform:               hyperv1.NonePlatform,
+		},
+		{
+			name:                   "Valid when installing with OpenShift SDN and version >= 4.11 with PowerVS platform",
+			currentVersion:         nil,
+			nextVersion:            v("4.11.0"),
+			latestVersionSupported: v("4.12.0"),
+			minVersionSupported:    v("4.10.0"),
+			networkType:            hyperv1.OpenShiftSDN,
+			expectError:            false,
+			platform:               hyperv1.PowerVSPlatform,
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			err := isValidReleaseVersion(test.nextVersion, test.currentVersion, test.latestVersionSupported, test.minVersionSupported, test.networkType)
+			err := isValidReleaseVersion(test.nextVersion, test.currentVersion, test.latestVersionSupported, test.minVersionSupported, test.networkType, test.platform)
 			if test.expectError {
 				g.Expect(err).To(HaveOccurred())
 				return


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

We are facing issues with OVN Kube CNI. RH JIRA: https://issues.redhat.com/browse/MULTIARCH-2631

Please temporarily allow OpenShift SDN CNI for PowerVS platform alone.
Once that is resolved will remove this change to block in PowerVS platform too.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.