### PR TITLE
Fix clusters where apiserver is exposed through LB and DNS indirection is used

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -581,7 +581,7 @@ func (r *HostedControlPlaneReconciler) update(ctx context.Context, hostedControl
 
 	// Reconcile router
 	kasServiceStrategy := servicePublishingStrategyByType(hostedControlPlane, hyperv1.APIServer)
-	if util.IsPrivateHCP(hostedControlPlane) || kasServiceStrategy.Type == hyperv1.Route {
+	if util.IsPrivateHCP(hostedControlPlane) || util.HasPublicLoadBalancerForPrivateRouter(hostedControlPlane) {
 		r.Log.Info("Reconciling router")
 		if err := r.reconcileRouter(ctx, hostedControlPlane, releaseImage, createOrUpdate, kasServiceStrategy.Type == hyperv1.Route); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to reconcile router: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -19,7 +19,7 @@ func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, strategy *hy
 	// and ignore updates.
 	if route.CreationTimestamp.IsZero() {
 		switch {
-		case strategy.Route != nil && strategy.Route.Hostname != "":
+		case util.HasPublicLoadBalancerForPrivateRouter(hcp) && strategy.Route != nil && strategy.Route.Hostname != "":
 			route.Spec.Host = strategy.Route.Hostname
 			ingress.AddRouteLabel(route)
 		case !util.IsPublicHCP(hcp):

--- a/support/util/expose.go
+++ b/support/util/expose.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+func ServicePublishingStrategyByTypeForHCP(hcp *hyperv1.HostedControlPlane, svcType hyperv1.ServiceType) *hyperv1.ServicePublishingStrategy {
+	for _, mapping := range hcp.Spec.Services {
+		if mapping.Service == svcType {
+			return &mapping.ServicePublishingStrategy
+		}
+	}
+	return nil
+}
+
+func HasPublicLoadBalancerForPrivateRouter(hcp *hyperv1.HostedControlPlane) bool {
+	if apiServerService := ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.APIServer); apiServerService != nil && apiServerService.Type == hyperv1.Route {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
If that happens, we must not use the private router as it does not have
a public LB.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.