### PR TITLE
AWS infra destroy: Handle bucket not found during batch delete

### DIFF
--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -150,7 +150,7 @@ func emptyBucket(ctx context.Context, client s3iface.S3API, name string) error {
 	})
 
 	if err := s3manager.NewBatchDeleteWithClient(client).Delete(ctx, iter); err != nil {
-		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchBucket {
+		if strings.Contains(err.Error(), s3.ErrCodeNoSuchBucket) {
 			return nil
 		}
 		return err


### PR DESCRIPTION
The current check assumes that we directly get an AWS error back, but we
always get a [batch error back][0]. Fix the current check and make it
more robust by simply checking for the substring.

[0]: https://github.com/openshift/hypershift/blob/0f997c1a8a8abd5831ae96ca6eb8f7b4f4c627ec/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/batch.go#L353

Samplejob where this failed: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ipi-deprovision-aws-osd-hypershift/1562548271694483456

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.