### PR TITLE
Add node controller to HCCO Manager

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -24,6 +24,8 @@ const (
 	NodePoolAsExpectedConditionReason            = "AsExpected"
 	NodePoolValidationFailedConditionReason      = "ValidationFailed"
 	NodePoolInplaceUpgradeFailedConditionReason  = "InplaceUpgradeFailed"
+	// NodePoolLabel is used to label Nodes.
+	NodePoolLabel = "hypershift.openshift.io/nodePool"
 )
 
 // The following are reasons for the IgnitionEndpointAvailable condition.

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/cmca"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/node"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
 	"github.com/openshift/hypershift/pkg/version"
@@ -52,6 +53,7 @@ var controllerFuncs = map[string]operator.ControllerSetupFunc{
 	"controller-manager-ca":  cmca.Setup,
 	resources.ControllerName: resources.Setup,
 	"inplaceupgrader":        inplaceupgrader.Setup,
+	"node":                   node.Setup,
 	hcpstatus.ControllerName: hcpstatus.Setup,
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/node/node.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/node/node.go
@@ -1,0 +1,97 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+
+	supportutil "github.com/openshift/hypershift/support/util"
+
+	"github.com/openshift/hypershift/support/upsert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	nodePoolAnnotation = "hypershift.openshift.io/nodePool"
+)
+
+type reconciler struct {
+	client             client.Client
+	guestClusterClient client.Client
+	upsert.CreateOrUpdateProvider
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Reconciling")
+
+	node := &corev1.Node{}
+	if err := r.guestClusterClient.Get(ctx, req.NamespacedName, node); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("not found", "request", req.String())
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get Node: %w", err)
+	}
+
+	var apiErr *apierrors.StatusError
+	nodePoolName, err := r.nodeToNodePoolName(node)
+	if err != nil {
+		if errors.As(err, &apiErr) && !apierrors.IsNotFound(err) {
+			// Return error and retry only if the API interaction failed. Other errors are because the nodeToNodePoolName expected
+			// annotations are not in place yet, so we'll reconcile triggered by the event which sets them in the Node.
+			return ctrl.Result{}, err
+		} else {
+			log.Error(err, "failed to get nodePool name from Node")
+			return ctrl.Result{}, nil
+		}
+	}
+
+	result, err := r.CreateOrUpdate(ctx, r.guestClusterClient, node, func() error {
+		node.Labels[hyperv1.NodePoolLabel] = nodePoolName
+		return nil
+	})
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile Node: %w", err)
+	}
+	log.Info("Reconciled Node", "result", result)
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) nodeToNodePoolName(node *corev1.Node) (string, error) {
+	machineName, ok := node.GetAnnotations()[capiv1.MachineAnnotation]
+	if !ok || machineName == "" {
+		return "", fmt.Errorf("failed to find MachineAnnotation on Node %q", node.Name)
+	}
+
+	machineNamespace, ok := node.GetAnnotations()[capiv1.ClusterNamespaceAnnotation]
+	if !ok || machineNamespace == "" {
+		return "", fmt.Errorf("failed to find ClusterNamespaceAnnotation on Node %q", node.Name)
+	}
+
+	machine := &capiv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: machineNamespace,
+			Name:      machineName,
+		},
+	}
+	if err := r.client.Get(context.TODO(), client.ObjectKeyFromObject(machine), machine); err != nil {
+		return "", fmt.Errorf("failed to get Machine: %w", err)
+	}
+
+	nodePoolName, ok := machine.Annotations[nodePoolAnnotation]
+	if !ok || nodePoolName == "" {
+		return "", fmt.Errorf("failed to find nodePoolAnnotation on Machine %q", machine.Name)
+	}
+
+	return supportutil.ParseNamespacedName(nodePoolName).Name, nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/node/node_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/node/node_test.go
@@ -1,0 +1,120 @@
+package node
+
+import (
+	"testing"
+
+	supportutil "github.com/openshift/hypershift/support/util"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNodeToNodePoolName(t *testing.T) {
+	capiv1.AddToScheme(scheme.Scheme)
+
+	machineNamespace := "test"
+	nodePoolName := "ns/name"
+	machineWithNodePoolAnnotation := &capiv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: machineNamespace,
+			Name:      "hasNodePoolAnnotation",
+			Annotations: map[string]string{
+				nodePoolAnnotation: nodePoolName,
+			},
+		},
+	}
+	machineWithOutNodePoolAnnotation := &capiv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: machineNamespace,
+			Name:      "DoNotHaveNodePoolAnnotation",
+		},
+	}
+
+	testCases := []struct {
+		name                 string
+		node                 *corev1.Node
+		expectedNodePoolName string
+		error                bool
+	}{
+		{
+			name: "When MachineAnnotation does not exist in Node it should fail",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						capiv1.ClusterNamespaceAnnotation: machineNamespace,
+					},
+				},
+			},
+			expectedNodePoolName: "",
+			error:                true,
+		},
+		{
+			name: "When ClusterNamespaceAnnotation does not exist in Node it should fail",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						capiv1.MachineAnnotation: machineWithNodePoolAnnotation.Name,
+					},
+				},
+			},
+			expectedNodePoolName: "",
+			error:                true,
+		},
+		{
+			name: "When nodePoolAnnotation does not exist in Machine it should fail",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						capiv1.ClusterNamespaceAnnotation: machineNamespace,
+						capiv1.MachineAnnotation:          machineWithOutNodePoolAnnotation.Name,
+					},
+				},
+			},
+			expectedNodePoolName: "",
+			error:                true,
+		},
+		{
+			name: "When Machine does not exist it should fail",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						capiv1.ClusterNamespaceAnnotation: machineNamespace,
+						capiv1.MachineAnnotation:          "doesNotExist",
+					},
+				},
+			},
+			expectedNodePoolName: "",
+			error:                true,
+		},
+		{
+			name: "When all annotations and Machine exist it should return the NodePool Name",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						capiv1.ClusterNamespaceAnnotation: machineNamespace,
+						capiv1.MachineAnnotation:          machineWithNodePoolAnnotation.Name,
+					},
+				},
+			},
+			expectedNodePoolName: supportutil.ParseNamespacedName(nodePoolName).Name,
+			error:                false,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithObjects(machineWithNodePoolAnnotation, machineWithOutNodePoolAnnotation).Build()
+	r := &reconciler{
+		client: c,
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := r.nodeToNodePoolName(tc.node)
+			g.Expect(got).To(Equal(tc.expectedNodePoolName))
+			g.Expect(err != nil).To(Equal(tc.error))
+		})
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/node/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/node/setup.go
@@ -1,0 +1,29 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
+	r := &reconciler{
+		client:                 opts.CPCluster.GetClient(),
+		guestClusterClient:     opts.Manager.GetClient(),
+		CreateOrUpdateProvider: opts.TargetCreateOrUpdateProvider,
+	}
+	c, err := controller.New("node", opts.Manager, controller.Options{Reconciler: r})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	if err := c.Watch(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("failed to watch Nodes: %w", err)
+	}
+
+	return nil
+}

--- a/hypershift-operator/controllers/nodepool/inplace.go
+++ b/hypershift-operator/controllers/nodepool/inplace.go
@@ -54,8 +54,13 @@ func (r *NodePoolReconciler) reconcileMachineSet(ctx context.Context,
 				resourcesName:           resourcesName,
 				capiv1.ClusterLabelName: CAPIClusterName,
 			},
+			// Annotations here propagate down to Machines
+			// https://cluster-api.sigs.k8s.io/developer/architecture/controllers/metadata-propagation.html#machinedeployment.
 			Annotations: map[string]string{
-				nodePoolAnnotationPlatformMachineTemplate: machineTemplateSpecJSON,
+				// TODO (alberto): Use conditions to signal an in progress rolling upgrade
+				// similar to what we do with nodePoolAnnotationCurrentConfig
+				nodePoolAnnotationPlatformMachineTemplate: machineTemplateSpecJSON, // This will trigger a deployment rolling upgrade when its value changes.
+				nodePoolAnnotation:                        client.ObjectKeyFromObject(nodePool).String(),
 			},
 		},
 

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -882,10 +882,13 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 				resourcesName:           resourcesName,
 				capiv1.ClusterLabelName: CAPIClusterName,
 			},
+			// Annotations here propagate down to Machines
+			// https://cluster-api.sigs.k8s.io/developer/architecture/controllers/metadata-propagation.html#machinedeployment.
 			Annotations: map[string]string{
 				// TODO (alberto): Use conditions to signal an in progress rolling upgrade
 				// similar to what we do with nodePoolAnnotationCurrentConfig
 				nodePoolAnnotationPlatformMachineTemplate: machineTemplateSpecJSON, // This will trigger a deployment rolling upgrade when its value changes.
+				nodePoolAnnotation:                        client.ObjectKeyFromObject(nodePool).String(),
 			},
 		},
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -13,6 +13,9 @@ import (
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ingress"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	promapi "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	promconfig "github.com/prometheus/common/config"
@@ -30,10 +33,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ingress"
-	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 )
 
 // DeleteNamespace deletes and finalizes the given namespace, logging any failures
@@ -173,11 +172,13 @@ func WaitForNReadyNodes(t *testing.T, ctx context.Context, client crclient.Clien
 			return false, nil
 		}
 		t.Logf("All nodes are ready. Count: %v", len(nodes.Items))
+
 		return true, nil
 	})
 	g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to ensure guest nodes became ready, ready: (%d/%d): ", readyNodeCount, n))
 
 	t.Logf("All nodes for nodepool appear to be ready in %s. Count: %v", time.Since(start).Round(time.Second), n)
+
 	return nodes.Items
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
What:
This introduces a feature to reconcile Nodes with an opinionated Hypershift label pointing to the owning NodePool.

Why:
This is useful to list and filter Nodes by NodePool. This is useful for all operators to have a single and consistent bidirectional way for NodePool<->Node without having to reimplement the same logic, vendoring clients and consuming compute resources. E.g NTO tuneD.

How:
Change the NodePool controller to propagate the NodePool annotation down to Machines.
Introduce a Node controller within the HCCO manager:
- Watches Nodes.
- Find the Machine by using the appropriate CAPI annotations.
- Find the NodePool annotation.
- Apply the annotation as a Label into the Node.

In future we might extend this to support label propagation into Nodes via NodePool API.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.