### PR TITLE
Use kubeconfig port for worker haproxy

### DIFF
--- a/hypershift-operator/controllers/nodepool/haproxy_test.go
+++ b/hypershift-operator/controllers/nodepool/haproxy_test.go
@@ -2,6 +2,7 @@ package nodepool
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -52,10 +53,10 @@ func TestReconcileHAProxyIgnitionConfig(t *testing.T) {
 		}
 		return hc
 	}
-	const kubeconfig = `apiVersion: v1
+	const kubeconfigTemplate = `apiVersion: v1
 clusters:
 - cluster:
-    server: https://kubeconfig-host:6443
+    server: https://kubeconfig-host:%d
   name: cluster
 contexts:
 - context:
@@ -65,6 +66,11 @@ contexts:
   name: cluster
 current-context: cluster
 kind: Config`
+
+	kubeconfig := func(port int32) string {
+		return fmt.Sprintf(kubeconfigTemplate, port)
+	}
+
 	testCases := []struct {
 		name                         string
 		hc                           *hyperv1.HostedCluster
@@ -114,7 +120,7 @@ kind: Config`
 			other: []crclient.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "kk", Namespace: hc().Namespace},
 				Data: map[string][]byte{
-					"kubeconfig": []byte(kubeconfig),
+					"kubeconfig": []byte(kubeconfig(6443)),
 				},
 			}},
 
@@ -130,7 +136,7 @@ kind: Config`
 			other: []crclient.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "kk", Namespace: hc().Namespace},
 				Data: map[string][]byte{
-					"kubeconfig": []byte(kubeconfig),
+					"kubeconfig": []byte(kubeconfig(443)),
 				},
 			}},
 

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -743,7 +743,7 @@ spec:
 					Data: map[string][]byte{"kubeconfig": []byte(`apiVersion: v1
 clusters:
 - cluster:
-    server: http://localhost:8080
+    server: http://localhost:6443
   name: static-kas
 contexts:
 - context:


### PR DESCRIPTION
**What this PR does / why we need it**:
We are currently only using a default port for the Kube APIServer in the
public case (unless it's overriden). This doesn't take into
consideration a nodeport in the case that the APIServer is exposed via
NodePort. A safer configuration route is to take the port of the
external kubeconfig which already has the calculated external endpoint
of the Kube APIServer.

When using private link, we can keep using what we had before because
the port is fixed.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] This change includes unit tests.