### PR TITLE
Reconcile default ingress controller on creation only

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -11,6 +11,11 @@ import (
 )
 
 func ReconcileDefaultIngressController(ingressController *operatorv1.IngressController, ingressSubdomain string, platformType hyperv1.PlatformType, replicas int32, isIBMCloudUPI bool, isPrivate bool) error {
+	// If ingress controller already exists, skip reconciliation to allow day-2 configuration
+	if ingressController.ResourceVersion != "" {
+		return nil
+	}
+
 	ingressController.Spec.Domain = ingressSubdomain
 	ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
 		Type: operatorv1.LoadBalancerServiceStrategyType,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
@@ -8,6 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestReconcileDefaultIngressController(t *testing.T) {
@@ -197,6 +198,26 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 						Name: manifests.IngressDefaultIngressControllerCert().Name,
 					},
 				},
+			},
+		},
+		{
+			name: "Existing ingress controller",
+			inputIngressController: func() *operatorv1.IngressController {
+				ic := manifests.IngressDefaultIngressController()
+				ic.ResourceVersion = "1"
+				return ic
+			}(),
+			inputIngressDomain: fakeIngressDomain,
+			inputReplicas:      fakeInputReplicas,
+			inputIsIBMCloudUPI: false,
+			inputIsPrivate:     false,
+			expectedIngressController: &operatorv1.IngressController{
+				ObjectMeta: func() metav1.ObjectMeta {
+					m := manifests.IngressDefaultIngressController().ObjectMeta
+					m.ResourceVersion = "1"
+					return m
+				}(),
+				Spec: operatorv1.IngressControllerSpec{},
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Stops continously reconciling the default ingress controller to allow
day 2 configuration of the ingress controller. This mirrors what the
installer does on a standalone OCP cluster.

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-491](https://issues.redhat.com//browse/HOSTEDCP-491)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.