### PR TITLE
Ensure generated junit.xml has a defined suite name

### DIFF
--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -19,6 +19,8 @@ fi
 generate_junit() {
   cat  /tmp/test_out | go tool test2json -t > /tmp/test_out.json
   gotestsum --raw-command --junitfile="${ARTIFACT_DIR}/junit.xml" --format=standard-verbose -- cat /tmp/test_out.json
+  # Ensure generated junit has a useful suite name
+  sed -i 's/\(<testsuite.*\)name=""/\1 name="hypershift-e2e"/' "${ARTIFACT_DIR}/junit.xml"
 }
 trap generate_junit EXIT
 


### PR DESCRIPTION
**What this PR does / why we need it**:

gotestsum's generated junit.xml doesn't have a suite name, and the test
names themselves are really generic sounding, e.g. 'TestAutoscaling'.
Adding a suite name will help us identify them in Sippy as belonging to
hypershift.

I couldn't find a way with gotestsum to get it to put something useful
in the suite name, so this just hacks it in with sed.  Open to better
solutions.

**Which issue(s) this PR fixes**:

[TRT-506](https://issues.redhat.com//browse/TRT-506)

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [N/A] This change includes docs. 
- [N/A] This change includes unit tests.
