### PR TITLE
Registry operator: Avoid restarts when token file changes

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -47,7 +47,6 @@ cp "{{ .CABundle }}" "{{ .TokenDir }}/ca.crt"
 export KUBERNETES_SERVICE_HOST=kube-apiserver
 export KUBERNETES_SERVICE_PORT=$KUBE_APISERVER_SERVICE_PORT
 exec /usr/bin/cluster-image-registry-operator \
-  --files="{{ .TokenDir }}/token" \
   --files="{{ .ServingCertDir }}/tls.crt" \
   --files="{{ .ServingCertDir }}/tls.key"
 `

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -68,7 +68,6 @@ spec:
           export KUBERNETES_SERVICE_HOST=kube-apiserver
           export KUBERNETES_SERVICE_PORT=$KUBE_APISERVER_SERVICE_PORT
           exec /usr/bin/cluster-image-registry-operator \
-            --files="/var/run/secrets/kubernetes.io/serviceaccount/token" \
             --files="/etc/secrets/tls.crt" \
             --files="/etc/secrets/tls.key"
         command:


### PR DESCRIPTION
Client-go sets the token file location when using in-cluster config:
https://github.com/openshift/cluster-image-registry-operator/blob/39ea65a1ea93043e8b3ec156fde719760a807e1f/vendor/k8s.io/client-go/rest/config.go#L540

This in turn results in the token-file being periodically live-reloaded,
without needing to restart the controller:
https://github.com/openshift/cluster-image-registry-operator/blob/39ea65a1ea93043e8b3ec156fde719760a807e1f/vendor/k8s.io/client-go/rest/config.go#L75-L77

/assign @csrwng 

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.