### PR TITLE
Extracts correct mco image based on managed cluster's arch

### DIFF
--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -12,9 +12,12 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/docker/distribution/manifest/manifestlist"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/certs"
@@ -188,6 +191,23 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 		}
 		if err := os.WriteFile(filepath.Join(mcoBaseDir, "cloud.conf.configmap.yaml"), cloudConfYaml, 0644); err != nil {
 			return nil, fmt.Errorf("failed to write bootstrap kubeconfig: %w", err)
+		}
+	}
+
+	isMultiArchManifestList, err := registryclient.IsMultiArchManifestList(ctx, mcoImage, pullSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine if image is manifest listed: %w", err)
+	}
+
+	if isMultiArchManifestList {
+		os := runtime.GOOS
+		arch := runtime.GOARCH
+		log.Info("mco image is a manifest listed image; extracting manifest for os/arch: " + os + "/" + arch)
+
+		// Verify MF Image has the right os/arch image
+		mcoImage, err = findImageRefByArch(ctx, mcoImage, pullSecret, os, arch)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract appropriate os/arch manifest from %s: %w", mcoImage, err)
 		}
 	}
 
@@ -450,4 +470,71 @@ func copyFile(src, dst string) error {
 		return err
 	}
 	return os.Chmod(dst, srcinfo.Mode())
+}
+
+// findImageRefByArch finds the appropriate image reference in a multi-arch manifest image based on the current platform's OS and processor architecture
+func findImageRefByArch(ctx context.Context, imageRef string, pullSecret []byte, osToFind string, archToFind string) (manifestImageRef string, err error) {
+	manifestList, err := registryclient.GetManifest(ctx, imageRef, pullSecret)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve manifest from image ref, %s: %w", imageRef, err)
+	}
+
+	_, payload, err := manifestList.Payload()
+	if err != nil {
+		return "", fmt.Errorf("failed to get manifest payload: %w", err)
+	}
+
+	deserializedManifestList := new(manifestlist.DeserializedManifestList)
+	if err = deserializedManifestList.UnmarshalJSON(payload); err != nil {
+		return "", fmt.Errorf("failed to get unmarshalled manifest list: %w", err)
+	}
+
+	matchingManifestForArch, err := findMatchingManifest(imageRef, deserializedManifestList, osToFind, archToFind)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve matching manifest for os/arch, %s/%s: %w", osToFind, archToFind, err)
+	}
+
+	return matchingManifestForArch, nil
+}
+
+// findMatchingManifest looks to find a manifest matching the current platform's OS and processor architecture from a deserialized manifest list from an image's payload
+func findMatchingManifest(imageRef string, deserializedManifestList *manifestlist.DeserializedManifestList, osToFind string, archToFind string) (string, error) {
+	var foundManifestDesc *manifestlist.ManifestDescriptor
+	for _, manifestDesc := range deserializedManifestList.ManifestList.Manifests {
+		if osToFind == manifestDesc.Platform.OS && archToFind == manifestDesc.Platform.Architecture {
+			foundManifestDesc = &manifestDesc
+			break
+		}
+	}
+
+	if foundManifestDesc == nil {
+		return "", fmt.Errorf("not found")
+	}
+
+	// Multi-arch image references look like either:
+	//	quay.io/openshift-release-dev/ocp-release@sha256:1a101ef5215da468cea8bd2eb47114e85b2b64a6b230d5882f845701f55d057f
+	//	quay.io/openshift-release-dev/ocp-release:4.11.0-0.nightly-multi-2022-07-12-131716
+	if strings.Contains(imageRef, "@sha") {
+		splitSHA := strings.Split(imageRef, "@")
+		if len(splitSHA) != 2 {
+			return "", fmt.Errorf("failed to parse imageRef %s", imageRef)
+		}
+
+		matchingManifestForArch := splitSHA[0] + "@" + string(foundManifestDesc.Descriptor.Digest)
+		log.Info("Found matching manifest of os/arch: " + matchingManifestForArch)
+		return matchingManifestForArch, nil
+	}
+
+	if strings.Contains(imageRef, "ocp-release:") {
+		splitSHA := strings.Split(imageRef, ":")
+		if len(splitSHA) != 2 {
+			return "", fmt.Errorf("failed to parse imageRef %s", imageRef)
+		}
+
+		matchingManifestForArch := splitSHA[0] + "@" + string(foundManifestDesc.Descriptor.Digest)
+		log.Info("Found matching manifest of os/arch: " + matchingManifestForArch)
+		return matchingManifestForArch, nil
+	}
+
+	return "", fmt.Errorf("imageRef is an unknown format to parse, imageRef: %s", imageRef)
 }

--- a/ignition-server/controllers/local_ignitionprovider_test.go
+++ b/ignition-server/controllers/local_ignitionprovider_test.go
@@ -1,0 +1,200 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	ReleaseImage1       = "quay.io/openshift-release-dev/ocp-release@sha256:1a101ef5215da468cea8bd2eb47114e85b2b64a6b230d5882f845701f55d057f"
+	ReleaseImage2       = "quay.io/openshift-release-dev/ocp-release:4.11.0-0.nightly-multi-2022-07-12-131716"
+	ManifestMediaType   = "application/vnd.docker.distribution.manifest.v2+json"
+	LinuxOS             = "linux"
+	ArchitectureAMD64   = "amd64"
+	ArchitectureS390X   = "s390x"
+	ArchitecturePPC64LE = "ppc64le"
+	ArchitectureARM64   = "arm64"
+)
+
+func TestFindMatchingManifest(t *testing.T) {
+	deserializedManifestList1 := &manifestlist.DeserializedManifestList{
+		ManifestList: manifestlist.ManifestList{
+			Manifests: []manifestlist.ManifestDescriptor{
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitectureAMD64,
+						OS:           LinuxOS,
+					},
+				},
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:f8dcd1dadc68b85ccf8737067f73fc03b0f6a1d81633fbdcdde2e3b5bc804d6a",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitectureS390X,
+						OS:           LinuxOS,
+					},
+				},
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:a46358bdcf31d39c23e7389e8b75d1e5efa7181cca8832e51697b6bb3470e4a5",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitecturePPC64LE,
+						OS:           LinuxOS,
+					},
+				},
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:4fe15a54f144d0200a39a93e2dc97b8b0e989e95cc076acbe2dfe129d0c04831",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitectureARM64,
+						OS:           LinuxOS,
+					},
+				},
+			},
+		},
+	}
+
+	deserializedManifestList2 := &manifestlist.DeserializedManifestList{
+		ManifestList: manifestlist.ManifestList{
+			Manifests: []manifestlist.ManifestDescriptor{
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:b593c6882f9c8d9d75f3d200fa3e02f7f8caa99cea595fd70bbdd495613fd23f",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitectureAMD64,
+						OS:           LinuxOS,
+					},
+				},
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:be53e6c50f1c97b4b34b341fada995f1e0c6c5e8305f3f373b9356ba82cc3d22",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitectureS390X,
+						OS:           LinuxOS,
+					},
+				},
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:a0f3d715a8947e45bdc9c9d2c1fcdccf8da6b216cb6efc38d75cec49a56f074b",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitecturePPC64LE,
+						OS:           LinuxOS,
+					},
+				},
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:f1c97cf57c57757fcd6d4314ff4b4cc792b27b904e949b840f902c104f1acf38",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitectureARM64,
+						OS:           LinuxOS,
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		testName                 string
+		releaseImage             string
+		deserializedManifestList *manifestlist.DeserializedManifestList
+		osToFind                 string
+		archToFind               string
+		expectedImageRef         string
+	}{
+		{
+			testName:                 "Find linux/amd64 in multi-arch ReleaseImage1",
+			releaseImage:             ReleaseImage1,
+			deserializedManifestList: deserializedManifestList1,
+			osToFind:                 LinuxOS,
+			archToFind:               ArchitectureAMD64,
+			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
+		},
+		{
+			testName:                 "Find linux/arm64 in multi-arch ReleaseImage1",
+			releaseImage:             ReleaseImage1,
+			deserializedManifestList: deserializedManifestList1,
+			osToFind:                 LinuxOS,
+			archToFind:               ArchitectureARM64,
+			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:4fe15a54f144d0200a39a93e2dc97b8b0e989e95cc076acbe2dfe129d0c04831",
+		},
+		{
+			testName:                 "Find linux/ppc64le in multi-arch ReleaseImage1",
+			releaseImage:             ReleaseImage1,
+			deserializedManifestList: deserializedManifestList1,
+			osToFind:                 LinuxOS,
+			archToFind:               ArchitecturePPC64LE,
+			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:a46358bdcf31d39c23e7389e8b75d1e5efa7181cca8832e51697b6bb3470e4a5",
+		},
+		{
+			testName:                 "Find linux/s390x in multi-arch ReleaseImage1",
+			releaseImage:             ReleaseImage1,
+			deserializedManifestList: deserializedManifestList1,
+			osToFind:                 LinuxOS,
+			archToFind:               ArchitectureS390X,
+			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:f8dcd1dadc68b85ccf8737067f73fc03b0f6a1d81633fbdcdde2e3b5bc804d6a",
+		},
+		{
+			testName:                 "Find linux/amd64 in multi-arch ReleaseImage2",
+			releaseImage:             ReleaseImage2,
+			deserializedManifestList: deserializedManifestList2,
+			osToFind:                 LinuxOS,
+			archToFind:               ArchitectureAMD64,
+			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:b593c6882f9c8d9d75f3d200fa3e02f7f8caa99cea595fd70bbdd495613fd23f",
+		},
+		{
+			testName:                 "Find linux/arm64 in multi-arch ReleaseImage2",
+			releaseImage:             ReleaseImage2,
+			deserializedManifestList: deserializedManifestList2,
+			osToFind:                 LinuxOS,
+			archToFind:               ArchitectureARM64,
+			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:f1c97cf57c57757fcd6d4314ff4b4cc792b27b904e949b840f902c104f1acf38",
+		},
+		{
+			testName:                 "Find linux/ppc64le in multi-arch ReleaseImage2",
+			releaseImage:             ReleaseImage2,
+			deserializedManifestList: deserializedManifestList2,
+			osToFind:                 LinuxOS,
+			archToFind:               ArchitecturePPC64LE,
+			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:a0f3d715a8947e45bdc9c9d2c1fcdccf8da6b216cb6efc38d75cec49a56f074b",
+		},
+		{
+			testName:                 "Find linux/s390x in multi-arch ReleaseImage2",
+			releaseImage:             ReleaseImage2,
+			deserializedManifestList: deserializedManifestList2,
+			osToFind:                 LinuxOS,
+			archToFind:               ArchitectureS390X,
+			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:be53e6c50f1c97b4b34b341fada995f1e0c6c5e8305f3f373b9356ba82cc3d22",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			g := NewWithT(t)
+
+			imageRef, err := findMatchingManifest(tc.releaseImage, tc.deserializedManifestList, tc.osToFind, tc.archToFind)
+			g.Expect(err).To(BeNil())
+			g.Expect(imageRef).To(Equal(tc.expectedImageRef))
+		})
+	}
+}

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -12,7 +12,9 @@ import (
 	"regexp"
 
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/registry/client/transport"
+	"github.com/opencontainers/go-digest"
 	"k8s.io/client-go/rest"
 
 	dockerarchive "github.com/openshift/hypershift/support/thirdparty/docker/pkg/archive"
@@ -20,6 +22,13 @@ import (
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/registryclient"
 	"github.com/openshift/hypershift/support/thirdparty/oc/pkg/cli/image/manifest"
 	"github.com/openshift/hypershift/support/thirdparty/oc/pkg/cli/image/manifest/dockercredentials"
+)
+
+const (
+	ArchitectureAMD64   = "amd64"
+	ArchitectureS390X   = "s390x"
+	ArchitecturePPC64LE = "ppc64le"
+	ArchitectureARM64   = "arm64"
 )
 
 // ExtractImageFiles extracts a list of files from a registry image given the image reference, pull secret and the
@@ -223,6 +232,24 @@ func ExtractImageFilesToDir(ctx context.Context, imageRef string, pullSecret []b
 }
 
 func getMetadata(ctx context.Context, imageRef string, pullSecret []byte) ([]distribution.Descriptor, distribution.BlobStore, error) {
+	repo, ref, err := GetRepoSetup(ctx, imageRef, pullSecret)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to repo setup: %w", err)
+	}
+	firstManifest, location, err := manifest.FirstManifest(ctx, *ref, repo)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to obtain root manifest for %s: %w", imageRef, err)
+	}
+	_, layers, err := manifest.ManifestToImageConfig(ctx, firstManifest, repo.Blobs(ctx), location)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to obtain image layers for %s: %w", imageRef, err)
+	}
+	return layers, repo.Blobs(ctx), nil
+}
+
+// GetRepoSetup connects to a repo and pulls the imageRef's docker image information from the repo. Returns the repo and the docker image.
+func GetRepoSetup(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Repository, *reference.DockerImageReference, error) {
+	var dockerImageRef *reference.DockerImageReference
 	rt, err := rest.TransportFor(&rest.Config{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create secure transport: %w", err)
@@ -239,6 +266,7 @@ func getMetadata(ctx context.Context, imageRef string, pullSecret []byte) ([]dis
 		WithRequestModifiers(transport.NewHeaderRequestModifier(http.Header{http.CanonicalHeaderKey("User-Agent"): []string{rest.DefaultKubernetesUserAgent()}}))
 
 	ref, err := reference.Parse(imageRef)
+	dockerImageRef = &ref
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
 	}
@@ -246,13 +274,75 @@ func getMetadata(ctx context.Context, imageRef string, pullSecret []byte) ([]dis
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create repository client for %s: %w", ref.DockerClientDefaults().RegistryURL(), err)
 	}
-	firstManifest, location, err := manifest.FirstManifest(ctx, ref, repo)
+	return repo, dockerImageRef, nil
+}
+
+// GetManifest gets the manifest from an image
+func GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error) {
+	repo, ref, err := GetRepoSetup(ctx, imageRef, pullSecret)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to obtain root manifest for %s: %w", imageRef, err)
+		return nil, err
 	}
-	_, layers, err := manifest.ManifestToImageConfig(ctx, firstManifest, repo.Blobs(ctx), location)
+
+	var srcDigest digest.Digest
+	if len(ref.Tag) > 0 {
+		desc, err := repo.Tags(ctx).Get(ctx, ref.Tag)
+		if err != nil {
+			return nil, err
+		}
+		srcDigest = desc.Digest
+	}
+
+	if len(ref.ID) > 0 {
+		srcDigest = digest.Digest(ref.ID)
+	}
+
+	manifests, err := repo.Manifests(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to obtain image layers for %s: %w", imageRef, err)
+		return nil, err
 	}
-	return layers, repo.Blobs(ctx), nil
+
+	digestsManifest, err := manifests.Get(ctx, srcDigest, manifest.PreferManifestList)
+	if err != nil {
+		return nil, err
+	}
+
+	return digestsManifest, nil
+}
+
+// IsMultiArchManifestList determines whether an image is a manifest listed image and contains manifests the following processor architectures: amd64, arm64, s390x, ppc64le
+func IsMultiArchManifestList(ctx context.Context, imageRef string, pullSecret []byte) (bool, error) {
+	srcManifest, err := GetManifest(ctx, imageRef, pullSecret)
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
+	}
+
+	mediaType, payload, err := srcManifest.Payload()
+	if err != nil {
+		return false, fmt.Errorf("failed to get payload %s: %w", imageRef, err)
+	}
+
+	// mediaType for manifest listed (aka fat manifest) images is either 'application/vnd.docker.distribution.manifest.list.v2+json' per the docker documentation - https://docs.docker.com/registry/spec/manifest-v2-2/
+	// or 'application/vnd.oci.image.index.v1+json' per https://github.com/opencontainers/image-spec/blob/main/media-types.md
+	if mediaType != "application/vnd.docker.distribution.manifest.list.v2+json" && mediaType != "application/vnd.oci.image.index.v1+json" {
+		return false, nil
+	}
+
+	deserializedManifestList := new(manifestlist.DeserializedManifestList)
+	if err = deserializedManifestList.UnmarshalJSON(payload); err != nil {
+		return false, fmt.Errorf("failed to get unmarshalled manifest list: %w", err)
+	}
+
+	count := 0
+	for _, arch := range deserializedManifestList.ManifestList.Manifests {
+		switch arch.Platform.Architecture {
+		case ArchitectureAMD64, ArchitectureS390X, ArchitecturePPC64LE, ArchitectureARM64:
+			count = count + 1
+		}
+	}
+
+	if count > 1 {
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Handles manifest listed images and extracts correct mco image based on the managed cluster's arch. This allows you to create HyperShift hosted control planes on other architectures other than AMD64.

**Which issue(s) this PR fixes** :
Fixes [ARMOCP-441](https://issues.redhat.com//browse/ARMOCP-441)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.