### PR TITLE
Add PowerVS OVN Kube routing config

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
@@ -45,7 +45,18 @@ func ReconcileNetworkOperator(network *operatorv1.Network, networkType hyperv1.N
 				network.Spec.DefaultNetwork.OVNKubernetesConfig.GenevePort = &port
 			}
 		}
-
+	case hyperv1.PowerVSPlatform:
+		if networkType == hyperv1.OVNKubernetes {
+			if network.Spec.DefaultNetwork.OVNKubernetesConfig == nil {
+				network.Spec.DefaultNetwork.OVNKubernetesConfig = &operatorv1.OVNKubernetesConfig{}
+			}
+			// Default shared routing causes egress traffic to use OVN routes, to use the routes present in host, need to use host routing
+			// BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1996108
+			if network.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig == nil {
+				network.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig = &operatorv1.GatewayConfig{}
+			}
+			network.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig.RoutingViaHost = true
+		}
 	default:
 		// do nothing
 	}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Fixes https://issues.redhat.com/browse/MULTIARCH-2631
Trying to add routing config for OVN Kube CNI for PowerVS platform 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.