### PR TITLE
Make zone spread only apply within a given revision

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -180,7 +180,7 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}
 
-	deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
+	deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
 	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	deploymentConfig.ApplyTo(deployment)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
@@ -24,11 +24,14 @@ var (
 			cpcVolumeKubeconfig().Name:  "/etc/kubernetes/secrets/svc-kubeconfig",
 		},
 	}
-	clusterPolicyControllerLabels = map[string]string{
+)
+
+func clusterPolicyControllerLabels() map[string]string {
+	return map[string]string{
 		"app":                         "cluster-policy-controller",
 		hyperv1.ControlPlaneComponent: "cluster-policy-controller",
 	}
-)
+}
 
 func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, image string, deploymentConfig config.DeploymentConfig, availabilityProberImage string, apiServerPort *int32) error {
 	// preserve existing resource requirements for main CPC container
@@ -46,10 +49,10 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	}
 	if deployment.Spec.Selector == nil {
 		deployment.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: clusterPolicyControllerLabels,
+			MatchLabels: clusterPolicyControllerLabels(),
 		}
 	}
-	deployment.Spec.Template.ObjectMeta.Labels = clusterPolicyControllerLabels
+	deployment.Spec.Template.ObjectMeta.Labels = clusterPolicyControllerLabels()
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{
 		util.BuildContainer(cpcContainerMain(), buildOCMContainerMain(image)),
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -42,7 +42,7 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, images ma
 	}
 
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, clusterPolicyControllerLabels, nil)
+	params.DeploymentConfig.SetDefaults(hcp, nil)
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	params.OwnerRef = config.OwnerRefFrom(hcp)

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -101,7 +101,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	if util.IsPrivateHCP(hcp) {
 		p.APIServerAddress = fmt.Sprintf("api.%s.hypershift.local", hcp.Name)

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
@@ -79,7 +79,7 @@ func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.Host
 	}
 
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
+	params.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return params

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -164,24 +164,27 @@ var (
 			hccVolumeClusterSignerCA().Name: "/etc/kubernetes/cluster-signer-ca",
 		},
 	}
-	hccLabels = map[string]string{
+)
+
+func hccLabels() map[string]string {
+	return map[string]string{
 		"app":                         "hosted-cluster-config-operator",
 		hyperv1.ControlPlaneComponent: "hosted-cluster-config-operator",
 	}
-)
+}
 
 func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, config *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, additionalTrustBundle *corev1.LocalObjectReference) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
-			MatchLabels: hccLabels,
+			MatchLabels: hccLabels(),
 		},
 		Strategy: appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: hccLabels,
+				Labels: hccLabels(),
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -45,7 +45,7 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane, images map[string]string, set
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return p

--- a/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
@@ -66,7 +66,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	}
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return p

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -46,7 +46,7 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *E
 	}
 	p.DeploymentConfig.AdditionalLabels[hyperv1.ControlPlaneComponent] = "etcd"
 	p.DeploymentConfig.Scheduling.PriorityClass = config.EtcdPriorityClass
-	p.DeploymentConfig.SetDefaults(hcp, etcdPodSelector(), nil)
+	p.DeploymentConfig.SetDefaults(hcp, nil)
 
 	if hcp.Spec.Etcd.Managed == nil {
 		hcp.Spec.Etcd.Managed = &hyperv1.ManagedEtcdSpec{

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -245,17 +245,20 @@ func ReconcileIgnitionServer(ctx context.Context,
 		if ignitionServerDeployment.Annotations == nil {
 			ignitionServerDeployment.Annotations = map[string]string{}
 		}
-		ignitionServerLabels := map[string]string{
-			"app":                         ignitionserver.ResourceName,
-			hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
+		ignitionServerLabels := func() map[string]string {
+			return map[string]string{
+				"app":                         ignitionserver.ResourceName,
+				hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
+				"hypershift.openshift.io/hosted-control-plane": hcp.Namespace,
+			}
 		}
 		ignitionServerDeployment.Spec = appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: ignitionServerLabels,
+				MatchLabels: ignitionServerLabels(),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: ignitionServerLabels,
+					Labels: ignitionServerLabels(),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            sa.Name,
@@ -369,7 +372,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 		deploymentConfig := config.DeploymentConfig{}
 		deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 		deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-		deploymentConfig.SetDefaults(hcp, ignitionServerLabels, nil)
+		deploymentConfig.SetDefaults(hcp, nil)
 		deploymentConfig.ApplyTo(ignitionServerDeployment)
 
 		return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -76,7 +76,7 @@ func PrivateRouterConfig(hcp *hyperv1.HostedControlPlane, setDefaultSecurityCont
 		},
 	}
 	cfg.Scheduling.PriorityClass = config.APICriticalPriorityClass
-	cfg.SetDefaults(hcp, privateRouterLabels(), nil)
+	cfg.SetDefaults(hcp, nil)
 	cfg.SetRestartAnnotation(hcp.ObjectMeta)
 	cfg.SetDefaultSecurityContext = setDefaultSecurityContext
 	return cfg

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -49,7 +49,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	}
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	p.DeploymentConfig.ReadinessProbes = config.ReadinessProbes{
 		ingressOperatorContainerName: {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -299,7 +299,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	params.OwnerRef = config.OwnerRefFrom(hcp)
 
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, kasLabels(), nil)
+	params.DeploymentConfig.SetDefaults(hcp, nil)
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return params

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -99,7 +99,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 			},
 		},
 	}
-	params.DeploymentConfig.SetDefaults(hcp, kcmLabels(), nil)
+	params.DeploymentConfig.SetDefaults(hcp, nil)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	switch hcp.Spec.Platform.Type {

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -75,7 +75,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 		},
 	}
 	p.ServerDeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
-	p.ServerDeploymentConfig.SetDefaults(hcp, nil, pointer.Int(1))
+	p.ServerDeploymentConfig.SetDefaults(hcp, pointer.Int(1))
 	p.ServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	p.AgentDeploymentConfig.Resources = config.ResourcesSpec{
@@ -105,7 +105,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	}
 
 	p.AgentDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.AgentDeploymentConfig.SetDefaults(hcp, konnectivityAgentLabels(), nil)
+	p.AgentDeploymentConfig.SetDefaults(hcp, nil)
 	p.AgentDeamonSetConfig.Resources = config.ResourcesSpec{
 		konnectivityAgentContainer().Name: {
 			Requests: corev1.ResourceList{

--- a/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
@@ -208,7 +208,7 @@ func ReconcileMachineApproverDeployment(deployment *appsv1.Deployment, hcp *hype
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}
 
-	deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
+	deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
 	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	deploymentConfig.ApplyTo(deployment)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -43,7 +43,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	}
 
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
-	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -106,7 +106,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig
 		},
 	}
 	params.OpenShiftAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.OpenShiftAPIServerDeploymentConfig.SetDefaults(hcp, openShiftAPIServerLabels(), nil)
+	params.OpenShiftAPIServerDeploymentConfig.SetDefaults(hcp, nil)
 
 	params.OpenShiftOAuthAPIServerDeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
@@ -157,7 +157,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.OpenShiftOAuthAPIServerDeploymentConfig.SetDefaults(hcp, openShiftOAuthAPIServerLabels(), nil)
+	params.OpenShiftOAuthAPIServerDeploymentConfig.SetDefaults(hcp, nil)
 	switch hcp.Spec.Etcd.ManagementType {
 	case hyperv1.Unmanaged:
 		params.EtcdURL = hcp.Spec.Etcd.Unmanaged.Endpoint

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -134,7 +134,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, images map[string]str
 			SuccessThreshold:    1,
 		},
 	}
-	p.DeploymentConfig.SetDefaults(hcp, oauthServerLabels, nil)
+	p.DeploymentConfig.SetDefaults(hcp, nil)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	p.OauthConfigOverrides = map[string]*ConfigOverride{}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -50,7 +50,7 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, observ
 		},
 	}
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, openShiftControllerManagerLabels(), nil)
+	params.DeploymentConfig.SetDefaults(hcp, nil)
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	params.OwnerRef = config.OwnerRefFrom(hcp)

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
@@ -7,11 +7,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var packageServerLabels = map[string]string{
-	"app":                         "packageserver",
-	hyperv1.ControlPlaneComponent: "packageserver",
-}
-
 type OperatorLifecycleManagerParams struct {
 	CLIImage                string
 	OLMImage                string
@@ -42,7 +37,7 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images m
 		},
 	}
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, nil, pointer.Int(1))
+	params.DeploymentConfig.SetDefaults(hcp, pointer.Int(1))
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	params.PackageServerConfig = config.DeploymentConfig{
@@ -50,7 +45,7 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images m
 			PriorityClass: config.APICriticalPriorityClass,
 		},
 	}
-	params.PackageServerConfig.SetDefaults(hcp, packageServerLabels, nil)
+	params.PackageServerConfig.SetDefaults(hcp, nil)
 	params.PackageServerConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.PackageServerConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -166,7 +166,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 			},
 		},
 	}
-	params.deploymentConfig.SetDefaults(hcp, selectorLabels(), pointer.Int(1))
+	params.deploymentConfig.SetDefaults(hcp, pointer.Int(1))
 	params.deploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	return params
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         hypershift.openshift.io/hosted-control-plane: test-namespace
+        hypershift.openshift.io/pod-template-hash: 589fffdd76
         name: cluster-image-registry-operator
     spec:
       affinity:
@@ -47,6 +48,14 @@ spec:
                   hypershift.openshift.io/hosted-control-plane: test-namespace
               topologyKey: kubernetes.io/hostname
             weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                hypershift.openshift.io/hosted-control-plane: test-namespace
+                hypershift.openshift.io/pod-template-hash: 589fffdd76
+                name: cluster-image-registry-operator
+            topologyKey: topology.kubernetes.io/zone
       automountServiceAccountToken: false
       containers:
       - args:

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -78,7 +78,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			TimeoutSeconds:      5,
 		},
 	}
-	params.DeploymentConfig.SetDefaults(hcp, labels, nil)
+	params.DeploymentConfig.SetDefaults(hcp, nil)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.SetDefaultSecurityContext = setDefaultSecurityContext
 	params.DisableProfiling = util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], manifests.SchedulerDeployment("").Name)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/cmca/configmap_observer.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/cmca/configmap_observer.go
@@ -119,6 +119,9 @@ func (r *ManagedCAObserver) ensureAnnotationOnDeployment(ctx context.Context, de
 	}
 	deployment.Spec.Template.ObjectMeta.Annotations["ca-checksum"] = hash
 
+	// Reset this, the CPO will instanntly update the deployment with a new checksum
+	deployment.Spec.Template.Spec.Affinity = nil
+
 	_, err = r.Client.AppsV1().Deployments(r.Namespace).Update(ctx, deployment, metav1.UpdateOptions{})
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/clarketm/json v1.14.1
 	github.com/coreos/ignition/v2 v2.10.1
+	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/go-logr/logr v1.2.1
 	github.com/go-logr/zapr v1.2.0
@@ -93,7 +94,6 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/coreos/vcontext v0.0.0-20210407161507-4ee6c745c8bd // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1704,7 +1704,7 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, cre
 			SetDefaultSecurityContext: r.SetDefaultSecurityContext,
 		}
 
-		deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
+		deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
 		deploymentConfig.ApplyTo(deployment)
 
 		return nil
@@ -2135,7 +2135,7 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}
 
-	deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
+	deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
 	deploymentConfig.ApplyTo(deployment)
 	deploymentConfig.SetRestartAnnotation(hc.ObjectMeta)
 	return nil
@@ -2478,7 +2478,7 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}
 
-	deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
+	deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
 	deploymentConfig.ApplyTo(deployment)
 	deploymentConfig.SetRestartAnnotation(hc.ObjectMeta)
 	return nil

--- a/support/config/deployment_test.go
+++ b/support/config/deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,12 +52,8 @@ func TestSetReleaseImageAnnotation(t *testing.T) {
 }
 
 func TestSetMultizoneSpread(t *testing.T) {
-	labels := map[string]string{
-		"app":                         "etcd",
-		hyperv1.ControlPlaneComponent: "etcd",
-	}
 	cfg := &DeploymentConfig{}
-	cfg.setMultizoneSpread(labels)
+	cfg.setMultizoneSpread(&corev1.PodTemplateSpec{})
 	if cfg.Scheduling.Affinity == nil {
 		t.Fatalf("Expecting affinity to be set on config")
 	}
@@ -65,12 +62,14 @@ func TestSetMultizoneSpread(t *testing.T) {
 	}
 	expectedTerm := corev1.PodAffinityTerm{
 		LabelSelector: &metav1.LabelSelector{
-			MatchLabels: labels,
+			MatchLabels: map[string]string{
+				"hypershift.openshift.io/pod-template-hash": "5d8d888c4d",
+			},
 		},
 		TopologyKey: corev1.LabelTopologyZone,
 	}
-	if !reflect.DeepEqual(expectedTerm, cfg.Scheduling.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]) {
-		t.Fatalf("Unexpected anti-affinity term")
+	if diff := cmp.Diff(cfg.Scheduling.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0], expectedTerm); diff != "" {
+		t.Fatalf("actual antiaffinity differs from expected: %s", diff)
 	}
 }
 
@@ -182,13 +181,9 @@ func TestSetLocation(t *testing.T) {
 	cfg := &DeploymentConfig{
 		Replicas: 2,
 	}
-	labels := map[string]string{
-		"app":                         "test",
-		hyperv1.ControlPlaneComponent: "test",
-	}
 
 	g := NewGomegaWithT(t)
-	cfg.setLocation(hcp, labels)
+	cfg.setLocation(hcp)
 
 	expected := &DeploymentConfig{
 		Scheduling: Scheduling{
@@ -269,17 +264,4 @@ func TestSetLocation(t *testing.T) {
 	}
 	g.Expect(expected.Scheduling.Affinity.PodAffinity).To(BeEquivalentTo(cfg.Scheduling.Affinity.PodAffinity))
 	g.Expect(expected.AdditionalLabels).To(BeEquivalentTo(cfg.AdditionalLabels))
-
-	// setMultizoneSpread expectations. PodAntiAffinity.
-	expected.Scheduling.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-			{
-				TopologyKey: corev1.LabelTopologyZone,
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: labels,
-				},
-			},
-		},
-	}
-	g.Expect(expected.Scheduling.Affinity.PodAntiAffinity).To(BeEquivalentTo(cfg.Scheduling.Affinity.PodAntiAffinity))
 }

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -96,7 +96,10 @@ func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, op
 	t.Cleanup(func() { EnsureAllContainersHavePullPolicyIfNotPresent(t, context.Background(), client, hc) })
 	t.Cleanup(func() { EnsureHCPContainersHaveResourceRequests(t, context.Background(), client, hc) })
 	t.Cleanup(func() { EnsureNoPodsWithTooHighPriority(t, context.Background(), client, hc) })
-	t.Cleanup(func() { NoticePreemptionOrFailedScheduling(t, context.Background(), client, hc) })
+	// TODO @alvaroaleman: Remove once the scheduling fixes are in a promoted payload
+	if !strings.Contains(t.Name(), "UpgradeControlPlane") {
+		t.Cleanup(func() { NoticePreemptionOrFailedScheduling(t, context.Background(), client, hc) })
+	}
 	t.Cleanup(func() { EnsureAllRoutesUseHCPRouter(t, context.Background(), client, hc) })
 
 	return hc

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -368,8 +368,24 @@ func NoticePreemptionOrFailedScheduling(t *testing.T, ctx context.Context, clien
 		}
 		for _, event := range eventList.Items {
 			if event.Reason == "FailedScheduling" || event.Reason == "Preempted" {
+				// TestHAEtcdChaos causes errors like
+				// "binding rejected: running Bind plugin "DefaultBinder": Operation cannot be fulfilled on pods "etcd-2": StorageError: invalid object, Code: 4, Key: /kubernetes.io/pods/e2e-clusters-vwckx-example-66phb/etcd-2, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: c75c414d-afeb-4f06-bf30-818e7dc0c603, UID in object meta: 0b97dda4-9fc8-4a79-bbb1-96da1dabaa3d"
+				// which presumbaly is caused by cache staleness in the scheduler, so just ignore those
+				if strings.Contains(event.Message, "AdditionalErrorMsg: Precondition failed: UID in precondition") {
+					continue
+				}
+				// Ignore sporadically observed errors like this one:
+				// 'error: observed FailedScheduling or Preempted event for pod etcd-0: running PreBind plugin "VolumeBinding": binding volumes: pod does not exist any more: pod "etcd-0" not found'
+				if strings.Contains(event.Message, `running PreBind plugin "VolumeBinding": binding volumes: pod does not exist any more: pod`) {
+					continue
+				}
+				// Ignore sporadic errors like this one:
+				// 'binding rejected: running Bind plugin "DefaultBinder": Operation cannot be fulfilled on pods/binding "etcd-0": pod etcd-0 is being deleted, cannot be assigned to a host'
+				if strings.Contains(event.Message, `is being deleted, cannot be assigned to a host`) {
+					continue
+				}
 				// "error: " is to trigger prow syntax highlight in prow
-				t.Logf("error: non-fatal, observed FailedScheduling or Preempted event: %s", event.Message)
+				t.Errorf("error: observed FailedScheduling or Preempted event for pod %s: %s", event.InvolvedObject.Name, event.Message)
 			}
 		}
 	})


### PR DESCRIPTION
We currently apply zone spread for all revisions for a given workload.
This means that a new revision can only be rolled out after a replica of
the old revision was removed.

This PR fixes that by:
* Moving the calculation of the zone spread affinity into the ApplyTo
  funcs
* Calculating a hash of the podTemplate there
* Applying a label to the pod with that hash
* Using all pod labels including the one with the hash in the
  AntiAffinity rule

As a sideeffect, this removes the requirement to know the pods labels by
the time DeploymentConfig.SetDefaults() is called. In many cases, they
weren't known by that time so it was called with a nil labelmap, which
resulted in the Zone spread code being short-circuited. With this
change, everything that calls SetDefaults and has more than one replica
will get the zone spread, as it is makes sense for all components.

I manually verified that with this change and a
sufficiently-sized management cluster, a HA controlplane upgrade results
in zero failed scheduling events.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
ref https://issues.redhat.com/browse/HOSTEDCP-518


**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.