### PR TITLE
Add Kubevirt Cloud Controller Manager

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/manifests.go
@@ -1,0 +1,71 @@
+package kubevirt
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CCMServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMRole(ns string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMRoleBinding(ns string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-cloud-config",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMContainer() *corev1.Container {
+	return &corev1.Container{
+		Name: "cloud-controller-manager",
+	}
+}
+
+func ccmVolumeKubeconfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "kubeconfig",
+	}
+}
+
+func ccmCloudConfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cloud-config",
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/providerconfig.go
@@ -1,0 +1,53 @@
+package kubevirt
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	CloudConfigKey = "cloud-config"
+)
+
+// Cloud Config is a copy of the relevant subset of the upstream type
+// at https://github.com/kubevirt/cloud-provider-kubevirt/blob/main/pkg/provider/cloud.go
+type CloudConfig struct {
+	Kubeconfig   string             `yaml:"kubeconfig"`
+	LoadBalancer LoadBalancerConfig `yaml:"loadBalancer"`
+	InstancesV2  InstancesV2Config  `yaml:"instancesV2"`
+	Namespace    string             `yaml:"namespace"`
+}
+
+type LoadBalancerConfig struct {
+	// Enabled activates the load balancer interface of the CCM
+	Enabled bool `yaml:"enabled"`
+	// CreationPollInterval determines how many seconds to wait for the load balancer creation
+	CreationPollInterval int `yaml:"creationPollInterval"`
+}
+
+type InstancesV2Config struct {
+	// Enabled activates the instances interface of the CCM
+	Enabled bool `yaml:"enabled"`
+	// ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider
+	ZoneAndRegionEnabled bool `yaml:"zoneAndRegionEnabled"`
+}
+
+func (c *CloudConfig) serialize() (string, error) {
+	out, err := yaml.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func cloudConfig(namespace string) CloudConfig {
+	return CloudConfig{
+		LoadBalancer: LoadBalancerConfig{
+			Enabled: true,
+		},
+		InstancesV2: InstancesV2Config{
+			Enabled:              true,
+			ZoneAndRegionEnabled: false,
+		},
+		Namespace: namespace,
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
@@ -1,0 +1,199 @@
+package kubevirt
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ReconcileCloudConfig(cm *corev1.ConfigMap, hcp *hyperv1.HostedControlPlane) error {
+	cfg := cloudConfig(hcp.Namespace)
+	serializedCfg, err := cfg.serialize()
+	if err != nil {
+		return fmt.Errorf("failed to serialize cloudconfig: %w", err)
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data[CloudConfigKey] = string(serializedCfg)
+
+	return nil
+}
+
+func ReconcileCCMServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sa)
+	return nil
+}
+
+func ReconcileCCMRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(role)
+	role.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"kubevirt.io"},
+			Resources: []string{"virtualmachines"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{"kubevirt.io"},
+			Resources: []string{"virtualmachineinstances"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"update",
+			},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"services"},
+			Verbs:     []string{rbacv1.VerbAll},
+		},
+	}
+	return nil
+}
+
+func ReconcileCCMRoleBinding(roleBinding *rbacv1.RoleBinding, ownerRef config.OwnerRef, sa *corev1.ServiceAccount, role *rbacv1.Role) error {
+	ownerRef.ApplyTo(roleBinding)
+	roleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "Role",
+		Name:     role.Name,
+	}
+	roleBinding.Subjects = []rbacv1.Subject{
+		{
+			Namespace: sa.Namespace,
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      sa.Name,
+		},
+	}
+	return nil
+}
+
+func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, serviceAccountName string, releaseImage *releaseinfo.ReleaseImage) error {
+	clusterName, ok := hcp.Labels["cluster.x-k8s.io/cluster-name"]
+	if !ok {
+		return fmt.Errorf("\"cluster.x-k8s.io/cluster-name\" label doesn't exist in HostedControlPlane")
+	}
+	deploymentConfig := newDeploymentConfig()
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: ccmLabels(),
+		},
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: ccmLabels(),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					util.BuildContainer(CCMContainer(), buildCCMContainer(clusterName, releaseImage)),
+				},
+				Volumes:            []corev1.Volume{},
+				ServiceAccountName: serviceAccountName,
+			},
+		},
+	}
+
+	addVolumes(deployment)
+
+	config.OwnerRefFrom(hcp).ApplyTo(deployment)
+	deploymentConfig.ApplyTo(deployment)
+	return nil
+}
+
+func addVolumes(deployment *appsv1.Deployment) {
+
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmVolumeKubeconfig(), buildCCMVolumeKubeconfig),
+	)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmCloudConfig(), buildCCMCloudConfig),
+	)
+}
+
+func podVolumeMounts() util.PodVolumeMounts {
+	return util.PodVolumeMounts{
+		CCMContainer().Name: util.ContainerVolumeMounts{
+			ccmVolumeKubeconfig().Name: "/etc/kubernetes/kubeconfig",
+			ccmCloudConfig().Name:      "/etc/cloud",
+		},
+	}
+}
+
+func buildCCMContainer(clusterName string, releaseImage *releaseinfo.ReleaseImage) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = releaseImage.ComponentImages()["kubevirt-cloud-controller-manager"]
+		c.ImagePullPolicy = corev1.PullIfNotPresent
+		c.Command = []string{"/bin/kubevirt-cloud-controller-manager"}
+		c.Args = []string{
+			"--cloud-provider=kubevirt",
+			"--cloud-config=/etc/cloud/cloud-config",
+			"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+			"--authentication-skip-lookup",
+			"--cluster-name", clusterName,
+		}
+		c.VolumeMounts = podVolumeMounts().ContainerMounts(c.Name)
+	}
+}
+
+func buildCCMVolumeKubeconfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+	}
+}
+
+func buildCCMCloudConfig(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: CCMConfigMap("").Name,
+		},
+	}
+}
+
+func newDeploymentConfig() config.DeploymentConfig {
+	result := config.DeploymentConfig{}
+	result.Resources = config.ResourcesSpec{
+		CCMContainer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+				corev1.ResourceCPU:    resource.MustParse("75m"),
+			},
+		},
+	}
+	result.AdditionalLabels = additionalLabels()
+	result.Scheduling.PriorityClass = config.DefaultPriorityClass
+
+	result.Replicas = 1
+
+	return result
+}
+
+func ccmLabels() map[string]string {
+	return map[string]string{
+		"app": "cloud-controller-manager",
+	}
+}
+
+func additionalLabels() map[string]string {
+	return map[string]string{
+		hyperv1.ControlPlaneComponent: "cloud-controller-manager",
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2254,6 +2254,11 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 			Resources: []string{"customresourcedefinitions"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
+		{
+			APIGroups: []string{"kubevirt.io"},
+			Resources: []string{"virtualmachines", "virtualmachineinstances"},
+			Verbs:     []string{rbacv1.VerbAll},
+		},
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new External cloud provider for Kubevirt platform
This new controller is running in the management cluster, in the
controlplane namespace
The infrastructure used for this controller is the management cluster,
therefore as part of the deployment, creating special ServiceAccount
including very limited permissions inside the namespace (Services, VMs
and VMIs)
For more info about the Kubevirt-cloud-controller-manager see:
https://github.com/openshift/cloud-provider-kubevirt


**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.