### PR TITLE
Add nodepool create cmd for PowerVS

### DIFF
--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/cmd/nodepool/azure"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
 	"github.com/openshift/hypershift/cmd/nodepool/kubevirt"
+	"github.com/openshift/hypershift/cmd/nodepool/powervs"
 )
 
 // The following lines are needed in order to validate that any platform implementing PlatformOptions satisfy the interface
@@ -42,6 +43,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(agent.NewCreateCommand(opts))
 	cmd.AddCommand(azure.NewCreateCommand(opts))
+	cmd.AddCommand(powervs.NewCreateCommand(opts))
 
 	return cmd
 }

--- a/cmd/nodepool/powervs/create.go
+++ b/cmd/nodepool/powervs/create.go
@@ -1,0 +1,75 @@
+package powervs
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/cmd/log"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+)
+
+type PowerVSPlatformCreateOptions struct {
+	SysType    string
+	ProcType   string
+	Processors string
+	Memory     int32
+}
+
+func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "powervs",
+		Short:        "Creates an PowerVS nodepool",
+		SilenceUsage: true,
+	}
+	opts := &PowerVSPlatformCreateOptions{
+		SysType:    "s922",
+		ProcType:   "shared",
+		Processors: "0.5",
+		Memory:     32,
+	}
+
+	cmd.Flags().StringVar(&opts.SysType, "sys-type", opts.SysType, "System type used to host the instance(e.g: s922, e980, e880). Default is s922")
+	cmd.Flags().StringVar(&opts.ProcType, "proc-type", opts.ProcType, "Processor type (dedicated, shared, capped). Default is shared")
+	cmd.Flags().StringVar(&opts.Processors, "processors", opts.Processors, "Number of processors allocated. Default is 0.5")
+	cmd.Flags().Int32Var(&opts.Memory, "memory", opts.Memory, "Amount of memory allocated (in GB). Default is 32")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		if err := coreOpts.CreateNodePool(ctx, opts); err != nil {
+			log.Log.Error(err, "Failed to create nodepool")
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}
+
+func (o *PowerVSPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, client crclient.Client) error {
+	nodePool.Spec.Platform.Type = hyperv1.PowerVSPlatform
+	nodePool.Spec.Platform.PowerVS = &hyperv1.PowerVSNodePoolPlatform{
+		SystemType:    o.SysType,
+		Processors:    intstr.FromString(o.Processors),
+		ProcessorType: o.ProcType,
+		MemoryGiB:     o.Memory,
+	}
+	return nil
+}
+
+func (o PowerVSPlatformCreateOptions) Type() hyperv1.PlatformType {
+	return hyperv1.PowerVSPlatform
+}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Fixes https://issues.redhat.com/browse/MULTIARCH-2534

Adding support for node pool create command for PowerVS platform.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.