### PR TITLE
Revert "Make zone spread only apply within a given revision"

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -180,7 +180,7 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}
 
-	deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
+	deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
 	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	deploymentConfig.ApplyTo(deployment)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
@@ -24,14 +24,11 @@ var (
 			cpcVolumeKubeconfig().Name:  "/etc/kubernetes/secrets/svc-kubeconfig",
 		},
 	}
-)
-
-func clusterPolicyControllerLabels() map[string]string {
-	return map[string]string{
+	clusterPolicyControllerLabels = map[string]string{
 		"app":                         "cluster-policy-controller",
 		hyperv1.ControlPlaneComponent: "cluster-policy-controller",
 	}
-}
+)
 
 func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, image string, deploymentConfig config.DeploymentConfig, availabilityProberImage string, apiServerPort *int32) error {
 	// preserve existing resource requirements for main CPC container
@@ -49,10 +46,10 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	}
 	if deployment.Spec.Selector == nil {
 		deployment.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: clusterPolicyControllerLabels(),
+			MatchLabels: clusterPolicyControllerLabels,
 		}
 	}
-	deployment.Spec.Template.ObjectMeta.Labels = clusterPolicyControllerLabels()
+	deployment.Spec.Template.ObjectMeta.Labels = clusterPolicyControllerLabels
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{
 		util.BuildContainer(cpcContainerMain(), buildOCMContainerMain(image)),
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -42,7 +42,7 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, images ma
 	}
 
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, nil)
+	params.DeploymentConfig.SetDefaults(hcp, clusterPolicyControllerLabels, nil)
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	params.OwnerRef = config.OwnerRefFrom(hcp)

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -101,7 +101,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	if util.IsPrivateHCP(hcp) {
 		p.APIServerAddress = fmt.Sprintf("api.%s.hypershift.local", hcp.Name)

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
@@ -79,7 +79,7 @@ func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.Host
 	}
 
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
+	params.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return params

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -164,27 +164,24 @@ var (
 			hccVolumeClusterSignerCA().Name: "/etc/kubernetes/cluster-signer-ca",
 		},
 	}
-)
-
-func hccLabels() map[string]string {
-	return map[string]string{
+	hccLabels = map[string]string{
 		"app":                         "hosted-cluster-config-operator",
 		hyperv1.ControlPlaneComponent: "hosted-cluster-config-operator",
 	}
-}
+)
 
 func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, config *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, additionalTrustBundle *corev1.LocalObjectReference) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
-			MatchLabels: hccLabels(),
+			MatchLabels: hccLabels,
 		},
 		Strategy: appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: hccLabels(),
+				Labels: hccLabels,
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -45,7 +45,7 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane, images map[string]string, set
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return p

--- a/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
@@ -66,7 +66,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	}
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return p

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -46,7 +46,7 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *E
 	}
 	p.DeploymentConfig.AdditionalLabels[hyperv1.ControlPlaneComponent] = "etcd"
 	p.DeploymentConfig.Scheduling.PriorityClass = config.EtcdPriorityClass
-	p.DeploymentConfig.SetDefaults(hcp, nil)
+	p.DeploymentConfig.SetDefaults(hcp, etcdPodSelector(), nil)
 
 	if hcp.Spec.Etcd.Managed == nil {
 		hcp.Spec.Etcd.Managed = &hyperv1.ManagedEtcdSpec{

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -245,20 +245,17 @@ func ReconcileIgnitionServer(ctx context.Context,
 		if ignitionServerDeployment.Annotations == nil {
 			ignitionServerDeployment.Annotations = map[string]string{}
 		}
-		ignitionServerLabels := func() map[string]string {
-			return map[string]string{
-				"app":                         ignitionserver.ResourceName,
-				hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
-				"hypershift.openshift.io/hosted-control-plane": hcp.Namespace,
-			}
+		ignitionServerLabels := map[string]string{
+			"app":                         ignitionserver.ResourceName,
+			hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
 		}
 		ignitionServerDeployment.Spec = appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: ignitionServerLabels(),
+				MatchLabels: ignitionServerLabels,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: ignitionServerLabels(),
+					Labels: ignitionServerLabels,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            sa.Name,
@@ -372,7 +369,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 		deploymentConfig := config.DeploymentConfig{}
 		deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 		deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-		deploymentConfig.SetDefaults(hcp, nil)
+		deploymentConfig.SetDefaults(hcp, ignitionServerLabels, nil)
 		deploymentConfig.ApplyTo(ignitionServerDeployment)
 
 		return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -76,7 +76,7 @@ func PrivateRouterConfig(hcp *hyperv1.HostedControlPlane, setDefaultSecurityCont
 		},
 	}
 	cfg.Scheduling.PriorityClass = config.APICriticalPriorityClass
-	cfg.SetDefaults(hcp, nil)
+	cfg.SetDefaults(hcp, privateRouterLabels(), nil)
 	cfg.SetRestartAnnotation(hcp.ObjectMeta)
 	cfg.SetDefaultSecurityContext = setDefaultSecurityContext
 	return cfg

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -49,7 +49,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	}
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	p.DeploymentConfig.ReadinessProbes = config.ReadinessProbes{
 		ingressOperatorContainerName: {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -299,7 +299,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	params.OwnerRef = config.OwnerRefFrom(hcp)
 
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, nil)
+	params.DeploymentConfig.SetDefaults(hcp, kasLabels(), nil)
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return params

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -99,7 +99,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 			},
 		},
 	}
-	params.DeploymentConfig.SetDefaults(hcp, nil)
+	params.DeploymentConfig.SetDefaults(hcp, kcmLabels(), nil)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	switch hcp.Spec.Platform.Type {

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -75,7 +75,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 		},
 	}
 	p.ServerDeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
-	p.ServerDeploymentConfig.SetDefaults(hcp, pointer.Int(1))
+	p.ServerDeploymentConfig.SetDefaults(hcp, nil, pointer.Int(1))
 	p.ServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	p.AgentDeploymentConfig.Resources = config.ResourcesSpec{
@@ -105,7 +105,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	}
 
 	p.AgentDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	p.AgentDeploymentConfig.SetDefaults(hcp, nil)
+	p.AgentDeploymentConfig.SetDefaults(hcp, konnectivityAgentLabels(), nil)
 	p.AgentDeamonSetConfig.Resources = config.ResourcesSpec{
 		konnectivityAgentContainer().Name: {
 			Requests: corev1.ResourceList{

--- a/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
@@ -208,7 +208,7 @@ func ReconcileMachineApproverDeployment(deployment *appsv1.Deployment, hcp *hype
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}
 
-	deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
+	deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
 	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	deploymentConfig.ApplyTo(deployment)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -43,7 +43,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	}
 
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
-	p.DeploymentConfig.SetDefaults(hcp, utilpointer.IntPtr(1))
+	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -106,7 +106,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig
 		},
 	}
 	params.OpenShiftAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.OpenShiftAPIServerDeploymentConfig.SetDefaults(hcp, nil)
+	params.OpenShiftAPIServerDeploymentConfig.SetDefaults(hcp, openShiftAPIServerLabels(), nil)
 
 	params.OpenShiftOAuthAPIServerDeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
@@ -157,7 +157,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	params.OpenShiftOAuthAPIServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.OpenShiftOAuthAPIServerDeploymentConfig.SetDefaults(hcp, nil)
+	params.OpenShiftOAuthAPIServerDeploymentConfig.SetDefaults(hcp, openShiftOAuthAPIServerLabels(), nil)
 	switch hcp.Spec.Etcd.ManagementType {
 	case hyperv1.Unmanaged:
 		params.EtcdURL = hcp.Spec.Etcd.Unmanaged.Endpoint

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -134,7 +134,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, images map[string]str
 			SuccessThreshold:    1,
 		},
 	}
-	p.DeploymentConfig.SetDefaults(hcp, nil)
+	p.DeploymentConfig.SetDefaults(hcp, oauthServerLabels, nil)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	p.OauthConfigOverrides = map[string]*ConfigOverride{}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -50,7 +50,7 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, observ
 		},
 	}
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, nil)
+	params.DeploymentConfig.SetDefaults(hcp, openShiftControllerManagerLabels(), nil)
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	params.OwnerRef = config.OwnerRefFrom(hcp)

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
@@ -7,6 +7,11 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+var packageServerLabels = map[string]string{
+	"app":                         "packageserver",
+	hyperv1.ControlPlaneComponent: "packageserver",
+}
+
 type OperatorLifecycleManagerParams struct {
 	CLIImage                string
 	OLMImage                string
@@ -37,7 +42,7 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images m
 		},
 	}
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, pointer.Int(1))
+	params.DeploymentConfig.SetDefaults(hcp, nil, pointer.Int(1))
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	params.PackageServerConfig = config.DeploymentConfig{
@@ -45,7 +50,7 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, images m
 			PriorityClass: config.APICriticalPriorityClass,
 		},
 	}
-	params.PackageServerConfig.SetDefaults(hcp, nil)
+	params.PackageServerConfig.SetDefaults(hcp, packageServerLabels, nil)
 	params.PackageServerConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.PackageServerConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -166,7 +166,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 			},
 		},
 	}
-	params.deploymentConfig.SetDefaults(hcp, pointer.Int(1))
+	params.deploymentConfig.SetDefaults(hcp, selectorLabels(), pointer.Int(1))
 	params.deploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	return params
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -20,7 +20,6 @@ spec:
       creationTimestamp: null
       labels:
         hypershift.openshift.io/hosted-control-plane: test-namespace
-        hypershift.openshift.io/pod-template-hash: 589fffdd76
         name: cluster-image-registry-operator
     spec:
       affinity:
@@ -48,14 +47,6 @@ spec:
                   hypershift.openshift.io/hosted-control-plane: test-namespace
               topologyKey: kubernetes.io/hostname
             weight: 100
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                hypershift.openshift.io/hosted-control-plane: test-namespace
-                hypershift.openshift.io/pod-template-hash: 589fffdd76
-                name: cluster-image-registry-operator
-            topologyKey: topology.kubernetes.io/zone
       automountServiceAccountToken: false
       containers:
       - args:

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -78,7 +78,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			TimeoutSeconds:      5,
 		},
 	}
-	params.DeploymentConfig.SetDefaults(hcp, nil)
+	params.DeploymentConfig.SetDefaults(hcp, labels, nil)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.SetDefaultSecurityContext = setDefaultSecurityContext
 	params.DisableProfiling = util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], manifests.SchedulerDeployment("").Name)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/cmca/configmap_observer.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/cmca/configmap_observer.go
@@ -119,9 +119,6 @@ func (r *ManagedCAObserver) ensureAnnotationOnDeployment(ctx context.Context, de
 	}
 	deployment.Spec.Template.ObjectMeta.Annotations["ca-checksum"] = hash
 
-	// Reset this, the CPO will instanntly update the deployment with a new checksum
-	deployment.Spec.Template.Spec.Affinity = nil
-
 	_, err = r.Client.AppsV1().Deployments(r.Namespace).Update(ctx, deployment, metav1.UpdateOptions{})
 	return err
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -829,15 +829,7 @@ func (r *reconciler) reconcileKubeadminPasswordHashSecret(ctx context.Context, h
 		if oauthDeployment.Spec.Template.ObjectMeta.Annotations == nil {
 			oauthDeployment.Spec.Template.ObjectMeta.Annotations = map[string]string{}
 		}
-
-		// We need to conditionalize this to be able to clear the affinity only when we change the field
-		// to not start fighting with the CPO. See setMultizoneSpread in support/config for why
-		// we need to clear the affinity.
-		hash := secretHash(kubeadminPasswordHashSecret.Data["kubeadmin"])
-		if oauthDeployment.Spec.Template.ObjectMeta.Annotations[SecretHashAnnotation] != hash {
-			oauthDeployment.Spec.Template.ObjectMeta.Annotations[SecretHashAnnotation] = hash
-			oauthDeployment.Spec.Template.Spec.Affinity = nil
-		}
+		oauthDeployment.Spec.Template.ObjectMeta.Annotations[SecretHashAnnotation] = secretHash(kubeadminPasswordHashSecret.Data["kubeadmin"])
 		return nil
 	}); err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/clarketm/json v1.14.1
 	github.com/coreos/ignition/v2 v2.10.1
-	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/go-logr/logr v1.2.1
 	github.com/go-logr/zapr v1.2.0
@@ -94,6 +93,7 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/coreos/vcontext v0.0.0-20210407161507-4ee6c745c8bd // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1704,7 +1704,7 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, cre
 			SetDefaultSecurityContext: r.SetDefaultSecurityContext,
 		}
 
-		deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
+		deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
 		deploymentConfig.ApplyTo(deployment)
 
 		return nil
@@ -2135,7 +2135,7 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}
 
-	deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
+	deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
 	deploymentConfig.ApplyTo(deployment)
 	deploymentConfig.SetRestartAnnotation(hc.ObjectMeta)
 	return nil
@@ -2478,7 +2478,7 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}
 
-	deploymentConfig.SetDefaults(hcp, k8sutilspointer.Int(1))
+	deploymentConfig.SetDefaults(hcp, nil, k8sutilspointer.Int(1))
 	deploymentConfig.ApplyTo(deployment)
 	deploymentConfig.SetRestartAnnotation(hc.ObjectMeta)
 	return nil

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -1,12 +1,8 @@
 package config
 
 import (
-	"fmt"
-	"hash"
-	"hash/fnv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 )
@@ -38,16 +33,16 @@ const (
 )
 
 type DeploymentConfig struct {
-	Replicas                  int
-	Scheduling                Scheduling
-	AdditionalLabels          AdditionalLabels
-	AdditionalAnnotations     AdditionalAnnotations
-	SecurityContexts          SecurityContextSpec
-	SetDefaultSecurityContext bool
-	LivenessProbes            LivenessProbes
-	ReadinessProbes           ReadinessProbes
-	Resources                 ResourcesSpec
-	DebugDeployments          sets.String
+	Replicas                  int                   `json:"replicas"`
+	Scheduling                Scheduling            `json:"scheduling"`
+	AdditionalLabels          AdditionalLabels      `json:"additionalLabels"`
+	AdditionalAnnotations     AdditionalAnnotations `json:"additionalAnnotations"`
+	SecurityContexts          SecurityContextSpec   `json:"securityContexts"`
+	SetDefaultSecurityContext bool                  `json:"setDefaultSecurityContext"`
+	LivenessProbes            LivenessProbes        `json:"livenessProbes"`
+	ReadinessProbes           ReadinessProbes       `json:"readinessProbes"`
+	Resources                 ResourcesSpec         `json:"resources"`
+	DebugDeployments          sets.String           `json:"debugDeployments"`
 }
 
 func (c *DeploymentConfig) SetContainerResourcesIfPresent(container *corev1.Container) {
@@ -116,7 +111,6 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 	c.ReadinessProbes.ApplyTo(&deployment.Spec.Template.Spec)
 	c.Resources.ApplyTo(&deployment.Spec.Template.Spec)
 	c.AdditionalAnnotations.ApplyTo(&deployment.Spec.Template.ObjectMeta)
-	c.setMultizoneSpread(&deployment.Spec.Template)
 }
 
 func (c *DeploymentConfig) ApplyToDaemonSet(daemonset *appsv1.DaemonSet) {
@@ -129,7 +123,6 @@ func (c *DeploymentConfig) ApplyToDaemonSet(daemonset *appsv1.DaemonSet) {
 	c.ReadinessProbes.ApplyTo(&daemonset.Spec.Template.Spec)
 	c.Resources.ApplyTo(&daemonset.Spec.Template.Spec)
 	c.AdditionalAnnotations.ApplyTo(&daemonset.Spec.Template.ObjectMeta)
-	c.setMultizoneSpread(&daemonset.Spec.Template)
 }
 
 func (c *DeploymentConfig) ApplyToStatefulSet(sts *appsv1.StatefulSet) {
@@ -142,7 +135,6 @@ func (c *DeploymentConfig) ApplyToStatefulSet(sts *appsv1.StatefulSet) {
 	c.ReadinessProbes.ApplyTo(&sts.Spec.Template.Spec)
 	c.Resources.ApplyTo(&sts.Spec.Template.Spec)
 	c.AdditionalAnnotations.ApplyTo(&sts.Spec.Template.ObjectMeta)
-	c.setMultizoneSpread(&sts.Spec.Template)
 }
 
 func clusterKey(hcp *hyperv1.HostedControlPlane) string {
@@ -153,25 +145,12 @@ func colocationLabelValue(hcp *hyperv1.HostedControlPlane) string {
 	return clusterKey(hcp)
 }
 
-const podHashLabel = "hypershift.openshift.io/pod-template-hash"
-
 // setMultizoneSpread sets PodAntiAffinity with corev1.LabelTopologyZone as the topology key for a given set of labels.
 // This is useful to e.g ensure pods are spread across availavility zones.
-// There are certain situations where this results in additional roll-outs, most namely when the HCCO updates a deployment
-// to add a checksum label in which case the CPO will instantly issue another update to update the hash label. We can
-// not share this logic though, because the HCCO sees the defaulted deployment wheras the code on the CPO acts on
-// undefaulted workloads. We can also not plug this into CreateOrUpdate, because it's defaulting is based on copying
-// fields from the existing deployment - If we add it there, _all_ workloads will end up getting updated once after
-// creation, which is strictly worse than having this issue just for the ones where the HCCO adds a label.
-// To avoid triggering the "Scheduling failed" verification, the HCCO should clear the affinity field whenever
-// a workload is updated.
-func (c *DeploymentConfig) setMultizoneSpread(pod *corev1.PodTemplateSpec) {
-	pod.Spec.Affinity = nil
-	delete(pod.Labels, podHashLabel)
-	if pod.Labels == nil {
-		pod.Labels = map[string]string{}
+func (c *DeploymentConfig) setMultizoneSpread(labels map[string]string) {
+	if labels == nil {
+		return
 	}
-	pod.Labels[podHashLabel] = computeHash(pod)
 
 	if c.Scheduling.Affinity == nil {
 		c.Scheduling.Affinity = &corev1.Affinity{}
@@ -179,16 +158,15 @@ func (c *DeploymentConfig) setMultizoneSpread(pod *corev1.PodTemplateSpec) {
 	if c.Scheduling.Affinity.PodAntiAffinity == nil {
 		c.Scheduling.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 	}
-	c.Scheduling.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = []corev1.PodAffinityTerm{
-		{
-			TopologyKey: corev1.LabelTopologyZone,
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: pod.Labels,
+	c.Scheduling.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution =
+		[]corev1.PodAffinityTerm{
+			{
+				TopologyKey: corev1.LabelTopologyZone,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
 			},
-		},
-	}
-
-	pod.Spec.Affinity = c.Scheduling.Affinity
+		}
 }
 
 // setColocation sets labels and PodAffinity rules for this deployment so that pods
@@ -279,10 +257,14 @@ func (c *DeploymentConfig) setNodeSelector(hcp *hyperv1.HostedControlPlane) {
 	c.Scheduling.NodeSelector = hcp.Spec.NodeSelector
 }
 
-func (c *DeploymentConfig) setLocation(hcp *hyperv1.HostedControlPlane) {
+func (c *DeploymentConfig) setLocation(hcp *hyperv1.HostedControlPlane, multiZoneSpreadLabels map[string]string) {
 	c.setNodeSelector(hcp)
 	c.setControlPlaneIsolation(hcp)
 	c.setColocation(hcp)
+	// TODO (alberto): pass labels with deployment hash and set this unconditionally so we don't skew setup.
+	if c.Replicas > 1 {
+		c.setMultizoneSpread(multiZoneSpreadLabels)
+	}
 }
 
 func (c *DeploymentConfig) setReplicas(availability hyperv1.AvailabilityPolicy) {
@@ -295,7 +277,7 @@ func (c *DeploymentConfig) setReplicas(availability hyperv1.AvailabilityPolicy) 
 }
 
 // SetDefaults populates opinionated default DeploymentConfig for any Deployment.
-func (c *DeploymentConfig) SetDefaults(hcp *hyperv1.HostedControlPlane, replicas *int) {
+func (c *DeploymentConfig) SetDefaults(hcp *hyperv1.HostedControlPlane, multiZoneSpreadLabels map[string]string, replicas *int) {
 	// If no replicas is specified then infer it from the ControllerAvailabilityPolicy.
 	if replicas == nil {
 		c.setReplicas(hcp.Spec.ControllerAvailabilityPolicy)
@@ -304,7 +286,7 @@ func (c *DeploymentConfig) SetDefaults(hcp *hyperv1.HostedControlPlane, replicas
 	}
 	c.DebugDeployments = debugDeployments(hcp)
 
-	c.setLocation(hcp)
+	c.setLocation(hcp, multiZoneSpreadLabels)
 	// TODO (alberto): make this private, atm is needed for the konnectivity agent daemonset.
 	c.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 }
@@ -319,28 +301,4 @@ func debugDeployments(hc *hyperv1.HostedControlPlane) sets.String {
 	}
 	names := strings.Split(val, ",")
 	return sets.NewString(names...)
-}
-
-// Borrowed from upstream: https://github.com/kubernetes/kubernetes/blob/d5fdf3135e7c99e5f81e67986ae930f6a2ffb047/pkg/controller/controller_utils.go#L1152-L1167
-// computeHash returns a hash value calculated from pod template.
-// The hash will be safe encoded to avoid bad words.
-func computeHash(template *corev1.PodTemplateSpec) string {
-	podTemplateSpecHasher := fnv.New32a()
-	deepHashObject(podTemplateSpecHasher, *template)
-
-	return rand.SafeEncodeString(fmt.Sprint(podTemplateSpecHasher.Sum32()))
-}
-
-// deepHashObject writes specified object to hash using the spew library
-// which follows pointers and prints actual values of the nested objects
-// ensuring the hash does not change when a pointer changes.
-func deepHashObject(hasher hash.Hash, objectToWrite interface{}) {
-	hasher.Reset()
-	printer := spew.ConfigState{
-		Indent:         " ",
-		SortKeys:       true,
-		DisableMethods: true,
-		SpewKeys:       true,
-	}
-	printer.Fprintf(hasher, "%#v", objectToWrite)
 }

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -96,10 +96,7 @@ func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, op
 	t.Cleanup(func() { EnsureAllContainersHavePullPolicyIfNotPresent(t, context.Background(), client, hc) })
 	t.Cleanup(func() { EnsureHCPContainersHaveResourceRequests(t, context.Background(), client, hc) })
 	t.Cleanup(func() { EnsureNoPodsWithTooHighPriority(t, context.Background(), client, hc) })
-	// TODO @alvaroaleman: Remove once the scheduling fixes are in a promoted payload
-	if !strings.Contains(t.Name(), "UpgradeControlPlane") {
-		t.Cleanup(func() { NoticePreemptionOrFailedScheduling(t, context.Background(), client, hc) })
-	}
+	t.Cleanup(func() { NoticePreemptionOrFailedScheduling(t, context.Background(), client, hc) })
 	t.Cleanup(func() { EnsureAllRoutesUseHCPRouter(t, context.Background(), client, hc) })
 
 	return hc

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -368,24 +368,8 @@ func NoticePreemptionOrFailedScheduling(t *testing.T, ctx context.Context, clien
 		}
 		for _, event := range eventList.Items {
 			if event.Reason == "FailedScheduling" || event.Reason == "Preempted" {
-				// TestHAEtcdChaos causes errors like
-				// "binding rejected: running Bind plugin "DefaultBinder": Operation cannot be fulfilled on pods "etcd-2": StorageError: invalid object, Code: 4, Key: /kubernetes.io/pods/e2e-clusters-vwckx-example-66phb/etcd-2, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: c75c414d-afeb-4f06-bf30-818e7dc0c603, UID in object meta: 0b97dda4-9fc8-4a79-bbb1-96da1dabaa3d"
-				// which presumbaly is caused by cache staleness in the scheduler, so just ignore those
-				if strings.Contains(event.Message, "AdditionalErrorMsg: Precondition failed: UID in precondition") {
-					continue
-				}
-				// Ignore sporadically observed errors like this one:
-				// 'error: observed FailedScheduling or Preempted event for pod etcd-0: running PreBind plugin "VolumeBinding": binding volumes: pod does not exist any more: pod "etcd-0" not found'
-				if strings.Contains(event.Message, `running PreBind plugin "VolumeBinding": binding volumes: pod does not exist any more: pod`) {
-					continue
-				}
-				// Ignore sporadic errors like this one:
-				// 'binding rejected: running Bind plugin "DefaultBinder": Operation cannot be fulfilled on pods/binding "etcd-0": pod etcd-0 is being deleted, cannot be assigned to a host'
-				if strings.Contains(event.Message, `is being deleted, cannot be assigned to a host`) {
-					continue
-				}
 				// "error: " is to trigger prow syntax highlight in prow
-				t.Errorf("error: observed FailedScheduling or Preempted event for pod %s: %s", event.InvolvedObject.Name, event.Message)
+				t.Logf("error: non-fatal, observed FailedScheduling or Preempted event: %s", event.Message)
 			}
 		}
 	})


### PR DESCRIPTION
This reverts https://github.com/openshift/hypershift/pull/1724 as it is permafailing CI on `TestUpgradeControlPlane` test.

Deployment `spec.selector` field is immutable making this whole approach unworkable.

This would have been blocked in the `TestUpgradeControlPlane` test, but we overrode it in the PR assuming that a known bug, which caused the test to fail before the point we would have observed this issue, was the only one.

https://github.com/openshift/hypershift/pull/1724#issuecomment-1242059582

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.