### PR TITLE
update OLM catalogs to 4.11

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/certified-operator-index:v4.9
+          image: registry.redhat.io/redhat/certified-operator-index:v4.11
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 50051
@@ -46,6 +46,15 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 15
           resources:
             requests:
               cpu: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/community-operator-index:v4.9
+          image: registry.redhat.io/redhat/community-operator-index:v4.11
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 50051
@@ -46,6 +46,15 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 15
           resources:
             requests:
               cpu: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/redhat-marketplace-index:v4.9
+          image: registry.redhat.io/redhat/redhat-marketplace-index:v4.11
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 50051
@@ -46,6 +46,15 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 15
           resources:
             requests:
               cpu: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: registry
-          image: registry.redhat.io/redhat/redhat-operator-index:v4.9
+          image: registry.redhat.io/redhat/redhat-operator-index:v4.11
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 50051
@@ -46,6 +46,15 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+                - grpc_health_probe
+                - '-addr=:50051'
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 15
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
4.12 images are not published yet.  4.11 is the latest.

Pulls fix for slow catalog start from https://github.com/operator-framework/operator-lifecycle-manager/pull/2791