### PR TITLE
[release-4.11] Bug OCPBUGS-1367: CNO: Handle long OVN SBDB route hostnames

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1994,7 +1994,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterVersionOperator(ctx conte
 }
 
 func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage, createOrUpdate upsert.CreateOrUpdateFN) error {
-	p := cno.NewParams(hcp, releaseImage.Version(), releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
+	p := cno.NewParams(hcp, releaseImage.Version(), releaseImage.ComponentImages(), r.SetDefaultSecurityContext, r.DefaultIngressDomain)
 
 	role := manifests.ClusterNetworkOperatorRole(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, role, func() error {


### PR DESCRIPTION
Handle long route hostnames and set OVN_SBDB_ROUTE_HOST.

This is a partial backport of https://github.com/openshift/hypershift/pull/1711 that only handles long route names.
As a follow up we should also backport https://github.com/openshift/hypershift/pull/1689 and the rest of the route hostname handling for CNO. 

Signed-off-by: Patryk Diak <pdiak@redhat.com>