### PR TITLE
STOR-1037: Add cluster-storage-operator to mgmt. cluster

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -80,6 +80,7 @@ var (
 		"0000_50_cluster-image-registry-operator_07-operator-ibm-cloud-managed.yaml",
 		"0000_50_cluster-image-registry-operator_07-operator-service.yaml",
 		"0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml",
+		"0000_50_cluster-storage-operator_10_deployment-ibm-cloud-managed.yaml",
 
 		// TODO: Remove these when cluster profiles annotations are fixed
 		"0000_50_cloud-credential-operator_01-operator-config.yaml",
@@ -249,6 +250,12 @@ func resourcesToRemove() []resourceDesc {
 			kind:       "Deployment",
 			name:       "cluster-image-registry-operator",
 			namespace:  "openshift-image-registry",
+		},
+		{
+			apiVersion: "apps/v1",
+			kind:       "Deployment",
+			name:       "cluster-storage-operator",
+			namespace:  "openshift-cluster-storage-operator",
 		},
 		{
 			apiVersion: "apps/v1",

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/storage.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/storage.go
@@ -1,0 +1,35 @@
+package manifests
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func ClusterStorageOperatorDeployment(ns string) *appsv1.Deployment {
+	dep := &appsv1.Deployment{}
+	dep.Name = "cluster-storage-operator"
+	dep.Namespace = ns
+	return dep
+}
+
+func ClusterStorageOperatorRole(ns string) *rbacv1.Role {
+	role := &rbacv1.Role{}
+	role.Name = "cluster-storage-operator-role"
+	role.Namespace = ns
+	return role
+}
+
+func ClusterStorageOperatorRoleBinding(ns string) *rbacv1.RoleBinding {
+	roleBinding := &rbacv1.RoleBinding{}
+	roleBinding.Name = "cluster-storage-operator-role"
+	roleBinding.Namespace = ns
+	return roleBinding
+}
+
+func ClusterStorageOperatorServiceAccount(ns string) *corev1.ServiceAccount {
+	sa := &corev1.ServiceAccount{}
+	sa.Name = "cluster-storage-operator"
+	sa.Namespace = ns
+	return sa
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/storage.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/storage.go
@@ -15,14 +15,14 @@ func ClusterStorageOperatorDeployment(ns string) *appsv1.Deployment {
 
 func ClusterStorageOperatorRole(ns string) *rbacv1.Role {
 	role := &rbacv1.Role{}
-	role.Name = "cluster-storage-operator-role"
+	role.Name = "cluster-storage-operator"
 	role.Namespace = ns
 	return role
 }
 
 func ClusterStorageOperatorRoleBinding(ns string) *rbacv1.RoleBinding {
 	roleBinding := &rbacv1.RoleBinding{}
-	roleBinding.Name = "cluster-storage-operator-role"
+	roleBinding.Name = "cluster-storage-operator"
 	roleBinding.Namespace = ns
 	return roleBinding
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
@@ -1,0 +1,134 @@
+# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-storage-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cluster-storage-operator
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        name: cluster-storage-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - -v=2
+        - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
+        command:
+        - cluster-storage-operator
+        - start
+        env:
+        - name: OPERATOR_IMAGE_VERSION
+          value: 0.0.1-snapshot
+        - name: OPERAND_IMAGE_VERSION
+          value: 0.0.1-snapshot
+        - name: AWS_EBS_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-aws-ebs-csi-driver-operator:latest
+        - name: AWS_EBS_DRIVER_IMAGE
+          value: quay.io/openshift/origin-aws-ebs-csi-driver:latest
+        - name: GCP_PD_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-gcp-pd-csi-driver-operator:latest
+        - name: GCP_PD_DRIVER_IMAGE
+          value: quay.io/openshift/origin-gcp-pd-csi-driver:latest
+        - name: OPENSTACK_CINDER_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-openstack-cinder-csi-driver-operator:latest
+        - name: OPENSTACK_CINDER_DRIVER_IMAGE
+          value: quay.io/openshift/origin-openstack-cinder-csi-driver:latest
+        - name: OVIRT_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-ovirt-csi-driver-operator:latest
+        - name: OVIRT_DRIVER_IMAGE
+          value: quay.io/openshift/origin-ovirt-csi-driver:latest
+        - name: MANILA_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-csi-driver-manila-operator:latest
+        - name: MANILA_DRIVER_IMAGE
+          value: quay.io/openshift/origin-csi-driver-manila:latest
+        - name: MANILA_NFS_DRIVER_IMAGE
+          value: quay.io/openshift/origin-csi-driver-nfs:latest
+        - name: PROVISIONER_IMAGE
+          value: quay.io/openshift/origin-csi-external-provisioner:latest
+        - name: ATTACHER_IMAGE
+          value: quay.io/openshift/origin-csi-external-attacher:latest
+        - name: RESIZER_IMAGE
+          value: quay.io/openshift/origin-csi-external-resizer:latest
+        - name: SNAPSHOTTER_IMAGE
+          value: quay.io/openshift/origin-csi-external-snapshotter:latest
+        - name: NODE_DRIVER_REGISTRAR_IMAGE
+          value: quay.io/openshift/origin-csi-node-driver-registrar:latest
+        - name: LIVENESS_PROBE_IMAGE
+          value: quay.io/openshift/origin-csi-livenessprobe:latest
+        - name: VSPHERE_PROBLEM_DETECTOR_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-vsphere-problem-detector:latest
+        - name: AZURE_DISK_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-azure-disk-csi-driver-operator:latest
+        - name: AZURE_DISK_DRIVER_IMAGE
+          value: quay.io/openshift/origin-azure-disk-csi-driver:latest
+        - name: AZURE_FILE_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-azure-file-csi-driver-operator:latest
+        - name: AZURE_FILE_DRIVER_IMAGE
+          value: quay.io/openshift/origin-azure-file-csi-driver:latest
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: quay.io/openshift/origin-kube-rbac-proxy:latest
+        - name: VMWARE_VSPHERE_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-vsphere-csi-driver-operator:latest
+        - name: VMWARE_VSPHERE_DRIVER_IMAGE
+          value: quay.io/openshift/origin-vsphere-csi-driver:latest
+        - name: VMWARE_VSPHERE_SYNCER_IMAGE
+          value: quay.io/openshift/origin-vsphere-csi-driver-syncer:latest
+        - name: CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-cluster-cloud-controller-manager-operator:latest
+        - name: SHARED_RESOURCE_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-csi-driver-shared-resource-operator:latest
+        - name: SHARED_RESOURCE_DRIVER_IMAGE
+          value: quay.io/openshift/origin-csi-driver-shared-resource:latest
+        - name: SHARED_RESOURCE_DRIVER_WEBHOOK_IMAGE
+          value: quay.io/openshift/origin-csi-driver-shared-resource-webhook:latest
+        - name: ALIBABA_DISK_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-alibaba-disk-csi-driver-operator:latest
+        - name: ALIBABA_CLOUD_DRIVER_IMAGE
+          value: quay.io/openshift/origin-alibaba-cloud-csi-driver:latest
+        - name: IBM_VPC_BLOCK_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-ibm-vpc-block-csi-driver-operator:latest
+        - name: IBM_VPC_BLOCK_DRIVER_IMAGE
+          value: quay.io/openshift/origin-ibm-vpc-block-csi-driver:latest
+        - name: IBM_VPC_NODE_LABEL_UPDATER_IMAGE
+          value: quay.io/openshift/origin-ibm-vpc-node-label-updater:latest
+        - name: POWERVS_BLOCK_CSI_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-powervs-block-csi-driver-operator:latest
+        - name: POWERVS_BLOCK_CSI_DRIVER_IMAGE
+          value: quay.io/openshift/origin-powervs-block-csi-driver:latest
+        - name: HYPERSHIFT_IMAGE
+          value: quay.io/openshift/origin-control-plane:latest
+        image: quay.io/openshift/origin-cluster-storage-operator:latest
+        imagePullPolicy: IfNotPresent
+        name: cluster-storage-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/guest-kubeconfig
+          name: guest-kubeconfig
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: cluster-storage-operator
+      volumes:
+      - name: guest-kubeconfig
+        secret:
+          secretName: service-network-admin-kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/README.md
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/README.md
@@ -1,0 +1,11 @@
+# Templates of cluster-storage-operator objects.
+
+Generated files in this directory with "hypershift" name come from https://github.com/openshift/cluster-storage-operator.
+
+* To update the generated files, copy
+  [`manifests/*-hypershift`](https://github.com/openshift/cluster-storage-operator/tree/master/manifests)
+  from github.com/openshift/cluster-storage-operator to here, without any changes.
+* All changes in these files should be done in github.com/openshift/cluster-storage-operator repository,
+  so we keep authoritative source of all cluster-storage-operator objects on a single place.
+
+Role and rolebinding is custom for hypershift only.

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/assets.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/assets.go
@@ -1,0 +1,13 @@
+package assets
+
+import (
+	"embed"
+)
+
+//go:embed *.yaml
+var f embed.FS
+
+// ReadFile reads and returns the content of the named file.
+func ReadFile(name string) ([]byte, error) {
+	return f.ReadFile(name)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/role.yaml
@@ -1,0 +1,48 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-storage-operator-role
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/role.yaml
@@ -1,48 +1,58 @@
+# TODO: Prune the RBACs as cluster-storage-operator and aws-ebs-csi-driver-operator are pruned.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cluster-storage-operator-role
 rules:
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - replicasets
-  verbs:
-  - '*'
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  - services
-  - configmaps
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - '*'
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - services
+      - configmaps
+      - pods
+      - endpoints
+      - events
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - watch
+      - list
+      - get
+      - create
+      - delete
+      - patch
+      - update

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: cluster-storage-operator-role
+  name: cluster-storage-operator
 rules:
   - apiGroups:
       - coordination.k8s.io

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+  name: cluster-storage-operator-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-storage-operator-role
+subjects:
+- kind: ServiceAccount
+  name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/rolebinding.yaml
@@ -2,11 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-  name: cluster-storage-operator-role
+  name: cluster-storage-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cluster-storage-operator-role
+  name: cluster-storage-operator
 subjects:
 - kind: ServiceAccount
   name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
@@ -1,0 +1,82 @@
+package storage
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+var (
+	// map env. variable in CSO Deployment -> name of the image in payload.
+	operatorImageRefs = map[string]string{
+		"AWS_EBS_DRIVER_OPERATOR_IMAGE":                   "aws-ebs-csi-driver-operator",
+		"AWS_EBS_DRIVER_IMAGE":                            "aws-ebs-csi-driver",
+		"GCP_PD_DRIVER_OPERATOR_IMAGE":                    "gcp-pd-csi-driver-operator",
+		"GCP_PD_DRIVER_IMAGE":                             "gcp-pd-csi-driver",
+		"OPENSTACK_CINDER_DRIVER_OPERATOR_IMAGE":          "openstack-cinder-csi-driver-operator",
+		"OPENSTACK_CINDER_DRIVER_IMAGE":                   "openstack-cinder-csi-driver",
+		"OVIRT_DRIVER_OPERATOR_IMAGE":                     "ovirt-csi-driver-operator",
+		"OVIRT_DRIVER_IMAGE":                              "ovirt-csi-driver",
+		"MANILA_DRIVER_OPERATOR_IMAGE":                    "csi-driver-manila-operator",
+		"MANILA_DRIVER_IMAGE":                             "csi-driver-manila",
+		"MANILA_NFS_DRIVER_IMAGE":                         "csi-driver-nfs",
+		"PROVISIONER_IMAGE":                               "csi-external-provisioner",
+		"ATTACHER_IMAGE":                                  "csi-external-attacher",
+		"RESIZER_IMAGE":                                   "csi-external-resizer",
+		"SNAPSHOTTER_IMAGE":                               "csi-external-snapshotter",
+		"NODE_DRIVER_REGISTRAR_IMAGE":                     "csi-node-driver-registrar",
+		"LIVENESS_PROBE_IMAGE":                            "csi-livenessprobe",
+		"VSPHERE_PROBLEM_DETECTOR_OPERATOR_IMAGE":         "vsphere-problem-detector",
+		"AZURE_DISK_DRIVER_OPERATOR_IMAGE":                "azure-disk-csi-driver-operator",
+		"AZURE_DISK_DRIVER_IMAGE":                         "azure-disk-csi-driver",
+		"AZURE_FILE_DRIVER_OPERATOR_IMAGE":                "azure-file-csi-driver-operator",
+		"AZURE_FILE_DRIVER_IMAGE":                         "azure-file-csi-driver",
+		"KUBE_RBAC_PROXY_IMAGE":                           "kube-rbac-proxy",
+		"VMWARE_VSPHERE_DRIVER_OPERATOR_IMAGE":            "vsphere-csi-driver-operator",
+		"VMWARE_VSPHERE_DRIVER_IMAGE":                     "vsphere-csi-driver",
+		"VMWARE_VSPHERE_SYNCER_IMAGE":                     "vsphere-csi-driver-syncer",
+		"CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE": "cluster-cloud-controller-manager-operator",
+		"SHARED_RESOURCE_DRIVER_OPERATOR_IMAGE":           "csi-driver-shared-resource-operator",
+		"SHARED_RESOURCE_DRIVER_IMAGE":                    "csi-driver-shared-resource",
+		"SHARED_RESOURCE_DRIVER_WEBHOOK_IMAGE":            "csi-driver-shared-resource-webhook",
+		"ALIBABA_DISK_DRIVER_OPERATOR_IMAGE":              "alibaba-disk-csi-driver-operator",
+		"ALIBABA_CLOUD_DRIVER_IMAGE":                      "alibaba-cloud-csi-driver",
+		"IBM_VPC_BLOCK_DRIVER_OPERATOR_IMAGE":             "ibm-vpc-block-csi-driver-operator",
+		"IBM_VPC_BLOCK_DRIVER_IMAGE":                      "ibm-vpc-block-csi-driver",
+		"IBM_VPC_NODE_LABEL_UPDATER_IMAGE":                "ibm-vpc-node-label-updater",
+		"POWERVS_BLOCK_CSI_DRIVER_OPERATOR_IMAGE":         "powervs-block-csi-driver-operator",
+		"POWERVS_BLOCK_CSI_DRIVER_IMAGE":                  "powervs-block-csi-driver",
+		"HYPERSHIFT_IMAGE":                                "token-minter",
+	}
+)
+
+type environmentReplacer struct {
+	// map env variable name -> new env. variable value
+	values map[string]string
+}
+
+func newEnvironmentReplacer() *environmentReplacer {
+	return &environmentReplacer{values: map[string]string{}}
+}
+
+func (er *environmentReplacer) setOperatorImageReferences(images map[string]string) {
+	// `operatorImageRefs` is map from env. var name -> payload image name
+	// `images` is map from payload image name -> image URL
+	// Create map from env. var name -> image URL
+	for envVar, payloadName := range operatorImageRefs {
+		if imageURL, ok := images[payloadName]; ok {
+			er.values[envVar] = imageURL
+		}
+	}
+}
+
+func (er *environmentReplacer) setVersions(ver string) {
+	er.values["OPERATOR_IMAGE_VERSION"] = ver
+	er.values["OPERAND_IMAGE_VERSION"] = ver
+}
+
+func (er *environmentReplacer) replaceEnvVars(envVars []v1.EnvVar) {
+	for i := range envVars {
+		if value, ok := er.values[envVars[i].Name]; ok {
+			envVars[i].Value = value
+		}
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace_test.go
@@ -1,0 +1,53 @@
+package storage
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/storage/assets"
+	assets2 "github.com/openshift/hypershift/support/assets"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func TestEnvironmentReplacer(t *testing.T) {
+	// Test that EnvironmentReplaces replaces **all** env. vars in the operator Deployment.
+	// This protects us from adding a new image to assets/10_deployment-hypershift.yaml
+	// and not adding it to envreplace.go.
+
+	// All image URLs will point to hash(env. name)
+	images := map[string]string{}
+	for envVarName, payloadName := range operatorImageRefs {
+		images[payloadName] = hash(envVarName)
+	}
+
+	er := newEnvironmentReplacer()
+	er.setOperatorImageReferences(images)
+	version := rand.String(10)
+	er.setVersions(version)
+
+	deployment := assets2.MustDeployment(assets.ReadFile, "10_deployment-hypershift.yaml")
+	er.replaceEnvVars(deployment.Spec.Template.Spec.Containers[0].Env)
+
+	// Check that all env. vars were replaced.
+	// Feel free to add exceptions in the future, but right now *all* env. vars of the operator
+	// refer either to version or image name.
+	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if strings.HasSuffix(env.Name, "_VERSION") {
+			if env.Value != version {
+				t.Errorf("Environment variable %q in assets/10_deployment-hypershift.yaml was not replaced by the operator. Please update envreplace.go!", env.Name)
+			}
+			continue
+		}
+		// Not version -> it must be an image name
+		if env.Value != hash(env.Name) {
+			t.Errorf("Environment variable %q in assets/10_deployment-hypershift.yaml was not replaced by the operator. Please update envreplace.go!", env.Name)
+		}
+	}
+}
+
+func hash(data string) string {
+	hashBytes := md5.Sum([]byte(data))
+	return hex.EncodeToString(hashBytes[0:])
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
@@ -1,0 +1,84 @@
+package storage
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/storage/assets"
+	assets2 "github.com/openshift/hypershift/support/assets"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	operatorDeployment  = assets2.MustDeployment(assets.ReadFile, "10_deployment-hypershift.yaml")
+	operatorRole        = assets2.MustRole(assets.ReadFile, "role.yaml")
+	operatorRoleBinding = assets2.MustRoleBinding(assets.ReadFile, "rolebinding.yaml")
+)
+
+func ReconcileOperatorDeployment(
+	deployment *appsv1.Deployment,
+	params *Params) error {
+
+	params.OwnerRef.ApplyTo(deployment)
+	deployment.Spec = operatorDeployment.DeepCopy().Spec
+	for i, container := range deployment.Spec.Template.Spec.Containers {
+		switch container.Name {
+		case "cluster-storage-operator":
+			deployment.Spec.Template.Spec.Containers[i].Image = params.StorageOperatorImage
+			// Substitute env. vars
+			for j, env := range deployment.Spec.Template.Spec.Containers[i].Env {
+				// Substitute image names in env. vars
+				for envName, imageName := range params.EnvImages {
+					if env.Name == envName {
+						deployment.Spec.Template.Spec.Containers[i].Env[j].Value = imageName
+					}
+				}
+				// Substitute other env vars.
+				switch env.Name {
+				case "OPERATOR_IMAGE_VERSION":
+					deployment.Spec.Template.Spec.Containers[i].Env[j].Value = params.Version
+				case "OPERAND_IMAGE_VERSION":
+					deployment.Spec.Template.Spec.Containers[i].Env[j].Value = params.Version
+				}
+			}
+		}
+	}
+
+	params.DeploymentConfig.ApplyTo(deployment)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, params.APIPort), params.AvailabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+		o.KubeconfigVolumeName = "guest-kubeconfig"
+		o.RequiredAPIs = []schema.GroupVersionKind{
+			{Group: "operator.openshift.io", Version: "v1", Kind: "Storage"},
+		}
+	})
+	return nil
+}
+
+func ReconcileOperatorRole(
+	role *rbacv1.Role,
+	params *Params) error {
+
+	params.OwnerRef.ApplyTo(role)
+	role.Rules = operatorRole.DeepCopy().Rules
+	return nil
+}
+
+func ReconcileOperatorRoleBinding(
+	roleBinding *rbacv1.RoleBinding,
+	params *Params) error {
+
+	params.OwnerRef.ApplyTo(roleBinding)
+	roleBinding.RoleRef = operatorRoleBinding.DeepCopy().RoleRef
+	roleBinding.Subjects = operatorRoleBinding.DeepCopy().Subjects
+	return nil
+}
+
+func ReconcileOperatorServiceAccount(
+	sa *corev1.ServiceAccount,
+	params *Params) error {
+
+	params.OwnerRef.ApplyTo(sa)
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
@@ -27,22 +27,7 @@ func ReconcileOperatorDeployment(
 		switch container.Name {
 		case "cluster-storage-operator":
 			deployment.Spec.Template.Spec.Containers[i].Image = params.StorageOperatorImage
-			// Substitute env. vars
-			for j, env := range deployment.Spec.Template.Spec.Containers[i].Env {
-				// Substitute image names in env. vars
-				for envName, imageName := range params.EnvImages {
-					if env.Name == envName {
-						deployment.Spec.Template.Spec.Containers[i].Env[j].Value = imageName
-					}
-				}
-				// Substitute other env vars.
-				switch env.Name {
-				case "OPERATOR_IMAGE_VERSION":
-					deployment.Spec.Template.Spec.Containers[i].Env[j].Value = params.Version
-				case "OPERAND_IMAGE_VERSION":
-					deployment.Spec.Template.Spec.Containers[i].Env[j].Value = params.Version
-				}
-			}
+			params.ImageReplacer.replaceEnvVars(deployment.Spec.Template.Spec.Containers[i].Env)
 		}
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
@@ -11,58 +11,12 @@ const (
 	storageOperatorImageName = "cluster-storage-operator"
 )
 
-var (
-	// map env. variable in CSO Deployment -> key in `images` map (= name of the image in payload).
-	operatorImageRefs = map[string]string{
-		"AWS_EBS_DRIVER_OPERATOR_IMAGE":                   "aws-ebs-csi-driver-operator",
-		"AWS_EBS_DRIVER_IMAGE":                            "aws-ebs-csi-driver",
-		"GCP_PD_DRIVER_OPERATOR_IMAGE":                    "gcp-pd-csi-driver-operator",
-		"GCP_PD_DRIVER_IMAGE":                             "gcp-pd-csi-driver",
-		"OPENSTACK_CINDER_DRIVER_OPERATOR_IMAGE":          "openstack-cinder-csi-driver-operator",
-		"OPENSTACK_CINDER_DRIVER_IMAGE":                   "openstack-cinder-csi-driver",
-		"OVIRT_DRIVER_OPERATOR_IMAGE":                     "ovirt-csi-driver-operator",
-		"OVIRT_DRIVER_IMAGE":                              "ovirt-csi-driver",
-		"MANILA_DRIVER_OPERATOR_IMAGE":                    "csi-driver-manila-operator",
-		"MANILA_DRIVER_IMAGE":                             "csi-driver-manila",
-		"MANILA_NFS_DRIVER_IMAGE":                         "csi-driver-nfs",
-		"PROVISIONER_IMAGE":                               "csi-external-provisioner",
-		"ATTACHER_IMAGE":                                  "csi-external-attacher",
-		"RESIZER_IMAGE":                                   "csi-external-resizer",
-		"SNAPSHOTTER_IMAGE":                               "csi-external-snapshotter",
-		"NODE_DRIVER_REGISTRAR_IMAGE":                     "csi-node-driver-registrar",
-		"LIVENESS_PROBE_IMAGE":                            "csi-livenessprobe",
-		"VSPHERE_PROBLEM_DETECTOR_OPERATOR_IMAGE":         "vsphere-problem-detector",
-		"AZURE_DISK_DRIVER_OPERATOR_IMAGE":                "azure-disk-csi-driver-operator",
-		"AZURE_DISK_DRIVER_IMAGE":                         "azure-disk-csi-driver",
-		"AZURE_FILE_DRIVER_OPERATOR_IMAGE":                "azure-file-csi-driver-operator",
-		"AZURE_FILE_DRIVER_IMAGE":                         "azure-file-csi-driver",
-		"KUBE_RBAC_PROXY_IMAGE":                           "kube-rbac-proxy",
-		"VMWARE_VSPHERE_DRIVER_OPERATOR_IMAGE":            "vsphere-csi-driver-operator",
-		"VMWARE_VSPHERE_DRIVER_IMAGE":                     "vsphere-csi-driver",
-		"VMWARE_VSPHERE_SYNCER_IMAGE":                     "vsphere-csi-driver-syncer",
-		"CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE": "cluster-cloud-controller-manager-operator",
-		"SHARED_RESOURCE_DRIVER_OPERATOR_IMAGE":           "csi-driver-shared-resource-operator",
-		"SHARED_RESOURCE_DRIVER_IMAGE":                    "csi-driver-shared-resource",
-		"SHARED_RESOURCE_DRIVER_WEBHOOK_IMAGE":            "csi-driver-shared-resource-webhook",
-		"ALIBABA_DISK_DRIVER_OPERATOR_IMAGE":              "alibaba-disk-csi-driver-operator",
-		"ALIBABA_CLOUD_DRIVER_IMAGE":                      "alibaba-cloud-csi-driver",
-		"IBM_VPC_BLOCK_DRIVER_OPERATOR_IMAGE":             "ibm-vpc-block-csi-driver-operator",
-		"IBM_VPC_BLOCK_DRIVER_IMAGE":                      "ibm-vpc-block-csi-driver",
-		"IBM_VPC_NODE_LABEL_UPDATER_IMAGE":                "ibm-vpc-node-label-updater",
-		"POWERVS_BLOCK_CSI_DRIVER_OPERATOR_IMAGE":         "powervs-block-csi-driver-operator",
-		"POWERVS_BLOCK_CSI_DRIVER_IMAGE":                  "powervs-block-csi-driver",
-		"HYPERSHIFT_IMAGE":                                "token-minter",
-	}
-)
-
 type Params struct {
 	OwnerRef             config.OwnerRef
 	StorageOperatorImage string
-	// Map env. variable -> image name
-	EnvImages map[string]string
+	ImageReplacer        *environmentReplacer
 
 	AvailabilityProberImage string
-	Version                 string
 	APIPort                 *int32
 	config.DeploymentConfig
 }
@@ -73,17 +27,16 @@ func NewParams(
 	images map[string]string,
 	setDefaultSecurityContext bool) *Params {
 
+	ir := newEnvironmentReplacer()
+	ir.setVersions(version)
+	ir.setOperatorImageReferences(images)
+
 	params := Params{
 		OwnerRef:                config.OwnerRefFrom(hcp),
 		StorageOperatorImage:    images[storageOperatorImageName],
 		AvailabilityProberImage: images[util.AvailabilityProberImageName],
-		EnvImages:               make(map[string]string),
-		Version:                 version,
+		ImageReplacer:           ir,
 		APIPort:                 util.APIPort(hcp),
-	}
-
-	for envVar, imageRef := range operatorImageRefs {
-		params.EnvImages[envVar] = images[imageRef]
 	}
 
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+const (
+	storageOperatorImageName = "cluster-storage-operator"
+)
+
+var (
+	// map env. variable in CSO Deployment -> key in `images` map (= name of the image in payload).
+	operatorImageRefs = map[string]string{
+		"AWS_EBS_DRIVER_OPERATOR_IMAGE":                   "aws-ebs-csi-driver-operator",
+		"AWS_EBS_DRIVER_IMAGE":                            "aws-ebs-csi-driver",
+		"GCP_PD_DRIVER_OPERATOR_IMAGE":                    "gcp-pd-csi-driver-operator",
+		"GCP_PD_DRIVER_IMAGE":                             "gcp-pd-csi-driver",
+		"OPENSTACK_CINDER_DRIVER_OPERATOR_IMAGE":          "openstack-cinder-csi-driver-operator",
+		"OPENSTACK_CINDER_DRIVER_IMAGE":                   "openstack-cinder-csi-driver",
+		"OVIRT_DRIVER_OPERATOR_IMAGE":                     "ovirt-csi-driver-operator",
+		"OVIRT_DRIVER_IMAGE":                              "ovirt-csi-driver",
+		"MANILA_DRIVER_OPERATOR_IMAGE":                    "csi-driver-manila-operator",
+		"MANILA_DRIVER_IMAGE":                             "csi-driver-manila",
+		"MANILA_NFS_DRIVER_IMAGE":                         "csi-driver-nfs",
+		"PROVISIONER_IMAGE":                               "csi-external-provisioner",
+		"ATTACHER_IMAGE":                                  "csi-external-attacher",
+		"RESIZER_IMAGE":                                   "csi-external-resizer",
+		"SNAPSHOTTER_IMAGE":                               "csi-external-snapshotter",
+		"NODE_DRIVER_REGISTRAR_IMAGE":                     "csi-node-driver-registrar",
+		"LIVENESS_PROBE_IMAGE":                            "csi-livenessprobe",
+		"VSPHERE_PROBLEM_DETECTOR_OPERATOR_IMAGE":         "vsphere-problem-detector",
+		"AZURE_DISK_DRIVER_OPERATOR_IMAGE":                "azure-disk-csi-driver-operator",
+		"AZURE_DISK_DRIVER_IMAGE":                         "azure-disk-csi-driver",
+		"AZURE_FILE_DRIVER_OPERATOR_IMAGE":                "azure-file-csi-driver-operator",
+		"AZURE_FILE_DRIVER_IMAGE":                         "azure-file-csi-driver",
+		"KUBE_RBAC_PROXY_IMAGE":                           "kube-rbac-proxy",
+		"VMWARE_VSPHERE_DRIVER_OPERATOR_IMAGE":            "vsphere-csi-driver-operator",
+		"VMWARE_VSPHERE_DRIVER_IMAGE":                     "vsphere-csi-driver",
+		"VMWARE_VSPHERE_SYNCER_IMAGE":                     "vsphere-csi-driver-syncer",
+		"CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE": "cluster-cloud-controller-manager-operator",
+		"SHARED_RESOURCE_DRIVER_OPERATOR_IMAGE":           "csi-driver-shared-resource-operator",
+		"SHARED_RESOURCE_DRIVER_IMAGE":                    "csi-driver-shared-resource",
+		"SHARED_RESOURCE_DRIVER_WEBHOOK_IMAGE":            "csi-driver-shared-resource-webhook",
+		"ALIBABA_DISK_DRIVER_OPERATOR_IMAGE":              "alibaba-disk-csi-driver-operator",
+		"ALIBABA_CLOUD_DRIVER_IMAGE":                      "alibaba-cloud-csi-driver",
+		"IBM_VPC_BLOCK_DRIVER_OPERATOR_IMAGE":             "ibm-vpc-block-csi-driver-operator",
+		"IBM_VPC_BLOCK_DRIVER_IMAGE":                      "ibm-vpc-block-csi-driver",
+		"IBM_VPC_NODE_LABEL_UPDATER_IMAGE":                "ibm-vpc-node-label-updater",
+		"POWERVS_BLOCK_CSI_DRIVER_OPERATOR_IMAGE":         "powervs-block-csi-driver-operator",
+		"POWERVS_BLOCK_CSI_DRIVER_IMAGE":                  "powervs-block-csi-driver",
+		"HYPERSHIFT_IMAGE":                                "token-minter",
+	}
+)
+
+type Params struct {
+	OwnerRef             config.OwnerRef
+	StorageOperatorImage string
+	// Map env. variable -> image name
+	EnvImages map[string]string
+
+	AvailabilityProberImage string
+	Version                 string
+	APIPort                 *int32
+	config.DeploymentConfig
+}
+
+func NewParams(
+	hcp *hyperv1.HostedControlPlane,
+	version string,
+	images map[string]string,
+	setDefaultSecurityContext bool) *Params {
+
+	params := Params{
+		OwnerRef:                config.OwnerRefFrom(hcp),
+		StorageOperatorImage:    images[storageOperatorImageName],
+		AvailabilityProberImage: images[util.AvailabilityProberImageName],
+		EnvImages:               make(map[string]string),
+		Version:                 version,
+		APIPort:                 util.APIPort(hcp),
+	}
+
+	for envVar, imageRef := range operatorImageRefs {
+		params.EnvImages[envVar] = images[imageRef]
+	}
+
+	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+	// Run only one replica of the operator
+	params.DeploymentConfig.Scheduling = config.Scheduling{
+		PriorityClass: config.DefaultPriorityClass,
+	}
+	params.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.IntPtr(1))
+	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+
+	return &params
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Move cluster-storage-operator + its operands (aws-ebs-csi-driver-operator + AWS EBS CSI driver control plane pods) to HyperShift mgmt. cluster.

[cluster-storage-operator](https://github.com/openshift/cluster-storage-operator/pull/318) must be updated first!

**Testing**
Update control-plane-operator RBACs:
1. Build your own hypershift-operator image.
   1. Clone  openshift/hypershift git repo + apply this PR.
   2. Build the custom image, e.g. quay.io/jsafrane/hypershift:latest:
        ```sh
        make docker-build docker-push quay.io/jsafrane/hypershift:latest
        ```
2. Install hypershift-operator from the custom image: `./hypershift install --hypershift-image=quay.io/jsafrane/hypershift:latest ...`

Install a guest cluster:
1. Build a release that contains this PR + cluster-storage-operator PR + AWS operator PR. For example, ask cluster-bot: `build openshift/hypershift#1698,openshift/aws-ebs-csi-driver-operator#159,openshift/cluster-storage-operator#XXX`
2. Use the release to install a guest cluster: `./hypershift create cluster aws --release-image=registry.build02.ci.openshift.org/ci-ln-ww5ihgt/release:latest ...`


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.