### PR TITLE
bug: HOSTEDCP-569 HC controller blocked reconcile verifying releaseImage

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -544,7 +544,7 @@ type ServiceNetworkEntry struct {
 	CIDR ipnet.IPNet `json:"cidr"`
 }
 
-//+kubebuilder:validation:Pattern:=`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$`
+// +kubebuilder:validation:Pattern:=`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$`
 type CIDRBlock string
 
 // APIServerNetworking specifies how the APIServer is exposed inside a cluster
@@ -1734,7 +1734,8 @@ const (
 	OIDCConfigurationInvalidReason    = "OIDCConfigurationInvalid"
 	PlatformCredentialsNotFoundReason = "PlatformCredentialsNotFound"
 
-	InvalidImageReason = "InvalidImage"
+	SecretNotFoundReason = "SecretNotFound"
+	InvalidImageReason   = "InvalidImage"
 )
 
 // HostedClusterStatus is the latest observed status of a HostedCluster.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -678,10 +678,15 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 				Type:               string(hyperv1.ValidReleaseImage),
 				ObservedGeneration: hcluster.Generation,
 			}
-			if err := r.validateReleaseImage(ctx, hcluster); err != nil {
+			err := r.validateReleaseImage(ctx, hcluster)
+			if err != nil {
 				condition.Status = metav1.ConditionFalse
 				condition.Message = err.Error()
-				condition.Reason = hyperv1.InvalidImageReason
+				if strings.Contains(err.Error(), "failed to get pull secret") {
+					condition.Reason = hyperv1.SecretNotFoundReason
+				} else {
+					condition.Reason = hyperv1.InvalidImageReason
+				}
 			} else {
 				condition.Status = metav1.ConditionTrue
 				condition.Message = "Release image is valid"
@@ -771,8 +776,8 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 		validReleaseImage := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.ValidReleaseImage))
 		if validReleaseImage != nil && validReleaseImage.Status == metav1.ConditionFalse {
-			if validReleaseImage.Reason == hyperv1.InvalidImageReason {
-				return ctrl.Result{}, fmt.Errorf("release Image validation error: %v", validReleaseImage.Message)
+			if validReleaseImage.Reason == hyperv1.SecretNotFoundReason {
+				return ctrl.Result{}, fmt.Errorf(validReleaseImage.Message)
 			}
 			log.Error(fmt.Errorf("release image is invalid"), "reconciliation is blocked", "message", validReleaseImage.Message)
 			return ctrl.Result{}, nil

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -682,7 +682,8 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			if err != nil {
 				condition.Status = metav1.ConditionFalse
 				condition.Message = err.Error()
-				if strings.Contains(err.Error(), "failed to get pull secret") {
+
+				if apierrors.IsNotFound(err) {
 					condition.Reason = hyperv1.SecretNotFoundReason
 				} else {
 					condition.Reason = hyperv1.InvalidImageReason


### PR DESCRIPTION
This bug happens when you try to provision a HC and you have not created the PullSecret. The reconcile process will try to pull the ReleaseImage and verify it, but it cannot because cannot recover the Pull Secret. 

With the current verification process the controller returns 'nil' and after 7 tries, the reconcile process gets blocked. 

The fix validates this situation of the missing pull secret before this second check, but in this case the controller returns an error, which made possible the controller to wait indefinitely until the PullSecret gets created by the user.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**What this PR does / why we need it**:

Fixes: [HOSTEDCP-569](https://issues.redhat.com//browse/HOSTEDCP-569)

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.