### PR TITLE
ARMOCP-411: Add ARM nodepool to Azure x86 Hosted Cluster

### DIFF
--- a/api/fixtures/example_azure.go
+++ b/api/fixtures/example_azure.go
@@ -1,0 +1,38 @@
+package fixtures
+
+type ExampleAzureOptions struct {
+	Creds             AzureCreds
+	Location          string
+	ResourceGroupName string
+	VnetName          string
+	VnetID            string
+	SubnetName        string
+	BootImageInfo     map[string]BootImageDetails
+	MachineIdentityID string
+	InstanceType      string
+	SecurityGroupName string
+	DiskSizeGB        int32
+	AvailabilityZones []string
+
+	EncryptionKey *AzureEncryptionKey
+}
+
+type BootImageDetails struct {
+	BootImageID string `json:"bootImageID"`
+}
+
+// AzureCreds is the fileformat we expect for credentials. It is copied from the installer
+// to allow using the same crededentials file for both:
+// https://github.com/openshift/installer/blob/8fca1ade5b096d9b2cd312c4599881d099439288/pkg/asset/installconfig/azure/session.go#L36
+type AzureCreds struct {
+	SubscriptionID string `json:"subscriptionId,omitempty"`
+	ClientID       string `json:"clientId,omitempty"`
+	ClientSecret   string `json:"clientSecret,omitempty"`
+	TenantID       string `json:"tenantId,omitempty"`
+}
+
+type AzureEncryptionKey struct {
+	KeyVaultName string
+	KeyName      string
+	KeyVersion   string
+}

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -72,7 +72,7 @@ type NodePool struct {
 
 // NodePoolSpec is the desired behavior of a NodePool.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.arch) || has(self.arch)", message="Arch is required once set"
-// +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws)", message="Setting Arch to arm64 is only supported for AWS"
+// +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure)", message="Setting Arch to arm64 is only supported for AWS and Azure"
 type NodePoolSpec struct {
 	// ClusterName is the name of the HostedCluster this NodePool belongs to.
 	//

--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -52,7 +52,6 @@ func NewDestroyCommand() *cobra.Command {
 	}
 
 	return cmd
-
 }
 
 func (o *DestroyInfraOptions) Run(ctx context.Context) error {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1864,8 +1864,8 @@ spec:
             x-kubernetes-validations:
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
-            - message: Setting Arch to arm64 is only supported for AWS
-              rule: self.arch != 'arm64' || has(self.platform.aws)
+            - message: Setting Arch to arm64 is only supported for AWS and Azure
+              rule: self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure)
           status:
             description: Status is the latest observed status of the NodePool.
             properties:

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -49,8 +49,22 @@ func (o *AzurePlatformCreateOptions) UpdateNodePool(_ context.Context, nodePool 
 	}
 
 	nodePool.Spec.Platform.Type = hyperv1.AzurePlatform
+
+	var instanceType string
+	if o.InstanceType != "" {
+		instanceType = o.InstanceType
+	} else {
+		// Aligning with Azure IPI instance type defaults
+		switch nodePool.Spec.Arch {
+		case hyperv1.ArchitectureAMD64:
+			instanceType = "Standard_D4s_v4"
+		case hyperv1.ArchitectureARM64:
+			instanceType = "Standard_D4ps_v5"
+		}
+	}
+
 	nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-		VMSize:              o.InstanceType,
+		VMSize:              instanceType,
 		DiskSizeGB:          o.DiskSize,
 		AvailabilityZone:    o.AvailabilityZone,
 		DiskEncryptionSetID: o.DiskEncryptionSetID,

--- a/docs/content/how-to/azure/create-azure-cluster-arm-workers.md
+++ b/docs/content/how-to/azure/create-azure-cluster-arm-workers.md
@@ -1,0 +1,49 @@
+# Create ARM NodePools
+
+## Creating a Hosted Cluster with ARM NodePool
+Create a new cluster, specifying the `RELEASE_IMAGE` and `ARCH`:
+
+```shell linenums="1"
+AZURE_REGION=centralus
+CLUSTER_NAME=example
+BASE_DOMAIN=example.com
+AZURE_CREDS="$HOME/.azure/credentials"
+PULL_SECRET="$HOME/pull-secret"
+RELEASE_IMAGE="quay.io/openshift-release-dev/ocp-release@sha256:1a101ef5215da468cea8bd2eb47114e85b2b64a6b230d5882f845701f55d057f"
+ARCH="arm64"
+
+hypershift create cluster azure \
+--name $CLUSTER_NAME \
+--node-pool-replicas=3 \
+--base-domain $BASE_DOMAIN \
+--pull-secret $PULL_SECRET \
+--azure-creds $AZURE_CREDS \
+--location $AZURE_REGION \
+--release-image $RELEASE_IMAGE \
+--arch $ARCH
+```
+
+!!! important
+
+    The release image used needs to be a manifest listed image.
+
+!!! note
+
+    Currently, the only valid values for '--arch' are 'arm64' and 'amd64'. 'amd64' is the default when '--arch' isn't used.
+
+The hosted cluster will spin up with an ARM NodePool. The default Azure ARM instance type is `Standard_D4ps_v5`.
+
+## Creating ARM NodePools on Existing Hosted Cluster
+As long as a hosted cluster was created with a manifest listed image in the `--release-image`, ARM NodePools can be added to the hosted cluster:
+
+```shell linenums="1"
+CLUSTER_NAME=example
+NODE_POOLNAME=example-worker
+ARCH="arm64"
+
+hypershift create nodepool azure \
+--cluster-name $CLUSTER_NAME \
+--name $NODE_POOLNAME \
+--node-count=3 \
+--arch $ARCH \
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
   - 'Azure':
     - how-to/azure/create-azure-cluster.md
     - how-to/azure/create-azure-cluster-with-options.md
+    - how-to/azure/create-azure-cluster-arm-workers.md
     - 'Troubleshooting':
         - how-to/azure/troubleshooting/index.md
         - how-to/azure/troubleshooting/debug-nodes.md

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -693,7 +693,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				}
 				nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
 					VMSize:              o.Azure.InstanceType,
-					ImageID:             o.Azure.BootImageID,
+					ImageID:             o.Azure.BootImageInfo[o.Arch].BootImageID,
 					DiskSizeGB:          o.Azure.DiskSizeGB,
 					AvailabilityZone:    availabilityZone,
 					DiskEncryptionSetID: o.Azure.DiskEncryptionSetID,
@@ -708,7 +708,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			}
 			nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
 				VMSize:              o.Azure.InstanceType,
-				ImageID:             o.Azure.BootImageID,
+				ImageID:             o.Azure.BootImageInfo[o.Arch].BootImageID,
 				DiskSizeGB:          o.Azure.DiskSizeGB,
 				DiskEncryptionSetID: o.Azure.DiskEncryptionSetID,
 			}

--- a/examples/fixtures/example_azure.go
+++ b/examples/fixtures/example_azure.go
@@ -1,6 +1,9 @@
 package fixtures
 
-import "github.com/openshift/hypershift/cmd/util"
+import (
+	"github.com/openshift/hypershift/api/fixtures"
+	"github.com/openshift/hypershift/cmd/util"
+)
 
 type ExampleAzureOptions struct {
 	Creds               util.AzureCreds
@@ -9,7 +12,7 @@ type ExampleAzureOptions struct {
 	VnetName            string
 	VnetID              string
 	SubnetName          string
-	BootImageID         string
+	BootImageInfo       map[string]fixtures.BootImageDetails
 	MachineIdentityID   string
 	InstanceType        string
 	SecurityGroupName   string

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -5,10 +5,10 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"golang.org/x/crypto/ssh"
 	utilpointer "k8s.io/utils/pointer"
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -25,9 +25,12 @@ func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1
 			return nil, fmt.Errorf("failed to generate a SSH key: %w", err)
 		}
 	}
+
+	bootImageToUse := bootImage(hcluster, nodePool)
+
 	azureMachineTemplate := &capiazure.AzureMachineTemplateSpec{Template: capiazure.AzureMachineTemplateResource{Spec: capiazure.AzureMachineSpec{
 		VMSize: nodePool.Spec.Platform.Azure.VMSize,
-		Image:  &capiazure.Image{ID: utilpointer.String(bootImage(hcluster, nodePool))},
+		Image:  &capiazure.Image{ID: utilpointer.String(bootImageToUse)},
 		OSDisk: capiazure.OSDisk{
 			DiskSizeGB: utilpointer.Int32(nodePool.Spec.Platform.Azure.DiskSizeGB),
 			ManagedDisk: &capiazure.ManagedDiskParameters{
@@ -69,11 +72,11 @@ func generateSSHPubkey() (string, error) {
 	return base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey)), nil
 }
 
-func bootImage(hcluster *hyperv1.HostedCluster, nodepool *hyperv1.NodePool) string {
+func bootImage(hostedCluster *hyperv1.HostedCluster, nodepool *hyperv1.NodePool) string {
 	if nodepool.Spec.Platform.Azure.ImageID != "" {
 		return nodepool.Spec.Platform.Azure.ImageID
 	}
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/rhcos.x86_64.vhd", hcluster.Spec.Platform.Azure.SubscriptionID, hcluster.Spec.Platform.Azure.ResourceGroupName)
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/rhcos.%s.vhd", hostedCluster.Spec.Platform.Azure.SubscriptionID, hostedCluster.Spec.Platform.Azure.ResourceGroupName, nodepool.Spec.Arch)
 }
 
 func failureDomain(nodepool *hyperv1.NodePool) *string {

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -8,32 +8,42 @@ import (
 
 func TestBootImage(t *testing.T) {
 	testCases := []struct {
-		name     string
-		hcluster *hyperv1.HostedCluster
-		nodepool *hyperv1.NodePool
-		expected string
+		name          string
+		hostedCluster *hyperv1.HostedCluster
+		nodepool      *hyperv1.NodePool
+		expected      string
 	}{
 		{
 			name: "Nodepool has image set, it is being used",
-			nodepool: &hyperv1.NodePool{Spec: hyperv1.NodePoolSpec{Platform: hyperv1.NodePoolPlatform{Azure: &hyperv1.AzureNodePoolPlatform{
-				ImageID: "nodepool-image",
-			}}}},
+			nodepool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Azure: &hyperv1.AzureNodePoolPlatform{
+							ImageID: "nodepool-image",
+						}},
+					Arch: "amd64",
+				}},
 			expected: "nodepool-image",
 		},
 		{
-			name: "Default bootimage is used",
-			hcluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{Azure: &hyperv1.AzurePlatformSpec{
+			name: "Default boot image is used",
+			hostedCluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{Azure: &hyperv1.AzurePlatformSpec{
 				SubscriptionID:    "123-123",
 				ResourceGroupName: "rg-name",
 			}}}},
-			nodepool: &hyperv1.NodePool{Spec: hyperv1.NodePoolSpec{Platform: hyperv1.NodePoolPlatform{Azure: &hyperv1.AzureNodePoolPlatform{}}}},
-			expected: "/subscriptions/123-123/resourceGroups/rg-name/providers/Microsoft.Compute/images/rhcos.x86_64.vhd",
+			nodepool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Azure: &hyperv1.AzureNodePoolPlatform{}},
+					Arch: "arm64",
+				}},
+			expected: "/subscriptions/123-123/resourceGroups/rg-name/providers/Microsoft.Compute/images/rhcos.arm64.vhd",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := bootImage(tc.hcluster, tc.nodepool)
+			result := bootImage(tc.hostedCluster, tc.nodepool)
 			if result != tc.expected {
 				t.Errorf("expected %s, got %s", tc.expected, result)
 			}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -456,7 +456,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	})
 
 	// Validate modifying CPU arch support for platform
-	if (nodePool.Spec.Arch != "amd64") && (nodePool.Spec.Platform.Type != hyperv1.AWSPlatform) {
+	if (nodePool.Spec.Arch != "amd64") && (nodePool.Spec.Platform.Type != hyperv1.AWSPlatform && nodePool.Spec.Platform.Type != hyperv1.AzurePlatform) {
 		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolValidArchPlatform,
 			Status:             corev1.ConditionFalse,

--- a/support/releaseinfo/registryclient/client_test.go
+++ b/support/releaseinfo/registryclient/client_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 )
 
 const (
@@ -26,7 +28,7 @@ func TestFindMatchingManifest(t *testing.T) {
 						Digest:    "sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
 					},
 					Platform: manifestlist.PlatformSpec{
-						Architecture: ArchitectureAMD64,
+						Architecture: hyperv1.ArchitectureAMD64,
 						OS:           LinuxOS,
 					},
 				},
@@ -36,7 +38,7 @@ func TestFindMatchingManifest(t *testing.T) {
 						Digest:    "sha256:f8dcd1dadc68b85ccf8737067f73fc03b0f6a1d81633fbdcdde2e3b5bc804d6a",
 					},
 					Platform: manifestlist.PlatformSpec{
-						Architecture: ArchitectureS390X,
+						Architecture: hyperv1.ArchitectureS390X,
 						OS:           LinuxOS,
 					},
 				},
@@ -46,7 +48,7 @@ func TestFindMatchingManifest(t *testing.T) {
 						Digest:    "sha256:a46358bdcf31d39c23e7389e8b75d1e5efa7181cca8832e51697b6bb3470e4a5",
 					},
 					Platform: manifestlist.PlatformSpec{
-						Architecture: ArchitecturePPC64LE,
+						Architecture: hyperv1.ArchitecturePPC64LE,
 						OS:           LinuxOS,
 					},
 				},
@@ -56,7 +58,7 @@ func TestFindMatchingManifest(t *testing.T) {
 						Digest:    "sha256:4fe15a54f144d0200a39a93e2dc97b8b0e989e95cc076acbe2dfe129d0c04831",
 					},
 					Platform: manifestlist.PlatformSpec{
-						Architecture: ArchitectureARM64,
+						Architecture: hyperv1.ArchitectureARM64,
 						OS:           LinuxOS,
 					},
 				},
@@ -73,7 +75,7 @@ func TestFindMatchingManifest(t *testing.T) {
 						Digest:    "sha256:b593c6882f9c8d9d75f3d200fa3e02f7f8caa99cea595fd70bbdd495613fd23f",
 					},
 					Platform: manifestlist.PlatformSpec{
-						Architecture: ArchitectureAMD64,
+						Architecture: hyperv1.ArchitectureAMD64,
 						OS:           LinuxOS,
 					},
 				},
@@ -83,7 +85,7 @@ func TestFindMatchingManifest(t *testing.T) {
 						Digest:    "sha256:be53e6c50f1c97b4b34b341fada995f1e0c6c5e8305f3f373b9356ba82cc3d22",
 					},
 					Platform: manifestlist.PlatformSpec{
-						Architecture: ArchitectureS390X,
+						Architecture: hyperv1.ArchitectureS390X,
 						OS:           LinuxOS,
 					},
 				},
@@ -93,7 +95,7 @@ func TestFindMatchingManifest(t *testing.T) {
 						Digest:    "sha256:a0f3d715a8947e45bdc9c9d2c1fcdccf8da6b216cb6efc38d75cec49a56f074b",
 					},
 					Platform: manifestlist.PlatformSpec{
-						Architecture: ArchitecturePPC64LE,
+						Architecture: hyperv1.ArchitecturePPC64LE,
 						OS:           LinuxOS,
 					},
 				},
@@ -103,7 +105,7 @@ func TestFindMatchingManifest(t *testing.T) {
 						Digest:    "sha256:f1c97cf57c57757fcd6d4314ff4b4cc792b27b904e949b840f902c104f1acf38",
 					},
 					Platform: manifestlist.PlatformSpec{
-						Architecture: ArchitectureARM64,
+						Architecture: hyperv1.ArchitectureARM64,
 						OS:           LinuxOS,
 					},
 				},
@@ -124,7 +126,7 @@ func TestFindMatchingManifest(t *testing.T) {
 			releaseImage:             ReleaseImage1,
 			deserializedManifestList: deserializedManifestList1,
 			osToFind:                 LinuxOS,
-			archToFind:               ArchitectureAMD64,
+			archToFind:               hyperv1.ArchitectureAMD64,
 			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
 		},
 		{
@@ -132,7 +134,7 @@ func TestFindMatchingManifest(t *testing.T) {
 			releaseImage:             ReleaseImage1,
 			deserializedManifestList: deserializedManifestList1,
 			osToFind:                 LinuxOS,
-			archToFind:               ArchitectureARM64,
+			archToFind:               hyperv1.ArchitectureARM64,
 			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:4fe15a54f144d0200a39a93e2dc97b8b0e989e95cc076acbe2dfe129d0c04831",
 		},
 		{
@@ -140,7 +142,7 @@ func TestFindMatchingManifest(t *testing.T) {
 			releaseImage:             ReleaseImage1,
 			deserializedManifestList: deserializedManifestList1,
 			osToFind:                 LinuxOS,
-			archToFind:               ArchitecturePPC64LE,
+			archToFind:               hyperv1.ArchitecturePPC64LE,
 			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:a46358bdcf31d39c23e7389e8b75d1e5efa7181cca8832e51697b6bb3470e4a5",
 		},
 		{
@@ -148,7 +150,7 @@ func TestFindMatchingManifest(t *testing.T) {
 			releaseImage:             ReleaseImage1,
 			deserializedManifestList: deserializedManifestList1,
 			osToFind:                 LinuxOS,
-			archToFind:               ArchitectureS390X,
+			archToFind:               hyperv1.ArchitectureS390X,
 			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:f8dcd1dadc68b85ccf8737067f73fc03b0f6a1d81633fbdcdde2e3b5bc804d6a",
 		},
 		{
@@ -156,7 +158,7 @@ func TestFindMatchingManifest(t *testing.T) {
 			releaseImage:             ReleaseImage2,
 			deserializedManifestList: deserializedManifestList2,
 			osToFind:                 LinuxOS,
-			archToFind:               ArchitectureAMD64,
+			archToFind:               hyperv1.ArchitectureAMD64,
 			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:b593c6882f9c8d9d75f3d200fa3e02f7f8caa99cea595fd70bbdd495613fd23f",
 		},
 		{
@@ -164,7 +166,7 @@ func TestFindMatchingManifest(t *testing.T) {
 			releaseImage:             ReleaseImage2,
 			deserializedManifestList: deserializedManifestList2,
 			osToFind:                 LinuxOS,
-			archToFind:               ArchitectureARM64,
+			archToFind:               hyperv1.ArchitectureARM64,
 			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:f1c97cf57c57757fcd6d4314ff4b4cc792b27b904e949b840f902c104f1acf38",
 		},
 		{
@@ -172,7 +174,7 @@ func TestFindMatchingManifest(t *testing.T) {
 			releaseImage:             ReleaseImage2,
 			deserializedManifestList: deserializedManifestList2,
 			osToFind:                 LinuxOS,
-			archToFind:               ArchitecturePPC64LE,
+			archToFind:               hyperv1.ArchitecturePPC64LE,
 			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:a0f3d715a8947e45bdc9c9d2c1fcdccf8da6b216cb6efc38d75cec49a56f074b",
 		},
 		{
@@ -180,7 +182,7 @@ func TestFindMatchingManifest(t *testing.T) {
 			releaseImage:             ReleaseImage2,
 			deserializedManifestList: deserializedManifestList2,
 			osToFind:                 LinuxOS,
-			archToFind:               ArchitectureS390X,
+			archToFind:               hyperv1.ArchitectureS390X,
 			expectedImageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:be53e6c50f1c97b4b34b341fada995f1e0c6c5e8305f3f373b9356ba82cc3d22",
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Allows a user to add an ARM nodepool to an Azure x86 hosted cluster
- Updates Azure VM image creation to use image gallery

**Which issue(s) this PR fixes**
Fixes - [ARMOCP-411 - Add arm nodepool to x86 managed cluster (Azure)](https://issues.redhat.com/browse/ARMOCP-411)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.