### PR TITLE
Add separate deployment for openshift route controller manager

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_route_cm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/openshift_route_cm.go
@@ -1,0 +1,35 @@
+package manifests
+
+import (
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func OpenShiftRouteControllerManagerDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-route-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func OpenShiftRouteControllerManagerService(ns string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-route-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func OpenShiftRouteControllerManagerServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
+	return &prometheusoperatorv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-route-controller-manager",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -176,6 +176,15 @@ func OpenShiftControllerManagerCertSecret(ns string) *corev1.Secret {
 	}
 }
 
+func OpenShiftRouteControllerManagerCertSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-route-controller-manager-cert",
+			Namespace: ns,
+		},
+	}
+}
+
 func ClusterPolicyControllerCertSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 )
 
@@ -50,4 +51,14 @@ func ReconcileClusterPolicyControllerCertSecret(secret, ca *corev1.Secret, owner
 		fmt.Sprintf("openshift-controller-manager.%s.svc.cluster.local", secret.Namespace),
 	}
 	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "cluster-policy-controller", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+}
+
+func ReconcileOpenShiftRouteControllerManagerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	svcName := manifests.OpenShiftRouteControllerManagerService("").Name
+	dnsNames := []string{
+		svcName,
+		fmt.Sprintf("%s.%s.svc", svcName, secret.Namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", svcName, secret.Namespace),
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, svcName, []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
@@ -1,0 +1,142 @@
+package routecm
+
+import (
+	"fmt"
+	"path"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+)
+
+const (
+	configHashAnnotation = "openshift-route-controller-manager.hypershift.openshift.io/config-hash"
+
+	servingPort int32 = 8443
+	configKey         = "config.yaml"
+)
+
+var (
+	volumeMounts = util.PodVolumeMounts{
+		routeOCMContainerMain().Name: {
+			routeOCMVolumeConfig().Name:      "/etc/kubernetes/config",
+			routeOCMVolumeServingCert().Name: "/etc/kubernetes/certs",
+			routeOCMVolumeKubeconfig().Name:  "/etc/kubernetes/secrets/svc-kubeconfig",
+		},
+	}
+)
+
+func openShiftRouteControllerManagerLabels() map[string]string {
+	return map[string]string{
+		"app":                         "openshift-route-controller-manager",
+		hyperv1.ControlPlaneComponent: "openshift-route-controller-manager",
+	}
+}
+
+func ReconcileDeployment(deployment *appsv1.Deployment, image string, config *corev1.ConfigMap, deploymentConfig config.DeploymentConfig) error {
+	configBytes, ok := config.Data[configKey]
+	if !ok {
+		return fmt.Errorf("openshift controller manager configuration is not expected to be empty")
+	}
+	configHash := util.ComputeHash(configBytes)
+
+	// preserve existing resource requirements for main OCM container
+	mainContainer := util.FindContainer(routeOCMContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	}
+
+	maxSurge := intstr.FromInt(0)
+	maxUnavailable := intstr.FromInt(1)
+	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
+	deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+		MaxSurge:       &maxSurge,
+		MaxUnavailable: &maxUnavailable,
+	}
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: openShiftRouteControllerManagerLabels(),
+		}
+	}
+	deployment.Spec.Template.ObjectMeta.Labels = openShiftRouteControllerManagerLabels()
+	deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
+		configHashAnnotation: configHash,
+	}
+	deployment.Spec.Template.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)
+	deployment.Spec.Template.Spec.Containers = []corev1.Container{
+		util.BuildContainer(routeOCMContainerMain(), buildRouteOCMContainerMain(image)),
+	}
+	deployment.Spec.Template.Spec.Volumes = []corev1.Volume{
+		util.BuildVolume(routeOCMVolumeConfig(), buildRouteOCMVolumeConfig),
+		util.BuildVolume(routeOCMVolumeServingCert(), buildRouteOCMVolumeServingCert),
+		util.BuildVolume(routeOCMVolumeKubeconfig(), buildRouteOCMVolumeKubeconfig),
+	}
+	deploymentConfig.ApplyTo(deployment)
+	return nil
+}
+
+func routeOCMContainerMain() *corev1.Container {
+	return &corev1.Container{
+		Name: "openshift-controller-manager",
+	}
+}
+
+func buildRouteOCMContainerMain(image string) func(*corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.Command = []string{"openshift-controller-manager"}
+		c.Args = []string{
+			"route-controller-manager-start",
+			"--config",
+			path.Join(volumeMounts.Path(c.Name, routeOCMVolumeConfig().Name), configKey),
+		}
+		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+		c.Ports = []corev1.ContainerPort{
+			{
+				Name:          "https",
+				ContainerPort: servingPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		}
+	}
+}
+
+func routeOCMVolumeConfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "config",
+	}
+}
+
+func buildRouteOCMVolumeConfig(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+	v.ConfigMap.Name = manifests.OpenShiftControllerManagerConfig("").Name
+}
+
+func routeOCMVolumeKubeconfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "kubeconfig",
+	}
+}
+
+func buildRouteOCMVolumeKubeconfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{}
+	v.Secret.SecretName = manifests.KASServiceKubeconfigSecret("").Name
+}
+
+func routeOCMVolumeServingCert() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "serving-cert",
+	}
+}
+
+func buildRouteOCMVolumeServingCert(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{}
+	v.Secret.SecretName = manifests.OpenShiftRouteControllerManagerCertSecret("").Name
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
@@ -1,0 +1,48 @@
+package routecm
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	configv1 "github.com/openshift/api/config/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/globalconfig"
+)
+
+type OpenShiftRouteControllerManagerParams struct {
+	OpenShiftControllerManagerImage string
+	APIServer                       *configv1.APIServerSpec
+
+	DeploymentConfig config.DeploymentConfig
+	config.OwnerRef
+}
+
+func NewOpenShiftRouteControllerManagerParams(hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, images map[string]string, setDefaultSecurityContext bool) *OpenShiftRouteControllerManagerParams {
+	params := &OpenShiftRouteControllerManagerParams{
+		OpenShiftControllerManagerImage: images["openshift-controller-manager"],
+	}
+	if hcp.Spec.Configuration != nil {
+		params.APIServer = hcp.Spec.Configuration.APIServer
+	}
+
+	params.DeploymentConfig = config.DeploymentConfig{
+		Scheduling: config.Scheduling{
+			PriorityClass: config.DefaultPriorityClass,
+		},
+		Resources: map[string]corev1.ResourceRequirements{
+			routeOCMContainerMain().Name: {
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+				},
+			},
+		},
+	}
+	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	params.DeploymentConfig.SetDefaults(hcp, openShiftRouteControllerManagerLabels(), nil)
+	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+
+	params.OwnerRef = config.OwnerRefFrom(hcp)
+	return params
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/service.go
@@ -1,0 +1,27 @@
+package routecm
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/openshift/hypershift/support/config"
+)
+
+func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(svc)
+	svc.Labels = openShiftRouteControllerManagerLabels()
+	svc.Spec.Selector = openShiftRouteControllerManagerLabels()
+	var portSpec corev1.ServicePort
+	if len(svc.Spec.Ports) > 0 {
+		portSpec = svc.Spec.Ports[0]
+	} else {
+		svc.Spec.Ports = []corev1.ServicePort{portSpec}
+	}
+	portSpec.Name = "https"
+	portSpec.Port = servingPort
+	portSpec.Protocol = corev1.ProtocolTCP
+	portSpec.TargetPort = intstr.FromString("https")
+	svc.Spec.Type = corev1.ServiceTypeClusterIP
+	svc.Spec.Ports[0] = portSpec
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/servicemonitor.go
@@ -1,0 +1,60 @@
+package routecm
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/util"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef config.OwnerRef, clusterID string, metricsSet metrics.MetricsSet) error {
+	ownerRef.ApplyTo(sm)
+
+	sm.Spec.Selector.MatchLabels = openShiftRouteControllerManagerLabels()
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+	targetPort := intstr.FromString("https")
+	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
+		{
+			Interval:   "15s",
+			TargetPort: &targetPort,
+			Scheme:     "https",
+			TLSConfig: &prometheusoperatorv1.TLSConfig{
+				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
+					ServerName: "openshift-route-controller-manager",
+					Cert: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "tls.crt",
+						},
+					},
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+						},
+						Key: "tls.key",
+					},
+					CA: prometheusoperatorv1.SecretOrConfigMap{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+							},
+							Key: "ca.crt",
+						},
+					},
+				},
+			},
+			MetricRelabelConfigs: metrics.OpenShiftRouteControllerManagerRelabelConfigs(metricsSet),
+		},
+	}
+
+	util.ApplyClusterIDLabel(&sm.Spec.Endpoints[0], clusterID)
+
+	return nil
+}

--- a/support/metrics/sets.go
+++ b/support/metrics/sets.go
@@ -285,6 +285,27 @@ func OpenShiftControllerManagerRelabelConfigs(set MetricsSet) []*prometheusopera
 	}
 }
 
+func OpenShiftRouteControllerManagerRelabelConfigs(set MetricsSet) []*prometheusoperatorv1.RelabelConfig {
+	switch set {
+	case MetricsSetTelemetry:
+		return []*prometheusoperatorv1.RelabelConfig{
+			{
+				Action:       "drop",
+				Regex:        "*",
+				SourceLabels: []prometheusoperatorv1.LabelName{"__name__"},
+			},
+		}
+	default:
+		return []*prometheusoperatorv1.RelabelConfig{
+			{
+				Action:       "drop",
+				Regex:        "etcd_(debugging|disk|request|server).*",
+				SourceLabels: []prometheusoperatorv1.LabelName{"__name__"},
+			},
+		}
+	}
+}
+
 func OLMRelabelConfigs(set MetricsSet) []*prometheusoperatorv1.RelabelConfig {
 	switch set {
 	case MetricsSetTelemetry:


### PR DESCRIPTION
**What this PR does / why we need it**:
In 4.12 the controller that converts ingress to routes has been separated from the main openshift controller manager into its own process. In HyperShift, we need to create a separate deployment along with corresponding service and servicemonitor to run the separate controller.

Fixes broken origin conformance tests

**Checklist**
- [x] Subject and description added to both, commit and PR.