### PR TITLE
MCO-358: inplaceupgrader: switch to using a daemonset for MCD

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/drainer.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/drainer.go
@@ -71,8 +71,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 func (r *Reconciler) handleNodeDrainRequest(ctx context.Context, node *corev1.Node, desiredState string) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	// TODO (jerzhang): this name is deterministic, but should make this a const somewhere
-	daemonPodOnNodeName := fmt.Sprintf("machine-config-daemon-%s", node.Name)
 	drainer := &drain.Helper{
 		Client:              r.guestClusterKubeClient,
 		Force:               true,
@@ -86,14 +84,6 @@ func (r *Reconciler) handleNodeDrainRequest(ctx context.Context, node *corev1.No
 				verbStr = "Evicted"
 			}
 			log.Info("Pod drained", "Action", verbStr, "Namespace", pod.Namespace, "Pod name", pod.Name)
-		},
-		AdditionalFilters: []drain.PodFilter{
-			func(pod corev1.Pod) drain.PodDeleteStatus {
-				if pod.Name == daemonPodOnNodeName {
-					return drain.MakePodDeleteStatusSkip()
-				}
-				return drain.MakePodDeleteStatusOkay()
-			},
 		},
 		// TODO (jerzhang): properly handle logging here, although this seems to work
 		Out:    writer{log.Info},


### PR DESCRIPTION
Today the inplace upgrader directly spins up pods for the
machine-config-daemons responsible for doing the inplace upgrade. This
was done for earlier versions of the logic where the pod was a oneshot,
but now the MCD is a state machine for Hypershift as well, so that is no
longer needed. Doing it as a pod has the following downsides:

1. the pods must be individually monitored for status
2. the pod must be referenced by the drainer so as not to drain it
   during upgrades
3. this deviates from self-driving OCP MCD behaviour

This PR aims to switch the MCD over to be a daemonset instead, with the
main downside that we now have to specify the SecurityContextConstraints
otherwise the pod cannot be created by the daemonset controller, meaning
that we will need a ServiceAccount, ClusterRole, and ClusterRoleBinding.

The other way I've found that can bypass the SecurityContextConstraints is to have a
"run-level" of 1 for the namespace, but that is not recommended. If there
are other options, I'm happy to change such that we don't need the
additional manifests.

cc @enxebre 