### PR TITLE
Add recording rule for NTO metric needed in telemetry

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/assets/recording-rules.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/assets/recording-rules.yaml
@@ -29,3 +29,5 @@ groups:
     labels:
       quantile: "0.99"
     record: instance:etcd_disk_backend_commit_duration_seconds:histogram_quantile
+  - expr: count by (_id) (nto_profile_calculated_total{profile!~"openshift-node",profile!~"openshift-control-plane",profile!~"openshift"})
+    record: nto_custom_profiles:count


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a recording rule that exists in standalone OCP which counts the number of nodes using custom TuneD profiles in the cluster. This metric is sent via telemetry to get an idea of how many users are customizing tuning on nodes.

**Which issue(s) this PR fixes**:
Part of enabling Node Tuning of HyperShift hosted cluster nodes: [PSAP-742](https://issues.redhat.com/browse/PSAP-742)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] (N/A) This change includes docs. 
- [ ] (N/A) This change includes unit tests. 