### PR TITLE
Don't consider version.Desired.Image for hcp rollout complete

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2679,7 +2679,7 @@ func computeClusterVersionStatus(clock clock.WithTickerAndDelayedExecution, hclu
 	// quite right because the intent here is to identify a terminal rollout
 	// state. For now it assumes when status.releaseImage matches, that rollout
 	// is definitely done.
-	hcpRolloutComplete := (hcp.Spec.ReleaseImage == hcp.Status.ReleaseImage) && (version.Desired.Image == hcp.Status.ReleaseImage)
+	hcpRolloutComplete := hcp.Spec.ReleaseImage == hcp.Status.ReleaseImage
 	if !hcpRolloutComplete {
 		return version
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

As it is now the following permanent blocking state is possible:
1 - User sets a non pulleable hc.releaseImage.
2 - ComputeVersion sets it as status.version.Desired.
3 - ValidateReleaseImage uses status.version.Desired to validate and fails. Blocks further progress.
4 - User updates hc.releaseImage to a valid value. New generation triggers reconcile of HC.
5 - ComputeVersion happens again but keeps status.version.Desired with the same old conflicting value. Go to 3.

This change effectively enables status.version.Desired to be updated with the value from hc.release.Image, letting validation succeed.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.