### PR TITLE
ignition-server: Also provide new `rhel-coreos-8` etc.

### DIFF
--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -232,6 +232,8 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 			"bootstrap",
 			fmt.Sprintf("--machine-config-operator-image=%s", images["machine-config-operator"]),
 			fmt.Sprintf("--machine-config-oscontent-image=%s", images["machine-os-content"]),
+			fmt.Sprintf("--baseos-image=%s", images["rhel-coreos-8"]),
+			fmt.Sprintf("--baseos-extensions-image=%s", images["rhel-coreos-8-extensions"]),
 			fmt.Sprintf("--infra-image=%s", images["pod"]),
 			fmt.Sprintf("--keepalived-image=%s", images["keepalived-ipfailover"]),
 			fmt.Sprintf("--coredns-image=%s", images["codedns"]),


### PR DESCRIPTION
What we really should do is just pass `--image-references` and avoid this manual indirection, but that seems to require some nontrivial work.  Just use the CLI arguments for now.

Closes: https://github.com/openshift/hypershift/issues/1767
