### PR TITLE
Specify ca for gitlab oauth only when passed as input

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
@@ -199,12 +199,12 @@ func convertProviderConfigToIDPData(
 			return nil, fmt.Errorf(missingProviderFmt, providerConfig.Type)
 		}
 
-		data.provider = &osinv1.GitLabIdentityProvider{
+		provider := &osinv1.GitLabIdentityProvider{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "GitLabIdentityProvider",
 				APIVersion: osinv1.GroupVersion.String(),
 			},
-			CA:       idpVolumeMounts.ConfigMapPath(i, gitlabConfig.CA.Name, "ca", corev1.ServiceAccountRootCAKey),
+
 			URL:      gitlabConfig.URL,
 			ClientID: gitlabConfig.ClientID,
 			ClientSecret: configv1.StringSource{
@@ -214,6 +214,11 @@ func convertProviderConfigToIDPData(
 			},
 			Legacy: new(bool), // we require OIDC for GitLab now
 		}
+		if gitlabConfig.CA.Name != "" {
+			provider.CA = idpVolumeMounts.ConfigMapPath(i, gitlabConfig.CA.Name, "ca", corev1.ServiceAccountRootCAKey)
+		}
+
+		data.provider = provider
 		data.challenge = true
 
 	case configv1.IdentityProviderTypeGoogle:


### PR DESCRIPTION
**What this PR does / why we need it**
Currently gitlab oauth is broken as it references a secret which does not necessarily exist.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
ref https://issues.redhat.com/browse/HOSTEDCP-421

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.