### PR TITLE
Remove KubeletConfig & ContainerRuntimeConfig CRDs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -70,6 +70,8 @@ var (
 		"0000_50_cluster-ingress-operator_02-deployment-ibm-cloud-managed.yaml",
 		"0000_70_cluster-network-operator_02_rbac.yaml",
 		"0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml",
+		"0000_80_machine-config-operator_01_containerruntimeconfig.crd.yaml",
+		"0000_80_machine-config-operator_01_kubeletconfig.crd.yaml",
 		"0000_80_machine-config-operator_01_machineconfig.crd.yaml",
 		"0000_80_machine-config-operator_01_machineconfigpool.crd.yaml",
 		"0000_50_cluster-node-tuning-operator_20-performance-profile.crd.yaml",


### PR DESCRIPTION
**What this PR does / why we need it**:
- Prevents kubeletconfigs.machineconfiguration.openshift.io and controllerconfigs.machineconfiguration.openshift.io CRDs from being created in the HyperShift cluster

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-516](https://issues.redhat.com/browse/HOSTEDCP-516)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.