### PR TITLE
network: Use non default ovn-k V4InternalSubnet at tenant

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
@@ -24,6 +24,11 @@ const kubevirtDefaultVXLANPort = uint32(9879)
 // 9880 is a currently unassigned IANA port in the user port range.
 const kubevirtDefaultGenevePort = uint32(9880)
 
+// The default OVN gateway router LRP CIDR is 100.64.0.0/16. We need to avoid
+// that for kubernetes which runs nested.
+// 100.65.0.0/16 is not used internally at OVN kubernetes.
+const kubevirtDefaultV4InternalSubnet = "100.65.0.0/16"
+
 func ReconcileNetworkOperator(network *operatorv1.Network, networkType hyperv1.NetworkType, platformType hyperv1.PlatformType) {
 	switch platformType {
 	case hyperv1.KubevirtPlatform:
@@ -40,6 +45,9 @@ func ReconcileNetworkOperator(network *operatorv1.Network, networkType hyperv1.N
 			port := kubevirtDefaultGenevePort
 			if network.Spec.DefaultNetwork.OVNKubernetesConfig == nil {
 				network.Spec.DefaultNetwork.OVNKubernetesConfig = &operatorv1.OVNKubernetesConfig{}
+			}
+			if network.Spec.DefaultNetwork.OVNKubernetesConfig.V4InternalSubnet == "" {
+				network.Spec.DefaultNetwork.OVNKubernetesConfig.V4InternalSubnet = kubevirtDefaultV4InternalSubnet
 			}
 			if network.Spec.DefaultNetwork.OVNKubernetesConfig.GenevePort == nil {
 				network.Spec.DefaultNetwork.OVNKubernetesConfig.GenevePort = &port

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile_test.go
@@ -11,6 +11,8 @@ import (
 func TestReconcileDefaultIngressController(t *testing.T) {
 	vxlanPort := kubevirtDefaultVXLANPort
 	genevePort := kubevirtDefaultGenevePort
+	v4InternalSubnet := kubevirtDefaultV4InternalSubnet
+
 	fakePort := uint32(11111)
 	testsCases := []struct {
 		name              string
@@ -32,7 +34,8 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 					},
 					DefaultNetwork: operatorv1.DefaultNetworkDefinition{
 						OVNKubernetesConfig: &operatorv1.OVNKubernetesConfig{
-							GenevePort: &genevePort,
+							GenevePort:       &genevePort,
+							V4InternalSubnet: v4InternalSubnet,
 						},
 					},
 				},
@@ -98,7 +101,8 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 					},
 					DefaultNetwork: operatorv1.DefaultNetworkDefinition{
 						OVNKubernetesConfig: &operatorv1.OVNKubernetesConfig{
-							GenevePort: &fakePort,
+							GenevePort:       &fakePort,
+							V4InternalSubnet: kubevirtDefaultV4InternalSubnet,
 						},
 					},
 				},
@@ -113,12 +117,47 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 					},
 					DefaultNetwork: operatorv1.DefaultNetworkDefinition{
 						OVNKubernetesConfig: &operatorv1.OVNKubernetesConfig{
-							GenevePort: &fakePort,
+							GenevePort:       &fakePort,
+							V4InternalSubnet: kubevirtDefaultV4InternalSubnet,
 						},
 					},
 				},
 			},
 		},
+		{
+			name: "KubeVirt with OVNKubernetes when v4InternalSubnet already exists",
+			inputNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+					DefaultNetwork: operatorv1.DefaultNetworkDefinition{
+						OVNKubernetesConfig: &operatorv1.OVNKubernetesConfig{
+							V4InternalSubnet: "100.66.0.0/16",
+							GenevePort:       &genevePort,
+						},
+					},
+				},
+			},
+			inputNetworkType:  hyperv1.OVNKubernetes,
+			inputPlatformType: hyperv1.KubevirtPlatform,
+			expectedNetwork: &operatorv1.Network{
+				ObjectMeta: NetworkOperator().ObjectMeta,
+				Spec: operatorv1.NetworkSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: "Managed",
+					},
+					DefaultNetwork: operatorv1.DefaultNetworkDefinition{
+						OVNKubernetesConfig: &operatorv1.OVNKubernetesConfig{
+							V4InternalSubnet: "100.66.0.0/16",
+							GenevePort:       &genevePort,
+						},
+					},
+				},
+			},
+		},
+
 		{
 			name:              "KubeVirt with non SDN network does not set unique vxlan port",
 			inputNetwork:      NetworkOperator(),


### PR DESCRIPTION
**What this PR does / why we need it**:

The ovn-k cluster has a CIDR for internal communication this CIDR appear
at the packages if the communication is from infra to tenant [1], so
ovn-k tenant routing get confused. This change use a non default value
for the tenant ovn-k V4InternalSubnet so there is no problem with that.

Depends on:
- https://github.com/openshift/cluster-network-operator/pull/1582

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

Fixes https://issues.redhat.com/browse/OCPBUGS-1150

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.