### PR TITLE
Revert "Decompress and ecode config always but when not supported by the CPO"

### DIFF
--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -18,4 +18,3 @@ LABEL io.openshift.hypershift.ignition-server-healthz-handler=true
 LABEL io.openshift.hypershift.control-plane-operator-manages-ignition-server=true
 LABEL io.openshift.hypershift.control-plane-operator-manages.cluster-machine-approver=true
 LABEL io.openshift.hypershift.control-plane-operator-manages.cluster-autoscaler=true
-LABEL io.openshift.hypershift.control-plane-operator-manages.decompress-decode-config=true

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/openshift/hypershift/support/supportedversion"
+
 	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -22,12 +24,10 @@ import (
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	api "github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
-	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/releaseinfo"
-	"github.com/openshift/hypershift/support/supportedversion"
 	"github.com/openshift/hypershift/support/upsert"
 	supportutil "github.com/openshift/hypershift/support/util"
 	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
@@ -83,8 +82,6 @@ const (
 
 	tunedConfigKey      = "tuned"
 	tunedConfigMapLabel = "hypershift.openshift.io/tuned-config"
-
-	controlPlaneOperatorManagesDecompressAndDecodeConfig = "io.openshift.hypershift.control-plane-operator-manages.decompress-decode-config"
 )
 
 type NodePoolReconciler struct {
@@ -581,22 +578,9 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 	// 2. - Reconcile towards expected state of the world.
 	targetConfigVersionHash := hashStruct(config + targetVersion)
-	compressedConfig, err := supportutil.CompressAndEncode([]byte(config))
+	compressedConfig, err := supportutil.Compress([]byte(config))
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to compress and decode config: %w", err)
-	}
-
-	// TODO (alberto): Drop this after dropping < 4.12 support.
-	// So all CPOs ign server will know to decompress and decode.
-	cpoDecompressAndDecodeConfig, err := r.doesCPODecompressAndDecodeConfig(ctx, hcluster)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to check if CPO decompress and encode config: %w", err)
-	}
-	if !cpoDecompressAndDecodeConfig {
-		compressedConfig, err = supportutil.Compress([]byte(config))
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to compress config: %w", err)
-		}
+		return ctrl.Result{}, fmt.Errorf("failed to compress config: %w", err)
 	}
 
 	// Token Secrets exist for each NodePool config/version and follow "prefixName-configVersionHash" naming convention.
@@ -1965,27 +1949,4 @@ func setExpirationTimestampOnToken(ctx context.Context, c client.Client, tokenSe
 	}
 	tokenSecret.Annotations[hyperv1.IgnitionServerTokenExpirationTimestampAnnotation] = time.Now().Add(timeUntilExpiry).Format(time.RFC3339)
 	return c.Update(ctx, tokenSecret)
-}
-
-func (r *NodePoolReconciler) doesCPODecompressAndDecodeConfig(ctx context.Context, hcluster *hyperv1.HostedCluster) (bool, error) {
-	var pullSecret corev1.Secret
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: hcluster.Namespace, Name: hcluster.Spec.PullSecret.Name}, &pullSecret); err != nil {
-		return false, fmt.Errorf("failed to get pull secret: %w", err)
-	}
-	pullSecretBytes, ok := pullSecret.Data[corev1.DockerConfigJsonKey]
-	if !ok {
-		return false, fmt.Errorf("expected %s key in pull secret", corev1.DockerConfigJsonKey)
-	}
-	controlPlaneOperatorImage, err := hostedcluster.GetControlPlaneOperatorImage(ctx, hcluster, r.ReleaseProvider, r.HypershiftOperatorImage, pullSecretBytes)
-	if err != nil {
-		return false, fmt.Errorf("failed to get controlPlaneOperatorImage: %w", err)
-	}
-
-	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes)
-	if err != nil {
-		return false, fmt.Errorf("failed to look up image metadata for %s: %w", controlPlaneOperatorImage, err)
-	}
-
-	_, managesDecompressAndDecodeConfig := supportutil.ImageLabels(controlPlaneOperatorImageMetadata)[controlPlaneOperatorManagesDecompressAndDecodeConfig]
-	return managesDecompressAndDecodeConfig, nil
 }

--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -79,7 +79,7 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 		return err
 	}
 	compressedConfig := token.Data[controllers.TokenSecretConfigKey]
-	config, err := util.DecodeAndDecompress(compressedConfig)
+	config, err := util.Decompress(compressedConfig)
 	if err != nil {
 		return nil
 	}

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -239,7 +239,7 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	releaseImage := string(tokenSecret.Data[TokenSecretReleaseKey])
 	compressedConfig := tokenSecret.Data[TokenSecretConfigKey]
-	config, err := util.DecodeAndDecompress(compressedConfig)
+	config, err := util.Decompress(compressedConfig)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/ignition-server/controllers/tokensecret_controller_test.go
+++ b/ignition-server/controllers/tokensecret_controller_test.go
@@ -31,7 +31,7 @@ func (p *fakeIgnitionProvider) GetPayload(ctx context.Context, releaseImage stri
 }
 
 func TestReconcile(t *testing.T) {
-	compressedConfig, err := util.CompressAndEncode([]byte("compressedConfig"))
+	compressedConfig, err := util.Compress([]byte("compressedConfig"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -18,7 +18,7 @@ import (
 const (
 	HypershiftRouteLabel = "hypershift.openshift.io/hosted-control-plane"
 
-	// DebugDeploymentsAnnotation contains a comma separated list of deployment names which should always be scaled to 0
+	// comma separated list of deployment names which should always be scaled to 0
 	// for development.
 	DebugDeploymentsAnnotation = "hypershift.openshift.io/debug-deployments"
 )
@@ -34,6 +34,10 @@ func ParseNamespacedName(name string) types.NamespacedName {
 	}
 	return types.NamespacedName{Name: parts[0]}
 }
+
+const (
+	UserDataKey = "data"
+)
 
 func DeleteIfNeeded(ctx context.Context, c client.Client, o client.Object) (exists bool, err error) {
 	if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
@@ -55,7 +59,7 @@ func DeleteIfNeeded(ctx context.Context, c client.Client, o client.Object) (exis
 	return true, nil
 }
 
-// CompressAndEncode compresses and base-64 encodes a given byte array. Ideal for loading an
+// Compresses and base-64 encodes a given byte array. Ideal for loading an
 // arbitrary byte array into a ConfigMap or Secret.
 func CompressAndEncode(payload []byte) (*bytes.Buffer, error) {
 	out := bytes.NewBuffer(nil)
@@ -82,7 +86,7 @@ func CompressAndEncode(payload []byte) (*bytes.Buffer, error) {
 	return out, err
 }
 
-// Compress compresses a given byte array.
+// Compresses a given byte array.
 func Compress(payload []byte) (*bytes.Buffer, error) {
 	in := bytes.NewBuffer(payload)
 	out := bytes.NewBuffer(nil)
@@ -95,7 +99,7 @@ func Compress(payload []byte) (*bytes.Buffer, error) {
 	return out, err
 }
 
-// DecodeAndDecompress decompresses and base-64 decodes a given byte array. Ideal for consuming a
+// Decompresses and base-64 decodes a given byte array. Ideal for consuming a
 // gzipped / base64-encoded byte array from a ConfigMap or Secret.
 func DecodeAndDecompress(payload []byte) (*bytes.Buffer, error) {
 	if len(payload) == 0 {
@@ -105,6 +109,15 @@ func DecodeAndDecompress(payload []byte) (*bytes.Buffer, error) {
 	base64Dec := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(payload))
 
 	return decompress(base64Dec)
+}
+
+// Decompresses a given gzipped byte array.
+func Decompress(payload []byte) (*bytes.Buffer, error) {
+	if len(payload) == 0 {
+		return bytes.NewBuffer(nil), nil
+	}
+
+	return decompress(bytes.NewBuffer(payload))
 }
 
 // Compresses a given io.Reader to a given io.Writer


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit 6948f4f4a71406a2aa13762e46a113fe633275d2.

The above commit results in a broken ignition-server in some cases. Reverting so we can have more time to look at it.

**Checklist**
- [x] Subject and description added to both, commit and PR.