### PR TITLE
Use separate image for route controller manager

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
@@ -84,16 +84,16 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image string, config *co
 
 func routeOCMContainerMain() *corev1.Container {
 	return &corev1.Container{
-		Name: "openshift-controller-manager",
+		Name: "route-controller-manager",
 	}
 }
 
 func buildRouteOCMContainerMain(image string) func(*corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = image
-		c.Command = []string{"openshift-controller-manager"}
+		c.Command = []string{"route-controller-manager"}
 		c.Args = []string{
-			"route-controller-manager-start",
+			"start",
 			"--config",
 			path.Join(volumeMounts.Path(c.Name, routeOCMVolumeConfig().Name), configKey),
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
@@ -20,7 +20,7 @@ type OpenShiftRouteControllerManagerParams struct {
 
 func NewOpenShiftRouteControllerManagerParams(hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, images map[string]string, setDefaultSecurityContext bool) *OpenShiftRouteControllerManagerParams {
 	params := &OpenShiftRouteControllerManagerParams{
-		OpenShiftControllerManagerImage: images["openshift-controller-manager"],
+		OpenShiftControllerManagerImage: images["route-controller-manager"],
 	}
 	if hcp.Spec.Configuration != nil {
 		params.APIServer = hcp.Spec.Configuration.APIServer


### PR DESCRIPTION
**What this PR does / why we need it**:
The route controller manager was recently separated into its own image and is no longer a subcommand of openshift-controller-manager. This change switches to using the separate route-controller-manager image and adjusts the deployment for it accordingly.

**Checklist**
- [x] Subject and description added to both, commit and PR.