### PR TITLE
Update Dockerfile with same labels as Dockerfile.control-plane

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,4 @@ LABEL io.openshift.hypershift.ignition-server-healthz-handler=true
 LABEL io.openshift.hypershift.control-plane-operator-manages-ignition-server=true
 LABEL io.openshift.hypershift.control-plane-operator-manages.cluster-machine-approver=true
 LABEL io.openshift.hypershift.control-plane-operator-manages.cluster-autoscaler=true
+LABEL io.openshift.hypershift.control-plane-operator-manages.decompress-decode-config=true


### PR DESCRIPTION
**What this PR does / why we need it**:
Because we include the control-plane-operator in the hypershift-operator image, we normally use that image when testing hypershift locally. The hypershift-operator image should have the same labels as the control plane operator one. This commit adds the most recent label to the hypershift-operator image.

**Checklist**
- [x] Subject and description added to both, commit and PR.