### PR TITLE
Fix image registry reconcile loop

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
@@ -25,7 +25,9 @@ func ReconcileRegistryConfig(cfg *imageregistryv1.Config, platform hyperv1.Platf
 	if cfg.Spec.HTTPSecret == "" {
 		cfg.Spec.HTTPSecret = generateImageRegistrySecret()
 	}
-	if platform == hyperv1.KubevirtPlatform || platform == hyperv1.NonePlatform {
+	if (platform == hyperv1.KubevirtPlatform || platform == hyperv1.NonePlatform) &&
+		cfg.Spec.Storage.EmptyDir == nil {
+
 		cfg.Spec.Storage = imageregistryv1.ImageRegistryConfigStorage{EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{}}
 	}
 }


### PR DESCRIPTION
When setting the image registry storage to EmptyDir{}, a reconcile loop is occurring for the KubeVirt and None platforms.

The issue is that the the `imageregistry.spec.storage` struct has a `managementState` field that now receives an default value, but our HCCO reconcile loop clobbers that default value over and over again.

Example. HCCO sets
```
spec:                   
  httpSecret: f840c08af1fe8d5a9e18467f6f304afd39a83b282efa201a6a76c7b836c0938cbfdcb25f039606b7170bb7ae42a793d03170f1ada8740a823732c45f2d366fdb
  logLevel: Normal
  managementState: Managed
  observedConfig: null
  operatorLogLevel: Normal  
  proxy: {}
  replicas: 1
  requests: 
    read:
      maxWaitInQueue: 0s
    write:
      maxWaitInQueue: 0s                   
  storage:
    emptyDir: {}      
```

Then the image registry gets the `spec.storage.managementState: Managed` field defaulted.

```
spec:                   
  httpSecret: f840c08af1fe8d5a9e18467f6f304afd39a83b282efa201a6a76c7b836c0938cbfdcb25f039606b7170bb7ae42a793d03170f1ada8740a823732c45f2d366fdb
  logLevel: Normal
  managementState: Managed
  observedConfig: null
  operatorLogLevel: Normal  
  proxy: {}
  replicas: 1
  requests: 
    read:
      maxWaitInQueue: 0s
    write:
      maxWaitInQueue: 0s                   
  storage:
    emptyDir: {}      
    managementState: Managed      
```

After that, the HCCO then clobbers that storage field again and removes the managementState default, then the default gets added back, then HCCO clobbers it, etc... reconcile loop.

To fix this, we should only cobber the storage field if the EmptyDir{} storage type isn't already in use.