### PR TITLE
Add compute and memory args for powervs e2e

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -80,6 +80,10 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSRegion, "e2e.powervs-region", "us-south", "IBM Cloud region. Default is us-south")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSZone, "e2e.powervs-zone", "us-south", "IBM Cloud zone. Default is us-sout")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSVpcRegion, "e2e.powervs-vpc-region", "us-south", "IBM Cloud VPC Region for VPC resources. Default is us-south")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSSysType, "e2e.powervs-sys-type", "s922", "System type used to host the instance(e.g: s922, e980, e880). Default is s922")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSProcType, "e2e.powervs-proc-type", "shared", "Processor type (dedicated, shared, capped). Default is shared")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSProcessors, "e2e.powervs-processors", "0.5", "Number of processors allocated. Default is 0.5")
+	flag.IntVar(&globalOpts.configurableClusterOptions.PowerVSMemory, "e2e.powervs-memory", 32, "Amount of memory allocated (in GB). Default is 32")
 
 	flag.Parse()
 
@@ -229,6 +233,10 @@ type configurableClusterOptions struct {
 	PowerVSRegion              string
 	PowerVSZone                string
 	PowerVSVpcRegion           string
+	PowerVSSysType             string
+	PowerVSProcType            string
+	PowerVSProcessors          string
+	PowerVSMemory              int
 }
 
 func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
@@ -264,10 +272,10 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 			Region:        o.configurableClusterOptions.PowerVSRegion,
 			Zone:          o.configurableClusterOptions.PowerVSZone,
 			VPCRegion:     o.configurableClusterOptions.PowerVSVpcRegion,
-			SysType:       "s922",
-			ProcType:      "shared",
-			Processors:    "0.5",
-			Memory:        32,
+			SysType:       o.configurableClusterOptions.PowerVSSysType,
+			ProcType:      o.configurableClusterOptions.PowerVSProcType,
+			Processors:    o.configurableClusterOptions.PowerVSProcessors,
+			Memory:        int32(o.configurableClusterOptions.PowerVSMemory),
 		},
 		ServiceCIDR: "172.31.0.0/16",
 		ClusterCIDR: "10.132.0.0/14",


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Fixes https://issues.redhat.com/browse/MULTIARCH-2967
Need this since we want to pass custom inputs for these args.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.