### PR TITLE
test: e2e: exclude catalog pods from restart check

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -349,6 +349,14 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 				continue
 			}
 
+			// TODO: 4.11 and later, FBC based catalogs can in excess of 150s to start
+			// https://github.com/openshift/hypershift/pull/1746
+			// https://github.com/operator-framework/operator-lifecycle-manager/pull/2791
+			// Investigate a fix.
+			if strings.Contains(pod.Name, "-catalog") {
+				continue
+			}
+
 			for _, containerStatus := range pod.Status.ContainerStatuses {
 				if containerStatus.RestartCount > 0 {
 					t.Errorf("Container %s in pod %s has a restartCount > 0 (%d)", containerStatus.Name, pod.Name, containerStatus.RestartCount)


### PR DESCRIPTION
Switching to file-based catalogs (FBC) in 4.11 has made `registry` container start times highly variable, sometimes in excess of the 150s `StartupProbe` timeout.

Exclude those pods from the restart check for now so they don't flake the e2e runs.

https://github.com/openshift/hypershift/pull/1746
https://github.com/operator-framework/operator-lifecycle-manager/pull/2791