### PR TITLE
increase loop detector threshold to 10

### DIFF
--- a/support/upsert/loopdetector.go
+++ b/support/upsert/loopdetector.go
@@ -37,7 +37,7 @@ const LoopDetectorWarningMessage = "WARNING: Object got updated more than one ti
 // a bug in the defaulting, we will end up always updating.
 func updateLoopThreshold(o runtime.Object) int {
 	// Give some leeway, if we actually revert defaults we will do a lot more than this
-	return 5
+	return 10
 }
 
 type updateLoopDetector struct {


### PR DESCRIPTION
Fix this flake

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-e2e-aws-periodic/1580166552538320896

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-e2e-aws-periodic/1580166552538320896/artifacts/e2e-aws-periodic/run-e2e/artifacts/TestReplaceUpgradeNodePool_PreTeardownClusterDump/namespaces/e2e-clusters-lhxk9-example-b5vhz/core/pods/logs/hosted-cluster-config-operator-7dd7bc5b8f-hdsk4-hosted-cluster-config-operator.log

I think we are just updating the Node legitimately a lot and triggering the loop detector