### PR TITLE
NodePool API: rename spec.tunedConfig to spec.tuningConfig

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -12,7 +12,7 @@ const (
 	NodePoolValidHostedClusterConditionType      = "ValidHostedCluster"
 	NodePoolValidReleaseImageConditionType       = "ValidReleaseImage"
 	NodePoolValidMachineConfigConditionType      = "ValidMachineConfig"
-	NodePoolValidTunedConfigConditionType        = "ValidTunedConfig"
+	NodePoolValidTuningConfigConditionType       = "ValidTuningConfig"
 	NodePoolUpdateManagementEnabledConditionType = "UpdateManagementEnabled"
 	NodePoolAutoscalingEnabledConditionType      = "AutoscalingEnabled"
 	NodePoolReadyConditionType                   = "Ready"
@@ -143,7 +143,7 @@ type NodePoolSpec struct {
 	// +optional
 	PausedUntil *string `json:"pausedUntil,omitempty"`
 
-	// TunedConfig is a list of references to ConfigMaps containing serialized
+	// TuningConfig is a list of references to ConfigMaps containing serialized
 	// Tuned resources to define the tuning configuration to be applied to
 	// nodes in the NodePool. The Tuned API is defined here:
 	//
@@ -152,7 +152,7 @@ type NodePoolSpec struct {
 	// Each ConfigMap must have a single key named "tuned" whose value is the
 	// JSON or YAML of a serialized Tuned.
 	// +kubebuilder:validation:Optional
-	TunedConfig []corev1.LocalObjectReference `json:"tunedConfig,omitempty"`
+	TuningConfig []corev1.LocalObjectReference `json:"tuningConfig,omitempty"`
 }
 
 // NodePoolStatus is the latest observed status of a NodePool.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1731,8 +1731,8 @@ func (in *NodePoolSpec) DeepCopyInto(out *NodePoolSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.TunedConfig != nil {
-		in, out := &in.TunedConfig, &out.TunedConfig
+	if in.TuningConfig != nil {
+		in, out := &in.TuningConfig, &out.TuningConfig
 		*out = make([]corev1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -693,8 +693,8 @@ spec:
                   maintain. If unset, the default value is 0.
                 format: int32
                 type: integer
-              tunedConfig:
-                description: "TunedConfig is a list of references to ConfigMaps containing
+              tuningConfig:
+                description: "TuningConfig is a list of references to ConfigMaps containing
                   serialized Tuned resources to define the tuning configuration to
                   be applied to nodes in the NodePool. The Tuned API is defined here:
                   \n https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go

--- a/docs/content/how-to/node-tuning.md
+++ b/docs/content/how-to/node-tuning.md
@@ -40,7 +40,7 @@ If you would like to set some node-level tuning on the nodes in your hosted clus
     oc --kubeconfig="$MGMT_KUBECONFIG" create -f tuned-1.yaml
     ```
 
-    Reference the ConfigMap in the NodePools `spec.tunedConfig` field, either by editing an existing NodePool or creating a new NodePool. In this example we assume we only have one NodePool called `nodepool-1`, containing 2 Nodes.
+    Reference the ConfigMap in the NodePools `spec.tuningConfig` field, either by editing an existing NodePool or creating a new NodePool. In this example we assume we only have one NodePool called `nodepool-1`, containing 2 Nodes.
     ```
     apiVersion: hypershift.openshift.io/v1alpha1
     kind: NodePool
@@ -51,7 +51,7 @@ If you would like to set some node-level tuning on the nodes in your hosted clus
     ...
     spec:
       ...
-      tunedConfig:
+      tuningConfig:
       - name: tuned-1
     status:
     ...
@@ -138,7 +138,7 @@ As an example, the following steps can be followed to create a NodePool with hug
     oc --kubeconfig="$MGMT_KUBECONFIG" create -f tuned-hugepages.yaml
     ```
 
-2. Create a new NodePool manifest YAML file, customize the NodePools upgrade type, and reference the previously created ConfigMap in the `spec.tunedConfig` section before creating it in the management cluster.
+2. Create a new NodePool manifest YAML file, customize the NodePools upgrade type, and reference the previously created ConfigMap in the `spec.tuningConfig` section before creating it in the management cluster.
 
     Create the NodePool manifest and save it in a file called `hugepages-nodepool.yaml`:
     ```
@@ -154,7 +154,7 @@ As an example, the following steps can be followed to create a NodePool with hug
       --render > hugepages-nodepool.yaml
     ```
 
-    Edit `hugepages-nodepool.yaml`. Set `.spec.management.upgradeType` to `InPlace`, and set `.spec.tunedConfig` to reference the `tuned-hugepages` ConfigMap you created.
+    Edit `hugepages-nodepool.yaml`. Set `.spec.management.upgradeType` to `InPlace`, and set `.spec.tuningConfig` to reference the `tuned-hugepages` ConfigMap you created.
     ```
     apiVersion: hypershift.openshift.io/v1alpha1
     kind: NodePool
@@ -167,7 +167,7 @@ As an example, the following steps can be followed to create a NodePool with hug
         ...
         upgradeType: InPlace
       ...
-      tunedConfig:
+      tuningConfig:
       - name: tuned-hugepages
     ```
     > **_NOTE:_**  Setting `.spec.management.upgradeType` to `InPlace` is recommended to avoid unnecessary Node recreations when applying the new MachineConfigs. With the `Replace` upgrade type, Nodes will be fully deleted and new nodes will replace them when applying the new kernel boot parameters that are calculated by the TuneD operand.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -692,7 +692,7 @@ provided: reconciliation is paused on the resource until the field is removed.</
 </tr>
 <tr>
 <td>
-<code>tunedConfig</code></br>
+<code>tuningConfig</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -700,7 +700,7 @@ provided: reconciliation is paused on the resource until the field is removed.</
 </em>
 </td>
 <td>
-<p>TunedConfig is a list of references to ConfigMaps containing serialized
+<p>TuningConfig is a list of references to ConfigMaps containing serialized
 Tuned resources to define the tuning configuration to be applied to
 nodes in the NodePool. The Tuned API is defined here:</p>
 <p><a href="https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go">https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go</a></p>
@@ -5710,7 +5710,7 @@ provided: reconciliation is paused on the resource until the field is removed.</
 </tr>
 <tr>
 <td>
-<code>tunedConfig</code></br>
+<code>tuningConfig</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -5718,7 +5718,7 @@ provided: reconciliation is paused on the resource until the field is removed.</
 </em>
 </td>
 <td>
-<p>TunedConfig is a list of references to ConfigMaps containing serialized
+<p>TuningConfig is a list of references to ConfigMaps containing serialized
 Tuned resources to define the tuning configuration to be applied to
 nodes in the NodePool. The Tuned API is defined here:</p>
 <p><a href="https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go">https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go</a></p>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -27596,8 +27596,8 @@ objects:
                     maintain. If unset, the default value is 0.
                   format: int32
                   type: integer
-                tunedConfig:
-                  description: "TunedConfig is a list of references to ConfigMaps
+                tuningConfig:
+                  description: "TuningConfig is a list of references to ConfigMaps
                     containing serialized Tuned resources to define the tuning configuration
                     to be applied to nodes in the NodePool. The Tuned API is defined
                     here: \n https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go

--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -60,7 +60,7 @@ func TokenSecret(namespace, name, payloadInputHash string) *corev1.Secret {
 	}
 }
 
-func TunedConfigMap(namespace, name string) *corev1.ConfigMap {
+func TuningConfigMap(namespace, name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -81,8 +81,8 @@ const (
 	TokenSecretConfigKey                      = "config"
 	TokenSecretAnnotation                     = "hypershift.openshift.io/ignition-config"
 
-	tunedConfigKey                 = "tuned"
-	tunedConfigMapLabel            = "hypershift.openshift.io/tuned-config"
+	tuningConfigKey                = "tuning"
+	tuningConfigMapLabel           = "hypershift.openshift.io/tuned-config"
 	nodeTuningGeneratedConfigLabel = "hypershift.openshift.io/nto-generated-machine-config"
 
 	controlPlaneOperatorManagesDecompressAndDecodeConfig = "io.openshift.hypershift.control-plane-operator-manages.decompress-decode-config"
@@ -520,21 +520,21 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		removeStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolUpdatingVersionConditionType)
 	}
 
-	// Validate tunedconfig input.
-	tunedConfig, err := r.getTunedConfig(ctx, nodePool)
+	// Validate tuningConfig input.
+	tuningConfig, err := r.getTuningConfig(ctx, nodePool)
 	if err != nil {
 		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
-			Type:               hyperv1.NodePoolValidTunedConfigConditionType,
+			Type:               hyperv1.NodePoolValidTuningConfigConditionType,
 			Status:             corev1.ConditionFalse,
 			Reason:             hyperv1.NodePoolValidationFailedConditionReason,
 			Message:            err.Error(),
 			ObservedGeneration: nodePool.Generation,
 		})
-		return ctrl.Result{}, fmt.Errorf("failed to get tunedConfig: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to get tuningConfig: %w", err)
 	}
 
 	setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
-		Type:               hyperv1.NodePoolValidTunedConfigConditionType,
+		Type:               hyperv1.NodePoolValidTuningConfigConditionType,
 		Status:             corev1.ConditionTrue,
 		Reason:             hyperv1.NodePoolAsExpectedConditionReason,
 		ObservedGeneration: nodePool.Generation,
@@ -559,20 +559,20 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		return ctrl.Result{RequeueAfter: duration}, nil
 	}
 
-	tunedConfigMap := TunedConfigMap(controlPlaneNamespace, nodePool.Name)
-	if tunedConfig == "" {
-		err = r.Get(ctx, client.ObjectKeyFromObject(tunedConfigMap), tunedConfigMap)
+	tuningConfigMap := TuningConfigMap(controlPlaneNamespace, nodePool.Name)
+	if tuningConfig == "" {
+		err = r.Get(ctx, client.ObjectKeyFromObject(tuningConfigMap), tuningConfigMap)
 		if err != nil && !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to get tunedConfig ConfigMap: %w", err)
+			return ctrl.Result{}, fmt.Errorf("failed to get tuningConfig ConfigMap: %w", err)
 		}
 		if err == nil {
-			if err := r.Delete(ctx, tunedConfigMap); err != nil && !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("failed to delete tunedConfig ConfigMap with no Tuneds defined: %w", err)
+			if err := r.Delete(ctx, tuningConfigMap); err != nil && !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to delete tuningConfig ConfigMap with no Tuneds defined: %w", err)
 			}
 		}
 	} else {
-		if result, err := r.CreateOrUpdate(ctx, r.Client, tunedConfigMap, func() error {
-			return reconcileTunedConfigMap(tunedConfigMap, nodePool, tunedConfig)
+		if result, err := r.CreateOrUpdate(ctx, r.Client, tuningConfigMap, func() error {
+			return reconcileTuningConfigMap(tuningConfigMap, nodePool, tuningConfig)
 		}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile Tuned ConfigMap: %w", err)
 		} else {
@@ -890,7 +890,7 @@ func (r *NodePoolReconciler) delete(ctx context.Context, nodePool *hyperv1.NodeP
 		}
 	}
 
-	// Delete any ConfigMap belonging to this NodePool i.e. TunedConfig ConfigMaps.
+	// Delete any ConfigMap belonging to this NodePool i.e. TuningConfig ConfigMaps.
 	err = r.DeleteAllOf(ctx, &corev1.ConfigMap{},
 		client.InNamespace(controlPlaneNamespace),
 		client.MatchingLabels{nodePoolAnnotation: nodePool.GetName()},
@@ -939,26 +939,26 @@ func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.No
 	return nil
 }
 
-// reconcileTunedConfigMap inserts the Tuned object manifest in tunedConfig into ConfigMap tunedConfigMap.
+// reconcileTuningConfigMap inserts the Tuned object manifest in tuningConfig into ConfigMap tuningConfigMap.
 // This is used to mirror the Tuned object manifest into the control plane namespace, for the Node
 // Tuning Operator to mirror and reconcile in the hosted cluster.
-func reconcileTunedConfigMap(tunedConfigMap *corev1.ConfigMap, nodePool *hyperv1.NodePool, tunedConfig string) error {
-	tunedConfigMap.Immutable = k8sutilspointer.BoolPtr(false)
-	if tunedConfigMap.Annotations == nil {
-		tunedConfigMap.Annotations = make(map[string]string)
+func reconcileTuningConfigMap(tuningConfigMap *corev1.ConfigMap, nodePool *hyperv1.NodePool, tuningConfig string) error {
+	tuningConfigMap.Immutable = k8sutilspointer.BoolPtr(false)
+	if tuningConfigMap.Annotations == nil {
+		tuningConfigMap.Annotations = make(map[string]string)
 	}
-	if tunedConfigMap.Labels == nil {
-		tunedConfigMap.Labels = make(map[string]string)
+	if tuningConfigMap.Labels == nil {
+		tuningConfigMap.Labels = make(map[string]string)
 	}
 
-	tunedConfigMap.Labels[tunedConfigMapLabel] = "true"
-	tunedConfigMap.Annotations[nodePoolAnnotation] = nodePool.GetName()
-	tunedConfigMap.Labels[nodePoolAnnotation] = nodePool.GetName()
+	tuningConfigMap.Labels[tuningConfigMapLabel] = "true"
+	tuningConfigMap.Annotations[nodePoolAnnotation] = nodePool.GetName()
+	tuningConfigMap.Labels[nodePoolAnnotation] = nodePool.GetName()
 
-	if tunedConfigMap.Data == nil {
-		tunedConfigMap.Data = map[string]string{}
+	if tuningConfigMap.Data == nil {
+		tuningConfigMap.Data = map[string]string{}
 	}
-	tunedConfigMap.Data[tunedConfigKey] = tunedConfig
+	tuningConfigMap.Data[tuningConfigKey] = tuningConfig
 
 	return nil
 }
@@ -1354,14 +1354,14 @@ func (r *NodePoolReconciler) getConfig(ctx context.Context,
 	return strings.Join(allConfigPlainText, "\n---\n"), missingConfigs, utilerrors.NewAggregate(errors)
 }
 
-func (r *NodePoolReconciler) getTunedConfig(ctx context.Context,
+func (r *NodePoolReconciler) getTuningConfig(ctx context.Context,
 	nodePool *hyperv1.NodePool,
 ) (configsRaw string, err error) {
 	var configs []corev1.ConfigMap
 	var allConfigPlainText []string
 	var errors []error
 
-	for _, config := range nodePool.Spec.TunedConfig {
+	for _, config := range nodePool.Spec.TuningConfig {
 		configConfigMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      config.Name,
@@ -1376,8 +1376,8 @@ func (r *NodePoolReconciler) getTunedConfig(ctx context.Context,
 	}
 
 	for _, config := range configs {
-		manifestRaw := config.Data[tunedConfigKey]
-		manifest, err := validateTunedConfigManifest([]byte(manifestRaw))
+		manifestRaw := config.Data[tuningConfigKey]
+		manifest, err := validateTuningConfigManifest([]byte(manifestRaw))
 		if err != nil {
 			errors = append(errors, fmt.Errorf("configmap %q failed validation: %w", config.Name, err))
 			continue
@@ -1391,7 +1391,7 @@ func (r *NodePoolReconciler) getTunedConfig(ctx context.Context,
 	return strings.Join(allConfigPlainText, "\n---\n"), utilerrors.NewAggregate(errors)
 }
 
-func validateTunedConfigManifest(manifest []byte) ([]byte, error) {
+func validateTuningConfigManifest(manifest []byte) ([]byte, error) {
 	scheme := runtime.NewScheme()
 	tunedv1.AddToScheme(scheme)
 
@@ -1409,12 +1409,12 @@ func validateTunedConfigManifest(manifest []byte) ([]byte, error) {
 	case *tunedv1.Tuned:
 		buff := bytes.Buffer{}
 		if err := yamlSerializer.Encode(obj, &buff); err != nil {
-			return nil, fmt.Errorf("failed to encode tuned config after defaulting it: %w", err)
+			return nil, fmt.Errorf("failed to encode Tuned object: %w", err)
 		}
 		manifest = buff.Bytes()
 
 	default:
-		return nil, fmt.Errorf("unsupported tunedConfig object type: %T", obj)
+		return nil, fmt.Errorf("unsupported tuningConfig object type: %T", obj)
 	}
 
 	return manifest, err
@@ -1687,7 +1687,7 @@ func (r *NodePoolReconciler) enqueueNodePoolsForConfig(obj client.Object) []reco
 
 	// If the ConfigMap is generated by the NodePool controller and contains Tuned manifests
 	// return the ConfigMaps parent NodePool.
-	if _, ok := obj.GetLabels()[tunedConfigMapLabel]; ok {
+	if _, ok := obj.GetLabels()[tuningConfigMapLabel]; ok {
 		return enqueueParentNodePool(obj)
 	}
 
@@ -1715,9 +1715,9 @@ func (r *NodePoolReconciler) enqueueNodePoolsForConfig(obj client.Object) []reco
 			}
 		}
 
-		// Check TunedConfig as well, unless ConfigMap was already found in .Spec.Config.
+		// Check TuningConfig as well, unless ConfigMap was already found in .Spec.Config.
 		if !reconcileNodePool {
-			for _, v := range nodePoolList.Items[key].Spec.TunedConfig {
+			for _, v := range nodePoolList.Items[key].Spec.TuningConfig {
 				if v.Name == cm.Name {
 					reconcileNodePool = true
 					break

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -808,7 +808,7 @@ kind: Config`)},
 	}
 }
 
-func TestGetTunedConfig(t *testing.T) {
+func TestGetTuningConfig(t *testing.T) {
 	tuned1 := `
 apiVersion: tuned.openshift.io/v1
 kind: Tuned
@@ -908,21 +908,20 @@ status: {}
 
 	namespace := "test"
 	testCases := []struct {
-		name                string
-		nodePool            *hyperv1.NodePool
-		tunedConfig         []client.Object
-		expect              string
-		missingTunedConfigs bool
-		error               bool
+		name         string
+		nodePool     *hyperv1.NodePool
+		tuningConfig []client.Object
+		expect       string
+		error        bool
 	}{
 		{
-			name: "gets a single valid TunedConfig",
+			name: "gets a single valid TuningConfig",
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 				},
 				Spec: hyperv1.NodePoolSpec{
-					TunedConfig: []corev1.LocalObjectReference{
+					TuningConfig: []corev1.LocalObjectReference{
 						{
 							Name: "tuned-1",
 						},
@@ -930,14 +929,14 @@ status: {}
 				},
 				Status: hyperv1.NodePoolStatus{},
 			},
-			tunedConfig: []client.Object{
+			tuningConfig: []client.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "tuned-1",
 						Namespace: namespace,
 					},
 					Data: map[string]string{
-						tunedConfigKey: tuned1,
+						tuningConfigKey: tuned1,
 					},
 					BinaryData: nil,
 				},
@@ -946,13 +945,13 @@ status: {}
 			error:  false,
 		},
 		{
-			name: "gets two valid TunedConfigs",
+			name: "gets two valid TuningConfigs",
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 				},
 				Spec: hyperv1.NodePoolSpec{
-					TunedConfig: []corev1.LocalObjectReference{
+					TuningConfig: []corev1.LocalObjectReference{
 						{
 							Name: "tuned-1",
 						},
@@ -963,14 +962,14 @@ status: {}
 				},
 				Status: hyperv1.NodePoolStatus{},
 			},
-			tunedConfig: []client.Object{
+			tuningConfig: []client.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "tuned-1",
 						Namespace: namespace,
 					},
 					Data: map[string]string{
-						tunedConfigKey: tuned1,
+						tuningConfigKey: tuned1,
 					},
 				},
 				&corev1.ConfigMap{
@@ -979,7 +978,7 @@ status: {}
 						Namespace: namespace,
 					},
 					Data: map[string]string{
-						tunedConfigKey: tuned2,
+						tuningConfigKey: tuned2,
 					},
 				},
 			},
@@ -987,13 +986,13 @@ status: {}
 			error:  false,
 		},
 		{
-			name: "fails if a non existent TunedConfig is referenced",
+			name: "fails if a non existent TuningConfig is referenced",
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 				},
 				Spec: hyperv1.NodePoolSpec{
-					TunedConfig: []corev1.LocalObjectReference{
+					TuningConfig: []corev1.LocalObjectReference{
 						{
 							Name: "does-not-exist",
 						},
@@ -1001,9 +1000,9 @@ status: {}
 				},
 				Status: hyperv1.NodePoolStatus{},
 			},
-			tunedConfig: []client.Object{},
-			expect:      "",
-			error:       true,
+			tuningConfig: []client.Object{},
+			expect:       "",
+			error:        true,
 		},
 	}
 
@@ -1012,10 +1011,10 @@ status: {}
 			g := NewWithT(t)
 
 			r := NodePoolReconciler{
-				Client: fake.NewClientBuilder().WithObjects(tc.tunedConfig...).Build(),
+				Client: fake.NewClientBuilder().WithObjects(tc.tuningConfig...).Build(),
 			}
 
-			got, err := r.getTunedConfig(context.Background(), tc.nodePool)
+			got, err := r.getTuningConfig(context.Background(), tc.nodePool)
 
 			if tc.error {
 				g.Expect(err).To(HaveOccurred())

--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -43,7 +43,7 @@ spec:
 `
 
 	hypershiftNodePoolNameLabel = "hypershift.openshift.io/nodePoolName" // HyperShift-enabled NTO adds this label to Tuned CRs bound to NodePools
-	tunedConfigKey              = "tuned"
+	tuningConfigKey             = "tuning"
 )
 
 func TestNTOMachineConfigGetsRolledOut(t *testing.T) {
@@ -88,14 +88,14 @@ func TestNTOMachineConfigGetsRolledOut(t *testing.T) {
 	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
-	tunedConfigConfigMap := &corev1.ConfigMap{
+	tuningConfigConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "hugepages-tuned-test",
 			Namespace: hostedCluster.Namespace,
 		},
-		Data: map[string]string{tunedConfigKey: hugepagesTuned},
+		Data: map[string]string{tuningConfigKey: hugepagesTuned},
 	}
-	if err := client.Create(ctx, tunedConfigConfigMap); err != nil {
+	if err := client.Create(ctx, tuningConfigConfigMap); err != nil {
 		t.Fatalf("failed to create configmap for custom Tuned object: %v", err)
 	}
 
@@ -111,7 +111,7 @@ func TestNTOMachineConfigGetsRolledOut(t *testing.T) {
 		}
 
 		np := nodePool.DeepCopy()
-		nodePool.Spec.TunedConfig = append(nodePool.Spec.TunedConfig, corev1.LocalObjectReference{Name: tunedConfigConfigMap.Name})
+		nodePool.Spec.TuningConfig = append(nodePool.Spec.TuningConfig, corev1.LocalObjectReference{Name: tuningConfigConfigMap.Name})
 		if err := client.Patch(ctx, &nodePool, crclient.MergeFrom(np)); err != nil {
 			t.Fatalf("failed to update nodepool %s after adding Tuned config: %v", nodePool.Name, err)
 		}
@@ -196,14 +196,14 @@ func TestNTOMachineConfigAppliedInPlace(t *testing.T) {
 	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
-	tunedConfigConfigMap := &corev1.ConfigMap{
+	tuningConfigConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "hugepages-tuned-test",
 			Namespace: hostedCluster.Namespace,
 		},
-		Data: map[string]string{tunedConfigKey: hugepagesTuned},
+		Data: map[string]string{tuningConfigKey: hugepagesTuned},
 	}
-	if err := client.Create(ctx, tunedConfigConfigMap); err != nil {
+	if err := client.Create(ctx, tuningConfigConfigMap); err != nil {
 		t.Fatalf("failed to create configmap for custom Tuned object: %v", err)
 	}
 
@@ -219,7 +219,7 @@ func TestNTOMachineConfigAppliedInPlace(t *testing.T) {
 		}
 
 		np := nodePool.DeepCopy()
-		nodePool.Spec.TunedConfig = append(nodePool.Spec.TunedConfig, corev1.LocalObjectReference{Name: tunedConfigConfigMap.Name})
+		nodePool.Spec.TuningConfig = append(nodePool.Spec.TuningConfig, corev1.LocalObjectReference{Name: tuningConfigConfigMap.Name})
 		if err := client.Patch(ctx, &nodePool, crclient.MergeFrom(np)); err != nil {
 			t.Fatalf("failed to update nodepool %s after adding Tuned config: %v", nodePool.Name, err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames the spec.TunedConfig field of the NodePool API to spec.tuningConfig. This is needed to keep the name general because we will likely use this field to reference PerformanceProfiles later on when we enable the PAO / PerformanceProfile functionality (~4.13 timeframe). 

As discussed in the HyperShift project sync meeting, we would like to make the change while the NodePool API is still in alpha.

/cc @jlojosnegros

**Which issue(s) this PR fixes**:
Related to [PSAP-742](https://issues.redhat.com/browse/PSAP-742) and [CNF-6291](https://issues.redhat.com/browse/CNF-6291)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.