### PR TITLE
Add custom types for enum fields in PowerVSNodePoolPlatform

### DIFF
--- a/api/fixtures/example_ibmcloud_powervs.go
+++ b/api/fixtures/example_ibmcloud_powervs.go
@@ -3,6 +3,8 @@ package fixtures
 import (
 	corev1 "k8s.io/api/core/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 )
 
 type ExamplePowerVSOptions struct {
@@ -22,7 +24,7 @@ type ExamplePowerVSOptions struct {
 
 	// nodepool related options
 	SysType    string
-	ProcType   string
+	ProcType   hyperv1.PowerVSNodePoolProcType
 	Processors string
 	Memory     int32
 }

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -347,6 +348,44 @@ type NodePoolPlatform struct {
 	PowerVS *PowerVSNodePoolPlatform `json:"powervs,omitempty"`
 }
 
+// PowerVSNodePoolProcType defines processor type to be used for PowerVSNodePoolPlatform
+type PowerVSNodePoolProcType string
+
+func (p *PowerVSNodePoolProcType) String() string {
+	return string(*p)
+}
+
+func (p *PowerVSNodePoolProcType) Set(s string) error {
+	switch s {
+	case string(PowerVSNodePoolSharedProcType), string(PowerVSNodePoolCappedProcType), string(PowerVSNodePoolDedicatedProcType):
+		*p = PowerVSNodePoolProcType(s)
+		return nil
+	default:
+		return fmt.Errorf("unknown processor type used %s", s)
+	}
+}
+
+func (p *PowerVSNodePoolProcType) Type() string {
+	return "PowerVSNodePoolProcType"
+}
+
+const (
+	// PowerVSNodePoolDedicatedProcType defines dedicated processor type
+	PowerVSNodePoolDedicatedProcType = PowerVSNodePoolProcType("dedicated")
+
+	// PowerVSNodePoolSharedProcType defines shared processor type
+	PowerVSNodePoolSharedProcType = PowerVSNodePoolProcType("shared")
+
+	// PowerVSNodePoolCappedProcType defines capped processor type
+	PowerVSNodePoolCappedProcType = PowerVSNodePoolProcType("capped")
+)
+
+// PowerVSNodePoolStorageType defines storage type to be used for PowerVSNodePoolPlatform
+type PowerVSNodePoolStorageType string
+
+// PowerVSNodePoolImageDeletePolicy defines image delete policy to be used for PowerVSNodePoolPlatform
+type PowerVSNodePoolImageDeletePolicy string
+
 // PowerVSNodePoolPlatform specifies the configuration of a NodePool when operating
 // on IBMCloud PowerVS platform.
 type PowerVSNodePoolPlatform struct {
@@ -376,7 +415,7 @@ type PowerVSNodePoolPlatform struct {
 	// +kubebuilder:default=shared
 	// +kubebuilder:validation:Enum=dedicated;shared;capped
 	// +optional
-	ProcessorType string `json:"processorType,omitempty"`
+	ProcessorType PowerVSNodePoolProcType `json:"processorType,omitempty"`
 
 	// Processors is the number of virtual processors in a virtual machine.
 	// when the processorType is selected as Dedicated the processors value cannot be fractional.
@@ -425,7 +464,7 @@ type PowerVSNodePoolPlatform struct {
 	// +kubebuilder:default=tier1
 	// +kubebuilder:validation:Enum=tier1;tier3
 	// +optional
-	StorageType string `json:"storageType,omitempty"`
+	StorageType PowerVSNodePoolStorageType `json:"storageType,omitempty"`
 
 	// ImageDeletePolicy is policy for the image deletion.
 	//
@@ -437,7 +476,7 @@ type PowerVSNodePoolPlatform struct {
 	// +kubebuilder:default=delete
 	// +kubebuilder:validation:Enum=delete;retain
 	// +optional
-	ImageDeletePolicy string `json:"imageDeletePolicy,omitempty"`
+	ImageDeletePolicy PowerVSNodePoolImageDeletePolicy `json:"imageDeletePolicy,omitempty"`
 }
 
 // KubevirtCompute contains values associated with the virtual compute hardware requested for the VM.

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -91,7 +91,7 @@ type PowerVSPlatformOptions struct {
 
 	// nodepool related options
 	SysType    string
-	ProcType   string
+	ProcType   hyperv1.PowerVSNodePoolProcType
 	Processors string
 	Memory     int32
 }

--- a/cmd/cluster/powervs/create.go
+++ b/cmd/cluster/powervs/create.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	powervsinfra "github.com/openshift/hypershift/cmd/infra/powervs"
 	"github.com/openshift/hypershift/support/infraid"
@@ -32,7 +33,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		Zone:       "us-south",
 		VPCRegion:  "us-south",
 		SysType:    "s922",
-		ProcType:   "shared",
+		ProcType:   hyperv1.PowerVSNodePoolSharedProcType,
 		Processors: "0.5",
 		Memory:     32,
 	}
@@ -45,7 +46,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.PowerVSPlatform.VPCRegion, "vpc-region", opts.PowerVSPlatform.VPCRegion, "IBM Cloud VPC Region for VPC resources. Default is us-south")
 	cmd.Flags().StringVar(&opts.PowerVSPlatform.VPC, "vpc", "", "IBM Cloud VPC Name")
 	cmd.Flags().StringVar(&opts.PowerVSPlatform.SysType, "sys-type", opts.PowerVSPlatform.SysType, "System type used to host the instance(e.g: s922, e980, e880). Default is s922")
-	cmd.Flags().StringVar(&opts.PowerVSPlatform.ProcType, "proc-type", opts.PowerVSPlatform.ProcType, "Processor type (dedicated, shared, capped). Default is shared")
+	cmd.Flags().Var(&opts.PowerVSPlatform.ProcType, "proc-type", "Processor type (dedicated, shared, capped). Default is shared")
 	cmd.Flags().StringVar(&opts.PowerVSPlatform.Processors, "processors", opts.PowerVSPlatform.Processors, "Number of processors allocated. Default is 0.5")
 	cmd.Flags().Int32Var(&opts.PowerVSPlatform.Memory, "memory", opts.PowerVSPlatform.Memory, "Amount of memory allocated (in GB). Default is 32")
 	cmd.Flags().BoolVar(&opts.PowerVSPlatform.Debug, "debug", opts.PowerVSPlatform.Debug, "Enabling this will print PowerVS API Request & Response logs")

--- a/cmd/nodepool/powervs/create.go
+++ b/cmd/nodepool/powervs/create.go
@@ -18,7 +18,7 @@ import (
 
 type PowerVSPlatformCreateOptions struct {
 	SysType    string
-	ProcType   string
+	ProcType   hyperv1.PowerVSNodePoolProcType
 	Processors string
 	Memory     int32
 }
@@ -37,7 +37,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.SysType, "sys-type", opts.SysType, "System type used to host the instance(e.g: s922, e980, e880). Default is s922")
-	cmd.Flags().StringVar(&opts.ProcType, "proc-type", opts.ProcType, "Processor type (dedicated, shared, capped). Default is shared")
+	cmd.Flags().Var(&opts.ProcType, "proc-type", "Processor type (dedicated, shared, capped). Default is shared")
 	cmd.Flags().StringVar(&opts.Processors, "processors", opts.Processors, "Number of processors allocated. Default is 0.5")
 	cmd.Flags().Int32Var(&opts.Memory, "memory", opts.Memory, "Amount of memory allocated (in GB). Default is 32")
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -6055,6 +6055,14 @@ This field is immutable. Once set, It can&rsquo;t be changed.</p>
 </td>
 </tr></tbody>
 </table>
+###PowerVSNodePoolImageDeletePolicy { #hypershift.openshift.io/v1alpha1.PowerVSNodePoolImageDeletePolicy }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>)
+</p>
+<p>
+<p>PowerVSNodePoolImageDeletePolicy defines image delete policy to be used for PowerVSNodePoolPlatform</p>
+</p>
 ###PowerVSNodePoolPlatform { #hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform }
 <p>
 (<em>Appears on:</em>
@@ -6094,7 +6102,9 @@ reasonable default. The current default is s922 which is generally available.</p
 <td>
 <code>processorType</code></br>
 <em>
-string
+<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolProcType">
+PowerVSNodePoolProcType
+</a>
 </em>
 </td>
 <td>
@@ -6107,6 +6117,12 @@ Capped: Shared, but resources do not expand beyond those that are requested, the
 <p>if the processorType is selected as Dedicated, then Processors value cannot be fractional.
 When omitted, this means that the user has no opinion and the platform is left to choose a
 reasonable default. The current default is Shared.</p>
+<p>
+Value must be one of:
+&#34;capped&#34;, 
+&#34;dedicated&#34;, 
+&#34;shared&#34;
+</p>
 </td>
 </tr>
 <tr>
@@ -6172,7 +6188,9 @@ is chosen based on the NodePool release payload image.</p>
 <td>
 <code>storageType</code></br>
 <em>
-string
+<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolStorageType">
+PowerVSNodePoolStorageType
+</a>
 </em>
 </td>
 <td>
@@ -6188,7 +6206,9 @@ Although, the exact numbers might change over time, the Tier 3 storage is curren
 <td>
 <code>imageDeletePolicy</code></br>
 <em>
-string
+<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolImageDeletePolicy">
+PowerVSNodePoolImageDeletePolicy
+</a>
 </em>
 </td>
 <td>
@@ -6201,6 +6221,40 @@ retain: delete the image from the openshift but retain in the infrastructure.</p
 </tr>
 </tbody>
 </table>
+###PowerVSNodePoolProcType { #hypershift.openshift.io/v1alpha1.PowerVSNodePoolProcType }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>)
+</p>
+<p>
+<p>PowerVSNodePoolProcType defines processor type to be used for PowerVSNodePoolPlatform</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;capped&#34;</p></td>
+<td><p>PowerVSNodePoolCappedProcType defines capped processor type</p>
+</td>
+</tr><tr><td><p>&#34;dedicated&#34;</p></td>
+<td><p>PowerVSNodePoolDedicatedProcType defines dedicated processor type</p>
+</td>
+</tr><tr><td><p>&#34;shared&#34;</p></td>
+<td><p>PowerVSNodePoolSharedProcType defines shared processor type</p>
+</td>
+</tr></tbody>
+</table>
+###PowerVSNodePoolStorageType { #hypershift.openshift.io/v1alpha1.PowerVSNodePoolStorageType }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>)
+</p>
+<p>
+<p>PowerVSNodePoolStorageType defines storage type to be used for PowerVSNodePoolPlatform</p>
+</p>
 ###PowerVSPlatformSpec { #hypershift.openshift.io/v1alpha1.PowerVSPlatformSpec }
 <p>
 (<em>Appears on:</em>

--- a/hypershift-operator/controllers/nodepool/powervs.go
+++ b/hypershift-operator/controllers/nodepool/powervs.go
@@ -67,7 +67,7 @@ func ibmPowerVSMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hy
 				ImageRef:          imageRef,
 				Network:           subnet,
 				SysType:           nodePool.Spec.Platform.PowerVS.SystemType,
-				ProcType:          nodePool.Spec.Platform.PowerVS.ProcessorType,
+				ProcType:          string(nodePool.Spec.Platform.PowerVS.ProcessorType),
 				Processors:        nodePool.Spec.Platform.PowerVS.Processors.String(),
 				Memory:            strconv.Itoa(int(nodePool.Spec.Platform.PowerVS.MemoryGiB)),
 			},
@@ -111,8 +111,8 @@ func reconcileIBMPowerVSImage(ibmPowerVSImage *capipowervs.IBMPowerVSImage, hclu
 		Bucket:            &img.Bucket,
 		Object:            &img.Object,
 		Region:            &region,
-		StorageType:       nodePool.Spec.Platform.PowerVS.StorageType,
-		DeletePolicy:      nodePool.Spec.Platform.PowerVS.ImageDeletePolicy,
+		StorageType:       string(nodePool.Spec.Platform.PowerVS.StorageType),
+		DeletePolicy:      string(nodePool.Spec.Platform.PowerVS.ImageDeletePolicy),
 	}
 	return nil
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -81,7 +81,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSZone, "e2e.powervs-zone", "us-south", "IBM Cloud zone. Default is us-sout")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSVpcRegion, "e2e.powervs-vpc-region", "us-south", "IBM Cloud VPC Region for VPC resources. Default is us-south")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSSysType, "e2e.powervs-sys-type", "s922", "System type used to host the instance(e.g: s922, e980, e880). Default is s922")
-	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSProcType, "e2e.powervs-proc-type", "shared", "Processor type (dedicated, shared, capped). Default is shared")
+	flag.Var(&globalOpts.configurableClusterOptions.PowerVSProcType, "e2e.powervs-proc-type", "Processor type (dedicated, shared, capped). Default is shared")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSProcessors, "e2e.powervs-processors", "0.5", "Number of processors allocated. Default is 0.5")
 	flag.IntVar(&globalOpts.configurableClusterOptions.PowerVSMemory, "e2e.powervs-memory", 32, "Amount of memory allocated (in GB). Default is 32")
 
@@ -234,7 +234,7 @@ type configurableClusterOptions struct {
 	PowerVSZone                string
 	PowerVSVpcRegion           string
 	PowerVSSysType             string
-	PowerVSProcType            string
+	PowerVSProcType            hyperv1.PowerVSNodePoolProcType
 	PowerVSProcessors          string
 	PowerVSMemory              int
 }


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Add custom types for enum fields in PowerVSNodePoolPlatform.
Constants used only for PowerVSNodePoolProcType not for PowerVSNodePoolStorageType, PowerVSNodePoolImageDeletePolicy since we are only using default value defined via kubebuilder. In future if requires will define constants and use it.

Fixes https://github.com/openshift/hypershift/issues/1769
Fixes https://issues.redhat.com/browse/MULTIARCH-2975

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.