### PR TITLE
PowerVS: Bug fix on flags usage

### DIFF
--- a/cmd/cluster/powervs/destroy.go
+++ b/cmd/cluster/powervs/destroy.go
@@ -77,6 +77,9 @@ func DestroyCluster(ctx context.Context, o *core.DestroyOptions) error {
 	if o.InfraID == "" {
 		inputErrors = append(inputErrors, fmt.Errorf("infrastructure ID is required"))
 	}
+	if o.PowerVSPlatform.BaseDomain == "" {
+		inputErrors = append(inputErrors, fmt.Errorf("base domain is required"))
+	}
 	if o.PowerVSPlatform.Region == "" {
 		inputErrors = append(inputErrors, fmt.Errorf("PowerVS region is required"))
 	}

--- a/cmd/infra/powervs/create.go
+++ b/cmd/infra/powervs/create.go
@@ -203,9 +203,9 @@ func NewCreateCommand() *cobra.Command {
 
 	// these options are only for development and testing purpose,
 	// can use these to reuse the existing resources, so hiding it.
-	cmd.Flags().MarkHidden("powervs-cloud-instance-id")
+	cmd.Flags().MarkHidden("cloud-instance-id")
 	cmd.Flags().MarkHidden("vpc")
-	cmd.Flags().MarkHidden("powervs-cloud-connection")
+	cmd.Flags().MarkHidden("cloud-connection")
 
 	cmd.MarkFlagRequired("base-domain")
 	cmd.MarkFlagRequired("resource-group")

--- a/cmd/infra/powervs/destroy.go
+++ b/cmd/infra/powervs/destroy.go
@@ -87,15 +87,15 @@ func NewDestroyCommand() *cobra.Command {
 	cmd.MarkFlagRequired("resource-group")
 	cmd.MarkFlagRequired("base-domain")
 	cmd.MarkFlagRequired("infra-id")
-	cmd.MarkFlagRequired("powervs-region")
-	cmd.MarkFlagRequired("powervs-zone")
+	cmd.MarkFlagRequired("region")
+	cmd.MarkFlagRequired("zone")
 	cmd.MarkFlagRequired("vpc-region")
 
 	// these options are only for development and testing purpose, user can pass these flags
 	// to destroy the resource created inside these resources for hypershift infra purpose
 	cmd.Flags().MarkHidden("vpc")
-	cmd.Flags().MarkHidden("powervs-cloud-connection")
-	cmd.Flags().MarkHidden("powervs-cloud-instance-id")
+	cmd.Flags().MarkHidden("cloud-connection")
+	cmd.Flags().MarkHidden("cloud-instance-id")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := opts.Run(cmd.Context()); err != nil {


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Fixes https://issues.redhat.com/browse/MULTIARCH-2974
Fixes https://issues.redhat.com/browse/MULTIARCH-2980

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #



**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.