### PR TITLE
Validate awsendpoint deletion

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -567,6 +567,27 @@ func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointSe
 		}); err != nil {
 			return false, err
 		}
+
+		// check if Endpoint exists in AWS
+		output, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{
+			VpcEndpointIds: []*string{aws.String(endpointID)},
+		})
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok {
+				if awsErr.Code() != "InvalidVpcEndpointId.NotFound" {
+					return false, err
+				}
+			} else {
+				return false, err
+			}
+
+		}
+
+		if output != nil && len(output.VpcEndpoints) != 0 {
+			return false, fmt.Errorf("resource requested for deletion but still present")
+		}
+
 		log.Info("endpoint deleted", "endpointID", endpointID)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With current implementation the cpo private link controller will consider deletion successfull after making the request, however if the resource keeps existing somehow in AWS it would prevent the deletion of the awsendpointService resource by the HO AWSEndpointServiceReconciler with "failed to delete resource: Service has existing active VPC Endpoint connections!"

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Ref https://issues.redhat.com/browse/HOSTEDCP-597

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.