### PR TITLE
Updated secret permissions to 0640

### DIFF
--- a/contrib/admission-tracer/manifests/deployment.yaml
+++ b/contrib/admission-tracer/manifests/deployment.yaml
@@ -35,5 +35,5 @@ spec:
       volumes:
       - name: serving-cert
         secret:
-          defaultMode: 416
+          defaultMode: 0640
           secretName: admission-tracer-serving-cert

--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -95,7 +95,8 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 						Name: "target-kubeconfig",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: kubeConfigSecret.Name,
+								SecretName:  kubeConfigSecret.Name,
+								DefaultMode: k8sutilspointer.Int32Ptr(0640),
 								Items: []corev1.KeyToPath{
 									{
 										// TODO: should the key be published on status?

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
@@ -117,6 +117,7 @@ func cpcVolumeKubeconfig() *corev1.Volume {
 func buildCPCVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.KASServiceKubeconfigSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 func cpcVolumeServingCert() *corev1.Volume {
@@ -128,4 +129,5 @@ func cpcVolumeServingCert() *corev1.Volume {
 func buildCPCVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.ClusterPolicyControllerCertSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -299,7 +299,8 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 
 func buildHCCVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+		SecretName:  manifests.KASServiceKubeconfigSecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 
@@ -311,6 +312,7 @@ func buildHCCVolumeRootCA(v *corev1.Volume) {
 
 func buildHCCClusterSignerCA(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.CSRSignerCASecret("").Name,
+		SecretName:  manifests.CSRSignerCASecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -430,6 +430,7 @@ func buildCVOVolumeUpdatePayloads(v *corev1.Volume) {
 func buildCVOVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.KASServiceKubeconfigSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 func buildCVOVolumePayload(v *corev1.Volume) {
@@ -445,7 +446,7 @@ func buildCVOVolumeServerCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.ClusterVersionOperatorServerCertSecret("").Name
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
@@ -143,7 +143,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  "dns-operator-kubeconfig",
-				DefaultMode: utilpointer.Int32Ptr(416),
+				DefaultMode: utilpointer.Int32Ptr(0640),
 			},
 		},
 	}}

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -254,7 +254,8 @@ func ReconcileIgnitionServer(ctx context.Context,
 							Name: "serving-cert",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: servingCertSecret.Name,
+									SecretName:  servingCertSecret.Name,
+									DefaultMode: utilpointer.Int32Ptr(0640),
 								},
 							},
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -153,9 +153,9 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 	}}
 	dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, ingressOperatorSocks5ProxyContainer(params.Socks5ProxyImage))
 	dep.Spec.Template.Spec.Volumes = []corev1.Volume{
-		{Name: "ingress-operator-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.IngressOperatorKubeconfig("").Name, DefaultMode: utilpointer.Int32Ptr(416)}}},
-		{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: utilpointer.Int32Ptr(416)}}},
-		{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: utilpointer.Int32Ptr(416)}}},
+		{Name: "ingress-operator-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.IngressOperatorKubeconfig("").Name, DefaultMode: utilpointer.Int32Ptr(0640)}}},
+		{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: utilpointer.Int32Ptr(0640)}}},
+		{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: utilpointer.Int32Ptr(0640)}}},
 	}
 
 	if params.Platform == hyperv1.AWSPlatform {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -432,7 +432,7 @@ func buildKASVolumeLocalhostKubeconfig(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.KASLocalhostKubeconfigSecret("").Name
 }
 
@@ -477,7 +477,7 @@ func buildKASVolumeRootCA(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.RootCASecret("").Name
 }
 
@@ -490,7 +490,7 @@ func buildKASVolumeServerCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.KASServerCertSecret("").Name
 }
 
@@ -516,7 +516,7 @@ func buildKASVolumeKonnectivityClientCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.KonnectivityClientSecret("").Name
 }
 
@@ -530,7 +530,7 @@ func buildKASVolumeAggregatorCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.KASAggregatorCertSecret("").Name
 }
 
@@ -557,7 +557,7 @@ func buildKASVolumeServiceAccountKey(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.ServiceAccountSigningKeySecret("").Name
 }
 
@@ -571,7 +571,7 @@ func buildKASVolumeKubeletClientCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.KASKubeletClientCertSecret("").Name
 }
 
@@ -584,7 +584,7 @@ func buildKASVolumeEtcdClientCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.EtcdClientSecret("").Name
 }
 
@@ -621,7 +621,7 @@ func buildKASVolumeAuthTokenWebhookConfig(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.KASAuthenticationTokenWebhookConfigSecret("").Name
 }
 
@@ -715,7 +715,8 @@ func applyNamedCertificateMounts(certs []configv1.APIServerNamedServingCert, spe
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: namedCert.ServingCertificate.Name,
+					SecretName:  namedCert.ServingCertificate.Name,
+					DefaultMode: pointer.Int32Ptr(0640),
 				},
 			},
 		})
@@ -790,6 +791,7 @@ func kasVolumeKubeconfig() *corev1.Volume {
 
 func buildKASVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+		SecretName:  manifests.KASServiceKubeconfigSecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/portieries.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/portieries.go
@@ -3,6 +3,7 @@ package kas
 import (
 	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 )
 
 const portierisPort = 8000
@@ -58,6 +59,7 @@ func kasVolumePortierisCerts() *corev1.Volume {
 
 func buildKASVolumePortierisCerts(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: v.Name,
+		SecretName:  v.Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -192,7 +192,8 @@ func kcmVolumeServiceSigner() *corev1.Volume {
 
 func buildKCMVolumeServiceSigner(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.ServiceAccountSigningKeySecret("").Name,
+		SecretName:  manifests.ServiceAccountSigningKeySecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 
@@ -214,7 +215,8 @@ func kcmVolumeClusterSigner() *corev1.Volume {
 
 func buildKCMVolumeClusterSigner(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.CSRSignerCASecret("").Name,
+		SecretName:  manifests.CSRSignerCASecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 
@@ -226,7 +228,8 @@ func kcmVolumeKubeconfig() *corev1.Volume {
 
 func buildKCMVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.KCMKubeconfigSecret("").Name,
+		SecretName:  manifests.KCMKubeconfigSecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 
@@ -261,8 +264,9 @@ func buildKCMVolumeServerCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
-	v.Secret.DefaultMode = pointer.Int32Ptr(416)
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	v.Secret.SecretName = manifests.KCMServerCertSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 type serviceCAVolumeBuilder string

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -137,7 +137,8 @@ func konnectivityVolumeServerCerts() *corev1.Volume {
 
 func buildKonnectivityVolumeServerCerts(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.KonnectivityServerSecret("").Name,
+		SecretName:  manifests.KonnectivityServerSecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 
@@ -149,7 +150,8 @@ func konnectivityVolumeClusterCerts() *corev1.Volume {
 
 func buildKonnectivityVolumeClusterCerts(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.KonnectivityClusterSecret("").Name,
+		SecretName:  manifests.KonnectivityClusterSecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 
@@ -288,7 +290,8 @@ func konnectivityVolumeAgentCerts() *corev1.Volume {
 
 func buildKonnectivityVolumeAgentCerts(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.KonnectivityAgentSecret("").Name,
+		SecretName:  manifests.KonnectivityAgentSecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -127,8 +127,9 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 			}),
 			util.BuildVolume(pullSecretVolume(), func(v *corev1.Volume) {
 				v.Secret = &corev1.SecretVolumeSource{
-					SecretName: common.PullSecret(deployment.Namespace).Name,
-					Items:      []corev1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
+					DefaultMode: pointer.Int32Ptr(0640),
+					SecretName:  common.PullSecret(deployment.Namespace).Name,
+					Items:       []corev1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
 				}
 			}),
 		},
@@ -278,6 +279,7 @@ func oasVolumeKubeconfig() *corev1.Volume {
 func buildOASVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.KASServiceKubeconfigSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 func oasVolumeEtcdClientCA() *corev1.Volume {
@@ -300,6 +302,7 @@ func oasVolumeServingCert() *corev1.Volume {
 func buildOASVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.OpenShiftAPIServerCertSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 func oasVolumeEtcdClientCert() *corev1.Volume {
@@ -311,6 +314,7 @@ func oasVolumeEtcdClientCert() *corev1.Volume {
 func buildOASVolumeEtcdClientCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.EtcdClientSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 func oasVolumeKonnectivityProxyCert() *corev1.Volume {
@@ -340,4 +344,5 @@ func pullSecretVolume() *corev1.Volume {
 func buildOASVolumeKonnectivityProxyCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.KonnectivityClientSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -175,6 +175,7 @@ func oauthVolumeKubeconfig() *corev1.Volume {
 func buildOAuthVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.KASServiceKubeconfigSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 func oauthVolumeEtcdClientCA() *corev1.Volume {
@@ -197,6 +198,7 @@ func oauthVolumeServingCert() *corev1.Volume {
 func buildOAuthVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.OpenShiftOAuthAPIServerCertSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 func oauthVolumeEtcdClientCert() *corev1.Volume {
@@ -208,6 +210,7 @@ func oauthVolumeEtcdClientCert() *corev1.Volume {
 func buildOAuthVolumeEtcdClientCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.EtcdClientSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 func ReconcileOpenShiftOAuthAPIServerPodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OAuthDeploymentParams) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -101,8 +101,8 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 			util.BuildVolume(oauthVolumeLoginTemplate(), buildOAuthVolumeLoginTemplate),
 			util.BuildVolume(oauthVolumeProvidersTemplate(), buildOAuthVolumeProvidersTemplate),
 			util.BuildVolume(oauthVolumeWorkLogs(), buildOAuthVolumeWorkLogs),
-			{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: utilpointer.Int32Ptr(416)}}},
-			{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: utilpointer.Int32Ptr(416)}}},
+			{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: utilpointer.Int32Ptr(0640)}}},
+			{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: utilpointer.Int32Ptr(0640)}}},
 		},
 	}
 	deploymentConfig.ApplyTo(deployment)
@@ -187,7 +187,8 @@ func oauthVolumeKubeconfig() *corev1.Volume {
 
 func buildOAuthVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+		DefaultMode: utilpointer.Int32Ptr(0640),
+		SecretName:  manifests.KASServiceKubeconfigSecret("").Name,
 	}
 }
 func oauthVolumeServingCert() *corev1.Volume {
@@ -198,7 +199,8 @@ func oauthVolumeServingCert() *corev1.Volume {
 
 func buildOAuthVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.OpenShiftOAuthServerCert("").Name,
+		DefaultMode: utilpointer.Int32Ptr(0640),
+		SecretName:  manifests.OpenShiftOAuthServerCert("").Name,
 	}
 }
 func oauthVolumeSessionSecret() *corev1.Volume {
@@ -208,7 +210,8 @@ func oauthVolumeSessionSecret() *corev1.Volume {
 }
 func buildOAuthVolumeSessionSecret(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.OAuthServerServiceSessionSecret("").Name,
+		DefaultMode: utilpointer.Int32Ptr(0640),
+		SecretName:  manifests.OAuthServerServiceSessionSecret("").Name,
 	}
 }
 func oauthVolumeErrorTemplate() *corev1.Volume {
@@ -219,7 +222,8 @@ func oauthVolumeErrorTemplate() *corev1.Volume {
 
 func buildOAuthVolumeErrorTemplate(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.OAuthServerDefaultErrorTemplateSecret("").Name,
+		DefaultMode: utilpointer.Int32Ptr(0640),
+		SecretName:  manifests.OAuthServerDefaultErrorTemplateSecret("").Name,
 	}
 }
 
@@ -231,7 +235,8 @@ func oauthVolumeLoginTemplate() *corev1.Volume {
 
 func buildOAuthVolumeLoginTemplate(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.OAuthServerDefaultLoginTemplateSecret("").Name,
+		DefaultMode: utilpointer.Int32Ptr(0640),
+		SecretName:  manifests.OAuthServerDefaultLoginTemplateSecret("").Name,
 	}
 }
 
@@ -243,7 +248,8 @@ func oauthVolumeProvidersTemplate() *corev1.Volume {
 
 func buildOAuthVolumeProvidersTemplate(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.OAuthServerDefaultProviderSelectionTemplateSecret("").Name,
+		DefaultMode: utilpointer.Int32Ptr(0640),
+		SecretName:  manifests.OAuthServerDefaultProviderSelectionTemplateSecret("").Name,
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
@@ -13,17 +13,17 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
+	osinv1 "github.com/openshift/api/osin/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/cache"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	configv1 "github.com/openshift/api/config/v1"
-	osinv1 "github.com/openshift/api/osin/v1"
 
 	"github.com/openshift/hypershift/support/util"
 )
@@ -71,6 +71,7 @@ func (i *IDPVolumeMountInfo) SecretPath(index int, secretName, field, key string
 	}
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = secretName
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 	i.Volumes = append(i.Volumes, v)
 	i.VolumeMounts[i.Container][v.Name] = fmt.Sprintf("%s/idp_secret_%d_%s", IDPVolumePathPrefix, index, field)
 	return path.Join(i.VolumeMounts[i.Container][v.Name], key)

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
@@ -130,6 +130,7 @@ func ocmVolumeKubeconfig() *corev1.Volume {
 func buildOCMVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.KASServiceKubeconfigSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }
 
 func ocmVolumeServingCert() *corev1.Volume {
@@ -141,4 +142,5 @@ func ocmVolumeServingCert() *corev1.Volume {
 func buildOCMVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.OpenShiftControllerManagerCertSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(0640)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-operator-deployment.yaml
@@ -19,15 +19,19 @@ spec:
       volumes:
         - name: srv-cert
           secret:
+            defaultMode: 0640
             secretName: catalog-operator-serving-cert
         - name: profile-collector
           secret:
+            defaultMode: 0640
             secretName: metrics-client
         - name: kubeconfig
           secret:
+            defaultMode: 0640
             secretName: service-network-admin-kubeconfig
         - name: oas-konnectivity-proxy-cert
           secret:
+            defaultMode: 0640
             secretName: konnectivity-client
       containers:
         - name: catalog-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
@@ -40,5 +40,6 @@ spec:
                 name: olm-collect-profiles
             - name: secret-volume
               secret:
+                defaultMode: 0640
                 secretName: metrics-client
           restartPolicy: Never

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
@@ -19,15 +19,19 @@ spec:
       volumes:
         - name: srv-cert
           secret:
+            defaultMode: 0640
             secretName: olm-operator-serving-cert
         - name: client-ca
           secret:
+            defaultMode: 0640
             secretName: metrics-client
         - name: kubeconfig
           secret:
+            defaultMode: 0640
             secretName: service-network-admin-kubeconfig
         - name: oas-konnectivity-proxy-cert
           secret:
+            defaultMode: 0640
             secretName: konnectivity-client
       containers:
         - name: olm-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
@@ -108,7 +108,7 @@ spec:
         name: tmpfs
       - name: apiservice-cert
         secret:
-          defaultMode: 416
+          defaultMode: 0640
           items:
           - key: tls.crt
             path: apiserver.crt
@@ -117,11 +117,13 @@ spec:
           secretName: packageserver-cert
       - name: webhook-cert
         secret:
-          defaultMode: 416
+          defaultMode: 0640
           secretName: packageserver-cert
       - name: kubeconfig
         secret:
+          defaultMode: 0640
           secretName: service-network-admin-kubeconfig
       - name: oas-konnectivity-proxy-cert
         secret:
+          defaultMode: 0640
           secretName: konnectivity-client

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -66,8 +66,8 @@ func ReconcileEtcdSignerSecret(secret *corev1.Secret, ownerRef config.OwnerRef) 
 	return reconcileSelfSignedCA(secret, ownerRef, "etcd-signer", "openshift")
 }
 
-func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdSigner, rootCA *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, etcdSigner, rootCA)
+func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdSigner *corev1.Secret) error {
+	return reconcileAggregateCA(cm, ownerRef, etcdSigner)
 }
 
 func ReconcileEtcdMetricsSignerSecret(secret *corev1.Secret, ownerref config.OwnerRef) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -363,7 +363,8 @@ func volumeServingCert() *corev1.Volume {
 
 func buildVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.ImageRegistryOperatorServingCert("").Name,
+		SecretName:  manifests.ImageRegistryOperatorServingCert("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 
@@ -375,7 +376,8 @@ func volumeAdminKubeconfig() *corev1.Volume {
 
 func buildVolumeAdminKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+		SecretName:  manifests.KASServiceKubeconfigSecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 
@@ -387,7 +389,8 @@ func volumeCABundle() *corev1.Volume {
 
 func buildVolumeCABundle(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.RootCASecret("").Name,
+		SecretName:  manifests.RootCASecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -188,12 +188,15 @@ spec:
         name: client-token
       - name: serving-cert
         secret:
+          defaultMode: 416
           secretName: cluster-image-registry-operator
       - name: kubeconfig
         secret:
+          defaultMode: 416
           secretName: service-network-admin-kubeconfig
       - name: ca-bundle
         secret:
+          defaultMode: 416
           secretName: root-ca
       - emptyDir: {}
         name: web-identity-token

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -166,6 +166,7 @@ func schedulerVolumeKubeconfig() *corev1.Volume {
 
 func buildSchedulerVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.SchedulerKubeconfigSecret("").Name,
+		SecretName:  manifests.SchedulerKubeconfigSecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -135,7 +135,8 @@ func buildKonnectivityWorkerAgentContainer(image, host string, port int32, proxy
 
 func buildKonnectivityVolumeWorkerAgentCerts(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.KonnectivityAgentSecret("").Name,
+		SecretName:  manifests.KonnectivityAgentSecret("").Name,
+		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2438,7 +2438,7 @@ func reconcileCAPICluster(cluster *capiv1.Cluster, hcluster *hyperv1.HostedClust
 }
 
 func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, sa *corev1.ServiceAccount, capiManagerImage string, setDefaultSecurityContext bool) error {
-	defaultMode := int32(416)
+	defaultMode := int32(0640)
 	capiManagerLabels := map[string]string{
 		"name":                        "cluster-api",
 		"app":                         "cluster-api",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -69,7 +69,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIProviderAWSImage]; ok {
 		providerImage = override
 	}
-	defaultMode := int32(416)
+	defaultMode := int32(0640)
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -63,7 +63,7 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 	if override, ok := hcluster.Annotations[hyperv1.ClusterAPIKubeVirtProviderImage]; ok {
 		providerImage = override
 	}
-	defaultMode := int32(416)
+	defaultMode := int32(0640)
 	return &appsv1.DeploymentSpec{
 		Replicas: k8sutilspointer.Int32Ptr(1),
 		Template: corev1.PodTemplateSpec{

--- a/ignition-server/controllers/machineconfigserver_ignitionprovider.go
+++ b/ignition-server/controllers/machineconfigserver_ignitionprovider.go
@@ -407,7 +407,8 @@ cat /tmp/custom-config/base64CompressedConfig | base64 -d | gunzip --force --std
 					Name: "kubeconfig",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: "bootstrap-kubeconfig",
+							DefaultMode: k8sutilspointer.Int32Ptr(0640),
+							SecretName:  "bootstrap-kubeconfig",
 						},
 					},
 				},
@@ -415,7 +416,8 @@ cat /tmp/custom-config/base64CompressedConfig | base64 -d | gunzip --force --std
 					Name: "mcs-tls",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: "mcs-crt",
+							DefaultMode: k8sutilspointer.Int32Ptr(0640),
+							SecretName:  "mcs-crt",
 						},
 					},
 				},

--- a/support/globalconfig/namedcerts.go
+++ b/support/globalconfig/namedcerts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 )
 
 func ApplyNamedCertificateMounts(containerName string, mountPrefix string, certs []configv1.APIServerNamedServingCert, spec *corev1.PodSpec) {
@@ -23,7 +24,8 @@ func ApplyNamedCertificateMounts(containerName string, mountPrefix string, certs
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: namedCert.ServingCertificate.Name,
+					SecretName:  namedCert.ServingCertificate.Name,
+					DefaultMode: pointer.Int32Ptr(0640),
 				},
 			},
 		})

--- a/support/globalconfig/namedcerts_test.go
+++ b/support/globalconfig/namedcerts_test.go
@@ -2,10 +2,12 @@ package globalconfig
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
+	"k8s.io/utils/pointer"
 )
 
 func TestApplyNamedCertificateMounts(t *testing.T) {
@@ -46,7 +48,8 @@ func TestApplyNamedCertificateMounts(t *testing.T) {
 					Name: "named-cert-1",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: "example-cert",
+							SecretName:  "example-cert",
+							DefaultMode: pointer.Int32Ptr(0640),
 						},
 					},
 				},


### PR DESCRIPTION
Updates default secret mode from 420 to 0640  for all hypershift mounted secrets
Continuation of https://github.com/openshift/hypershift/issues/1031

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.