### PR TITLE
HOSTEDCP-576: E2E Test NodePool Scale Down

### DIFF
--- a/test/e2e/nodepool_scaledown_dataplane_test.go
+++ b/test/e2e/nodepool_scaledown_dataplane_test.go
@@ -1,0 +1,92 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestScaleDownDataPlane(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	var nodePools hyperv1.NodePoolList
+	var zeroReplicas int32 = 0
+
+	testContext := context.Background()
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	numZones := int32(len(clusterOpts.AWSPlatform.Zones))
+	if numZones <= 1 {
+		clusterOpts.NodePoolReplicas = 3
+	} else if numZones == 2 {
+		clusterOpts.NodePoolReplicas = 2
+	} else {
+		clusterOpts.NodePoolReplicas = 1
+	}
+	clusterOpts.AutoRepair = true
+	clusterOpts.BeforeApply = func(o crclient.Object) {
+		switch v := o.(type) {
+		case *hyperv1.NodePool:
+			v.Spec.NodeDrainTimeout = &metav1.Duration{
+				Duration: 1 * time.Second,
+			}
+		}
+	}
+
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
+
+	// Wait for HC to finish the deployment
+	t.Logf("Waiting for initial cluster rollout. Image: %s", hostedCluster.Spec.Release.Image)
+	e2eutil.WaitForImageRollout(t, ctx, client, guestClient, hostedCluster, hostedCluster.Spec.Release.Image)
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+
+	// Find NodePools.
+	err = client.List(ctx, &nodePools, &crclient.ListOptions{Namespace: hostedCluster.Namespace})
+	g.Expect(err).NotTo(HaveOccurred(), "failed to list NodePools")
+	numNodes := int32(numZones * clusterOpts.NodePoolReplicas)
+
+	// Wait for NodePools to roll out the initial version.
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
+
+	// Update NodePool images to the latest.
+	for _, nodePool := range nodePools.Items {
+		err = client.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get NodePool")
+
+		t.Logf("Scalling down NodePool %s to replicas %d", nodePool.Name, zeroReplicas)
+		original := nodePool.DeepCopy()
+		nodePool.Spec.Replicas = &zeroReplicas
+		err = client.Patch(ctx, &nodePool, crclient.MergeFrom(original))
+		g.Expect(err).NotTo(HaveOccurred(), "failed update NodePool replicas")
+	}
+
+	// Wait for NodePools to get updated
+	for _, nodePool := range nodePools.Items {
+		err := wait.PollUntil(10*time.Second, func() (done bool, err error) {
+			t.Logf("Waiting until NodePool scales to the desired state: Nodepool %s Replicas %d\n", nodePool.Name, zeroReplicas)
+			err = client.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get NodePool")
+
+			return nodePool.Status.Replicas == *nodePool.Spec.Replicas, nil
+		}, ctx.Done())
+		g.Expect(err).NotTo(HaveOccurred(), "failed to wait for new node to become available")
+		t.Logf("Scale down Done!: Nodepool %s Replicas %d\n", nodePool.Name, zeroReplicas)
+	}
+}

--- a/test/e2e/nodepool_scaledown_dataplane_test.go
+++ b/test/e2e/nodepool_scaledown_dataplane_test.go
@@ -32,13 +32,14 @@ func TestScaleDownDataPlane(t *testing.T) {
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	numZones := int32(len(clusterOpts.AWSPlatform.Zones))
 	if numZones <= 1 {
-		clusterOpts.NodePoolReplicas = 3
-	} else if numZones == 2 {
 		clusterOpts.NodePoolReplicas = 2
+	} else if numZones == 2 {
+		clusterOpts.NodePoolReplicas = 1
 	} else {
 		clusterOpts.NodePoolReplicas = 1
 	}
 	clusterOpts.AutoRepair = true
+	clusterOpts.AWSPlatform.InstanceType = "m6i.xlarge"
 	clusterOpts.BeforeApply = func(o crclient.Object) {
 		switch v := o.(type) {
 		case *hyperv1.NodePool:

--- a/test/e2e/nodepool_scaledown_dataplane_test.go
+++ b/test/e2e/nodepool_scaledown_dataplane_test.go
@@ -10,7 +10,8 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/cmd/cluster/core"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,97 +19,100 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestScaleDownDataPlane(t *testing.T) {
-	g := NewWithT(t)
+func testNodepoolScaleDownDataPlane(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
 
-	ctx, cancel := context.WithCancel(parentCtx)
-	originalNP := hyperv1.NodePool{}
-	defer func() {
-		t.Log("Test: NodePool ScaleDown DataPlane finished")
-		cancel()
-	}()
+		ctx, cancel := context.WithCancel(parentCtx)
+		originalNP := hyperv1.NodePool{}
+		defer func() {
+			t.Log("Test: NodePool Scaledown Dataplane finished")
+			cancel()
+		}()
 
-	// List NodePools (should exists only one)
-	nodePools := &hyperv1.NodePoolList{}
-	err := mgmtClient.List(ctx, nodePools, &crclient.ListOptions{
-		Namespace: hostedCluster.Namespace,
-	})
-	g.Expect(err).NotTo(HaveOccurred(), "failed getting existant nodepools")
-	for _, nodePool := range nodePools.Items {
-		if !strings.Contains(nodePool.Name, "-test-") {
-			originalNP = nodePool
-		}
-	}
-	g.Expect(originalNP.Name).NotTo(BeEmpty())
-	g.Expect(originalNP.Name).NotTo(ContainSubstring("test"))
-	awsNPInfo := originalNP.Spec.Platform.AWS
-
-	// Define a new Nodepool
-	nodePool := &hyperv1.NodePool{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "NodePool",
-			APIVersion: hyperv1.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      hostedCluster.Name + "-" + "test-autorepair",
+		// List NodePools (should exists only one)
+		nodePools := &hyperv1.NodePoolList{}
+		err := mgmtClient.List(ctx, nodePools, &crclient.ListOptions{
 			Namespace: hostedCluster.Namespace,
-		},
-		Spec: hyperv1.NodePoolSpec{
-			NodeDrainTimeout: &metav1.Duration{
-				Duration: 1 * time.Second,
-			},
-			Management: hyperv1.NodePoolManagement{
-				UpgradeType: hyperv1.UpgradeTypeReplace,
-				AutoRepair:  true,
-			},
-			ClusterName: hostedCluster.Name,
-			Replicas:    &oneReplicas,
-			Release: hyperv1.Release{
-				Image: hostedCluster.Spec.Release.Image,
-			},
-			Platform: hyperv1.NodePoolPlatform{
-				Type: hostedCluster.Spec.Platform.Type,
-				AWS:  awsNPInfo,
-			},
-		},
-	}
-
-	// Create NodePool for current test
-	err = mgmtClient.Create(ctx, nodePool)
-	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			t.Fatalf("failed to create nodePool %s with Autorepair function: %v", nodePool.Name, err)
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed getting existant nodepools")
+		for _, nodePool := range nodePools.Items {
+			if !strings.Contains(nodePool.Name, "-test-") {
+				originalNP = nodePool
+			}
 		}
-		err = nodePoolRecreate(t, ctx, nodePool, mgmtClient)
-		g.Expect(err).NotTo(HaveOccurred(), "failed to Create the NodePool")
+		g.Expect(originalNP.Name).NotTo(BeEmpty())
+		g.Expect(originalNP.Name).NotTo(ContainSubstring("test"))
+		awsNPInfo := originalNP.Spec.Platform.AWS
+
+		// Define a new Nodepool
+		nodePool := &hyperv1.NodePool{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "NodePool",
+				APIVersion: hyperv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hostedCluster.Name + "-" + "test-scaledowndataplane",
+				Namespace: hostedCluster.Namespace,
+			},
+			Spec: hyperv1.NodePoolSpec{
+				NodeDrainTimeout: &metav1.Duration{
+					Duration: 1 * time.Second,
+				},
+				Management: hyperv1.NodePoolManagement{
+					UpgradeType: hyperv1.UpgradeTypeReplace,
+					AutoRepair:  true,
+				},
+				ClusterName: hostedCluster.Name,
+				Replicas:    &oneReplicas,
+				Release: hyperv1.Release{
+					Image: hostedCluster.Spec.Release.Image,
+				},
+				Platform: hyperv1.NodePoolPlatform{
+					Type: hostedCluster.Spec.Platform.Type,
+					AWS:  awsNPInfo,
+				},
+			},
+		}
+
+		// Create NodePool for current test
+		err = mgmtClient.Create(ctx, nodePool)
+		if err != nil {
+			if !errors.IsAlreadyExists(err) {
+				t.Fatalf("failed to create nodePool %s with Autorepair function: %v", nodePool.Name, err)
+			}
+			err = nodePoolRecreate(t, ctx, nodePool, mgmtClient)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to Create the NodePool")
+		}
+		defer nodePoolScaleDownToZero(ctx, mgmtClient, *nodePool, t)
+
+		numNodes := int32(1)
+
+		t.Logf("Waiting for Nodes %d\n", numNodes)
+		_ = e2eutil.WaitForNReadyNodesByNodePool(t, ctx, hostedClusterClient, numNodes, hostedCluster.Spec.Platform.Type, nodePool.Name)
+		t.Logf("Desired replicas available for nodePool: %v", nodePool.Name)
+
+		// Wait for the rollout to be reported complete
+		t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
+		e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedClusterClient, hostedCluster, globalOpts.LatestReleaseImage)
+
+		// Update NodePool images to the latest.
+		t.Logf("Scalling down NodePool %s to replicas %d", nodePool.Name, zeroReplicas)
+		np := nodePool.DeepCopy()
+		nodePool.Spec.Replicas = &zeroReplicas
+		err = mgmtClient.Patch(ctx, nodePool, crclient.MergeFrom(np))
+		g.Expect(err).NotTo(HaveOccurred(), "failed update NodePool replicas")
+
+		// Wait for NodePools to get updated
+		err = wait.PollUntil(10*time.Second, func() (done bool, err error) {
+			t.Logf("Waiting until NodePool scales to the desired state: Nodepool %s Replicas %d\n", nodePool.Name, zeroReplicas)
+			err = mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(nodePool), nodePool)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			return nodePool.Status.Replicas == *nodePool.Spec.Replicas, nil
+		}, ctx.Done())
+		g.Expect(err).NotTo(HaveOccurred(), "failed to wait for new node to become available")
+		t.Logf("Scale down Done!: Nodepool %s Replicas %d\n", nodePool.Name, zeroReplicas)
 	}
-	defer nodePoolScaleDownToZero(ctx, mgmtClient, *nodePool, t)
-
-	numNodes := int32(1)
-
-	t.Logf("Waiting for Nodes %d\n", numNodes)
-	nodes := e2eutil.WaitForNReadyNodesByNodePool(t, ctx, hostedClusterClient, numNodes, hostedCluster.Spec.Platform.Type, nodePool.Name)
-	t.Logf("Desired replicas available for nodePool: %v", nodePool.Name)
-
-	// Wait for the rollout to be reported complete
-	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
-	e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedClusterClient, hostedCluster, globalOpts.LatestReleaseImage)
-
-	// Update NodePool images to the latest.
-	t.Logf("Scalling down NodePool %s to replicas %d", nodePool.Name, zeroReplicas)
-	np := nodePool.DeepCopy()
-	nodePool.Spec.Replicas = &zeroReplicas
-	err = client.Patch(ctx, &nodePool, crclient.MergeFrom(np))
-	g.Expect(err).NotTo(HaveOccurred(), "failed update NodePool replicas")
-
-	// Wait for NodePools to get updated
-	err := wait.PollUntil(10*time.Second, func() (done bool, err error) {
-		t.Logf("Waiting until NodePool scales to the desired state: Nodepool %s Replicas %d\n", nodePool.Name, zeroReplicas)
-		err = client.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		return nodePool.Status.Replicas == *nodePool.Spec.Replicas, nil
-	}, ctx.Done())
-	g.Expect(err).NotTo(HaveOccurred(), "failed to wait for new node to become available")
-	t.Logf("Scale down Done!: Nodepool %s Replicas %d\n", nodePool.Name, zeroReplicas)
 }

--- a/test/e2e/nodepool_scaledown_dataplane_test.go
+++ b/test/e2e/nodepool_scaledown_dataplane_test.go
@@ -95,7 +95,7 @@ func testNodepoolScaleDownDataPlane(parentCtx context.Context, mgmtClient crclie
 
 		// Wait for the rollout to be reported complete
 		t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
-		e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedClusterClient, hostedCluster, globalOpts.LatestReleaseImage)
+		e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedCluster, globalOpts.LatestReleaseImage)
 
 		// Update NodePool images to the latest.
 		t.Logf("Scalling down NodePool %s to replicas %d", nodePool.Name, zeroReplicas)

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -49,6 +49,7 @@ func TestNodePool(t *testing.T) {
 	t.Run("Refactored", func(t *testing.T) {
 		t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
 		t.Run("TestNodepoolMachineconfigGetsRolledout", testNodepoolMachineconfigGetsRolledout(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
+		t.Run("TestNodepoolScaleDownDataPlane", testNodepoolScaleDownDataPlane(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This E2E test will go throught:

- HostedCluster deployment
- The NodePool has the drainTimeout set to 1 second (This way will not wait for draining on ScaleDown)
- The NodePool replicas set to 1
- After the NodePool deployment (for that test), it will check if the Cluster is Ready.
- Then it will scale all the NodePool replicas to zero
- After wait for the workers to scale down, we check if the desired nodes vs current nodes are the same values.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-576](https://issues.redhat.com/browse/HOSTEDCP-576)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.