### PR TITLE
Refactor powervs infra for reusing fields in create cluster cmd

### DIFF
--- a/cmd/cluster/powervs/create.go
+++ b/cmd/cluster/powervs/create.go
@@ -51,20 +51,12 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.PowerVSPlatform.Debug, "debug", opts.PowerVSPlatform.Debug, "Enabling this will print PowerVS API Request & Response logs")
 	cmd.Flags().BoolVar(&opts.PowerVSPlatform.RecreateSecrets, "recreate-secrets", opts.PowerVSPlatform.RecreateSecrets, "Enabling this flag will recreate creds mentioned https://hypershift-docs.netlify.app/reference/api/#hypershift.openshift.io/v1alpha1.PowerVSPlatformSpec here. This is required when rerunning 'hypershift create cluster powervs' or 'hypershift create infra powervs' commands, since API key once created cannot be retrieved again. Please make sure that cluster name used is unique across different management clusters before using this flag")
 
-	cmd.MarkFlagRequired("resource-group")
-
 	// these options are only for development and testing purpose,
 	// can use these to reuse the existing resources, so hiding it.
 	cmd.Flags().MarkHidden("cloud-instance-id")
 	cmd.Flags().MarkHidden("cloud-connection")
 	cmd.Flags().MarkHidden("vpc")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		if opts.BaseDomain == "" {
-			return fmt.Errorf("--base-domain can't be empty")
-		}
-		return nil
-	}
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
 		sigs := make(chan os.Signal, 1)
@@ -85,20 +77,10 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 
 func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
 	var err error
-	if err = validate(opts); err != nil {
-		return err
-	}
 	if err = core.Validate(ctx, opts); err != nil {
 		return err
 	}
 	return core.CreateCluster(ctx, opts, applyPlatformSpecificsValues)
-}
-
-func validate(opts *core.CreateOptions) error {
-	if opts.BaseDomain == "" {
-		return fmt.Errorf("--base-domain can't be empty")
-	}
-	return nil
 }
 
 func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
@@ -120,10 +102,15 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		}
 	}
 
+	if opts.BaseDomain == "" && infra == nil {
+		return fmt.Errorf("base-domain flag is required if infra-json is not provided")
+	}
+
+	if opts.PowerVSPlatform.ResourceGroup == "" && infra == nil {
+		return fmt.Errorf("resource-group flag is required if infra-json is not provided")
+	}
+
 	if infra == nil {
-		if len(infraID) == 0 {
-			infraID = infraid.New(opts.Name)
-		}
 		opt := &powervsinfra.CreateInfraOptions{
 			Name:            opts.Name,
 			Namespace:       opts.Namespace,
@@ -140,28 +127,35 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			Debug:           opts.PowerVSPlatform.Debug,
 			RecreateSecrets: opts.PowerVSPlatform.RecreateSecrets,
 		}
-		infra = &powervsinfra.Infra{ID: opts.InfraID}
+		infra = &powervsinfra.Infra{
+			ID:            infraID,
+			BaseDomain:    opts.BaseDomain,
+			ResourceGroup: opts.PowerVSPlatform.ResourceGroup,
+			Region:        opts.PowerVSPlatform.Region,
+			Zone:          opts.PowerVSPlatform.Zone,
+			VPCRegion:     opts.PowerVSPlatform.VPCRegion,
+		}
 		err = infra.SetupInfra(ctx, opt)
 		if err != nil {
 			return fmt.Errorf("failed to create infra: %w", err)
 		}
 	}
 
-	exampleOptions.BaseDomain = opts.BaseDomain
+	exampleOptions.BaseDomain = infra.BaseDomain
 	exampleOptions.MachineCIDR = defaultCIDRBlock
 	exampleOptions.PrivateZoneID = infra.CISDomainID
 	exampleOptions.PublicZoneID = infra.CISDomainID
-	exampleOptions.InfraID = infraID
+	exampleOptions.InfraID = infra.ID
 	exampleOptions.PowerVS = &apifixtures.ExamplePowerVSOptions{
 		AccountID:       infra.AccountID,
-		ResourceGroup:   opts.PowerVSPlatform.ResourceGroup,
-		Region:          opts.PowerVSPlatform.Region,
-		Zone:            opts.PowerVSPlatform.Zone,
+		ResourceGroup:   infra.ResourceGroup,
+		Region:          infra.Region,
+		Zone:            infra.Zone,
 		CISInstanceCRN:  infra.CISCRN,
 		CloudInstanceID: infra.CloudInstanceID,
 		Subnet:          infra.DHCPSubnet,
 		SubnetID:        infra.DHCPSubnetID,
-		VPCRegion:       opts.PowerVSPlatform.VPCRegion,
+		VPCRegion:       infra.VPCRegion,
 		VPC:             infra.VPCName,
 		VPCSubnet:       infra.VPCSubnetName,
 		SysType:         opts.PowerVSPlatform.SysType,

--- a/cmd/infra/powervs/create.go
+++ b/cmd/infra/powervs/create.go
@@ -152,21 +152,26 @@ type Secrets struct {
 // Infra resource info in IBM Cloud for setting up hypershift nodepool
 type Infra struct {
 	ID                string            `json:"id"`
+	Region            string            `json:"region"`
+	Zone              string            `json:"zone"`
+	VPCRegion         string            `json:"vpcRegion"`
 	AccountID         string            `json:"accountID"`
+	BaseDomain        string            `json:"baseDomain"`
 	CISCRN            string            `json:"cisCrn"`
 	CISDomainID       string            `json:"cisDomainID"`
-	ResourceGroupID   string            `json:"resourceGroupID"`
+	ResourceGroup     string            `json:"resourceGroup"`
+	ResourceGroupID   string            `json:"-"`
 	CloudInstanceID   string            `json:"cloudInstanceID"`
 	DHCPSubnet        string            `json:"dhcpSubnet"`
 	DHCPSubnetID      string            `json:"dhcpSubnetID"`
-	DHCPID            string            `json:"dhcpID"`
-	CloudConnectionID string            `json:"cloudConnectionID"`
+	DHCPID            string            `json:"-"`
+	CloudConnectionID string            `json:"-"`
 	VPCName           string            `json:"vpcName"`
-	VPCID             string            `json:"vpcID"`
-	VPCCRN            string            `json:"vpcCrn"`
+	VPCID             string            `json:"-"`
+	VPCCRN            string            `json:"-"`
 	VPCRoutingTableID string            `json:"-"`
 	VPCSubnetName     string            `json:"vpcSubnetName"`
-	VPCSubnetID       string            `json:"vpcSubnetID"`
+	VPCSubnetID       string            `json:"-"`
 	Stats             InfraCreationStat `json:"stats"`
 	Secrets           Secrets           `json:"secrets"`
 }
@@ -230,7 +235,14 @@ func (options *CreateInfraOptions) Run(ctx context.Context) error {
 		return err
 	}
 
-	infra := &Infra{ID: options.InfraID}
+	infra := &Infra{
+		ID:            options.InfraID,
+		BaseDomain:    options.BaseDomain,
+		ResourceGroup: options.ResourceGroup,
+		Region:        options.Region,
+		Zone:          options.Zone,
+		VPCRegion:     options.VPCRegion,
+	}
 
 	defer func() {
 		out := os.Stdout


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Fixes https://issues.redhat.com/browse/MULTIARCH-2984
Removed some of the dup blocks like validating empty base-domain and generating infraID.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.