### PR TITLE
Retrieve CAPI/CAPA from release image

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -15,6 +15,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	version "github.com/openshift/hypershift/cmd/version"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt"
@@ -840,7 +841,7 @@ func expectedRules(addRules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
 }
 
 func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
-
+	releaseImage, _ := version.LookupDefaultOCPVersion()
 	hostedClusters := []*hyperv1.HostedCluster{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "agent"},
@@ -848,6 +849,9 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 				Platform: hyperv1.PlatformSpec{
 					Type:  hyperv1.AgentPlatform,
 					Agent: &hyperv1.AgentPlatformSpec{AgentNamespace: "agent-namespace"},
+				},
+				Release: hyperv1.Release{
+					Image: releaseImage.PullSpec,
 				},
 			},
 			Status: hyperv1.HostedClusterStatus{
@@ -872,6 +876,9 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 						},
 					},
 				},
+				Release: hyperv1.Release{
+					Image: releaseImage.PullSpec,
+				},
 			},
 		},
 		{
@@ -879,6 +886,9 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 			Spec: hyperv1.HostedClusterSpec{
 				Platform: hyperv1.PlatformSpec{
 					Type: hyperv1.NonePlatform,
+				},
+				Release: hyperv1.Release{
+					Image: releaseImage.PullSpec,
 				},
 			},
 		},
@@ -889,6 +899,9 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 					Type:     hyperv1.IBMCloudPlatform,
 					IBMCloud: &hyperv1.IBMCloudPlatformSpec{},
 				},
+				Release: hyperv1.Release{
+					Image: releaseImage.PullSpec,
+				},
 			},
 		},
 		{
@@ -896,6 +909,9 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 			Spec: hyperv1.HostedClusterSpec{
 				Platform: hyperv1.PlatformSpec{
 					Type: hyperv1.KubevirtPlatform,
+				},
+				Release: hyperv1.Release{
+					Image: releaseImage.PullSpec,
 				},
 			},
 		},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
@@ -10,6 +10,7 @@ import (
 	hyperapi "github.com/openshift/hypershift/api"
 	"github.com/openshift/hypershift/api/util/ipnet"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	version "github.com/openshift/hypershift/cmd/version"
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
@@ -30,6 +31,7 @@ import (
 )
 
 func TestWebhookAllowsHostedClusterReconcilerUpdates(t *testing.T) {
+	releaseImage, _ := version.LookupDefaultOCPVersion()
 	t.Parallel()
 	testCases := []struct {
 		name              string
@@ -55,6 +57,9 @@ func TestWebhookAllowsHostedClusterReconcilerUpdates(t *testing.T) {
 							},
 						},
 					},
+					Release: hyperv1.Release{
+						Image: releaseImage.PullSpec,
+					},
 				},
 			},
 			additionalObjects: []crclient.Object{
@@ -64,7 +69,7 @@ func TestWebhookAllowsHostedClusterReconcilerUpdates(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns"},
-					Data:       map[string][]byte{".dockerconfigjson": []byte("something")},
+					Data:       map[string][]byte{".dockerconfigjson": []byte("{\"something\": \"something\"}")},
 				},
 				&configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "none-cluster"}},

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -25,20 +25,19 @@ import (
 )
 
 const (
-	// Image built from https://github.com/openshift/cluster-api-provider-aws/tree/release-1.1
-	// Upstream canonical image comes from  https://console.cloud.google.com/gcr/images/k8s-artifacts-prod
-	// us.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller:v1.1.0
-	imageCAPA = "registry.ci.openshift.org/hypershift/cluster-api-aws-controller:v1.1.0"
+	ImageStreamCAPA = "aws-cluster-api-controllers"
 )
 
-func New(utilitiesImage string) *AWS {
+func New(utilitiesImage string, capiProviderImage string) *AWS {
 	return &AWS{
-		utilitiesImage: utilitiesImage,
+		utilitiesImage:    utilitiesImage,
+		capiProviderImage: capiProviderImage,
 	}
 }
 
 type AWS struct {
-	utilitiesImage string
+	utilitiesImage    string
+	capiProviderImage string
 }
 
 func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
@@ -63,7 +62,7 @@ func (p AWS) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOr
 }
 
 func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
-	providerImage := imageCAPA
+	providerImage := p.capiProviderImage
 	if envImage := os.Getenv(images.AWSCAPIProviderEnvVar); len(envImage) > 0 {
 		providerImage = envImage
 	}
@@ -161,7 +160,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 								Value: "true",
 							},
 						},
-						Command: []string{"/manager"},
+						Command: []string{"/bin/cluster-api-provider-aws-controller-manager"},
 						Args: []string{"--namespace", "$(MY_NAMESPACE)",
 							"--alsologtostderr",
 							"--v=4",

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -234,7 +234,7 @@ func ExtractImageFilesToDir(ctx context.Context, imageRef string, pullSecret []b
 func getMetadata(ctx context.Context, imageRef string, pullSecret []byte) ([]distribution.Descriptor, distribution.BlobStore, error) {
 	repo, ref, err := GetRepoSetup(ctx, imageRef, pullSecret)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to repo setup: %w", err)
+		return nil, nil, fmt.Errorf("failed to get repo setup: %w", err)
 	}
 	firstManifest, location, err := manifest.FirstManifest(ctx, *ref, repo)
 	if err != nil {

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -9,6 +9,8 @@ import (
 	"github.com/golang/groupcache/lru"
 	"k8s.io/client-go/rest"
 
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/registryclient"
@@ -91,4 +93,19 @@ func ImageLabels(metadata *dockerv1client.DockerImageConfig) map[string]string {
 	} else {
 		return metadata.ContainerConfig.Labels
 	}
+}
+
+// GetPayloadImage get an image from the payload for a particular component
+func GetPayloadImage(ctx context.Context, hc *hyperv1.HostedCluster, component string, pullSecret []byte) (string, error) {
+	releaseImageProvider := &releaseinfo.RegistryClientProvider{}
+	releaseImage, err := releaseinfo.Provider.Lookup(releaseImageProvider, ctx, hc.Spec.Release.Image, pullSecret)
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup release image: %w", err)
+	}
+
+	image, exists := releaseImage.ComponentImages()[component]
+	if !exists {
+		return "", fmt.Errorf("image does not exist for release: %q", image)
+	}
+	return image, nil
 }

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -287,7 +287,7 @@ func validateAWSGuestResourcesDeletedFunc(ctx context.Context, t *testing.T, inf
 		taggingClient := resourcegroupstaggingapi.New(awsSession, awsConfig)
 
 		// Find load balancers, persistent volumes, or s3 buckets belonging to the guest cluster
-		err := wait.PollImmediate(5*time.Second, 40*time.Minute, func() (bool, error) {
+		err := wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
 			// Filter get cluster resources.
 			output, err := taggingClient.GetResourcesWithContext(ctx, &resourcegroupstaggingapi.GetResourcesInput{
 				ResourceTypeFilters: []*string{

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -287,7 +287,7 @@ func validateAWSGuestResourcesDeletedFunc(ctx context.Context, t *testing.T, inf
 		taggingClient := resourcegroupstaggingapi.New(awsSession, awsConfig)
 
 		// Find load balancers, persistent volumes, or s3 buckets belonging to the guest cluster
-		err := wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
+		err := wait.PollImmediate(5*time.Second, 40*time.Minute, func() (bool, error) {
 			// Filter get cluster resources.
 			output, err := taggingClient.GetResourcesWithContext(ctx, &resourcegroupstaggingapi.GetResourcesInput{
 				ResourceTypeFilters: []*string{


### PR DESCRIPTION
**What this PR does / why we need it**:
Retrieves the CAPI and CAPA image components from the release image rather than registry.ci.openshift.org/hypershift/cluster-api:v1.0.0 and registry.ci.openshift.org/hypershift/cluster-api-aws-controller:v1.1.0 respectively

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-577](https://issues.redhat.com/browse/HOSTEDCP-577)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.