### PR TITLE
reduce konnectivity-agent log verbosity

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -396,6 +396,8 @@ func buildKonnectivityAgentContainer(image string, ips []string) func(c *corev1.
 			"1m",
 			"--sync-interval-cap",
 			"5m",
+			"--v",
+			"3",
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -112,6 +112,8 @@ func buildKonnectivityWorkerAgentContainer(image, host string, port int32, proxy
 			"1m",
 			"--sync-interval-cap",
 			"5m",
+			"--v",
+			"3",
 		}
 		c.Env = []corev1.EnvVar{
 			{


### PR DESCRIPTION
konnectivity-agent is overly verbose as currently configured. Dropped loglevel from 4 to 3, removes lines
`received DATA`
`write to remote`
`close connection`
`received DIAL_REQ`