### PR TITLE
aws: use gp3-csi storage class by default

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -163,6 +163,9 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	exampleOptions.PublicZoneID = infra.PublicZoneID
 	exampleOptions.InfraID = infraID
 	exampleOptions.ExternalDNSDomain = opts.ExternalDNSDomain
+	if exampleOptions.EtcdStorageClass == "" {
+		exampleOptions.EtcdStorageClass = "gp3-csi"
+	}
 	var zones []apifixtures.ExampleAWSOptionsZones
 	for _, outputZone := range infra.Zones {
 		zones = append(zones, apifixtures.ExampleAWSOptionsZones{


### PR DESCRIPTION
Currently we use the default gp2 volumes for etcd's PV because we don't default a storage class in the `EtcdSpec` so the cluster uses the default storage class, which is still gp2.

Because the default size of the volume is 4Gi and IOPS are provisioned proportial to size in gp2, the PV only has 100 IOPS and could be the cause of our CI troubles.  gp3 is 3000 IOPS at any size.

Switch to gp3 volumes by default, provided by the `gp3-csi` storage class in OpenShift, for etcd PVs.

Oh, and it is cheaper.