### PR TITLE
AUTH-323: Separate Aggregate Client trust chain from rootCA

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -536,6 +536,7 @@ func kasVolumeAggregatorCert() *corev1.Volume {
 		Name: "aggregator-crt",
 	}
 }
+
 func buildKASVolumeAggregatorCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
@@ -554,7 +555,7 @@ func buildKASVolumeAggregatorCA(v *corev1.Volume) {
 		v.ConfigMap = &corev1.ConfigMapVolumeSource{}
 	}
 	v.ConfigMap.DefaultMode = pointer.Int32Ptr(420)
-	v.ConfigMap.Name = manifests.CombinedCAConfigMap("").Name
+	v.ConfigMap.Name = manifests.AggregateClientCAConfigMap("").Name
 }
 
 func kasVolumeEgressSelectorConfig() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -32,6 +32,15 @@ func CombinedCAConfigMap(ns string) *corev1.ConfigMap {
 	}
 }
 
+func AggregateClientCAConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aggregator-client-ca",
+			Namespace: ns,
+		},
+	}
+}
+
 func MetricsClientCertSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -90,6 +99,15 @@ func KASKubeletClientCertSecret(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kas-kubelet-client-crt",
+			Namespace: ns,
+		},
+	}
+}
+
+func AggregateClientSigner(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kas-aggregator-client-signer",
 			Namespace: ns,
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -30,6 +30,14 @@ func reconcileAggregateCA(configMap *corev1.ConfigMap, ownerRef config.OwnerRef,
 	return nil
 }
 
+func ReconcileAggregateClientSigner(secret *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSelfSignedCA(secret, ownerRef, "kas-aggregator-signer", "openshift")
+}
+
+func ReconcileAggregateClientCA(cm *corev1.ConfigMap, ownerRef config.OwnerRef, signer *corev1.Secret) error {
+	return reconcileAggregateCA(cm, ownerRef, signer)
+}
+
 func ReconcileRootCA(secret *corev1.Secret, ownerRef config.OwnerRef) error {
 	return reconcileSelfSignedCA(secret, ownerRef, "root-ca", "openshift")
 }


### PR DESCRIPTION
## What

This is a WIP for a distinct CA for the aggregated client certs.

## Why

- [Trust Chain Separation](https://github.com/openshift/enhancements/blob/master/enhancements/hypershift/trust-chain-separation.md)

Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.