### PR TITLE
Added capability to WaitFor(Un)ReadyNodes to filter by NodePool

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -216,6 +216,91 @@ func WaitForNUnReadyNodes(t *testing.T, ctx context.Context, client crclient.Cli
 	return nodes.Items
 }
 
+func WaitForNReadyNodesByNodePool(t *testing.T, ctx context.Context, client crclient.Client, n int32, platform hyperv1.PlatformType, nodePoolName string) []corev1.Node {
+	g := NewWithT(t)
+	start := time.Now()
+
+	// waitTimeout for nodes to become Ready
+	waitTimeout := 30 * time.Minute
+	switch platform {
+	case hyperv1.PowerVSPlatform:
+		waitTimeout = 60 * time.Minute
+	}
+
+	t.Logf("Waiting for nodes to become ready by NodePool. NodePool: %s Want: %v", nodePoolName, n)
+	nodes := &corev1.NodeList{}
+	readyNodeCount := 0
+	err := wait.PollImmediateWithContext(ctx, 5*time.Second, waitTimeout, func(ctx context.Context) (done bool, err error) {
+		err = client.List(ctx, nodes)
+		if err != nil {
+			return false, nil
+		}
+		if len(nodes.Items) == 0 {
+			return false, nil
+		}
+		var readyNodes []string
+		for _, node := range nodes.Items {
+			if node.Labels["hypershift.openshift.io/nodePool"] == nodePoolName {
+				for _, cond := range node.Status.Conditions {
+					if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+						readyNodes = append(readyNodes, node.Name)
+					}
+				}
+			}
+		}
+		if len(readyNodes) != int(n) {
+			readyNodeCount = len(readyNodes)
+			return false, nil
+		}
+		t.Logf("All nodes are ready. Count: %v", len(nodes.Items))
+
+		return true, nil
+	})
+	g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to ensure guest nodes became ready, ready: (%d/%d): ", readyNodeCount, n))
+	t.Logf("All nodes for NodePool %s appear to be ready in %s. Count: %v", nodePoolName, time.Since(start).Round(time.Second), n)
+
+	return nodes.Items
+}
+
+func WaitForNUnReadyNodesByNodePool(t *testing.T, ctx context.Context, client crclient.Client, n int32, nodePoolName string) []corev1.Node {
+	g := NewWithT(t)
+
+	t.Logf("Waiting for Nodes to become unready by NodePool. NodePool: %s Want: %v", nodePoolName, n)
+	nodes := &corev1.NodeList{}
+	readyNodeCount := 0
+
+	err := wait.PollImmediateWithContext(ctx, 5*time.Second, 30*time.Minute, func(ctx context.Context) (done bool, err error) {
+		// TODO (alberto): have ability to filter nodes by NodePool. NodePool.Status.Nodes?
+		err = client.List(ctx, nodes)
+		if err != nil {
+			return false, nil
+		}
+		if len(nodes.Items) == 0 {
+			return false, nil
+		}
+		var readyNodes []string
+		for _, node := range nodes.Items {
+			if node.Labels["hypershift.openshift.io/nodePool"] == nodePoolName {
+				for _, cond := range node.Status.Conditions {
+					if cond.Type == corev1.NodeReady && cond.Status != corev1.ConditionTrue {
+						readyNodes = append(readyNodes, node.Name)
+					}
+				}
+			}
+		}
+
+		if len(readyNodes) != int(n) {
+			readyNodeCount = len(readyNodes)
+			return false, nil
+		}
+		return true, nil
+	})
+	g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to ensure guest nodes became ready, ready: (%d/%d): ", readyNodeCount, n))
+
+	t.Logf("Wanted Nodes are unready for NodePool %s. Count: %v", nodePoolName, n)
+	return nodes.Items
+}
+
 func preRolloutPlatformCheck(t *testing.T, ctx context.Context, client crclient.Client, guestClient crclient.Client, hc *hyperv1.HostedCluster) {
 	switch hc.Spec.Platform.Type {
 	case hyperv1.KubevirtPlatform:


### PR DESCRIPTION
This capability give some powerfull function to check the nodes which belongs to a NodePool without using the NodePool object itself. we just need to add as an optional parameter an slice of strings as las argument in the function call. Warning: For now we only supports the first element of the slice as NodePool name, but in the future we will include also the rest of them.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**What this PR does / why we need it**:

Requirement for #[HOSTEDCP-596](https://issues.redhat.com/browse/HOSTEDCP-596)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.