### PR TITLE
Adds davidvossel as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - enxebre
 - csrwng
 - sjenning
+- davidvossel
 options: {}
 reviewers:
 - enxebre


### PR DESCRIPTION
While I've made an effort to isolate as much of the KubeVirt platform into separate directories as possible, the reality is much of our work at least touches other components as an entry point into our platform specific code. In order to make the KubeVirt hypershift platform more self sufficient, I'm asking for project wide approval access with the understanding that I'm only approving items isolated to the KubeVirt platform initially.

Note that I didn't put myself as a project wide reviewer. I'm already a reviewer in all the kubevirt directories of openshift/hypershift, so I should get automatically assigned as a reviewer just for KubeVirt related PRs.