### PR TITLE
build and include multi-arch hypershift CLI binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ RUN make build
 
 FROM quay.io/openshift/origin-base:4.12
 COPY --from=builder /hypershift/bin/hypershift \
+                    /hypershift/bin/hypershift-linux-amd64 \
+                    /hypershift/bin/hypershift-linux-arm64 \
+                    /hypershift/bin/hypershift-linux-ppc64le \
+                    /hypershift/bin/hypershift-darwin-amd64 \
+                    /hypershift/bin/hypershift-darwin-arm64 \
+                    /hypershift/bin/hypershift-windows-amd64 \
                     /hypershift/bin/hypershift-operator \
                     /hypershift/bin/control-plane-operator \
      /usr/bin/

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 
 all: build e2e
 
-build: hypershift-operator control-plane-operator hypershift
+build: hypershift-operator control-plane-operator hypershift hypershift-multi-arch
 
 .PHONY: update
 update: deps api api-docs app-sre-saas-template
@@ -74,6 +74,15 @@ control-plane-operator:
 .PHONY: hypershift
 hypershift:
 	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift .
+
+.PHONY: hypershift-multi-arch
+hypershift-multi-arch:
+	GOOS=linux GOARCH=amd64 $(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift-linux-amd64 .
+	GOOS=linux GOARCH=arm64 $(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift-linux-arm64 .
+	GOOS=linux GOARCH=ppc64le $(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift-linux-ppc64le .
+	GOOS=darwin GOARCH=amd64 $(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift-darwin-amd64 .
+	GOOS=darwin GOARCH=arm64 $(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift-darwin-arm64 .
+	GOOS=windows GOARCH=amd64 $(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift-windows-amd64 .
 
 # Run this when updating any of the types in the api package to regenerate the
 # deepcopy code and CRD manifest files.


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

**What this PR does / why we need it**:
ACM users need to have the hypershift CLI that is compatible with the hypershift operator version ACM packages. ACM document will instruct users to get the binary file from the hypershift operator pod using the `oc rsync` command and install it locally.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
[Fixes ACM-1722](https://issues.redhat.com/browse/ACM-1722)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.