### PR TITLE
Use default namespace filtering for events

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -205,11 +205,6 @@ func NewStartCommand() *cobra.Command {
 				DefaultSelector: cache.ObjectSelector{Field: fields.OneTermEqualSelector("metadata.namespace", namespace)},
 				SelectorsByObject: cache.SelectorsByObject{
 					&operatorv1.IngressController{}: {Field: fields.OneTermEqualSelector("metadata.namespace", manifests.IngressPrivateIngressController("").Namespace)},
-					// We watch warning events to be able to surface cloud provider errors as conditions
-					// Surfacing cloud-provider specific status is discussed in:
-					// https://github.com/kubernetes/kubernetes/issues/70159
-					// https://github.com/kubernetes/kubernetes/issues/52670
-					&corev1.Event{}: {Field: fields.AndSelectors(fields.OneTermEqualSelector("metadata.namespace", namespace), fields.OneTermEqualSelector("type", "warning"))},
 				},
 			}),
 		})

--- a/support/util/services.go
+++ b/support/util/services.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/hypershift/support/events"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+func CollectLBMessageIfNotProvisioned(svc *corev1.Service, messageCollector events.MessageCollector) (string, error) {
+	if len(svc.Status.LoadBalancer.Ingress) > 0 {
+		return "", nil
+	}
+	message := fmt.Sprintf("%s load balancer is not provisioned; %v since creation.", svc.Name, duration.ShortHumanDuration(time.Since(svc.ObjectMeta.CreationTimestamp.Time)))
+	var eventMessages []string
+	eventMessages, err := messageCollector.ErrorMessages(svc)
+	if err != nil {
+		return message, fmt.Errorf("failed to get events for service %s/%s: %w", svc.Namespace, svc.Name, err)
+	}
+	if len(eventMessages) > 0 {
+		message = fmt.Sprintf("%s load balancer is not provisioned: %s", svc.Name, strings.Join(eventMessages, "; "))
+	}
+
+	return message, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Using a 2-term selector for events in the client cache results in no events listed when querying for events. The code that looks at events will skip over 'Normal' type of events already. 

This fixes reporting of cloud provider issues while provisioning infra for a control plane such as apiserver load balancer, etcd pv's, etc.

ref https://issues.redhat.com/browse/HOSTEDCP-592

**Checklist**
- [x] Subject and description added to both, commit and PR.