### PR TITLE
node tuning: Fix docs and improve logs

### DIFF
--- a/docs/content/how-to/node-tuning.md
+++ b/docs/content/how-to/node-tuning.md
@@ -13,7 +13,7 @@ If you would like to set some node-level tuning on the nodes in your hosted clus
       name: tuned-1
       namespace: clusters
     data:
-      tuned: |
+      tuning: |
         apiVersion: tuned.openshift.io/v1
         kind: Tuned
         metadata:
@@ -112,7 +112,7 @@ As an example, the following steps can be followed to create a NodePool with hug
       name: tuned-hugepages
       namespace: clusters
     data:
-      tuned: |
+      tuning: |
         apiVersion: tuned.openshift.io/v1
         kind: Tuned
         metadata:

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1378,7 +1378,11 @@ func (r *NodePoolReconciler) getTuningConfig(ctx context.Context,
 	}
 
 	for _, config := range configs {
-		manifestRaw := config.Data[tuningConfigKey]
+		manifestRaw, ok := config.Data[tuningConfigKey]
+		if !ok {
+			errors = append(errors, fmt.Errorf("no manifest found in configmap %q with key %q", config.Name, tuningConfigKey))
+			continue
+		}
 		manifest, err := validateTuningConfigManifest([]byte(manifestRaw))
 		if err != nil {
 			errors = append(errors, fmt.Errorf("configmap %q failed validation: %w", config.Name, err))


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the ConfigMap key in the docs from tuned to tuning, as this was missing in PR#1802. Improve logs when wrong key is used or the ConfigMap has no contents.

**Which issue(s) this PR fixes**:
Related to [PSAP-742](https://issues.redhat.com/browse/PSAP-742). Docs fix should have been included in #1802.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests. (N/A)

/cc @jmencak @liqcui 