### PR TITLE
refactor route reconcilation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -11,7 +11,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ingress"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
@@ -260,7 +259,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 	}
 
 	if params.ExposedThroughHCPRouter {
-		cnoEnv = append(cnoEnv, corev1.EnvVar{Name: "OVN_SBDB_ROUTE_LABELS", Value: ingress.HCPRouteLabel + "=" + dep.Namespace})
+		cnoEnv = append(cnoEnv, corev1.EnvVar{Name: "OVN_SBDB_ROUTE_LABELS", Value: util.HCPRouteLabel + "=" + dep.Namespace})
 	}
 
 	var proxyVars []corev1.EnvVar

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -193,7 +193,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 			s.Spec.LoadBalancerSourceRanges = nil
 		})...)
 	}
-	kasPublicRoute := routev1.Route{
+	kasExternalRoute := routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: targetNamespace,
 			Name:      "kube-apiserver",
@@ -203,6 +203,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 			Annotations: map[string]string{
 				"external-dns.alpha.kubernetes.io/hostname": hostname,
 			},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: routev1.RouteSpec{
 			Host: hostname,
@@ -222,10 +223,12 @@ func TestReconcileAPIServerService(t *testing.T) {
 			Name:      "kube-apiserver-internal",
 			Labels: map[string]string{
 				"hypershift.openshift.io/hosted-control-plane": targetNamespace,
+				"hypershift.openshift.io/internal-route":       "true",
 			},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: routev1.RouteSpec{
-			Host: "kubernetes.default",
+			Host: "api.test.hypershift.local",
 			To: routev1.RouteTargetReference{
 				Kind: "Service",
 				Name: manifests.KubeAPIServerService("").Name,
@@ -308,7 +311,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 				}),
 			},
 			expectedRoutes: []routev1.Route{
-				kasPublicRoute,
+				kasExternalRoute,
 				kasInternalRoute,
 			},
 		},
@@ -329,7 +332,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 				}),
 			},
 			expectedRoutes: []routev1.Route{
-				kasPublicRoute,
+				kasExternalRoute,
 				kasInternalRoute,
 			},
 		},
@@ -955,6 +958,7 @@ func TestReconcileRouter(t *testing.T) {
 						"",
 						"publicRouterHost",
 						true,
+						false,
 					)
 
 					return *dep
@@ -981,6 +985,7 @@ func TestReconcileRouter(t *testing.T) {
 						"",
 						"publicRouterHost",
 						true,
+						false,
 					)
 
 					return *dep
@@ -1007,6 +1012,7 @@ func TestReconcileRouter(t *testing.T) {
 						ingress.HCPRouterConfig(&hyperv1.HostedControlPlane{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}}, false),
 						"",
 						"privateRouterHost",
+						true,
 						true,
 					)
 
@@ -1038,6 +1044,7 @@ func TestReconcileRouter(t *testing.T) {
 						"",
 						"privateRouterHost",
 						false,
+						false,
 					)
 
 					return *dep
@@ -1063,6 +1070,7 @@ func TestReconcileRouter(t *testing.T) {
 						"",
 						"privateRouterHost",
 						false,
+						true,
 					)
 
 					return *dep
@@ -1094,6 +1102,7 @@ func TestReconcileRouter(t *testing.T) {
 						"",
 						"publicRouterHost",
 						true,
+						false,
 					)
 
 					return *dep
@@ -1124,6 +1133,7 @@ func TestReconcileRouter(t *testing.T) {
 						ingress.HCPRouterConfig(&hyperv1.HostedControlPlane{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}}, false),
 						"",
 						"privateRouterHost",
+						false,
 						false,
 					)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -8,7 +8,6 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ingress"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/certs"
@@ -41,7 +40,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 	log := ctrl.LoggerFrom(ctx)
 
 	controlPlaneNamespace := hcp.Namespace
-	serviceStrategy := servicePublishingStrategyByType(hcp, hyperv1.Ignition)
+	serviceStrategy := util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.Ignition)
 	if serviceStrategy == nil {
 		//lint:ignore ST1005 Ignition is proper name
 		return fmt.Errorf("Ignition service strategy not specified")
@@ -56,42 +55,26 @@ func ReconcileIgnitionServer(ctx context.Context,
 	var ignitionServerAddress string
 	switch serviceStrategy.Type {
 	case hyperv1.Route:
-		// Reconcile route
+		// Reconcile routes
 		ignitionServerRoute := ignitionserver.Route(controlPlaneNamespace)
-		if _, err := createOrUpdate(ctx, c, ignitionServerRoute, func() error {
-			// The route host is considered immutable, so set it only once upon creation
-			// and ignore updates.
-			if ignitionServerRoute.CreationTimestamp.IsZero() {
-				switch {
-				case !util.ConnectsThroughInternetToControlplane(hcp.Spec.Platform):
-					ignitionServerRoute.Spec.Host = fmt.Sprintf("%s.apps.%s.hypershift.local", ignitionServerRoute.Name, hcp.Name)
-					ingress.AddHCPRouteLabel(ignitionServerRoute)
-				case serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "":
-					ignitionServerRoute.Spec.Host = serviceStrategy.Route.Hostname
-					ingress.AddHCPRouteLabel(ignitionServerRoute)
-				default:
-					ignitionServerRoute.Spec.Host = util.ShortenRouteHostnameIfNeeded(ignitionServerRoute.Name, ignitionServerRoute.Namespace, defaultIngressDomain)
+		if util.IsPrivateHCP(hcp) {
+			if _, err := createOrUpdate(ctx, c, ignitionServerRoute, func() error {
+				reconcileInternalRoute(ignitionServerRoute, config.OwnerRefFrom(hcp))
+				return nil
+			}); err != nil {
+				return fmt.Errorf("failed to reconcile ignition internal route: %w", err)
+			}
+		} else {
+			if _, err := createOrUpdate(ctx, c, ignitionServerRoute, func() error {
+				hostname := ""
+				if serviceStrategy.Route != nil {
+					hostname = serviceStrategy.Route.Hostname
 				}
+				reconcileExternalRoute(ignitionServerRoute, config.OwnerRefFrom(hcp), hostname, defaultIngressDomain)
+				return nil
+			}); err != nil {
+				return fmt.Errorf("failed to reconcile ignition external route: %w", err)
 			}
-
-			if ignitionServerRoute.Annotations == nil {
-				ignitionServerRoute.Annotations = map[string]string{}
-			}
-			if serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
-				ignitionServerRoute.ObjectMeta.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = serviceStrategy.Route.Hostname
-			}
-			ignitionServerRoute.Spec.TLS = &routev1.TLSConfig{
-				Termination:                   routev1.TLSTerminationPassthrough,
-				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
-			}
-			ignitionServerRoute.Spec.To = routev1.RouteTargetReference{
-				Kind:   "Service",
-				Name:   ignitionserver.ResourceName,
-				Weight: utilpointer.Int32Ptr(100),
-			}
-			return nil
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile ignition route: %w", err)
 		}
 
 		// The route must be admitted and assigned a host before we can generate certs
@@ -407,15 +390,6 @@ func ReconcileIgnitionServer(ctx context.Context,
 	return nil
 }
 
-func servicePublishingStrategyByType(hcp *hyperv1.HostedControlPlane, svcType hyperv1.ServiceType) *hyperv1.ServicePublishingStrategy {
-	for _, mapping := range hcp.Spec.Services {
-		if mapping.Service == svcType {
-			return &mapping.ServicePublishingStrategy
-		}
-	}
-	return nil
-}
-
 func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy) error {
 	svc.Spec.Selector = map[string]string{
 		"app": ignitionserver.ResourceName,
@@ -443,6 +417,17 @@ func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.Servi
 	}
 	svc.Spec.Ports[0] = portSpec
 	return nil
+}
+
+func reconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
+	ownerRef.ApplyTo(route)
+	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, ignitionserver.Service(route.Namespace).Name)
+}
+
+func reconcileInternalRoute(route *routev1.Route, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(route)
+	// Assumes ownerRef is the HCP
+	return util.ReconcileInternalRoute(route, ownerRef.Reference.Name, ignitionserver.Service(route.Namespace).Name)
 }
 
 func convertRegistryOverridesToCommandLineFlag(registryOverrides map[string]string) string {

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -18,11 +18,9 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	HCPRouteLabel   = "hypershift.openshift.io/hosted-control-plane"
 	metricsPort     = 1936
 	routerHTTPPort  = 8080
 	routerHTTPSPort = 8443
@@ -98,7 +96,7 @@ func ReconcileRouterTemplateConfigmap(cm *corev1.ConfigMap) {
 	cm.Data[routerTemplateConfigMapKey] = string(bytes.Replace(routerTemplate, []byte(`<<namespace>>`), []byte(cm.Namespace), 1))
 }
 
-func ReconcileRouterDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, image string, canonicalHostname string, exposeAPIServerThroughRouter bool) error {
+func ReconcileRouterDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, image string, canonicalHostname string, exposeAPIServerThroughRouter bool, isPrivateOnly bool) error {
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: hcpRouterLabels(),
@@ -109,7 +107,7 @@ func ReconcileRouterDeployment(deployment *appsv1.Deployment, ownerRef config.Ow
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
-					util.BuildContainer(hcpRouterContainerMain(), buildHCPRouterContainerMain(image, deployment.Namespace, canonicalHostname, exposeAPIServerThroughRouter)),
+					util.BuildContainer(hcpRouterContainerMain(), buildHCPRouterContainerMain(image, deployment.Namespace, canonicalHostname, exposeAPIServerThroughRouter, isPrivateOnly)),
 				},
 				ServiceAccountName: manifests.RouterServiceAccount("").Name,
 				Volumes:            nil,
@@ -129,14 +127,17 @@ func ReconcileRouterDeployment(deployment *appsv1.Deployment, ownerRef config.Ow
 }
 
 func hcpRouterContainerMain() *corev1.Container {
-
 	return &corev1.Container{
 		Name: "private-router",
 	}
 }
 
-func buildHCPRouterContainerMain(image, namespace, canonicalHostname string, exposeAPIServerThroughRouter bool) func(*corev1.Container) {
+func buildHCPRouterContainerMain(image, namespace, canonicalHostname string, exposeAPIServerThroughRouter bool, isPrivateOnly bool) func(*corev1.Container) {
 	const haproxyTemplateMountPath = "/usr/local/haproxy/hypershift-template"
+	routeLabels := fmt.Sprintf("%s=%s", util.HCPRouteLabel, namespace)
+	if isPrivateOnly {
+		routeLabels = fmt.Sprintf("%s,%s=%s", routeLabels, util.InternalRouteLabel, "true")
+	}
 	return func(c *corev1.Container) {
 		c.Env = []corev1.EnvVar{
 			{
@@ -193,7 +194,7 @@ func buildHCPRouterContainerMain(image, namespace, canonicalHostname string, exp
 			},
 			{
 				Name:  "ROUTE_LABELS",
-				Value: fmt.Sprintf("%s=%s", HCPRouteLabel, namespace),
+				Value: routeLabels,
 			},
 			{
 				Name:  "SSL_MIN_VERSION",
@@ -213,19 +214,19 @@ func buildHCPRouterContainerMain(image, namespace, canonicalHostname string, exp
 			},
 		}
 
+		c.Image = image
+		c.Args = []string{
+			"--namespace", namespace,
+		}
+
 		if exposeAPIServerThroughRouter {
 			c.Env = append(c.Env, corev1.EnvVar{
 				Name:  "ROUTER_CANONICAL_HOSTNAME",
 				Value: canonicalHostname,
 			})
-		}
-		c.Image = image
-		c.Args = []string{
-			"--namespace", namespace,
-		}
-		if exposeAPIServerThroughRouter {
 			c.Args = append(c.Args, "--template="+haproxyTemplateMountPath+"/"+routerTemplateConfigMapKey)
 		}
+
 		c.StartupProbe = &corev1.Probe{
 			FailureThreshold: 120,
 			ProbeHandler: corev1.ProbeHandler{
@@ -411,12 +412,3 @@ func ReconcileRouterService(svc *corev1.Service, kasPort int32, internal bool) e
 
 //go:embed router.template
 var routerTemplate []byte
-
-func AddHCPRouteLabel(target crclient.Object) {
-	labels := target.GetLabels()
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	labels[HCPRouteLabel] = target.GetNamespace()
-	target.SetLabels(labels)
-}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
@@ -9,8 +9,11 @@ import (
 const (
 	KubeAPIServerServiceName        = "kube-apiserver"
 	KubeAPIServerPrivateServiceName = "kube-apiserver-private"
-	OauthServiceName                = "oauth-openshift"
-	oauthRouteName                  = "oauth"
+	kubeAPIServerExternalRouteName  = "kube-apiserver"
+	kubeAPIServerInternalRouteName  = "kube-apiserver-internal"
+	oauthServiceName                = "oauth-openshift"
+	oauthExternalRouteName          = "oauth"
+	oauthInternalRouteName          = "oauth-internal"
 	konnectivityServerServiceName   = "konnectivity-server"
 	openshiftAPIServerServiceName   = "openshift-apiserver"
 	oauthAPIServerName              = "openshift-oauth-apiserver"
@@ -38,7 +41,7 @@ func KubeAPIServerPrivateService(hostedClusterNamespace string) *corev1.Service 
 func KubeAPIServerExternalRoute(hostedClusterNamespace string) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver",
+			Name:      kubeAPIServerExternalRouteName,
 			Namespace: hostedClusterNamespace,
 		},
 	}
@@ -47,7 +50,7 @@ func KubeAPIServerExternalRoute(hostedClusterNamespace string) *routev1.Route {
 func KubeAPIServerInternalRoute(hostedClusterNamespace string) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-internal",
+			Name:      kubeAPIServerInternalRouteName,
 			Namespace: hostedClusterNamespace,
 		},
 	}
@@ -56,17 +59,26 @@ func KubeAPIServerInternalRoute(hostedClusterNamespace string) *routev1.Route {
 func OauthServerService(hostedClusterNamespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      OauthServiceName,
+			Name:      oauthServiceName,
 			Namespace: hostedClusterNamespace,
 		},
 	}
 }
 
-func OauthServerRoute(hostedClusterNamespace string) *routev1.Route {
+func OauthServerExternalRoute(hostedClusterNamespace string) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedClusterNamespace,
-			Name:      oauthRouteName,
+			Name:      oauthExternalRouteName,
+		},
+	}
+}
+
+func OauthServerInternalRoute(hostedClusterNamespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hostedClusterNamespace,
+			Name:      oauthInternalRouteName,
 		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -1,59 +1,20 @@
 package oauth
 
 import (
-	"fmt"
-
 	routev1 "github.com/openshift/api/route/v1"
 
-	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ingress"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 )
 
-func ReconcileRoute(route *routev1.Route, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy, defaultIngressDomain string, hcp *hyperv1.HostedControlPlane) error {
+func ReconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
 	ownerRef.ApplyTo(route)
+	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.OauthServerService(route.Namespace).Name)
+}
 
-	// The route host is considered immutable, so set it only once upon creation
-	// and ignore updates.
-	if route.CreationTimestamp.IsZero() {
-		switch {
-		// There's a HCP router with Service type LB external, use service domain DNS if present and HCP router.
-		case util.IsPublicKASWithDNS(hcp) && strategy.Route != nil && strategy.Route.Hostname != "":
-			route.Spec.Host = strategy.Route.Hostname
-			ingress.AddHCPRouteLabel(route)
-
-		// Public with Service domain DNS without Service type LB external on HCP router: Use service
-		// domain Hostname, otherwise the name-based virtual hosting on the router won't work
-		case util.IsPublicHCP(hcp) && strategy.Route != nil && strategy.Route.Hostname != "":
-			route.Spec.Host = strategy.Route.Hostname
-
-		// Private cluster: Private DNS
-		case !util.IsPublicHCP(hcp):
-			route.Spec.Host = fmt.Sprintf("oauth.apps.%s.hypershift.local", hcp.Name)
-			ingress.AddHCPRouteLabel(route)
-
-		// Public cluster without service domain: Fall through to using the default router
-		default:
-			route.Spec.Host = util.ShortenRouteHostnameIfNeeded(route.Name, route.Namespace, defaultIngressDomain)
-		}
-	}
-
-	if strategy.Route != nil && strategy.Route.Hostname != "" {
-		if route.Annotations == nil {
-			route.Annotations = map[string]string{}
-		}
-		route.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.Route.Hostname
-	}
-
-	route.Spec.To = routev1.RouteTargetReference{
-		Kind: "Service",
-		Name: manifests.OauthServerService(route.Namespace).Name,
-	}
-	route.Spec.TLS = &routev1.TLSConfig{
-		Termination:                   routev1.TLSTerminationPassthrough,
-		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
-	}
-	return nil
+func ReconcileInternalRoute(route *routev1.Route, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(route)
+	// Assumes ownerRef is the HCP
+	return util.ReconcileInternalRoute(route, ownerRef.Reference.Name, manifests.OauthServerService(route.Namespace).Name)
 }

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -334,14 +334,14 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 				ic.Spec.RouteSelector.MatchExpressions = []metav1.LabelSelectorRequirement{}
 			}
 			for _, requirement := range ic.Spec.RouteSelector.MatchExpressions {
-				if requirement.Key != hyperutil.HypershiftRouteLabel {
+				if requirement.Key != hyperutil.HCPRouteLabel {
 					continue
 				}
 				requirement.Operator = metav1.LabelSelectorOpDoesNotExist
 				return nil
 			}
 			ic.Spec.RouteSelector.MatchExpressions = append(ic.Spec.RouteSelector.MatchExpressions, metav1.LabelSelectorRequirement{
-				Key:      hyperutil.HypershiftRouteLabel,
+				Key:      hyperutil.HCPRouteLabel,
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			})
 			return nil

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	HypershiftRouteLabel = "hypershift.openshift.io/hosted-control-plane"
-
 	// DebugDeploymentsAnnotation contains a comma separated list of deployment names which should always be scaled to 0
 	// for development.
 	DebugDeploymentsAnnotation = "hypershift.openshift.io/debug-deployments"

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -14,8 +14,8 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ingress"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/support/util"
 	promapi "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	promconfig "github.com/prometheus/common/config"
@@ -640,7 +640,7 @@ func EnsureAllRoutesUseHCPRouter(t *testing.T, ctx context.Context, hostClient c
 		}
 		for _, route := range routes.Items {
 			original := route.DeepCopy()
-			ingress.AddHCPRouteLabel(&route)
+			util.AddHCPRouteLabel(&route)
 			if diff := cmp.Diff(route.GetLabels(), original.GetLabels()); diff != "" {
 				t.Errorf("route %s is missing the label to use the per-HCP router: %s", route.Name, diff)
 			}


### PR DESCRIPTION
This PR is a refactor of the route reconcilation with a change needed for https://issues.redhat.com/browse/HOSTEDCP-572

Private routes for `oauth` and `kube-apiserver` are now seperate and the resource name is suffixed with `-private` and the route has a new `hypershift.openshift.io/private-route` label.

When the HCP router is deployed in an `endpointAccess: Private` mode, it will only admit routes with the new label.  This prevents it from admitting the public routes with the wrong `routerCanonicalHostname` during a `Private` -> `PublicAndPrivate` transition.

The refactor combines all route reconciliation on a common path in the `util` package in separate `ReconcilePublicRoute` and `ReconcilePrivateRoute` functions.

Note: This leaves the `kube-apiserver-internal` orphaned on upgrade as the new route name is `kube-apiserver-private` and the host is `api.$hcpName.hypershift.local`, like the other private routes, rather than `kubernetes.default`.  The `spec.host` of this route has no function as the haproxy template we inject makes the `kube-apiserver-private` route the default backend.