### PR TITLE
Pluggable konnectivity

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -118,6 +118,11 @@ const (
 	// removed when deleting the corresponding HostedCluster. If set to "true", resources created on the cloud provider during the life
 	// of the cluster will be removed, including image registry storage, ingress dns records, load balancers, and persistent storage.
 	CleanupCloudResourcesAnnotation = "hypershift.openshift.io/cleanup-cloud-resources"
+
+	// EnableKonnectivityLabel is a label on a Service in a HostedControlPlane's namespace indicating that
+	// the Service should be plugged into the konnectivity agent for that HCP by adding its ClusterIP. The value must
+	// be the name of the HostedControlPlane.
+	EnableKonnectivityLabel = "hypershift.openshift.io/konnectivity-service-for-hcp"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -361,6 +361,9 @@ func buildKonnectivityAgentContainer(image string, ips []string) func(c *corev1.
 	var agentIDs bytes.Buffer
 	seperator := ""
 	for i, ip := range ips {
+		if ip == "" {
+			continue
+		}
 		agentIDs.WriteString(fmt.Sprintf("%sipv4=%s", seperator, ip))
 		if i == 0 {
 			seperator = "&"

--- a/control-plane-operator/controllers/hostedcontrolplane/owner_or_label_mapper.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/owner_or_label_mapper.go
@@ -1,0 +1,62 @@
+package hostedcontrolplane
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+)
+
+// EnqueueForOwnerOrLabel is a superset of EnqueueRequestForOwner -- if the object has an
+// appropriate OwnerReference, the owner is enqueued -- that also enqueues an object in
+// the same namespace with a name indicated by the
+type EnqueueForOwnerOrLabel struct {
+	handler.EnqueueRequestForOwner
+}
+
+// Create is called in response to an create event - e.g. Pod Creation.
+func (e *EnqueueForOwnerOrLabel) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	e.EnqueueRequestForOwner.Create(evt, q)
+	enqueueForLabel(evt.Object, q)
+}
+
+// Update is called in response to an update event -  e.g. Pod Updated.
+func (e *EnqueueForOwnerOrLabel) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	e.EnqueueRequestForOwner.Update(evt, q)
+	enqueueForLabel(evt.ObjectOld, q)
+	enqueueForLabel(evt.ObjectNew, q)
+}
+
+// Delete is called in response to a delete event - e.g. Pod Deleted.
+func (e *EnqueueForOwnerOrLabel) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	e.EnqueueRequestForOwner.Delete(evt, q)
+	enqueueForLabel(evt.Object, q)
+}
+
+// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
+// external trigger request - e.g. reconcile Autoscaling, or a Webhook.
+func (e *EnqueueForOwnerOrLabel) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	e.EnqueueRequestForOwner.Generic(evt, q)
+	enqueueForLabel(evt.Object, q)
+}
+
+var _ handler.EventHandler = &EnqueueForOwnerOrLabel{}
+
+func enqueueForLabel(obj metav1.Object, q workqueue.RateLimitingInterface) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return
+	}
+	if hcpName := labels[hyperv1.EnableKonnectivityLabel]; hcpName != "" {
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: obj.GetNamespace(),
+				Name:      hcpName,
+			},
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

With this commit, you can label a Service in your HostedControlPlane's namespace thusly:

`hypershift.openshift.io/konnectivity-service-for-hcp: hcp-name-here`

...and its `spec.clusterIP` will be added to the list of IPs brokered by the konnectivity-agent, enabling communication _from_ the HCP _to_ your service running on the hosting cluster.

This facilitates use cases such as admission webhooks (where the webhook configuration is on the HCP but the service is on the hosting cluster) without the need for a separate proxy agent.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

Implements https://github.com/openshift/enhancements/pull/1284

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.