### PR TITLE
Defines resourceTags merge granularity

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -905,6 +905,8 @@ type AWSPlatformSpec struct {
 	// for the user.
 	//
 	// +kubebuilder:validation:MaxItems=25
+	// +listType=map
+	// +listMapKey=key
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
 

--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -640,6 +640,8 @@ type AWSNodePoolPlatform struct {
 	// for the user.
 	//
 	// +kubebuilder:validation:MaxItems=25
+	// +listType=map
+	// +listMapKey=key
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -2376,6 +2376,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       roles:
                         description: Deprecated This field will be removed in the
                           next API release. Use RolesRef instead.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -2375,6 +2375,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       roles:
                         description: Deprecated This field will be removed in the
                           next API release. Use RolesRef instead.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -341,6 +341,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rootVolume:
                         description: RootVolume specifies configuration for the root
                           volume of node instances.

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -22585,6 +22585,9 @@ objects:
                             type: object
                           maxItems: 25
                           type: array
+                          x-kubernetes-list-map-keys:
+                          - key
+                          x-kubernetes-list-type: map
                         roles:
                           description: Deprecated This field will be removed in the
                             next API release. Use RolesRef instead.
@@ -25988,6 +25991,9 @@ objects:
                             type: object
                           maxItems: 25
                           type: array
+                          x-kubernetes-list-map-keys:
+                          - key
+                          x-kubernetes-list-type: map
                         roles:
                           description: Deprecated This field will be removed in the
                             next API release. Use RolesRef instead.
@@ -27262,6 +27268,9 @@ objects:
                             type: object
                           maxItems: 25
                           type: array
+                          x-kubernetes-list-map-keys:
+                          - key
+                          x-kubernetes-list-type: map
                         rootVolume:
                           description: RootVolume specifies configuration for the
                             root volume of node instances.


### PR DESCRIPTION
This is to prevent conflicts from happening during server side apply as see in https://issues.redhat.com/browse/HOSTEDCP-644
Source:
https://github.com/kubernetes/kube-openapi/blob/master/pkg/idl/doc.go#L42-L51 Examples https://github.com/openshift/api/search?q=listType

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.