### PR TITLE
Add CLI support for Multi-cluster engine secret:

### DIFF
--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -29,6 +29,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AgentPlatform.APIServerAddress, "api-server-address", opts.AgentPlatform.APIServerAddress, "The API server address that should be used for components outside the control plane")
 	cmd.Flags().StringVar(&opts.AgentPlatform.AgentNamespace, "agent-namespace", opts.AgentPlatform.AgentNamespace, "The namespace in which to search for Agents")
 	cmd.MarkFlagRequired("agent-namespace")
+	cmd.MarkPersistentFlagRequired("pull-secret")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -32,6 +32,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.AzurePlatform.AvailabilityZones, "availablity-zones", opts.AzurePlatform.AvailabilityZones, "The availablity zones in which NodePools will be created. Must be left unspecified if the region does not support AZs. If set, one nodepool per zone will be created.")
 
 	cmd.MarkFlagRequired("azure-creds")
+	cmd.MarkPersistentFlagRequired("pull-secret")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -69,8 +69,6 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
 
-	cmd.MarkPersistentFlagRequired("pull-secret")
-
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(none.NewCreateCommand(opts))
 	cmd.AddCommand(agent.NewCreateCommand(opts))

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -36,6 +36,7 @@ type DestroyOptions struct {
 	InfraID               string
 	DestroyCloudResources bool
 	Log                   logr.Logger
+	CredentialSecretName  string
 }
 
 type AWSPlatformDestroyOptions struct {

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -40,6 +40,8 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.ContainerDiskImage, "containerdisk", opts.KubevirtPlatform.ContainerDiskImage, "A reference to docker image with the embedded disk to be used to create the machines")
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.ServicePublishingStrategy, "service-publishing-strategy", opts.KubevirtPlatform.ServicePublishingStrategy, fmt.Sprintf("Define how to expose the cluster services. Supported options: %s (Use LoadBalancer and Route to expose services), %s (Select a random node to expose service access through)", IngressServicePublishingStrategy, NodePortServicePublishingStrategy))
 
+	cmd.MarkPersistentFlagRequired("pull-secret")
+
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		if opts.Timeout > 0 {

--- a/cmd/cluster/none/create.go
+++ b/cmd/cluster/none/create.go
@@ -23,6 +23,8 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.NonePlatform.APIServerAddress, "external-api-server-address", opts.NonePlatform.APIServerAddress, "The external API Server Address when using platform none")
 	cmd.Flags().BoolVar(&opts.NonePlatform.ExposeThroughLoadBalancer, "expose-through-load-balancer", opts.NonePlatform.ExposeThroughLoadBalancer, "If the services should be exposed through LoadBalancer. If not set, nodeports will be used instead")
 
+	cmd.MarkPersistentFlagRequired("pull-secret")
+
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		if opts.Timeout > 0 {

--- a/cmd/cluster/powervs/create.go
+++ b/cmd/cluster/powervs/create.go
@@ -51,6 +51,9 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.PowerVSPlatform.Debug, "debug", opts.PowerVSPlatform.Debug, "Enabling this will print PowerVS API Request & Response logs")
 	cmd.Flags().BoolVar(&opts.PowerVSPlatform.RecreateSecrets, "recreate-secrets", opts.PowerVSPlatform.RecreateSecrets, "Enabling this flag will recreate creds mentioned https://hypershift-docs.netlify.app/reference/api/#hypershift.openshift.io/v1alpha1.PowerVSPlatformSpec here. This is required when rerunning 'hypershift create cluster powervs' or 'hypershift create infra powervs' commands, since API key once created cannot be retrieved again. Please make sure that cluster name used is unique across different management clusters before using this flag")
 
+	cmd.MarkFlagRequired("resource-group")
+	cmd.MarkPersistentFlagRequired("pull-secret")
+
 	// these options are only for development and testing purpose,
 	// can use these to reuse the existing resources, so hiding it.
 	cmd.Flags().MarkHidden("cloud-instance-id")

--- a/cmd/util/secrets.go
+++ b/cmd/util/secrets.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetSecret(name string, namespace string) (*corev1.Secret, error) {
+	return GetSecretWithClient(nil, name, namespace)
+}
+
+func GetSecretWithClient(client client.Client, name string, namespace string) (*corev1.Secret, error) {
+	var err error
+	if client == nil {
+		client, err = GetClient()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	secret := &corev1.Secret{}
+	err = client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, secret)
+	return secret, err
+}
+
+// ExtractOptionsFromSecret
+// Returns baseDomain, awsAccessKeyID & awsSecretAccessKey
+// If len(baseDomain) > 0 we override the value found in the secret
+func ExtractOptionsFromSecret(client client.Client, name string, namespace string, baseDomain string) (string, string, string, error) {
+	secret, err := GetSecretWithClient(client, name, namespace)
+	if err != nil {
+		return baseDomain, "", "", err
+	}
+
+	if len(baseDomain) == 0 {
+		fmt.Println("Using baseDomain from the secret-creds", "baseDomain", string(secret.Data["baseDomain"]))
+		baseDomain = string(secret.Data["baseDomain"])
+	} else {
+		fmt.Println("Using baseDomain from the --base-domain flag")
+	}
+	awsAccessKeyID := string(secret.Data["aws_access_key_id"])
+	awsSecretAccessKey := string(secret.Data["aws_secret_access_key"])
+
+	if len(baseDomain) == 0 {
+		return "", "", "", fmt.Errorf("the baseDomain key is invalid, {namespace: %s, secret: %s}", namespace, name)
+	}
+	if len(awsAccessKeyID) == 0 {
+		return "", "", "", fmt.Errorf("the aws_access_key_id key is invalid, {namespace: %s, secret: %s}", namespace, name)
+	}
+	if len(awsSecretAccessKey) == 0 {
+		return "", "", "", fmt.Errorf("the aws_secret_access_key key is invalid, {namespace: %s, secret: %s}", namespace, name)
+	}
+	return baseDomain, awsAccessKeyID, awsSecretAccessKey, nil
+}
+
+func GetDockerConfigJSON(name string, namespace string) ([]byte, error) {
+	secret, err := GetSecret(name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	dockerConfigJSON := secret.Data[".dockerconfigjson"]
+	if len(dockerConfigJSON) == 0 {
+		return nil, fmt.Errorf("the .dockerconfigjson key is invalid, {namespace: %s, secret: %s}", namespace, name)
+	}
+	return dockerConfigJSON, nil
+}

--- a/docs/content/how-to/aws/create-aws-hosted-cluster-secret-credentials.md
+++ b/docs/content/how-to/aws/create-aws-hosted-cluster-secret-credentials.md
@@ -1,0 +1,75 @@
+---
+title: Create an AWS Hosted Cluster using a credential secret
+---
+
+# Create an AWS Hosted Cluster using a credential secret
+
+## Creating the credential secret
+
+If using the Multi-cluster Engine, the console provides a credential page that allows you to create the AWS credential secret.
+
+To manually create the secret, apply the following secret yaml:
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: my-aws-credentials
+  namespace: clusters
+  labels:
+    cluster.open-cluster-management.io/credentials: ""
+    cluster.open-cluster-management.io/type: aws
+stringData:
+  aws_access_key_id: <value>
+  aws_secret_access_key: <value>
+  baseDomain: <value>
+  pullSecret: <value>
+  ssh-privatekey: <value>
+  ssh-publickey: <value>
+```
+
+!!! important
+    
+    The required parameters when using a secret to create a cluster are `--secret-creds <SECRET_NAME> --namespace <NAMESPACE_NAME>`. 
+    
+    If `--namespace` is not included, then the "clusters" namespace will used.
+
+!!! note
+    
+    The labels on this secret allow it to be displayed by the multi-cluster engine console.
+
+## Create a HostedCluster using a credential secret
+
+[Prerequisites](#prerequisites):
+
+```shell linenums="1"
+REGION=us-east-1
+CLUSTER_NAME=example
+SECRET_CREDS="example-multi-cluster-engine-credential-secret"
+NAMESPACE="example-namespace"
+
+hypershift create cluster aws \
+  --name $CLUSTER_NAME \
+  --namespace $NAMESPACE \
+  --node-pool-replicas=3 \
+  --secret-creds $SECRET_CREDS \
+  --region $REGION \
+```
+
+## Credential secret defaults
+The following values will be extracted from the credential and used when creating the hosted cluster:
+
+  * AWS key id and AWS secret key
+  * Base domain
+  * Pull secret
+  * SSH key
+
+## Using credential secret overrides
+The following command line parameters can be used with `--secret-creds`. Each is optional, but when provided they will override the
+values found in the credential secret.
+
+  * `--aws-creds`
+  * `--base-domain`
+  * `--pull-secret`
+  * `--ssh-key`


### PR DESCRIPTION
  * Documentation
  * Secret support:
    * Base Domain
    * AWS Key ID
    * AWS Secret Key 
    * SSH Keys Public/private 
    * Pull-Secret

This allows existing MCE credentials or new credentials created via the MCE console to be consumed by the CLI. This is a known quantity in MCE that is documented and utilized by MCE/ACM users

Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
  1. Allows the hypershift CLI to leverage MCE created Credential Secrets for the AWS provider.
  2. This provides an easy repeatable provisioning flow with less chance of a typo
  3. This helps the MCE Console generate/describe a hypershift cli command to create a cluster
  4. Users can create secret to represent a number of parameters the CLI uses, having the secret ties nicely into a tekton task for GitOps and other run scenarios.
 
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
https://issues.redhat.com/browse/HOSTEDCP-640

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] ~This change includes unit tests.~