### PR TITLE
kubevirt: Install virt-launcher networkpolicy

### DIFF
--- a/hypershift-operator/controllers/manifests/networkpolicy/manifests.go
+++ b/hypershift-operator/controllers/manifests/networkpolicy/manifests.go
@@ -76,3 +76,12 @@ func NodePortKonnectivityNetworkPolicy(namespace string) *networkingv1.NetworkPo
 		},
 	}
 }
+
+func VirtLauncherNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "virt-launcher",
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When a LB service is created to expose a pod at kubevirt hosted cluster, at some environments (azure, google cloud) connectivity with LB ingress IP is not permited, this change add a network policy that permites ingress to all the ports for virt-launcher pod.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.