### PR TITLE
Don't store machine payload in token secret for replace node pools

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -83,6 +83,7 @@ const (
 	TokenSecretTokenKey                       = "token"
 	TokenSecretConfigKey                      = "config"
 	TokenSecretAnnotation                     = "hypershift.openshift.io/ignition-config"
+	TokenSecretNodePoolUpgradeType            = "hypershift.openshift.io/node-pool-upgrade-type"
 
 	tuningConfigKey                = "tuning"
 	tuningConfigMapLabel           = "hypershift.openshift.io/tuned-config"
@@ -1035,6 +1036,7 @@ func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool
 	}
 
 	tokenSecret.Annotations[TokenSecretAnnotation] = "true"
+	tokenSecret.Annotations[TokenSecretNodePoolUpgradeType] = string(nodePool.Spec.Management.UpgradeType)
 	tokenSecret.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
 	// active token should never be marked as expired.
 	delete(tokenSecret.Annotations, hyperv1.IgnitionServerTokenExpirationTimestampAnnotation)

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -32,6 +32,7 @@ const (
 	InvalidConfigReason            = "InvalidConfig"
 	TokenSecretReasonKey           = "reason"
 	TokenSecretAnnotation          = "hypershift.openshift.io/ignition-config"
+	TokenSecretNodePoolUpgradeType = "hypershift.openshift.io/node-pool-upgrade-type"
 	TokenSecretTokenGenerationTime = "hypershift.openshift.io/last-token-generation-time"
 	// Set the ttl 1h above the reconcile resync period so every existing
 	// token Secret has the chance to rotate their token ID during a reconciliation cycle
@@ -284,11 +285,17 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.PayloadStore.Set(string(oldToken), CacheValue{Payload: payload, SecretName: tokenSecret.Name})
 	}
 
-	// Store the cached payload in the secret to be consumed by in place upgrades.
 	patch := tokenSecret.DeepCopy()
-	patch.Data[TokenSecretPayloadKey] = payload
-	patch.Data[TokenSecretReasonKey] = []byte(hyperv1.NodePoolAsExpectedConditionReason)
-	patch.Data[TokenSecretMessageKey] = []byte("Payload generated successfully")
+	nodePoolUpgradeType, ok := tokenSecret.Annotations[TokenSecretNodePoolUpgradeType]
+	if ok && nodePoolUpgradeType == string(hyperv1.UpgradeTypeReplace) {
+		delete(patch.Data, TokenSecretPayloadKey)
+	} else {
+		// Store the cached payload in the secret to be consumed by in place upgrades (can skip if upgrade type is replace).
+		patch.Data[TokenSecretPayloadKey] = payload
+		patch.Data[TokenSecretReasonKey] = []byte(hyperv1.NodePoolAsExpectedConditionReason)
+		patch.Data[TokenSecretMessageKey] = []byte("Payload generated successfully")
+	}
+
 	if err := r.Client.Patch(ctx, patch, client.MergeFrom(tokenSecret)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to patch tokenSecret with payload content: %w", err)
 	}

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -286,8 +286,8 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	patch := tokenSecret.DeepCopy()
-	nodePoolUpgradeType, ok := tokenSecret.Annotations[TokenSecretNodePoolUpgradeType]
-	if ok && nodePoolUpgradeType == string(hyperv1.UpgradeTypeReplace) {
+	nodePoolUpgradeType := tokenSecret.Annotations[TokenSecretNodePoolUpgradeType]
+	if nodePoolUpgradeType == string(hyperv1.UpgradeTypeReplace) {
 		delete(patch.Data, TokenSecretPayloadKey)
 	} else {
 		// Store the cached payload in the secret to be consumed by in place upgrades (can skip if upgrade type is replace).


### PR DESCRIPTION
**What this PR does / why we need it**:
Storing the machine payload in the token secrets causes performance issues at a large scale. We can omit that field in replace upgrade node pools

**Which issue(s) this PR fixes**:
Fixes #1843
ref https://issues.redhat.com/browse/HOSTEDCP-604

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.