### PR TITLE
HOSTEDCP-582: Add CEL immutability validations to nodepool.

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,6 +84,7 @@ type NodePoolSpec struct {
 	// TODO(dan): Should this be a LocalObjectReference?
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="ClusterName is immutable"
 	ClusterName string `json:"clusterName"`
 
 	// Release specifies the OCP release used for the NodePool. This informs the
@@ -94,6 +96,7 @@ type NodePoolSpec struct {
 	// and is used to configure platform specific behavior.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Platform is immutable"
 	Platform NodePoolPlatform `json:"platform"`
 
 	// Deprecated: Use Replicas instead. NodeCount will be dropped in the next
@@ -299,6 +302,7 @@ type NodePoolManagement struct {
 	// UpgradeType specifies the type of strategy for handling upgrades.
 	//
 	// +kubebuilder:validation:Enum=Replace;InPlace
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="UpgradeType is immutable"
 	UpgradeType UpgradeType `json:"upgradeType"`
 
 	// Replace is the configuration for rolling upgrades.
@@ -339,6 +343,7 @@ type NodePoolPlatform struct {
 	//
 	// +unionDiscriminator
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Type is immutable"
 	Type PlatformType `json:"type"`
 
 	// AWS specifies the configuration used when operating on AWS.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -100,6 +100,9 @@ spec:
                 description: "ClusterName is the name of the HostedCluster this NodePool
                   belongs to. \n TODO(dan): Should this be a LocalObjectReference?"
                 type: string
+                x-kubernetes-validations:
+                - message: ClusterName is immutable
+                  rule: self == oldSelf
               config:
                 description: "Config is a list of references to ConfigMaps containing
                   serialized MachineConfig resources to be injected into the ignition
@@ -209,6 +212,9 @@ spec:
                     - Replace
                     - InPlace
                     type: string
+                    x-kubernetes-validations:
+                    - message: UpgradeType is immutable
+                      rule: self == oldSelf
                 required:
                 - upgradeType
                 type: object
@@ -687,9 +693,15 @@ spec:
                     - Azure
                     - PowerVS
                     type: string
+                    x-kubernetes-validations:
+                    - message: Type is immutable
+                      rule: self == oldSelf
                 required:
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: Platform is immutable
+                  rule: self == oldSelf
               release:
                 description: Release specifies the OCP release used for the NodePool.
                   This informs the ignition configuration for machines, as well as

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -27017,6 +27017,9 @@ objects:
                   description: "ClusterName is the name of the HostedCluster this
                     NodePool belongs to. \n TODO(dan): Should this be a LocalObjectReference?"
                   type: string
+                  x-kubernetes-validations:
+                  - message: ClusterName is immutable
+                    rule: self == oldSelf
                 config:
                   description: "Config is a list of references to ConfigMaps containing
                     serialized MachineConfig resources to be injected into the ignition
@@ -27129,6 +27132,9 @@ objects:
                       - Replace
                       - InPlace
                       type: string
+                      x-kubernetes-validations:
+                      - message: UpgradeType is immutable
+                        rule: self == oldSelf
                   required:
                   - upgradeType
                   type: object
@@ -27610,9 +27616,15 @@ objects:
                       - Azure
                       - PowerVS
                       type: string
+                      x-kubernetes-validations:
+                      - message: Type is immutable
+                        rule: self == oldSelf
                   required:
                   - type
                   type: object
+                  x-kubernetes-validations:
+                  - message: Platform is immutable
+                    rule: self == oldSelf
                 release:
                   description: Release specifies the OCP release used for the NodePool.
                     This informs the ignition configuration for machines, as well


### PR DESCRIPTION
    This uses the new CEL validations available in kubernetes 1.25 and
    above, requiring OpenShift 4.12 or greater.  I tested with OpenShift
    4.10 and while the validations do not work, they are also ignored so it
    should be safe to have them in place for all versions.
    
    For HOSTEDCP-582

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.