### PR TITLE
Replace deprecated ioutil calls

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -548,7 +548,7 @@ type ServiceNetworkEntry struct {
 	CIDR ipnet.IPNet `json:"cidr"`
 }
 
-//+kubebuilder:validation:Pattern:=`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$`
+// +kubebuilder:validation:Pattern:=`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$`
 type CIDRBlock string
 
 // APIServerNetworking specifies how the APIServer is exposed inside a cluster

--- a/cmd/bastion/aws/create.go
+++ b/cmd/bastion/aws/create.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"time"
 
@@ -137,7 +137,7 @@ func (o *CreateBastionOpts) Run(ctx context.Context) (string, string, error) {
 	// Read SSH public key
 	if len(o.SSHKeyFile) > 0 {
 		var err error
-		sshPublicKey, err = ioutil.ReadFile(o.SSHKeyFile)
+		sshPublicKey, err = os.ReadFile(o.SSHKeyFile)
 		if err != nil {
 			return "", "", fmt.Errorf("cannot read SSH public key from %s: %v", o.SSHKeyFile, err)
 		}

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
@@ -82,7 +82,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	// Load or create infrastructure for the cluster
 	var infra *awsinfra.CreateInfraOutput
 	if len(opts.InfrastructureJSON) > 0 {
-		rawInfra, err := ioutil.ReadFile(opts.InfrastructureJSON)
+		rawInfra, err := os.ReadFile(opts.InfrastructureJSON)
 		if err != nil {
 			return fmt.Errorf("failed to read infra json file: %w", err)
 		}
@@ -121,7 +121,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 
 	var iamInfo *awsinfra.CreateIAMOutput
 	if len(opts.AWSPlatform.IAMJSON) > 0 {
-		rawIAM, err := ioutil.ReadFile(opts.AWSPlatform.IAMJSON)
+		rawIAM, err := os.ReadFile(opts.AWSPlatform.IAMJSON)
 		if err != nil {
 			return fmt.Errorf("failed to read iam json file: %w", err)
 		}

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -3,7 +3,6 @@ package azure
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -68,7 +67,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	var infra *azureinfra.CreateInfraOutput
 	var err error
 	if opts.InfrastructureJSON != "" {
-		rawInfra, err := ioutil.ReadFile(opts.InfrastructureJSON)
+		rawInfra, err := os.ReadFile(opts.InfrastructureJSON)
 		if err != nil {
 			return fmt.Errorf("failed to read infra json file: %w", err)
 		}
@@ -107,7 +106,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		AvailabilityZones: opts.AzurePlatform.AvailabilityZones,
 	}
 
-	azureCredsRaw, err := ioutil.ReadFile(opts.AzurePlatform.CredentialsFile)
+	azureCredsRaw, err := os.ReadFile(opts.AzurePlatform.CredentialsFile)
 	if err != nil {
 		return fmt.Errorf("failed to read --azure-creds file %s: %w", opts.AzurePlatform.CredentialsFile, err)
 	}

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -8,7 +8,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -151,7 +150,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		}
 		opts.ReleaseImage = defaultVersion.PullSpec
 	}
-	if err := defaultNetworkType(ctx, opts, &releaseinfo.RegistryClientProvider{}, ioutil.ReadFile); err != nil {
+	if err := defaultNetworkType(ctx, opts, &releaseinfo.RegistryClientProvider{}, os.ReadFile); err != nil {
 		return nil, fmt.Errorf("failed to default network: %w", err)
 	}
 
@@ -169,7 +168,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		annotations[hyperv1.ControlPlaneOperatorImageAnnotation] = opts.ControlPlaneOperatorImage
 	}
 
-	pullSecret, err := ioutil.ReadFile(opts.PullSecretFile)
+	pullSecret, err := os.ReadFile(opts.PullSecretFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read pull secret file: %w", err)
 	}
@@ -178,7 +177,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		if opts.GenerateSSH {
 			return nil, fmt.Errorf("--generate-ssh and --ssh-key cannot be specified together")
 		}
-		key, err := ioutil.ReadFile(opts.SSHKeyFile)
+		key, err := os.ReadFile(opts.SSHKeyFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read ssh key file: %w", err)
 		}
@@ -192,7 +191,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 
 	var userCABundle []byte
 	if len(opts.AdditionalTrustBundle) > 0 {
-		userCABundle, err = ioutil.ReadFile(opts.AdditionalTrustBundle)
+		userCABundle, err = os.ReadFile(opts.AdditionalTrustBundle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read additional trust bundle file: %w", err)
 		}
@@ -200,7 +199,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 
 	var imageContentSources []hyperv1.ImageContentSource
 	if len(opts.ImageContentSources) > 0 {
-		icspFileBytes, err := ioutil.ReadFile(opts.ImageContentSources)
+		icspFileBytes, err := os.ReadFile(opts.ImageContentSources)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read image content sources file: %w", err)
 		}

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -112,7 +111,7 @@ func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 	if err := c.Get(ctx, client.ObjectKeyFromObject(kubeconfigSecret), kubeconfigSecret); err != nil {
 		return fmt.Errorf("failed to get guest cluster kubeconfig secret: %w", err)
 	}
-	kubeconfigFile, err := ioutil.TempFile(os.TempDir(), "kubeconfig-")
+	kubeconfigFile, err := os.CreateTemp(os.TempDir(), "kubeconfig-")
 	if err != nil {
 		return fmt.Errorf("failed to create tempfile for kubeconfig: %w", err)
 	}
@@ -238,7 +237,7 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 		}
 	}
 
-	files, err := ioutil.ReadDir(opts.ArtifactDir)
+	files, err := os.ReadDir(opts.ArtifactDir)
 	if err != nil {
 		return fmt.Errorf("failed to list artifactDir %s: %w", opts.ArtifactDir, err)
 	}
@@ -408,7 +407,7 @@ func outputLog(ctx context.Context, l logr.Logger, fileName string, req *restcli
 	for _, c := range checker {
 		c(fileName, b)
 	}
-	if err := ioutil.WriteFile(fileName, b, 0644); err != nil {
+	if err := os.WriteFile(fileName, b, 0644); err != nil {
 		l.Error(err, "Failed to write file", "file", fileName)
 	}
 }
@@ -450,7 +449,7 @@ func gatherNetworkLogs(ocCommand, controlPlaneNamespace, artifactDir string, ctx
 				l.Info("Get ovn db status command returned an error", "args", allArgs, "error", err.Error(), "output", string(out))
 			}
 			fileName := filepath.Join(dir, fmt.Sprintf("%s_%s_status", pod.Name, dbName))
-			if err := ioutil.WriteFile(fileName, out, 0644); err != nil {
+			if err := os.WriteFile(fileName, out, 0644); err != nil {
 				l.Error(err, "Failed to write file", "file", fileName)
 			}
 		}

--- a/cmd/cluster/powervs/create.go
+++ b/cmd/cluster/powervs/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -111,7 +110,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	// Load or create infrastructure for the cluster
 	var infra *powervsinfra.Infra
 	if len(opts.InfrastructureJSON) > 0 {
-		rawInfra, err := ioutil.ReadFile(opts.InfrastructureJSON)
+		rawInfra, err := os.ReadFile(opts.InfrastructureJSON)
 		if err != nil {
 			return fmt.Errorf("failed to read infra json file: %w", err)
 		}

--- a/cmd/consolelogs/aws/getlogs.go
+++ b/cmd/consolelogs/aws/getlogs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -145,7 +144,7 @@ func getInstanceConsoleOutput(ctx context.Context, ec2Client *ec2.EC2, instances
 			errs = append(errs, err)
 			continue
 		}
-		if err := ioutil.WriteFile(filepath.Join(outputDir, name+".log"), logOutput, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(outputDir, name+".log"), logOutput, 0644); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -244,7 +243,7 @@ func (o *CreateInfraOptions) CreateInfra(ctx context.Context, l logr.Logger) (*C
 	if o.EnableProxy {
 		var sshKeyFile []byte
 		if o.SSHKeyFile != "" {
-			sshKeyFile, err = ioutil.ReadFile(o.SSHKeyFile)
+			sshKeyFile, err = os.ReadFile(o.SSHKeyFile)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read ssh-key-file from %s: %w", o.SSHKeyFile, err)
 			}

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -81,7 +81,7 @@ func NewCreateCommand() *cobra.Command {
 }
 
 func readCredentials(path string) (*apifixtures.AzureCreds, error) {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from %s: %w", path, err)
 	}
@@ -395,7 +395,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize result: %w", err)
 		}
-		if err := ioutil.WriteFile(o.OutputFile, resultSerialized, 0644); err != nil {
+		if err := os.WriteFile(o.OutputFile, resultSerialized, 0644); err != nil {
 			// Be nice and print the data so it doesn't get lost
 			l.Error(err, "Writing output file failed", "outputfile", o.OutputFile, "data", string(resultSerialized))
 			return nil, fmt.Errorf("failed to write result to --output-file: %w", err)

--- a/cmd/infra/powervs/destroy.go
+++ b/cmd/infra/powervs/destroy.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/IBM-Cloud/power-go-client/power/models"
-	"github.com/IBM/networking-go-sdk/dnsrecordsv1"
-	"io/ioutil"
-	"k8s.io/apimachinery/pkg/util/errors"
+	"os"
 	"strings"
 	"time"
+
+	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/IBM/networking-go-sdk/dnsrecordsv1"
+	"k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -113,7 +114,7 @@ func NewDestroyCommand() *cobra.Command {
 func (options *DestroyInfraOptions) Run(ctx context.Context) error {
 	var infra *Infra
 	if len(options.InfrastructureJson) > 0 {
-		rawInfra, err := ioutil.ReadFile(options.InfrastructureJson)
+		rawInfra, err := os.ReadFile(options.InfrastructureJson)
 		if err != nil {
 			return fmt.Errorf("failed to read infra json file: %w", err)
 		}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -330,7 +329,7 @@ func operatorEndpoints(opts Options) *corev1.Endpoints {
 }
 
 func fetchImageRefs(file string) (map[string]string, error) {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read image references file: %w", err)
 	}
@@ -402,7 +401,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 
 	var oidcSecret *corev1.Secret
 	if opts.OIDCStorageProviderS3Credentials != "" {
-		oidcCreds, err := ioutil.ReadFile(opts.OIDCStorageProviderS3Credentials)
+		oidcCreds, err := os.ReadFile(opts.OIDCStorageProviderS3Credentials)
 		if err != nil {
 			return nil, err
 		}
@@ -426,7 +425,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	switch hyperv1.PlatformType(opts.PrivatePlatform) {
 	case hyperv1.AWSPlatform:
 		if opts.AWSPrivateCreds != "" {
-			credBytes, err := ioutil.ReadFile(opts.AWSPrivateCreds)
+			credBytes, err := os.ReadFile(opts.AWSPrivateCreds)
 			if err != nil {
 				return objects, err
 			}
@@ -449,7 +448,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 
 	var userCABundleCM *corev1.ConfigMap
 	if opts.AdditionalTrustBundle != "" {
-		userCABundle, err := ioutil.ReadFile(opts.AdditionalTrustBundle)
+		userCABundle, err := os.ReadFile(opts.AdditionalTrustBundle)
 		if err != nil {
 			return nil, err
 		}
@@ -482,7 +481,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 
 		var externalDNSSecret *corev1.Secret
 		if opts.ExternalDNSCredentials != "" {
-			externalDNSCreds, err := ioutil.ReadFile(opts.ExternalDNSCredentials)
+			externalDNSCreds, err := os.ReadFile(opts.ExternalDNSCredentials)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/install/install_render_test.go
+++ b/cmd/install/install_render_test.go
@@ -3,7 +3,7 @@ package install
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -18,7 +18,7 @@ func ExecuteTestCommand(args []string) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
-	return ioutil.ReadAll(b)
+	return io.ReadAll(b)
 }
 
 func ExecuteTemplateYamlGenerationCommand(args []string) (map[string]interface{}, error) {

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -3,7 +3,7 @@ package version
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/openshift/hypershift/pkg/version"
@@ -32,7 +32,7 @@ func LookupDefaultOCPVersion() (OCPVersion, error) {
 		return version, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return version, err
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
@@ -164,13 +163,13 @@ func (o *HostedClusterConfigOperator) Validate() error {
 func (o *HostedClusterConfigOperator) Complete() error {
 	var err error
 	if len(o.InitialCAFile) > 0 {
-		o.initialCA, err = ioutil.ReadFile(o.InitialCAFile)
+		o.initialCA, err = os.ReadFile(o.InitialCAFile)
 		if err != nil {
 			return err
 		}
 	}
 	if o.ClusterSignerCAFile != "" {
-		o.clusterSignerCA, err = ioutil.ReadFile(o.ClusterSignerCAFile)
+		o.clusterSignerCA, err = os.ReadFile(o.ClusterSignerCAFile)
 		if err != nil {
 			return err
 		}

--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -84,7 +83,7 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 		return nil
 	}
 	// Set up the cache directory
-	cacheDir, err := ioutil.TempDir("", "cache")
+	cacheDir, err := os.MkdirTemp("", "cache")
 	if err != nil {
 		return fmt.Errorf("failed to create cache directory: %w", err)
 	}

--- a/ignition-server/controllers/image_file_cache.go
+++ b/ignition-server/controllers/image_file_cache.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -137,7 +136,7 @@ func returnCacheFile(fullCacheFileName string, out io.Writer) error {
 }
 
 func downloadImageFile(ctx context.Context, regClient regClient, imageRef string, pullSecret []byte, imageFile string, cacheDir string) (_ string, err error) {
-	newFile, err := ioutil.TempFile(cacheDir, filepath.Base(imageFile)+"-*")
+	newFile, err := os.CreateTemp(cacheDir, filepath.Base(imageFile)+"-*")
 	if err != nil {
 		return "", fmt.Errorf("failed to create cache file: %w", err)
 	}

--- a/ignition-server/controllers/image_file_cache_test.go
+++ b/ignition-server/controllers/image_file_cache_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -88,7 +87,7 @@ func getImageFile(t *testing.T, sut *imageFileCache, imageRef string, imageFile 
 }
 
 func simulateFileCorruption(t *testing.T, cacheDir string) {
-	files, err := ioutil.ReadDir(cacheDir)
+	files, err := os.ReadDir(cacheDir)
 	if err != nil {
 		t.Fatal("failed to open cache directory", err)
 	}

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -130,7 +129,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 	log.Info("discovered mco image", "image", mcoImage)
 
 	// Set up the base working directory
-	workDir, err := ioutil.TempDir(p.WorkDir, "get-payload")
+	workDir, err := os.MkdirTemp(p.WorkDir, "get-payload")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create working directory: %w", err)
 	}
@@ -333,7 +332,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 
 		// Copy output to the MCC base directory
 		bootstrapManifestsDir := filepath.Join(destDir, "bootstrap", "manifests")
-		manifests, err := ioutil.ReadDir(bootstrapManifestsDir)
+		manifests, err := os.ReadDir(bootstrapManifestsDir)
 		if err != nil {
 			return fmt.Errorf("failed to read dir: %w", err)
 		}
@@ -471,7 +470,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 					log.Error(err, "failed to close mcs response body")
 				}
 			}()
-			p, err := ioutil.ReadAll(res.Body)
+			p, err := io.ReadAll(res.Body)
 			if err != nil {
 				log.Error(err, "failed to read mcs response body")
 				return false, nil

--- a/ignition-server/controllers/machineconfigserver_ignitionprovider.go
+++ b/ignition-server/controllers/machineconfigserver_ignitionprovider.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"text/template"
@@ -161,7 +161,7 @@ func (p *MCSIgnitionProvider) GetPayload(ctx context.Context, releaseImage strin
 		}
 
 		defer res.Body.Close()
-		payload, err = ioutil.ReadAll(res.Body)
+		payload, err = io.ReadAll(res.Body)
 		if err != nil {
 			return false, fmt.Errorf("error reading http request body for machine config server pod: %w", err)
 		}

--- a/support/releaseinfo/pod_provider.go
+++ b/support/releaseinfo/pod_provider.go
@@ -3,7 +3,7 @@ package releaseinfo
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -144,7 +144,7 @@ func getContainerLogs(ctx context.Context, pods v1.PodInterface, podName, contai
 		return nil, fmt.Errorf("failed to read logs from %s/%s: %w", podName, containerName, err)
 	}
 	defer logs.Close()
-	data, err := ioutil.ReadAll(logs)
+	data, err := io.ReadAll(logs)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't decode logs from %s/%s: %w", podName, containerName, err)
 	}

--- a/support/testutil/testutil.go
+++ b/support/testutil/testutil.go
@@ -2,7 +2,6 @@ package testutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,11 +50,11 @@ func CompareWithFixture(t *testing.T, output interface{}, opts ...option) {
 		if err := os.MkdirAll(filepath.Dir(golden), 0755); err != nil {
 			t.Fatalf("failed to create fixture directory: %v", err)
 		}
-		if err := ioutil.WriteFile(golden, serializedOutput, 0644); err != nil {
+		if err := os.WriteFile(golden, serializedOutput, 0644); err != nil {
 			t.Fatalf("failed to write updated fixture: %v", err)
 		}
 	}
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	if err != nil {
 		t.Fatalf("failed to read testdata file: %v", err)
 	}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -137,7 +136,7 @@ func decompress(r io.Reader) (*bytes.Buffer, error) {
 
 	defer gz.Close()
 
-	data, err := ioutil.ReadAll(gz)
+	data, err := io.ReadAll(gz)
 	if err != nil {
 		return bytes.NewBuffer(nil), fmt.Errorf("could not decompress payload: %w", err)
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"os"
@@ -180,7 +180,7 @@ func dumpTestMetrics(log logr.Logger, artifactDir string) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Error(err, "failed to read response body from metrics endpoint")
 		return

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -5,7 +5,8 @@ package e2e
 
 import (
 	"context"
-	"io/ioutil"
+
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -57,7 +58,7 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 	pullSecretFile, err := os.Open(clusterOpts.PullSecretFile)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to open pull secret file")
 	defer pullSecretFile.Close()
-	pullSecret, err := ioutil.ReadAll(pullSecretFile)
+	pullSecret, err := io.ReadAll(pullSecretFile)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to read pull secret file")
 	previousReleaseInfo, err := releaseInfoProvider.Lookup(ctx, globalOpts.PreviousReleaseImage, pullSecret)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get release info for previous image")
@@ -165,7 +166,7 @@ func TestInPlaceUpgradeNodePool(t *testing.T) {
 	pullSecretFile, err := os.Open(clusterOpts.PullSecretFile)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to open pull secret file")
 	defer pullSecretFile.Close()
-	pullSecret, err := ioutil.ReadAll(pullSecretFile)
+	pullSecret, err := io.ReadAll(pullSecretFile)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to read pull secret file")
 	previousReleaseInfo, err := releaseInfoProvider.Lookup(ctx, globalOpts.PreviousReleaseImage, pullSecret)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get release info for previous image")

--- a/test/e2e/util/dump/journals.go
+++ b/test/e2e/util/dump/journals.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,24 +44,24 @@ func DumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 	if !exists {
 		return fmt.Errorf("cannot find SSH private key in SSH key secret %s/%s", sshKeySecret.Namespace, sshKeySecret.Name)
 	}
-	privateSSHKeyDir, err := ioutil.TempDir("", "")
+	privateSSHKeyDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return fmt.Errorf("cannot create temp dir for ssh key: %w", err)
 	}
 	privateKeyFile := filepath.Join(privateSSHKeyDir, "id_rsa")
-	if err := ioutil.WriteFile(privateKeyFile, privateKey, 0600); err != nil {
+	if err := os.WriteFile(privateKeyFile, privateKey, 0600); err != nil {
 		return fmt.Errorf("error writing private ssh key file: %w", err)
 	}
 
 	// Write out dump script where we can find it and invoke it
-	copyJournalFile, err := ioutil.TempFile("", "copy-journal-")
+	copyJournalFile, err := os.CreateTemp("", "copy-journal-")
 	if err != nil {
 		return err
 	}
 	if err := copyJournalFile.Close(); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(copyJournalFile.Name(), copyJournalsScript, 0644); err != nil {
+	if err := os.WriteFile(copyJournalFile.Name(), copyJournalsScript, 0644); err != nil {
 		return err
 	}
 	if err := os.Chmod(copyJournalFile.Name(), 0755); err != nil {

--- a/test/setup/main.go
+++ b/test/setup/main.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"text/template"
 
@@ -104,7 +103,7 @@ func (o *MonitoringOptions) Configure(ctx context.Context, k client.Client) erro
 		log.Info("remote write will be enabled")
 		username = o.RemoteWriteUsername
 		if len(o.RemoteWriteUsernameFile) > 0 {
-			u, err := ioutil.ReadFile(o.RemoteWriteUsernameFile)
+			u, err := os.ReadFile(o.RemoteWriteUsernameFile)
 			if err != nil {
 				return err
 			}
@@ -112,7 +111,7 @@ func (o *MonitoringOptions) Configure(ctx context.Context, k client.Client) erro
 		}
 		password = o.RemoteWritePassword
 		if len(o.RemoteWritePasswordFile) > 0 {
-			p, err := ioutil.ReadFile(o.RemoteWritePasswordFile)
+			p, err := os.ReadFile(o.RemoteWritePasswordFile)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
As of Go 1.16, the same functionality, previously provided in `ioutil`, is now provided by package `io` or package `os`, and those implementations should be preferred.

**Which issue(s) this PR fixes**
Fixes [HOSTEDCP-649](https://issues.redhat.com/browse/HOSTEDCP-649)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.