### PR TITLE
[release-4.12] Bug HOSTEDCP-604: Don't store machine payload in token secret for replace node pools (#1873)

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -82,6 +82,7 @@ const (
 	TokenSecretTokenKey                       = "token"
 	TokenSecretConfigKey                      = "config"
 	TokenSecretAnnotation                     = "hypershift.openshift.io/ignition-config"
+	TokenSecretNodePoolUpgradeType            = "hypershift.openshift.io/node-pool-upgrade-type"
 
 	tuningConfigKey                = "tuning"
 	tuningConfigMapLabel           = "hypershift.openshift.io/tuned-config"
@@ -975,6 +976,7 @@ func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool
 	}
 
 	tokenSecret.Annotations[TokenSecretAnnotation] = "true"
+	tokenSecret.Annotations[TokenSecretNodePoolUpgradeType] = string(nodePool.Spec.Management.UpgradeType)
 	tokenSecret.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
 	// active token should never be marked as expired.
 	delete(tokenSecret.Annotations, hyperv1.IgnitionServerTokenExpirationTimestampAnnotation)

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -271,8 +271,8 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	patch := tokenSecret.DeepCopy()
-	nodePoolUpgradeType, ok := tokenSecret.Annotations[TokenSecretNodePoolUpgradeType]
-	if ok && nodePoolUpgradeType == string(hyperv1.UpgradeTypeReplace) {
+	nodePoolUpgradeType := tokenSecret.Annotations[TokenSecretNodePoolUpgradeType]
+	if nodePoolUpgradeType == string(hyperv1.UpgradeTypeReplace) {
 		delete(patch.Data, TokenSecretPayloadKey)
 	} else {
 		// Store the cached payload in the secret to be consumed by in place upgrades (can skip if upgrade type is replace).

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -29,6 +29,7 @@ const (
 	TokenSecretOldTokenKey         = "old_token"
 	TokenSecretPayloadKey          = "payload"
 	TokenSecretAnnotation          = "hypershift.openshift.io/ignition-config"
+	TokenSecretNodePoolUpgradeType = "hypershift.openshift.io/node-pool-upgrade-type"
 	TokenSecretTokenGenerationTime = "hypershift.openshift.io/last-token-generation-time"
 	// Set the ttl 1h above the reconcile resync period so every existing
 	// token Secret has the chance to rotate their token ID during a reconciliation cycle
@@ -269,9 +270,15 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.PayloadStore.Set(string(oldToken), CacheValue{Payload: payload, SecretName: tokenSecret.Name})
 	}
 
-	// Store the cached payload in the secret to be consumed by in place upgrades.
 	patch := tokenSecret.DeepCopy()
-	patch.Data[TokenSecretPayloadKey] = payload
+	nodePoolUpgradeType, ok := tokenSecret.Annotations[TokenSecretNodePoolUpgradeType]
+	if ok && nodePoolUpgradeType == string(hyperv1.UpgradeTypeReplace) {
+		delete(patch.Data, TokenSecretPayloadKey)
+	} else {
+		// Store the cached payload in the secret to be consumed by in place upgrades (can skip if upgrade type is replace).
+		patch.Data[TokenSecretPayloadKey] = payload
+	}
+
 	if err := r.Client.Patch(ctx, patch, client.MergeFrom(tokenSecret)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to patch tokenSecret with payload content")
 	}

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -271,12 +271,9 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	patch := tokenSecret.DeepCopy()
-	nodePoolUpgradeType := tokenSecret.Annotations[TokenSecretNodePoolUpgradeType]
-	if nodePoolUpgradeType == string(hyperv1.UpgradeTypeReplace) {
+	patch.Data[TokenSecretPayloadKey] = payload
+	if string(hyperv1.UpgradeTypeReplace) == tokenSecret.Annotations[TokenSecretNodePoolUpgradeType] {
 		delete(patch.Data, TokenSecretPayloadKey)
-	} else {
-		// Store the cached payload in the secret to be consumed by in place upgrades (can skip if upgrade type is replace).
-		patch.Data[TokenSecretPayloadKey] = payload
 	}
 
 	if err := r.Client.Patch(ctx, patch, client.MergeFrom(tokenSecret)); err != nil {

--- a/ignition-server/controllers/tokensecret_controller_test.go
+++ b/ignition-server/controllers/tokensecret_controller_test.go
@@ -6,11 +6,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/openshift/hypershift/support/util"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -211,6 +211,45 @@ func TestReconcile(t *testing.T) {
 				g.Expect(value.Payload).To(BeEquivalentTo(fakePayload))
 			},
 		},
+		{
+			name: "When the nodepool upgrade strategy is replace, the token secret should not contain the machine payload",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						TokenSecretAnnotation:          "true",
+						TokenSecretNodePoolUpgradeType: string(hyperv1.UpgradeTypeReplace),
+					},
+					CreationTimestamp: metav1.Now(),
+				},
+				Immutable: nil,
+				Data: map[string][]byte{
+					TokenSecretTokenKey:   []byte(uuid.New().String()),
+					TokenSecretReleaseKey: []byte("release"),
+					TokenSecretConfigKey:  compressedConfigBytes,
+				},
+			},
+			validation: func(t *testing.T, secret client.Object) {
+				ctx := context.Background()
+				r := TokenSecretReconciler{
+					Client:           fake.NewClientBuilder().WithObjects(secret).Build(),
+					IgnitionProvider: &fakeIgnitionProvider{},
+					PayloadStore:     NewPayloadStore(),
+				}
+				g := NewWithT(t)
+				_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(secret)})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Get the secret.
+				freshSecret := &corev1.Secret{}
+				err = r.Client.Get(ctx, client.ObjectKeyFromObject(secret), freshSecret)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Validate that the payload was not stored in the token secret
+				g.Expect(freshSecret.Data[TokenSecretPayloadKey]).To(BeEmpty())
+			},
+		},
 	}
 
 	// Set the logger so the tested funcs log accordingly.
@@ -374,21 +413,21 @@ func TestIsTokenExpired(t *testing.T) {
 		{
 			name: "when the token expiration timestamp is in the past it should return that it is expired (true)",
 			annotations: map[string]string{
-				v1alpha1.IgnitionServerTokenExpirationTimestampAnnotation: time.Now().Add(-4 * time.Hour).Format(time.RFC3339),
+				hyperv1.IgnitionServerTokenExpirationTimestampAnnotation: time.Now().Add(-4 * time.Hour).Format(time.RFC3339),
 			},
 			expectedIsExpired: true,
 		},
 		{
 			name: "when the token expiration timestamp is in the future it should return that it is not expired (false)",
 			annotations: map[string]string{
-				v1alpha1.IgnitionServerTokenExpirationTimestampAnnotation: time.Now().Add(4 * time.Hour).Format(time.RFC3339),
+				hyperv1.IgnitionServerTokenExpirationTimestampAnnotation: time.Now().Add(4 * time.Hour).Format(time.RFC3339),
 			},
 			expectedIsExpired: false,
 		},
 		{
 			name: "when the token expiration timestamp has an invalid value it should return that it is expired (true)",
 			annotations: map[string]string{
-				v1alpha1.IgnitionServerTokenExpirationTimestampAnnotation: "badvalue",
+				hyperv1.IgnitionServerTokenExpirationTimestampAnnotation: "badvalue",
 			},
 			expectedIsExpired: true,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of https://github.com/openshift/hypershift/pull/1873

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.