### PR TITLE
AUTH-323: pki: remove root-ca from the aggregator CA bundle

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas_pki_setup.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas_pki_setup.go
@@ -69,7 +69,7 @@ func (r *HostedControlPlaneReconciler) setupKASClientSigners(
 	// KAS aggregator client CA
 	kasAggregatorClientCA := manifests.AggregatorClientCAConfigMap(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, kasAggregatorClientCA, func() error {
-		return pki.ReconcileAggregatorClientCA(kasAggregatorClientCA, p.OwnerRef, kasAggregateClientSigner, rootCASecret)
+		return pki.ReconcileAggregatorClientCA(kasAggregatorClientCA, p.OwnerRef, kasAggregateClientSigner)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile combined CA: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -50,8 +50,8 @@ func ReconcileKubeCSRSigner(secret *corev1.Secret, ownerRef config.OwnerRef) err
 	return reconcileSelfSignedCA(secret, ownerRef, "kube-csr-signer", "openshift")
 }
 
-func ReconcileAggregatorClientCA(cm *corev1.ConfigMap, ownerRef config.OwnerRef, signer, rootCA *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, signer, rootCA)
+func ReconcileAggregatorClientCA(cm *corev1.ConfigMap, ownerRef config.OwnerRef, signer *corev1.Secret) error {
+	return reconcileAggregateCA(cm, ownerRef, signer)
 }
 
 func ReconcileTotalClientCA(cm *corev1.ConfigMap, ownerRef config.OwnerRef, signers ...*corev1.Secret) error {


### PR DESCRIPTION
This is a continuation of the client-cert trust split.

/assign @csrwng 
/cc @ibihim 