### PR TITLE
AUTH-323: pki: remove root-ca from the client CA bundle

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas_pki_setup.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas_pki_setup.go
@@ -201,7 +201,7 @@ func (r *HostedControlPlaneReconciler) setupKASClientSigners(
 		return pki.ReconcileTotalClientCA(
 			totalClientCA,
 			p.OwnerRef,
-			append(totalClientCABundle, rootCASecret)...,
+			totalClientCABundle...,
 		)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile combined CA: %w", err)

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -81,6 +81,10 @@ func TestUpgradeControlPlane(t *testing.T) {
 	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
+	// Sanity check the cluster by waiting for the nodes to report ready
+	t.Logf("Waiting for guest client to become available after upgrade")
+	guestClient = e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
+
 	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 	e2eutil.EnsureMachineDeploymentGeneration(t, ctx, client, hostedCluster, 1)


### PR DESCRIPTION
This is a continuation of the client-cert trust split.

/assign @csrwng
/cc @ibihim
