### PR TITLE
Optionally use rhobs.monitoring group for monitoring resources

### DIFF
--- a/api/scheme.go
+++ b/api/scheme.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"os"
+
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -8,6 +10,7 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -55,7 +58,11 @@ func init() {
 	corev1.AddToScheme(Scheme)
 	apiextensionsv1.AddToScheme(Scheme)
 	kasv1beta1.AddToScheme(Scheme)
-	prometheusoperatorv1.AddToScheme(Scheme)
+	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
+		rhobsmonitoring.AddToScheme(Scheme)
+	} else {
+		prometheusoperatorv1.AddToScheme(Scheme)
+	}
 	agentv1.AddToScheme(Scheme)
 	capikubevirt.AddToScheme(Scheme)
 	capiazure.AddToScheme(Scheme)

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/pkg/version"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/util"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -277,6 +278,7 @@ type HyperShiftOperatorDeployment struct {
 	MetricsSet                     metrics.MetricsSet
 	IncludeVersion                 bool
 	UWMTelemetry                   bool
+	RHOBSMonitoring                bool
 }
 
 func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
@@ -422,6 +424,13 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 				},
 			})
 		}
+	}
+
+	if o.RHOBSMonitoring {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  rhobsmonitoring.EnvironmentVariable,
+			Value: "1",
+		})
 	}
 
 	deployment := &appsv1.Deployment{
@@ -746,6 +755,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 					"exp.cluster.x-k8s.io",
 					"cluster.x-k8s.io",
 					"monitoring.coreos.com",
+					"monitoring.rhobs",
 				},
 				Resources: []string{"*"},
 				Verbs:     []string{"*"},
@@ -816,7 +826,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Verbs:     []string{"*"},
 			},
 			{
-				APIGroups: []string{"monitoring.coreos.com"},
+				APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs"},
 				Resources: []string{"podmonitors"},
 				Verbs:     []string{"get", "list", "watch", "create", "update"},
 			},
@@ -1301,7 +1311,7 @@ func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
-				APIGroups: []string{"monitoring.coreos.com"},
+				APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs"},
 				Resources: []string{"podmonitors"},
 				Verbs:     []string{"get", "list", "watch"},
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -2,7 +2,10 @@ package cno
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/openshift/hypershift/support/proxy"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 
 	"github.com/blang/semver"
 	routev1 "github.com/openshift/api/route/v1"
@@ -148,7 +151,7 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
 			Verbs:     []string{"*"},
 		},
 		{
-			APIGroups: []string{"monitoring.coreos.com"},
+			APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs"},
 			Resources: []string{
 				"servicemonitors",
 				"prometheusrules",
@@ -246,6 +249,13 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 	if !params.IsPrivate {
 		cnoEnv = append(cnoEnv, corev1.EnvVar{
 			Name: "PROXY_INTERNAL_APISERVER_ADDRESS", Value: "true",
+		})
+	}
+
+	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
+		cnoEnv = append(cnoEnv, corev1.EnvVar{
+			Name:  rhobsmonitoring.EnvironmentVariable,
+			Value: "1",
 		})
 	}
 

--- a/control-plane-operator/hostedclusterconfigoperator/api/scheme.go
+++ b/control-plane-operator/hostedclusterconfigoperator/api/scheme.go
@@ -59,6 +59,8 @@ func init() {
 	openshiftcpv1.AddToScheme(Scheme)
 	v1alpha1.AddToScheme(Scheme)
 	apiserverconfigv1.AddToScheme(Scheme)
+	// RHOBS monitoring does not impact this scheme because this scheme
+	// is used for resources inside the guest cluster.
 	prometheusoperatorv1.AddToScheme(Scheme)
 	imageregistryv1.AddToScheme(Scheme)
 	operatorsv1alpha1.AddToScheme(Scheme)

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -101,6 +101,7 @@ objects:
     - exp.cluster.x-k8s.io
     - cluster.x-k8s.io
     - monitoring.coreos.com
+    - monitoring.rhobs
     resources:
     - '*'
     verbs:
@@ -178,6 +179,7 @@ objects:
     - '*'
   - apiGroups:
     - monitoring.coreos.com
+    - monitoring.rhobs
     resources:
     - podmonitors
     verbs:
@@ -27912,6 +27914,7 @@ objects:
     - watch
   - apiGroups:
     - monitoring.coreos.com
+    - monitoring.rhobs
     resources:
     - podmonitors
     verbs:

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -64,6 +64,7 @@ import (
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/supportedversion"
 	"github.com/openshift/hypershift/support/upsert"
 	hyperutil "github.com/openshift/hypershift/support/util"
@@ -2099,6 +2100,15 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 		},
 	}
 
+	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  rhobsmonitoring.EnvironmentVariable,
+				Value: "1",
+			},
+		)
+	}
+
 	if envImage := os.Getenv(images.KonnectivityEnvVar); len(envImage) > 0 {
 		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
@@ -2240,6 +2250,7 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 				"exp.cluster.x-k8s.io",
 				"cluster.x-k8s.io",
 				"monitoring.coreos.com",
+				"monitoring.rhobs",
 			},
 			Resources: []string{"*"},
 			Verbs:     []string{"*"},

--- a/support/api/scheme.go
+++ b/support/api/scheme.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"os"
+
 	configv1 "github.com/openshift/api/config/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
@@ -10,6 +12,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -66,6 +69,10 @@ func init() {
 	openshiftcpv1.AddToScheme(Scheme)
 	v1alpha1.AddToScheme(Scheme)
 	apiserverconfigv1.AddToScheme(Scheme)
-	prometheusoperatorv1.AddToScheme(Scheme)
+	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
+		rhobsmonitoring.AddToScheme(Scheme)
+	} else {
+		prometheusoperatorv1.AddToScheme(Scheme)
+	}
 	mcfgv1.AddToScheme(Scheme)
 }

--- a/support/rhobsmonitoring/scheme.go
+++ b/support/rhobsmonitoring/scheme.go
@@ -1,0 +1,56 @@
+package rhobsmonitoring
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+// SchemeGroupVersion is the group version used to register these objects
+var SchemeGroupVersion = schema.GroupVersion{Group: "monitoring.rhobs", Version: "v1"}
+
+// EnvironmentVariable indicates whether RHOBS monitoring resources should be used
+var EnvironmentVariable = "RHOBS_MONITORING"
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+var (
+	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
+	SchemeBuilder      runtime.SchemeBuilder
+	localSchemeBuilder = &SchemeBuilder
+	AddToScheme        = localSchemeBuilder.AddToScheme
+)
+
+func init() {
+	// We only register manually written functions here. The registration of the
+	// generated functions takes place in the generated files. The separation
+	// makes the code compile even when the generated files are missing.
+	localSchemeBuilder.Register(addKnownTypes)
+}
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&prometheusoperatorv1.Prometheus{},
+		&prometheusoperatorv1.PrometheusList{},
+		&prometheusoperatorv1.ServiceMonitor{},
+		&prometheusoperatorv1.ServiceMonitorList{},
+		&prometheusoperatorv1.PodMonitor{},
+		&prometheusoperatorv1.PodMonitorList{},
+		&prometheusoperatorv1.Probe{},
+		&prometheusoperatorv1.ProbeList{},
+		&prometheusoperatorv1.Alertmanager{},
+		&prometheusoperatorv1.AlertmanagerList{},
+		&prometheusoperatorv1.PrometheusRule{},
+		&prometheusoperatorv1.PrometheusRuleList{},
+		&prometheusoperatorv1.ThanosRuler{},
+		&prometheusoperatorv1.ThanosRulerList{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This change enables the CLI, hypershift operator, and control plane operator to optionally use the rhobs.monitoring/v1 group version when creating and reconciling monitoring resources. This is a global setting that must be set on the HyperShift  operator and gets propagated to all hosted control planes managed by the operator.

This will enable the HyperShift operator to create resources that can be understood by the RHOBS monitoring stack.

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-624](https://issues.redhat.com//browse/HOSTEDCP-624)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.