### PR TITLE
Fix CA bundle in podmonitors/servicemonitors

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -453,24 +453,10 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 			TLSConfig: &prometheusoperatorv1.TLSConfig{
 				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
 					ServerName: "cluster-version-operator",
-					Cert: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
-							},
-							Key: "tls.crt",
-						},
-					},
-					KeySecret: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
-						},
-						Key: "tls.key",
-					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
+						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.TotalClientCABundle(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
@@ -45,9 +45,9 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, apiServerP
 						Key: "tls.key",
 					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
+						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.TotalClientCABundle(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
@@ -41,9 +41,9 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 						Key: "tls.key",
 					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
+						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.TotalClientCABundle(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/servicemonitor.go
@@ -41,9 +41,9 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 						Key: "tls.key",
 					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
+						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.TotalClientCABundle(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/servicemonitor.go
@@ -41,9 +41,9 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 						Key: "tls.key",
 					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
+						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.TotalClientCABundle(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -182,9 +182,9 @@ func ReconcileCatalogServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, own
 						Key: "tls.key",
 					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
+						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.TotalClientCABundle(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -166,9 +166,9 @@ func ReconcileOLMOperatorServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor,
 						Key: "tls.key",
 					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
+						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.TotalClientCABundle(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -422,20 +422,19 @@ func ReconcilePodMonitor(pm *prometheusoperatorv1.PodMonitor, clusterID string, 
 	pm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
 		MatchNames: []string{pm.Namespace},
 	}
-	targetPort := intstr.FromString("metrics")
 	pm.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{
 		{
-			Interval:   "60s",
-			TargetPort: &targetPort,
-			Path:       "/metrics",
-			Scheme:     "https",
+			Interval: "60s",
+			Port:     "metrics",
+			Path:     "/metrics",
+			Scheme:   "https",
 			TLSConfig: &prometheusoperatorv1.PodMetricsEndpointTLSConfig{
 				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
 					ServerName: metricsHostname,
 					CA: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
+						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(pm.Namespace).Name,
+								Name: manifests.TotalClientCABundle(pm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcilePodMonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcilePodMonitor.yaml
@@ -21,17 +21,17 @@ spec:
       replacement: the-cluster-id
       targetLabel: _id
     path: /metrics
+    port: metrics
     relabelings:
     - action: replace
       replacement: the-cluster-id
       targetLabel: _id
     scheme: https
-    targetPort: metrics
     tlsConfig:
       ca:
-        secret:
+        configMap:
           key: ca.crt
-          name: metrics-client
+          name: client-ca
       cert: {}
       serverName: cluster-image-registry-operator
   selector:

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/servicemonitor.go
@@ -25,7 +25,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{
 				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
-					ServerName: "openshift-route-controller-manager",
+					ServerName: "openshift-controller-manager",
 					Cert: prometheusoperatorv1.SecretOrConfigMap{
 						Secret: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
@@ -41,9 +41,9 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 						Key: "tls.key",
 					},
 					CA: prometheusoperatorv1.SecretOrConfigMap{
-						Secret: &corev1.SecretKeySelector{
+						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.MetricsClientCertSecret(sm.Namespace).Name,
+								Name: manifests.TotalClientCABundle(sm.Namespace).Name,
 							},
 							Key: "ca.crt",
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
The recent split in CAs from root-ca requires that servicemonitors and podmonitors that we create use the client-ca bundle that can validate the root-ca which is used for creating metrics serving certs.

**Checklist**
- [x] Subject and description added to both, commit and PR.