### PR TITLE
doc: OVN Pod restart needed after the HC migration

### DIFF
--- a/docs/content/how-to/aws/migrate-hosted-cluster.md
+++ b/docs/content/how-to/aws/migrate-hosted-cluster.md
@@ -656,6 +656,16 @@ oc get clusterversion
 oc get nodes
 ```
 
+After the Teardown of the HostedCluster in the source Management Cluster **you will need to delete the OVN pods in the HostedCluster** in order to perform the connection with the new OVN Master running in the new Management Cluster.
+
+To do that you just need to load the proper KUBECONFIG env var with the Hosted Cluster Kubeconfig path and execute this command:
+
+```bash
+oc delete pod -n openshift-ovn-kubernetes --all
+```
+
+with that, all the ClusterOperators that were failling and all the new pods generated, will get executed without issues.
+
 ## Migration Helper script
 
 In order to ensure the that whole migration works fine, you could use this helper script that should work out of the box.


### PR DESCRIPTION
After the HC migration, the OVN pods still have the connections "opened" with the old OVN master in the source Management cluster. In order to create new pods in the HC and regenerate the network sandbox, we need to delete the OVN pods to connect with the new OVN Master in the destination Management cluster.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.