### PR TITLE
WIP: HOSTEDCP-582: Add CEL immutability validations to hostedcluster.

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -128,6 +128,16 @@ const (
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.clusterID) || has(self.clusterID)", message="clusterID is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.infraID) || has(self.infraID)", message="infraID is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.controllerAvailabilityPolicy) || has(self.controllerAvailabilityPolicy)", message="controllerAvailabilityPolicy is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.infrastructureAvailabilityPolicy) || has(self.infrastructureAvailabilityPolicy)", message="infrastructureAvailabilityPolicy is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.issuerURL) || has(self.issuerURL)", message="issuerURL is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.serviceAccountSigningKey) || has(self.serviceAccountSigningKey)", message="serviceAccountSigningKey is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.auditWebhook) || has(self.auditWebhook)", message="auditWebhook is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.imageContentSources) || has(self.imageContentSources)", message="imageContentSources is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.fips) || has(self.fips)", message="fips is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.olmCatalogPlacement) || has(self.olmCatalogPlacement)", message="olmCatalogPlacement is required once set"
 type HostedClusterSpec struct {
 	// Release specifies the desired OCP release payload for the hosted cluster.
 	//
@@ -145,8 +155,12 @@ type HostedClusterSpec struct {
 	// metrics produced by the control plane operators. If a value is not
 	// specified, an ID is generated. After initial creation, the value is
 	// immutable.
-	// +kubebuilder:validation:Pattern:="[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
 	// +optional
+	// +immutable
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern:="[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="clusterID is immutable"
+	// +kubebuilder:validation:MaxLength=40
 	ClusterID string `json:"clusterID,omitempty"`
 
 	// InfraID is a globally unique identifier for the cluster. This identifier
@@ -155,12 +169,14 @@ type HostedClusterSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="infraID is immutable"
 	InfraID string `json:"infraID,omitempty"`
 
 	// Platform specifies the underlying infrastructure provider for the cluster
 	// and is used to configure platform specific behavior.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="platform is immutable"
 	Platform PlatformSpec `json:"platform"`
 
 	// ControllerAvailabilityPolicy specifies the availability policy applied to
@@ -169,6 +185,7 @@ type HostedClusterSpec struct {
 	// +optional
 	// +kubebuilder:default:="SingleReplica"
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="controllerAvailabilityPolicy is immutable"
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
 
 	// InfrastructureAvailabilityPolicy specifies the availability policy applied
@@ -178,16 +195,19 @@ type HostedClusterSpec struct {
 	// +optional
 	// +kubebuilder:default:="SingleReplica"
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="infrastructureAvailabilityPolicy is immutable"
 	InfrastructureAvailabilityPolicy AvailabilityPolicy `json:"infrastructureAvailabilityPolicy,omitempty"`
 
 	// DNS specifies DNS configuration for the cluster.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="dns is immutable"
 	DNS DNSSpec `json:"dns,omitempty"`
 
 	// Networking specifies network configuration for the cluster.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="networking is immutable"
 	Networking ClusterNetworking `json:"networking"`
 
 	// Autoscaling specifies auto-scaling behavior that applies to all NodePools
@@ -203,6 +223,7 @@ type HostedClusterSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={managementType: "Managed", managed: {storage: {type: "PersistentVolume", persistentVolume: {size: "4Gi"}}}}
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="etcd is immutable"
 	Etcd EtcdSpec `json:"etcd"`
 
 	// Services specifies how individual control plane services are published from
@@ -215,8 +236,6 @@ type HostedClusterSpec struct {
 	// PullSecret references a pull secret to be injected into the container
 	// runtime of all cluster nodes. The secret must have a key named
 	// ".dockerconfigjson" whose value is the pull secret JSON.
-	//
-	// +immutable
 	PullSecret corev1.LocalObjectReference `json:"pullSecret"`
 
 	// SSHKey references an SSH key to be injected into all cluster node sshd
@@ -224,6 +243,7 @@ type HostedClusterSpec struct {
 	// public part of an SSH key.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="sshKey is immutable"
 	SSHKey corev1.LocalObjectReference `json:"sshKey"`
 
 	// IssuerURL is an OIDC issuer URL which is used as the issuer in all
@@ -233,6 +253,7 @@ type HostedClusterSpec struct {
 	//
 	// +kubebuilder:default:="https://kubernetes.default.svc"
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="issuerURL is immutable"
 	// +optional
 	// +kubebuilder:validation:Format=uri
 	IssuerURL string `json:"issuerURL,omitempty"`
@@ -245,6 +266,7 @@ type HostedClusterSpec struct {
 	//
 	// +immutable
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="serviceAccountSigningKey is immutable"
 	// +optional
 	ServiceAccountSigningKey *corev1.LocalObjectReference `json:"serviceAccountSigningKey,omitempty"`
 
@@ -267,6 +289,7 @@ type HostedClusterSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="auditWebhook is immutable"
 	AuditWebhook *corev1.LocalObjectReference `json:"auditWebhook,omitempty"`
 
 	// ImageContentSources specifies image mirrors that can be used by cluster
@@ -274,6 +297,7 @@ type HostedClusterSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="imageContentSources is immutable"
 	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
 
 	// AdditionalTrustBundle is a reference to a ConfigMap containing a
@@ -294,6 +318,7 @@ type HostedClusterSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="fips is immutable"
 	FIPS bool `json:"fips"`
 
 	// PausedUntil is a field that can be used to pause reconciliation on a resource.
@@ -311,6 +336,7 @@ type HostedClusterSpec struct {
 	// +kubebuilder:default=management
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="olmCatalogPlacement is immutable"
 	OLMCatalogPlacement OLMCatalogPlacement `json:"olmCatalogPlacement,omitempty"`
 
 	// NodeSelector when specified, must be true for the pods managed by the HostedCluster to be scheduled.
@@ -337,17 +363,21 @@ const (
 // to pull content. For cluster workloads, if a container image registry host of
 // the pullspec matches Source then one of the Mirrors are substituted as hosts
 // in the pullspec and tried in order to fetch the image.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.mirrors) || has(self.mirrors)", message="mirrors is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.mirrors) || has(self.mirrors)", message="mirrors is required once set"
 type ImageContentSource struct {
 	// Source is the repository that users refer to, e.g. in image pull
 	// specifications.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="source is immutable"
 	Source string `json:"source"`
 
 	// Mirrors are one or more repositories that may also contain the same images.
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="mirrors is immutable"
 	Mirrors []string `json:"mirrors,omitempty"`
 }
 
@@ -358,6 +388,7 @@ type ServicePublishingStrategyMapping struct {
 	//
 	// +kubebuilder:validation:Enum=APIServer;OAuthServer;OIDC;Konnectivity;Ignition;OVNSbDb
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="service is immutable"
 	Service ServiceType `json:"service"`
 
 	// ServicePublishingStrategy specifies how to publish Service.
@@ -370,6 +401,7 @@ type ServicePublishingStrategy struct {
 	//
 	// +kubebuilder:validation:Enum=LoadBalancer;NodePort;Route;None;S3
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="type is immutable"
 	Type PublishingStrategyType `json:"type"`
 
 	// NodePort configures exposing a service using a NodePort.
@@ -447,10 +479,13 @@ type RoutePublishingStrategy struct {
 }
 
 // DNSSpec specifies the DNS configuration in the cluster.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.publicZoneID) || has(self.publicZoneID)", message="publicZoneID is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.privateZoneID) || has(self.privateZoneID)", message="privateZoneID is required once set"
 type DNSSpec struct {
 	// BaseDomain is the base domain of the cluster.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="baseDomain is immutable"
 	BaseDomain string `json:"baseDomain"`
 
 	// PublicZoneID is the Hosted Zone ID where all the DNS records that are
@@ -458,6 +493,7 @@ type DNSSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="publicZoneID is immutable"
 	PublicZoneID string `json:"publicZoneID,omitempty"`
 
 	// PrivateZoneID is the Hosted Zone ID where all the DNS records that are only
@@ -465,10 +501,18 @@ type DNSSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="privateZoneID is immutable"
 	PrivateZoneID string `json:"privateZoneID,omitempty"`
 }
 
 // ClusterNetworking specifies network configuration for a cluster.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.serviceCIDR) || has(self.serviceCIDR)", message="serviceCIDR is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.podCIDR) || has(self.podCIDR)", message="podCIDR is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.machineCIDR) || has(self.machineCIDR)", message="machineCIDR is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.machineNetwork) || has(self.machineNetwork)", message="machineNetwork is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.clusterNetwork) || has(self.clusterNetwork)", message="clusterNetwork is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.serviceNetwork) || has(self.serviceNetwork)", message="serviceNetwork is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.networkType) || has(self.networkType)", message="networkType is required once set"
 type ClusterNetworking struct {
 	// Deprecated
 	// This field will be removed in the next API release.
@@ -476,6 +520,7 @@ type ClusterNetworking struct {
 	// +immutable
 	// +optional
 	// +kubebuilder:validation:Format=cidr
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="serviceCIDR is immutable"
 	ServiceCIDR string `json:"serviceCIDR,omitempty"`
 
 	// Deprecated
@@ -485,6 +530,7 @@ type ClusterNetworking struct {
 	// +immutable
 	// +optional
 	// +kubebuilder:validation:Format=cidr
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="podCIDR is immutable"
 	PodCIDR string `json:"podCIDR,omitempty"`
 
 	// Deprecated
@@ -493,6 +539,7 @@ type ClusterNetworking struct {
 	// +immutable
 	// +optional
 	// +kubebuilder:validation:Format=cidr
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="machineCIDR is immutable"
 	MachineCIDR string `json:"machineCIDR,omitempty"`
 
 	// MachineNetwork is the list of IP address pools for machines.
@@ -500,6 +547,7 @@ type ClusterNetworking struct {
 	//
 	// +immutable
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="machineNetwork is immutable"
 	MachineNetwork []MachineNetworkEntry `json:"machineNetwork,omitempty"`
 
 	// ClusterNetwork is the list of IP address pools for pods.
@@ -507,6 +555,7 @@ type ClusterNetworking struct {
 	//
 	// +immutable
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="clusterNetwork is immutable"
 	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork,omitempty"`
 
 	// ServiceNetwork is the list of IP address pools for services.
@@ -515,18 +564,21 @@ type ClusterNetworking struct {
 	//
 	// +immutable
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="serviceNetwork is immutable"
 	ServiceNetwork []ServiceNetworkEntry `json:"serviceNetwork,omitempty"`
 
 	// NetworkType specifies the SDN provider used for cluster networking.
 	//
 	// +kubebuilder:default:="OVNKubernetes"
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
 	NetworkType NetworkType `json:"networkType"`
 
 	// APIServer contains advanced network settings for the API server that affect
 	// how the APIServer is exposed inside a cluster node.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="apiServer is immutable"
 	APIServer *APIServerNetworking `json:"apiServer,omitempty"`
 }
 
@@ -626,23 +678,29 @@ const (
 
 // PlatformSpec specifies the underlying infrastructure provider for the cluster
 // and is used to configure platform specific behavior.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.aws) || has(self.aws)", message="aws is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.agent) || has(self.agent)", message="agent is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.powervs) || has(self.powervs)", message="powervs is required once set"
 type PlatformSpec struct {
 	// Type is the type of infrastructure provider for the cluster.
 	//
 	// +unionDiscriminator
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="type is immutable"
 	Type PlatformType `json:"type"`
 
 	// AWS specifies configuration for clusters running on Amazon Web Services.
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="aws is immutable"
 	AWS *AWSPlatformSpec `json:"aws,omitempty"`
 
 	// Agent specifies configuration for agent-based installations.
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="agent is immutable"
 	Agent *AgentPlatformSpec `json:"agent,omitempty"`
 
 	// IBMCloud defines IBMCloud specific settings for components
@@ -677,6 +735,7 @@ type PowerVSPlatformSpec struct {
 	// This field is immutable. Once set, It can't be changed.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="accountID is immutable"
 	AccountID string `json:"accountID"`
 
 	// CISInstanceCRN is the IBMCloud CIS Service Instance's Cloud Resource Name
@@ -684,12 +743,14 @@ type PowerVSPlatformSpec struct {
 	//
 	// +kubebuilder:validation:Pattern=`^crn:`
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="cisInstanceCRN is immutable"
 	CISInstanceCRN string `json:"cisInstanceCRN"`
 
 	// ResourceGroup is the IBMCloud Resource Group in which the cluster resides.
 	// This field is immutable. Once set, It can't be changed.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="resourceGroup is immutable"
 	ResourceGroup string `json:"resourceGroup"`
 
 	// Region is the IBMCloud region in which the cluster resides. This configures the
@@ -698,6 +759,7 @@ type PowerVSPlatformSpec struct {
 	// This field is immutable. Once set, It can't be changed.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="region is immutable"
 	Region string `json:"region"`
 
 	// Zone is the availability zone where control plane cloud resources are
@@ -705,12 +767,14 @@ type PowerVSPlatformSpec struct {
 	// This field is immutable. Once set, It can't be changed.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="zone is immutable"
 	Zone string `json:"zone"`
 
 	// Subnet is the subnet to use for control plane cloud resources.
 	// This field is immutable. Once set, It can't be changed.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="subnet is immutable"
 	Subnet *PowerVSResourceReference `json:"subnet"`
 
 	// ServiceInstance is the reference to the Power VS service on which the server instance(VM) will be created.
@@ -724,6 +788,7 @@ type PowerVSPlatformSpec struct {
 	// This field is immutable. Once set, It can't be changed.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="serviceInstanceID is immutable"
 	ServiceInstanceID string `json:"serviceInstanceID"`
 
 	// VPC specifies IBM Cloud PowerVS Load Balancing configuration for the control
@@ -731,6 +796,7 @@ type PowerVSPlatformSpec struct {
 	// This field is immutable. Once set, It can't be changed.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="vpc is immutable"
 	VPC *PowerVSVPC `json:"vpc"`
 
 	// KubeCloudControllerCreds is a reference to a secret containing cloud
@@ -740,6 +806,7 @@ type PowerVSPlatformSpec struct {
 	// TODO(dan): document the "cloud controller policy"
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="kubeCloudControllerCreds is immutable"
 	KubeCloudControllerCreds corev1.LocalObjectReference `json:"kubeCloudControllerCreds"`
 
 	// NodePoolManagementCreds is a reference to a secret containing cloud
@@ -749,28 +816,34 @@ type PowerVSPlatformSpec struct {
 	// TODO(dan): document the "node pool management policy"
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="nodePoolManagementCreds is immutable"
 	NodePoolManagementCreds corev1.LocalObjectReference `json:"nodePoolManagementCreds"`
 
 	// IngressOperatorCloudCreds is a reference to a secret containing ibm cloud
 	// credentials for ingress operator to get authenticated with ibm cloud.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="ingressOperatorCloudCreds is immutable"
 	IngressOperatorCloudCreds corev1.LocalObjectReference `json:"ingressOperatorCloudCreds"`
 
 	// StorageOperatorCloudCreds is a reference to a secret containing ibm cloud
 	// credentials for storage operator to get authenticated with ibm cloud.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="storageOperatorCloudCreds is immutable"
 	StorageOperatorCloudCreds corev1.LocalObjectReference `json:"storageOperatorCloudCreds"`
 }
 
 // PowerVSVPC specifies IBM Cloud PowerVS LoadBalancer configuration for the control
 // plane.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.zone) || has(self.zone)", message="zone is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.subnet) || has(self.subnet)", message="subnet is required once set"
 type PowerVSVPC struct {
 	// Name for VPC to used for all the service load balancer.
 	// This field is immutable. Once set, It can't be changed.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="name is immutable"
 	Name string `json:"name"`
 
 	// Region is the IBMCloud region in which VPC gets created, this VPC used for all the ingress traffic
@@ -778,6 +851,7 @@ type PowerVSVPC struct {
 	// This field is immutable. Once set, It can't be changed.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="region is immutable"
 	Region string `json:"region"`
 
 	// Zone is the availability zone where load balancer cloud resources are
@@ -786,6 +860,7 @@ type PowerVSVPC struct {
 	//
 	// +immutable
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="zone is immutable"
 	Zone string `json:"zone,omitempty"`
 
 	// Subnet is the subnet to use for load balancer.
@@ -793,6 +868,7 @@ type PowerVSVPC struct {
 	//
 	// +immutable
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="subnet is immutable"
 	Subnet string `json:"subnet,omitempty"`
 }
 
@@ -844,12 +920,15 @@ const (
 )
 
 // AWSPlatformSpec specifies configuration for clusters running on Amazon Web Services.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.cloudProviderConfig) || has(self.cloudProviderConfig)", message="cloudProviderConfig is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.serviceEndpoints) || has(self.serviceEndpoints)", message="serviceEndpoints is required once set"
 type AWSPlatformSpec struct {
 	// Region is the AWS region in which the cluster resides. This configures the
 	// OCP control plane cloud integrations, and is used by NodePool to resolve
 	// the correct boot AMI for a given release.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="region is immutable"
 	Region string `json:"region"`
 
 	// CloudProviderConfig specifies AWS networking configuration for the control
@@ -860,6 +939,7 @@ type AWSPlatformSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="cloudProviderConfig is immutable"
 	CloudProviderConfig *AWSCloudProviderConfig `json:"cloudProviderConfig,omitempty"`
 
 	// ServiceEndpoints specifies optional custom endpoints which will override
@@ -869,18 +949,21 @@ type AWSPlatformSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="serviceEndpoints is immutable"
 	ServiceEndpoints []AWSServiceEndpoint `json:"serviceEndpoints,omitempty"`
 
 	// RolesRef contains references to various AWS IAM roles required to enable
 	// integrations such as OIDC.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="rolesRef is immutable"
 	RolesRef AWSRolesRef `json:"rolesRef"`
 
 	// Deprecated
 	// This field will be removed in the next API release.
 	// Use RolesRef instead.
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="roles is immutable"
 	Roles []AWSRoleCredentials `json:"roles,omitempty"`
 
 	// Deprecated
@@ -888,6 +971,7 @@ type AWSPlatformSpec struct {
 	// Use RolesRef instead.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="kubeCloudControllerCreds is immutable"
 	KubeCloudControllerCreds corev1.LocalObjectReference `json:"kubeCloudControllerCreds"`
 
 	// Deprecated
@@ -895,6 +979,7 @@ type AWSPlatformSpec struct {
 	// Use RolesRef instead.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="nodePoolManagementCreds is immutable"
 	NodePoolManagementCreds corev1.LocalObjectReference `json:"nodePoolManagementCreds"`
 
 	// Deprecated
@@ -902,6 +987,7 @@ type AWSPlatformSpec struct {
 	// Use RolesRef instead.
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="controlPlaneOperatorCreds is immutable"
 	ControlPlaneOperatorCreds corev1.LocalObjectReference `json:"controlPlaneOperatorCreds"`
 
 	// ResourceTags is a list of additional tags to apply to AWS resources created
@@ -1167,6 +1253,7 @@ type AWSRolesRef struct {
 	//  ]
 	// }
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="kubeCloudControllerARN is immutable"
 	KubeCloudControllerARN string `json:"kubeCloudControllerARN"`
 
 	// NodePoolManagementARN is an ARN value referencing a role appropriate for the CAPI Controller.
@@ -1260,6 +1347,7 @@ type AWSRolesRef struct {
 	// }
 	//
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="nodePoolManagementARN is immutable"
 	NodePoolManagementARN string `json:"nodePoolManagementARN"`
 
 	// ControlPlaneOperatorARN  is an ARN value referencing a role appropriate for the Control Plane Operator.
@@ -1292,6 +1380,7 @@ type AWSRolesRef struct {
 	//	]
 	// }
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="controlPlaneOperatorARN is immutable"
 	ControlPlaneOperatorARN string `json:"controlPlaneOperatorARN"`
 }
 
@@ -1379,6 +1468,8 @@ const (
 )
 
 // EtcdSpec specifies configuration for a control plane etcd cluster.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.managed) || has(self.managed)", message="managed is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.unmanaged) || has(self.unmanaged)", message="unmanaged is required once set"
 type EtcdSpec struct {
 	// ManagementType defines how the etcd cluster is managed.
 	//
@@ -1422,11 +1513,13 @@ var (
 )
 
 // ManagedEtcdStorageSpec describes the storage configuration for etcd data.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.restoreSnapshotURL) || has(self.restoreSnapshotURL)", message="restoreSnapshotURL is required once set"
 type ManagedEtcdStorageSpec struct {
 	// Type is the kind of persistent storage implementation to use for etcd.
 	//
 	// +immutable
 	// +unionDiscriminator
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="type is immutable"
 	Type ManagedEtcdStorageType `json:"type"`
 
 	// PersistentVolume is the configuration for PersistentVolume etcd storage.
@@ -1445,11 +1538,13 @@ type ManagedEtcdStorageSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="restoreSnapshotURL is immutable"
 	RestoreSnapshotURL []string `json:"restoreSnapshotURL,omitempty"`
 }
 
 // PersistentVolumeEtcdStorageSpec is the configuration for PersistentVolume
 // etcd storage.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.storageClassName) || has(self.storageClassName)", message="storageClassName is required once set"
 type PersistentVolumeEtcdStorageSpec struct {
 	// StorageClassName is the StorageClass of the data volume for each etcd member.
 	//
@@ -1457,6 +1552,7 @@ type PersistentVolumeEtcdStorageSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="storageClassName is immutable"
 	StorageClassName *string `json:"storageClassName,omitempty"`
 
 	// Size is the minimum size of the data volume for each etcd member.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -94,6 +94,9 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: auditWebhook is immutable
+                  rule: self == oldSelf
               autoscaling:
                 description: Autoscaling specifies auto-scaling behavior that applies
                   to all NodePools associated with the control plane.
@@ -135,8 +138,12 @@ spec:
                   identifies the cluster in metrics pushed to telemetry and metrics
                   produced by the control plane operators. If a value is not specified,
                   an ID is generated. After initial creation, the value is immutable.
+                maxLength: 40
                 pattern: '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
                 type: string
+                x-kubernetes-validations:
+                - message: clusterID is immutable
+                  rule: self == oldSelf
               configuration:
                 description: Configuration specifies configuration for individual
                   OCP components in the cluster, represented as embedded resources
@@ -1921,25 +1928,55 @@ spec:
                   policy applied to critical control plane components. The default
                   value is SingleReplica.
                 type: string
+                x-kubernetes-validations:
+                - message: controllerAvailabilityPolicy is immutable
+                  rule: self == oldSelf
               dns:
+                allOf:
+                - x-kubernetes-validations:
+                  - message: publicZoneID is required once set
+                    rule: '!has(oldSelf.publicZoneID) || has(self.publicZoneID)'
+                  - message: privateZoneID is required once set
+                    rule: '!has(oldSelf.privateZoneID) || has(self.privateZoneID)'
+                - x-kubernetes-validations:
+                  - message: dns is immutable
+                    rule: self == oldSelf
                 description: DNS specifies DNS configuration for the cluster.
                 properties:
                   baseDomain:
                     description: BaseDomain is the base domain of the cluster.
                     type: string
+                    x-kubernetes-validations:
+                    - message: baseDomain is immutable
+                      rule: self == oldSelf
                   privateZoneID:
                     description: PrivateZoneID is the Hosted Zone ID where all the
                       DNS records that are only available internally to the cluster
                       exist.
                     type: string
+                    x-kubernetes-validations:
+                    - message: privateZoneID is immutable
+                      rule: self == oldSelf
                   publicZoneID:
                     description: PublicZoneID is the Hosted Zone ID where all the
                       DNS records that are publicly accessible to the internet exist.
                     type: string
+                    x-kubernetes-validations:
+                    - message: publicZoneID is immutable
+                      rule: self == oldSelf
                 required:
                 - baseDomain
                 type: object
               etcd:
+                allOf:
+                - x-kubernetes-validations:
+                  - message: managed is required once set
+                    rule: '!has(oldSelf.managed) || has(self.managed)'
+                  - message: unmanaged is required once set
+                    rule: '!has(oldSelf.unmanaged) || has(self.unmanaged)'
+                - x-kubernetes-validations:
+                  - message: etcd is immutable
+                    rule: self == oldSelf
                 default:
                   managed:
                     storage:
@@ -1979,7 +2016,13 @@ spec:
                                   of the data volume for each etcd member. \n See
                                   https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1."
                                 type: string
+                                x-kubernetes-validations:
+                                - message: storageClassName is immutable
+                                  rule: self == oldSelf
                             type: object
+                            x-kubernetes-validations:
+                            - message: storageClassName is required once set
+                              rule: '!has(oldSelf.storageClassName) || has(self.storageClassName)'
                           restoreSnapshotURL:
                             description: RestoreSnapshotURL allows an optional list
                               of URLs to be provided where an etcd snapshot can be
@@ -1990,15 +2033,24 @@ spec:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-validations:
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: Type is the kind of persistent storage implementation
                               to use for etcd.
                             enum:
                             - PersistentVolume
                             type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable
+                              rule: self == oldSelf
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL is required once set
+                          rule: '!has(oldSelf.restoreSnapshotURL) || has(self.restoreSnapshotURL)'
                     required:
                     - storage
                     type: object
@@ -2053,6 +2105,9 @@ spec:
                   will be configured to expect that nodes joining the cluster will
                   be FIPS-enabled.
                 type: boolean
+                x-kubernetes-validations:
+                - message: fips is immutable
+                  rule: self == oldSelf
               imageContentSources:
                 description: ImageContentSources specifies image mirrors that can
                   be used by cluster nodes to pull content.
@@ -2069,25 +2124,45 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-validations:
+                      - message: mirrors is immutable
+                        rule: self == oldSelf
                     source:
                       description: Source is the repository that users refer to, e.g.
                         in image pull specifications.
                       type: string
+                      x-kubernetes-validations:
+                      - message: source is immutable
+                        rule: self == oldSelf
                   required:
                   - source
                   type: object
+                  x-kubernetes-validations:
+                  - message: mirrors is required once set
+                    rule: '!has(oldSelf.mirrors) || has(self.mirrors)'
+                  - message: mirrors is required once set
+                    rule: '!has(oldSelf.mirrors) || has(self.mirrors)'
                 type: array
+                x-kubernetes-validations:
+                - message: imageContentSources is immutable
+                  rule: self == oldSelf
               infraID:
                 description: InfraID is a globally unique identifier for the cluster.
                   This identifier will be used to associate various cloud resources
                   with the HostedCluster and its associated NodePools.
                 type: string
+                x-kubernetes-validations:
+                - message: infraID is immutable
+                  rule: self == oldSelf
               infrastructureAvailabilityPolicy:
                 default: SingleReplica
                 description: InfrastructureAvailabilityPolicy specifies the availability
                   policy applied to infrastructure services which run on cluster nodes.
                   The default value is SingleReplica.
                 type: string
+                x-kubernetes-validations:
+                - message: infrastructureAvailabilityPolicy is immutable
+                  rule: self == oldSelf
               issuerURL:
                 default: https://kubernetes.default.svc
                 description: IssuerURL is an OIDC issuer URL which is used as the
@@ -2096,7 +2171,29 @@ spec:
                   works for in-cluster validation.
                 format: uri
                 type: string
+                x-kubernetes-validations:
+                - message: issuerURL is immutable
+                  rule: self == oldSelf
               networking:
+                allOf:
+                - x-kubernetes-validations:
+                  - message: serviceCIDR is required once set
+                    rule: '!has(oldSelf.serviceCIDR) || has(self.serviceCIDR)'
+                  - message: podCIDR is required once set
+                    rule: '!has(oldSelf.podCIDR) || has(self.podCIDR)'
+                  - message: machineCIDR is required once set
+                    rule: '!has(oldSelf.machineCIDR) || has(self.machineCIDR)'
+                  - message: machineNetwork is required once set
+                    rule: '!has(oldSelf.machineNetwork) || has(self.machineNetwork)'
+                  - message: clusterNetwork is required once set
+                    rule: '!has(oldSelf.clusterNetwork) || has(self.clusterNetwork)'
+                  - message: serviceNetwork is required once set
+                    rule: '!has(oldSelf.serviceNetwork) || has(self.serviceNetwork)'
+                  - message: networkType is required once set
+                    rule: '!has(oldSelf.networkType) || has(self.networkType)'
+                - x-kubernetes-validations:
+                  - message: networking is immutable
+                    rule: self == oldSelf
                 description: Networking specifies network configuration for the cluster.
                 properties:
                   apiServer:
@@ -2126,6 +2223,9 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                    x-kubernetes-validations:
+                    - message: apiServer is immutable
+                      rule: self == oldSelf
                   clusterNetwork:
                     description: 'ClusterNetwork is the list of IP address pools for
                       pods. TODO: make this required in the next version of the API'
@@ -2147,11 +2247,17 @@ spec:
                       - cidr
                       type: object
                     type: array
+                    x-kubernetes-validations:
+                    - message: clusterNetwork is immutable
+                      rule: self == oldSelf
                   machineCIDR:
                     description: Deprecated This field will be removed in the next
                       API release. Use MachineNetwork instead
                     format: cidr
                     type: string
+                    x-kubernetes-validations:
+                    - message: machineCIDR is immutable
+                      rule: self == oldSelf
                   machineNetwork:
                     description: 'MachineNetwork is the list of IP address pools for
                       machines. TODO: make this required in the next version of the
@@ -2168,6 +2274,9 @@ spec:
                       - cidr
                       type: object
                     type: array
+                    x-kubernetes-validations:
+                    - message: machineNetwork is immutable
+                      rule: self == oldSelf
                   networkType:
                     default: OVNKubernetes
                     description: NetworkType specifies the SDN provider used for cluster
@@ -2178,16 +2287,25 @@ spec:
                     - OVNKubernetes
                     - Other
                     type: string
+                    x-kubernetes-validations:
+                    - message: networkType is immutable
+                      rule: self == oldSelf
                   podCIDR:
                     description: Deprecated This field will be removed in the next
                       API release. Use ClusterNetwork instead
                     format: cidr
                     type: string
+                    x-kubernetes-validations:
+                    - message: podCIDR is immutable
+                      rule: self == oldSelf
                   serviceCIDR:
                     description: Deprecated This field will be removed in the next
                       API release. Use ServiceNetwork instead
                     format: cidr
                     type: string
+                    x-kubernetes-validations:
+                    - message: serviceCIDR is immutable
+                      rule: self == oldSelf
                   serviceNetwork:
                     description: 'ServiceNetwork is the list of IP address pools for
                       services. NOTE: currently only one entry is supported. TODO:
@@ -2204,6 +2322,9 @@ spec:
                       - cidr
                       type: object
                     type: array
+                    x-kubernetes-validations:
+                    - message: serviceNetwork is immutable
+                      rule: self == oldSelf
                 required:
                 - networkType
                 type: object
@@ -2223,6 +2344,9 @@ spec:
                 - management
                 - guest
                 type: string
+                x-kubernetes-validations:
+                - message: olmCatalogPlacement is immutable
+                  rule: self == oldSelf
               pausedUntil:
                 description: 'PausedUntil is a field that can be used to pause reconciliation
                   on a resource. Either a date can be provided in RFC3339 format or
@@ -2231,6 +2355,17 @@ spec:
                   is paused on the resource until the field is removed.'
                 type: string
               platform:
+                allOf:
+                - x-kubernetes-validations:
+                  - message: aws is required once set
+                    rule: '!has(oldSelf.aws) || has(self.aws)'
+                  - message: agent is required once set
+                    rule: '!has(oldSelf.agent) || has(self.agent)'
+                  - message: powervs is required once set
+                    rule: '!has(oldSelf.powervs) || has(self.powervs)'
+                - x-kubernetes-validations:
+                  - message: platform is immutable
+                    rule: self == oldSelf
                 description: Platform specifies the underlying infrastructure provider
                   for the cluster and is used to configure platform specific behavior.
                 properties:
@@ -2244,7 +2379,19 @@ spec:
                     required:
                     - agentNamespace
                     type: object
+                    x-kubernetes-validations:
+                    - message: agent is immutable
+                      rule: self == oldSelf
                   aws:
+                    allOf:
+                    - x-kubernetes-validations:
+                      - message: cloudProviderConfig is required once set
+                        rule: '!has(oldSelf.cloudProviderConfig) || has(self.cloudProviderConfig)'
+                      - message: serviceEndpoints is required once set
+                        rule: '!has(oldSelf.serviceEndpoints) || has(self.serviceEndpoints)'
+                    - x-kubernetes-validations:
+                      - message: aws is immutable
+                        rule: self == oldSelf
                     description: AWS specifies configuration for clusters running
                       on Amazon Web Services.
                     properties:
@@ -2299,6 +2446,9 @@ spec:
                         required:
                         - vpc
                         type: object
+                        x-kubernetes-validations:
+                        - message: cloudProviderConfig is immutable
+                          rule: self == oldSelf
                       controlPlaneOperatorCreds:
                         description: Deprecated This field will be removed in the
                           next API release. Use RolesRef instead.
@@ -2309,6 +2459,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: controlPlaneOperatorCreds is immutable
+                          rule: self == oldSelf
                       endpointAccess:
                         default: Public
                         description: EndpointAccess specifies the publishing scope
@@ -2328,6 +2481,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: kubeCloudControllerCreds is immutable
+                          rule: self == oldSelf
                       nodePoolManagementCreds:
                         description: Deprecated This field will be removed in the
                           next API release. Use RolesRef instead.
@@ -2338,12 +2494,18 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: nodePoolManagementCreds is immutable
+                          rule: self == oldSelf
                       region:
                         description: Region is the AWS region in which the cluster
                           resides. This configures the OCP control plane cloud integrations,
                           and is used by NodePool to resolve the correct boot AMI
                           for a given release.
                         type: string
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: self == oldSelf
                       resourceTags:
                         description: ResourceTags is a list of additional tags to
                           apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
@@ -2396,6 +2558,9 @@ spec:
                           - namespace
                           type: object
                         type: array
+                        x-kubernetes-validations:
+                        - message: roles is immutable
+                          rule: self == oldSelf
                       rolesRef:
                         description: RolesRef contains references to various AWS IAM
                           roles required to enable integrations such as OIDC.
@@ -2412,6 +2577,9 @@ spec:
                               [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
                               ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
                             type: string
+                            x-kubernetes-validations:
+                            - message: controlPlaneOperatorARN is immutable
+                              rule: self == oldSelf
                           imageRegistryARN:
                             description: "ImageRegistryARN is an ARN value referencing
                               a role appropriate for the Image Registry Operator.
@@ -2481,6 +2649,9 @@ spec:
                               ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\" }
                               ] }"
                             type: string
+                            x-kubernetes-validations:
+                            - message: kubeCloudControllerARN is immutable
+                              rule: self == oldSelf
                           networkARN:
                             description: "NetworkARN is an ARN value referencing a
                               role appropriate for the Network Operator. \n The following
@@ -2528,6 +2699,9 @@ spec:
                               ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                               ], \"Effect\": \"Allow\" } ] }"
                             type: string
+                            x-kubernetes-validations:
+                            - message: nodePoolManagementARN is immutable
+                              rule: self == oldSelf
                           storageARN:
                             description: "StorageARN is an ARN value referencing a
                               role appropriate for the Storage Operator. \n The following
@@ -2549,6 +2723,9 @@ spec:
                         - nodePoolManagementARN
                         - storageARN
                         type: object
+                        x-kubernetes-validations:
+                        - message: rolesRef is immutable
+                          rule: self == oldSelf
                       serviceEndpoints:
                         description: "ServiceEndpoints specifies optional custom endpoints
                           which will override the default service endpoint of specific
@@ -2574,6 +2751,9 @@ spec:
                           - url
                           type: object
                         type: array
+                        x-kubernetes-validations:
+                        - message: serviceEndpoints is immutable
+                          rule: self == oldSelf
                     required:
                     - controlPlaneOperatorCreds
                     - kubeCloudControllerCreds
@@ -2639,12 +2819,18 @@ spec:
                         description: AccountID is the IBMCloud account id. This field
                           is immutable. Once set, It can't be changed.
                         type: string
+                        x-kubernetes-validations:
+                        - message: accountID is immutable
+                          rule: self == oldSelf
                       cisInstanceCRN:
                         description: CISInstanceCRN is the IBMCloud CIS Service Instance's
                           Cloud Resource Name This field is immutable. Once set, It
                           can't be changed.
                         pattern: '^crn:'
                         type: string
+                        x-kubernetes-validations:
+                        - message: cisInstanceCRN is immutable
+                          rule: self == oldSelf
                       ingressOperatorCloudCreds:
                         description: IngressOperatorCloudCreds is a reference to a
                           secret containing ibm cloud credentials for ingress operator
@@ -2656,6 +2842,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressOperatorCloudCreds is immutable
+                          rule: self == oldSelf
                       kubeCloudControllerCreds:
                         description: "KubeCloudControllerCreds is a reference to a
                           secret containing cloud credentials with permissions matching
@@ -2669,6 +2858,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: kubeCloudControllerCreds is immutable
+                          rule: self == oldSelf
                       nodePoolManagementCreds:
                         description: "NodePoolManagementCreds is a reference to a
                           secret containing cloud credentials with permissions matching
@@ -2682,6 +2874,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: nodePoolManagementCreds is immutable
+                          rule: self == oldSelf
                       region:
                         description: Region is the IBMCloud region in which the cluster
                           resides. This configures the OCP control plane cloud integrations,
@@ -2689,11 +2884,17 @@ spec:
                           for a given release. This field is immutable. Once set,
                           It can't be changed.
                         type: string
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: self == oldSelf
                       resourceGroup:
                         description: ResourceGroup is the IBMCloud Resource Group
                           in which the cluster resides. This field is immutable. Once
                           set, It can't be changed.
                         type: string
+                        x-kubernetes-validations:
+                        - message: resourceGroup is immutable
+                          rule: self == oldSelf
                       serviceInstanceID:
                         description: "ServiceInstance is the reference to the Power
                           VS service on which the server instance(VM) will be created.
@@ -2705,6 +2906,9 @@ spec:
                           instance. https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server
                           \n This field is immutable. Once set, It can't be changed."
                         type: string
+                        x-kubernetes-validations:
+                        - message: serviceInstanceID is immutable
+                          rule: self == oldSelf
                       storageOperatorCloudCreds:
                         description: StorageOperatorCloudCreds is a reference to a
                           secret containing ibm cloud credentials for storage operator
@@ -2716,6 +2920,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: storageOperatorCloudCreds is immutable
+                          rule: self == oldSelf
                       subnet:
                         description: Subnet is the subnet to use for control plane
                           cloud resources. This field is immutable. Once set, It can't
@@ -2728,7 +2935,19 @@ spec:
                             description: Name of resource
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: subnet is immutable
+                          rule: self == oldSelf
                       vpc:
+                        allOf:
+                        - x-kubernetes-validations:
+                          - message: zone is required once set
+                            rule: '!has(oldSelf.zone) || has(self.zone)'
+                          - message: subnet is required once set
+                            rule: '!has(oldSelf.subnet) || has(self.subnet)'
+                        - x-kubernetes-validations:
+                          - message: vpc is immutable
+                            rule: self == oldSelf
                         description: VPC specifies IBM Cloud PowerVS Load Balancing
                           configuration for the control plane. This field is immutable.
                           Once set, It can't be changed.
@@ -2738,21 +2957,33 @@ spec:
                               load balancer. This field is immutable. Once set, It
                               can't be changed.
                             type: string
+                            x-kubernetes-validations:
+                            - message: name is immutable
+                              rule: self == oldSelf
                           region:
                             description: Region is the IBMCloud region in which VPC
                               gets created, this VPC used for all the ingress traffic
                               into the OCP cluster. This field is immutable. Once
                               set, It can't be changed.
                             type: string
+                            x-kubernetes-validations:
+                            - message: region is immutable
+                              rule: self == oldSelf
                           subnet:
                             description: Subnet is the subnet to use for load balancer.
                               This field is immutable. Once set, It can't be changed.
                             type: string
+                            x-kubernetes-validations:
+                            - message: subnet is immutable
+                              rule: self == oldSelf
                           zone:
                             description: Zone is the availability zone where load
                               balancer cloud resources are created. This field is
                               immutable. Once set, It can't be changed.
                             type: string
+                            x-kubernetes-validations:
+                            - message: zone is immutable
+                              rule: self == oldSelf
                         required:
                         - name
                         - region
@@ -2762,6 +2993,9 @@ spec:
                           cloud resources are created. This field is immutable. Once
                           set, It can't be changed.
                         type: string
+                        x-kubernetes-validations:
+                        - message: zone is immutable
+                          rule: self == oldSelf
                     required:
                     - accountID
                     - cisInstanceCRN
@@ -2788,6 +3022,9 @@ spec:
                     - Azure
                     - PowerVS
                     type: string
+                    x-kubernetes-validations:
+                    - message: type is immutable
+                      rule: self == oldSelf
                 required:
                 - type
                 type: object
@@ -3035,6 +3272,9 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: serviceAccountSigningKey is immutable
+                  rule: self == oldSelf
               services:
                 description: "Services specifies how individual control plane services
                   are published from the hosting cluster of the control plane. \n
@@ -3055,6 +3295,9 @@ spec:
                       - Ignition
                       - OVNSbDb
                       type: string
+                      x-kubernetes-validations:
+                      - message: service is immutable
+                        rule: self == oldSelf
                     servicePublishingStrategy:
                       description: ServicePublishingStrategy specifies how to publish
                         Service.
@@ -3104,6 +3347,9 @@ spec:
                           - None
                           - S3
                           type: string
+                          x-kubernetes-validations:
+                          - message: type is immutable
+                            rule: self == oldSelf
                       required:
                       - type
                       type: object
@@ -3123,6 +3369,9 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: sshKey is immutable
+                  rule: self == oldSelf
             required:
             - networking
             - platform
@@ -3131,6 +3380,27 @@ spec:
             - services
             - sshKey
             type: object
+            x-kubernetes-validations:
+            - message: clusterID is required once set
+              rule: '!has(oldSelf.clusterID) || has(self.clusterID)'
+            - message: infraID is required once set
+              rule: '!has(oldSelf.infraID) || has(self.infraID)'
+            - message: controllerAvailabilityPolicy is required once set
+              rule: '!has(oldSelf.controllerAvailabilityPolicy) || has(self.controllerAvailabilityPolicy)'
+            - message: infrastructureAvailabilityPolicy is required once set
+              rule: '!has(oldSelf.infrastructureAvailabilityPolicy) || has(self.infrastructureAvailabilityPolicy)'
+            - message: issuerURL is required once set
+              rule: '!has(oldSelf.issuerURL) || has(self.issuerURL)'
+            - message: serviceAccountSigningKey is required once set
+              rule: '!has(oldSelf.serviceAccountSigningKey) || has(self.serviceAccountSigningKey)'
+            - message: auditWebhook is required once set
+              rule: '!has(oldSelf.auditWebhook) || has(self.auditWebhook)'
+            - message: imageContentSources is required once set
+              rule: '!has(oldSelf.imageContentSources) || has(self.imageContentSources)'
+            - message: fips is required once set
+              rule: '!has(oldSelf.fips) || has(self.fips)'
+            - message: olmCatalogPlacement is required once set
+              rule: '!has(oldSelf.olmCatalogPlacement) || has(self.olmCatalogPlacement)'
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -1914,18 +1914,32 @@ spec:
                   baseDomain:
                     description: BaseDomain is the base domain of the cluster.
                     type: string
+                    x-kubernetes-validations:
+                    - message: baseDomain is immutable
+                      rule: self == oldSelf
                   privateZoneID:
                     description: PrivateZoneID is the Hosted Zone ID where all the
                       DNS records that are only available internally to the cluster
                       exist.
                     type: string
+                    x-kubernetes-validations:
+                    - message: privateZoneID is immutable
+                      rule: self == oldSelf
                   publicZoneID:
                     description: PublicZoneID is the Hosted Zone ID where all the
                       DNS records that are publicly accessible to the internet exist.
                     type: string
+                    x-kubernetes-validations:
+                    - message: publicZoneID is immutable
+                      rule: self == oldSelf
                 required:
                 - baseDomain
                 type: object
+                x-kubernetes-validations:
+                - message: publicZoneID is required once set
+                  rule: '!has(oldSelf.publicZoneID) || has(self.publicZoneID)'
+                - message: privateZoneID is required once set
+                  rule: '!has(oldSelf.privateZoneID) || has(self.privateZoneID)'
               etcd:
                 description: Etcd contains metadata about the etcd cluster the hypershift
                   managed Openshift control plane components use to store data.
@@ -1958,7 +1972,13 @@ spec:
                                   of the data volume for each etcd member. \n See
                                   https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1."
                                 type: string
+                                x-kubernetes-validations:
+                                - message: storageClassName is immutable
+                                  rule: self == oldSelf
                             type: object
+                            x-kubernetes-validations:
+                            - message: storageClassName is required once set
+                              rule: '!has(oldSelf.storageClassName) || has(self.storageClassName)'
                           restoreSnapshotURL:
                             description: RestoreSnapshotURL allows an optional list
                               of URLs to be provided where an etcd snapshot can be
@@ -1969,15 +1989,24 @@ spec:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-validations:
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: Type is the kind of persistent storage implementation
                               to use for etcd.
                             enum:
                             - PersistentVolume
                             type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable
+                              rule: self == oldSelf
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL is required once set
+                          rule: '!has(oldSelf.restoreSnapshotURL) || has(self.restoreSnapshotURL)'
                     required:
                     - storage
                     type: object
@@ -2026,6 +2055,11 @@ spec:
                 required:
                 - managementType
                 type: object
+                x-kubernetes-validations:
+                - message: managed is required once set
+                  rule: '!has(oldSelf.managed) || has(self.managed)'
+                - message: unmanaged is required once set
+                  rule: '!has(oldSelf.unmanaged) || has(self.unmanaged)'
               fips:
                 description: FIPS specifies if the nodes for the cluster will be running
                   in FIPS mode
@@ -2046,13 +2080,24 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-validations:
+                      - message: mirrors is immutable
+                        rule: self == oldSelf
                     source:
                       description: Source is the repository that users refer to, e.g.
                         in image pull specifications.
                       type: string
+                      x-kubernetes-validations:
+                      - message: source is immutable
+                        rule: self == oldSelf
                   required:
                   - source
                   type: object
+                  x-kubernetes-validations:
+                  - message: mirrors is required once set
+                    rule: '!has(oldSelf.mirrors) || has(self.mirrors)'
+                  - message: mirrors is required once set
+                    rule: '!has(oldSelf.mirrors) || has(self.mirrors)'
                 type: array
               infraID:
                 type: string
@@ -2124,6 +2169,9 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                    x-kubernetes-validations:
+                    - message: apiServer is immutable
+                      rule: self == oldSelf
                   clusterNetwork:
                     description: 'ClusterNetwork is the list of IP address pools for
                       pods. TODO: make this required in the next version of the API'
@@ -2145,11 +2193,17 @@ spec:
                       - cidr
                       type: object
                     type: array
+                    x-kubernetes-validations:
+                    - message: clusterNetwork is immutable
+                      rule: self == oldSelf
                   machineCIDR:
                     description: Deprecated This field will be removed in the next
                       API release. Use MachineNetwork instead
                     format: cidr
                     type: string
+                    x-kubernetes-validations:
+                    - message: machineCIDR is immutable
+                      rule: self == oldSelf
                   machineNetwork:
                     description: 'MachineNetwork is the list of IP address pools for
                       machines. TODO: make this required in the next version of the
@@ -2166,6 +2220,9 @@ spec:
                       - cidr
                       type: object
                     type: array
+                    x-kubernetes-validations:
+                    - message: machineNetwork is immutable
+                      rule: self == oldSelf
                   networkType:
                     default: OVNKubernetes
                     description: NetworkType specifies the SDN provider used for cluster
@@ -2176,16 +2233,25 @@ spec:
                     - OVNKubernetes
                     - Other
                     type: string
+                    x-kubernetes-validations:
+                    - message: networkType is immutable
+                      rule: self == oldSelf
                   podCIDR:
                     description: Deprecated This field will be removed in the next
                       API release. Use ClusterNetwork instead
                     format: cidr
                     type: string
+                    x-kubernetes-validations:
+                    - message: podCIDR is immutable
+                      rule: self == oldSelf
                   serviceCIDR:
                     description: Deprecated This field will be removed in the next
                       API release. Use ServiceNetwork instead
                     format: cidr
                     type: string
+                    x-kubernetes-validations:
+                    - message: serviceCIDR is immutable
+                      rule: self == oldSelf
                   serviceNetwork:
                     description: 'ServiceNetwork is the list of IP address pools for
                       services. NOTE: currently only one entry is supported. TODO:
@@ -2202,9 +2268,27 @@ spec:
                       - cidr
                       type: object
                     type: array
+                    x-kubernetes-validations:
+                    - message: serviceNetwork is immutable
+                      rule: self == oldSelf
                 required:
                 - networkType
                 type: object
+                x-kubernetes-validations:
+                - message: serviceCIDR is required once set
+                  rule: '!has(oldSelf.serviceCIDR) || has(self.serviceCIDR)'
+                - message: podCIDR is required once set
+                  rule: '!has(oldSelf.podCIDR) || has(self.podCIDR)'
+                - message: machineCIDR is required once set
+                  rule: '!has(oldSelf.machineCIDR) || has(self.machineCIDR)'
+                - message: machineNetwork is required once set
+                  rule: '!has(oldSelf.machineNetwork) || has(self.machineNetwork)'
+                - message: clusterNetwork is required once set
+                  rule: '!has(oldSelf.clusterNetwork) || has(self.clusterNetwork)'
+                - message: serviceNetwork is required once set
+                  rule: '!has(oldSelf.serviceNetwork) || has(self.serviceNetwork)'
+                - message: networkType is required once set
+                  rule: '!has(oldSelf.networkType) || has(self.networkType)'
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -2243,7 +2327,19 @@ spec:
                     required:
                     - agentNamespace
                     type: object
+                    x-kubernetes-validations:
+                    - message: agent is immutable
+                      rule: self == oldSelf
                   aws:
+                    allOf:
+                    - x-kubernetes-validations:
+                      - message: cloudProviderConfig is required once set
+                        rule: '!has(oldSelf.cloudProviderConfig) || has(self.cloudProviderConfig)'
+                      - message: serviceEndpoints is required once set
+                        rule: '!has(oldSelf.serviceEndpoints) || has(self.serviceEndpoints)'
+                    - x-kubernetes-validations:
+                      - message: aws is immutable
+                        rule: self == oldSelf
                     description: AWS specifies configuration for clusters running
                       on Amazon Web Services.
                     properties:
@@ -2298,6 +2394,9 @@ spec:
                         required:
                         - vpc
                         type: object
+                        x-kubernetes-validations:
+                        - message: cloudProviderConfig is immutable
+                          rule: self == oldSelf
                       controlPlaneOperatorCreds:
                         description: Deprecated This field will be removed in the
                           next API release. Use RolesRef instead.
@@ -2308,6 +2407,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: controlPlaneOperatorCreds is immutable
+                          rule: self == oldSelf
                       endpointAccess:
                         default: Public
                         description: EndpointAccess specifies the publishing scope
@@ -2327,6 +2429,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: kubeCloudControllerCreds is immutable
+                          rule: self == oldSelf
                       nodePoolManagementCreds:
                         description: Deprecated This field will be removed in the
                           next API release. Use RolesRef instead.
@@ -2337,12 +2442,18 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: nodePoolManagementCreds is immutable
+                          rule: self == oldSelf
                       region:
                         description: Region is the AWS region in which the cluster
                           resides. This configures the OCP control plane cloud integrations,
                           and is used by NodePool to resolve the correct boot AMI
                           for a given release.
                         type: string
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: self == oldSelf
                       resourceTags:
                         description: ResourceTags is a list of additional tags to
                           apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
@@ -2395,6 +2506,9 @@ spec:
                           - namespace
                           type: object
                         type: array
+                        x-kubernetes-validations:
+                        - message: roles is immutable
+                          rule: self == oldSelf
                       rolesRef:
                         description: RolesRef contains references to various AWS IAM
                           roles required to enable integrations such as OIDC.
@@ -2411,6 +2525,9 @@ spec:
                               [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
                               ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
                             type: string
+                            x-kubernetes-validations:
+                            - message: controlPlaneOperatorARN is immutable
+                              rule: self == oldSelf
                           imageRegistryARN:
                             description: "ImageRegistryARN is an ARN value referencing
                               a role appropriate for the Image Registry Operator.
@@ -2480,6 +2597,9 @@ spec:
                               ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\" }
                               ] }"
                             type: string
+                            x-kubernetes-validations:
+                            - message: kubeCloudControllerARN is immutable
+                              rule: self == oldSelf
                           networkARN:
                             description: "NetworkARN is an ARN value referencing a
                               role appropriate for the Network Operator. \n The following
@@ -2527,6 +2647,9 @@ spec:
                               ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                               ], \"Effect\": \"Allow\" } ] }"
                             type: string
+                            x-kubernetes-validations:
+                            - message: nodePoolManagementARN is immutable
+                              rule: self == oldSelf
                           storageARN:
                             description: "StorageARN is an ARN value referencing a
                               role appropriate for the Storage Operator. \n The following
@@ -2548,6 +2671,9 @@ spec:
                         - nodePoolManagementARN
                         - storageARN
                         type: object
+                        x-kubernetes-validations:
+                        - message: rolesRef is immutable
+                          rule: self == oldSelf
                       serviceEndpoints:
                         description: "ServiceEndpoints specifies optional custom endpoints
                           which will override the default service endpoint of specific
@@ -2573,6 +2699,9 @@ spec:
                           - url
                           type: object
                         type: array
+                        x-kubernetes-validations:
+                        - message: serviceEndpoints is immutable
+                          rule: self == oldSelf
                     required:
                     - controlPlaneOperatorCreds
                     - kubeCloudControllerCreds
@@ -2638,12 +2767,18 @@ spec:
                         description: AccountID is the IBMCloud account id. This field
                           is immutable. Once set, It can't be changed.
                         type: string
+                        x-kubernetes-validations:
+                        - message: accountID is immutable
+                          rule: self == oldSelf
                       cisInstanceCRN:
                         description: CISInstanceCRN is the IBMCloud CIS Service Instance's
                           Cloud Resource Name This field is immutable. Once set, It
                           can't be changed.
                         pattern: '^crn:'
                         type: string
+                        x-kubernetes-validations:
+                        - message: cisInstanceCRN is immutable
+                          rule: self == oldSelf
                       ingressOperatorCloudCreds:
                         description: IngressOperatorCloudCreds is a reference to a
                           secret containing ibm cloud credentials for ingress operator
@@ -2655,6 +2790,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressOperatorCloudCreds is immutable
+                          rule: self == oldSelf
                       kubeCloudControllerCreds:
                         description: "KubeCloudControllerCreds is a reference to a
                           secret containing cloud credentials with permissions matching
@@ -2668,6 +2806,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: kubeCloudControllerCreds is immutable
+                          rule: self == oldSelf
                       nodePoolManagementCreds:
                         description: "NodePoolManagementCreds is a reference to a
                           secret containing cloud credentials with permissions matching
@@ -2681,6 +2822,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: nodePoolManagementCreds is immutable
+                          rule: self == oldSelf
                       region:
                         description: Region is the IBMCloud region in which the cluster
                           resides. This configures the OCP control plane cloud integrations,
@@ -2688,11 +2832,17 @@ spec:
                           for a given release. This field is immutable. Once set,
                           It can't be changed.
                         type: string
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: self == oldSelf
                       resourceGroup:
                         description: ResourceGroup is the IBMCloud Resource Group
                           in which the cluster resides. This field is immutable. Once
                           set, It can't be changed.
                         type: string
+                        x-kubernetes-validations:
+                        - message: resourceGroup is immutable
+                          rule: self == oldSelf
                       serviceInstanceID:
                         description: "ServiceInstance is the reference to the Power
                           VS service on which the server instance(VM) will be created.
@@ -2704,6 +2854,9 @@ spec:
                           instance. https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server
                           \n This field is immutable. Once set, It can't be changed."
                         type: string
+                        x-kubernetes-validations:
+                        - message: serviceInstanceID is immutable
+                          rule: self == oldSelf
                       storageOperatorCloudCreds:
                         description: StorageOperatorCloudCreds is a reference to a
                           secret containing ibm cloud credentials for storage operator
@@ -2715,6 +2868,9 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: storageOperatorCloudCreds is immutable
+                          rule: self == oldSelf
                       subnet:
                         description: Subnet is the subnet to use for control plane
                           cloud resources. This field is immutable. Once set, It can't
@@ -2727,7 +2883,19 @@ spec:
                             description: Name of resource
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: subnet is immutable
+                          rule: self == oldSelf
                       vpc:
+                        allOf:
+                        - x-kubernetes-validations:
+                          - message: zone is required once set
+                            rule: '!has(oldSelf.zone) || has(self.zone)'
+                          - message: subnet is required once set
+                            rule: '!has(oldSelf.subnet) || has(self.subnet)'
+                        - x-kubernetes-validations:
+                          - message: vpc is immutable
+                            rule: self == oldSelf
                         description: VPC specifies IBM Cloud PowerVS Load Balancing
                           configuration for the control plane. This field is immutable.
                           Once set, It can't be changed.
@@ -2737,21 +2905,33 @@ spec:
                               load balancer. This field is immutable. Once set, It
                               can't be changed.
                             type: string
+                            x-kubernetes-validations:
+                            - message: name is immutable
+                              rule: self == oldSelf
                           region:
                             description: Region is the IBMCloud region in which VPC
                               gets created, this VPC used for all the ingress traffic
                               into the OCP cluster. This field is immutable. Once
                               set, It can't be changed.
                             type: string
+                            x-kubernetes-validations:
+                            - message: region is immutable
+                              rule: self == oldSelf
                           subnet:
                             description: Subnet is the subnet to use for load balancer.
                               This field is immutable. Once set, It can't be changed.
                             type: string
+                            x-kubernetes-validations:
+                            - message: subnet is immutable
+                              rule: self == oldSelf
                           zone:
                             description: Zone is the availability zone where load
                               balancer cloud resources are created. This field is
                               immutable. Once set, It can't be changed.
                             type: string
+                            x-kubernetes-validations:
+                            - message: zone is immutable
+                              rule: self == oldSelf
                         required:
                         - name
                         - region
@@ -2761,6 +2941,9 @@ spec:
                           cloud resources are created. This field is immutable. Once
                           set, It can't be changed.
                         type: string
+                        x-kubernetes-validations:
+                        - message: zone is immutable
+                          rule: self == oldSelf
                     required:
                     - accountID
                     - cisInstanceCRN
@@ -2787,9 +2970,19 @@ spec:
                     - Azure
                     - PowerVS
                     type: string
+                    x-kubernetes-validations:
+                    - message: type is immutable
+                      rule: self == oldSelf
                 required:
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: aws is required once set
+                  rule: '!has(oldSelf.aws) || has(self.aws)'
+                - message: agent is required once set
+                  rule: '!has(oldSelf.agent) || has(self.agent)'
+                - message: powervs is required once set
+                  rule: '!has(oldSelf.powervs) || has(self.powervs)'
               podCIDR:
                 description: deprecated use networking.ClusterNetwork
                 type: string
@@ -3046,6 +3239,9 @@ spec:
                       - Ignition
                       - OVNSbDb
                       type: string
+                      x-kubernetes-validations:
+                      - message: service is immutable
+                        rule: self == oldSelf
                     servicePublishingStrategy:
                       description: ServicePublishingStrategy specifies how to publish
                         Service.
@@ -3095,6 +3291,9 @@ spec:
                           - None
                           - S3
                           type: string
+                          x-kubernetes-validations:
+                          - message: type is immutable
+                            rule: self == oldSelf
                       required:
                       - type
                       type: object

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -20264,6 +20264,9 @@ objects:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                  - message: auditWebhook is immutable
+                    rule: self == oldSelf
                 autoscaling:
                   description: Autoscaling specifies auto-scaling behavior that applies
                     to all NodePools associated with the control plane.
@@ -20305,8 +20308,12 @@ objects:
                     identifies the cluster in metrics pushed to telemetry and metrics
                     produced by the control plane operators. If a value is not specified,
                     an ID is generated. After initial creation, the value is immutable.
+                  maxLength: 40
                   pattern: '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
                   type: string
+                  x-kubernetes-validations:
+                  - message: clusterID is immutable
+                    rule: self == oldSelf
                 configuration:
                   description: Configuration specifies configuration for individual
                     OCP components in the cluster, represented as embedded resources
@@ -22128,24 +22135,39 @@ objects:
                     policy applied to critical control plane components. The default
                     value is SingleReplica.
                   type: string
+                  x-kubernetes-validations:
+                  - message: controllerAvailabilityPolicy is immutable
+                    rule: self == oldSelf
                 dns:
                   description: DNS specifies DNS configuration for the cluster.
                   properties:
                     baseDomain:
                       description: BaseDomain is the base domain of the cluster.
                       type: string
+                      x-kubernetes-validations:
+                      - message: baseDomain is immutable
+                        rule: self == oldSelf
                     privateZoneID:
                       description: PrivateZoneID is the Hosted Zone ID where all the
                         DNS records that are only available internally to the cluster
                         exist.
                       type: string
+                      x-kubernetes-validations:
+                      - message: privateZoneID is immutable
+                        rule: self == oldSelf
                     publicZoneID:
                       description: PublicZoneID is the Hosted Zone ID where all the
                         DNS records that are publicly accessible to the internet exist.
                       type: string
+                      x-kubernetes-validations:
+                      - message: publicZoneID is immutable
+                        rule: self == oldSelf
                   required:
                   - baseDomain
                   type: object
+                  x-kubernetes-validations:
+                  - message: dns is immutable
+                    rule: self == oldSelf
                 etcd:
                   default:
                     managed:
@@ -22186,6 +22208,9 @@ objects:
                                     of the data volume for each etcd member. \n See
                                     https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1."
                                   type: string
+                                  x-kubernetes-validations:
+                                  - message: storageClassName is immutable
+                                    rule: self == oldSelf
                               type: object
                             restoreSnapshotURL:
                               description: RestoreSnapshotURL allows an optional list
@@ -22197,12 +22222,18 @@ objects:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-validations:
+                              - message: restoreSnapshotURL is immutable
+                                rule: self == oldSelf
                             type:
                               description: Type is the kind of persistent storage
                                 implementation to use for etcd.
                               enum:
                               - PersistentVolume
                               type: string
+                              x-kubernetes-validations:
+                              - message: type is immutable
+                                rule: self == oldSelf
                           required:
                           - type
                           type: object
@@ -22256,12 +22287,18 @@ objects:
                   required:
                   - managementType
                   type: object
+                  x-kubernetes-validations:
+                  - message: etcd is immutable
+                    rule: self == oldSelf
                 fips:
                   description: FIPS indicates whether this cluster's nodes will be
                     running in FIPS mode. If set to true, the control plane's ignition
                     server will be configured to expect that nodes joining the cluster
                     will be FIPS-enabled.
                   type: boolean
+                  x-kubernetes-validations:
+                  - message: fips is immutable
+                    rule: self == oldSelf
                 imageContentSources:
                   description: ImageContentSources specifies image mirrors that can
                     be used by cluster nodes to pull content.
@@ -22278,25 +22315,41 @@ objects:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-validations:
+                        - message: mirrors is immutable
+                          rule: self == oldSelf
                       source:
                         description: Source is the repository that users refer to,
                           e.g. in image pull specifications.
                         type: string
+                        x-kubernetes-validations:
+                        - message: source is immutable
+                          rule: self == oldSelf
                     required:
                     - source
                     type: object
                   type: array
+                  x-kubernetes-validations:
+                  - message: imageContentSources is immutable
+                    rule: self == oldSelf
                 infraID:
                   description: InfraID is a globally unique identifier for the cluster.
                     This identifier will be used to associate various cloud resources
                     with the HostedCluster and its associated NodePools.
+                  maxLength: 1024
                   type: string
+                  x-kubernetes-validations:
+                  - message: infraID is immutable
+                    rule: self == oldSelf
                 infrastructureAvailabilityPolicy:
                   default: SingleReplica
                   description: InfrastructureAvailabilityPolicy specifies the availability
                     policy applied to infrastructure services which run on cluster
                     nodes. The default value is SingleReplica.
                   type: string
+                  x-kubernetes-validations:
+                  - message: infrastructureAvailabilityPolicy is immutable
+                    rule: self == oldSelf
                 issuerURL:
                   default: https://kubernetes.default.svc
                   description: IssuerURL is an OIDC issuer URL which is used as the
@@ -22305,6 +22358,9 @@ objects:
                     only works for in-cluster validation.
                   format: uri
                   type: string
+                  x-kubernetes-validations:
+                  - message: issuerURL is immutable
+                    rule: self == oldSelf
                 networking:
                   description: Networking specifies network configuration for the
                     cluster.
@@ -22337,6 +22393,9 @@ objects:
                           format: int32
                           type: integer
                       type: object
+                      x-kubernetes-validations:
+                      - message: apiServer is immutable
+                        rule: self == oldSelf
                     clusterNetwork:
                       description: 'ClusterNetwork is the list of IP address pools
                         for pods. TODO: make this required in the next version of
@@ -22359,11 +22418,17 @@ objects:
                         - cidr
                         type: object
                       type: array
+                      x-kubernetes-validations:
+                      - message: clusterNetwork is immutable
+                        rule: self == oldSelf
                     machineCIDR:
                       description: Deprecated This field will be removed in the next
                         API release. Use MachineNetwork instead
                       format: cidr
                       type: string
+                      x-kubernetes-validations:
+                      - message: machineCIDR is immutable
+                        rule: self == oldSelf
                     machineNetwork:
                       description: 'MachineNetwork is the list of IP address pools
                         for machines. TODO: make this required in the next version
@@ -22380,6 +22445,9 @@ objects:
                         - cidr
                         type: object
                       type: array
+                      x-kubernetes-validations:
+                      - message: machineNetwork is immutable
+                        rule: self == oldSelf
                     networkType:
                       default: OVNKubernetes
                       description: NetworkType specifies the SDN provider used for
@@ -22390,16 +22458,25 @@ objects:
                       - OVNKubernetes
                       - Other
                       type: string
+                      x-kubernetes-validations:
+                      - message: networkType is immutable
+                        rule: self == oldSelf
                     podCIDR:
                       description: Deprecated This field will be removed in the next
                         API release. Use ClusterNetwork instead
                       format: cidr
                       type: string
+                      x-kubernetes-validations:
+                      - message: podCIDR is immutable
+                        rule: self == oldSelf
                     serviceCIDR:
                       description: Deprecated This field will be removed in the next
                         API release. Use ServiceNetwork instead
                       format: cidr
                       type: string
+                      x-kubernetes-validations:
+                      - message: serviceCIDR is immutable
+                        rule: self == oldSelf
                     serviceNetwork:
                       description: 'ServiceNetwork is the list of IP address pools
                         for services. NOTE: currently only one entry is supported.
@@ -22416,9 +22493,15 @@ objects:
                         - cidr
                         type: object
                       type: array
+                      x-kubernetes-validations:
+                      - message: serviceNetwork is immutable
+                        rule: self == oldSelf
                   required:
                   - networkType
                   type: object
+                  x-kubernetes-validations:
+                  - message: networking is immutable
+                    rule: self == oldSelf
                 nodeSelector:
                   additionalProperties:
                     type: string
@@ -22436,6 +22519,9 @@ objects:
                   - management
                   - guest
                   type: string
+                  x-kubernetes-validations:
+                  - message: olmCatalogPlacement is immutable
+                    rule: self == oldSelf
                 pausedUntil:
                   description: 'PausedUntil is a field that can be used to pause reconciliation
                     on a resource. Either a date can be provided in RFC3339 format
@@ -22457,6 +22543,9 @@ objects:
                       required:
                       - agentNamespace
                       type: object
+                      x-kubernetes-validations:
+                      - message: agent is immutable
+                        rule: self == oldSelf
                     aws:
                       description: AWS specifies configuration for clusters running
                         on Amazon Web Services.
@@ -22512,6 +22601,9 @@ objects:
                           required:
                           - vpc
                           type: object
+                          x-kubernetes-validations:
+                          - message: cloudProviderConfig is immutable
+                            rule: self == oldSelf
                         controlPlaneOperatorCreds:
                           description: Deprecated This field will be removed in the
                             next API release. Use RolesRef instead.
@@ -22522,6 +22614,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: controlPlaneOperatorCreds is immutable
+                            rule: self == oldSelf
                         endpointAccess:
                           default: Public
                           description: EndpointAccess specifies the publishing scope
@@ -22541,6 +22636,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: kubeCloudControllerCreds is immutable
+                            rule: self == oldSelf
                         nodePoolManagementCreds:
                           description: Deprecated This field will be removed in the
                             next API release. Use RolesRef instead.
@@ -22551,12 +22649,18 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: nodePoolManagementCreds is immutable
+                            rule: self == oldSelf
                         region:
                           description: Region is the AWS region in which the cluster
                             resides. This configures the OCP control plane cloud integrations,
                             and is used by NodePool to resolve the correct boot AMI
                             for a given release.
                           type: string
+                          x-kubernetes-validations:
+                          - message: region is immutable
+                            rule: self == oldSelf
                         resourceTags:
                           description: ResourceTags is a list of additional tags to
                             apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
@@ -22610,6 +22714,9 @@ objects:
                             - namespace
                             type: object
                           type: array
+                          x-kubernetes-validations:
+                          - message: roles is immutable
+                            rule: self == oldSelf
                         rolesRef:
                           description: RolesRef contains references to various AWS
                             IAM roles required to enable integrations such as OIDC.
@@ -22627,6 +22734,9 @@ objects:
                                 [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
                                 ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
                               type: string
+                              x-kubernetes-validations:
+                              - message: controlPlaneOperatorARN is immutable
+                                rule: self == oldSelf
                             imageRegistryARN:
                               description: "ImageRegistryARN is an ARN value referencing
                                 a role appropriate for the Image Registry Operator.
@@ -22699,6 +22809,9 @@ objects:
                                 ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\"
                                 } ] }"
                               type: string
+                              x-kubernetes-validations:
+                              - message: kubeCloudControllerARN is immutable
+                                rule: self == oldSelf
                             networkARN:
                               description: "NetworkARN is an ARN value referencing
                                 a role appropriate for the Network Operator. \n The
@@ -22748,6 +22861,9 @@ objects:
                                 ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                                 ], \"Effect\": \"Allow\" } ] }"
                               type: string
+                              x-kubernetes-validations:
+                              - message: nodePoolManagementARN is immutable
+                                rule: self == oldSelf
                             storageARN:
                               description: "StorageARN is an ARN value referencing
                                 a role appropriate for the Storage Operator. \n The
@@ -22770,6 +22886,9 @@ objects:
                           - nodePoolManagementARN
                           - storageARN
                           type: object
+                          x-kubernetes-validations:
+                          - message: rolesRef is immutable
+                            rule: self == oldSelf
                         serviceEndpoints:
                           description: "ServiceEndpoints specifies optional custom
                             endpoints which will override the default service endpoint
@@ -22795,6 +22914,9 @@ objects:
                             - url
                             type: object
                           type: array
+                          x-kubernetes-validations:
+                          - message: serviceEndpoints is immutable
+                            rule: self == oldSelf
                       required:
                       - controlPlaneOperatorCreds
                       - kubeCloudControllerCreds
@@ -22802,6 +22924,9 @@ objects:
                       - region
                       - rolesRef
                       type: object
+                      x-kubernetes-validations:
+                      - message: aws is immutable
+                        rule: self == oldSelf
                     azure:
                       description: Azure defines azure specific settings
                       properties:
@@ -22861,12 +22986,18 @@ objects:
                           description: AccountID is the IBMCloud account id. This
                             field is immutable. Once set, It can't be changed.
                           type: string
+                          x-kubernetes-validations:
+                          - message: accountID is immutable
+                            rule: self == oldSelf
                         cisInstanceCRN:
                           description: CISInstanceCRN is the IBMCloud CIS Service
                             Instance's Cloud Resource Name This field is immutable.
                             Once set, It can't be changed.
                           pattern: '^crn:'
                           type: string
+                          x-kubernetes-validations:
+                          - message: cisInstanceCRN is immutable
+                            rule: self == oldSelf
                         ingressOperatorCloudCreds:
                           description: IngressOperatorCloudCreds is a reference to
                             a secret containing ibm cloud credentials for ingress
@@ -22878,6 +23009,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: ingressOperatorCloudCreds is immutable
+                            rule: self == oldSelf
                         kubeCloudControllerCreds:
                           description: "KubeCloudControllerCreds is a reference to
                             a secret containing cloud credentials with permissions
@@ -22891,6 +23025,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: kubeCloudControllerCreds is immutable
+                            rule: self == oldSelf
                         nodePoolManagementCreds:
                           description: "NodePoolManagementCreds is a reference to
                             a secret containing cloud credentials with permissions
@@ -22904,6 +23041,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: nodePoolManagementCreds is immutable
+                            rule: self == oldSelf
                         region:
                           description: Region is the IBMCloud region in which the
                             cluster resides. This configures the OCP control plane
@@ -22911,11 +23051,17 @@ objects:
                             the correct boot image for a given release. This field
                             is immutable. Once set, It can't be changed.
                           type: string
+                          x-kubernetes-validations:
+                          - message: region is immutable
+                            rule: self == oldSelf
                         resourceGroup:
                           description: ResourceGroup is the IBMCloud Resource Group
                             in which the cluster resides. This field is immutable.
                             Once set, It can't be changed.
                           type: string
+                          x-kubernetes-validations:
+                          - message: resourceGroup is immutable
+                            rule: self == oldSelf
                         serviceInstanceID:
                           description: "ServiceInstance is the reference to the Power
                             VS service on which the server instance(VM) will be created.
@@ -22927,6 +23073,9 @@ objects:
                             VS service instance. https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server
                             \n This field is immutable. Once set, It can't be changed."
                           type: string
+                          x-kubernetes-validations:
+                          - message: serviceInstanceID is immutable
+                            rule: self == oldSelf
                         storageOperatorCloudCreds:
                           description: StorageOperatorCloudCreds is a reference to
                             a secret containing ibm cloud credentials for storage
@@ -22938,6 +23087,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: storageOperatorCloudCreds is immutable
+                            rule: self == oldSelf
                         subnet:
                           description: Subnet is the subnet to use for control plane
                             cloud resources. This field is immutable. Once set, It
@@ -22950,6 +23102,9 @@ objects:
                               description: Name of resource
                               type: string
                           type: object
+                          x-kubernetes-validations:
+                          - message: subnet is immutable
+                            rule: self == oldSelf
                         vpc:
                           description: VPC specifies IBM Cloud PowerVS Load Balancing
                             configuration for the control plane. This field is immutable.
@@ -22960,30 +23115,48 @@ objects:
                                 load balancer. This field is immutable. Once set,
                                 It can't be changed.
                               type: string
+                              x-kubernetes-validations:
+                              - message: name is immutable
+                                rule: self == oldSelf
                             region:
                               description: Region is the IBMCloud region in which
                                 VPC gets created, this VPC used for all the ingress
                                 traffic into the OCP cluster. This field is immutable.
                                 Once set, It can't be changed.
                               type: string
+                              x-kubernetes-validations:
+                              - message: region is immutable
+                                rule: self == oldSelf
                             subnet:
                               description: Subnet is the subnet to use for load balancer.
                                 This field is immutable. Once set, It can't be changed.
                               type: string
+                              x-kubernetes-validations:
+                              - message: subnet is immutable
+                                rule: self == oldSelf
                             zone:
                               description: Zone is the availability zone where load
                                 balancer cloud resources are created. This field is
                                 immutable. Once set, It can't be changed.
                               type: string
+                              x-kubernetes-validations:
+                              - message: zone is immutable
+                                rule: self == oldSelf
                           required:
                           - name
                           - region
                           type: object
+                          x-kubernetes-validations:
+                          - message: vpc is immutable
+                            rule: self == oldSelf
                         zone:
                           description: Zone is the availability zone where control
                             plane cloud resources are created. This field is immutable.
                             Once set, It can't be changed.
                           type: string
+                          x-kubernetes-validations:
+                          - message: zone is immutable
+                            rule: self == oldSelf
                       required:
                       - accountID
                       - cisInstanceCRN
@@ -23010,9 +23183,15 @@ objects:
                       - Azure
                       - PowerVS
                       type: string
+                      x-kubernetes-validations:
+                      - message: type is immutable
+                        rule: self == oldSelf
                   required:
                   - type
                   type: object
+                  x-kubernetes-validations:
+                  - message: platform is immutable
+                    rule: self == oldSelf
                 pullSecret:
                   description: PullSecret references a pull secret to be injected
                     into the container runtime of all cluster nodes. The secret must
@@ -23259,6 +23438,9 @@ objects:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                  - message: serviceAccountSigningKey is immutable
+                    rule: self == oldSelf
                 services:
                   description: "Services specifies how individual control plane services
                     are published from the hosting cluster of the control plane. \n
@@ -23280,6 +23462,9 @@ objects:
                         - Ignition
                         - OVNSbDb
                         type: string
+                        x-kubernetes-validations:
+                        - message: service is immutable
+                          rule: self == oldSelf
                       servicePublishingStrategy:
                         description: ServicePublishingStrategy specifies how to publish
                           Service.
@@ -23329,6 +23514,9 @@ objects:
                             - None
                             - S3
                             type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable
+                              rule: self == oldSelf
                         required:
                         - type
                         type: object
@@ -23348,6 +23536,9 @@ objects:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                  - message: sshKey is immutable
+                    rule: self == oldSelf
               required:
               - networking
               - platform
@@ -23356,6 +23547,11 @@ objects:
               - services
               - sshKey
               type: object
+              x-kubernetes-validations:
+              - message: clusterID is required once set
+                rule: '!has(oldSelf.clusterID) || has(self.clusterID)'
+              - message: infraID is required once set
+                rule: '!has(oldSelf.infraID) || has(self.infraID)'
             status:
               description: Status is the latest observed status of the HostedCluster.
               properties:
@@ -25529,15 +25725,24 @@ objects:
                     baseDomain:
                       description: BaseDomain is the base domain of the cluster.
                       type: string
+                      x-kubernetes-validations:
+                      - message: baseDomain is immutable
+                        rule: self == oldSelf
                     privateZoneID:
                       description: PrivateZoneID is the Hosted Zone ID where all the
                         DNS records that are only available internally to the cluster
                         exist.
                       type: string
+                      x-kubernetes-validations:
+                      - message: privateZoneID is immutable
+                        rule: self == oldSelf
                     publicZoneID:
                       description: PublicZoneID is the Hosted Zone ID where all the
                         DNS records that are publicly accessible to the internet exist.
                       type: string
+                      x-kubernetes-validations:
+                      - message: publicZoneID is immutable
+                        rule: self == oldSelf
                   required:
                   - baseDomain
                   type: object
@@ -25573,6 +25778,9 @@ objects:
                                     of the data volume for each etcd member. \n See
                                     https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1."
                                   type: string
+                                  x-kubernetes-validations:
+                                  - message: storageClassName is immutable
+                                    rule: self == oldSelf
                               type: object
                             restoreSnapshotURL:
                               description: RestoreSnapshotURL allows an optional list
@@ -25584,12 +25792,18 @@ objects:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-validations:
+                              - message: restoreSnapshotURL is immutable
+                                rule: self == oldSelf
                             type:
                               description: Type is the kind of persistent storage
                                 implementation to use for etcd.
                               enum:
                               - PersistentVolume
                               type: string
+                              x-kubernetes-validations:
+                              - message: type is immutable
+                                rule: self == oldSelf
                           required:
                           - type
                           type: object
@@ -25663,10 +25877,16 @@ objects:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-validations:
+                        - message: mirrors is immutable
+                          rule: self == oldSelf
                       source:
                         description: Source is the repository that users refer to,
                           e.g. in image pull specifications.
                         type: string
+                        x-kubernetes-validations:
+                        - message: source is immutable
+                          rule: self == oldSelf
                     required:
                     - source
                     type: object
@@ -25742,6 +25962,9 @@ objects:
                           format: int32
                           type: integer
                       type: object
+                      x-kubernetes-validations:
+                      - message: apiServer is immutable
+                        rule: self == oldSelf
                     clusterNetwork:
                       description: 'ClusterNetwork is the list of IP address pools
                         for pods. TODO: make this required in the next version of
@@ -25764,11 +25987,17 @@ objects:
                         - cidr
                         type: object
                       type: array
+                      x-kubernetes-validations:
+                      - message: clusterNetwork is immutable
+                        rule: self == oldSelf
                     machineCIDR:
                       description: Deprecated This field will be removed in the next
                         API release. Use MachineNetwork instead
                       format: cidr
                       type: string
+                      x-kubernetes-validations:
+                      - message: machineCIDR is immutable
+                        rule: self == oldSelf
                     machineNetwork:
                       description: 'MachineNetwork is the list of IP address pools
                         for machines. TODO: make this required in the next version
@@ -25785,6 +26014,9 @@ objects:
                         - cidr
                         type: object
                       type: array
+                      x-kubernetes-validations:
+                      - message: machineNetwork is immutable
+                        rule: self == oldSelf
                     networkType:
                       default: OVNKubernetes
                       description: NetworkType specifies the SDN provider used for
@@ -25795,16 +26027,25 @@ objects:
                       - OVNKubernetes
                       - Other
                       type: string
+                      x-kubernetes-validations:
+                      - message: networkType is immutable
+                        rule: self == oldSelf
                     podCIDR:
                       description: Deprecated This field will be removed in the next
                         API release. Use ClusterNetwork instead
                       format: cidr
                       type: string
+                      x-kubernetes-validations:
+                      - message: podCIDR is immutable
+                        rule: self == oldSelf
                     serviceCIDR:
                       description: Deprecated This field will be removed in the next
                         API release. Use ServiceNetwork instead
                       format: cidr
                       type: string
+                      x-kubernetes-validations:
+                      - message: serviceCIDR is immutable
+                        rule: self == oldSelf
                     serviceNetwork:
                       description: 'ServiceNetwork is the list of IP address pools
                         for services. NOTE: currently only one entry is supported.
@@ -25821,6 +26062,9 @@ objects:
                         - cidr
                         type: object
                       type: array
+                      x-kubernetes-validations:
+                      - message: serviceNetwork is immutable
+                        rule: self == oldSelf
                   required:
                   - networkType
                   type: object
@@ -25863,6 +26107,9 @@ objects:
                       required:
                       - agentNamespace
                       type: object
+                      x-kubernetes-validations:
+                      - message: agent is immutable
+                        rule: self == oldSelf
                     aws:
                       description: AWS specifies configuration for clusters running
                         on Amazon Web Services.
@@ -25918,6 +26165,9 @@ objects:
                           required:
                           - vpc
                           type: object
+                          x-kubernetes-validations:
+                          - message: cloudProviderConfig is immutable
+                            rule: self == oldSelf
                         controlPlaneOperatorCreds:
                           description: Deprecated This field will be removed in the
                             next API release. Use RolesRef instead.
@@ -25928,6 +26178,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: controlPlaneOperatorCreds is immutable
+                            rule: self == oldSelf
                         endpointAccess:
                           default: Public
                           description: EndpointAccess specifies the publishing scope
@@ -25947,6 +26200,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: kubeCloudControllerCreds is immutable
+                            rule: self == oldSelf
                         nodePoolManagementCreds:
                           description: Deprecated This field will be removed in the
                             next API release. Use RolesRef instead.
@@ -25957,12 +26213,18 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: nodePoolManagementCreds is immutable
+                            rule: self == oldSelf
                         region:
                           description: Region is the AWS region in which the cluster
                             resides. This configures the OCP control plane cloud integrations,
                             and is used by NodePool to resolve the correct boot AMI
                             for a given release.
                           type: string
+                          x-kubernetes-validations:
+                          - message: region is immutable
+                            rule: self == oldSelf
                         resourceTags:
                           description: ResourceTags is a list of additional tags to
                             apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
@@ -26016,6 +26278,9 @@ objects:
                             - namespace
                             type: object
                           type: array
+                          x-kubernetes-validations:
+                          - message: roles is immutable
+                            rule: self == oldSelf
                         rolesRef:
                           description: RolesRef contains references to various AWS
                             IAM roles required to enable integrations such as OIDC.
@@ -26033,6 +26298,9 @@ objects:
                                 [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
                                 ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
                               type: string
+                              x-kubernetes-validations:
+                              - message: controlPlaneOperatorARN is immutable
+                                rule: self == oldSelf
                             imageRegistryARN:
                               description: "ImageRegistryARN is an ARN value referencing
                                 a role appropriate for the Image Registry Operator.
@@ -26105,6 +26373,9 @@ objects:
                                 ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\"
                                 } ] }"
                               type: string
+                              x-kubernetes-validations:
+                              - message: kubeCloudControllerARN is immutable
+                                rule: self == oldSelf
                             networkARN:
                               description: "NetworkARN is an ARN value referencing
                                 a role appropriate for the Network Operator. \n The
@@ -26154,6 +26425,9 @@ objects:
                                 ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                                 ], \"Effect\": \"Allow\" } ] }"
                               type: string
+                              x-kubernetes-validations:
+                              - message: nodePoolManagementARN is immutable
+                                rule: self == oldSelf
                             storageARN:
                               description: "StorageARN is an ARN value referencing
                                 a role appropriate for the Storage Operator. \n The
@@ -26176,6 +26450,9 @@ objects:
                           - nodePoolManagementARN
                           - storageARN
                           type: object
+                          x-kubernetes-validations:
+                          - message: rolesRef is immutable
+                            rule: self == oldSelf
                         serviceEndpoints:
                           description: "ServiceEndpoints specifies optional custom
                             endpoints which will override the default service endpoint
@@ -26201,6 +26478,9 @@ objects:
                             - url
                             type: object
                           type: array
+                          x-kubernetes-validations:
+                          - message: serviceEndpoints is immutable
+                            rule: self == oldSelf
                       required:
                       - controlPlaneOperatorCreds
                       - kubeCloudControllerCreds
@@ -26208,6 +26488,9 @@ objects:
                       - region
                       - rolesRef
                       type: object
+                      x-kubernetes-validations:
+                      - message: aws is immutable
+                        rule: self == oldSelf
                     azure:
                       description: Azure defines azure specific settings
                       properties:
@@ -26267,12 +26550,18 @@ objects:
                           description: AccountID is the IBMCloud account id. This
                             field is immutable. Once set, It can't be changed.
                           type: string
+                          x-kubernetes-validations:
+                          - message: accountID is immutable
+                            rule: self == oldSelf
                         cisInstanceCRN:
                           description: CISInstanceCRN is the IBMCloud CIS Service
                             Instance's Cloud Resource Name This field is immutable.
                             Once set, It can't be changed.
                           pattern: '^crn:'
                           type: string
+                          x-kubernetes-validations:
+                          - message: cisInstanceCRN is immutable
+                            rule: self == oldSelf
                         ingressOperatorCloudCreds:
                           description: IngressOperatorCloudCreds is a reference to
                             a secret containing ibm cloud credentials for ingress
@@ -26284,6 +26573,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: ingressOperatorCloudCreds is immutable
+                            rule: self == oldSelf
                         kubeCloudControllerCreds:
                           description: "KubeCloudControllerCreds is a reference to
                             a secret containing cloud credentials with permissions
@@ -26297,6 +26589,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: kubeCloudControllerCreds is immutable
+                            rule: self == oldSelf
                         nodePoolManagementCreds:
                           description: "NodePoolManagementCreds is a reference to
                             a secret containing cloud credentials with permissions
@@ -26310,6 +26605,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: nodePoolManagementCreds is immutable
+                            rule: self == oldSelf
                         region:
                           description: Region is the IBMCloud region in which the
                             cluster resides. This configures the OCP control plane
@@ -26317,11 +26615,17 @@ objects:
                             the correct boot image for a given release. This field
                             is immutable. Once set, It can't be changed.
                           type: string
+                          x-kubernetes-validations:
+                          - message: region is immutable
+                            rule: self == oldSelf
                         resourceGroup:
                           description: ResourceGroup is the IBMCloud Resource Group
                             in which the cluster resides. This field is immutable.
                             Once set, It can't be changed.
                           type: string
+                          x-kubernetes-validations:
+                          - message: resourceGroup is immutable
+                            rule: self == oldSelf
                         serviceInstanceID:
                           description: "ServiceInstance is the reference to the Power
                             VS service on which the server instance(VM) will be created.
@@ -26333,6 +26637,9 @@ objects:
                             VS service instance. https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server
                             \n This field is immutable. Once set, It can't be changed."
                           type: string
+                          x-kubernetes-validations:
+                          - message: serviceInstanceID is immutable
+                            rule: self == oldSelf
                         storageOperatorCloudCreds:
                           description: StorageOperatorCloudCreds is a reference to
                             a secret containing ibm cloud credentials for storage
@@ -26344,6 +26651,9 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: storageOperatorCloudCreds is immutable
+                            rule: self == oldSelf
                         subnet:
                           description: Subnet is the subnet to use for control plane
                             cloud resources. This field is immutable. Once set, It
@@ -26356,6 +26666,9 @@ objects:
                               description: Name of resource
                               type: string
                           type: object
+                          x-kubernetes-validations:
+                          - message: subnet is immutable
+                            rule: self == oldSelf
                         vpc:
                           description: VPC specifies IBM Cloud PowerVS Load Balancing
                             configuration for the control plane. This field is immutable.
@@ -26366,30 +26679,48 @@ objects:
                                 load balancer. This field is immutable. Once set,
                                 It can't be changed.
                               type: string
+                              x-kubernetes-validations:
+                              - message: name is immutable
+                                rule: self == oldSelf
                             region:
                               description: Region is the IBMCloud region in which
                                 VPC gets created, this VPC used for all the ingress
                                 traffic into the OCP cluster. This field is immutable.
                                 Once set, It can't be changed.
                               type: string
+                              x-kubernetes-validations:
+                              - message: region is immutable
+                                rule: self == oldSelf
                             subnet:
                               description: Subnet is the subnet to use for load balancer.
                                 This field is immutable. Once set, It can't be changed.
                               type: string
+                              x-kubernetes-validations:
+                              - message: subnet is immutable
+                                rule: self == oldSelf
                             zone:
                               description: Zone is the availability zone where load
                                 balancer cloud resources are created. This field is
                                 immutable. Once set, It can't be changed.
                               type: string
+                              x-kubernetes-validations:
+                              - message: zone is immutable
+                                rule: self == oldSelf
                           required:
                           - name
                           - region
                           type: object
+                          x-kubernetes-validations:
+                          - message: vpc is immutable
+                            rule: self == oldSelf
                         zone:
                           description: Zone is the availability zone where control
                             plane cloud resources are created. This field is immutable.
                             Once set, It can't be changed.
                           type: string
+                          x-kubernetes-validations:
+                          - message: zone is immutable
+                            rule: self == oldSelf
                       required:
                       - accountID
                       - cisInstanceCRN
@@ -26416,6 +26747,9 @@ objects:
                       - Azure
                       - PowerVS
                       type: string
+                      x-kubernetes-validations:
+                      - message: type is immutable
+                        rule: self == oldSelf
                   required:
                   - type
                   type: object
@@ -26677,6 +27011,9 @@ objects:
                         - Ignition
                         - OVNSbDb
                         type: string
+                        x-kubernetes-validations:
+                        - message: service is immutable
+                          rule: self == oldSelf
                       servicePublishingStrategy:
                         description: ServicePublishingStrategy specifies how to publish
                           Service.
@@ -26726,6 +27063,9 @@ objects:
                             - None
                             - S3
                             type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable
+                              rule: self == oldSelf
                         required:
                         - type
                         type: object


### PR DESCRIPTION
This uses CEL validations available in kubernetes 1.25 and above, requiring OpenShift 4.12 or greater.  Tested with OpenShift 4.10 and while the validations do not work, they are also ignored so it should be safe to have them in place for all versions.

