### PR TITLE
Update filter for listing ec2 private nodes

### DIFF
--- a/docs/content/how-to/aws/deploy-aws-private-clusters.md
+++ b/docs/content/how-to/aws/deploy-aws-private-clusters.md
@@ -173,7 +173,7 @@ hypershift create bastion aws --aws-creds=$AWS_CREDS --infra-id=$INFRA_ID --regi
 Find the private IPs of nodes in the cluster's NodePool.
 
 ```shell
-aws ec2 describe-instances --filter="Name=tag:kubernetes.io/cluster/$CLUSTER_NAME,Values=owned" | jq '.Reservations[] | .Instances[] | select(.PublicDnsName=="") | .PrivateIpAddress'
+aws ec2 describe-instances --filter="Name=tag:kubernetes.io/cluster/$INFRA_ID,Values=owned" | jq '.Reservations[] | .Instances[] | select(.PublicDnsName=="") | .PrivateIpAddress'
 ```
 
 Create a kubeconfig for the cluster which can be copied to a node.


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR fixes a command to find private node IP addresses by a filter to use `$INFRA_ID` instead of `$CLUSTER_NAME` in the tag name

Signed-off-by: Moti Asayag <masayag@redhat.com>


**Which issue(s) this PR fixes** *:
Fixes https://github.com/openshift/hypershift/issues/1904

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.