### PR TITLE
Add AllMachinesReady and AllNodesHealthy conditions to NodePool

### DIFF
--- a/hypershift-operator/controllers/nodepool/conditions.go
+++ b/hypershift-operator/controllers/nodepool/conditions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -18,6 +19,9 @@ const (
 )
 
 // These are copies pf metav1.Condition to accept hyperv1.NodePoolCondition
+// We use differnt conditions struct to relax metav1 input validation.
+// We want to relax validation to ease bubbling up from CAPI which uses their own type not honouring metav1 validations, particularly "Reason" accepts pretty much free string.
+// TODO (alberto): work upstream towards consolidation and programmatic Reasons.
 
 // setStatusCondition sets the corresponding condition in conditions to newCondition.
 // conditions must be non-nil.
@@ -70,6 +74,17 @@ func removeStatusCondition(conditions *[]hyperv1.NodePoolCondition, conditionTyp
 
 // findStatusCondition finds the conditionType in conditions.
 func findStatusCondition(conditions []hyperv1.NodePoolCondition, conditionType string) *hyperv1.NodePoolCondition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+
+	return nil
+}
+
+// findStatusCondition finds the conditionType in conditions.
+func findCAPIStatusCondition(conditions []capiv1.Condition, conditionType capiv1.ConditionType) *capiv1.Condition {
 	for i := range conditions {
 		if conditions[i].Type == conditionType {
 			return &conditions[i]


### PR DESCRIPTION
At the moment if the infra for a Machine or the software for a Node fail to operate it's completely transparent for NodePool API consumers.
We need to solve agreggation upstream:
https://github.com/kubernetes-sigs/cluster-api/pull/6218
https://github.com/kubernetes-sigs/cluster-api/pull/6025

This PR is a stopgap to mitigate the above and facilitate reaction and decisions for NodePool consumers.

Examples
In progesss:
```
- lastTransitionTime: "2022-11-30T09:03:08Z"
message: |
Machine agl-nested-us-east-1a-6d9fcd6565-n5lpf: InstanceProvisionStarted
Machine agl-nested-us-east-1a-6d9fcd6565-k872l: InstanceProvisionStarted
observedGeneration: 6
reason: InstanceProvisionStarted
status: "False"
type: AllMachinesReady
- lastTransitionTime: "2022-11-30T09:03:08Z"
message: |
Machine agl-nested-us-east-1a-6d9fcd6565-n5lpf: WaitingForNodeRef
Machine agl-nested-us-east-1a-6d9fcd6565-k872l: WaitingForNodeRef
observedGeneration: 6
reason: WaitingForNodeRef
status: "False"
type: AllNodesHealthy
```

```
- lastTransitionTime: "2022-11-30T09:03:27Z"
message: All is well
observedGeneration: 6
reason: AsExpected
status: "True"
type: AllMachinesReady
- lastTransitionTime: "2022-11-30T09:03:08Z"
message: |
Machine agl-nested-us-east-1a-6d9fcd6565-n5lpf: NodeProvisioning
Machine agl-nested-us-east-1a-6d9fcd6565-k872l: NodeProvisioning
observedGeneration: 6
reason: NodeProvisioning
status: "False"
type: AllNodesHealthy
```

Failure - Instance terminated out of band
```
- lastTransitionTime: "2022-11-30T09:10:59Z"
message: |
Machine agl-nested-us-east-1a-6d9fcd6565-k872l: InstanceTerminated
observedGeneration: 6
reason: InstanceTerminated
status: "False"
type: AllMachinesReady
- lastTransitionTime: "2022-11-30T09:10:59Z"
message: |
Machine agl-nested-us-east-1a-6d9fcd6565-k872l: NodeConditionsFailed
observedGeneration: 6
reason: NodeConditionsFailed
status: "False"
type: AllNodesHealthy
```
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Ref https://issues.redhat.com/browse/HOSTEDCP-647

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.