### PR TITLE
Add ValidIdentityProvider condition

### DIFF
--- a/api/v1beta1/hostedcluster_conditions.go
+++ b/api/v1beta1/hostedcluster_conditions.go
@@ -87,6 +87,27 @@ const (
 	// A failure here is unlikely to resolve without the changing user input.
 	ValidReleaseImage ConditionType = "ValidReleaseImage"
 
+	// ValidAWSIdentityProvider indicates if the Identity Provider referenced
+	// in the cloud credentials is healthy. E.g. for AWS the idp ARN is referenced in the iam roles.
+	// 		"Version": "2012-10-17",
+	//		"Statement": [
+	//			{
+	//				"Effect": "Allow",
+	//				"Principal": {
+	//					"Federated": "{{ .ProviderARN }}"
+	//				},
+	//					"Action": "sts:AssumeRoleWithWebIdentity",
+	//				"Condition": {
+	//					"StringEquals": {
+	//						"{{ .ProviderName }}:sub": {{ .ServiceAccounts }}
+	//					}
+	//				}
+	//			}
+	//		]
+	//
+	// A failure here may require external user intervention to resolve.
+	ValidAWSIdentityProvider ConditionType = "ValidAWSIdentityProvider"
+
 	// PlatformCredentialsFound indicates that credentials required for the
 	// desired platform are valid.
 	// A failure here is unlikely to resolve without the changing user input.
@@ -128,6 +149,7 @@ const (
 	OIDCConfigurationInvalidReason        = "OIDCConfigurationInvalid"
 	PlatformCredentialsNotFoundReason     = "PlatformCredentialsNotFound"
 	InvalidImageReason                    = "InvalidImage"
+	InvalidIdentityProvider               = "InvalidIdentityProvider"
 )
 
 // Messages.

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1215,7 +1215,8 @@ type AWSRolesRef struct {
 	//				"ec2:ModifyVpcEndpoint",
 	//				"ec2:DeleteVpcEndpoints",
 	//				"ec2:CreateTags",
-	//				"route53:ListHostedZones"
+	//				"route53:ListHostedZones",
+	// 				"route53:ListHostedZonesByName"
 	//			],
 	//			"Resource": "*"
 	//		},

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -313,7 +313,8 @@ func controlPlaneOperatorPolicy(hostedZone string) string {
 				"ec2:ModifyVpcEndpoint",
 				"ec2:DeleteVpcEndpoints",
 				"ec2:CreateTags",
-				"route53:ListHostedZones"
+				"route53:ListHostedZones",
+				"route53:ListHostedZonesByName"
 			],
 			"Resource": "*"
 		},

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5639,10 +5639,11 @@ spec:
                               policy document: \n { \"Version\": \"2012-10-17\", \"Statement\":
                               [ { \"Effect\": \"Allow\", \"Action\": [ \"ec2:CreateVpcEndpoint\",
                               \"ec2:DescribeVpcEndpoints\", \"ec2:ModifyVpcEndpoint\",
-                              \"ec2:DeleteVpcEndpoints\", \"ec2:CreateTags\", \"route53:ListHostedZones\"
-                              ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
-                              [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
-                              ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
+                              \"ec2:DeleteVpcEndpoints\", \"ec2:CreateTags\", \"route53:ListHostedZones\",
+                              \"route53:ListHostedZonesByName\" ], \"Resource\": \"*\"
+                              }, { \"Effect\": \"Allow\", \"Action\": [ \"route53:ChangeResourceRecordSets\",
+                              \"route53:ListResourceRecordSets\" ], \"Resource\":
+                              \"arn:aws:route53:::%s\" } ] }"
                             type: string
                           imageRegistryARN:
                             description: "ImageRegistryARN is an ARN value referencing

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -5526,10 +5526,11 @@ spec:
                               policy document: \n { \"Version\": \"2012-10-17\", \"Statement\":
                               [ { \"Effect\": \"Allow\", \"Action\": [ \"ec2:CreateVpcEndpoint\",
                               \"ec2:DescribeVpcEndpoints\", \"ec2:ModifyVpcEndpoint\",
-                              \"ec2:DeleteVpcEndpoints\", \"ec2:CreateTags\", \"route53:ListHostedZones\"
-                              ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
-                              [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
-                              ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
+                              \"ec2:DeleteVpcEndpoints\", \"ec2:CreateTags\", \"route53:ListHostedZones\",
+                              \"route53:ListHostedZonesByName\" ], \"Resource\": \"*\"
+                              }, { \"Effect\": \"Allow\", \"Action\": [ \"route53:ChangeResourceRecordSets\",
+                              \"route53:ListResourceRecordSets\" ], \"Resource\":
+                              \"arn:aws:route53:::%s\" } ] }"
                             type: string
                           imageRegistryARN:
                             description: "ImageRegistryARN is an ARN value referencing

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -10,10 +10,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
+
+	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/autoscaler"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
@@ -75,13 +79,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
 )
 
 const (
-	finalizer                  = "hypershift.openshift.io/finalizer"
-	DefaultAdminKubeconfigName = "admin-kubeconfig"
-	DefaultAdminKubeconfigKey  = "kubeconfig"
-
+	finalizer                              = "hypershift.openshift.io/finalizer"
+	DefaultAdminKubeconfigKey              = "kubeconfig"
+	hypershiftLocalZone                    = "hypershift.local"
 	ImageStreamAutoscalerImage             = "cluster-autoscaler"
 	ImageStreamClusterMachineApproverImage = "cluster-machine-approver"
 )
@@ -211,6 +216,11 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	originalHostedControlPlane := hostedControlPlane.DeepCopy()
+	// This is a best effort ping to the identity provider
+	// that enables access from the operator to the cloud provider resources.
+	healthCheckIdentityProvider(ctx, hostedControlPlane)
+
 	// Return early if deleted
 	if !hostedControlPlane.DeletionTimestamp.IsZero() {
 		if shouldCleanupCloudResources(hostedControlPlane) {
@@ -245,8 +255,6 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		r.Log.Info("releaseImage is %s, but this operator is configured for %s, skipping reconciliation", hostedControlPlane.Spec.ReleaseImage, r.OperateOnReleaseImage)
 		return ctrl.Result{}, nil
 	}
-
-	originalHostedControlPlane := hostedControlPlane.DeepCopy()
 
 	// Reconcile global configuration validation status
 	{
@@ -3254,4 +3262,70 @@ func (r *HostedControlPlaneReconciler) reconcileCSISnapshotControllerOperator(ct
 	// TODO: create custom kubeconfig to the guest cluster + RBAC
 
 	return nil
+}
+
+func healthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane) {
+	if hcp.Spec.Platform.AWS == nil {
+		return
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+
+	awsSession := awsutil.NewSession("control-plane-operator", "", "", "", "")
+	awsConfig := awssdk.NewConfig()
+	awsConfig.Region = awssdk.String("us-east-1")
+	route53Client := route53.New(awsSession, awsConfig)
+
+	// We try to interact with cloud provider to see validate is operational.
+	if _, err := route53Client.ListHostedZonesByNameWithContext(ctx, &route53.ListHostedZonesByNameInput{
+		DNSName: pointer.String(fmt.Sprintf("%s.%s", hcp.Name, hypershiftLocalZone)),
+	}); err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			// When awsErr.Code() is WebIdentityErr it's likely to be an external issue, e.g the idp resource was deleted.
+			// We don't set awsErr.Message() in the condition as it might contain aws requests IDs that would make the condition be updated in loop.
+			if awsErr.Code() == "WebIdentityErr" {
+				condition := metav1.Condition{
+					Type:               string(hyperv1.ValidAWSIdentityProvider),
+					ObservedGeneration: hcp.Generation,
+					Status:             metav1.ConditionFalse,
+					Message:            awsErr.Code(),
+					Reason:             hyperv1.InvalidIdentityProvider,
+				}
+				meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+				log.Info("Error health checking AWS identity provider", awsErr.Code(), awsErr.Message())
+				return
+			}
+
+			condition := metav1.Condition{
+				Type:               string(hyperv1.ValidAWSIdentityProvider),
+				ObservedGeneration: hcp.Generation,
+				Status:             metav1.ConditionUnknown,
+				Message:            awsErr.Code(),
+				Reason:             hyperv1.AWSErrorReason,
+			}
+			meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+			log.Info("Error health checking AWS identity provider", awsErr.Code(), awsErr.Message())
+			return
+		}
+
+		condition := metav1.Condition{
+			Type:               string(hyperv1.ValidAWSIdentityProvider),
+			ObservedGeneration: hcp.Generation,
+			Status:             metav1.ConditionUnknown,
+			Message:            err.Error(),
+			Reason:             hyperv1.StatusUnknownReason,
+		}
+		meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+		log.Info("Error health checking AWS identity provider", "error", err)
+		return
+	}
+
+	condition := metav1.Condition{
+		Type:               string(hyperv1.ValidAWSIdentityProvider),
+		ObservedGeneration: hcp.Generation,
+		Status:             metav1.ConditionTrue,
+		Message:            hyperv1.AllIsWellMessage,
+		Reason:             hyperv1.AsExpectedReason,
+	}
+	meta.SetStatusCondition(&hcp.Status.Conditions, condition)
 }

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -26103,10 +26103,11 @@ objects:
                                 \"Statement\": [ { \"Effect\": \"Allow\", \"Action\":
                                 [ \"ec2:CreateVpcEndpoint\", \"ec2:DescribeVpcEndpoints\",
                                 \"ec2:ModifyVpcEndpoint\", \"ec2:DeleteVpcEndpoints\",
-                                \"ec2:CreateTags\", \"route53:ListHostedZones\" ],
-                                \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
-                                [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
-                                ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
+                                \"ec2:CreateTags\", \"route53:ListHostedZones\", \"route53:ListHostedZonesByName\"
+                                ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\",
+                                \"Action\": [ \"route53:ChangeResourceRecordSets\",
+                                \"route53:ListResourceRecordSets\" ], \"Resource\":
+                                \"arn:aws:route53:::%s\" } ] }"
                               type: string
                             imageRegistryARN:
                               description: "ImageRegistryARN is an ARN value referencing
@@ -32708,10 +32709,11 @@ objects:
                                 \"Statement\": [ { \"Effect\": \"Allow\", \"Action\":
                                 [ \"ec2:CreateVpcEndpoint\", \"ec2:DescribeVpcEndpoints\",
                                 \"ec2:ModifyVpcEndpoint\", \"ec2:DeleteVpcEndpoints\",
-                                \"ec2:CreateTags\", \"route53:ListHostedZones\" ],
-                                \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
-                                [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
-                                ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
+                                \"ec2:CreateTags\", \"route53:ListHostedZones\", \"route53:ListHostedZonesByName\"
+                                ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\",
+                                \"Action\": [ \"route53:ChangeResourceRecordSets\",
+                                \"route53:ListResourceRecordSets\" ], \"Resource\":
+                                \"arn:aws:route53:::%s\" } ] }"
                               type: string
                             imageRegistryARN:
                               description: "ImageRegistryARN is an ARN value referencing


### PR DESCRIPTION
There's scenarios where the identity provider might have been conflicted, e.g. delete by accident. In that case the HC is not able to operate successfully e.g. aws endpoints, ec2 machines... and there's no clear signal in the HC. This is also true if the HC is in deleting state, which will hang forever with no clear signal.

This PR tries to allivites those scenarios by capturing them in a condition.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Ref [HOSTEDCP-660](https://issues.redhat.com/browse/HOSTEDCP-660)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.