### PR TITLE
OCPBUGS-3900: Fix CA passed to MCO for kubelet 

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
@@ -10,18 +10,19 @@ import (
 )
 
 type MCSParams struct {
-	OwnerRef       config.OwnerRef
-	RootCA         *corev1.Secret
-	UserCA         *corev1.ConfigMap
-	PullSecret     *corev1.Secret
-	DNS            *configv1.DNS
-	Infrastructure *configv1.Infrastructure
-	Network        *configv1.Network
-	Proxy          *configv1.Proxy
-	InstallConfig  *globalconfig.InstallConfig
+	OwnerRef             config.OwnerRef
+	RootCA               *corev1.Secret
+	KASToKubeletSignerCA *corev1.Secret
+	UserCA               *corev1.ConfigMap
+	PullSecret           *corev1.Secret
+	DNS                  *configv1.DNS
+	Infrastructure       *configv1.Infrastructure
+	Network              *configv1.Network
+	Proxy                *configv1.Proxy
+	InstallConfig        *globalconfig.InstallConfig
 }
 
-func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Secret, userCA *corev1.ConfigMap) *MCSParams {
+func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, kasToKubeletSignerCA, pullSecret *corev1.Secret, userCA *corev1.ConfigMap) *MCSParams {
 	dns := globalconfig.DNSConfig()
 	globalconfig.ReconcileDNSConfig(dns, hcp)
 
@@ -35,14 +36,15 @@ func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Se
 	globalconfig.ReconcileProxyConfigWithStatus(proxy, hcp)
 
 	return &MCSParams{
-		OwnerRef:       config.OwnerRefFrom(hcp),
-		RootCA:         rootCA,
-		UserCA:         userCA,
-		PullSecret:     pullSecret,
-		DNS:            dns,
-		Infrastructure: infra,
-		Network:        network,
-		Proxy:          proxy,
-		InstallConfig:  globalconfig.NewInstallConfig(hcp),
+		OwnerRef:             config.OwnerRefFrom(hcp),
+		RootCA:               rootCA,
+		KASToKubeletSignerCA: kasToKubeletSignerCA,
+		UserCA:               userCA,
+		PullSecret:           pullSecret,
+		DNS:                  dns,
+		Infrastructure:       infra,
+		Network:              network,
+		Proxy:                proxy,
+		InstallConfig:        globalconfig.NewInstallConfig(hcp),
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
@@ -53,6 +53,7 @@ func ReconcileMachineConfigServerConfig(cm *corev1.ConfigMap, p *MCSParams) erro
 	}
 
 	cm.Data["root-ca.crt"] = string(p.RootCA.Data[certs.CASignerCertMapKey])
+	cm.Data["signer-ca.crt"] = string(p.KASToKubeletSignerCA.Data[certs.CASignerCertMapKey])
 	cm.Data["cluster-dns-02-config.yaml"] = serializedDNS
 	cm.Data["cluster-infrastructure-02-config.yaml"] = serializedInfra
 	cm.Data["cluster-network-02-config.yaml"] = serializedNetwork

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -261,7 +261,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 			"bootstrap",
 			fmt.Sprintf("--image-references=%s", path.Join(configDir, "release-manifests", "image-references")),
 			fmt.Sprintf("--root-ca=%s/root-ca.crt", configDir),
-			fmt.Sprintf("--kube-ca=%s/root-ca.crt", configDir),
+			fmt.Sprintf("--kube-ca=%s/signer-ca.crt", configDir),
 			fmt.Sprintf("--infra-config-file=%s/cluster-infrastructure-02-config.yaml", configDir),
 			fmt.Sprintf("--network-config-file=%s/cluster-network-02-config.yaml", configDir),
 			fmt.Sprintf("--proxy-config-file=%s/cluster-proxy-01-config.yaml", configDir),

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -84,4 +84,6 @@ func TestUpgradeControlPlane(t *testing.T) {
 	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 	e2eutil.EnsureMachineDeploymentGeneration(t, ctx, client, hostedCluster, 1)
+	// TODO (cewong): enable this test once the fix for KAS->Kubelet communication has merged
+	// e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
 }

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -60,6 +60,7 @@ func TestCreateCluster(t *testing.T) {
 
 	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+	e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
 }
 
 func TestNoneCreateCluster(t *testing.T) {

--- a/test/e2e/util/node.go
+++ b/test/e2e/util/node.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func EnsureNodeCommunication(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	t.Run("EnsureNodeCommunication", func(t *testing.T) {
+		g := NewWithT(t)
+
+		guestKubeConfigSecretData, err := WaitForGuestKubeConfig(t, ctx, client, hostedCluster)
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't get kubeconfig")
+
+		guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
+		guestClient := kubeclient.NewForConfigOrDie(guestConfig)
+
+		podList, err := guestClient.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{LabelSelector: "app=konnectivity-agent"})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(podList.Items).ToNot(BeEmpty())
+		_, err = guestClient.CoreV1().Pods("kube-system").GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{Container: "konnectivity-agent"}).DoRaw(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The client certificate used by the Kube APIServer is no longer signed by
the root-ca. We need to pass the right CA to the kubelet so it can
properly authenticate the KAS.

Added e2e check to ensure we don't break KAS->Kubelet communication in the future.

**Which issue(s) this PR fixes**
Fixes #OCPBUGS-3900 

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes e2e tests.