### PR TITLE
Add clusterID to ignition-server PodMonitor

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -380,6 +380,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 		if podMonitor.Annotations == nil {
 			podMonitor.Annotations = map[string]string{}
 		}
+		util.ApplyClusterIDLabelToPodMonitor(&podMonitor.Spec.PodMetricsEndpoints[0], hcp.Spec.ClusterID)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition server pod monitor: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
All metrics produced by a HostedControlPlane should contain the _id label identifying the cluster that they come from

**Checklist**
- [x] Subject and description added to both, commit and PR.
