### PR TITLE
Bug 2066664: Sync manifests from cluster-csi-snapsht-controller-operator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/05_operator_role-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/05_operator_role-hypershift.yaml
@@ -9,20 +9,35 @@ rules:
   resources:
   - leases
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 - apiGroups:
   - apps
   resources:
   - deployments
   - replicasets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 - apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -30,7 +45,12 @@ rules:
   - services
   - configmaps
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR doesn't introduce any new functionality, it simply syncs manifests from https://github.com/openshift/cluster-csi-snapshot-controller-operator/tree/master/manifests.

The old manifests contain wildcards in RBAC rules, which is not recommended.

CC @openshift/storage 