### PR TITLE
Enable HCCO to set owner references on configmaps it reconciles

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -34,7 +34,6 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
 		{
 			APIGroups: []string{corev1.SchemeGroupVersion.Group},
 			Resources: []string{
-				"configmaps",
 				"pods",
 			},
 			Verbs: []string{
@@ -44,6 +43,21 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
 				"create",
 				"list",
 				"watch",
+			},
+		},
+		{
+			APIGroups: []string{corev1.SchemeGroupVersion.Group},
+			Resources: []string{
+				"configmaps",
+			},
+			Verbs: []string{
+				"get",
+				"patch",
+				"update",
+				"create",
+				"list",
+				"watch",
+				"delete", // Needed to be able to set owner reference on configmaps
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Without delete permission on configmaps the HCCO can only set the owner reference on create, but cannot update it afterwards. This change adds the delete permission on configmaps to the HCCO role

**Checklist**
- [x] Subject and description added to both, commit and PR.