### PR TITLE
availability-prober: add wait for cluster infrastructure resource

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -402,6 +402,7 @@ kubectl --kubeconfig $kc config use-context default`,
 			{Group: "network.operator.openshift.io", Version: "v1", Kind: "EgressRouter"},
 			{Group: "network.operator.openshift.io", Version: "v1", Kind: "OperatorPKI"},
 		}
+		o.WaitForInfrastructureResource = true
 	})
 	return nil
 }

--- a/support/util/containers.go
+++ b/support/util/containers.go
@@ -64,11 +64,15 @@ func AvailabilityProber(target string, image string, spec *corev1.PodSpec, o ...
 	if !reflect.DeepEqual(spec.InitContainers[0], availabilityProberContainer) {
 		spec.InitContainers[0] = availabilityProberContainer
 	}
+	if opts.WaitForInfrastructureResource {
+		availabilityProberContainer.Command = append(availabilityProberContainer.Command, fmt.Sprintf("--wait-for-infrastructure-resource"))
+	}
 }
 
 type AvailabilityProberOpts struct {
-	KubeconfigVolumeName string
-	RequiredAPIs         []schema.GroupVersionKind
+	KubeconfigVolumeName          string
+	RequiredAPIs                  []schema.GroupVersionKind
+	WaitForInfrastructureResource bool
 }
 
 type AvailabilityProberOpt func(*AvailabilityProberOpts)


### PR DESCRIPTION
Fixes an issue in CI where the CNO starts before the `cluster` Infrastructure resource is available.