### PR TITLE
always set ROUTER_CANONICAL_HOSTNAME

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2806,7 +2806,7 @@ func (r *HostedControlPlaneReconciler) reconcileRouter(ctx context.Context, hcp 
 
 	// Calculate router canonical hostname
 	var canonicalHostname string
-	if util.IsPublicHCP(hcp) && exposeKASThroughRouter {
+	if util.IsPublicHCP(hcp) {
 		canonicalHostname = externalRouterHost
 	} else if util.IsPrivateHCP(hcp) {
 		canonicalHostname = privateRouterHost

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1042,7 +1042,7 @@ func TestReconcileRouter(t *testing.T) {
 						}}),
 						ingress.HCPRouterConfig(&hyperv1.HostedControlPlane{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}}, false),
 						"",
-						"privateRouterHost",
+						"publicRouterHost",
 						false,
 						false,
 					)
@@ -1132,7 +1132,7 @@ func TestReconcileRouter(t *testing.T) {
 						}}),
 						ingress.HCPRouterConfig(&hyperv1.HostedControlPlane{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}}, false),
 						"",
-						"privateRouterHost",
+						"publicRouterHost",
 						false,
 						false,
 					)

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -212,6 +212,10 @@ func buildHCPRouterContainerMain(image, namespace, canonicalHostname string, exp
 				Name:  "STATS_PORT",
 				Value: fmt.Sprintf("%d", metricsPort),
 			},
+			{
+				Name:  "ROUTER_CANONICAL_HOSTNAME",
+				Value: canonicalHostname,
+			},
 		}
 
 		c.Image = image
@@ -220,10 +224,6 @@ func buildHCPRouterContainerMain(image, namespace, canonicalHostname string, exp
 		}
 
 		if exposeAPIServerThroughRouter {
-			c.Env = append(c.Env, corev1.EnvVar{
-				Name:  "ROUTER_CANONICAL_HOSTNAME",
-				Value: canonicalHostname,
-			})
 			c.Args = append(c.Args, "--template="+haproxyTemplateMountPath+"/"+routerTemplateConfigMapKey)
 		}
 


### PR DESCRIPTION
Consider the following `services` block on a cluster with `endpointAccess: PublicAndPrivate`.

```
   services:
  - service: APIServer
    servicePublishingStrategy:
      type: LoadBalancer
  - service: OAuthServer
    servicePublishingStrategy:
      route:
        hostname: oauth-sjenning-guest.service.ci.hypershift.devcluster.openshift.com
```

Currently the `routerCanonicalHostname` is not set on the `oauth` route because the router is not configured with the `ROUTER_CANONICAL_HOSTNAME` env var because we only set it when the KAS is exposed through the router.  This results in external-dns not registering the oauth DNS record and the `console` ClusterOperator in the guest failing to become Available since it requires oauth connectivity for `console` pods to be ready.

We should set the `ROUTER_CANONICAL_HOSTNAME` on the `router` deployment regardless of whether or not the KAS is exposed through the router.

Fixes: [HOSTEDCP-672](https://issues.redhat.com//browse/HOSTEDCP-672)