### PR TITLE
fix nil deref in nodepool controller

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -621,7 +621,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	// with a consumable "Reason" and an aggregated "Message".
 	for _, machine := range machines {
 		condition := findCAPIStatusCondition(machine.Status.Conditions, capiv1.ReadyCondition)
-		if condition.Status != corev1.ConditionTrue {
+		if condition != nil && condition.Status != corev1.ConditionTrue {
 			status = corev1.ConditionFalse
 			reason = condition.Reason
 			// We append the reason as part of the higher Message, since the message is meaningless.
@@ -661,7 +661,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 	for _, machine := range machines {
 		condition := findCAPIStatusCondition(machine.Status.Conditions, capiv1.MachineNodeHealthyCondition)
-		if condition.Status != corev1.ConditionTrue {
+		if condition != nil && condition.Status != corev1.ConditionTrue {
 			status = corev1.ConditionFalse
 			reason = condition.Reason
 			message = message + fmt.Sprintf("Machine %s: %s\n", machine.Name, condition.Reason)


### PR DESCRIPTION
https://github.com/openshift/hypershift/pull/1907 introduced unchecked condition logic

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x266e6a4]

goroutine 1131 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:118 +0x2d7
panic({0x2e3a780, 0x48d4120})
	/usr/local/go/src/runtime/panic.go:844 +0x25a
github.com/openshift/hypershift/hypershift-operator/controllers/nodepool.(*NodePoolReconciler).reconcile(0xc000ef6a80, {0x36aca20, 0xc00cf7b980}, 0xc00a920000, 0xc00a86fd40)
	/hypershift/hypershift-operator/controllers/nodepool/nodepool_controller.go:624 +0x98c4
```