### PR TITLE
Temporarily override the CAPI AWS provider image 

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -925,7 +925,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	_, ignitionServerHasHealthzHandler := hyperutil.ImageLabels(controlPlaneOperatorImageMetadata)[ignitionServerHealthzHandlerLabel]
 	_, controlplaneOperatorManagesIgnitionServer := hyperutil.ImageLabels(controlPlaneOperatorImageMetadata)[controlplaneOperatorManagesIgnitionServerLabel]
 
-	p, err := platform.GetPlatform(hcluster, utilitiesImage, pullSecretBytes)
+	p, err := platform.GetPlatform(hcluster, r.ReleaseProvider, utilitiesImage, pullSecretBytes)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -1640,7 +1640,7 @@ func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, crea
 		capiImage = hcluster.Annotations[hyperv1.ClusterAPIManagerImage]
 	}
 	if capiImage == "" {
-		if capiImage, err = hyperutil.GetPayloadImage(ctx, hcluster, ImageStreamCAPI, pullSecretBytes); err != nil {
+		if capiImage, err = hyperutil.GetPayloadImage(ctx, r.ReleaseProvider, hcluster, ImageStreamCAPI, pullSecretBytes); err != nil {
 			return fmt.Errorf("failed to retrieve capi image: %w", err)
 		}
 	}
@@ -1883,7 +1883,7 @@ func servicePublishingStrategyByType(hcp *hyperv1.HostedCluster, svcType hyperv1
 // both the HostedCluster and the HostedControlPlane which the autoscaler takes
 // inputs from.
 func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, utilitiesImage string, pullSecretBytes []byte) error {
-	clusterAutoscalerImage, err := hyperutil.GetPayloadImage(ctx, hcluster, ImageStreamAutoscalerImage, pullSecretBytes)
+	clusterAutoscalerImage, err := hyperutil.GetPayloadImage(ctx, r.ReleaseProvider, hcluster, ImageStreamAutoscalerImage, pullSecretBytes)
 	if err != nil {
 		return fmt.Errorf("failed to get image for machine approver: %w", err)
 	}
@@ -2960,7 +2960,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	}
 
 	// Cleanup Platform specifics.
-	p, err := platform.GetPlatform(hc, "", nil)
+	p, err := platform.GetPlatform(hc, nil, "", nil)
 	if err != nil {
 		return false, err
 	}
@@ -3120,7 +3120,7 @@ func (r *HostedClusterReconciler) reconcileClusterPrometheusRBAC(ctx context.Con
 }
 
 func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, utilitiesImage string, pullSecretBytes []byte) error {
-	machineApproverImage, err := hyperutil.GetPayloadImage(ctx, hcluster, ImageStreamClusterMachineApproverImage, pullSecretBytes)
+	machineApproverImage, err := hyperutil.GetPayloadImage(ctx, r.ReleaseProvider, hcluster, ImageStreamClusterMachineApproverImage, pullSecretBytes)
 	if err != nil {
 		return fmt.Errorf("failed to get image for machine approver: %w", err)
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/none"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/powervs"
+	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	imgUtil "github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -63,7 +64,7 @@ type Platform interface {
 }
 
 // GetPlatform gets and initializes the cloud platform the hosted cluster was created on
-func GetPlatform(hcluster *hyperv1.HostedCluster, utilitiesImage string, pullSecretBytes []byte) (Platform, error) {
+func GetPlatform(hcluster *hyperv1.HostedCluster, releaseProvider releaseinfo.Provider, utilitiesImage string, pullSecretBytes []byte) (Platform, error) {
 	var (
 		platform          Platform
 		capiImageProvider string
@@ -73,9 +74,9 @@ func GetPlatform(hcluster *hyperv1.HostedCluster, utilitiesImage string, pullSec
 	switch hcluster.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		if pullSecretBytes != nil {
-			capiImageProvider, err = imgUtil.GetPayloadImage(context.TODO(), hcluster, AWSCAPIProvider, pullSecretBytes)
+			capiImageProvider, err = imgUtil.GetPayloadImage(context.TODO(), releaseProvider, hcluster, AWSCAPIProvider, pullSecretBytes)
 			if err != nil {
-				return nil, fmt.Errorf("failed to retrieve capa image: %w", err)
+				return nil, fmt.Errorf("failed to retrieve capi image: %w", err)
 			}
 		}
 		platform = aws.New(utilitiesImage, capiImageProvider)

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -231,7 +231,14 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		HypershiftOperatorImage:       operatorImage,
 		ReleaseProvider: &releaseinfo.RegistryMirrorProviderDecorator{
 			Delegate: &releaseinfo.CachedProvider{
-				Inner: &releaseinfo.RegistryClientProvider{},
+				Inner: &releaseinfo.StaticProviderDecorator{
+					Delegate: &releaseinfo.RegistryClientProvider{},
+					ComponentImages: map[string]string{
+						// TODO: Remove this override when we update CAPA to match the master branch of openshift/cluster-api-provider-aws
+						// Currently, this image points to CAPA in OCP 4.12.0-ec.3-multi
+						"aws-cluster-api-controllers": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cadab6529bfc7327ac64d0b7d71023df062a553a16c307b537e60aabc7d3e4c9",
+					},
+				},
 				Cache: map[string]*releaseinfo.ReleaseImage{},
 			},
 			RegistryOverrides: opts.RegistryOverrides,

--- a/support/releaseinfo/fake/fake.go
+++ b/support/releaseinfo/fake/fake.go
@@ -37,6 +37,14 @@ func (f *FakeReleaseProvider) Lookup(ctx context.Context, image string, pullSecr
 						From: &corev1.ObjectReference{Name: ""},
 					},
 					{
+						Name: "aws-cluster-api-controllers",
+						From: &corev1.ObjectReference{Name: ""},
+					},
+					{
+						Name: "cluster-capi-controllers",
+						From: &corev1.ObjectReference{Name: ""},
+					},
+					{
 						Name: util.AvailabilityProberImageName,
 						From: &corev1.ObjectReference{Name: ""},
 					},

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -95,10 +95,8 @@ func ImageLabels(metadata *dockerv1client.DockerImageConfig) map[string]string {
 	}
 }
 
-// GetPayloadImage get an image from the payload for a particular component
-func GetPayloadImage(ctx context.Context, hc *hyperv1.HostedCluster, component string, pullSecret []byte) (string, error) {
-	releaseImageProvider := &releaseinfo.RegistryClientProvider{}
-	releaseImage, err := releaseinfo.Provider.Lookup(releaseImageProvider, ctx, hc.Spec.Release.Image, pullSecret)
+func GetPayloadImage(ctx context.Context, releaseImageProvider releaseinfo.Provider, hc *hyperv1.HostedCluster, component string, pullSecret []byte) (string, error) {
+	releaseImage, err := releaseImageProvider.Lookup(ctx, hc.Spec.Release.Image, pullSecret)
 	if err != nil {
 		return "", fmt.Errorf("failed to lookup release image: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows OCP 4.13 clusters to work while we bump the CAPA dependency (and API version) in our code

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.