### PR TITLE
Added regression tests to ensure certain deployment fields do not get…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment_test.go
@@ -1,0 +1,52 @@
+package clusterpolicy
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestReconcileClusterPolicyDeployment(t *testing.T) {
+
+	imageName := "clusterPolicyImage"
+	// Setup expected values that are universal
+
+	// Setup hypershift hosted control plane.
+	targetNamespace := "test"
+	clusterPolicyDeployment := manifests.ClusterPolicyControllerDeployment(targetNamespace)
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: targetNamespace,
+		},
+	}
+	hcp.Name = "name"
+	hcp.Namespace = "namespace"
+	ownerRef := config.OwnerRefFrom(hcp)
+
+	testCases := []struct {
+		deploymentConfig config.DeploymentConfig
+	}{
+		// empty deployment config
+		{
+			deploymentConfig: config.DeploymentConfig{},
+		},
+	}
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		clusterPolicyDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64(60)
+		expectedTermGraceSeconds := clusterPolicyDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds
+		clusterPolicyDeployment.Spec.MinReadySeconds = 60
+		expectedMinReadySeconds := clusterPolicyDeployment.Spec.MinReadySeconds
+		err := ReconcileDeployment(clusterPolicyDeployment, ownerRef, imageName, tc.deploymentConfig, util.AvailabilityProberImageName, pointer.Int32(1234))
+		g.Expect(err).To(BeNil())
+		g.Expect(expectedTermGraceSeconds).To(Equal(clusterPolicyDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds))
+		g.Expect(expectedMinReadySeconds).To(Equal(clusterPolicyDeployment.Spec.MinReadySeconds))
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment_test.go
@@ -1,0 +1,64 @@
+package kas
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReconcileKubeAPIServerDeployment(t *testing.T) {
+
+	// Setup expected values that are universal
+
+	// Setup hypershift hosted control plane.
+	targetNamespace := "test"
+	kubeAPIDeployment := manifests.KASDeployment(targetNamespace)
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: targetNamespace,
+		},
+	}
+	hcp.Name = "name"
+	hcp.Namespace = "namespace"
+	ownerRef := config.OwnerRefFrom(hcp)
+
+	testCases := []struct {
+		cm               corev1.ConfigMap
+		deploymentConfig config.DeploymentConfig
+		params           KubeAPIServerParams
+		activeKey        []byte
+		backupKey        []byte
+	}{
+		// empty deployment config
+		{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kube-api-config",
+					Namespace: targetNamespace,
+				},
+				Data: map[string]string{"config.json": "test-data"},
+			},
+			deploymentConfig: config.DeploymentConfig{},
+			params: KubeAPIServerParams{
+				CloudProvider: "test-cloud-provider",
+				APIServerPort: util.APIPortWithDefault(hcp, config.DefaultAPIServerPort),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		kubeAPIDeployment.Spec.MinReadySeconds = 60
+		expectedMinReadySeconds := kubeAPIDeployment.Spec.MinReadySeconds
+		err := ReconcileKubeAPIServerDeployment(kubeAPIDeployment, hcp, ownerRef, tc.deploymentConfig, tc.params.NamedCertificates(), tc.params.CloudProvider,
+			tc.params.CloudProviderConfig, tc.params.CloudProviderCreds, tc.params.Images, &tc.cm, tc.params.AuditWebhookRef, tc.activeKey, tc.backupKey, tc.params.APIServerPort)
+		g.Expect(err).To(BeNil())
+		g.Expect(expectedMinReadySeconds).To(Equal(kubeAPIDeployment.Spec.MinReadySeconds))
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment_test.go
@@ -4,6 +4,14 @@ import (
 	"strings"
 	"testing"
 
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -53,5 +61,47 @@ func TestKCMArgs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestKubeControllerManagerDeployment(t *testing.T) {
+
+	// Setup hypershift hosted control plane.
+	targetNamespace := "test"
+	kcmDeployment := manifests.KCMDeployment(targetNamespace)
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: targetNamespace,
+		},
+	}
+	hcp.Name = "name"
+	hcp.Namespace = "namespace"
+
+	testCases := []struct {
+		cm               corev1.ConfigMap
+		params           KubeControllerManagerParams
+		deploymentConfig config.DeploymentConfig
+	}{
+		// empty deployment config and params
+		{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcm-config",
+					Namespace: targetNamespace,
+				},
+				Data: map[string]string{"config.json": "test-data"},
+			},
+			deploymentConfig: config.DeploymentConfig{},
+			params:           KubeControllerManagerParams{},
+		},
+	}
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		kcmDeployment.Spec.MinReadySeconds = 60
+		expectedMinReadySeconds := kcmDeployment.Spec.MinReadySeconds
+		err := ReconcileDeployment(kcmDeployment, &tc.cm, nil, &tc.params, pointer.Int32(1234))
+		g.Expect(err).To(BeNil())
+		g.Expect(expectedMinReadySeconds).To(Equal(kcmDeployment.Spec.MinReadySeconds))
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -311,23 +311,21 @@ func buildKonnectivityVolumeAgentCerts(v *corev1.Volume) {
 
 func ReconcileAgentDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, image string, ips []string) error {
 	ownerRef.ApplyTo(deployment)
-	deployment.Spec = appsv1.DeploymentSpec{
-		Selector: &metav1.LabelSelector{
-			MatchLabels: konnectivityAgentLabels(),
+	deployment.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: konnectivityAgentLabels(),
+	}
+	deployment.Spec.Template = corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: konnectivityAgentLabels(),
 		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: konnectivityAgentLabels(),
+		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken: pointer.BoolPtr(false),
+			Containers: []corev1.Container{
+				util.BuildContainer(konnectivityAgentContainer(), buildKonnectivityAgentContainer(image, ips)),
 			},
-			Spec: corev1.PodSpec{
-				AutomountServiceAccountToken: pointer.BoolPtr(false),
-				Containers: []corev1.Container{
-					util.BuildContainer(konnectivityAgentContainer(), buildKonnectivityAgentContainer(image, ips)),
-				},
-				Volumes: []corev1.Volume{
-					util.BuildVolume(konnectivityVolumeAgentCerts(), buildKonnectivityVolumeAgentCerts),
-					util.BuildVolume(konnectivitySignerCA(), buildKonnectivitySignerCAkonnectivitySignerCAVolume),
-				},
+
+			Volumes: []corev1.Volume{
+				util.BuildVolume(konnectivityVolumeAgentCerts(), buildKonnectivityVolumeAgentCerts),
 			},
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile_test.go
@@ -1,0 +1,49 @@
+package konnectivity
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReconcileKonnectivityAgentDeployment(t *testing.T) {
+
+	imageName := "konnectivity-agent-image"
+	// Setup expected values that are universal
+
+	// Setup hypershift hosted control plane.
+	targetNamespace := "test"
+	konnectivityAgentDeployment := manifests.KonnectivityAgentDeployment(targetNamespace)
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: targetNamespace,
+		},
+	}
+	hcp.Name = "name"
+	hcp.Namespace = "namespace"
+	ownerRef := config.OwnerRefFrom(hcp)
+
+	testCases := []struct {
+		deploymentConfig config.DeploymentConfig
+		ips              []string
+	}{
+		// empty deployment config
+		{
+			deploymentConfig: config.DeploymentConfig{},
+			ips:              []string{"1.2.3.4"},
+		},
+	}
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		konnectivityAgentDeployment.Spec.MinReadySeconds = 60
+		expectedMinReadySeconds := konnectivityAgentDeployment.Spec.MinReadySeconds
+		err := ReconcileAgentDeployment(konnectivityAgentDeployment, ownerRef, tc.deploymentConfig, imageName, tc.ips)
+		g.Expect(err).To(BeNil())
+		g.Expect(expectedMinReadySeconds).To(Equal(konnectivityAgentDeployment.Spec.MinReadySeconds))
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -104,37 +104,37 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	}
 	deployment.Spec.Template.Annotations[configHashAnnotation] = configHash
 
-	deployment.Spec.Template.Spec = corev1.PodSpec{
-		AutomountServiceAccountToken: pointer.BoolPtr(false),
-		InitContainers:               []corev1.Container{util.BuildContainer(oasTrustAnchorGenerator(), buildOASTrustAnchorGenerator(image))},
-		Containers: []corev1.Container{
-			util.BuildContainer(oasContainerMain(), buildOASContainerMain(image, strings.Split(etcdUrlData.Host, ":")[0], defaultOAPIPort)),
-			util.BuildContainer(oasSocks5ProxyContainer(), buildOASSocks5ProxyContainer(socks5ProxyImage)),
-		},
-		Volumes: []corev1.Volume{
-			util.BuildVolume(oasVolumeWorkLogs(), buildOASVolumeWorkLogs),
-			util.BuildVolume(oasVolumeConfig(), buildOASVolumeConfig),
-			util.BuildVolume(oasVolumeAuditConfig(), buildOASVolumeAuditConfig),
-			util.BuildVolume(common.VolumeAggregatorCA(), common.BuildVolumeAggregatorCA),
-			util.BuildVolume(oasVolumeEtcdClientCA(), buildOASVolumeEtcdClientCA),
-			util.BuildVolume(common.VolumeTotalClientCA(), common.BuildVolumeTotalClientCA),
-			util.BuildVolume(oasVolumeKubeconfig(), buildOASVolumeKubeconfig),
-			util.BuildVolume(oasVolumeServingCert(), buildOASVolumeServingCert),
-			util.BuildVolume(oasVolumeEtcdClientCert(), buildOASVolumeEtcdClientCert),
-			util.BuildVolume(oasVolumeKonnectivityProxyCert(), buildOASVolumeKonnectivityProxyCert),
-			util.BuildVolume(oasVolumeKonnectivityProxyCA(), buildOASVolumeKonnectivityProxyCA),
-			util.BuildVolume(oasTrustAnchorVolume(), func(v *corev1.Volume) { v.EmptyDir = &corev1.EmptyDirVolumeSource{} }),
-			util.BuildVolume(serviceCASignerVolume(), func(v *corev1.Volume) {
-				v.ConfigMap = &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: manifests.ServiceServingCA(deployment.Namespace).Name}}
-			}),
-			util.BuildVolume(pullSecretVolume(), func(v *corev1.Volume) {
-				v.Secret = &corev1.SecretVolumeSource{
-					DefaultMode: pointer.Int32Ptr(0640),
-					SecretName:  common.PullSecret(deployment.Namespace).Name,
-					Items:       []corev1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
-				}
-			}),
-		},
+	deployment.Spec.Template.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)
+	deployment.Spec.Template.Spec.InitContainers = []corev1.Container{util.BuildContainer(oasTrustAnchorGenerator(), buildOASTrustAnchorGenerator(image))}
+
+	deployment.Spec.Template.Spec.Containers = []corev1.Container{
+		util.BuildContainer(oasContainerMain(), buildOASContainerMain(image, strings.Split(etcdUrlData.Host, ":")[0], defaultOAPIPort)),
+		util.BuildContainer(oasSocks5ProxyContainer(), buildOASSocks5ProxyContainer(socks5ProxyImage)),
+	}
+
+	deployment.Spec.Template.Spec.Volumes = []corev1.Volume{
+		util.BuildVolume(oasVolumeWorkLogs(), buildOASVolumeWorkLogs),
+		util.BuildVolume(oasVolumeConfig(), buildOASVolumeConfig),
+		util.BuildVolume(oasVolumeAuditConfig(), buildOASVolumeAuditConfig),
+		util.BuildVolume(common.VolumeAggregatorCA(), common.BuildVolumeAggregatorCA),
+		util.BuildVolume(oasVolumeEtcdClientCA(), buildOASVolumeEtcdClientCA),
+		util.BuildVolume(common.VolumeTotalClientCA(), common.BuildVolumeTotalClientCA),
+		util.BuildVolume(oasVolumeKubeconfig(), buildOASVolumeKubeconfig),
+		util.BuildVolume(oasVolumeServingCert(), buildOASVolumeServingCert),
+		util.BuildVolume(oasVolumeEtcdClientCert(), buildOASVolumeEtcdClientCert),
+		util.BuildVolume(oasVolumeKonnectivityProxyCert(), buildOASVolumeKonnectivityProxyCert),
+		util.BuildVolume(oasVolumeKonnectivityProxyCA(), buildOASVolumeKonnectivityProxyCA),
+		util.BuildVolume(oasTrustAnchorVolume(), func(v *corev1.Volume) { v.EmptyDir = &corev1.EmptyDirVolumeSource{} }),
+		util.BuildVolume(serviceCASignerVolume(), func(v *corev1.Volume) {
+			v.ConfigMap = &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: manifests.ServiceServingCA(deployment.Namespace).Name}}
+		}),
+		util.BuildVolume(pullSecretVolume(), func(v *corev1.Volume) {
+			v.Secret = &corev1.SecretVolumeSource{
+				DefaultMode: pointer.Int32Ptr(0640),
+				SecretName:  common.PullSecret(deployment.Namespace).Name,
+				Items:       []corev1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
+			}
+		}),
 	}
 
 	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec)

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
@@ -1,0 +1,97 @@
+package oapi
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestReconcileOpenshiftAPIServerDeployment(t *testing.T) {
+
+	imageName := "oapiImage"
+	// Setup expected values that are universal
+
+	// Setup hypershift hosted control plane.
+	targetNamespace := "test"
+	oapiDeployment := manifests.OpenShiftAPIServerDeployment(targetNamespace)
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: targetNamespace,
+		},
+	}
+	hcp.Name = "name"
+	hcp.Namespace = "namespace"
+	ownerRef := config.OwnerRefFrom(hcp)
+
+	testCases := []struct {
+		cm               corev1.ConfigMap
+		deploymentConfig config.DeploymentConfig
+	}{
+		// empty deployment config
+		{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-oapi-config",
+					Namespace: targetNamespace,
+				},
+				Data: map[string]string{"config.yaml": "test-data"},
+			},
+			deploymentConfig: config.DeploymentConfig{},
+		},
+	}
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		oapiDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64(60)
+		expectedTermGraceSeconds := oapiDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds
+		oapiDeployment.Spec.MinReadySeconds = 60
+		expectedMinReadySeconds := oapiDeployment.Spec.MinReadySeconds
+		err := ReconcileDeployment(oapiDeployment, ownerRef, &tc.cm, tc.deploymentConfig, imageName, "socks5ProxyImage", config.DefaultEtcdURL, util.AvailabilityProberImageName, pointer.Int32(1234))
+		g.Expect(err).To(BeNil())
+		g.Expect(expectedTermGraceSeconds).To(Equal(oapiDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds))
+		g.Expect(expectedMinReadySeconds).To(Equal(oapiDeployment.Spec.MinReadySeconds))
+	}
+}
+
+func TestReconcileOpenshiftOAuthAPIServerDeployment(t *testing.T) {
+	// Setup expected values that are universal
+
+	// Setup hypershift hosted control plane.
+	targetNamespace := "test"
+	oauthAPIDeployment := manifests.OpenShiftOAuthAPIServerDeployment(targetNamespace)
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: targetNamespace,
+		},
+	}
+	hcp.Name = "name"
+	hcp.Namespace = "namespace"
+	ownerRef := config.OwnerRefFrom(hcp)
+
+	testCases := []struct {
+		deploymentConfig config.DeploymentConfig
+		params           OAuthDeploymentParams
+	}{
+		// empty deployment config and oauth params
+		{
+			deploymentConfig: config.DeploymentConfig{},
+			params:           OAuthDeploymentParams{},
+		},
+	}
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		oauthAPIDeployment.Spec.MinReadySeconds = 60
+		expectedMinReadySeconds := oauthAPIDeployment.Spec.MinReadySeconds
+		err := ReconcileOAuthAPIServerDeployment(oauthAPIDeployment, ownerRef, &tc.params, pointer.Int32(1234))
+		g.Expect(err).To(BeNil())
+		g.Expect(expectedMinReadySeconds).To(Equal(oauthAPIDeployment.Spec.MinReadySeconds))
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment_test.go
@@ -1,0 +1,68 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileOauthDeployment(t *testing.T) {
+
+	// Setup expected values that are universal
+	imageName := "oauthImage"
+
+	// Setup hypershift hosted control plane.
+	targetNamespace := "test"
+	oauthDeployment := manifests.OAuthDeployment(targetNamespace)
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: targetNamespace,
+		},
+	}
+	hcp.Name = "name"
+	hcp.Namespace = "namespace"
+	ownerRef := config.OwnerRefFrom(hcp)
+
+	testCases := []struct {
+		cm               corev1.ConfigMap
+		deploymentConfig config.DeploymentConfig
+		params           OAuthServerParams
+	}{
+		// empty deployment config
+		{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-oauth-config",
+					Namespace: targetNamespace,
+				},
+				Data: map[string]string{"config.yaml": "test-data"},
+			},
+			deploymentConfig: config.DeploymentConfig{},
+			params: OAuthServerParams{
+				AvailabilityProberImage: "test-availability-image",
+				Socks5ProxyImage:        "test-socks-5-proxy-image",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		ctx := context.Background()
+		fakeClient := fake.NewClientBuilder().WithScheme(api.Scheme).Build()
+		oauthDeployment.Spec.MinReadySeconds = 60
+		expectedMinReadySeconds := oauthDeployment.Spec.MinReadySeconds
+		err := ReconcileDeployment(ctx, fakeClient, oauthDeployment, ownerRef, &tc.cm, imageName, tc.deploymentConfig, tc.params.IdentityProviders(), tc.params.OauthConfigOverrides,
+			tc.params.AvailabilityProberImage, pointer.Int32(1234), tc.params.NamedCertificates(), tc.params.Socks5ProxyImage, tc.params.NoProxy)
+		g.Expect(err).To(BeNil())
+		g.Expect(expectedMinReadySeconds).To(Equal(oauthDeployment.Spec.MinReadySeconds))
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment_test.go
@@ -1,0 +1,60 @@
+package ocm
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestReconcileOpenshiftControllerManagerDeployment(t *testing.T) {
+
+	// Setup expected values that are universal
+	imageName := "ocmImage"
+
+	// Setup hypershift hosted control plane.
+	targetNamespace := "test"
+	ocmDeployment := manifests.OpenShiftControllerManagerDeployment(targetNamespace)
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: targetNamespace,
+		},
+	}
+	hcp.Name = "name"
+	hcp.Namespace = "namespace"
+	ownerRef := config.OwnerRefFrom(hcp)
+
+	testCases := []struct {
+		cm               corev1.ConfigMap
+		deploymentConfig config.DeploymentConfig
+	}{
+		// empty deployment config
+		{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ocm-config",
+					Namespace: targetNamespace,
+				},
+				Data: map[string]string{"config.yaml": "test-data"},
+			},
+			deploymentConfig: config.DeploymentConfig{},
+		},
+	}
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		ocmDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64(60)
+		expectedTermGraceSeconds := ocmDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds
+		ocmDeployment.Spec.MinReadySeconds = 60
+		expectedMinReadySeconds := ocmDeployment.Spec.MinReadySeconds
+		err := ReconcileDeployment(ocmDeployment, ownerRef, imageName, &tc.cm, tc.deploymentConfig)
+		g.Expect(err).To(BeNil())
+		g.Expect(expectedTermGraceSeconds).To(Equal(ocmDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds))
+		g.Expect(expectedMinReadySeconds).To(Equal(ocmDeployment.Spec.MinReadySeconds))
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -62,29 +62,27 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 			MatchLabels: selector,
 		}
 	}
-	deployment.Spec = appsv1.DeploymentSpec{
-		Selector: s,
-		Strategy: appsv1.DeploymentStrategy{
-			Type: appsv1.RollingUpdateDeploymentStrategyType,
-			RollingUpdate: &appsv1.RollingUpdateDeployment{
-				MaxSurge:       &maxSurge,
-				MaxUnavailable: &maxUnavailable,
-			},
+	deployment.Spec.Selector = s
+	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxSurge:       &maxSurge,
+			MaxUnavailable: &maxUnavailable,
 		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: labels,
+	}
+	deployment.Spec.Template = corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: labels,
+		},
+		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken: pointer.BoolPtr(false),
+			Containers: []corev1.Container{
+				util.BuildContainer(schedulerContainerMain(), buildSchedulerContainerMain(image, deployment.Namespace, featureGates, policy, ciphers, tlsVersion, disableProfiling)),
 			},
-			Spec: corev1.PodSpec{
-				AutomountServiceAccountToken: pointer.BoolPtr(false),
-				Containers: []corev1.Container{
-					util.BuildContainer(schedulerContainerMain(), buildSchedulerContainerMain(image, deployment.Namespace, featureGates, policy, ciphers, tlsVersion, disableProfiling)),
-				},
-				Volumes: []corev1.Volume{
-					util.BuildVolume(schedulerVolumeConfig(), buildSchedulerVolumeConfig),
-					util.BuildVolume(schedulerVolumeCertWorkDir(), buildSchedulerVolumeCertWorkDir),
-					util.BuildVolume(schedulerVolumeKubeconfig(), buildSchedulerVolumeKubeconfig),
-				},
+			Volumes: []corev1.Volume{
+				util.BuildVolume(schedulerVolumeConfig(), buildSchedulerVolumeConfig),
+				util.BuildVolume(schedulerVolumeCertWorkDir(), buildSchedulerVolumeCertWorkDir),
+				util.BuildVolume(schedulerVolumeKubeconfig(), buildSchedulerVolumeKubeconfig),
 			},
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment_test.go
@@ -1,0 +1,57 @@
+package scheduler
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestReconcileSchedulerDeployment(t *testing.T) {
+
+	// Setup expected values that are universal
+	imageName := "schedulerImage"
+
+	// Setup hypershift hosted control plane.
+	targetNamespace := "test"
+	schedulerDeployment := manifests.SchedulerDeployment(targetNamespace)
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: targetNamespace,
+		},
+	}
+	hcp.Name = "name"
+	hcp.Namespace = "namespace"
+	ownerRef := config.OwnerRefFrom(hcp)
+
+	testCases := []struct {
+		deploymentConfig config.DeploymentConfig
+		params           KubeSchedulerParams
+		featureGates     []string
+		ciphers          []string
+	}{
+		// empty deployment config
+		{
+			deploymentConfig: config.DeploymentConfig{},
+			params: KubeSchedulerParams{
+				DisableProfiling:        false,
+				AvailabilityProberImage: "availability-prober",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		g := NewGomegaWithT(t)
+		schedulerDeployment.Spec.MinReadySeconds = 60
+		expectedMinReadySeconds := schedulerDeployment.Spec.MinReadySeconds
+		err := ReconcileDeployment(schedulerDeployment, ownerRef, tc.deploymentConfig, imageName,
+			tc.params.FeatureGates(), tc.params.SchedulerPolicy(), tc.params.AvailabilityProberImage,
+			pointer.Int32(1234), tc.params.CipherSuites(), tc.params.MinTLSVersion(), tc.params.DisableProfiling)
+		g.Expect(err).To(BeNil())
+		g.Expect(expectedMinReadySeconds).To(Equal(schedulerDeployment.Spec.MinReadySeconds))
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is to ensure that when configurable fields such as minReadySeconds are updated for different deployment strategies, they will not be reset by the hypershift operator in the future

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.