### PR TITLE
STOR-1038: Reconcile Storage and ClusterCSIDrivers in the guest clusters

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/storage.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/storage.go
@@ -12,3 +12,19 @@ func CSISnapshotController() *operatorv1.CSISnapshotController {
 		},
 	}
 }
+
+func Storage() *operatorv1.Storage {
+	return &operatorv1.Storage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	}
+}
+
+func ClusterCSIDriver(name operatorv1.CSIDriverName) *operatorv1.ClusterCSIDriver {
+	return &operatorv1.ClusterCSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: string(name),
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/storage/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/storage/reconcile.go
@@ -13,3 +13,11 @@ func ReconcileOperatorSpec(spec *operatorv1.OperatorSpec) {
 func ReconcileCSISnapshotController(csi *operatorv1.CSISnapshotController) {
 	ReconcileOperatorSpec(&csi.Spec.OperatorSpec)
 }
+
+func ReconcileStorage(storage *operatorv1.Storage) {
+	ReconcileOperatorSpec(&storage.Spec.OperatorSpec)
+}
+
+func ReconcileClusterCSIDriver(driver *operatorv1.ClusterCSIDriver) {
+	ReconcileOperatorSpec(&driver.Spec.OperatorSpec)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Overwrite any user changes in `Storage` and `ClusterCSIDriver` CRs that are managed by CPO and other operators in the hosted control plane.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.