### PR TITLE
Storage: cleanup operand deployments on upgrade

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -262,7 +262,32 @@ func resourcesToRemove() []resourceDesc {
 			kind:       "Deployment",
 			name:       "csi-snapshot-controller-operator",
 			namespace:  "openshift-cluster-storage-operator",
-		}}
+		},
+		{
+			apiVersion: "apps/v1",
+			kind:       "Deployment",
+			name:       "aws-ebs-csi-driver-operator",
+			namespace:  "openshift-cluster-csi-drivers",
+		},
+		{
+			apiVersion: "apps/v1",
+			kind:       "Deployment",
+			name:       "aws-ebs-csi-driver-controller",
+			namespace:  "openshift-cluster-csi-drivers",
+		},
+		{
+			apiVersion: "apps/v1",
+			kind:       "Deployment",
+			name:       "csi-snapshot-webhook",
+			namespace:  "openshift-cluster-storage-operator",
+		},
+		{
+			apiVersion: "apps/v1",
+			kind:       "Deployment",
+			name:       "csi-snapshot-controller",
+			namespace:  "openshift-cluster-storage-operator",
+		},
+	}
 }
 
 func preparePayloadScript() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
When upgrading from an AWS cluster that runs the cluster storage operator
inside the guest cluster, operand deployments such as the aws-csi-driver-operator,
aws-csi-driver-controller, csi-snapshot-webhook, and
csi-snapshot-controller need to be explicitly removed from the guest
cluster so that they won't fight with the deployments on the control plane side.

**Checklist**
- [x] Subject and description added to both, commit and PR.