### PR TITLE
Prevent cluster deletion hangs by using heartbeat condition

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -625,7 +625,7 @@ func TestDestroyCloudResources(t *testing.T) {
 				cpClient:               cpClient,
 				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
 			}
-			err := r.destroyCloudResources(context.Background(), fakeHCP)
+			_, err := r.destroyCloudResources(context.Background(), fakeHCP)
 			g.Expect(err).ToNot(HaveOccurred())
 			verifyCleanupWebhook(g, guestClient)
 			if test.verify != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
If the hcco is not available, the cpo will wait indefinitely for it to update hcp conditions to indicate that guest resources have been deleted. To solve that, the hcco will periodically update a condition to let the CPO that it's working on deletion. If the condition is not updated after a certain amount of time, the CPO gives up waiting and proceeds with the rest of the deletion.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-667](https://issues.redhat.com//browse/HOSTEDCP-667)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.