### PR TITLE
AUTH-323: remove rootCA from CA bundle for etcd certs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1404,8 +1404,7 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 
 	etcdSignerCM := manifests.EtcdSignerCAConfigMap(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, etcdSignerCM, func() error {
-		// TODO remove rootCA. rootCASecret is temporarily added for upgrade scenarios. ibihim
-		return pki.ReconcileEtcdSignerConfigMap(etcdSignerCM, p.OwnerRef, etcdSignerSecret, rootCASecret)
+		return pki.ReconcileEtcdSignerConfigMap(etcdSignerCM, p.OwnerRef, etcdSignerSecret)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile etcd signer CA configmap: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -66,8 +66,8 @@ func ReconcileEtcdSignerSecret(secret *corev1.Secret, ownerRef config.OwnerRef) 
 	return reconcileSelfSignedCA(secret, ownerRef, "etcd-signer", "openshift")
 }
 
-func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdSigner, rootCA *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, etcdSigner, rootCA)
+func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdSigner *corev1.Secret) error {
+	return reconcileAggregateCA(cm, ownerRef, etcdSigner)
 }
 
 func ReconcileEtcdMetricsSignerSecret(secret *corev1.Secret, ownerref config.OwnerRef) error {


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

What:
- It removes the rootCA from the CA bundle used by etcd.

Why:
On upgrades, the transition from a rootCA-signed to an etcd-signer-signed certificate failed as the peers didn't know the old etcd instances didn't know etcd-signer-CA and the new ones didn't know rootCA.

This is the third PR of this series:
1. Introduce etcd-signer-CA to etcd's CA bundle alongside rootCA.
2. Use etcd-signer instead of root. Keep etcd-signer and rootCA in the CA Bundle.
3. Remove rootCA from the CA bundle.

The transition from 1 to 2 and from 2 to 3 works on upgrades.

**Which issue(s) this PR fixes**:
Fixes [AUTH-323](https://issues.redhat.com/browse/AUTH-323)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.