### PR TITLE
test: dynamically assign single AWS zone to SingleReplica guest clusters

### DIFF
--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -31,7 +31,6 @@ bin/test-e2e \
   -test.parallel=20 \
   --e2e.aws-credentials-file=/etc/hypershift-pool-aws-credentials/credentials \
   --e2e.aws-zones=us-east-1a,us-east-1b,us-east-1c \
-  --e2e.node-pool-replicas=1 \
   --e2e.pull-secret-file=/etc/ci-pull-credentials/.dockerconfigjson \
   --e2e.base-domain=ci.hypershift.devcluster.openshift.com \
   --e2e.latest-release-image="${OCP_IMAGE_LATEST}" \

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -24,13 +23,6 @@ func TestAutoscaling(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
 
-	if globalOpts.configurableClusterOptions.NodePoolReplicas != 1 {
-		t.Fatalf("this test must be run with --e2e.node-pool-replicas=1, is configured to run with %d", globalOpts.configurableClusterOptions.NodePoolReplicas)
-	}
-	if len(globalOpts.configurableClusterOptions.Zone) == 0 {
-		t.Fatal("this test must be run with multiple Availability Zones")
-	}
-
 	client, err := e2eutil.GetClient()
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
@@ -41,45 +33,21 @@ func TestAutoscaling(t *testing.T) {
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
 
-	// Get one of the newly created NodePools
+	// Get the newly created NodePool
 	nodepools := &hyperv1.NodePoolList{}
 	if err := client.List(ctx, nodepools, crclient.InNamespace(hostedCluster.Namespace)); err != nil {
 		t.Fatalf("failed to list nodepools in namespace %s: %v", hostedCluster.Namespace, err)
 	}
-
-	var nodepool *hyperv1.NodePool
-	for _, np := range nodepools.Items {
-		if np.Spec.ClusterName != hostedCluster.Name {
-			continue
-		}
-		nodepool = &np
-		break
+	if len(nodepools.Items) != 1 {
+		t.Fatalf("expected exactly one nodepool, got %d", len(nodepools.Items))
 	}
-	if nodepool == nil {
-		t.Fatalf("no nodepool in nodepool list %+v matches hostedcluster UID %s", nodepool, hostedCluster.UID)
-	}
-	t.Logf("Found nodepool. Namespace: %s, name: %s", nodepool.Namespace, nodepool.Name)
+	nodepool := &nodepools.Items[0]
 
 	// Perform some very basic assertions about the guest cluster
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
 	// TODO (alberto): have ability to label and get Nodes by NodePool. NodePool.Status.Nodes?
-	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	numNodes := clusterOpts.NodePoolReplicas
 	nodes := e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
-
-	// find the zone value. This might not be identical to the zone value passed
-	// in during node creation, e.G. in azure this is $region-$zone, on AWS it is
-	// just $zone.
-	var zone string
-	for _, node := range nodes {
-		if !strings.HasPrefix(node.Annotations["cluster.x-k8s.io/owner-name"], nodepool.Name) {
-			continue
-		}
-		zone = node.Labels["topology.kubernetes.io/zone"]
-		break
-	}
-	if zone == "" {
-		t.Fatalf("Found no node whose 'cluster.x-k8s.io/owner-name' annotation has the nodepool name %s as prefix. Nodes: %+v", nodepool.Name, nodes)
-	}
 
 	// Wait for the rollout to be reported complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
@@ -88,13 +56,9 @@ func TestAutoscaling(t *testing.T) {
 	// Enable autoscaling.
 	err = client.Get(ctx, crclient.ObjectKeyFromObject(nodepool), nodepool)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get nodepool")
-	var max int32 = 2
 
-	// This Deployment have replicas=2 with
-	// anti-affinity rules resulting in scheduling constraints
-	// that prevent the cluster from ever scaling back down to 1:
-	// aws-ebs-csi-driver-controller
-	var min int32 = 1
+	min := numNodes
+	max := min + 1
 	original := nodepool.DeepCopy()
 	nodepool.Spec.AutoScaling = &hyperv1.NodePoolAutoScaling{
 		Min: min,
@@ -119,7 +83,7 @@ func TestAutoscaling(t *testing.T) {
 	// be used, not enough to have more than 1 pod per
 	// node.
 	workloadMemRequest := resource.MustParse(fmt.Sprintf("%v", 0.6*float32(bytes)))
-	workload := newWorkLoad(max, workloadMemRequest, "", globalOpts.LatestReleaseImage, zone)
+	workload := newWorkLoad(max, workloadMemRequest, "", globalOpts.LatestReleaseImage)
 	err = guestClient.Create(ctx, workload)
 	g.Expect(err).NotTo(HaveOccurred())
 	t.Logf("Created workload. Node: %s, memcapacity: %s", nodes[0].Name, memCapacity.String())
@@ -142,7 +106,7 @@ func TestAutoscaling(t *testing.T) {
 	_ = e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 }
 
-func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, image string, zone string) *batchv1.Job {
+func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, image string) *batchv1.Job {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "autoscaling-workload",
@@ -172,9 +136,6 @@ func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, ima
 						},
 					},
 					RestartPolicy: corev1.RestartPolicy("Never"),
-					NodeSelector: map[string]string{
-						"topology.kubernetes.io/zone": zone,
-					},
 				},
 			},
 			BackoffLimit: pointer.Int32Ptr(4),

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -61,7 +61,6 @@ func TestEtcdChaos(t *testing.T) {
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.NodePoolReplicas = 0
 
 	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir)

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -36,7 +36,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
 
 	// Wait for Nodes to be Ready
-	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	numNodes := int32(int(clusterOpts.NodePoolReplicas) * len(clusterOpts.AWSPlatform.Zones))
 	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the first rollout to be complete

--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -57,7 +57,6 @@ func TestNTOMachineConfigGetsRolledOut(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.BeforeApply = func(o crclient.Object) {
 		nodePool, isNodepool := o.(*hyperv1.NodePool)
 		if !isNodepool {
@@ -79,8 +78,7 @@ func TestNTOMachineConfigGetsRolledOut(t *testing.T) {
 	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
 
 	// Wait for Nodes to be Ready
-	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
+	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, clusterOpts.NodePoolReplicas, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the rollout to be complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
@@ -171,7 +169,6 @@ func TestNTOMachineConfigAppliedInPlace(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.BeforeApply = func(o crclient.Object) {
 		nodePool, isNodepool := o.(*hyperv1.NodePool)
 		if !isNodepool {
@@ -187,8 +184,7 @@ func TestNTOMachineConfigAppliedInPlace(t *testing.T) {
 	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
 
 	// Wait for Nodes to be Ready
-	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
+	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, clusterOpts.NodePoolReplicas, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the rollout to be complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -32,8 +32,6 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ReleaseImage = globalOpts.LatestReleaseImage
-	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
-
 	clusterOpts.BeforeApply = func(o crclient.Object) {
 		switch v := o.(type) {
 		case *hyperv1.NodePool:
@@ -69,7 +67,7 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
 
 	// Wait for Nodes to be Ready.
-	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
+	numNodes := clusterOpts.NodePoolReplicas
 	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the first rollout to be complete and refresh the HostedCluster.
@@ -127,8 +125,6 @@ func TestInPlaceUpgradeNodePool(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ReleaseImage = globalOpts.LatestReleaseImage
-	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
-
 	clusterOpts.BeforeApply = func(o crclient.Object) {
 		switch v := o.(type) {
 		case *hyperv1.NodePool:
@@ -158,8 +154,7 @@ func TestInPlaceUpgradeNodePool(t *testing.T) {
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, client, hostedCluster)
 
 	// Wait for Nodes to be Ready
-	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, clusterOpts.NodePoolReplicas, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the first rollout to be complete and refresh the hostedcluster
 	t.Logf("Waiting for initial cluster rollout. Image: %s", hostedCluster.Spec.Release.Image)
@@ -197,7 +192,7 @@ func TestInPlaceUpgradeNodePool(t *testing.T) {
 	}
 
 	// Verify all nodes are ready after the upgrade
-	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
+	e2eutil.WaitForNReadyNodes(t, ctx, guestClient, clusterOpts.NodePoolReplicas, hostedCluster.Spec.Platform.Type)
 
 	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
 }

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -48,7 +48,6 @@ func TestOLM(t *testing.T) {
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	clusterOpts.NodePoolReplicas = 1
 	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
 
 	// Get guest client

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -328,7 +328,9 @@ func WaitForNodePoolVersion(t *testing.T, ctx context.Context, client crclient.C
 	start := time.Now()
 
 	t.Logf("Waiting for nodepool %s/%s to report version %s (currently %s)", nodePool.Namespace, nodePool.Name, version, nodePool.Status.Version)
-	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
+	// TestInPlaceUpgradeNodePool must update nodes in the pool squentially and it takes about 5m per node
+	// TestInPlaceUpgradeNodePool currently uses a single nodepool with 2 replicas so 20m should be enough time (2x expected)
+	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 20*time.Minute, func(ctx context.Context) (done bool, err error) {
 		latest := nodePool.DeepCopy()
 		err = client.Get(ctx, crclient.ObjectKeyFromObject(nodePool), latest)
 		if err != nil {


### PR DESCRIPTION
Currently, we create test clusters with NodePools and AWS networking infra in all zones specified in the `--e2e.availability-zones` flag.

However, all test clusters are currently `InfrastructureAvailabilityPolicy: SingleReplica` and can operate on 2 workers in a single zone.

Limiting the test cluster to a single zone prevents a considerable number of AWS resources from being created, particularly NAT gateways.

This PR uses `--e2e.availability-zones` as a bank zones to which test clusters can be assigned and created.  It also removes the `-e2e.node-pool-replicas` flag from the e2e binary and allows each test to control this.

Tests default to running `InfrastructureAvailabilityPolicy: SingleReplica` with 2 workers in a single assigned zone.  `TestCreateCluster` exercises  `InfrastructureAvailabilityPolicy: HighlyAvailable` guest clusters, which we have not exercised in e2e up until now.