### PR TITLE
Moving from HC Migration to Disaster Recovery in documentation

### DIFF
--- a/docs/content/how-to/aws/external-dns.md
+++ b/docs/content/how-to/aws/external-dns.md
@@ -105,7 +105,7 @@ The resulting HostedCluster `services` block looks like this:
 
 When the `Services` and `Routes` are created by the Control Plane Operator (CPO), it will annotate them with the `external-dns.alpha.kubernetes.io/hostname` annotation. The value will be the `hostname` field in the `servicePublishingStrategy` for that type.  The CPO uses this name blindly for the service endpoints and assumes that if `hostname` is set, there is some mechanism external-dns or otherwise, that will create the DNS records.
 
-There is an interaction between the `spec.platform.aws.endpointAccess` and which services are permitted to set `hostname` when using [AWS Private clustering](aws/deploy-aws-private-clusters.md).  Only *public* services can have service-level DNS indirection.  Private services use the `hypershift.local` private zone and it is not valid to set `hostname` for `services` that are private for a given `endpointAccess` type.
+There is an interaction between the `spec.platform.aws.endpointAccess` and which services are permitted to set `hostname` when using [AWS Private clustering](deploy-aws-private-clusters.md).  Only *public* services can have service-level DNS indirection.  Private services use the `hypershift.local` private zone and it is not valid to set `hostname` for `services` that are private for a given `endpointAccess` type.
 
 The following table notes when it is valid to set hostname for a particular `service` and `endpointAccess` combination:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,7 +28,7 @@ extra_javascript:
   - https://unpkg.com/mermaid@9.2.2/dist/mermaid.min.js
 markdown_extensions:
 - toc:
-    toc_depth: "2-2"
+    toc_depth: "2-3"
 - attr_list:
 - pymdownx.highlight
 - pymdownx.inlinehilite
@@ -66,7 +66,7 @@ nav:
     - how-to/aws/deploy-aws-private-clusters.md
     - how-to/aws/external-dns.md
     - how-to/aws/etc-backup-restore.md
-    - how-to/aws/migrate-hosted-cluster.md
+    - how-to/aws/disaster-recovery.md
   - 'Azure':
     - how-to/azure/create-azure-cluster.md
   - 'Agent':


### PR DESCRIPTION
Making clear in the documentation that the Migration capability it's just for disaster recovery purposes.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>