### PR TITLE
Add metrics for hostedCluster deletion SLIs

### DIFF
--- a/api/v1beta1/hosted_controlplane.go
+++ b/api/v1beta1/hosted_controlplane.go
@@ -171,7 +171,6 @@ const (
 	HostedControlPlaneDegraded  ConditionType = "Degraded"
 	EtcdSnapshotRestored        ConditionType = "EtcdSnapshotRestored"
 	CVOScaledDown               ConditionType = "CVOScaledDown"
-	CloudResourcesDestroyed     ConditionType = "CloudResourcesDestroyed"
 )
 
 // HostedControlPlaneStatus defines the observed state of HostedControlPlane

--- a/api/v1beta1/hostedcluster_conditions.go
+++ b/api/v1beta1/hostedcluster_conditions.go
@@ -34,6 +34,11 @@ const (
 	// supported by the underlying management cluster.
 	// A failure here is unlikely to resolve without the changing user input.
 	ValidHostedControlPlaneConfiguration ConditionType = "ValidHostedControlPlaneConfiguration"
+	// CloudResourcesDestroyed bubbles up the same condition from HCP. It signals if the cloud provider infrastructure created by Kubernetes
+	// in the consumer cloud provider account was destroyed.
+	// A failure here may require external user intervention to resolve. E.g. cloud provider perms were corrupted. E.g. the guest cluster was broken
+	// and kube resource deletion that affects cloud infra like service type load balancer can't succeed.
+	CloudResourcesDestroyed ConditionType = "CloudResourcesDestroyed"
 
 	// Bubble up from HCP which bubbles up from CVO.
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -346,10 +346,35 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			meta.SetStatusCondition(&hcluster.Status.Conditions, *freshCondition)
 			// Persist status updates
 			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
-				if apierrors.IsConflict(err) {
-					return ctrl.Result{Requeue: true}, nil
-				}
 				return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+			}
+		}
+	}
+
+	// Bubble up CloudResourcesDestroyed condition from the hostedControlPlane.
+	// We set this condition even if the HC is being deleted, so we can construct SLIs for deletion times.
+	{
+		if hcp != nil && hcp.DeletionTimestamp != nil {
+			freshCondition := &metav1.Condition{
+				Type:               string(hyperv1.CloudResourcesDestroyed),
+				Status:             metav1.ConditionUnknown,
+				Reason:             hyperv1.StatusUnknownReason,
+				ObservedGeneration: hcluster.Generation,
+			}
+
+			cloudResourcesDestroyedCondition := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
+			if cloudResourcesDestroyedCondition != nil {
+				freshCondition = cloudResourcesDestroyedCondition
+			}
+
+			oldCondition := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
+			if oldCondition == nil || oldCondition.Status != freshCondition.Status {
+				freshCondition.ObservedGeneration = hcluster.Generation
+				meta.SetStatusCondition(&hcluster.Status.Conditions, *freshCondition)
+				// Persist status updates
+				if err := r.Client.Status().Update(ctx, hcluster); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+				}
 			}
 		}
 	}

--- a/hypershift-operator/metrics.go
+++ b/hypershift-operator/metrics.go
@@ -30,6 +30,11 @@ type hypershiftMetrics struct {
 	// repeatedly with the same value.
 	clusterAvailableTime *prometheus.GaugeVec
 
+	// clusterDeletionTime is the time it takes between the HostedCluster gests a deletion timestamp until
+	// it performs all its deletion tasks and so the finalizer is removed and it's removed from etcd.
+	clusterDeletionTime                    *prometheus.GaugeVec
+	clusterGuestCloudResourcesDeletionTime *prometheus.GaugeVec
+
 	hostedClusters                     *prometheus.GaugeVec
 	hostedClustersWithFailureCondition *prometheus.GaugeVec
 	hostedClustersNodePools            *prometheus.GaugeVec
@@ -39,6 +44,8 @@ type hypershiftMetrics struct {
 
 	client crclient.Client
 
+	hostedClusterDeletingCache map[string]*metav1.Time
+
 	log logr.Logger
 }
 
@@ -47,6 +54,14 @@ func newMetrics(client crclient.Client, log logr.Logger) *hypershiftMetrics {
 		clusterCreationTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Help: "Time in seconds it took from initial cluster creation and rollout of initial version",
 			Name: "hypershift_cluster_initial_rollout_duration_seconds",
+		}, []string{"name"}),
+		clusterDeletionTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help: "Time in seconds it took from initial cluster deletion to the resource being removed from etcd",
+			Name: "hypershift_cluster_deletion_duration_seconds",
+		}, []string{"name"}),
+		clusterGuestCloudResourcesDeletionTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help: "Time in seconds it took from initial cluster deletion to the resource being removed from etcd",
+			Name: "hypershift_cluster_guest_cloud_resources_deletion_duration_seconds",
 		}, []string{"name"}),
 		clusterAvailableTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Help: "Time in seconds it took from initial cluster creation to HostedClusterAvailable condition becoming true",
@@ -115,6 +130,12 @@ func setupMetrics(mgr manager.Manager) error {
 	if err := crmetrics.Registry.Register(metrics.clusterCreationTime); err != nil {
 		return fmt.Errorf("failed to to register clusterCreationTime metric: %w", err)
 	}
+	if err := crmetrics.Registry.Register(metrics.clusterDeletionTime); err != nil {
+		return fmt.Errorf("failed to to register clusterDeletionTime metric: %w", err)
+	}
+	if err := crmetrics.Registry.Register(metrics.clusterGuestCloudResourcesDeletionTime); err != nil {
+		return fmt.Errorf("failed to to register clusterDeletionTime metric: %w", err)
+	}
 	if err := crmetrics.Registry.Register(metrics.clusterAvailableTime); err != nil {
 		return fmt.Errorf("failed to to register clusterAvailableTime metric: %w", err)
 	}
@@ -156,11 +177,13 @@ var expectedHCConditionStates = map[hyperv1.ConditionType]bool{
 func (m *hypershiftMetrics) observeHostedClusters(hostedClusters *hyperv1.HostedClusterList) {
 	hcCount := newLabelCounter()
 	hcByConditions := newLabelCounter()
+
 	for _, hc := range hostedClusters.Items {
 		creationTime := clusterCreationTime(&hc)
 		if creationTime != nil {
 			m.clusterCreationTime.WithLabelValues(hc.Namespace + "/" + hc.Name).Set(*creationTime)
 		}
+
 		availableTime := clusterAvailableTime(&hc)
 		if availableTime != nil {
 			m.clusterAvailableTime.WithLabelValues(hc.Namespace + "/" + hc.Name).Set(*availableTime)
@@ -182,6 +205,36 @@ func (m *hypershiftMetrics) observeHostedClusters(hostedClusters *hyperv1.Hosted
 				}
 			}
 		}
+
+		guestCloudResourcesDeletionTime := clusterGuestCloudResourcesDeletionTime(&hc)
+		if guestCloudResourcesDeletionTime != nil {
+			m.clusterAvailableTime.WithLabelValues(crclient.ObjectKeyFromObject(&hc).String()).Set(*guestCloudResourcesDeletionTime)
+		}
+	}
+
+	// Capture cluster deletion time.
+	existingHostedClusters := make(map[string]bool)
+	if m.hostedClusterDeletingCache == nil {
+		m.hostedClusterDeletingCache = make(map[string]*metav1.Time)
+	}
+	for _, hc := range hostedClusters.Items {
+		// store hostedClusters with a deletion timestamp.
+		if deletionTime := hc.DeletionTimestamp; deletionTime != nil {
+			m.hostedClusterDeletingCache[crclient.ObjectKeyFromObject(&hc).String()] = deletionTime
+		}
+
+		// store all existing hostedClusters
+		existingHostedClusters[crclient.ObjectKeyFromObject(&hc).String()] = true
+	}
+	for key, deletionTime := range m.hostedClusterDeletingCache {
+		if ok := existingHostedClusters[key]; ok {
+			continue
+		}
+
+		// If the hostedCluster had a deletion timestamp and does not exist anymore, capture metric.
+		deletionTime := time.Now().Sub(deletionTime.Time).Seconds()
+		m.clusterDeletionTime.WithLabelValues(key).Set(deletionTime)
+		delete(m.hostedClusterDeletingCache, key)
 	}
 
 	for key, count := range hcCount.Counts() {
@@ -217,6 +270,19 @@ func clusterAvailableTime(hc *hyperv1.HostedCluster) *float64 {
 	}
 	transitionTime := condition.LastTransitionTime
 	availableTime := transitionTime.Sub(hc.CreationTimestamp.Time).Seconds()
+	return &availableTime
+}
+
+func clusterGuestCloudResourcesDeletionTime(hc *hyperv1.HostedCluster) *float64 {
+	condition := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
+	if condition == nil {
+		return nil
+	}
+	if condition.Status == metav1.ConditionFalse {
+		return nil
+	}
+	transitionTime := condition.LastTransitionTime
+	availableTime := transitionTime.Sub(hc.DeletionTimestamp.Time).Seconds()
 	return &availableTime
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds two new metrics
hypershift_cluster_deletion_duration_seconds
hypershift_cluster_guest_cloud_resources_deletion_duration_seconds

As a consequence CloudResourcesDestroyed is bubble up from HCP into HC.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Ref https://issues.redhat.com/browse/HOSTEDCP-635


**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.