### PR TITLE
Bug hypershift cli timeout to long when invalid region is provided

### DIFF
--- a/cmd/infra/aws/util/util.go
+++ b/cmd/infra/aws/util/util.go
@@ -35,9 +35,11 @@ func NewSession(agent string, credentialsFile string, credKey string, credSecret
 func NewAWSRoute53Config() *aws.Config {
 	awsRoute53Config := NewConfig()
 	awsRoute53Config.Retryer = client.DefaultRetryer{
-		NumMaxRetries:    10,
+		NumMaxRetries:    5,
 		MinRetryDelay:    5 * time.Second,
 		MinThrottleDelay: 10 * time.Second,
+		MaxRetryDelay:    5 * time.Second,
+		MaxThrottleDelay: 10 * time.Second,
 	}
 	return awsRoute53Config
 }
@@ -47,9 +49,11 @@ func NewConfig() *aws.Config {
 
 	awsConfig := aws.NewConfig()
 	awsConfig.Retryer = client.DefaultRetryer{
-		NumMaxRetries:    10,
+		NumMaxRetries:    5,
 		MinRetryDelay:    5 * time.Second,
 		MinThrottleDelay: 5 * time.Second,
+		MaxRetryDelay:    5 * time.Second,
+		MaxThrottleDelay: 5 * time.Second,
 	}
 	return awsConfig
 }


### PR DESCRIPTION
* Decrease the number of retries from 10 to 5, set the MaxRetryDelay and MaxThrottleDelay to cap the timeout to 25s

Signed-off-by: Joshua Packer <jpacker@redhat.com>

**What this PR does / why we need it**:
* hypershift cli timeout on connection error is to long and disrupts normal user flow

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
https://github.com/openshift/hypershift/issues/1957

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.