### PR TITLE
fix(ho): Use v1alpha1 ownerRef for future CPO managed components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -21,8 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, sa *corev1.ServiceAccount, kubeConfigSecret *corev1.Secret, options hyperv1.ClusterAutoscaling, clusterAutoscalerImage, availabilityProberImage string, setDefaultSecurityContext bool) error {
-	config.OwnerRefFrom(hcp).ApplyTo(deployment)
+func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, sa *corev1.ServiceAccount, kubeConfigSecret *corev1.Secret, options hyperv1.ClusterAutoscaling, clusterAutoscalerImage, availabilityProberImage string, setDefaultSecurityContext bool, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(deployment)
 	args := []string{
 		"--cloud-provider=clusterapi",
 		"--node-group-auto-discovery=clusterapi:namespace=$(MY_NAMESPACE)",
@@ -225,10 +225,10 @@ func ReconcileAutoscalerRoleBinding(binding *rbacv1.RoleBinding, role *rbacv1.Ro
 }
 
 // ReconcileAutoscaler orchestrates reconciliation of autoscaler components.
-func ReconcileAutoscaler(ctx context.Context, c client.Client, hcp *hyperv1.HostedControlPlane, autoscalerImage, availabilityProberImage string, createOrUpdate upsert.CreateOrUpdateFN, setDefaultSecurityContext bool) error {
+func ReconcileAutoscaler(ctx context.Context, c client.Client, hcp *hyperv1.HostedControlPlane, autoscalerImage, availabilityProberImage string, createOrUpdate upsert.CreateOrUpdateFN, setDefaultSecurityContext bool, ownerRef config.OwnerRef) error {
 	autoscalerRole := manifests.AutoscalerRole(hcp.Namespace)
 	_, err := createOrUpdate(ctx, c, autoscalerRole, func() error {
-		return ReconcileAutoscalerRole(autoscalerRole, config.OwnerRefFrom(hcp))
+		return ReconcileAutoscalerRole(autoscalerRole, ownerRef)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile autoscaler role: %w", err)
@@ -237,7 +237,7 @@ func ReconcileAutoscaler(ctx context.Context, c client.Client, hcp *hyperv1.Host
 	autoscalerServiceAccount := manifests.AutoscalerServiceAccount(hcp.Namespace)
 	_, err = createOrUpdate(ctx, c, autoscalerServiceAccount, func() error {
 		util.EnsurePullSecret(autoscalerServiceAccount, controlplaneoperator.PullSecret("").Name)
-		config.OwnerRefFrom(hcp).ApplyTo(autoscalerServiceAccount)
+		ownerRef.ApplyTo(autoscalerServiceAccount)
 		return nil
 	})
 	if err != nil {
@@ -246,7 +246,7 @@ func ReconcileAutoscaler(ctx context.Context, c client.Client, hcp *hyperv1.Host
 
 	autoscalerRoleBinding := manifests.AutoscalerRoleBinding(hcp.Namespace)
 	_, err = createOrUpdate(ctx, c, autoscalerRoleBinding, func() error {
-		return ReconcileAutoscalerRoleBinding(autoscalerRoleBinding, autoscalerRole, autoscalerServiceAccount, config.OwnerRefFrom(hcp))
+		return ReconcileAutoscalerRoleBinding(autoscalerRoleBinding, autoscalerRole, autoscalerServiceAccount, ownerRef)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile autoscaler role binding: %w", err)
@@ -269,7 +269,7 @@ func ReconcileAutoscaler(ctx context.Context, c client.Client, hcp *hyperv1.Host
 
 		autoscalerDeployment := manifests.AutoscalerDeployment(hcp.Namespace)
 		_, err = createOrUpdate(ctx, c, autoscalerDeployment, func() error {
-			return ReconcileAutoscalerDeployment(autoscalerDeployment, hcp, autoscalerServiceAccount, capiKubeConfigSecret, hcp.Spec.Autoscaling, autoscalerImage, availabilityProberImage, setDefaultSecurityContext)
+			return ReconcileAutoscalerDeployment(autoscalerDeployment, hcp, autoscalerServiceAccount, capiKubeConfigSecret, hcp.Spec.Autoscaling, autoscalerImage, availabilityProberImage, setDefaultSecurityContext, ownerRef)
 		})
 		if err != nil {
 			return fmt.Errorf("failed to reconcile autoscaler deployment: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -669,6 +669,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 		// The healthz handler was added before the CPO started to mange te ignition server and its the same binary,
 		// so we know it always exists here.
 		true,
+		config.OwnerRefFrom(hostedControlPlane),
 	); err != nil {
 		return fmt.Errorf("failed to reconcile ignition server: %w", err)
 	}
@@ -3189,7 +3190,7 @@ func (r *HostedControlPlaneReconciler) reconcileAutoscaler(ctx context.Context, 
 		return fmt.Errorf("availability prober image not found")
 	}
 
-	return autoscaler.ReconcileAutoscaler(ctx, r.Client, hcp, autoscalerImage, availabilityProberImage, createOrUpdate, r.SetDefaultSecurityContext)
+	return autoscaler.ReconcileAutoscaler(ctx, r.Client, hcp, autoscalerImage, availabilityProberImage, createOrUpdate, r.SetDefaultSecurityContext, config.OwnerRefFrom(hcp))
 }
 
 func (r *HostedControlPlaneReconciler) reconcileMachineApprover(ctx context.Context, hcp *hyperv1.HostedControlPlane, images map[string]string, createOrUpdate upsert.CreateOrUpdateFN) error {
@@ -3203,7 +3204,7 @@ func (r *HostedControlPlaneReconciler) reconcileMachineApprover(ctx context.Cont
 		return fmt.Errorf("availability prober image not found")
 	}
 
-	return machineapprover.ReconcileMachineApprover(ctx, r.Client, hcp, machineApproverImage, availabilityProberImage, createOrUpdate, r.SetDefaultSecurityContext)
+	return machineapprover.ReconcileMachineApprover(ctx, r.Client, hcp, machineApproverImage, availabilityProberImage, createOrUpdate, r.SetDefaultSecurityContext, config.OwnerRefFrom(hcp))
 }
 
 func shouldCleanupCloudResources(hcp *hyperv1.HostedControlPlane) bool {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -478,7 +478,7 @@ func TestClusterAutoscalerArgs(t *testing.T) {
 			hcp := &hyperv1.HostedControlPlane{}
 			hcp.Name = "name"
 			hcp.Namespace = "namespace"
-			err := autoscaler.ReconcileAutoscalerDeployment(deployment, hcp, sa, secret, test.AutoscalerOptions, "clusterAutoscalerImage", "availabilityProberImage", false)
+			err := autoscaler.ReconcileAutoscalerDeployment(deployment, hcp, sa, secret, test.AutoscalerOptions, "clusterAutoscalerImage", "availabilityProberImage", false, config.OwnerRefFrom(hcp))
 			if err != nil {
 				t.Error(err)
 			}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -132,7 +132,7 @@ type HostedClusterReconciler struct {
 	// 2) The OCP version being deployed is the latest version supported by Hypershift
 	HypershiftOperatorImage string
 
-	// releaseProvider looks up the OCP version for the release images in HostedClusters
+	// ReleaseProvider looks up the OCP version for the release images in HostedClusters
 	ReleaseProvider releaseinfo.ProviderWithRegistryOverrides
 
 	// SetDefaultSecurityContext is used to configure Security Context for containers
@@ -924,6 +924,8 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	}
 	_, ignitionServerHasHealthzHandler := hyperutil.ImageLabels(controlPlaneOperatorImageMetadata)[ignitionServerHealthzHandlerLabel]
 	_, controlplaneOperatorManagesIgnitionServer := hyperutil.ImageLabels(controlPlaneOperatorImageMetadata)[controlplaneOperatorManagesIgnitionServerLabel]
+	_, controlPlaneOperatorManagesMachineAutoscaler := hyperutil.ImageLabels(controlPlaneOperatorImageMetadata)[controlPlaneOperatorManagesMachineAutoscaler]
+	_, controlPlaneOperatorManagesMachineApprover := hyperutil.ImageLabels(controlPlaneOperatorImageMetadata)[controlPlaneOperatorManagesMachineApprover]
 
 	p, err := platform.GetPlatform(ctx, hcluster, r.ReleaseProvider, utilitiesImage, pullSecretBytes)
 	if err != nil {
@@ -1365,19 +1367,32 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile capi provider: %w", err)
 	}
 
+	// Get release image version, if needed
+	var releaseImageVersion semver.Version
+	if !controlPlaneOperatorManagesMachineAutoscaler || !controlPlaneOperatorManagesMachineApprover || !controlplaneOperatorManagesIgnitionServer {
+		releaseInfo, err := r.ReleaseProvider.Lookup(ctx, hcluster.Spec.Release.Image, pullSecretBytes)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to lookup release image: %w", err)
+		}
+		releaseImageVersion, err = semver.Parse(releaseInfo.Version())
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to parse release image version: %w", err)
+		}
+	}
+
 	// In >= 4.11 We want to move most of the components reconciliation down to the CPO https://issues.redhat.com/browse/HOSTEDCP-375.
 	// For IBM existing clusters < 4.11 we need to stay consistent and keep deploying existing pods to satisfy validations.
 	// TODO (alberto): drop this after dropping < 4.11 support.
-	if _, hasLabel := hyperutil.ImageLabels(controlPlaneOperatorImageMetadata)[controlPlaneOperatorManagesMachineAutoscaler]; !hasLabel {
+	if !controlPlaneOperatorManagesMachineAutoscaler {
 		// Reconcile the autoscaler.
-		err = r.reconcileAutoscaler(ctx, createOrUpdate, hcluster, hcp, utilitiesImage, pullSecretBytes)
+		err = r.reconcileAutoscaler(ctx, createOrUpdate, hcluster, hcp, utilitiesImage, pullSecretBytes, releaseImageVersion)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile autoscaler: %w", err)
 		}
 	}
-	if _, hasLabel := hyperutil.ImageLabels(controlPlaneOperatorImageMetadata)[controlPlaneOperatorManagesMachineApprover]; !hasLabel {
+	if !controlPlaneOperatorManagesMachineApprover {
 		// Reconcile the machine approver.
-		if err = r.reconcileMachineApprover(ctx, createOrUpdate, hcluster, hcp, utilitiesImage, pullSecretBytes); err != nil {
+		if err = r.reconcileMachineApprover(ctx, createOrUpdate, hcluster, hcp, utilitiesImage, pullSecretBytes, releaseImageVersion); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile machine approver: %w", err)
 		}
 	}
@@ -1404,6 +1419,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			ignitionServerHasHealthzHandler,
 			r.ReleaseProvider.GetRegistryOverrides(),
 			r.ManagementClusterCapabilities.Has(capabilities.CapabilitySecurityContextConstraint),
+			config.MutatingOwnerRefFromHCP(hcp, releaseImageVersion),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile ignition server: %w", err)
 		}
@@ -1889,17 +1905,17 @@ func servicePublishingStrategyByType(hcp *hyperv1.HostedCluster, svcType hyperv1
 // reconcileAutoscaler orchestrates reconciliation of autoscaler components using
 // both the HostedCluster and the HostedControlPlane which the autoscaler takes
 // inputs from.
-func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, utilitiesImage string, pullSecretBytes []byte) error {
+func (r *HostedClusterReconciler) reconcileAutoscaler(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, utilitiesImage string, pullSecretBytes []byte, releaseVersion semver.Version) error {
 	clusterAutoscalerImage, err := hyperutil.GetPayloadImage(ctx, r.ReleaseProvider, hcluster, ImageStreamAutoscalerImage, pullSecretBytes)
 	if err != nil {
-		return fmt.Errorf("failed to get image for machine approver: %w", err)
+		return fmt.Errorf("failed to get image for cluster autoscaler: %w", err)
 	}
 	// TODO: can remove this override when all IBM production clusters upgraded to a version that uses the release image
 	if imageVal, ok := hcluster.Annotations[hyperv1.ClusterAutoscalerImage]; ok {
 		clusterAutoscalerImage = imageVal
 	}
 
-	return autoscaler.ReconcileAutoscaler(ctx, r.Client, hcp, clusterAutoscalerImage, utilitiesImage, createOrUpdate, r.SetDefaultSecurityContext)
+	return autoscaler.ReconcileAutoscaler(ctx, r.Client, hcp, clusterAutoscalerImage, utilitiesImage, createOrUpdate, r.SetDefaultSecurityContext, config.MutatingOwnerRefFromHCP(hcp, releaseVersion))
 }
 
 // GetControlPlaneOperatorImage resolves the appropriate control plane operator
@@ -3125,7 +3141,7 @@ func (r *HostedClusterReconciler) reconcileClusterPrometheusRBAC(ctx context.Con
 	return nil
 }
 
-func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, utilitiesImage string, pullSecretBytes []byte) error {
+func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, utilitiesImage string, pullSecretBytes []byte, releaseVersion semver.Version) error {
 	machineApproverImage, err := hyperutil.GetPayloadImage(ctx, r.ReleaseProvider, hcluster, ImageStreamClusterMachineApproverImage, pullSecretBytes)
 	if err != nil {
 		return fmt.Errorf("failed to get image for machine approver: %w", err)
@@ -3135,7 +3151,7 @@ func (r *HostedClusterReconciler) reconcileMachineApprover(ctx context.Context, 
 		machineApproverImage = imageVal
 	}
 
-	return machineapprover.ReconcileMachineApprover(ctx, r.Client, hcp, machineApproverImage, utilitiesImage, createOrUpdate, r.SetDefaultSecurityContext)
+	return machineapprover.ReconcileMachineApprover(ctx, r.Client, hcp, machineApproverImage, utilitiesImage, createOrUpdate, r.SetDefaultSecurityContext, config.MutatingOwnerRefFromHCP(hcp, releaseVersion))
 }
 
 func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster) error {
@@ -3322,22 +3338,27 @@ func isProgressing(ctx context.Context, hc *hyperv1.HostedCluster) (bool, error)
 // Depending on the awsEndpointAccessType, the routes will be exposed through a HCP router exposed via load balancer external or internal,
 // or through the management cluster ingress.
 // 1 - When Public
-//		If the HO has external DNS support:
-// 			All serviceTypes including KAS should be Routes (with RoutePublishingStrategy.hostname != "").
-// 			They will be exposed through a common HCP router exposed via Service type LB external.
-//		If the HO has no external DNS support:
-//			The KAS serviceType should be LoadBalancer. It will be exposed through a dedicated Service type LB external.
-// 			All other serviceTypes should be Routes. They will be exposed by the management cluster default ingress.
+//
+//	If the HO has external DNS support:
+//		All serviceTypes including KAS should be Routes (with RoutePublishingStrategy.hostname != "").
+//		They will be exposed through a common HCP router exposed via Service type LB external.
+//	If the HO has no external DNS support:
+//		The KAS serviceType should be LoadBalancer. It will be exposed through a dedicated Service type LB external.
+//		All other serviceTypes should be Routes. They will be exposed by the management cluster default ingress.
+//
 // 2 - When PublicAndPrivate
-//		If the HO has external DNS support:
-// 			All serviceTypes including KAS should be Routes (with RoutePublishingStrategy.hostname != "").
-// 			They will be exposed through a common HCP router exposed via both Service type LB internal and external.
-//		If the HO has no external DNS support:
-//			The KAS serviceType should be LoadBalancer. It will be exposed through a dedicated Service type LB external.
-// 			All other serviceTypes should be Routes. They will be exposed by a common HCP router is exposed via Service type LB internal.
+//
+//	If the HO has external DNS support:
+//		All serviceTypes including KAS should be Routes (with RoutePublishingStrategy.hostname != "").
+//		They will be exposed through a common HCP router exposed via both Service type LB internal and external.
+//	If the HO has no external DNS support:
+//		The KAS serviceType should be LoadBalancer. It will be exposed through a dedicated Service type LB external.
+//		All other serviceTypes should be Routes. They will be exposed by a common HCP router is exposed via Service type LB internal.
+//
 // 3 - When Private
-//		The KAS serviceType should be Route or Load balancer. TODO (alberto): remove Load balancer choice for private.
-// 		All other serviceTypes should be Routes. They will be exposed by a common HCP router exposed via Service type LB internal.
+//
+//	The KAS serviceType should be Route or Load balancer. TODO (alberto): remove Load balancer choice for private.
+//	All other serviceTypes should be Routes. They will be exposed by a common HCP router exposed via Service type LB internal.
 func (r *HostedClusterReconciler) validateAWSConfig(hc *hyperv1.HostedCluster) error {
 	if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
 		return nil

--- a/support/config/ownerref.go
+++ b/support/config/ownerref.go
@@ -5,6 +5,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
+	"github.com/blang/semver"
+	hyperv1alpha1 "github.com/openshift/hypershift/api/v1alpha1"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/util"
 )
@@ -29,4 +32,13 @@ func ControllerOwnerRef(obj client.Object) *metav1.OwnerReference {
 		return nil
 	}
 	return metav1.NewControllerRef(obj, gvk)
+}
+
+// MutatingOwnerRefFromHCP returns ownerRef with altered API version based on OCP release version
+func MutatingOwnerRefFromHCP(hcp *hyperv1.HostedControlPlane, version semver.Version) OwnerRef {
+	ownerRef := OwnerRefFrom(hcp)
+	if version.Major == 4 && version.Minor < 12 {
+		ownerRef.Reference.APIVersion = hyperv1alpha1.GroupVersion.String()
+	}
+	return ownerRef
 }

--- a/support/config/ownerref_test.go
+++ b/support/config/ownerref_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+
+	"github.com/blang/semver"
+)
+
+func TestMutatingOwnerRefFromHCP(t *testing.T) {
+	tests := []struct {
+		name           string
+		releaseVersion semver.Version
+		expected       string
+	}{
+		{
+			name:           "4.9.0 should use v1alpha1",
+			releaseVersion: semver.MustParse("4.9.0"),
+			expected:       "hypershift.openshift.io/v1alpha1",
+		},
+		{
+			name:           "4.10.0 should use v1alpha1",
+			releaseVersion: semver.MustParse("4.10.0"),
+			expected:       "hypershift.openshift.io/v1alpha1",
+		},
+		{
+			name:           "4.11.0 should use v1alpha1",
+			releaseVersion: semver.MustParse("4.11.0"),
+			expected:       "hypershift.openshift.io/v1alpha1",
+		},
+		{
+			name:           "4.12.0 should use v1beta1",
+			releaseVersion: semver.MustParse("4.12.0"),
+			expected:       "hypershift.openshift.io/v1beta1",
+		},
+		{
+			name:           "4.13.0 should use v1beta1",
+			releaseVersion: semver.MustParse("4.13.0"),
+			expected:       "hypershift.openshift.io/v1beta1",
+		},
+		{
+			name:           "default should use v1beta1",
+			releaseVersion: semver.MustParse("0.0.0"),
+			expected:       "hypershift.openshift.io/v1beta1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := MutatingOwnerRefFromHCP(&hyperv1.HostedControlPlane{}, test.releaseVersion)
+			g.Expect(result.Reference.APIVersion).To(Equal(test.expected))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates HO to continue using `v1alpha1` ownerRefs for components (cluster-autoscaler, machine-approver, ignition-server) that will eventually move to CPO management. This will be the case for HCs < 4.12.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #1955 

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.