### PR TITLE
Block CPO from proceeding with deployment on Etcd rollout

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -707,6 +707,14 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 		if err := r.reconcileManagedEtcd(ctx, hostedControlPlane, releaseImage, createOrUpdate); err != nil {
 			return fmt.Errorf("failed to reconcile etcd: %w", err)
 		}
+		ready, err := util.IsStatefulSetReady(ctx, r, manifests.EtcdStatefulSet(hostedControlPlane.Namespace))
+		if err != nil {
+			return fmt.Errorf("failed to determine whether etcd is ready: %w", err)
+		}
+		if !ready {
+			r.Log.Info("Waiting for etcd statefulset to become ready")
+			return nil
+		}
 	case hyperv1.Unmanaged:
 		if err := r.reconcileUnmanagedEtcd(ctx, hostedControlPlane, createOrUpdate); err != nil {
 			return fmt.Errorf("failed to reconcile etcd: %w", err)

--- a/support/util/statefulset.go
+++ b/support/util/statefulset.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsStatefulSetReady(ctx context.Context, c crclient.Client, statefulSet *appsv1.StatefulSet) (bool, error) {
+	if err := c.Get(ctx, crclient.ObjectKeyFromObject(statefulSet), statefulSet); err != nil {
+		return false, fmt.Errorf("failed to fetch %s statefulset: %w", statefulSet.Name, err)
+	}
+
+	if *statefulSet.Spec.Replicas != statefulSet.Status.AvailableReplicas ||
+		*statefulSet.Spec.Replicas != statefulSet.Status.ReadyReplicas ||
+		*statefulSet.Spec.Replicas != statefulSet.Status.UpdatedReplicas ||
+		statefulSet.ObjectMeta.Generation > statefulSet.Status.ObservedGeneration {
+		return false, nil
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Blocking until etcd has rolled out will prevent instances in which the KAS fails to access etcd because there are no endpoints on the etcd service.

**Checklist**
- [x] Subject and description added to both, commit and PR.