### PR TITLE
Ignore CAPI/CAPA env var image overrides for 4.12 and later

### DIFF
--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/blang/semver"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/golang/groupcache/lru"
 	"k8s.io/client-go/rest"
@@ -106,4 +107,17 @@ func GetPayloadImage(ctx context.Context, releaseImageProvider releaseinfo.Provi
 		return "", fmt.Errorf("image does not exist for release: %q", image)
 	}
 	return image, nil
+}
+
+func GetPayloadVersion(ctx context.Context, releaseImageProvider releaseinfo.Provider, hc *hyperv1.HostedCluster, pullSecret []byte) (*semver.Version, error) {
+	releaseImage, err := releaseImageProvider.Lookup(ctx, hc.Spec.Release.Image, pullSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup release image: %w", err)
+	}
+	versionStr := releaseImage.Version()
+	version, err := semver.Parse(versionStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version (%s): %w", versionStr, err)
+	}
+	return &version, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Starting with 4.12, the CAPI/CAPA images we use should come from the release payload. In an MCE deployment, we should ignore env vars set by MCE for those images, but only if the release payload is >= 4.12.

**Checklist**
- [x] Subject and description added to both, commit and PR.