### PR TITLE
MachineConfig E2E test refactored

### DIFF
--- a/test/e2e/nodepool_autorepair_test.go
+++ b/test/e2e/nodepool_autorepair_test.go
@@ -22,7 +22,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func testNodePoolAutoRepair(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions, nptSigEnd chan<- bool) func(t *testing.T) {
+func testNodePoolAutoRepair(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions, testSigEnd chan<- bool) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
@@ -32,7 +32,7 @@ func testNodePoolAutoRepair(parentCtx context.Context, mgmtClient crclient.Clien
 		defer func() {
 			t.Log("Test: NodePoolAutoRepair finished")
 			cancel()
-			nptSigEnd <- true
+			testSigEnd <- true
 		}()
 
 		// List NodePools (should exists only one)

--- a/test/e2e/nodepool_autorepair_test.go
+++ b/test/e2e/nodepool_autorepair_test.go
@@ -22,7 +22,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func testNodePoolAutoRepair(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions, testSigEnd chan<- bool) func(t *testing.T) {
+func testNodePoolAutoRepair(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
@@ -32,7 +32,6 @@ func testNodePoolAutoRepair(parentCtx context.Context, mgmtClient crclient.Clien
 		defer func() {
 			t.Log("Test: NodePoolAutoRepair finished")
 			cancel()
-			testSigEnd <- true
 		}()
 
 		// List NodePools (should exists only one)

--- a/test/e2e/nodepool_autorepair_test.go
+++ b/test/e2e/nodepool_autorepair_test.go
@@ -22,8 +22,9 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func testNodePoolAutoRepair(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions) func(t *testing.T) {
+func testNodePoolAutoRepair(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions, nptSigEnd chan<- bool) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Parallel()
 		g := NewWithT(t)
 
 		ctx, cancel := context.WithCancel(parentCtx)
@@ -31,6 +32,7 @@ func testNodePoolAutoRepair(parentCtx context.Context, mgmtClient crclient.Clien
 		defer func() {
 			t.Log("Test: NodePoolAutoRepair finished")
 			cancel()
+			nptSigEnd <- true
 		}()
 
 		// List NodePools (should exists only one)

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,11 +16,13 @@ import (
 
 	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/cmd/cluster/core"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -29,147 +33,173 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func TestNodepoolMachineconfigGetsRolledout(t *testing.T) {
-	t.Parallel()
-	g := NewWithT(t)
+func testNodepoolMachineconfigGetsRolledout(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions, nptSigEnd chan<- bool) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
 
-	ctx, cancel := context.WithCancel(testContext)
-	defer cancel()
+		ctx, cancel := context.WithCancel(parentCtx)
+		originalNP := hyperv1.NodePool{}
+		defer func() {
+			t.Log("Test: NodePool MachineConfig finished")
+			cancel()
+			nptSigEnd <- true
+		}()
 
-	client, err := e2eutil.GetClient()
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
-
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
-	clusterOpts.BeforeApply = func(o crclient.Object) {
-		nodePool, isNodepool := o.(*hyperv1.NodePool)
-		if !isNodepool {
-			return
-		}
-		nodePool.Spec.Management.Replace = &hyperv1.ReplaceUpgrade{
-			Strategy: hyperv1.UpgradeStrategyRollingUpdate,
-			RollingUpdate: &hyperv1.RollingUpdate{
-				MaxUnavailable: func(v intstr.IntOrString) *intstr.IntOrString { return &v }(intstr.FromInt(0)),
-				MaxSurge:       func(v intstr.IntOrString) *intstr.IntOrString { return &v }(intstr.FromInt(int(*nodePool.Spec.Replicas))),
-			},
-		}
-	}
-
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
-
-	// Sanity check the cluster by waiting for the nodes to report ready
-	t.Logf("Waiting for guest client to become available")
-	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
-
-	// Wait for Nodes to be Ready
-	numNodes := int32(globalOpts.configurableClusterOptions.NodePoolReplicas * len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
-
-	// Wait for the rollout to be complete
-	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
-	e2eutil.WaitForImageRollout(t, testContext, client, guestClient, hostedCluster, globalOpts.LatestReleaseImage)
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
-
-	ignitionConfig := ignitionapi.Config{
-		Ignition: ignitionapi.Ignition{
-			Version: "3.2.0",
-		},
-		Storage: ignitionapi.Storage{
-			Files: []ignitionapi.File{{
-				Node:          ignitionapi.Node{Path: "/etc/custom-config"},
-				FileEmbedded1: ignitionapi.FileEmbedded1{Contents: ignitionapi.Resource{Source: utilpointer.String("data:,content%0A")}},
-			}},
-		},
-	}
-	serializedIgnitionConfig, err := json.Marshal(ignitionConfig)
-	if err != nil {
-		t.Fatalf("failed to serialize ignition config: %v", err)
-	}
-	machineConfig := &mcfgv1.MachineConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "custom",
-			Labels: map[string]string{"machineconfiguration.openshift.io/role": "worker"},
-		},
-		Spec: mcfgv1.MachineConfigSpec{Config: runtime.RawExtension{Raw: serializedIgnitionConfig}},
-	}
-	gvk, err := apiutil.GVKForObject(machineConfig, hyperapi.Scheme)
-	if err != nil {
-		t.Fatalf("failed to get typeinfo for %T from scheme: %v", machineConfig, err)
-	}
-	machineConfig.SetGroupVersionKind(gvk)
-	serializedMachineConfig, err := yaml.Marshal(machineConfig)
-	if err != nil {
-		t.Fatalf("failed to serialize machineConfig: %v", err)
-	}
-	machineConfigConfigMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "custom-machine-config",
+		// List NodePools (should exists only one)
+		nodePools := &hyperv1.NodePoolList{}
+		err := mgmtClient.List(ctx, nodePools, &crclient.ListOptions{
 			Namespace: hostedCluster.Namespace,
-		},
-		Data: map[string]string{"config": string(serializedMachineConfig)},
-	}
-	if err := client.Create(ctx, machineConfigConfigMap); err != nil {
-		t.Fatalf("failed to create configmap for custom machineconfig: %v", err)
-	}
-
-	nodepools := &hyperv1.NodePoolList{}
-	if err := client.List(ctx, nodepools, crclient.InNamespace(hostedCluster.Namespace)); err != nil {
-		t.Fatalf("failed to list nodepools in namespace %s: %v", hostedCluster.Namespace, err)
-	}
-
-	for _, nodepool := range nodepools.Items {
-		if nodepool.Spec.ClusterName != hostedCluster.Name {
-			continue
-		}
-		np := nodepool.DeepCopy()
-		nodepool.Spec.Config = append(nodepool.Spec.Config, corev1.LocalObjectReference{Name: machineConfigConfigMap.Name})
-		if err := client.Patch(ctx, &nodepool, crclient.MergeFrom(np)); err != nil {
-			t.Fatalf("failed to update nodepool %s after adding machineconfig: %v", nodepool.Name, err)
-		}
-	}
-
-	ds := machineConfigUpdatedVerificationDS.DeepCopy()
-	if err := guestClient.Create(ctx, ds); err != nil {
-		t.Fatalf("failed to create %s DaemonSet in guestcluster: %v", ds.Name, err)
-	}
-
-	t.Logf("waiting for rollout of updated nodepools")
-	err = wait.PollImmediateWithContext(ctx, 5*time.Second, 15*time.Minute, func(ctx context.Context) (bool, error) {
-		if ctx.Err() != nil {
-			return false, err
-		}
-		pods := &corev1.PodList{}
-		if err := guestClient.List(ctx, pods, crclient.InNamespace(ds.Namespace), crclient.MatchingLabels(ds.Spec.Selector.MatchLabels)); err != nil {
-			t.Logf("WARNING: failed to list pods, will retry: %v", err)
-			return false, nil
-		}
-		nodes := &corev1.NodeList{}
-		if err := guestClient.List(ctx, nodes); err != nil {
-			t.Logf("WARNING: failed to list nodes, will retry: %v", err)
-			return false, nil
-		}
-		if len(pods.Items) != len(nodes.Items) {
-			return false, nil
-		}
-
-		for _, pod := range pods.Items {
-			if !isPodReady(&pod) {
-				return false, nil
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed getting existant nodepools")
+		for _, nodePool := range nodePools.Items {
+			if !strings.Contains(nodePool.Name, "-test-") {
+				originalNP = nodePool
 			}
 		}
+		g.Expect(originalNP.Name).NotTo(BeEmpty())
+		g.Expect(originalNP.Name).NotTo(ContainSubstring("test"))
+		awsNPInfo := originalNP.Spec.Platform.AWS
 
-		return true, nil
-	})
-	if err != nil {
-		t.Fatalf("failed waiting for all pods in the machine config update verification DS to be ready: %v", err)
+		// Define a new Nodepool
+		nodePool := &hyperv1.NodePool{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "NodePool",
+				APIVersion: hyperv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hostedCluster.Name + "-" + "test-machineconfig",
+				Namespace: hostedCluster.Namespace,
+			},
+			Spec: hyperv1.NodePoolSpec{
+				Management: hyperv1.NodePoolManagement{
+					UpgradeType: hyperv1.UpgradeTypeReplace,
+					AutoRepair:  true,
+					Replace: &hyperv1.ReplaceUpgrade{
+						Strategy: hyperv1.UpgradeStrategyRollingUpdate,
+						RollingUpdate: &hyperv1.RollingUpdate{
+							MaxUnavailable: func(v intstr.IntOrString) *intstr.IntOrString { return &v }(intstr.FromInt(0)),
+							MaxSurge:       func(v intstr.IntOrString) *intstr.IntOrString { return &v }(intstr.FromInt(int(oneReplicas))),
+						},
+					},
+				},
+				ClusterName: hostedCluster.Name,
+				Replicas:    &oneReplicas,
+				Release: hyperv1.Release{
+					Image: hostedCluster.Spec.Release.Image,
+				},
+				Platform: hyperv1.NodePoolPlatform{
+					Type: hostedCluster.Spec.Platform.Type,
+					AWS:  awsNPInfo,
+				},
+			},
+		}
+
+		// Create NodePool for current test
+		err = mgmtClient.Create(ctx, nodePool)
+		if err != nil {
+			if !errors.IsAlreadyExists(err) {
+				t.Fatalf("failed to create nodePool %s with Autorepair function: %v", nodePool.Name, err)
+			}
+			err = nodePoolRecreate(t, ctx, nodePool, mgmtClient)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to Create the NodePool")
+		}
+		defer nodePoolScaleDownToZero(ctx, mgmtClient, *nodePool, t)
+
+		numNodes := int32(2)
+		t.Logf("Waiting for Nodes %d\n", numNodes)
+		nodes := e2eutil.WaitForNReadyNodesByNodePool(t, ctx, hostedClusterClient, numNodes, hostedCluster.Spec.Platform.Type, nodePool.Name)
+		t.Logf("Desired replicas available for nodePool: %v", nodePool.Name)
+
+		// Wait for the rollout to be complete
+		t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
+		e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedClusterClient, hostedCluster, globalOpts.LatestReleaseImage)
+
+		// MachineConfig Actions
+		ignitionConfig := ignitionapi.Config{
+			Ignition: ignitionapi.Ignition{
+				Version: "3.2.0",
+			},
+			Storage: ignitionapi.Storage{
+				Files: []ignitionapi.File{{
+					Node:          ignitionapi.Node{Path: "/etc/custom-config"},
+					FileEmbedded1: ignitionapi.FileEmbedded1{Contents: ignitionapi.Resource{Source: utilpointer.String("data:,content%0A")}},
+				}},
+			},
+		}
+		serializedIgnitionConfig, err := json.Marshal(ignitionConfig)
+		if err != nil {
+			t.Fatalf("failed to serialize ignition config: %v", err)
+		}
+		machineConfig := &mcfgv1.MachineConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "custom",
+				Labels: map[string]string{"machineconfiguration.openshift.io/role": "worker"},
+			},
+			Spec: mcfgv1.MachineConfigSpec{Config: runtime.RawExtension{Raw: serializedIgnitionConfig}},
+		}
+		gvk, err := apiutil.GVKForObject(machineConfig, hyperapi.Scheme)
+		if err != nil {
+			t.Fatalf("failed to get typeinfo for %T from scheme: %v", machineConfig, err)
+		}
+		machineConfig.SetGroupVersionKind(gvk)
+		serializedMachineConfig, err := yaml.Marshal(machineConfig)
+		if err != nil {
+			t.Fatalf("failed to serialize machineConfig: %v", err)
+		}
+		machineConfigConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "custom-machine-config",
+				Namespace: hostedCluster.Namespace,
+			},
+			Data: map[string]string{"config": string(serializedMachineConfig)},
+		}
+		if err := mgmtClient.Create(ctx, machineConfigConfigMap); err != nil {
+			t.Fatalf("failed to create configmap for custom machineconfig: %v", err)
+		}
+
+		np := nodePool.DeepCopy()
+		nodePool.Spec.Config = append(nodePool.Spec.Config, corev1.LocalObjectReference{Name: machineConfigConfigMap.Name})
+		if err := mgmtClient.Patch(ctx, nodePool, crclient.MergeFrom(np)); err != nil {
+			t.Fatalf("failed to update nodepool %s after adding machineconfig: %v", nodePool.Name, err)
+		}
+
+		ds := machineConfigUpdatedVerificationDS.DeepCopy()
+		if err := hostedClusterClient.Create(ctx, ds); err != nil {
+			t.Fatalf("failed to create %s DaemonSet in guestcluster: %v", ds.Name, err)
+		}
+
+		t.Logf("waiting for rollout of updated nodepools")
+		err = wait.PollImmediateWithContext(ctx, 5*time.Second, 15*time.Minute, func(ctx context.Context) (bool, error) {
+			if ctx.Err() != nil {
+				return false, err
+			}
+			pods := &corev1.PodList{}
+			if err := hostedClusterClient.List(ctx, pods, crclient.InNamespace(ds.Namespace), crclient.MatchingLabels(ds.Spec.Selector.MatchLabels)); err != nil {
+				t.Logf("WARNING: failed to list pods, will retry: %v", err)
+				return false, nil
+			}
+
+			if len(pods.Items) != len(nodes) {
+				return false, nil
+			}
+
+			for _, pod := range pods.Items {
+				if !isPodReady(&pod) {
+					return false, nil
+				}
+			}
+
+			return true, nil
+		})
+		g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed waiting for all pods in the machine config update verification DS to be ready: %v", err))
+
+		e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mgmtClient, hostedClusterClient, hostedCluster.Namespace)
+		e2eutil.EnsureNoCrashingPods(t, ctx, mgmtClient, hostedCluster)
+		e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, ctx, mgmtClient, hostedCluster)
+		e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, mgmtClient, hostedCluster)
+		e2eutil.EnsureNoPodsWithTooHighPriority(t, ctx, mgmtClient, hostedCluster)
 	}
-
-	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
-	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-	e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, ctx, client, hostedCluster)
-	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, client, hostedCluster)
-	e2eutil.EnsureNoPodsWithTooHighPriority(t, ctx, client, hostedCluster)
 }
 
 //go:embed nodepool_machineconfig_verification_ds.yaml

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func testNodepoolMachineconfigGetsRolledout(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions, nptSigEnd chan<- bool) func(t *testing.T) {
+func testNodepoolMachineconfigGetsRolledout(parentCtx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions, testSigEnd chan<- bool) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
@@ -43,7 +43,7 @@ func testNodepoolMachineconfigGetsRolledout(parentCtx context.Context, mgmtClien
 		defer func() {
 			t.Log("Test: NodePool MachineConfig finished")
 			cancel()
-			nptSigEnd <- true
+			testSigEnd <- true
 		}()
 
 		// List NodePools (should exists only one)
@@ -106,7 +106,7 @@ func testNodepoolMachineconfigGetsRolledout(parentCtx context.Context, mgmtClien
 		}
 		defer nodePoolScaleDownToZero(ctx, mgmtClient, *nodePool, t)
 
-		numNodes := int32(2)
+		numNodes := oneReplicas
 		t.Logf("Waiting for Nodes %d\n", numNodes)
 		nodes := e2eutil.WaitForNReadyNodesByNodePool(t, ctx, hostedClusterClient, numNodes, hostedCluster.Spec.Platform.Type, nodePool.Name)
 		t.Logf("Desired replicas available for nodePool: %v", nodePool.Name)

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -21,18 +21,26 @@ import (
 var (
 	zeroReplicas int32 = 0
 	oneReplicas  int32 = 1
+	// This Counter refers to the total number of tests that this one will run.
+	tNPCounter int32 = 2
 )
 
 func TestNodePool(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
-
+	nptSigEnd := make(chan bool, tNPCounter)
 	ctx, cancel := context.WithCancel(testContext)
-	defer func() {
+	go func() {
+		for _ = range nptSigEnd {
+			t.Logf("Finish signal received")
+		}
 		t.Log("Test: NodePool finished")
+		close(nptSigEnd)
 		cancel()
 	}()
 
+	// Set of tests
+	// Each test should have their own NodePool
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 
 	mgmtClient, err := e2eutil.GetClient()
@@ -44,9 +52,10 @@ func TestNodePool(t *testing.T) {
 	guestCluster := e2eutil.CreateCluster(t, ctx, mgmtClient, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, mgmtClient, guestCluster)
 
-	// Set of tests
-	// Each test should have their own NodePool
-	t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
+	//IMPORTANT: Ensure you updates the "tNPCounter" with the right number of test to execute.
+	//This way the buffered channel will be closed accordingly
+	t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, nptSigEnd))
+	t.Run("TestNodepoolMachineconfigGetsRolledout", testNodepoolMachineconfigGetsRolledout(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, nptSigEnd))
 }
 
 // nodePoolScaleDownToZero function will scaleDown the nodePool created for the current tests

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -28,14 +28,14 @@ var (
 func TestNodePool(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
-	nptSigEnd := make(chan bool, tNPCounter)
+	testSigEnd := make(chan bool, tNPCounter)
 	ctx, cancel := context.WithCancel(testContext)
 	go func() {
-		for _ = range nptSigEnd {
+		for _ = range testSigEnd {
 			t.Logf("Finish signal received")
 		}
 		t.Log("Test: NodePool finished")
-		close(nptSigEnd)
+		close(testSigEnd)
 		cancel()
 	}()
 
@@ -54,8 +54,8 @@ func TestNodePool(t *testing.T) {
 
 	//IMPORTANT: Ensure you updates the "tNPCounter" with the right number of test to execute.
 	//This way the buffered channel will be closed accordingly
-	t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, nptSigEnd))
-	t.Run("TestNodepoolMachineconfigGetsRolledout", testNodepoolMachineconfigGetsRolledout(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, nptSigEnd))
+	t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, testSigEnd))
+	t.Run("TestNodepoolMachineconfigGetsRolledout", testNodepoolMachineconfigGetsRolledout(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, testSigEnd))
 }
 
 // nodePoolScaleDownToZero function will scaleDown the nodePool created for the current tests

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -22,13 +22,13 @@ var (
 	zeroReplicas int32 = 0
 	oneReplicas  int32 = 1
 	// This Counter refers to the total number of tests that this one will run.
-	tNPCounter int32 = 2
+	testNodePoolCounter int32 = 2
 )
 
 func TestNodePool(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
-	testSigEnd := make(chan bool, tNPCounter)
+	testSigEnd := make(chan bool, testNodePoolCounter)
 	ctx, cancel := context.WithCancel(testContext)
 	go func() {
 		for _ = range testSigEnd {
@@ -52,8 +52,8 @@ func TestNodePool(t *testing.T) {
 	guestCluster := e2eutil.CreateCluster(t, ctx, mgmtClient, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, mgmtClient, guestCluster)
 
-	//IMPORTANT: Ensure you updates the "tNPCounter" with the right number of test to execute.
-	//This way the buffered channel will be closed accordingly
+	// IMPORTANT: Ensure you updates the "testNodePoolCounter" with the right number of test to execute.
+	// This way the buffered channel will be closed accordingly
 	t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, testSigEnd))
 	t.Run("TestNodepoolMachineconfigGetsRolledout", testNodepoolMachineconfigGetsRolledout(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, testSigEnd))
 }

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -21,21 +21,15 @@ import (
 var (
 	zeroReplicas int32 = 0
 	oneReplicas  int32 = 1
-	// This Counter refers to the total number of tests that this one will run.
-	testNodePoolCounter int32 = 2
 )
 
 func TestNodePool(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)
-	testSigEnd := make(chan bool, testNodePoolCounter)
 	ctx, cancel := context.WithCancel(testContext)
-	go func() {
-		for _ = range testSigEnd {
-			t.Logf("Finish signal received")
-		}
+
+	defer func() {
 		t.Log("Test: NodePool finished")
-		close(testSigEnd)
 		cancel()
 	}()
 
@@ -52,10 +46,10 @@ func TestNodePool(t *testing.T) {
 	guestCluster := e2eutil.CreateCluster(t, ctx, mgmtClient, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
 	guestClient := e2eutil.WaitForGuestClient(t, ctx, mgmtClient, guestCluster)
 
-	// IMPORTANT: Ensure you updates the "testNodePoolCounter" with the right number of test to execute.
-	// This way the buffered channel will be closed accordingly
-	t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, testSigEnd))
-	t.Run("TestNodepoolMachineconfigGetsRolledout", testNodepoolMachineconfigGetsRolledout(ctx, mgmtClient, guestCluster, guestClient, clusterOpts, testSigEnd))
+	t.Run("Refactored", func(t *testing.T) {
+		t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
+		t.Run("TestNodepoolMachineconfigGetsRolledout", testNodepoolMachineconfigGetsRolledout(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
+	})
 }
 
 // nodePoolScaleDownToZero function will scaleDown the nodePool created for the current tests


### PR DESCRIPTION
This PR refactors the E2E MachineConfig test. Also it implements a mechanism to signal the TestNodePool set of test to avoid context cancelation.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**What this PR does / why we need it**:
Fixes #[HOSTEDCP-686](https://issues.redhat.com/browse/HOSTEDCP-686)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.