### PR TITLE
[doc] fix nodepool name description error

### DIFF
--- a/docs/content/how-to/agent/create-agent-cluster.md
+++ b/docs/content/how-to/agent/create-agent-cluster.md
@@ -416,7 +416,7 @@ In order to get the cluster in a running state we need to add some nodes to it. 
 We add nodes to our HostedCluster by scaling the NodePool object. In this case we will start by scaling the NodePool object to two nodes:
 
 ~~~sh
-oc -n ${CLUSTERS_NAMESPACE} scale nodepool ${HOSTED_CLUSTER_NAME} --replicas 2
+oc -n ${CLUSTERS_NAMESPACE} scale nodepool ${NODEPOOL_NAME} --replicas 2
 ~~~
 
 The ClusterAPI Agent provider will pick two agents randomly that will get assigned to the HostedCluster. These agents will go over different states and will finally join the HostedCluster as OpenShift nodes.


### PR DESCRIPTION
fix doc description error. Now the nodepool name is not same with hostedcluster name anymore.  The nodepool name now is {hostedcluster}-{az}, e.g. 
```
$ oc get nodepool -n clusters
NAME                            CLUSTER              DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION       UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
hypershift-ci-8712-us-east-2a   hypershift-ci-8712   2               2               False         False        4.12.0-rc.4  
```

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ x] This change includes docs. 
- [ ] This change includes unit tests.