### PR TITLE
Signal when ignition is reached via event, metric and condition and delay MHC creation

### DIFF
--- a/api/v1beta1/nodepool_conditions.go
+++ b/api/v1beta1/nodepool_conditions.go
@@ -51,6 +51,10 @@ const (
 
 	// NodePoolReconciliationActiveConditionType signals the state of nodePool.spec.pausedUntil.
 	NodePoolReconciliationActiveConditionType = "ReconciliationActive"
+
+	// NodePoolReachedIgnitionEndpoint signals if at least an instance was able to reach the ignition endpoint to get the payload.
+	// When this is false for too long it may require external user intervention to resolve. E.g. Enable AWS security groups to enable networking access.
+	NodePoolReachedIgnitionEndpoint = "ReachedIgnitionEndpoint"
 )
 
 // Reasons
@@ -61,4 +65,5 @@ const (
 	NodePoolFailedToGetReason          = "FailedToGet"
 	IgnitionEndpointMissingReason      = "IgnitionEndpointMissing"
 	IgnitionCACertMissingReason        = "IgnitionCACertMissing"
+	IgnitionNotReached                 = "ignitionNotReached"
 )

--- a/hypershift-operator/controllers/nodepool/conditions.go
+++ b/hypershift-operator/controllers/nodepool/conditions.go
@@ -23,16 +23,16 @@ const (
 // We want to relax validation to ease bubbling up from CAPI which uses their own type not honouring metav1 validations, particularly "Reason" accepts pretty much free string.
 // TODO (alberto): work upstream towards consolidation and programmatic Reasons.
 
-// setStatusCondition sets the corresponding condition in conditions to newCondition.
+// SetStatusCondition sets the corresponding condition in conditions to newCondition.
 // conditions must be non-nil.
 // 1. if the condition of the specified type already exists (all fields of the existing condition are updated to
 //    newCondition, LastTransitionTime is set to now if the new status differs from the old status)
 // 2. if a condition of the specified type does not exist (LastTransitionTime is set to now() if unset, and newCondition is appended)
-func setStatusCondition(conditions *[]hyperv1.NodePoolCondition, newCondition hyperv1.NodePoolCondition) {
+func SetStatusCondition(conditions *[]hyperv1.NodePoolCondition, newCondition hyperv1.NodePoolCondition) {
 	if conditions == nil {
 		return
 	}
-	existingCondition := findStatusCondition(*conditions, newCondition.Type)
+	existingCondition := FindStatusCondition(*conditions, newCondition.Type)
 	if existingCondition == nil {
 		if newCondition.LastTransitionTime.IsZero() {
 			newCondition.LastTransitionTime = metav1.NewTime(time.Now())
@@ -72,8 +72,8 @@ func removeStatusCondition(conditions *[]hyperv1.NodePoolCondition, conditionTyp
 	*conditions = newConditions
 }
 
-// findStatusCondition finds the conditionType in conditions.
-func findStatusCondition(conditions []hyperv1.NodePoolCondition, conditionType string) *hyperv1.NodePoolCondition {
+// FindStatusCondition finds the conditionType in conditions.
+func FindStatusCondition(conditions []hyperv1.NodePoolCondition, conditionType string) *hyperv1.NodePoolCondition {
 	for i := range conditions {
 		if conditions[i].Type == conditionType {
 			return &conditions[i]
@@ -83,7 +83,7 @@ func findStatusCondition(conditions []hyperv1.NodePoolCondition, conditionType s
 	return nil
 }
 
-// findStatusCondition finds the conditionType in conditions.
+// FindStatusCondition finds the conditionType in conditions.
 func findCAPIStatusCondition(conditions []capiv1.Condition, conditionType capiv1.ConditionType) *capiv1.Condition {
 	for i := range conditions {
 		if conditions[i].Type == conditionType {

--- a/hypershift-operator/controllers/nodepool/inplace.go
+++ b/hypershift-operator/controllers/nodepool/inplace.go
@@ -176,7 +176,7 @@ func (r *NodePoolReconciler) reconcileMachineSet(ctx context.Context,
 	isUpdatingVersion := isUpdatingVersion(nodePool, targetVersion)
 
 	if message != "" && isUpdatingVersion {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolUpdatingVersionConditionType,
 			Status:             status,
 			ObservedGeneration: nodePool.Generation,
@@ -186,7 +186,7 @@ func (r *NodePoolReconciler) reconcileMachineSet(ctx context.Context,
 	}
 
 	if message != "" && isUpdatingConfig {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolUpdatingConfigConditionType,
 			Status:             status,
 			ObservedGeneration: nodePool.Generation,
@@ -208,7 +208,7 @@ func (r *NodePoolReconciler) reconcileMachineSet(ctx context.Context,
 				reason = c.Reason
 			}
 
-			setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 				Type:               hyperv1.NodePoolReadyConditionType,
 				Status:             c.Status,
 				ObservedGeneration: nodePool.Generation,

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -83,6 +83,7 @@ const (
 	TokenSecretTokenKey                       = "token"
 	TokenSecretConfigKey                      = "config"
 	TokenSecretAnnotation                     = "hypershift.openshift.io/ignition-config"
+	TokenSecretIgnitionReachedAnnotation      = "hypershift.openshift.io/ignition-reached"
 	TokenSecretNodePoolUpgradeType            = "hypershift.openshift.io/node-pool-upgrade-type"
 
 	tuningConfigKey                = "tuning"
@@ -234,7 +235,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 	// Validate autoscaling input.
 	if err := validateAutoscaling(nodePool); err != nil {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolAutoscalingEnabledConditionType,
 			Status:             corev1.ConditionFalse,
 			Message:            err.Error(),
@@ -247,7 +248,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		return ctrl.Result{}, nil
 	}
 	if isAutoscalingEnabled(nodePool) {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolAutoscalingEnabledConditionType,
 			Status:             corev1.ConditionTrue,
 			Reason:             hyperv1.AsExpectedReason,
@@ -255,7 +256,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			ObservedGeneration: nodePool.Generation,
 		})
 	} else {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolAutoscalingEnabledConditionType,
 			Status:             corev1.ConditionFalse,
 			Reason:             hyperv1.AsExpectedReason,
@@ -265,7 +266,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 	// Validate management input.
 	if err := validateManagement(nodePool); err != nil {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolUpdateManagementEnabledConditionType,
 			Status:             corev1.ConditionFalse,
 			Message:            err.Error(),
@@ -277,7 +278,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		log.Error(err, "validating management parameters failed")
 		return ctrl.Result{}, nil
 	}
-	setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+	SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 		Type:               hyperv1.NodePoolUpdateManagementEnabledConditionType,
 		Status:             corev1.ConditionTrue,
 		Reason:             hyperv1.AsExpectedReason,
@@ -286,7 +287,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 	// Validate IgnitionEndpoint.
 	if ignEndpoint == "" {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               string(hyperv1.IgnitionEndpointAvailable),
 			Status:             corev1.ConditionFalse,
 			Message:            "Ignition endpoint not available, waiting",
@@ -302,7 +303,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	caSecret := ignitionserver.IgnitionCACertSecret(controlPlaneNamespace)
 	if err := r.Get(ctx, client.ObjectKeyFromObject(caSecret), caSecret); err != nil {
 		if apierrors.IsNotFound(err) {
-			setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 				Type:               string(hyperv1.IgnitionEndpointAvailable),
 				Status:             corev1.ConditionFalse,
 				Reason:             hyperv1.IgnitionCACertMissingReason,
@@ -319,7 +320,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 	caCertBytes, hasCACert := caSecret.Data[corev1.TLSCertKey]
 	if !hasCACert {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               string(hyperv1.IgnitionEndpointAvailable),
 			Status:             corev1.ConditionFalse,
 			Reason:             hyperv1.IgnitionCACertMissingReason,
@@ -334,7 +335,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	// Validate and get releaseImage.
 	releaseImage, err := r.getReleaseImage(ctx, hcluster, nodePool.Status.Version, nodePool.Spec.Release.Image)
 	if err != nil {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolValidReleaseImageConditionType,
 			Status:             corev1.ConditionFalse,
 			Reason:             hyperv1.NodePoolValidationFailedReason,
@@ -343,7 +344,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		})
 		return ctrl.Result{}, fmt.Errorf("failed to look up release image metadata: %w", err)
 	}
-	setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+	SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 		Type:               hyperv1.NodePoolValidReleaseImageConditionType,
 		Status:             corev1.ConditionTrue,
 		Reason:             hyperv1.AsExpectedReason,
@@ -365,7 +366,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			// TODO: Should the region be included in the NodePool platform information?
 			ami, err = defaultNodePoolAMI(hcluster.Spec.Platform.AWS.Region, releaseImage)
 			if err != nil {
-				setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+				SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 					Type:               hyperv1.NodePoolValidPlatformImageType,
 					Status:             corev1.ConditionFalse,
 					Reason:             hyperv1.NodePoolValidationFailedReason,
@@ -374,7 +375,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 				})
 				return ctrl.Result{}, fmt.Errorf("couldn't discover an AMI for release image: %w", err)
 			}
-			setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 				Type:               hyperv1.NodePoolValidPlatformImageType,
 				Status:             corev1.ConditionTrue,
 				Reason:             hyperv1.AsExpectedReason,
@@ -391,7 +392,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	if nodePool.Spec.Platform.Type == hyperv1.PowerVSPlatform {
 		coreOSPowerVSImage, powervsImageRegion, err = getPowerVSImage(hcluster.Spec.Platform.PowerVS.Region, releaseImage)
 		if err != nil {
-			setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 				Type:               hyperv1.NodePoolValidPlatformImageType,
 				Status:             corev1.ConditionFalse,
 				Reason:             hyperv1.NodePoolValidationFailedReason,
@@ -401,7 +402,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			return ctrl.Result{}, fmt.Errorf("couldn't discover a PowerVS Image for release image: %w", err)
 		}
 		powervsBootImage = coreOSPowerVSImage.Release
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolValidPlatformImageType,
 			Status:             corev1.ConditionTrue,
 			Reason:             hyperv1.AsExpectedReason,
@@ -414,7 +415,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	var kubevirtBootImage string
 	if nodePool.Spec.Platform.Type == hyperv1.KubevirtPlatform {
 		if err := kubevirt.PlatformValidation(nodePool); err != nil {
-			setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 				Type:               hyperv1.NodePoolValidMachineConfigConditionType,
 				Status:             corev1.ConditionFalse,
 				Reason:             hyperv1.NodePoolValidationFailedReason,
@@ -427,7 +428,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 		kubevirtBootImage, err = kubevirt.GetImage(nodePool, releaseImage)
 		if err != nil {
-			setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 				Type:               hyperv1.NodePoolValidPlatformImageType,
 				Status:             corev1.ConditionFalse,
 				Reason:             hyperv1.NodePoolValidationFailedReason,
@@ -436,7 +437,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			})
 			return ctrl.Result{}, fmt.Errorf("couldn't discover a KubeVirt Image in release payload image: %w", err)
 		}
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolValidPlatformImageType,
 			Status:             corev1.ConditionTrue,
 			Reason:             hyperv1.AsExpectedReason,
@@ -456,7 +457,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 	config, missingConfigs, err := r.getConfig(ctx, nodePool, expectedCoreConfigResources, controlPlaneNamespace, releaseImage, hcluster)
 	if err != nil {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolValidMachineConfigConditionType,
 			Status:             corev1.ConditionFalse,
 			Reason:             hyperv1.NodePoolValidationFailedReason,
@@ -466,7 +467,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		return ctrl.Result{}, fmt.Errorf("failed to get config: %w", err)
 	}
 	if missingConfigs {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolValidMachineConfigConditionType,
 			Status:             corev1.ConditionFalse,
 			Reason:             hyperv1.NodePoolValidationFailedReason,
@@ -476,7 +477,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		// We watch configmaps so we will get an event when these get created
 		return ctrl.Result{}, nil
 	}
-	setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+	SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 		Type:               hyperv1.NodePoolValidMachineConfigConditionType,
 		Status:             corev1.ConditionTrue,
 		Reason:             hyperv1.AsExpectedReason,
@@ -487,7 +488,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	targetConfigHash := hashStruct(config)
 	isUpdatingConfig := isUpdatingConfig(nodePool, targetConfigHash)
 	if isUpdatingConfig {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolUpdatingConfigConditionType,
 			Status:             corev1.ConditionTrue,
 			Reason:             hyperv1.AsExpectedReason,
@@ -505,7 +506,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	targetVersion := releaseImage.Version()
 	isUpdatingVersion := isUpdatingVersion(nodePool, targetVersion)
 	if isUpdatingVersion {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolUpdatingVersionConditionType,
 			Status:             corev1.ConditionTrue,
 			Reason:             hyperv1.AsExpectedReason,
@@ -525,12 +526,18 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error setting ValidGeneratedPayload condition: %w", err)
 	}
-	setStatusCondition(&nodePool.Status.Conditions, *condition)
+	SetStatusCondition(&nodePool.Status.Conditions, *condition)
+
+	reachedIgnitionEndpointCondition, err := r.createReachedIgnitionEndpointCondition(ctx, tokenSecret, nodePool.Generation)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error setting IgnitionReached condition: %w", err)
+	}
+	SetStatusCondition(&nodePool.Status.Conditions, *reachedIgnitionEndpointCondition)
 
 	// Validate tuningConfig input.
 	tuningConfig, err := r.getTuningConfig(ctx, nodePool)
 	if err != nil {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolValidTuningConfigConditionType,
 			Status:             corev1.ConditionFalse,
 			Reason:             hyperv1.NodePoolValidationFailedReason,
@@ -540,7 +547,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		return ctrl.Result{}, fmt.Errorf("failed to get tuningConfig: %w", err)
 	}
 
-	setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+	SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 		Type:               hyperv1.NodePoolValidTuningConfigConditionType,
 		Status:             corev1.ConditionTrue,
 		Reason:             hyperv1.AsExpectedReason,
@@ -548,7 +555,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	})
 
 	// Set ReconciliationActive condition
-	setStatusCondition(&nodePool.Status.Conditions, generateReconciliationActiveCondition(nodePool.Spec.PausedUntil, nodePool.Generation))
+	SetStatusCondition(&nodePool.Status.Conditions, generateReconciliationActiveCondition(nodePool.Spec.PausedUntil, nodePool.Generation))
 
 	// If reconciliation is paused we return before modifying any state
 	if isPaused, duration := supportutil.IsReconciliationPaused(log, nodePool.Spec.PausedUntil); isPaused {
@@ -591,7 +598,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	// Get all Machines for NodePool.
 	machines, err := r.getMachinesForNodePool(nodePool)
 	if err != nil {
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolAllMachinesReadyConditionType,
 			Status:             corev1.ConditionUnknown,
 			Reason:             hyperv1.NodePoolFailedToGetReason,
@@ -640,7 +647,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		message = hyperv1.AllIsWellMessage
 	}
 
-	setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+	SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 		Type:               hyperv1.NodePoolAllMachinesReadyConditionType,
 		Status:             status,
 		Reason:             reason,
@@ -672,7 +679,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		message = hyperv1.AllIsWellMessage
 	}
 
-	setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+	SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 		Type:               hyperv1.NodePoolAllNodesHealthyConditionType,
 		Status:             status,
 		Reason:             reason,
@@ -735,7 +742,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 	userDataSecret := IgnitionUserDataSecret(controlPlaneNamespace, nodePool.GetName(), targetConfigVersionHash)
 	if result, err := r.CreateOrUpdate(ctx, r.Client, userDataSecret, func() error {
-		return reconcileUserDataSecret(userDataSecret, nodePool, caCertBytes, tokenBytes, ignEndpoint, proxy)
+		return reconcileUserDataSecret(userDataSecret, nodePool, caCertBytes, tokenBytes, ignEndpoint, targetConfigVersionHash, proxy)
 	}); err != nil {
 		return ctrl.Result{}, err
 	} else {
@@ -824,6 +831,11 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 
 	mhc := machineHealthCheck(nodePool, controlPlaneNamespace)
 	if nodePool.Spec.Management.AutoRepair {
+		if c := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolReachedIgnitionEndpoint); c == nil || c.Status != corev1.ConditionTrue {
+			log.Info("ReachedIgnitionEndpoint is false, MachineHealthCheck won't be created until this is true")
+			return ctrl.Result{}, nil
+		}
+
 		if result, err := ctrl.CreateOrUpdate(ctx, r.Client, mhc, func() error {
 			return r.reconcileMachineHealthCheck(mhc, nodePool, infraID)
 		}); err != nil {
@@ -832,7 +844,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		} else {
 			log.Info("Reconciled MachineHealthCheck", "result", result)
 		}
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolAutorepairEnabledConditionType,
 			Status:             corev1.ConditionTrue,
 			Reason:             hyperv1.AsExpectedReason,
@@ -848,7 +860,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 				return ctrl.Result{}, err
 			}
 		}
-		setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolAutorepairEnabledConditionType,
 			Status:             corev1.ConditionFalse,
 			Reason:             hyperv1.AsExpectedReason,
@@ -856,6 +868,53 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		})
 	}
 	return ctrl.Result{}, nil
+}
+
+// createReachedIgnitionEndpointCondition creates a condition for the NodePool based on the tokenSecret data.
+func (r NodePoolReconciler) createReachedIgnitionEndpointCondition(ctx context.Context, tokenSecret *corev1.Secret, generation int64) (*hyperv1.NodePoolCondition, error) {
+	var condition *hyperv1.NodePoolCondition
+	if err := r.Get(ctx, client.ObjectKeyFromObject(tokenSecret), tokenSecret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			condition = &hyperv1.NodePoolCondition{
+				Type:               hyperv1.NodePoolReachedIgnitionEndpoint,
+				Status:             corev1.ConditionFalse,
+				Reason:             hyperv1.NodePoolFailedToGetReason,
+				Message:            err.Error(),
+				ObservedGeneration: generation,
+			}
+			return nil, fmt.Errorf("failed to get token secret: %w", err)
+		} else {
+			condition = &hyperv1.NodePoolCondition{
+				Type:               hyperv1.NodePoolReachedIgnitionEndpoint,
+				Status:             corev1.ConditionFalse,
+				Reason:             hyperv1.NodePoolNotFoundReason,
+				Message:            err.Error(),
+				ObservedGeneration: generation,
+			}
+		}
+		return condition, nil
+	}
+
+	if _, ok := tokenSecret.Annotations[TokenSecretIgnitionReachedAnnotation]; !ok {
+		condition = &hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolReachedIgnitionEndpoint,
+			Status:             corev1.ConditionFalse,
+			Reason:             hyperv1.IgnitionNotReached,
+			Message:            "",
+			ObservedGeneration: generation,
+		}
+		return condition, nil
+	}
+
+	condition = &hyperv1.NodePoolCondition{
+		Type:               hyperv1.NodePoolReachedIgnitionEndpoint,
+		Status:             corev1.ConditionTrue,
+		Reason:             hyperv1.AsExpectedReason,
+		Message:            "",
+		ObservedGeneration: generation,
+	}
+
+	return condition, nil
 }
 
 // createValidGeneratedPayloadCondition creates a condition for the NodePool based on the tokenSecret data.
@@ -1070,7 +1129,7 @@ func (r *NodePoolReconciler) deleteNodePoolSecrets(ctx context.Context, nodePool
 	return nil
 }
 
-func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.NodePool, CA, token []byte, ignEndpoint string, proxy *configv1.Proxy) error {
+func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.NodePool, CA, token []byte, ignEndpoint, targetConfigVersionHash string, proxy *configv1.Proxy) error {
 	// The token secret controller deletes expired token Secrets.
 	// When that happens the NodePool controller reconciles and create a new one.
 	// Then it reconciles the userData Secret with the new generated token.
@@ -1084,7 +1143,7 @@ func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.No
 
 	encodedCACert := base64.StdEncoding.EncodeToString(CA)
 	encodedToken := base64.StdEncoding.EncodeToString(token)
-	ignConfig := ignConfig(encodedCACert, encodedToken, ignEndpoint, proxy)
+	ignConfig := ignConfig(encodedCACert, encodedToken, ignEndpoint, targetConfigVersionHash, proxy, nodePool)
 	userDataValue, err := json.Marshal(ignConfig)
 	if err != nil {
 		return fmt.Errorf("failed to marshal ignition config: %w", err)
@@ -1295,7 +1354,7 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 				reason = c.Reason
 			}
 
-			setStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 				Type:               hyperv1.NodePoolReadyConditionType,
 				Status:             c.Status,
 				ObservedGeneration: nodePool.Generation,
@@ -1373,7 +1432,7 @@ func setMachineDeploymentReplicas(nodePool *hyperv1.NodePool, machineDeployment 
 	}
 }
 
-func ignConfig(encodedCACert, encodedToken, endpoint string, proxy *configv1.Proxy) ignitionapi.Config {
+func ignConfig(encodedCACert, encodedToken, endpoint, targetConfigVersionHash string, proxy *configv1.Proxy, nodePool *hyperv1.NodePool) ignitionapi.Config {
 	cfg := ignitionapi.Config{
 		Ignition: ignitionapi.Ignition{
 			Version: "3.2.0",
@@ -1389,11 +1448,19 @@ func ignConfig(encodedCACert, encodedToken, endpoint string, proxy *configv1.Pro
 			Config: ignitionapi.IgnitionConfig{
 				Merge: []ignitionapi.Resource{
 					{
-						Source: k8sutilspointer.StringPtr(fmt.Sprintf("https://%s/ignition", endpoint)),
+						Source: k8sutilspointer.String(fmt.Sprintf("https://%s/ignition", endpoint)),
 						HTTPHeaders: []ignitionapi.HTTPHeader{
 							{
 								Name:  "Authorization",
-								Value: k8sutilspointer.StringPtr(fmt.Sprintf("Bearer %s", encodedToken)),
+								Value: k8sutilspointer.String(fmt.Sprintf("Bearer %s", encodedToken)),
+							},
+							{
+								Name:  "NodePool",
+								Value: k8sutilspointer.String(client.ObjectKeyFromObject(nodePool).String()),
+							},
+							{
+								Name:  "TargetConfigVersionHash",
+								Value: k8sutilspointer.String(targetConfigVersionHash),
 							},
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
There're scenarios where is diffcult too understand why an instance does not become a Kubernetes Node. Once concrete problem is the instances because of reasons are not able to reach the ignition endpoint, e.g. bad networling blocking security groups.

This PR tries to makes obvious and expliciti when an instance for a NodePool was able to reach the ignition endpoint. When that happens the ign server creates an event, sends a metric and sets the conditions in the NodePool.

Additionally this PR delays MHC creation until the previous conditions is set and true, as otherwise keep recreating Machines in loop won't fix the problem but would rather result in very awkward UX.

ref https://issues.redhat.com/browse/HOSTEDCP-678
ref https://issues.redhat.com/browse/HOSTEDCP-659

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.