### PR TITLE
v1beta1: add missing S3 publishing strategy type

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -367,7 +367,7 @@ type ServicePublishingStrategyMapping struct {
 type ServicePublishingStrategy struct {
 	// Type is the publishing strategy used for the service.
 	//
-	// +kubebuilder:validation:Enum=LoadBalancer;NodePort;Route;None
+	// +kubebuilder:validation:Enum=LoadBalancer;NodePort;Route;None;S3
 	// +immutable
 	Type PublishingStrategyType `json:"type"`
 
@@ -391,6 +391,8 @@ var (
 	NodePort PublishingStrategyType = "NodePort"
 	// Route exposes services with a Route + ClusterIP kube service.
 	Route PublishingStrategyType = "Route"
+	// S3 exposes a service through an S3 bucket
+	S3 PublishingStrategyType = "S3"
 	// None disables exposing the service
 	None PublishingStrategyType = "None"
 )

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -6332,6 +6332,7 @@ spec:
                           - NodePort
                           - Route
                           - None
+                          - S3
                           type: string
                       required:
                       - type

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -6203,6 +6203,7 @@ spec:
                           - NodePort
                           - Route
                           - None
+                          - S3
                           type: string
                       required:
                       - type

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -26951,6 +26951,7 @@ objects:
                             - NodePort
                             - Route
                             - None
+                            - S3
                             type: string
                         required:
                         - type
@@ -33540,6 +33541,7 @@ objects:
                             - NodePort
                             - Route
                             - None
+                            - S3
                             type: string
                         required:
                         - type


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing S3 publishing strategy option to v1beta1 so it can be compatible with HostedClusters converted from v1alpha1

**Checklist**
- [x] Subject and description added to both, commit and PR.