### PR TITLE
Add annotation for cross zone lb

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -124,6 +124,13 @@ const (
 	// For example, to override the memory and cpu request for the Kubernetes APIServer:
 	// resource-request-override.hypershift.openshift.io/kube-apiserver.kube-apiserver: memory=3Gi,cpu=2000m
 	ResourceRequestOverrideAnnotationPrefix = "resource-request-override.hypershift.openshift.io"
+
+	// HypershiftAWSLoadBalancerCrossZoneLoadBalancingEnabled applies https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/service/annotations/
+	// service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled in the load balancer services of the hosted control plane endpoints.
+	// AWS Private link requires endpoint and service endpoints to exist in the same underlying zone. To ensure that requirement is satisfied in
+	// Regions with more than 3 zones, managed services create subnets in all of them. That and having this enabled in the load balancers would make the private link
+	// communication to always succeed.
+	HypershiftAWSLoadBalancerCrossZoneLoadBalancingEnabled = "hypershift.openshift.io/aws-load-balancer-cross-zone-load-balancing-enabled"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -906,7 +906,7 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Con
 	p := kas.NewKubeAPIServerServiceParams(hcp)
 	apiServerService := manifests.KubeAPIServerService(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, apiServerService, func() error {
-		return kas.ReconcileService(apiServerService, serviceStrategy, p.OwnerReference, p.APIServerPort, p.AllowedCIDRBlocks, util.IsPublicHCP(hcp))
+		return kas.ReconcileService(apiServerService, serviceStrategy, p.OwnerReference, p.APIServerPort, p.AllowedCIDRBlocks, util.IsPublicHCP(hcp), hcp)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile API server service: %w", err)
 	}
@@ -1081,10 +1081,11 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	exposeKASThroughRouter := util.IsRouteKAS(hcp)
 	// Create the Service type LB internal for private endpoints.
 	pubSvc := manifests.RouterPublicService(hcp.Namespace)
+	_, crossZoneLoadBalancingEnabled := hcp.Annotations[hyperv1.HypershiftAWSLoadBalancerCrossZoneLoadBalancingEnabled]
 	if util.IsPrivateHCP(hcp) {
 		svc := manifests.PrivateRouterService(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r.Client, svc, func() error {
-			return ingress.ReconcileRouterService(svc, util.APIPortWithDefault(hcp, config.DefaultAPIServerPort), true)
+			return ingress.ReconcileRouterService(svc, util.APIPortWithDefault(hcp, config.DefaultAPIServerPort), true, crossZoneLoadBalancingEnabled)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile private router service: %w", err)
 		}
@@ -1106,7 +1107,7 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	// When Public access endpoint we need to create a Service type LB external for the KAS.
 	if util.IsPublicHCP(hcp) && exposeKASThroughRouter {
 		if _, err := createOrUpdate(ctx, r.Client, pubSvc, func() error {
-			return ingress.ReconcileRouterService(pubSvc, util.APIPortWithDefault(hcp, config.DefaultAPIServerPort), false)
+			return ingress.ReconcileRouterService(pubSvc, util.APIPortWithDefault(hcp, config.DefaultAPIServerPort), false, crossZoneLoadBalancingEnabled)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile router service: %w", err)
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -354,13 +354,16 @@ func ReconcileRouterServiceAccount(sa *corev1.ServiceAccount, ownerRef config.Ow
 	return nil
 }
 
-func ReconcileRouterService(svc *corev1.Service, kasPort int32, internal bool) error {
+func ReconcileRouterService(svc *corev1.Service, kasPort int32, internal, crossZoneLoadBalancingEnabled bool) error {
 	if svc.Annotations == nil {
 		svc.Annotations = map[string]string{}
 	}
 	svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
 	if internal {
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
+	}
+	if crossZoneLoadBalancingEnabled {
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
 	}
 
 	if svc.Labels == nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/hypershift/support/util"
 )
 
-func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy, owner *metav1.OwnerReference, apiServerPort int, apiAllowedCIDRBlocks []string, isPublic bool) error {
+func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy, owner *metav1.OwnerReference, apiServerPort int, apiAllowedCIDRBlocks []string, isPublic bool, hcp *hyperv1.HostedControlPlane) error {
 	util.EnsureOwnerRef(svc, owner)
 	if svc.Spec.Selector == nil {
 		svc.Spec.Selector = kasLabels()
@@ -48,6 +48,9 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 			if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
 				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+			}
+			if _, crossZoneLoadBalancingEnabled := hcp.Annotations[hyperv1.HypershiftAWSLoadBalancerCrossZoneLoadBalancingEnabled]; crossZoneLoadBalancingEnabled {
+				svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
 			}
 		} else {
 			svc.Spec.Type = corev1.ServiceTypeClusterIP
@@ -122,6 +125,11 @@ func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlan
 	if svc.Annotations == nil {
 		svc.Annotations = map[string]string{}
 	}
+
+	if _, crossZoneLoadBalancingEnabled := hcp.Annotations[hyperv1.HypershiftAWSLoadBalancerCrossZoneLoadBalancingEnabled]; crossZoneLoadBalancingEnabled {
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+	}
+
 	svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
 	svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
 	svc.Spec.Ports[0] = portSpec

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1472,6 +1472,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.DisableProfilingAnnotation,
 		hyperv1.PrivateIngressControllerAnnotation,
 		hyperv1.CleanupCloudResourcesAnnotation,
+		hyperv1.HypershiftAWSLoadBalancerCrossZoneLoadBalancingEnabled,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]


### PR DESCRIPTION
**What this PR does / why we need it**:
HypershiftAWSLoadBalancerCrossZoneLoadBalancingEnabled applies https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/service/annotations/ service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled in the load balancer services of the hosted control plane endpoints. AWS Private link requires endpoint and service endpoints to exist in the same underlying zone. To ensure that requirement is satisfied in Regions with more than 3 zones, managed services create subnets in all of them. That and having this enabled in the load balancers would make the private link communication to always succeed.

ref https://issues.redhat.com/browse/HOSTEDCP-670

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.