### PR TITLE
Remove CAPA command from deployment

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -166,7 +166,6 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 								Value: "true",
 							},
 						},
-						Command: []string{"/bin/cluster-api-provider-aws-controller-manager"},
 						Args: []string{"--namespace", "$(MY_NAMESPACE)",
 							"--alsologtostderr",
 							"--v=4",


### PR DESCRIPTION
**What this PR does / why we need it**:
The ENTRYPOINT in the CAPA image should dictate the command used. This allows us to use either images built via OCP release process or via ACM pipeline.

**Checklist**
- [x] Subject and description added to both, commit and PR.