### PR TITLE
Fix send clusterGuestCloudResourcesDeletionTime metric

### DIFF
--- a/hypershift-operator/metrics.go
+++ b/hypershift-operator/metrics.go
@@ -134,7 +134,7 @@ func setupMetrics(mgr manager.Manager) error {
 		return fmt.Errorf("failed to to register clusterDeletionTime metric: %w", err)
 	}
 	if err := crmetrics.Registry.Register(metrics.clusterGuestCloudResourcesDeletionTime); err != nil {
-		return fmt.Errorf("failed to to register clusterDeletionTime metric: %w", err)
+		return fmt.Errorf("failed to to register clusterGuestCloudResourcesDeletionTime metric: %w", err)
 	}
 	if err := crmetrics.Registry.Register(metrics.clusterAvailableTime); err != nil {
 		return fmt.Errorf("failed to to register clusterAvailableTime metric: %w", err)
@@ -208,7 +208,7 @@ func (m *hypershiftMetrics) observeHostedClusters(hostedClusters *hyperv1.Hosted
 
 		guestCloudResourcesDeletionTime := clusterGuestCloudResourcesDeletionTime(&hc)
 		if guestCloudResourcesDeletionTime != nil {
-			m.clusterAvailableTime.WithLabelValues(crclient.ObjectKeyFromObject(&hc).String()).Set(*guestCloudResourcesDeletionTime)
+			m.clusterGuestCloudResourcesDeletionTime.WithLabelValues(crclient.ObjectKeyFromObject(&hc).String()).Set(*guestCloudResourcesDeletionTime)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up for https://github.com/openshift/hypershift/pull/1956 to send the right clusterGuestCloudResourcesDeletionTime metric

Ref https://issues.redhat.com/browse/HOSTEDCP-635

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.