### PR TITLE
Revert etcd pki

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1394,22 +1394,6 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		return fmt.Errorf("failed to reconcile root CA configmap: %w", err)
 	}
 
-	// Etcd signer for all the etcd-related certs
-	etcdSignerSecret := manifests.EtcdSignerSecret(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, etcdSignerSecret, func() error {
-		return pki.ReconcileEtcdSignerSecret(etcdSignerSecret, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile etcd signer CA secret: %w", err)
-	}
-
-	etcdSignerCM := manifests.EtcdSignerCAConfigMap(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, etcdSignerCM, func() error {
-		// TODO remove rootCA. rootCASecret is temporarily added for upgrade scenarios. ibihim
-		return pki.ReconcileEtcdSignerConfigMap(etcdSignerCM, p.OwnerRef, etcdSignerSecret, rootCASecret)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile etcd signer CA configmap: %w", err)
-	}
-
 	// Etcd client secret
 	etcdClientSecret := manifests.EtcdClientSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, etcdClientSecret, func() error {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1412,7 +1412,7 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 	// Etcd client secret
 	etcdClientSecret := manifests.EtcdClientSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, etcdClientSecret, func() error {
-		return pki.ReconcileEtcdClientSecret(etcdClientSecret, etcdSignerSecret, p.OwnerRef)
+		return pki.ReconcileEtcdClientSecret(etcdClientSecret, rootCASecret, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile etcd client secret: %w", err)
 	}
@@ -1420,7 +1420,7 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 	// Etcd server secret
 	etcdServerSecret := manifests.EtcdServerSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, etcdServerSecret, func() error {
-		return pki.ReconcileEtcdServerSecret(etcdServerSecret, etcdSignerSecret, p.OwnerRef)
+		return pki.ReconcileEtcdServerSecret(etcdServerSecret, rootCASecret, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile etcd server secret: %w", err)
 	}
@@ -1428,33 +1428,9 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 	// Etcd peer secret
 	etcdPeerSecret := manifests.EtcdPeerSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, etcdPeerSecret, func() error {
-		return pki.ReconcileEtcdPeerSecret(etcdPeerSecret, etcdSignerSecret, p.OwnerRef)
+		return pki.ReconcileEtcdPeerSecret(etcdPeerSecret, rootCASecret, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile etcd peer secret: %w", err)
-	}
-
-	// Etcd metrics signer
-	// Etcd signer for all the etcd-related certs
-	etcdMetricsSignerSecret := manifests.EtcdMetricsSignerSecret(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, etcdMetricsSignerSecret, func() error {
-		return pki.ReconcileEtcdMetricsSignerSecret(etcdMetricsSignerSecret, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile etcd signer CA secret: %w", err)
-	}
-
-	etcdMetricsSignerCM := manifests.EtcdMetricsSignerCAConfigMap(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, etcdMetricsSignerCM, func() error {
-		return pki.ReconcileEtcdMetricsSignerConfigMap(etcdMetricsSignerCM, p.OwnerRef, etcdMetricsSignerSecret)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile etcd signer CA configmap: %w", err)
-	}
-
-	// Etcd client secret
-	etcdMetricsClientSecret := manifests.EtcdMetricsClientSecret(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, etcdMetricsClientSecret, func() error {
-		return pki.ReconcileEtcdMetricsClientSecret(etcdMetricsClientSecret, etcdMetricsSignerSecret, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile etcd client secret: %w", err)
 	}
 
 	// KAS server secret

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1404,7 +1404,8 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 
 	etcdSignerCM := manifests.EtcdSignerCAConfigMap(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, etcdSignerCM, func() error {
-		return pki.ReconcileEtcdSignerConfigMap(etcdSignerCM, p.OwnerRef, etcdSignerSecret)
+		// TODO remove rootCA. rootCASecret is temporarily added for upgrade scenarios. ibihim
+		return pki.ReconcileEtcdSignerConfigMap(etcdSignerCM, p.OwnerRef, etcdSignerSecret, rootCASecret)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile etcd signer CA configmap: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -169,7 +169,7 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 	args.Set("enable-aggregator-routing", "true")
 	args.Set("enable-logs-handler", "false")
 	args.Set("endpoint-reconciler-type", "lease")
-	args.Set("etcd-cafile", cpath(kasVolumeEtcdCA().Name, certs.CASignerCertMapKey))
+	args.Set("etcd-cafile", cpath(kasVolumeEtcdClientCert().Name, pki.EtcdClientCAKey))
 	args.Set("etcd-certfile", cpath(kasVolumeEtcdClientCert().Name, pki.EtcdClientCrtKey))
 	args.Set("etcd-keyfile", cpath(kasVolumeEtcdClientCert().Name, pki.EtcdClientKeyKey))
 	args.Set("etcd-prefix", "kubernetes.io")

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -47,7 +47,6 @@ var (
 			kasVolumeAggregatorCert().Name:         "/etc/kubernetes/certs/aggregator",
 			common.VolumeAggregatorCA().Name:       "/etc/kubernetes/certs/aggregator-ca",
 			common.VolumeTotalClientCA().Name:      "/etc/kubernetes/certs/client-ca",
-			kasVolumeEtcdCA().Name:                 "/etc/kubernetes/certs/etcd-ca",
 			kasVolumeEtcdClientCert().Name:         "/etc/kubernetes/certs/etcd",
 			kasVolumeServiceAccountKey().Name:      "/etc/kubernetes/secrets/svcacct-key",
 			kasVolumeOauthMetadata().Name:          "/etc/kubernetes/oauth",
@@ -180,7 +179,6 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 				util.BuildVolume(kasVolumeAggregatorCert(), buildKASVolumeAggregatorCert),
 				util.BuildVolume(common.VolumeAggregatorCA(), common.BuildVolumeAggregatorCA),
 				util.BuildVolume(kasVolumeServiceAccountKey(), buildKASVolumeServiceAccountKey),
-				util.BuildVolume(kasVolumeEtcdCA(), buildKASVolumeEtcdCA),
 				util.BuildVolume(kasVolumeEtcdClientCert(), buildKASVolumeEtcdClientCert),
 				util.BuildVolume(kasVolumeOauthMetadata(), buildKASVolumeOauthMetadata),
 				util.BuildVolume(kasVolumeAuthTokenWebhookConfig(), buildKASVolumeAuthTokenWebhookConfig),
@@ -586,17 +584,6 @@ func buildKASVolumeEtcdClientCert(v *corev1.Volume) {
 	}
 	v.Secret.DefaultMode = pointer.Int32Ptr(416)
 	v.Secret.SecretName = manifests.EtcdClientSecret("").Name
-}
-
-func kasVolumeEtcdCA() *corev1.Volume {
-	return &corev1.Volume{
-		Name: "etcd-ca",
-	}
-}
-
-func buildKASVolumeEtcdCA(v *corev1.Volume) {
-	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
-	v.ConfigMap.Name = manifests.EtcdSignerCAConfigMap("").Name
 }
 
 func kasVolumeOauthMetadata() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -36,15 +36,6 @@ func EtcdSignerCAConfigMap(ns string) *corev1.ConfigMap {
 	}
 }
 
-func EtcdMetricsSignerCAConfigMap(ns string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "etcd-metrics-ca",
-			Namespace: ns,
-		},
-	}
-}
-
 func AggregatorClientCAConfigMap(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -78,25 +69,11 @@ func EtcdSignerSecret(ns string) *corev1.Secret {
 	return secretFor(ns, "etcd-signer")
 }
 
-func EtcdClientSecret(ns string) *corev1.Secret {
-	return secretFor(ns, "etcd-client-tls")
-}
+func EtcdClientSecret(ns string) *corev1.Secret { return secretFor(ns, "etcd-client-tls") }
 
-func EtcdServerSecret(ns string) *corev1.Secret {
-	return secretFor(ns, "etcd-server-tls")
-}
+func EtcdServerSecret(ns string) *corev1.Secret { return secretFor(ns, "etcd-server-tls") }
 
-func EtcdPeerSecret(ns string) *corev1.Secret {
-	return secretFor(ns, "etcd-peer-tls")
-}
-
-func EtcdMetricsSignerSecret(ns string) *corev1.Secret {
-	return secretFor(ns, "etcd-metrics-signer")
-}
-
-func EtcdMetricsClientSecret(ns string) *corev1.Secret {
-	return secretFor(ns, "etcd-metrics-client-tls")
-}
+func EtcdPeerSecret(ns string) *corev1.Secret { return secretFor(ns, "etcd-peer-tls") }
 
 func KASServerCertSecret(ns string) *corev1.Secret { return secretFor(ns, "kas-server-crt") }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -27,15 +27,6 @@ func RootCAConfigMap(ns string) *corev1.ConfigMap {
 	}
 }
 
-func EtcdSignerCAConfigMap(ns string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "etcd-ca",
-			Namespace: ns,
-		},
-	}
-}
-
 func AggregatorClientCAConfigMap(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -63,10 +54,6 @@ func UserCAConfigMap(ns string) *corev1.ConfigMap {
 			Namespace: ns,
 		},
 	}
-}
-
-func EtcdSignerSecret(ns string) *corev1.Secret {
-	return secretFor(ns, "etcd-signer")
 }
 
 func EtcdClientSecret(ns string) *corev1.Secret { return secretFor(ns, "etcd-client-tls") }

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -287,8 +287,8 @@ func oasVolumeEtcdClientCA() *corev1.Volume {
 }
 
 func buildOASVolumeEtcdClientCA(v *corev1.Volume) {
-	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
-	v.ConfigMap.Name = manifests.EtcdSignerCAConfigMap("").Name
+	v.Secret = &corev1.SecretVolumeSource{}
+	v.Secret.SecretName = manifests.RootCASecret("").Name
 }
 
 func oasVolumeServingCert() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -184,8 +184,8 @@ func oauthVolumeEtcdClientCA() *corev1.Volume {
 }
 
 func buildOAuthVolumeEtcdClientCA(v *corev1.Volume) {
-	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
-	v.ConfigMap.Name = manifests.EtcdSignerCAConfigMap("").Name
+	v.Secret = &corev1.SecretVolumeSource{}
+	v.Secret.SecretName = manifests.RootCASecret("").Name
 }
 
 func oauthVolumeServingCert() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -70,14 +70,6 @@ func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef
 	return reconcileAggregateCA(cm, ownerRef, etcdSigner)
 }
 
-func ReconcileEtcdMetricsSignerSecret(secret *corev1.Secret, ownerref config.OwnerRef) error {
-	return reconcileSelfSignedCA(secret, ownerref, "etcd-metrics-signer", "openshift")
-}
-
-func ReconcileEtcdMetricsSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdMetricsSigner *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, etcdMetricsSigner)
-}
-
 func ReconcileClusterSignerCA(secret *corev1.Secret, ownerRef config.OwnerRef) error {
 	return reconcileSelfSignedCA(secret, ownerRef, "cluster-signer", "openshift")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -66,8 +66,8 @@ func ReconcileEtcdSignerSecret(secret *corev1.Secret, ownerRef config.OwnerRef) 
 	return reconcileSelfSignedCA(secret, ownerRef, "etcd-signer", "openshift")
 }
 
-func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdSigner *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, etcdSigner)
+func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdSigner, rootCA *corev1.Secret) error {
+	return reconcileAggregateCA(cm, ownerRef, etcdSigner, rootCA)
 }
 
 func ReconcileClusterSignerCA(secret *corev1.Secret, ownerRef config.OwnerRef) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -62,14 +62,6 @@ func ReconcileRootCA(secret *corev1.Secret, ownerRef config.OwnerRef) error {
 	return reconcileSelfSignedCA(secret, ownerRef, "root-ca", "openshift")
 }
 
-func ReconcileEtcdSignerSecret(secret *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSelfSignedCA(secret, ownerRef, "etcd-signer", "openshift")
-}
-
-func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdSigner, rootCA *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, etcdSigner, rootCA)
-}
-
 func ReconcileClusterSignerCA(secret *corev1.Secret, ownerRef config.OwnerRef) error {
 	return reconcileSelfSignedCA(secret, ownerRef, "cluster-signer", "openshift")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
@@ -12,20 +12,19 @@ import (
 const (
 	EtcdClientCrtKey = "etcd-client.crt"
 	EtcdClientKeyKey = "etcd-client.key"
+	EtcdClientCAKey  = "etcd-client-ca.crt"
 
 	EtcdServerCrtKey = "server.crt"
 	EtcdServerKeyKey = "server.key"
+	EtcdServerCAKey  = "server-ca.crt"
 
 	EtcdPeerCrtKey = "peer.crt"
 	EtcdPeerKeyKey = "peer.key"
+	EtcdPeerCAKey  = "peer-ca.crt"
 )
 
 func ReconcileEtcdClientSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCertWithKeys(secret, ca, ownerRef, "etcd-client", []string{"kubernetes"}, X509UsageClientAuth, EtcdClientCrtKey, EtcdClientKeyKey, "")
-}
-
-func ReconcileEtcdMetricsClientSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCertWithKeys(secret, ca, ownerRef, "etcd-metrics-client", []string{"kubernetes"}, X509UsageClientAuth, EtcdClientCrtKey, EtcdClientKeyKey, "")
+	return reconcileSignedCertWithKeys(secret, ca, ownerRef, "etcd-client", []string{"kubernetes"}, X509UsageClientAuth, EtcdClientCrtKey, EtcdClientKeyKey, EtcdClientCAKey)
 }
 
 func ReconcileEtcdServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
@@ -37,17 +36,14 @@ func ReconcileEtcdServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerR
 		"etcd-client",
 		"localhost",
 	}
-
-	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-server", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdServerCrtKey, EtcdServerKeyKey, "", dnsNames, nil)
+	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-server", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdServerCrtKey, EtcdServerKeyKey, EtcdServerCAKey, dnsNames, nil)
 }
 
 func ReconcileEtcdPeerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
 	dnsNames := []string{
 		fmt.Sprintf("*.etcd-discovery.%s.svc", secret.Namespace),
 		fmt.Sprintf("*.etcd-discovery.%s.svc.cluster.local", secret.Namespace),
-		"127.0.0.1",
-		"::1",
 	}
 
-	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-discovery", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdPeerCrtKey, EtcdPeerKeyKey, "", dnsNames, nil)
+	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-discovery", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdPeerCrtKey, EtcdPeerKeyKey, EtcdPeerCAKey, dnsNames, nil)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
@@ -44,6 +44,5 @@ func ReconcileEtcdPeerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef
 		fmt.Sprintf("*.etcd-discovery.%s.svc", secret.Namespace),
 		fmt.Sprintf("*.etcd-discovery.%s.svc.cluster.local", secret.Namespace),
 	}
-
 	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-discovery", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdPeerCrtKey, EtcdPeerKeyKey, EtcdPeerCAKey, dnsNames, nil)
 }


### PR DESCRIPTION
etcd pki work has resulted in etcd issues, especially during upgrade where peers are rejecting connections with tls errors.  Reverting to get CI operational again.