### PR TITLE
Fixing issue between UpdatingVersion and UpdatingConfig at InPlace Up…

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
@@ -211,7 +211,7 @@ func (r *Reconciler) reconcileInPlaceUpgrade(ctx context.Context, nodePoolUpgrad
 	// Signal in-place upgrade progress.
 	result, err := r.CreateOrUpdate(ctx, r.client, machineSet, func() error {
 		delete(machineSet.Annotations, nodePoolAnnotationUpgradeInProgressFalse)
-		machineSet.Annotations[nodePoolAnnotationUpgradeInProgressTrue] = fmt.Sprintf("Updating version in progress. Target version: %q. Total Nodes: %d. Upgraded: %d", *machineSet.Spec.Template.Spec.Version, len(nodes), len(nodes)-nodeNeedUpgradeCount)
+		machineSet.Annotations[nodePoolAnnotationUpgradeInProgressTrue] = fmt.Sprintf("Nodepool update in progress. Target Config version: %s. Total Nodes: %d. Upgraded: %d", targetConfigVersionHash, len(nodes), len(nodes)-nodeNeedUpgradeCount)
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
There was a bug into InPlace upgrade which mixes the UpdateConfig with UpdateVersion at the NodePool `status.conditions` field.

Now the NodePool shows properly the real conditions of the machines:

- When an Upgrade happens, it shows ConfigUpdate and VersionUpdate
- When the Config change happens (through MachineConfig) it shows only that the Config is updating.

I also changed the annotation message in the MachineSet because it always shows that a version change is happening even if that was not the case. Now shows that an upgrade is happening and shows the TargetConfig hash where it will upgrade to (that does not differentiate among Config or Version update) 

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**Which issue(s) this PR fixes**

- Fixes a Bug found at #[HOSTEDCP-403](https://issues.redhat.com/browse/HOSTEDCP-403)