### PR TITLE
Revert "AUTH-323: remove rootCA from CA bundle for etcd certs"

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1404,7 +1404,8 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 
 	etcdSignerCM := manifests.EtcdSignerCAConfigMap(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, etcdSignerCM, func() error {
-		return pki.ReconcileEtcdSignerConfigMap(etcdSignerCM, p.OwnerRef, etcdSignerSecret)
+		// TODO remove rootCA. rootCASecret is temporarily added for upgrade scenarios. ibihim
+		return pki.ReconcileEtcdSignerConfigMap(etcdSignerCM, p.OwnerRef, etcdSignerSecret, rootCASecret)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile etcd signer CA configmap: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -66,8 +66,8 @@ func ReconcileEtcdSignerSecret(secret *corev1.Secret, ownerRef config.OwnerRef) 
 	return reconcileSelfSignedCA(secret, ownerRef, "etcd-signer", "openshift")
 }
 
-func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdSigner *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, etcdSigner)
+func ReconcileEtcdSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdSigner, rootCA *corev1.Secret) error {
+	return reconcileAggregateCA(cm, ownerRef, etcdSigner, rootCA)
 }
 
 func ReconcileEtcdMetricsSignerSecret(secret *corev1.Secret, ownerref config.OwnerRef) error {


### PR DESCRIPTION
Reverts openshift/hypershift#1948

# What

First of 2 PRs that try to fix CI by reverting the changes to the etcd certificates.
We need to first add the rootCA to the CA bundle of etcd, before removing the etcd-signer signed etcd certificates.

# Why

The etcd peers [can't talk to each other](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_hypershift/1976/pull-ci-openshift-hypershift-main-e2e-aws/1605595064392749056/artifacts/e2e-aws/run-e2e/artifacts/TestUpgradeControlPlane_PreTeardownClusterDump/namespaces/e2e-clusters-tbtjq-example-42dtd/core/pods/logs/etcd-0-etcd.log) in HA mode. The reason is that the IP gets verified[ in addition to the DNS names](https://etcd.io/docs/v3.3/op-guide/security/#notes-for-tls-authentication).

**This is the current working assumption.**