### PR TITLE
OCPBUGS-4973: Reinstate hosted cluster configuration propagation

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1565,6 +1565,12 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hcp.Spec.Platform.Type = hyperv1.NonePlatform
 	}
 
+	if hcluster.Spec.Configuration != nil {
+		hcp.Spec.Configuration = hcluster.Spec.Configuration.DeepCopy()
+	} else {
+		hcp.Spec.Configuration = nil
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The code that propagated the HostedCluster configuration spec to the HostedControlPlane resource was dropped in the v1beta1 PR. This PR reinstates the propagation of the configuration to the HostedControlPlane resource.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-4973

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.