### PR TITLE
Add pull secret to storage service accounts

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator.go
@@ -1,6 +1,7 @@
 package snapshotcontroller
 
 import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets"
 	assets2 "github.com/openshift/hypershift/support/assets"
@@ -78,5 +79,6 @@ func ReconcileOperatorServiceAccount(
 
 	params.OwnerRef.ApplyTo(sa)
 	sa.AutomountServiceAccountToken = operatorServiceAccount.AutomountServiceAccountToken
+	util.EnsurePullSecret(sa, common.PullSecret("").Name)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/storage/assets"
 	assets2 "github.com/openshift/hypershift/support/assets"
@@ -65,5 +66,6 @@ func ReconcileOperatorServiceAccount(
 	params *Params) error {
 
 	params.OwnerRef.ApplyTo(sa)
+	util.EnsurePullSecret(sa, common.PullSecret("").Name)
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
All service accounts used to run workloads pulled from the release payload should use the pull secret that was specified for the HostedCluster. This commit adds the pull secret to the service accounts used for cluster-storage-operator and csi-snapshot-controller-operator

**Checklist**
- [x] Subject and description added to both, commit and PR.