### PR TITLE
autoscaler get/list for infrastructure.cluster.x-k8s.io api group

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -201,6 +201,11 @@ func ReconcileAutoscalerRole(role *rbacv1.Role, owner config.OwnerRef) error {
 			},
 			Verbs: []string{"*"},
 		},
+		{
+			APIGroups: []string{"infrastructure.cluster.x-k8s.io"},
+			Resources: []string{"*"},
+			Verbs:     []string{"get", "list"},
+		},
 	}
 	return nil
 }


### PR DESCRIPTION
https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/clusterapi#scale-from-zero-support

When deployed with NodePool with 0 replicas, `cluster-autoscaler` logs errors:

```
User "system:serviceaccount:clusters-sjenning-guest:cluster-autoscaler" cannot list resource "awsmachinetemplates" in API group "infrastructure.cluster.x-k8s.io" in the namespace "clusters-sjenning-guest
```