### PR TITLE
Add init container to etcd pods to test DNS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -12,6 +12,7 @@ import (
 
 type EtcdParams struct {
 	EtcdImage string
+	CPOImage  string
 
 	OwnerRef         config.OwnerRef `json:"ownerRef"`
 	DeploymentConfig config.DeploymentConfig
@@ -30,6 +31,7 @@ func etcdPodSelector() map[string]string {
 func NewEtcdParams(hcp *hyperv1.HostedControlPlane, images map[string]string) *EtcdParams {
 	p := &EtcdParams{
 		EtcdImage:    images["etcd"],
+		CPOImage:     images["controlplane-operator"],
 		OwnerRef:     config.OwnerRefFrom(hcp),
 		Availability: hcp.Spec.ControllerAvailabilityPolicy,
 	}

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator"
+	"github.com/openshift/hypershift/dnsresolver"
 	ignitionserver "github.com/openshift/hypershift/ignition-server/cmd"
 	konnectivitysocks5proxy "github.com/openshift/hypershift/konnectivity-socks5-proxy"
 	kubernetesdefaultproxy "github.com/openshift/hypershift/kubernetes-default-proxy"
@@ -126,6 +127,7 @@ func defaultCommand() *cobra.Command {
 	cmd.AddCommand(tokenminter.NewStartCommand())
 	cmd.AddCommand(ignitionserver.NewStartCommand())
 	cmd.AddCommand(kubernetesdefaultproxy.NewStartCommand())
+	cmd.AddCommand(dnsresolver.NewCommand())
 
 	return cmd
 

--- a/dnsresolver/cmd.go
+++ b/dnsresolver/cmd.go
@@ -1,0 +1,46 @@
+package dnsresolver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resolve-dns NAME",
+		Short: "Utility that ensures a DNS name can be resolved.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				fmt.Printf("Specify a DNS name to lookup\n")
+			}
+			if err := resolveDNS(context.Background(), args[0]); err != nil {
+				fmt.Printf("Error: %v", err)
+				os.Exit(1)
+			}
+		},
+	}
+	return cmd
+}
+
+func resolveDNS(ctx context.Context, hostName string) error {
+	err := wait.PollImmediateWithContext(ctx, time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, hostName)
+		if err == nil && len(ips) > 0 {
+			fmt.Printf("Address %s resolved to %s\n", hostName, ips[0].String())
+			return true, nil
+		}
+		fmt.Printf("Address %s not resolved yet: %v\n", hostName, err)
+		return false, nil
+	})
+	if err != nil {
+		fmt.Printf("failed to resolve DNS name, giving up\n")
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Waits until a reverse dns lookup of the pod's IP address returns the pod's expected hostname. This ensures that a statefulset does not rollout until names can be resolved.

**Checklist**
- [x] Subject and description added to both, commit and PR.