### PR TITLE
test: disable OLM test until catalog pods are fixed

### DIFF
--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -33,6 +33,9 @@ const (
 // TestOLM executes a suite of olm tests which ensure that olm is
 // behaving as expected on the guest cluster.
 func TestOLM(t *testing.T) {
+	// Skip test until https://issues.redhat.com/browse/OCPBUGS-4600 is fixed
+	// Pod restarts are already ignored for *-catalog pods
+	t.SkipNow()
 	t.Parallel()
 
 	g := NewWithT(t)


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-4600 is currently blocking CI

Skip the OLM test until it is fixed