### PR TITLE
Set missing internal route label for ovnkube-sbdb  and add e2e smoke test for private clusters

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -258,8 +258,14 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 		})
 	}
 
-	if params.ExposedThroughHCPRouter {
+	if params.ExposedThroughHCPRouter && !params.IsPrivate {
 		cnoEnv = append(cnoEnv, corev1.EnvVar{Name: "OVN_SBDB_ROUTE_LABELS", Value: util.HCPRouteLabel + "=" + dep.Namespace})
+	}
+	if params.IsPrivate {
+		cnoEnv = append(cnoEnv, corev1.EnvVar{Name: "OVN_SBDB_ROUTE_LABELS", Value: fmt.Sprintf("%v=%v,%v=%v",
+			util.HCPRouteLabel, dep.Namespace,
+			util.InternalRouteLabel, "true"),
+		})
 	}
 
 	var proxyVars []corev1.EnvVar

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -311,11 +311,16 @@ func preRolloutPlatformCheck(t *testing.T, ctx context.Context, client crclient.
 }
 
 func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Client, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster, image string) {
-	g := NewWithT(t)
-	start := time.Now()
-
 	preRolloutPlatformCheck(t, ctx, client, guestClient, hostedCluster)
+	WaitForImageRolloutWithNoPreRolloutPlatformCheck(t, ctx, client, hostedCluster, image)
 
+}
+
+// WaitForImageRolloutWithNoPreRolloutPlatformCheck is like WaitForImageRollout but without calling preRolloutPlatformCheck.
+// This is useful when your test can't access the guest cluster e.g. TestCreateClusterPrivate.
+func WaitForImageRolloutWithNoPreRolloutPlatformCheck(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, image string) {
+	start := time.Now()
+	g := NewWithT(t)
 	t.Logf("Waiting for hostedcluster to rollout image. Namespace: %s, name: %s, image: %s", hostedCluster.Namespace, hostedCluster.Name, image)
 	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 30*time.Minute, func(ctx context.Context) (done bool, err error) {
 		latest := hostedCluster.DeepCopy()


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now in a private setup the ovnkube-sbdb route is never addmited as it's missing the label that let the ingress controller reconcile it.
This was most likely missed here https://github.com/openshift/hypershift/pull/1861/files.
The e2e included in this PR should prevent this from happening again.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Ref https://issues.redhat.com/browse/OCPBUGS-5026


**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.