### PR TITLE
Fix parameters used to reconcile the ignition server

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -664,11 +664,11 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 		releaseImage.ComponentImages()[util.CPOImageName],
 		hostedControlPlane,
 		r.DefaultIngressDomain,
-		r.ManagementClusterCapabilities.Has(capabilities.CapabilitySecurityContextConstraint),
-		r.ReleaseProvider.GetRegistryOverrides(),
-		// The healthz handler was added before the CPO started to mange te ignition server and its the same binary,
+	        // The healthz handler was added before the CPO started to mange te ignition server and its the same binary,
 		// so we know it always exists here.
-		true,
+		true,		
+		r.ReleaseProvider.GetRegistryOverrides(),
+		r.ManagementClusterCapabilities.Has(capabilities.CapabilitySecurityContextConstraint),
 		config.OwnerRefFrom(hostedControlPlane),
 	); err != nil {
 		return fmt.Errorf("failed to reconcile ignition server: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -664,9 +664,9 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 		releaseImage.ComponentImages()[util.CPOImageName],
 		hostedControlPlane,
 		r.DefaultIngressDomain,
-	        // The healthz handler was added before the CPO started to mange te ignition server and its the same binary,
+		// The healthz handler was added before the CPO started to mange te ignition server and its the same binary,
 		// so we know it always exists here.
-		true,		
+		true,
 		r.ReleaseProvider.GetRegistryOverrides(),
 		r.ManagementClusterCapabilities.Has(capabilities.CapabilitySecurityContextConstraint),
 		config.OwnerRefFrom(hostedControlPlane),


### PR DESCRIPTION
parameters were being passed in the wrong order.

Healthz handler should be the 7th parameter and managementClusterHasCapabilitySecurityContextConstraint be the 9th as seen here: https://github.com/openshift/hypershift/blob/release-4.11/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go#L41

Hypershift operator is doing it correctly: https://github.com/openshift/hypershift/blob/ad40abf4f1ed00c7fb70d05bef26dbb2d15b14c2/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go#L1443-L1446

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Fixing parameters being passed to reconcile the ignition server. 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
