### PR TITLE
external-dns: set AWS batch internal to 10s

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -251,7 +251,10 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 				// thus we can assume us-east-1 without having to request it on the command line
 				Value: "us-east-1",
 			})
-		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--aws-zone-type=public")
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
+			"--aws-zone-type=public",
+			"--aws-batch-change-interval=10s",
+		)
 	}
 
 	return deployment

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -360,6 +360,7 @@ objects:
           - --txt-suffix=-external-dns
           - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
           - --aws-zone-type=public
+          - --aws-batch-change-interval=10s
           command:
           - /external-dns
           env:


### PR DESCRIPTION
Changes `aws-batch-change-interval` from 1s (default) to 10s.  Hopefully this results in fewer, larger change batches to avoid route53 rate limiting.