### PR TITLE
set imagePullPolicy to Always on OLM catalogs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified.deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: registry
           image: registry.redhat.io/redhat/certified-operator-index:v4.11
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 50051
               name: grpc

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-community.deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: registry
           image: registry.redhat.io/redhat/community-operator-index:v4.11
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 50051
               name: grpc

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-marketplace.deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: registry
           image: registry.redhat.io/redhat/redhat-marketplace-index:v4.11
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 50051
               name: grpc

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-redhat-operators.deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: registry
           image: registry.redhat.io/redhat/redhat-operator-index:v4.11
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 50051
               name: grpc

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -444,6 +444,10 @@ func EnsureAllContainersHavePullPolicyIfNotPresent(t *testing.T, ctx context.Con
 			t.Fatalf("failed to list pods in namespace %s: %v", namespace, err)
 		}
 		for _, pod := range podList.Items {
+			// OLM catalogs rely on imagePullPolicy Always for updates
+			if strings.HasPrefix(pod.Name, "catalog-") {
+				continue
+			}
 			for _, initContainer := range pod.Spec.InitContainers {
 				if initContainer.ImagePullPolicy != corev1.PullIfNotPresent {
 					t.Errorf("container %s in pod %s has doesn't have imagePullPolicy %s but %s", initContainer.Name, pod.Name, corev1.PullIfNotPresent, initContainer.ImagePullPolicy)


### PR DESCRIPTION
OLM catalog pods rely on `imagePullPolicy: Always` for their update mechanism to work.  Currently that mechanism is a per-catalog cronjob deployed in the HCP namespace that restarts each catalog every hour with `oc rollout restart`.  


https://github.com/openshift/hypershift/blob/main/control-plane-operator/controllers/hostedcontrolplane/olm/assets/catalog-certified-rollout.cronjob.yaml