### PR TITLE
add missing app label to HCP components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
@@ -62,6 +62,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	}
 	p.DeploymentConfig.AdditionalLabels = map[string]string{
 		"name":                        "dns-operator",
+		"app":                         "dns-operator",
 		hyperv1.ControlPlaneComponent: "dns-operator",
 	}
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass

--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -142,6 +142,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
 	}
 	dep.Spec.Template.Labels = map[string]string{
 		"name":                        operatorName,
+		"app":                         operatorName,
 		hyperv1.ControlPlaneComponent: operatorName,
 	}
 


### PR DESCRIPTION
Our recording rules aggregate on the `app` label and two HCP components lack that label