### PR TITLE
Expose proxy, identityProviders and limited support metrics

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -124,6 +124,11 @@ const (
 	// For example, to override the memory and cpu request for the Kubernetes APIServer:
 	// resource-request-override.hypershift.openshift.io/kube-apiserver.kube-apiserver: memory=3Gi,cpu=2000m
 	ResourceRequestOverrideAnnotationPrefix = "resource-request-override.hypershift.openshift.io"
+
+	// LimitedSupportLabel is a label that can be used by consumers to indicate
+	// a cluster is somehow out of regular support policy.
+	// https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-limited-support_rosa-service-definition.
+	LimitedSupportLabel = "hypershift.openshift.io/limited-support"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
This extend existing metrics exposed by the HO to include hostedClusterInfo with relevant information for HCs. These metrics are useful to infer symptons and point to causes when observing a fleet of clusters. E.g. Lets say we notice a subset of customers having IDP issues but no reported outages on github. We would be able to analyze the metrics and indeed say that github was having issues if we had outages fleetwide across github. These metrics are used in ROSA today. In future if they grow in a very opinionated way we might want to decouple them from the HO.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
ref https://issues.redhat.com/browse/HOSTEDCP-642

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.