### PR TITLE
avoid using route53 api for OIDC health check

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1218,7 +1218,6 @@ type AWSRolesRef struct {
 	//				"ec2:DeleteVpcEndpoints",
 	//				"ec2:CreateTags",
 	//				"route53:ListHostedZones",
-	// 				"route53:ListHostedZonesByName"
 	//			],
 	//			"Resource": "*"
 	//		},

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -313,8 +313,7 @@ func controlPlaneOperatorPolicy(hostedZone string) string {
 				"ec2:ModifyVpcEndpoint",
 				"ec2:DeleteVpcEndpoints",
 				"ec2:CreateTags",
-				"route53:ListHostedZones",
-				"route53:ListHostedZonesByName"
+				"route53:ListHostedZones"
 			],
 			"Resource": "*"
 		},

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5640,10 +5640,9 @@ spec:
                               [ { \"Effect\": \"Allow\", \"Action\": [ \"ec2:CreateVpcEndpoint\",
                               \"ec2:DescribeVpcEndpoints\", \"ec2:ModifyVpcEndpoint\",
                               \"ec2:DeleteVpcEndpoints\", \"ec2:CreateTags\", \"route53:ListHostedZones\",
-                              \"route53:ListHostedZonesByName\" ], \"Resource\": \"*\"
-                              }, { \"Effect\": \"Allow\", \"Action\": [ \"route53:ChangeResourceRecordSets\",
-                              \"route53:ListResourceRecordSets\" ], \"Resource\":
-                              \"arn:aws:route53:::%s\" } ] }"
+                              ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
+                              [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
+                              ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
                             type: string
                           imageRegistryARN:
                             description: "ImageRegistryARN is an ARN value referencing

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -5527,10 +5527,9 @@ spec:
                               [ { \"Effect\": \"Allow\", \"Action\": [ \"ec2:CreateVpcEndpoint\",
                               \"ec2:DescribeVpcEndpoints\", \"ec2:ModifyVpcEndpoint\",
                               \"ec2:DeleteVpcEndpoints\", \"ec2:CreateTags\", \"route53:ListHostedZones\",
-                              \"route53:ListHostedZonesByName\" ], \"Resource\": \"*\"
-                              }, { \"Effect\": \"Allow\", \"Action\": [ \"route53:ChangeResourceRecordSets\",
-                              \"route53:ListResourceRecordSets\" ], \"Resource\":
-                              \"arn:aws:route53:::%s\" } ] }"
+                              ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
+                              [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
+                              ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
                             type: string
                           imageRegistryARN:
                             description: "ImageRegistryARN is an ARN value referencing

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 
-	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
@@ -88,7 +88,6 @@ import (
 const (
 	finalizer                              = "hypershift.openshift.io/finalizer"
 	DefaultAdminKubeconfigKey              = "kubeconfig"
-	hypershiftLocalZone                    = "hypershift.local"
 	ImageStreamAutoscalerImage             = "cluster-autoscaler"
 	ImageStreamClusterMachineApproverImage = "cluster-machine-approver"
 
@@ -3360,12 +3359,10 @@ func healthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControl
 	awsSession := awsutil.NewSession("control-plane-operator", "", "", "", "")
 	awsConfig := awssdk.NewConfig()
 	awsConfig.Region = awssdk.String("us-east-1")
-	route53Client := route53.New(awsSession, awsConfig)
+	ec2Client := ec2.New(awsSession, awsConfig)
 
 	// We try to interact with cloud provider to see validate is operational.
-	if _, err := route53Client.ListHostedZonesByNameWithContext(ctx, &route53.ListHostedZonesByNameInput{
-		DNSName: pointer.String(fmt.Sprintf("%s.%s", hcp.Name, hypershiftLocalZone)),
-	}); err != nil {
+	if _, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{}); err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			// When awsErr.Code() is WebIdentityErr it's likely to be an external issue, e.g the idp resource was deleted.
 			// We don't set awsErr.Message() in the condition as it might contain aws requests IDs that would make the condition be updated in loop.

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -26249,11 +26249,10 @@ objects:
                                 \"Statement\": [ { \"Effect\": \"Allow\", \"Action\":
                                 [ \"ec2:CreateVpcEndpoint\", \"ec2:DescribeVpcEndpoints\",
                                 \"ec2:ModifyVpcEndpoint\", \"ec2:DeleteVpcEndpoints\",
-                                \"ec2:CreateTags\", \"route53:ListHostedZones\", \"route53:ListHostedZonesByName\"
-                                ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\",
-                                \"Action\": [ \"route53:ChangeResourceRecordSets\",
-                                \"route53:ListResourceRecordSets\" ], \"Resource\":
-                                \"arn:aws:route53:::%s\" } ] }"
+                                \"ec2:CreateTags\", \"route53:ListHostedZones\", ],
+                                \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
+                                [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
+                                ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
                               type: string
                             imageRegistryARN:
                               description: "ImageRegistryARN is an ARN value referencing
@@ -32856,11 +32855,10 @@ objects:
                                 \"Statement\": [ { \"Effect\": \"Allow\", \"Action\":
                                 [ \"ec2:CreateVpcEndpoint\", \"ec2:DescribeVpcEndpoints\",
                                 \"ec2:ModifyVpcEndpoint\", \"ec2:DeleteVpcEndpoints\",
-                                \"ec2:CreateTags\", \"route53:ListHostedZones\", \"route53:ListHostedZonesByName\"
-                                ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\",
-                                \"Action\": [ \"route53:ChangeResourceRecordSets\",
-                                \"route53:ListResourceRecordSets\" ], \"Resource\":
-                                \"arn:aws:route53:::%s\" } ] }"
+                                \"ec2:CreateTags\", \"route53:ListHostedZones\", ],
+                                \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
+                                [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
+                                ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
                               type: string
                             imageRegistryARN:
                               description: "ImageRegistryARN is an ARN value referencing


### PR DESCRIPTION
route53 has very aggressive rate limiting and doing this health check of every reconcile loop can lead to rate limiting and delays in external-dns registration