### PR TITLE
workaround OpenShiftSDN network policy egress bug

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -916,6 +916,14 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 				".dockerconfigjson": []byte("{}"),
 			},
 		},
+		&configv1.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster",
+			},
+			Spec: configv1.NetworkSpec{
+				NetworkType: "OVNKubernetes",
+			},
+		},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "agent-namespace"}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "agent"}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "aws"}},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
@@ -72,6 +72,14 @@ func TestWebhookAllowsHostedClusterReconcilerUpdates(t *testing.T) {
 				},
 				&configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "none-cluster"}},
+				&configv1.Network{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.NetworkSpec{
+						NetworkType: "OVNKubernetes",
+					},
+				},
 			},
 		},
 	}

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -41,6 +41,10 @@ const (
 	// CapabilityDNS indicates if the cluster supports the
 	// dnses.config.openshift.io api
 	CapabilityDNS
+
+	// CapabilityNetworks indicates if the cluster supports the
+	// networks.config.openshift.io api
+	CapabilityNetworks
 )
 
 // ManagementClusterCapabilities holds all information about optional capabilities of
@@ -138,6 +142,15 @@ func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterfa
 	}
 	if hasDNSCap {
 		discoveredCapabilities[CapabilityDNS] = struct{}{}
+	}
+
+	// check for networks capability
+	hasNetworksCap, err := isAPIResourceRegistered(client, configv1.GroupVersion, "networks")
+	if err != nil {
+		return nil, err
+	}
+	if hasNetworksCap {
+		discoveredCapabilities[CapabilityNetworks] = struct{}{}
 	}
 
 	return &ManagementClusterCapabilities{capabilities: discoveredCapabilities}, nil


### PR DESCRIPTION
OpenShiftSDN bug prevent proper application of egress network policy.  We use `OpenShiftSDN` in our root CI cluster.

Workaround is to not apply the egress rules of the mgmt cluster is detected to be OCP with OpenShiftSDN.

https://issues.redhat.com/browse/OCPBUGS-2105
https://github.com/openshift/sdn/pull/464
