### PR TITLE
add node-drain-timeout flag to create cluster cmd

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -3,6 +3,7 @@ package fixtures
 import (
 	"crypto/rand"
 	"fmt"
+	"time"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 
@@ -57,6 +58,7 @@ type ExampleOptions struct {
 	SSHPublicKey                     []byte
 	SSHPrivateKey                    []byte
 	NodePoolReplicas                 int32
+	NodeDrainTimeout                 time.Duration
 	ImageContentSources              []hyperv1.ImageContentSource
 	InfraID                          string
 	MachineCIDR                      string
@@ -505,6 +507,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 				Platform: hyperv1.NodePoolPlatform{
 					Type: cluster.Spec.Platform.Type,
 				},
+				NodeDrainTimeout: &metav1.Duration{Duration: o.NodeDrainTimeout},
 			},
 		}
 	}

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -34,6 +34,7 @@ func NewCreateCommands() *cobra.Command {
 		ImageContentSources:            "",
 		NodeSelector:                   nil,
 		Log:                            log.Log,
+		NodeDrainTimeout:               0,
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -55,6 +56,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.AdditionalTrustBundle, "additional-trust-bundle", opts.AdditionalTrustBundle, "Path to a file with user CA bundle")
 	cmd.PersistentFlags().StringVar(&opts.ImageContentSources, "image-content-sources", opts.ImageContentSources, "Path to a file with image content sources")
 	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If >-1, create a default NodePool with this many replicas")
+	cmd.PersistentFlags().DurationVar(&opts.NodeDrainTimeout, "node-drain-timeout", opts.NodeDrainTimeout, "The NodeDrainTimeout on any created NodePools")
 	cmd.PersistentFlags().StringArrayVar(&opts.Annotations, "annotations", opts.Annotations, "Annotations to apply to the hostedcluster (key=value). Can be specified multiple times.")
 	cmd.PersistentFlags().BoolVar(&opts.FIPS, "fips", opts.FIPS, "Enables FIPS mode for nodes in the cluster")
 	cmd.PersistentFlags().BoolVar(&opts.AutoRepair, "auto-repair", opts.AutoRepair, "Enables machine autorepair with machine health checks")

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -53,6 +53,7 @@ type CreateOptions struct {
 	BaseDomain                       string
 	NetworkType                      string
 	NodePoolReplicas                 int32
+	NodeDrainTimeout                 time.Duration
 	PullSecretFile                   string
 	ReleaseImage                     string
 	Render                           bool
@@ -254,6 +255,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		Name:                             opts.Name,
 		NetworkType:                      hyperv1.NetworkType(opts.NetworkType),
 		NodePoolReplicas:                 opts.NodePoolReplicas,
+		NodeDrainTimeout:                 opts.NodeDrainTimeout,
 		PullSecret:                       pullSecret,
 		ReleaseImage:                     opts.ReleaseImage,
 		SSHPrivateKey:                    sshPrivateKey,


### PR DESCRIPTION
Allows setting `nodeDrainTimeout` on NodePools created with `hypershift create cluster`