### PR TITLE
Makefile: Include full 'git diff' output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ update: deps api api-docs app-sre-saas-template
 verify: update staticcheck fmt vet promtool
 	git diff-index --cached --quiet --ignore-submodules HEAD --
 	git diff-files --quiet --ignore-submodules
+	git diff --exit-code HEAD --
 	$(eval STATUS = $(shell git status -s))
 	$(if $(strip $(STATUS)),$(error untracked files detected: ${STATUS}))
 


### PR DESCRIPTION
[Because][1]:

```
Makefile:54: *** untracked files detected: M api/v1beta1/hosted_controlplane.go  M api/v1beta1/zz_generated.deepcopy.go  M cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml  M cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml  M hack/app-sre/saas_template.yaml.  Stop.
```

isn't as easy for contributors to fix, vs. giving them a patch with recommended changes to make to their local checkout, to bring it in line with what CI is expecting.

And actually, even with this pull request, I had trouble figuring out the changes I wanted, so in #1954, I've been supplementing with f77a0c4bc439641f3f5e03b2f1663a7468274fa1's:

```Makefile
verify: update staticcheck fmt vet promtool
  ...
  $(eval STATUS = $(shell sh -c 'git diff --exit-code HEAD -- | base64 -w0'))
  $(if $(strip $(STATUS)),$(error Git diff detected changes: ${STATUS}))
  ...
```

to give some base-64 that's easier to copy/paste out of the log without needing to worry about whitespace corruption and similar.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hypershift/1954/pull-ci-openshift-hypershift-main-verify/1603153782781251584#1:build-log.txt%3A290