### PR TITLE
Add CSR signer to Kubelet client CA

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -63,6 +63,15 @@ func TotalClientCABundle(ns string) *corev1.ConfigMap {
 	}
 }
 
+func KubeletClientCABundle(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubelet-client-ca",
+			Namespace: ns,
+		},
+	}
+}
+
 func MetricsClientCertSecret(ns string) *corev1.Secret { return secretFor(ns, "metrics-client") }
 
 func UserCAConfigMap(ns string) *corev1.ConfigMap {

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
@@ -10,19 +10,19 @@ import (
 )
 
 type MCSParams struct {
-	OwnerRef             config.OwnerRef
-	RootCA               *corev1.Secret
-	KASToKubeletSignerCA *corev1.Secret
-	UserCA               *corev1.ConfigMap
-	PullSecret           *corev1.Secret
-	DNS                  *configv1.DNS
-	Infrastructure       *configv1.Infrastructure
-	Network              *configv1.Network
-	Proxy                *configv1.Proxy
-	InstallConfig        *globalconfig.InstallConfig
+	OwnerRef        config.OwnerRef
+	RootCA          *corev1.Secret
+	KubeletClientCA *corev1.ConfigMap
+	UserCA          *corev1.ConfigMap
+	PullSecret      *corev1.Secret
+	DNS             *configv1.DNS
+	Infrastructure  *configv1.Infrastructure
+	Network         *configv1.Network
+	Proxy           *configv1.Proxy
+	InstallConfig   *globalconfig.InstallConfig
 }
 
-func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, kasToKubeletSignerCA, pullSecret *corev1.Secret, userCA *corev1.ConfigMap) *MCSParams {
+func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Secret, userCA, kubeletClientCA *corev1.ConfigMap) *MCSParams {
 	dns := globalconfig.DNSConfig()
 	globalconfig.ReconcileDNSConfig(dns, hcp)
 
@@ -36,15 +36,15 @@ func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, kasToKubeletSignerCA,
 	globalconfig.ReconcileProxyConfigWithStatus(proxy, hcp)
 
 	return &MCSParams{
-		OwnerRef:             config.OwnerRefFrom(hcp),
-		RootCA:               rootCA,
-		KASToKubeletSignerCA: kasToKubeletSignerCA,
-		UserCA:               userCA,
-		PullSecret:           pullSecret,
-		DNS:                  dns,
-		Infrastructure:       infra,
-		Network:              network,
-		Proxy:                proxy,
-		InstallConfig:        globalconfig.NewInstallConfig(hcp),
+		OwnerRef:        config.OwnerRefFrom(hcp),
+		RootCA:          rootCA,
+		KubeletClientCA: kubeletClientCA,
+		UserCA:          userCA,
+		PullSecret:      pullSecret,
+		DNS:             dns,
+		Infrastructure:  infra,
+		Network:         network,
+		Proxy:           proxy,
+		InstallConfig:   globalconfig.NewInstallConfig(hcp),
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
@@ -53,7 +53,7 @@ func ReconcileMachineConfigServerConfig(cm *corev1.ConfigMap, p *MCSParams) erro
 	}
 
 	cm.Data["root-ca.crt"] = string(p.RootCA.Data[certs.CASignerCertMapKey])
-	cm.Data["signer-ca.crt"] = string(p.KASToKubeletSignerCA.Data[certs.CASignerCertMapKey])
+	cm.Data["signer-ca.crt"] = string(p.KubeletClientCA.Data[certs.CASignerCertMapKey])
 	cm.Data["cluster-dns-02-config.yaml"] = serializedDNS
 	cm.Data["cluster-infrastructure-02-config.yaml"] = serializedInfra
 	cm.Data["cluster-network-02-config.yaml"] = serializedNetwork

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -58,6 +58,10 @@ func ReconcileTotalClientCA(cm *corev1.ConfigMap, ownerRef config.OwnerRef, sign
 	return reconcileAggregateCA(cm, ownerRef, signers...)
 }
 
+func ReconcileKubeletClientCA(cm *corev1.ConfigMap, ownerRef config.OwnerRef, signers ...*corev1.Secret) error {
+	return reconcileAggregateCA(cm, ownerRef, signers...)
+}
+
 func ReconcileRootCA(secret *corev1.Secret, ownerRef config.OwnerRef) error {
 	return reconcileSelfSignedCA(secret, ownerRef, "root-ca", "openshift")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The CA bundle that the kubelet uses to verify mTLS certificates needs to include the CA used to sign the KAS client certs to allow communication from the KAS as well as the CSR signer CA to allow service accounts that have the right RBAC to access metrics.

This commit adds a new CA bundle (kubelet-client-ca) that includes both the KASToKubelet signer as well as the CSR signer. This allows the prometheus-k8s service account to scrape metrics from the kubelet.

**Checklist**
- [x] Subject and description added to both, commit and PR.