### PR TITLE
Fix OpenID OAuth config parsing

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
@@ -362,7 +362,7 @@ func convertProviderConfigToIDPData(
 		}
 		data.provider = openIDProvider
 
-		if configOverride.Challenge != nil {
+		if configOverride != nil && configOverride.Challenge != nil {
 			data.challenge = *configOverride.Challenge
 		} else {
 			// openshift CR validating in kube-apiserver does not allow


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a missing nil check in the parsing when configOverride is not present.
This causes CPO to crash and the config is not applied

**Which issue(s) this PR fixes** 
* Fixes https://issues.redhat.com/browse/HOSTEDCP-719

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.