### PR TITLE
adjust rate interval on hypershift:controlplane:component_cpu_usage_s…

### DIFF
--- a/cmd/install/assets/recordingrules/hypershift.yaml
+++ b/cmd/install/assets/recordingrules/hypershift.yaml
@@ -40,7 +40,7 @@ groups:
     expr: avg by (app, namespace, pod) (
             sum(
               rate(
-                container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
+                container_cpu_usage_seconds_total{container_name!="POD",container!=""}[2m]
               )
             ) by (pod, namespace)
           * on (pod, namespace) group_left(app)
@@ -50,7 +50,7 @@ groups:
           count by (app, namespace, pod) (
             sum(
               rate(
-                container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
+                container_cpu_usage_seconds_total{container_name!="POD",container!=""}[2m]
               )
             ) by (pod, namespace)
           * on (pod, namespace) group_left(app)

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -629,10 +629,10 @@ objects:
         record: hypershift:controlplane:component_memory_request
       - expr: histogram_quantile(0.9, sum by (namespace, le) (rate(ign_server_payload_generation_seconds_bucket{container="ignition-server"}[3m])))
         record: hypershift:controlplane:ign_payload_generation_seconds_p90
-      - expr: avg by (app, namespace, pod) ( sum( rate( container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
+      - expr: avg by (app, namespace, pod) ( sum( rate( container_cpu_usage_seconds_total{container_name!="POD",container!=""}[2m]
           ) ) by (pod, namespace) * on (pod, namespace) group_left(app) label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""},
           "app", "$1", "label_app", "(.*)") ) / count by (app, namespace, pod) ( sum(
-          rate( container_cpu_usage_seconds_total{container_name!="POD",container!=""}[1m]
+          rate( container_cpu_usage_seconds_total{container_name!="POD",container!=""}[2m]
           ) ) by (pod, namespace) * on (pod, namespace) group_left(app) label_replace(kube_pod_labels{label_hypershift_openshift_io_control_plane_component!=""},
           "app", "$1", "label_app", "(.*)") )
         record: hypershift:controlplane:component_cpu_usage_seconds


### PR DESCRIPTION
In 4.13, the scape interval for the kubelet ServiceMonitor increased from 30s to 1m.  Thus a `rate` over `[1m]` interval doesn't work anymore.