### PR TITLE
Add autoscaler balancing ignore labels args

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -40,6 +40,11 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 		"--v=4",
 	}
 
+	ignoreLabels := GetIgnoreLabels()
+	for _, v := range ignoreLabels {
+		args = append(args, fmt.Sprintf("%s=%v", BalancingIgnoreLabelArg, v))
+	}
+
 	// TODO if the options for the cluster autoscaler continues to grow, we should take inspiration
 	// from the cluster-autoscaler-operator and create some utility functions for these assignments.
 	if options.MaxNodesTotal != nil {
@@ -283,4 +288,39 @@ func ReconcileAutoscaler(ctx context.Context, c client.Client, hcp *hyperv1.Host
 	}
 
 	return nil
+}
+
+const BalancingIgnoreLabelArg = "--balancing-ignore-label"
+
+// AWS cloud provider ignore labels for the autoscaler.
+const (
+	// AwsIgnoredLabelEbsCsiZone is a label used by the AWS EBS CSI driver as a target for Persistent Volume Node Affinity.
+	AwsIgnoredLabelEbsCsiZone = "topology.ebs.csi.aws.com/zone"
+)
+
+// IBM cloud provider ignore labels for the autoscaler.
+const (
+	// IbmcloudIgnoredLabelWorkerId is a label used by the IBM Cloud Cloud Controler Manager.
+	IbmcloudIgnoredLabelWorkerId = "ibm-cloud.kubernetes.io/worker-id"
+
+	// IbmcloudIgnoredLabelVpcBlockCsi is a label used by the IBM Cloud CSI driver as a target for Persistent Volume Node Affinity.
+	IbmcloudIgnoredLabelVpcBlockCsi = "vpc-block-csi-driver-labels"
+)
+
+// Azure cloud provider ignore labels for the autoscaler.
+const (
+	// AzureDiskTopologyKey is the topology key of Azure Disk CSI driver.
+	AzureDiskTopologyKey = "topology.disk.csi.azure.com/zone"
+)
+
+func GetIgnoreLabels() []string {
+	return []string{
+		// AWS
+		AwsIgnoredLabelEbsCsiZone,
+		// Azure
+		AzureDiskTopologyKey,
+		// IBM
+		IbmcloudIgnoredLabelWorkerId,
+		IbmcloudIgnoredLabelVpcBlockCsi,
+	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -422,6 +422,11 @@ func TestReconcileAPIServerService(t *testing.T) {
 // TestClusterAutoscalerArgs checks to make sure that fields specified in a ClusterAutoscaling spec
 // become arguments to the autoscaler.
 func TestClusterAutoscalerArgs(t *testing.T) {
+	IgnoreLabelArgs := make([]string, 0)
+	for _, v := range autoscaler.GetIgnoreLabels() {
+		IgnoreLabelArgs = append(IgnoreLabelArgs, fmt.Sprintf("%s=%v", autoscaler.BalancingIgnoreLabelArg, v))
+	}
+
 	tests := map[string]struct {
 		AutoscalerOptions   hyperv1.ClusterAutoscaling
 		ExpectedArgs        []string
@@ -466,6 +471,10 @@ func TestClusterAutoscalerArgs(t *testing.T) {
 				"--expendable-pods-priority-cutoff=-5",
 			},
 			ExpectedMissingArgs: []string{},
+		},
+		"balancing ignore labels": {
+			AutoscalerOptions: hyperv1.ClusterAutoscaling{},
+			ExpectedArgs:      IgnoreLabelArgs,
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
This ensures that cloud platform specific node labels are ignored by the cluster autoscaler

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-711](https://issues.redhat.com/browse/HOSTEDCP-711)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.