### PR TITLE
fix cluster csi driver reconcile

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1658,7 +1658,7 @@ func (r *reconciler) reconcileStorage(ctx context.Context, hcp *hyperv1.HostedCo
 
 	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
 		driver := manifests.ClusterCSIDriver(operatorv1.AWSEBSCSIDriver)
-		if _, err := r.CreateOrUpdate(ctx, r.client, storageCR, func() error {
+		if _, err := r.CreateOrUpdate(ctx, r.client, driver, func() error {
 			storage.ReconcileClusterCSIDriver(driver)
 			return nil
 		}); err != nil {


### PR DESCRIPTION
resulting in failed reconciliation in the HCCO
```
{"level":"error","ts":"2023-01-16T17:00:11Z","msg":"Reconciler error","controller":"resources","object":{"name":""},"namespace":"","name":"","reconcileID":"80729130-cf29-4546-8453-fe52fdfe23a9","error":"failed to reconcile ClusterCSIDriver ebs.csi.aws.com: resourceVersion should not be set on objects to be created","errorCauses":[{"error":"failed to reconcile ClusterCSIDriver ebs.csi.aws.com: resourceVersion should not be set on objects to be created"}],"stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/root/go/src/github.com/openshift/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/root/go/src/github.com/openshift/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234"}
```