### PR TITLE
Refactoring NTO MachineConfig InPlace and Replace E2E Tests

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -21,6 +21,7 @@ import (
 var (
 	zeroReplicas int32 = 0
 	oneReplicas  int32 = 1
+	twoReplicas  int32 = 2
 )
 
 func TestNodePool(t *testing.T) {
@@ -49,6 +50,8 @@ func TestNodePool(t *testing.T) {
 	t.Run("Refactored", func(t *testing.T) {
 		t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
 		t.Run("TestNodepoolMachineconfigGetsRolledout", testNodepoolMachineconfigGetsRolledout(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
+		t.Run("TestNTOMachineConfigGetsRolledOut", testNTOMachineConfigGetsRolledOut(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
+		t.Run("TestNTOMachineConfigAppliedInPlace", testNTOMachineConfigAppliedInPlace(ctx, mgmtClient, guestCluster, guestClient, clusterOpts))
 	})
 }
 


### PR DESCRIPTION
Refactor of NTO MachineConfig for InPlace and Replace upgrade modes

- [x] Added refactored NTO MachineConfig test to the E2E suite
- [x] Modified current already refactored MachineConfig tests to avoid conflicting with other Nodes
- [x] Added `imagev1` to the API scheme (It was generating issues on data recollection after a test failure)

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**Which issue(s) this PR fixes**:

- Fixes #[HOSTEDCP-687](https://issues.redhat.com/browse/HOSTEDCP-687)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.