### PR TITLE
Add imagev1 to scheme used by dump command

### DIFF
--- a/api/scheme.go
+++ b/api/scheme.go
@@ -5,6 +5,7 @@ import (
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	configv1 "github.com/openshift/api/config/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
@@ -69,4 +70,5 @@ func init() {
 	capikubevirt.AddToScheme(Scheme)
 	capiazure.AddToScheme(Scheme)
 	snapshotv1.AddToScheme(Scheme)
+	imagev1.AddToScheme(Scheme)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The dump cluster command is failing to ouptut artifacts because the scheme it uses to convert go types to resources is missing the imagev1 group, resulting in `unknown.unknown` in the types it needs to output and failing to output anything.

**Checklist**
- [x] Subject and description added to both, commit and PR.