### PR TITLE
Switch API documentation to v1beta1

### DIFF
--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -8,12 +8,12 @@ title: API
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#hypershift.openshift.io%2fv1alpha1">hypershift.openshift.io/v1alpha1</a>
+<a href="#hypershift.openshift.io%2fv1beta1">hypershift.openshift.io/v1beta1</a>
 </li>
 </ul>
-<h2 id="hypershift.openshift.io/v1alpha1">hypershift.openshift.io/v1alpha1</h2>
+<h2 id="hypershift.openshift.io/v1beta1">hypershift.openshift.io/v1beta1</h2>
 <p>
-<p>Package v1alpha1 contains the HyperShift API.</p>
+<p>Package v1beta1 contains the HyperShift API.</p>
 <p>The HyperShift API enables creating and managing lightweight, flexible, heterogeneous
 OpenShift clusters at scale.</p>
 <p>HyperShift clusters are deployed in a topology which isolates the &ldquo;control plane&rdquo;
@@ -21,7 +21,7 @@ OpenShift clusters at scale.</p>
 worker nodes and their kubelets, and the infrastructure on which they run). This
 enables &ldquo;hosted control plane as a service&rdquo; use cases.</p>
 </p>
-##HostedCluster { #hypershift.openshift.io/v1alpha1.HostedCluster }
+##HostedCluster { #hypershift.openshift.io/v1beta1.HostedCluster }
 <p>
 <p>HostedCluster is the primary representation of a HyperShift cluster and encapsulates
 the control plane and common data plane configuration. Creating a HostedCluster
@@ -43,7 +43,7 @@ NodePool resources.</p>
 string</td>
 <td>
 <code>
-hypershift.openshift.io/v1alpha1
+hypershift.openshift.io/v1beta1
 </code>
 </td>
 </tr>
@@ -72,7 +72,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">
 HostedClusterSpec
 </a>
 </em>
@@ -86,7 +86,7 @@ HostedClusterSpec
 <td>
 <code>release</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.Release">
+<a href="#hypershift.openshift.io/v1beta1.Release">
 Release
 </a>
 </em>
@@ -150,7 +150,7 @@ and its associated NodePools.</p>
 <td>
 <code>platform</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">
 PlatformSpec
 </a>
 </em>
@@ -164,7 +164,7 @@ and is used to configure platform specific behavior.</p>
 <td>
 <code>controllerAvailabilityPolicy</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AvailabilityPolicy">
+<a href="#hypershift.openshift.io/v1beta1.AvailabilityPolicy">
 AvailabilityPolicy
 </a>
 </em>
@@ -173,18 +173,13 @@ AvailabilityPolicy
 <em>(Optional)</em>
 <p>ControllerAvailabilityPolicy specifies the availability policy applied to
 critical control plane components. The default value is SingleReplica.</p>
-<p>
-Value must be one of:
-&#34;HighlyAvailable&#34;, 
-&#34;SingleReplica&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>infrastructureAvailabilityPolicy</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AvailabilityPolicy">
+<a href="#hypershift.openshift.io/v1beta1.AvailabilityPolicy">
 AvailabilityPolicy
 </a>
 </em>
@@ -194,18 +189,13 @@ AvailabilityPolicy
 <p>InfrastructureAvailabilityPolicy specifies the availability policy applied
 to infrastructure services which run on cluster nodes. The default value is
 SingleReplica.</p>
-<p>
-Value must be one of:
-&#34;HighlyAvailable&#34;, 
-&#34;SingleReplica&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>dns</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.DNSSpec">
+<a href="#hypershift.openshift.io/v1beta1.DNSSpec">
 DNSSpec
 </a>
 </em>
@@ -218,7 +208,7 @@ DNSSpec
 <td>
 <code>networking</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">
+<a href="#hypershift.openshift.io/v1beta1.ClusterNetworking">
 ClusterNetworking
 </a>
 </em>
@@ -231,7 +221,7 @@ ClusterNetworking
 <td>
 <code>autoscaling</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterAutoscaling">
+<a href="#hypershift.openshift.io/v1beta1.ClusterAutoscaling">
 ClusterAutoscaling
 </a>
 </em>
@@ -246,7 +236,7 @@ associated with the control plane.</p>
 <td>
 <code>etcd</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">
+<a href="#hypershift.openshift.io/v1beta1.EtcdSpec">
 EtcdSpec
 </a>
 </em>
@@ -261,7 +251,7 @@ changed.</p>
 <td>
 <code>services</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping">
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategyMapping">
 []ServicePublishingStrategyMapping
 </a>
 </em>
@@ -340,7 +330,7 @@ signing key, a IssuerURL must also be specified.</p>
 <td>
 <code>configuration</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterConfiguration">
+<a href="#hypershift.openshift.io/v1beta1.ClusterConfiguration">
 ClusterConfiguration
 </a>
 </em>
@@ -376,7 +366,7 @@ name that corresponds to the constant AuditWebhookKubeconfigKey.</p>
 <td>
 <code>imageContentSources</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ImageContentSource">
+<a href="#hypershift.openshift.io/v1beta1.ImageContentSource">
 []ImageContentSource
 </a>
 </em>
@@ -406,7 +396,7 @@ PEM-encoded X.509 certificate bundle that will be added to the hosted controlpla
 <td>
 <code>secretEncryption</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">
+<a href="#hypershift.openshift.io/v1beta1.SecretEncryptionSpec">
 SecretEncryptionSpec
 </a>
 </em>
@@ -450,7 +440,7 @@ provided: reconciliation is paused on the resource until the field is removed.</
 <td>
 <code>olmCatalogPlacement</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.OLMCatalogPlacement">
+<a href="#hypershift.openshift.io/v1beta1.OLMCatalogPlacement">
 OLMCatalogPlacement
 </a>
 </em>
@@ -461,11 +451,6 @@ OLMCatalogPlacement
 this is set to management and OLM catalog components are deployed onto the management
 cluster. If set to guest, the OLM catalog components will be deployed onto the guest
 cluster.</p>
-<p>
-Value must be one of:
-&#34;guest&#34;, 
-&#34;management&#34;
-</p>
 </td>
 </tr>
 <tr>
@@ -487,7 +472,7 @@ map[string]string
 <td>
 <code>status</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterStatus">
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">
 HostedClusterStatus
 </a>
 </em>
@@ -498,7 +483,7 @@ HostedClusterStatus
 </tr>
 </tbody>
 </table>
-##NodePool { #hypershift.openshift.io/v1alpha1.NodePool }
+##NodePool { #hypershift.openshift.io/v1beta1.NodePool }
 <p>
 <p>NodePool is a scalable set of worker nodes attached to a HostedCluster.
 NodePool machine architectures are uniform within a given pool, and are
@@ -518,7 +503,7 @@ independent of the control plane’s underlying machine architecture.</p>
 string</td>
 <td>
 <code>
-hypershift.openshift.io/v1alpha1
+hypershift.openshift.io/v1beta1
 </code>
 </td>
 </tr>
@@ -547,7 +532,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">
+<a href="#hypershift.openshift.io/v1beta1.NodePoolSpec">
 NodePoolSpec
 </a>
 </em>
@@ -573,7 +558,7 @@ string
 <td>
 <code>release</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.Release">
+<a href="#hypershift.openshift.io/v1beta1.Release">
 Release
 </a>
 </em>
@@ -588,7 +573,7 @@ machine properties (e.g. an AMI on the AWS platform).</p>
 <td>
 <code>platform</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">
 NodePoolPlatform
 </a>
 </em>
@@ -596,19 +581,6 @@ NodePoolPlatform
 <td>
 <p>Platform specifies the underlying infrastructure provider for the NodePool
 and is used to configure platform specific behavior.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodeCount</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: Use Replicas instead. NodeCount will be dropped in the next
-api release.</p>
 </td>
 </tr>
 <tr>
@@ -628,7 +600,7 @@ unset, the default value is 0.</p>
 <td>
 <code>management</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">
+<a href="#hypershift.openshift.io/v1beta1.NodePoolManagement">
 NodePoolManagement
 </a>
 </em>
@@ -642,7 +614,7 @@ upgrade strategies and auto-repair behaviors.</p>
 <td>
 <code>autoScaling</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolAutoScaling">
+<a href="#hypershift.openshift.io/v1beta1.NodePoolAutoScaling">
 NodePoolAutoScaling
 </a>
 </em>
@@ -706,7 +678,7 @@ Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/
 <td>
 <code>taints</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.Taint">
+<a href="#hypershift.openshift.io/v1beta1.Taint">
 []Taint
 </a>
 </em>
@@ -756,7 +728,7 @@ JSON or YAML of a serialized Tuned.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolStatus">
+<a href="#hypershift.openshift.io/v1beta1.NodePoolStatus">
 NodePoolStatus
 </a>
 </em>
@@ -767,10 +739,10 @@ NodePoolStatus
 </tr>
 </tbody>
 </table>
-###AESCBCSpec { #hypershift.openshift.io/v1alpha1.AESCBCSpec }
+###AESCBCSpec { #hypershift.openshift.io/v1beta1.AESCBCSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
 </p>
 <p>
 <p>AESCBCSpec defines metadata about the AESCBC secret encryption strategy</p>
@@ -813,10 +785,10 @@ secrets can continue to be decrypted until they are all re-encrypted with the ac
 </tr>
 </tbody>
 </table>
-###APIServerNetworking { #hypershift.openshift.io/v1alpha1.APIServerNetworking }
+###APIServerNetworking { #hypershift.openshift.io/v1beta1.APIServerNetworking }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">ClusterNetworking</a>)
+<a href="#hypershift.openshift.io/v1beta1.ClusterNetworking">ClusterNetworking</a>)
 </p>
 <p>
 <p>APIServerNetworking specifies how the APIServer is exposed inside a cluster
@@ -860,7 +832,7 @@ pods using host networking cannot listen on this port. If not specified,
 <td>
 <code>allowedCIDRBlocks</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.CIDRBlock">
+<a href="#hypershift.openshift.io/v1beta1.CIDRBlock">
 []CIDRBlock
 </a>
 </em>
@@ -873,10 +845,10 @@ This depends on underlying support by the cloud provider for Service LoadBalance
 </tr>
 </tbody>
 </table>
-###AWSCloudProviderConfig { #hypershift.openshift.io/v1alpha1.AWSCloudProviderConfig }
+###AWSCloudProviderConfig { #hypershift.openshift.io/v1beta1.AWSCloudProviderConfig }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
 </p>
 <p>
 <p>AWSCloudProviderConfig specifies AWS networking configuration.</p>
@@ -893,7 +865,7 @@ This depends on underlying support by the cloud provider for Service LoadBalance
 <td>
 <code>subnet</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">
+<a href="#hypershift.openshift.io/v1beta1.AWSResourceReference">
 AWSResourceReference
 </a>
 </em>
@@ -929,10 +901,10 @@ string
 </tr>
 </tbody>
 </table>
-###AWSEndpointAccessType { #hypershift.openshift.io/v1alpha1.AWSEndpointAccessType }
+###AWSEndpointAccessType { #hypershift.openshift.io/v1beta1.AWSEndpointAccessType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
 </p>
 <p>
 <p>AWSEndpointAccessType specifies the publishing scope of cluster endpoints.</p>
@@ -958,13 +930,13 @@ private node communication with the control plane.</p>
 </td>
 </tr></tbody>
 </table>
-###AWSKMSAuthSpec { #hypershift.openshift.io/v1alpha1.AWSKMSAuthSpec }
+###AWSKMSAuthSpec { #hypershift.openshift.io/v1beta1.AWSKMSAuthSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSSpec">AWSKMSSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSKMSSpec">AWSKMSSpec</a>)
 </p>
 <p>
-<p>AWSKMSAuthSpec defines metadata about the management of credentials used to interact with AWS KMS</p>
+<p>AWSKMSAuthSpec defines metadata about the management of credentials used to interact and encrypt data via AWS KMS key.</p>
 </p>
 <table>
 <thead>
@@ -974,23 +946,6 @@ private node communication with the control plane.</p>
 </tr>
 </thead>
 <tbody>
-<tr>
-<td>
-<code>credentials</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated
-This field is deprecated and will be removed in a future release. Use AWSKMSRoleARN instead.
-Credentials contains the name of the secret that holds the aws credentials that can be used
-to make the necessary KMS calls. It should at key AWSCredentialsFileSecretKey contain the
-aws credentials file that can be used to configure AWS SDKs</p>
-</td>
-</tr>
 <tr>
 <td>
 <code>awsKms</code></br>
@@ -1041,10 +996,10 @@ Example:
 </tr>
 </tbody>
 </table>
-###AWSKMSKeyEntry { #hypershift.openshift.io/v1alpha1.AWSKMSKeyEntry }
+###AWSKMSKeyEntry { #hypershift.openshift.io/v1beta1.AWSKMSKeyEntry }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSSpec">AWSKMSSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSKMSSpec">AWSKMSSpec</a>)
 </p>
 <p>
 <p>AWSKMSKeyEntry defines metadata to locate the encryption key in AWS</p>
@@ -1070,10 +1025,10 @@ string
 </tr>
 </tbody>
 </table>
-###AWSKMSSpec { #hypershift.openshift.io/v1alpha1.AWSKMSSpec }
+###AWSKMSSpec { #hypershift.openshift.io/v1beta1.AWSKMSSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KMSSpec">KMSSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.KMSSpec">KMSSpec</a>)
 </p>
 <p>
 <p>AWSKMSSpec defines metadata about the configuration of the AWS KMS Secret Encryption provider</p>
@@ -1101,7 +1056,7 @@ string
 <td>
 <code>activeKey</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSKeyEntry">
+<a href="#hypershift.openshift.io/v1beta1.AWSKMSKeyEntry">
 AWSKMSKeyEntry
 </a>
 </em>
@@ -1114,7 +1069,7 @@ AWSKMSKeyEntry
 <td>
 <code>backupKey</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSKeyEntry">
+<a href="#hypershift.openshift.io/v1beta1.AWSKMSKeyEntry">
 AWSKMSKeyEntry
 </a>
 </em>
@@ -1129,7 +1084,7 @@ secrets can continue to be decrypted until they are all re-encrypted with the ac
 <td>
 <code>auth</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSAuthSpec">
+<a href="#hypershift.openshift.io/v1beta1.AWSKMSAuthSpec">
 AWSKMSAuthSpec
 </a>
 </em>
@@ -1140,10 +1095,10 @@ AWSKMSAuthSpec
 </tr>
 </tbody>
 </table>
-###AWSNodePoolPlatform { #hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform }
+###AWSNodePoolPlatform { #hypershift.openshift.io/v1beta1.AWSNodePoolPlatform }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>)
 </p>
 <p>
 <p>AWSNodePoolPlatform specifies the configuration of a NodePool when operating
@@ -1183,7 +1138,7 @@ string
 <td>
 <code>subnet</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">
+<a href="#hypershift.openshift.io/v1beta1.AWSResourceReference">
 AWSResourceReference
 </a>
 </em>
@@ -1210,7 +1165,7 @@ is chosen based on the NodePool release payload image.</p>
 <td>
 <code>securityGroups</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">
+<a href="#hypershift.openshift.io/v1beta1.AWSResourceReference">
 []AWSResourceReference
 </a>
 </em>
@@ -1225,7 +1180,7 @@ instances.</p>
 <td>
 <code>rootVolume</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.Volume">
+<a href="#hypershift.openshift.io/v1beta1.Volume">
 Volume
 </a>
 </em>
@@ -1239,7 +1194,7 @@ Volume
 <td>
 <code>resourceTags</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceTag">
+<a href="#hypershift.openshift.io/v1beta1.AWSResourceTag">
 []AWSResourceTag
 </a>
 </em>
@@ -1258,10 +1213,10 @@ for the user.</p>
 </tr>
 </tbody>
 </table>
-###AWSPlatformSpec { #hypershift.openshift.io/v1alpha1.AWSPlatformSpec }
+###AWSPlatformSpec { #hypershift.openshift.io/v1beta1.AWSPlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
 <p>AWSPlatformSpec specifies configuration for clusters running on Amazon Web Services.</p>
@@ -1291,7 +1246,7 @@ the correct boot AMI for a given release.</p>
 <td>
 <code>cloudProviderConfig</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSCloudProviderConfig">
+<a href="#hypershift.openshift.io/v1beta1.AWSCloudProviderConfig">
 AWSCloudProviderConfig
 </a>
 </em>
@@ -1309,7 +1264,7 @@ TODO(dan): should this be named AWSNetworkConfig?</p>
 <td>
 <code>serviceEndpoints</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSServiceEndpoint">
+<a href="#hypershift.openshift.io/v1beta1.AWSServiceEndpoint">
 []AWSServiceEndpoint
 </a>
 </em>
@@ -1325,7 +1280,7 @@ the default service endpoint of specific AWS Services.</p>
 <td>
 <code>rolesRef</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSRolesRef">
+<a href="#hypershift.openshift.io/v1beta1.AWSRolesRef">
 AWSRolesRef
 </a>
 </em>
@@ -1337,69 +1292,9 @@ integrations such as OIDC.</p>
 </tr>
 <tr>
 <td>
-<code>roles</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSRoleCredentials">
-[]AWSRoleCredentials
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated
-This field will be removed in the next API release.
-Use RolesRef instead.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kubeCloudControllerCreds</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated
-This field will be removed in the next API release.
-Use RolesRef instead.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodePoolManagementCreds</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated
-This field will be removed in the next API release.
-Use RolesRef instead.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>controlPlaneOperatorCreds</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated
-This field will be removed in the next API release.
-Use RolesRef instead.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>resourceTags</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceTag">
+<a href="#hypershift.openshift.io/v1beta1.AWSResourceTag">
 []AWSResourceTag
 </a>
 </em>
@@ -1418,7 +1313,7 @@ for the user.</p>
 <td>
 <code>endpointAccess</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSEndpointAccessType">
+<a href="#hypershift.openshift.io/v1beta1.AWSEndpointAccessType">
 AWSEndpointAccessType
 </a>
 </em>
@@ -1427,12 +1322,6 @@ AWSEndpointAccessType
 <em>(Optional)</em>
 <p>EndpointAccess specifies the publishing scope of cluster endpoints. The
 default is Public.</p>
-<p>
-Value must be one of:
-&#34;Private&#34;, 
-&#34;Public&#34;, 
-&#34;PublicAndPrivate&#34;
-</p>
 </td>
 </tr>
 <tr>
@@ -1453,11 +1342,11 @@ for more details around VPC Endpoint Service allowed principals.</p>
 </tr>
 </tbody>
 </table>
-###AWSResourceReference { #hypershift.openshift.io/v1alpha1.AWSResourceReference }
+###AWSResourceReference { #hypershift.openshift.io/v1beta1.AWSResourceReference }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>, 
+<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)
 </p>
 <p>
 <p>AWSResourceReference is a reference to a specific AWS resource by ID or filters.
@@ -1488,7 +1377,7 @@ string
 <td>
 <code>filters</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.Filter">
+<a href="#hypershift.openshift.io/v1beta1.Filter">
 []Filter
 </a>
 </em>
@@ -1502,11 +1391,11 @@ They are applied according to the rules defined by the AWS API:
 </tr>
 </tbody>
 </table>
-###AWSResourceTag { #hypershift.openshift.io/v1alpha1.AWSResourceTag }
+###AWSResourceTag { #hypershift.openshift.io/v1beta1.AWSResourceTag }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
 </p>
 <p>
 <p>AWSResourceTag is a tag to apply to AWS resources created for the cluster.</p>
@@ -1546,11 +1435,7 @@ requirements of all services.</p>
 </tr>
 </tbody>
 </table>
-###AWSRoleCredentials { #hypershift.openshift.io/v1alpha1.AWSRoleCredentials }
-<p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
-</p>
+###AWSRoleCredentials { #hypershift.openshift.io/v1beta1.AWSRoleCredentials }
 <p>
 </p>
 <table>
@@ -1593,10 +1478,10 @@ string
 </tr>
 </tbody>
 </table>
-###AWSRolesRef { #hypershift.openshift.io/v1alpha1.AWSRolesRef }
+###AWSRolesRef { #hypershift.openshift.io/v1beta1.AWSRolesRef }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
 </p>
 <p>
 <p>AWSRolesRef contains references to various AWS IAM roles required for operators to make calls against the AWS API.</p>
@@ -1970,7 +1855,7 @@ string
 &ldquo;ec2:ModifyVpcEndpoint&rdquo;,
 &ldquo;ec2:DeleteVpcEndpoints&rdquo;,
 &ldquo;ec2:CreateTags&rdquo;,
-&ldquo;route53:ListHostedZones&rdquo;
+&ldquo;route53:ListHostedZones&rdquo;,
 ],
 &ldquo;Resource&rdquo;: &ldquo;*&rdquo;
 },
@@ -1988,10 +1873,10 @@ string
 </tr>
 </tbody>
 </table>
-###AWSServiceEndpoint { #hypershift.openshift.io/v1alpha1.AWSServiceEndpoint }
+###AWSServiceEndpoint { #hypershift.openshift.io/v1beta1.AWSServiceEndpoint }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">AWSPlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
 </p>
 <p>
 <p>AWSServiceEndpoint stores the configuration for services to
@@ -2032,10 +1917,10 @@ This must be provided and cannot be empty.</p>
 </tr>
 </tbody>
 </table>
-###AgentNodePoolPlatform { #hypershift.openshift.io/v1alpha1.AgentNodePoolPlatform }
+###AgentNodePoolPlatform { #hypershift.openshift.io/v1beta1.AgentNodePoolPlatform }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>)
 </p>
 <p>
 <p>AgentNodePoolPlatform specifies the configuration of a NodePool when operating
@@ -2066,10 +1951,10 @@ be selected for a Machine.</p>
 </tr>
 </tbody>
 </table>
-###AgentPlatformSpec { #hypershift.openshift.io/v1alpha1.AgentPlatformSpec }
+###AgentPlatformSpec { #hypershift.openshift.io/v1beta1.AgentPlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
 <p>AgentPlatformSpec specifies configuration for agent-based installations.</p>
@@ -2095,11 +1980,11 @@ string
 </tr>
 </tbody>
 </table>
-###AvailabilityPolicy { #hypershift.openshift.io/v1alpha1.AvailabilityPolicy }
+###AvailabilityPolicy { #hypershift.openshift.io/v1beta1.AvailabilityPolicy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>AvailabilityPolicy specifies a high level availability policy for components.</p>
@@ -2125,10 +2010,10 @@ toleration of full disruption of the component.</p>
 </td>
 </tr></tbody>
 </table>
-###AzureNodePoolPlatform { #hypershift.openshift.io/v1alpha1.AzureNodePoolPlatform }
+###AzureNodePoolPlatform { #hypershift.openshift.io/v1beta1.AzureNodePoolPlatform }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>)
 </p>
 <p>
 </p>
@@ -2207,10 +2092,10 @@ in a location that does not support AvailabilityZone.</p>
 </tr>
 </tbody>
 </table>
-###AzurePlatformSpec { #hypershift.openshift.io/v1alpha1.AzurePlatformSpec }
+###AzurePlatformSpec { #hypershift.openshift.io/v1beta1.AzurePlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
 </p>
@@ -2316,19 +2201,18 @@ string
 </tr>
 </tbody>
 </table>
-###CIDRBlock { #hypershift.openshift.io/v1alpha1.CIDRBlock }
+###CIDRBlock { #hypershift.openshift.io/v1beta1.CIDRBlock }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.APIServerNetworking">APIServerNetworking</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.APIServerNetworking">APIServerNetworking</a>)
 </p>
 <p>
 </p>
-###ClusterAutoscaling { #hypershift.openshift.io/v1alpha1.ClusterAutoscaling }
+###ClusterAutoscaling { #hypershift.openshift.io/v1beta1.ClusterAutoscaling }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>ClusterAutoscaling specifies auto-scaling behavior that applies to all
@@ -2398,11 +2282,11 @@ resources available. The default is -10.</p>
 </tr>
 </tbody>
 </table>
-###ClusterConfiguration { #hypershift.openshift.io/v1alpha1.ClusterConfiguration }
+###ClusterConfiguration { #hypershift.openshift.io/v1beta1.ClusterConfiguration }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>ClusterConfiguration specifies configuration for individual OCP components in the
@@ -2419,57 +2303,6 @@ configuration API.</p>
 </tr>
 </thead>
 <tbody>
-<tr>
-<td>
-<code>secretRefs</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-[]Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecretRefs holds references to any secrets referenced by configuration
-entries. Entries can reference the secrets using local object references.</p>
-<p>Deprecated
-This field is deprecated and will be removed in a future release</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>configMapRefs</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
-[]Kubernetes core/v1.LocalObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ConfigMapRefs holds references to any configmaps referenced by
-configuration entries. Entries can reference the configmaps using local
-object references.</p>
-<p>Deprecated
-This field is deprecated and will be removed in a future release</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>items</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#rawextension-runtime-pkg">
-[]k8s.io/apimachinery/pkg/runtime.RawExtension
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Items embeds the serialized configuration resources.</p>
-<p>Deprecated
-This field is deprecated and will be removed in a future release</p>
-</td>
-</tr>
 <tr>
 <td>
 <code>apiServer</code></br>
@@ -2612,10 +2445,10 @@ github.com/openshift/api/config/v1.ProxySpec
 </tr>
 </tbody>
 </table>
-###ClusterNetworkEntry { #hypershift.openshift.io/v1alpha1.ClusterNetworkEntry }
+###ClusterNetworkEntry { #hypershift.openshift.io/v1beta1.ClusterNetworkEntry }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">ClusterNetworking</a>)
+<a href="#hypershift.openshift.io/v1beta1.ClusterNetworking">ClusterNetworking</a>)
 </p>
 <p>
 <p>ClusterNetworkEntry is a single IP address block for pod IP blocks. IP blocks
@@ -2658,11 +2491,11 @@ field is not used by the plugin, it can be left unset.</p>
 </tr>
 </tbody>
 </table>
-###ClusterNetworking { #hypershift.openshift.io/v1alpha1.ClusterNetworking }
+###ClusterNetworking { #hypershift.openshift.io/v1beta1.ClusterNetworking }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>ClusterNetworking specifies network configuration for a cluster.</p>
@@ -2677,81 +2510,36 @@ field is not used by the plugin, it can be left unset.</p>
 <tbody>
 <tr>
 <td>
-<code>serviceCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated
-This field will be removed in the next API release.
-Use ServiceNetwork instead</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>podCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated
-This field will be removed in the next API release.
-Use ClusterNetwork instead</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>machineCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated
-This field will be removed in the next API release.
-Use MachineNetwork instead</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>machineNetwork</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.MachineNetworkEntry">
+<a href="#hypershift.openshift.io/v1beta1.MachineNetworkEntry">
 []MachineNetworkEntry
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>MachineNetwork is the list of IP address pools for machines.
-TODO: make this required in the next version of the API</p>
+<p>MachineNetwork is the list of IP address pools for machines.</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>clusterNetwork</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworkEntry">
+<a href="#hypershift.openshift.io/v1beta1.ClusterNetworkEntry">
 []ClusterNetworkEntry
 </a>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>ClusterNetwork is the list of IP address pools for pods.
-TODO: make this required in the next version of the API</p>
+<p>ClusterNetwork is the list of IP address pools for pods.</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>serviceNetwork</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ServiceNetworkEntry">
+<a href="#hypershift.openshift.io/v1beta1.ServiceNetworkEntry">
 []ServiceNetworkEntry
 </a>
 </em>
@@ -2759,35 +2547,27 @@ TODO: make this required in the next version of the API</p>
 <td>
 <em>(Optional)</em>
 <p>ServiceNetwork is the list of IP address pools for services.
-NOTE: currently only one entry is supported.
-TODO: make this required in the next version of the API</p>
+NOTE: currently only one entry is supported.</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>networkType</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NetworkType">
+<a href="#hypershift.openshift.io/v1beta1.NetworkType">
 NetworkType
 </a>
 </em>
 </td>
 <td>
 <p>NetworkType specifies the SDN provider used for cluster networking.</p>
-<p>
-Value must be one of:
-&#34;Calico&#34;, 
-&#34;OVNKubernetes&#34;, 
-&#34;OpenShiftSDN&#34;, 
-&#34;Other&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>apiServer</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.APIServerNetworking">
+<a href="#hypershift.openshift.io/v1beta1.APIServerNetworking">
 APIServerNetworking
 </a>
 </em>
@@ -2799,11 +2579,11 @@ how the APIServer is exposed inside a cluster node.</p>
 </tr>
 </tbody>
 </table>
-###ClusterVersionStatus { #hypershift.openshift.io/v1alpha1.ClusterVersionStatus }
+###ClusterVersionStatus { #hypershift.openshift.io/v1beta1.ClusterVersionStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterStatus">HostedClusterStatus</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
 </p>
 <p>
 <p>ClusterVersionStatus reports the status of the cluster versioning,
@@ -2907,7 +2687,7 @@ or invalid channel has been specified.</p>
 </tr>
 </tbody>
 </table>
-###ConditionType { #hypershift.openshift.io/v1alpha1.ConditionType }
+###ConditionType { #hypershift.openshift.io/v1beta1.ConditionType }
 <p>
 </p>
 <table>
@@ -2928,7 +2708,11 @@ has been created for the specified NLB in the management VPC</p>
 </tr><tr><td><p>&#34;CVOScaledDown&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;CloudResourcesDestroyed&#34;</p></td>
-<td></td>
+<td><p>CloudResourcesDestroyed bubbles up the same condition from HCP. It signals if the cloud provider infrastructure created by Kubernetes
+in the consumer cloud provider account was destroyed.
+A failure here may require external user intervention to resolve. E.g. cloud provider perms were corrupted. E.g. the guest cluster was broken
+and kube resource deletion that affects cloud infra like service type load balancer can&rsquo;t succeed.</p>
+</td>
 </tr><tr><td><p>&#34;ClusterVersionAvailable&#34;</p></td>
 <td><p>ClusterVersionAvailable bubbles up Failing configv1.OperatorAvailable from the CVO.</p>
 </td>
@@ -2951,13 +2735,15 @@ underlying cluster&rsquo;s ClusterVersion.</p>
 underlying cluster&rsquo;s ClusterVersion.</p>
 </td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
-<td><p>EtcdAvailable bubbles up the same condition from HCP.</p>
+<td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.
+A failure here often means a software bug or a non-stable cluster.</p>
 </td>
 </tr><tr><td><p>&#34;EtcdSnapshotRestored&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;Available&#34;</p></td>
 <td><p>HostedClusterAvailable indicates whether the HostedCluster has a healthy
-control plane.</p>
+control plane.
+When this is false for too long and there&rsquo;s no clear indication in the &ldquo;Reason&rdquo;, please check the remaining more granular conditions.</p>
 </td>
 </tr><tr><td><p>&#34;Degraded&#34;</p></td>
 <td><p>HostedClusterDegraded indicates whether the HostedCluster is encountering
@@ -2965,7 +2751,8 @@ an error that may require user intervention to resolve.</p>
 </td>
 </tr><tr><td><p>&#34;Progressing&#34;</p></td>
 <td><p>HostedClusterProgressing indicates whether the HostedCluster is attempting
-an initial deployment or upgrade.</p>
+an initial deployment or upgrade.
+When this is false for too long and there&rsquo;s no clear indication in the &ldquo;Reason&rdquo;, please check the remaining more granular conditions.</p>
 </td>
 </tr><tr><td><p>&#34;Available&#34;</p></td>
 <td></td>
@@ -2973,61 +2760,93 @@ an initial deployment or upgrade.</p>
 <td></td>
 </tr><tr><td><p>&#34;IgnitionEndpointAvailable&#34;</p></td>
 <td><p>IgnitionEndpointAvailable indicates whether the ignition server for the
-HostedCluster is available to handle ignition requests.</p>
+HostedCluster is available to handle ignition requests.
+A failure here often means a software bug or a non-stable cluster.</p>
 </td>
 </tr><tr><td><p>&#34;InfrastructureReady&#34;</p></td>
-<td><p>InfrastructureReady bubbles up the same condition from HCP.</p>
+<td><p>InfrastructureReady bubbles up the same condition from HCP. It signals if the infrastructure for a control plane to be operational,
+e.g. load balancers were created successfully.
+A failure here may require external user intervention to resolve. E.g. hitting quotas on the cloud provider.</p>
 </td>
 </tr><tr><td><p>&#34;KubeAPIServerAvailable&#34;</p></td>
-<td><p>KubeAPIServerAvailable bubbles up the same condition from HCP.</p>
+<td><p>KubeAPIServerAvailable bubbles up the same condition from HCP. It signals if the kube API server is available.
+A failure here often means a software bug or a non-stable cluster.</p>
 </td>
 </tr><tr><td><p>&#34;PlatformCredentialsFound&#34;</p></td>
 <td><p>PlatformCredentialsFound indicates that credentials required for the
-desired platform are valid.</p>
+desired platform are valid.
+A failure here is unlikely to resolve without the changing user input.</p>
 </td>
 </tr><tr><td><p>&#34;ReconciliationActive&#34;</p></td>
 <td><p>ReconciliationActive indicates if reconciliation of the HostedCluster is
-active or paused.</p>
+active or paused hostedCluster.spec.pausedUntil.</p>
 </td>
 </tr><tr><td><p>&#34;ReconciliationSucceeded&#34;</p></td>
 <td><p>ReconciliationSucceeded indicates if the HostedCluster reconciliation
-succeeded.</p>
+succeeded.
+A failure here often means a software bug or a non-stable cluster.</p>
 </td>
 </tr><tr><td><p>&#34;SupportedHostedCluster&#34;</p></td>
 <td><p>SupportedHostedCluster indicates whether a HostedCluster is supported by
 the current configuration of the hypershift-operator.
 e.g. If HostedCluster requests endpointAcess Private but the hypershift-operator
 is running on a management cluster outside AWS or is not configured with AWS
-credentials, the HostedCluster is not supported.</p>
+credentials, the HostedCluster is not supported.
+A failure here is unlikely to resolve without the changing user input.</p>
 </td>
 </tr><tr><td><p>&#34;UnmanagedEtcdAvailable&#34;</p></td>
 <td><p>UnmanagedEtcdAvailable indicates whether a user-managed etcd cluster is
 healthy.</p>
 </td>
+</tr><tr><td><p>&#34;ValidAWSIdentityProvider&#34;</p></td>
+<td><p>ValidAWSIdentityProvider indicates if the Identity Provider referenced
+in the cloud credentials is healthy. E.g. for AWS the idp ARN is referenced in the iam roles.
+&ldquo;Version&rdquo;: &ldquo;2012-10-17&rdquo;,
+&ldquo;Statement&rdquo;: [
+{
+&ldquo;Effect&rdquo;: &ldquo;Allow&rdquo;,
+&ldquo;Principal&rdquo;: {
+&ldquo;Federated&rdquo;: &ldquo;{{ .ProviderARN }}&rdquo;
+},
+&ldquo;Action&rdquo;: &ldquo;sts:AssumeRoleWithWebIdentity&rdquo;,
+&ldquo;Condition&rdquo;: {
+&ldquo;StringEquals&rdquo;: {
+&ldquo;{{ .ProviderName }}:sub&rdquo;: {{ .ServiceAccounts }}
+}
+}
+}
+]</p>
+<p>A failure here may require external user intervention to resolve.</p>
+</td>
 </tr><tr><td><p>&#34;ValidConfiguration&#34;</p></td>
-<td><p>ValidHostedClusterConfiguration indicates (if status is true) that the
-ClusterConfiguration specified for the HostedCluster is valid.</p>
+<td><p>ValidHostedClusterConfiguration signals if the hostedCluster input is valid and
+supported by the underlying management cluster.
+A failure here is unlikely to resolve without the changing user input.</p>
 </td>
 </tr><tr><td><p>&#34;ValidHostedControlPlaneConfiguration&#34;</p></td>
-<td><p>ValidHostedControlPlaneConfiguration bubbles up the same condition from HCP.</p>
+<td><p>ValidHostedControlPlaneConfiguration bubbles up the same condition from HCP. It signals if the hostedControlPlane input is valid and
+supported by the underlying management cluster.
+A failure here is unlikely to resolve without the changing user input.</p>
 </td>
 </tr><tr><td><p>&#34;ValidOIDCConfiguration&#34;</p></td>
 <td><p>ValidOIDCConfiguration indicates if an AWS cluster&rsquo;s OIDC condition is
-detected as invalid.</p>
+detected as invalid.
+A failure here may require external user intervention to resolve. E.g. oidc was deleted out of band.</p>
 </td>
 </tr><tr><td><p>&#34;ValidReleaseImage&#34;</p></td>
 <td><p>ValidReleaseImage indicates if the release image set in the spec is valid
 for the HostedCluster. For example, this can be set false if the
 HostedCluster itself attempts an unsupported version before 4.9 or an
-unsupported upgrade e.g y-stream upgrade before 4.11.</p>
+unsupported upgrade e.g y-stream upgrade before 4.11.
+A failure here is unlikely to resolve without the changing user input.</p>
 </td>
 </tr></tbody>
 </table>
-###DNSSpec { #hypershift.openshift.io/v1alpha1.DNSSpec }
+###DNSSpec { #hypershift.openshift.io/v1beta1.DNSSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>DNSSpec specifies the DNS configuration in the cluster.</p>
@@ -3079,10 +2898,10 @@ available internally to the cluster exist.</p>
 </tr>
 </tbody>
 </table>
-###EtcdManagementType { #hypershift.openshift.io/v1alpha1.EtcdManagementType }
+###EtcdManagementType { #hypershift.openshift.io/v1beta1.EtcdManagementType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">EtcdSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.EtcdSpec">EtcdSpec</a>)
 </p>
 <p>
 <p>EtcdManagementType is a enum specifying the strategy for managing the cluster&rsquo;s etcd instance</p>
@@ -3104,11 +2923,11 @@ and the user is responsible for doing so.</p>
 </td>
 </tr></tbody>
 </table>
-###EtcdSpec { #hypershift.openshift.io/v1alpha1.EtcdSpec }
+###EtcdSpec { #hypershift.openshift.io/v1beta1.EtcdSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>EtcdSpec specifies configuration for a control plane etcd cluster.</p>
@@ -3125,25 +2944,20 @@ and the user is responsible for doing so.</p>
 <td>
 <code>managementType</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdManagementType">
+<a href="#hypershift.openshift.io/v1beta1.EtcdManagementType">
 EtcdManagementType
 </a>
 </em>
 </td>
 <td>
 <p>ManagementType defines how the etcd cluster is managed.</p>
-<p>
-Value must be one of:
-&#34;Managed&#34;, 
-&#34;Unmanaged&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>managed</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdSpec">
+<a href="#hypershift.openshift.io/v1beta1.ManagedEtcdSpec">
 ManagedEtcdSpec
 </a>
 </em>
@@ -3157,7 +2971,7 @@ ManagedEtcdSpec
 <td>
 <code>unmanaged</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.UnmanagedEtcdSpec">
+<a href="#hypershift.openshift.io/v1beta1.UnmanagedEtcdSpec">
 UnmanagedEtcdSpec
 </a>
 </em>
@@ -3170,10 +2984,10 @@ integrate with an eternally managed etcd cluster.</p>
 </tr>
 </tbody>
 </table>
-###EtcdTLSConfig { #hypershift.openshift.io/v1alpha1.EtcdTLSConfig }
+###EtcdTLSConfig { #hypershift.openshift.io/v1beta1.EtcdTLSConfig }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.UnmanagedEtcdSpec">UnmanagedEtcdSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.UnmanagedEtcdSpec">UnmanagedEtcdSpec</a>)
 </p>
 <p>
 <p>EtcdTLSConfig specifies TLS configuration for HTTPS etcd client endpoints.</p>
@@ -3206,10 +3020,10 @@ etcd-client.key: Client certificate key value
 </tr>
 </tbody>
 </table>
-###Filter { #hypershift.openshift.io/v1alpha1.Filter }
+###Filter { #hypershift.openshift.io/v1beta1.Filter }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSResourceReference">AWSResourceReference</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSResourceReference">AWSResourceReference</a>)
 </p>
 <p>
 <p>Filter is a filter used to identify an AWS resource</p>
@@ -3246,10 +3060,10 @@ string
 </tr>
 </tbody>
 </table>
-###HostedClusterSpec { #hypershift.openshift.io/v1alpha1.HostedClusterSpec }
+###HostedClusterSpec { #hypershift.openshift.io/v1beta1.HostedClusterSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedCluster">HostedCluster</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedCluster">HostedCluster</a>)
 </p>
 <p>
 <p>HostedClusterSpec is the desired behavior of a HostedCluster.</p>
@@ -3266,7 +3080,7 @@ string
 <td>
 <code>release</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.Release">
+<a href="#hypershift.openshift.io/v1beta1.Release">
 Release
 </a>
 </em>
@@ -3330,7 +3144,7 @@ and its associated NodePools.</p>
 <td>
 <code>platform</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">
 PlatformSpec
 </a>
 </em>
@@ -3344,7 +3158,7 @@ and is used to configure platform specific behavior.</p>
 <td>
 <code>controllerAvailabilityPolicy</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AvailabilityPolicy">
+<a href="#hypershift.openshift.io/v1beta1.AvailabilityPolicy">
 AvailabilityPolicy
 </a>
 </em>
@@ -3353,18 +3167,13 @@ AvailabilityPolicy
 <em>(Optional)</em>
 <p>ControllerAvailabilityPolicy specifies the availability policy applied to
 critical control plane components. The default value is SingleReplica.</p>
-<p>
-Value must be one of:
-&#34;HighlyAvailable&#34;, 
-&#34;SingleReplica&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>infrastructureAvailabilityPolicy</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AvailabilityPolicy">
+<a href="#hypershift.openshift.io/v1beta1.AvailabilityPolicy">
 AvailabilityPolicy
 </a>
 </em>
@@ -3374,18 +3183,13 @@ AvailabilityPolicy
 <p>InfrastructureAvailabilityPolicy specifies the availability policy applied
 to infrastructure services which run on cluster nodes. The default value is
 SingleReplica.</p>
-<p>
-Value must be one of:
-&#34;HighlyAvailable&#34;, 
-&#34;SingleReplica&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>dns</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.DNSSpec">
+<a href="#hypershift.openshift.io/v1beta1.DNSSpec">
 DNSSpec
 </a>
 </em>
@@ -3398,7 +3202,7 @@ DNSSpec
 <td>
 <code>networking</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">
+<a href="#hypershift.openshift.io/v1beta1.ClusterNetworking">
 ClusterNetworking
 </a>
 </em>
@@ -3411,7 +3215,7 @@ ClusterNetworking
 <td>
 <code>autoscaling</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterAutoscaling">
+<a href="#hypershift.openshift.io/v1beta1.ClusterAutoscaling">
 ClusterAutoscaling
 </a>
 </em>
@@ -3426,7 +3230,7 @@ associated with the control plane.</p>
 <td>
 <code>etcd</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">
+<a href="#hypershift.openshift.io/v1beta1.EtcdSpec">
 EtcdSpec
 </a>
 </em>
@@ -3441,7 +3245,7 @@ changed.</p>
 <td>
 <code>services</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping">
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategyMapping">
 []ServicePublishingStrategyMapping
 </a>
 </em>
@@ -3520,7 +3324,7 @@ signing key, a IssuerURL must also be specified.</p>
 <td>
 <code>configuration</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterConfiguration">
+<a href="#hypershift.openshift.io/v1beta1.ClusterConfiguration">
 ClusterConfiguration
 </a>
 </em>
@@ -3556,7 +3360,7 @@ name that corresponds to the constant AuditWebhookKubeconfigKey.</p>
 <td>
 <code>imageContentSources</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ImageContentSource">
+<a href="#hypershift.openshift.io/v1beta1.ImageContentSource">
 []ImageContentSource
 </a>
 </em>
@@ -3586,7 +3390,7 @@ PEM-encoded X.509 certificate bundle that will be added to the hosted controlpla
 <td>
 <code>secretEncryption</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">
+<a href="#hypershift.openshift.io/v1beta1.SecretEncryptionSpec">
 SecretEncryptionSpec
 </a>
 </em>
@@ -3630,7 +3434,7 @@ provided: reconciliation is paused on the resource until the field is removed.</
 <td>
 <code>olmCatalogPlacement</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.OLMCatalogPlacement">
+<a href="#hypershift.openshift.io/v1beta1.OLMCatalogPlacement">
 OLMCatalogPlacement
 </a>
 </em>
@@ -3641,11 +3445,6 @@ OLMCatalogPlacement
 this is set to management and OLM catalog components are deployed onto the management
 cluster. If set to guest, the OLM catalog components will be deployed onto the guest
 cluster.</p>
-<p>
-Value must be one of:
-&#34;guest&#34;, 
-&#34;management&#34;
-</p>
 </td>
 </tr>
 <tr>
@@ -3662,10 +3461,10 @@ map[string]string
 </tr>
 </tbody>
 </table>
-###HostedClusterStatus { #hypershift.openshift.io/v1alpha1.HostedClusterStatus }
+###HostedClusterStatus { #hypershift.openshift.io/v1beta1.HostedClusterStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedCluster">HostedCluster</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedCluster">HostedCluster</a>)
 </p>
 <p>
 <p>HostedClusterStatus is the latest observed status of a HostedCluster.</p>
@@ -3682,7 +3481,7 @@ map[string]string
 <td>
 <code>version</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterVersionStatus">
+<a href="#hypershift.openshift.io/v1beta1.ClusterVersionStatus">
 ClusterVersionStatus
 </a>
 </em>
@@ -3740,7 +3539,7 @@ It exposes the config for instances to become kubernetes nodes.</p>
 <td>
 <code>controlPlaneEndpoint</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.APIEndpoint">
+<a href="#hypershift.openshift.io/v1beta1.APIEndpoint">
 APIEndpoint
 </a>
 </em>
@@ -3782,7 +3581,7 @@ plane&rsquo;s current state.</p>
 </tr>
 </tbody>
 </table>
-###HostedControlPlaneSpec { #hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec }
+###HostedControlPlaneSpec { #hypershift.openshift.io/v1beta1.HostedControlPlaneSpec }
 <p>
 <p>HostedControlPlaneSpec defines the desired state of HostedControlPlane</p>
 </p>
@@ -3849,7 +3648,7 @@ validation.</p>
 <td>
 <code>networking</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">
+<a href="#hypershift.openshift.io/v1beta1.ClusterNetworking">
 ClusterNetworking
 </a>
 </em>
@@ -3858,68 +3657,6 @@ ClusterNetworking
 <em>(Optional)</em>
 <p>Networking specifies network configuration for the cluster.
 Temporarily optional for backward compatibility, required in future releases.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>deprecated
-use networking.ServiceNetwork</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>podCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>deprecated
-use networking.ClusterNetwork</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>machineCIDR</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>deprecated
-use networking.MachineNetwork</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>networkType</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.NetworkType">
-NetworkType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>deprecated
-use networking.NetworkType
-NetworkType specifies the SDN provider used for cluster networking.</p>
-<p>
-Value must be one of:
-&#34;Calico&#34;, 
-&#34;OVNKubernetes&#34;, 
-&#34;OpenShiftSDN&#34;, 
-&#34;Other&#34;
-</p>
 </td>
 </tr>
 <tr>
@@ -3963,7 +3700,7 @@ string
 <td>
 <code>platform</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">
 PlatformSpec
 </a>
 </em>
@@ -3975,7 +3712,7 @@ PlatformSpec
 <td>
 <code>dns</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.DNSSpec">
+<a href="#hypershift.openshift.io/v1beta1.DNSSpec">
 DNSSpec
 </a>
 </em>
@@ -4002,56 +3739,9 @@ be generated automatically for the cluster.</p>
 </tr>
 <tr>
 <td>
-<code>apiPort</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>deprecated
-use networking.apiServer.APIPort
-APIPort is the port at which the APIServer listens inside a worker</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiAdvertiseAddress</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>deprecated
-use networking.apiServer.AdvertiseAddress
-APIAdvertiseAddress is the address at which the APIServer listens
-inside a worker.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiAllowedCIDRBlocks</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1alpha1.CIDRBlock">
-[]CIDRBlock
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>deprecated
-use networking.apiServer.APIAllowedCIDRBlocks
-APIAllowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
-If not specified, traffic is allowed from all addresses.
-This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>controllerAvailabilityPolicy</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AvailabilityPolicy">
+<a href="#hypershift.openshift.io/v1beta1.AvailabilityPolicy">
 AvailabilityPolicy
 </a>
 </em>
@@ -4060,18 +3750,13 @@ AvailabilityPolicy
 <em>(Optional)</em>
 <p>ControllerAvailabilityPolicy specifies the availability policy applied to
 critical control plane components. The default value is SingleReplica.</p>
-<p>
-Value must be one of:
-&#34;HighlyAvailable&#34;, 
-&#34;SingleReplica&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>infrastructureAvailabilityPolicy</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AvailabilityPolicy">
+<a href="#hypershift.openshift.io/v1beta1.AvailabilityPolicy">
 AvailabilityPolicy
 </a>
 </em>
@@ -4081,11 +3766,6 @@ AvailabilityPolicy
 <p>InfrastructureAvailabilityPolicy specifies the availability policy applied
 to infrastructure services which run on cluster nodes. The default value is
 SingleReplica.</p>
-<p>
-Value must be one of:
-&#34;HighlyAvailable&#34;, 
-&#34;SingleReplica&#34;
-</p>
 </td>
 </tr>
 <tr>
@@ -4104,7 +3784,7 @@ bool
 <td>
 <code>kubeconfig</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubeconfigSecretRef">
+<a href="#hypershift.openshift.io/v1beta1.KubeconfigSecretRef">
 KubeconfigSecretRef
 </a>
 </em>
@@ -4118,7 +3798,7 @@ KubeconfigSecretRef
 <td>
 <code>services</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping">
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategyMapping">
 []ServicePublishingStrategyMapping
 </a>
 </em>
@@ -4151,7 +3831,7 @@ in the secret with a secret key name that corresponds to the constant AuditWebho
 <td>
 <code>etcd</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">
+<a href="#hypershift.openshift.io/v1beta1.EtcdSpec">
 EtcdSpec
 </a>
 </em>
@@ -4165,7 +3845,7 @@ use to store data.</p>
 <td>
 <code>configuration</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterConfiguration">
+<a href="#hypershift.openshift.io/v1beta1.ClusterConfiguration">
 ClusterConfiguration
 </a>
 </em>
@@ -4179,7 +3859,7 @@ ClusterConfiguration
 <td>
 <code>imageContentSources</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ImageContentSource">
+<a href="#hypershift.openshift.io/v1beta1.ImageContentSource">
 []ImageContentSource
 </a>
 </em>
@@ -4207,7 +3887,7 @@ Kubernetes core/v1.LocalObjectReference
 <td>
 <code>secretEncryption</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">
+<a href="#hypershift.openshift.io/v1beta1.SecretEncryptionSpec">
 SecretEncryptionSpec
 </a>
 </em>
@@ -4237,7 +3917,7 @@ provided: reconciliation is paused on the resource until the field is removed.</
 <td>
 <code>olmCatalogPlacement</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.OLMCatalogPlacement">
+<a href="#hypershift.openshift.io/v1beta1.OLMCatalogPlacement">
 OLMCatalogPlacement
 </a>
 </em>
@@ -4248,18 +3928,13 @@ OLMCatalogPlacement
 this is set to management and OLM catalog components are deployed onto the management
 cluster. If set to guest, the OLM catalog components will be deployed onto the guest
 cluster.</p>
-<p>
-Value must be one of:
-&#34;guest&#34;, 
-&#34;management&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>autoscaling</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterAutoscaling">
+<a href="#hypershift.openshift.io/v1beta1.ClusterAutoscaling">
 ClusterAutoscaling
 </a>
 </em>
@@ -4284,7 +3959,7 @@ map[string]string
 </tr>
 </tbody>
 </table>
-###HostedControlPlaneStatus { #hypershift.openshift.io/v1alpha1.HostedControlPlaneStatus }
+###HostedControlPlaneStatus { #hypershift.openshift.io/v1beta1.HostedControlPlaneStatus }
 <p>
 <p>HostedControlPlaneStatus defines the observed state of HostedControlPlane</p>
 </p>
@@ -4341,7 +4016,7 @@ is managed by an external service.
 <td>
 <code>controlPlaneEndpoint</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.APIEndpoint">
+<a href="#hypershift.openshift.io/v1beta1.APIEndpoint">
 APIEndpoint
 </a>
 </em>
@@ -4370,7 +4045,7 @@ This is populated after the infrastructure is ready.</p>
 <td>
 <code>versionStatus</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterVersionStatus">
+<a href="#hypershift.openshift.io/v1beta1.ClusterVersionStatus">
 ClusterVersionStatus
 </a>
 </em>
@@ -4426,7 +4101,7 @@ releaseImage property.</p>
 <td>
 <code>kubeConfig</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubeconfigSecretRef">
+<a href="#hypershift.openshift.io/v1beta1.KubeconfigSecretRef">
 KubeconfigSecretRef
 </a>
 </em>
@@ -4468,10 +4143,10 @@ Current condition types are: &ldquo;Available&rdquo;</p>
 </tr>
 </tbody>
 </table>
-###IBMCloudKMSAuthSpec { #hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec }
+###IBMCloudKMSAuthSpec { #hypershift.openshift.io/v1beta1.IBMCloudKMSAuthSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSSpec">IBMCloudKMSSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSSpec">IBMCloudKMSSpec</a>)
 </p>
 <p>
 <p>IBMCloudKMSAuthSpec defines metadata for how authentication is done with IBM Cloud KMS</p>
@@ -4488,25 +4163,20 @@ Current condition types are: &ldquo;Available&rdquo;</p>
 <td>
 <code>type</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthType">
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSAuthType">
 IBMCloudKMSAuthType
 </a>
 </em>
 </td>
 <td>
 <p>Type defines the IBM Cloud KMS authentication strategy</p>
-<p>
-Value must be one of:
-&#34;Managed&#34;, 
-&#34;Unmanaged&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>unmanaged</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSUnmanagedAuthSpec">
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSUnmanagedAuthSpec">
 IBMCloudKMSUnmanagedAuthSpec
 </a>
 </em>
@@ -4520,7 +4190,7 @@ IBMCloudKMSUnmanagedAuthSpec
 <td>
 <code>managed</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSManagedAuthSpec">
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSManagedAuthSpec">
 IBMCloudKMSManagedAuthSpec
 </a>
 </em>
@@ -4533,10 +4203,10 @@ KMS system (all provider managed).</p>
 </tr>
 </tbody>
 </table>
-###IBMCloudKMSAuthType { #hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthType }
+###IBMCloudKMSAuthType { #hypershift.openshift.io/v1beta1.IBMCloudKMSAuthType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec</a>)
 </p>
 <p>
 <p>IBMCloudKMSAuthType defines the IBM Cloud KMS authentication strategy</p>
@@ -4558,10 +4228,10 @@ authentication to interact with IBM Cloud KMS APIs</p>
 </td>
 </tr></tbody>
 </table>
-###IBMCloudKMSKeyEntry { #hypershift.openshift.io/v1alpha1.IBMCloudKMSKeyEntry }
+###IBMCloudKMSKeyEntry { #hypershift.openshift.io/v1beta1.IBMCloudKMSKeyEntry }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSSpec">IBMCloudKMSSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSSpec">IBMCloudKMSSpec</a>)
 </p>
 <p>
 <p>IBMCloudKMSKeyEntry defines metadata for an IBM Cloud KMS encryption key</p>
@@ -4632,19 +4302,19 @@ key is enabled for data encryption.</p>
 </tr>
 </tbody>
 </table>
-###IBMCloudKMSManagedAuthSpec { #hypershift.openshift.io/v1alpha1.IBMCloudKMSManagedAuthSpec }
+###IBMCloudKMSManagedAuthSpec { #hypershift.openshift.io/v1beta1.IBMCloudKMSManagedAuthSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec</a>)
 </p>
 <p>
 <p>IBMCloudKMSManagedAuthSpec defines metadata around the service to service authentication strategy for the IBM Cloud
 KMS system (all provider managed).</p>
 </p>
-###IBMCloudKMSSpec { #hypershift.openshift.io/v1alpha1.IBMCloudKMSSpec }
+###IBMCloudKMSSpec { #hypershift.openshift.io/v1beta1.IBMCloudKMSSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KMSSpec">KMSSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.KMSSpec">KMSSpec</a>)
 </p>
 <p>
 <p>IBMCloudKMSSpec defines metadata for the IBM Cloud KMS encryption strategy</p>
@@ -4672,7 +4342,7 @@ string
 <td>
 <code>auth</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec">
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSAuthSpec">
 IBMCloudKMSAuthSpec
 </a>
 </em>
@@ -4685,7 +4355,7 @@ IBMCloudKMSAuthSpec
 <td>
 <code>keyList</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSKeyEntry">
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSKeyEntry">
 []IBMCloudKMSKeyEntry
 </a>
 </em>
@@ -4696,10 +4366,10 @@ IBMCloudKMSAuthSpec
 </tr>
 </tbody>
 </table>
-###IBMCloudKMSUnmanagedAuthSpec { #hypershift.openshift.io/v1alpha1.IBMCloudKMSUnmanagedAuthSpec }
+###IBMCloudKMSUnmanagedAuthSpec { #hypershift.openshift.io/v1beta1.IBMCloudKMSUnmanagedAuthSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSAuthSpec">IBMCloudKMSAuthSpec</a>)
 </p>
 <p>
 <p>IBMCloudKMSUnmanagedAuthSpec defines the auth metadata the customer provides to interact with IBM Cloud KMS</p>
@@ -4728,11 +4398,11 @@ call IBM Cloud KMS APIs</p>
 </tr>
 </tbody>
 </table>
-###IBMCloudPlatformSpec { #hypershift.openshift.io/v1alpha1.IBMCloudPlatformSpec }
+###IBMCloudPlatformSpec { #hypershift.openshift.io/v1beta1.IBMCloudPlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
 <p>IBMCloudPlatformSpec defines IBMCloud specific settings for components</p>
@@ -4760,11 +4430,11 @@ github.com/openshift/api/config/v1.IBMCloudProviderType
 </tr>
 </tbody>
 </table>
-###ImageContentSource { #hypershift.openshift.io/v1alpha1.ImageContentSource }
+###ImageContentSource { #hypershift.openshift.io/v1beta1.ImageContentSource }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>ImageContentSource specifies image mirrors that can be used by cluster nodes
@@ -4806,10 +4476,10 @@ specifications.</p>
 </tr>
 </tbody>
 </table>
-###InPlaceUpgrade { #hypershift.openshift.io/v1alpha1.InPlaceUpgrade }
+###InPlaceUpgrade { #hypershift.openshift.io/v1beta1.InPlaceUpgrade }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">NodePoolManagement</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolManagement">NodePoolManagement</a>)
 </p>
 <p>
 <p>InPlaceUpgrade specifies an upgrade strategy which upgrades nodes in-place
@@ -4849,10 +4519,10 @@ the update is at least 70% of desired nodes.</p>
 </tr>
 </tbody>
 </table>
-###KMSProvider { #hypershift.openshift.io/v1alpha1.KMSProvider }
+###KMSProvider { #hypershift.openshift.io/v1beta1.KMSProvider }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KMSSpec">KMSSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.KMSSpec">KMSSpec</a>)
 </p>
 <p>
 <p>KMSProvider defines the supported KMS providers</p>
@@ -4870,10 +4540,10 @@ the update is at least 70% of desired nodes.</p>
 <td></td>
 </tr></tbody>
 </table>
-###KMSSpec { #hypershift.openshift.io/v1alpha1.KMSSpec }
+###KMSSpec { #hypershift.openshift.io/v1beta1.KMSSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
 </p>
 <p>
 <p>KMSSpec defines metadata about the kms secret encryption strategy</p>
@@ -4890,25 +4560,20 @@ the update is at least 70% of desired nodes.</p>
 <td>
 <code>provider</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KMSProvider">
+<a href="#hypershift.openshift.io/v1beta1.KMSProvider">
 KMSProvider
 </a>
 </em>
 </td>
 <td>
 <p>Provider defines the KMS provider</p>
-<p>
-Value must be one of:
-&#34;AWS&#34;, 
-&#34;IBMCloud&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>ibmcloud</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudKMSSpec">
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudKMSSpec">
 IBMCloudKMSSpec
 </a>
 </em>
@@ -4922,7 +4587,7 @@ IBMCloudKMSSpec
 <td>
 <code>aws</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSKMSSpec">
+<a href="#hypershift.openshift.io/v1beta1.AWSKMSSpec">
 AWSKMSSpec
 </a>
 </em>
@@ -4934,10 +4599,10 @@ AWSKMSSpec
 </tr>
 </tbody>
 </table>
-###KubevirtCompute { #hypershift.openshift.io/v1alpha1.KubevirtCompute }
+###KubevirtCompute { #hypershift.openshift.io/v1beta1.KubevirtCompute }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtNodePoolPlatform">KubevirtNodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.KubevirtNodePoolPlatform">KubevirtNodePoolPlatform</a>)
 </p>
 <p>
 <p>KubevirtCompute contains values associated with the virtual compute hardware requested for the VM.</p>
@@ -4978,10 +4643,10 @@ uint32
 </tr>
 </tbody>
 </table>
-###KubevirtDiskImage { #hypershift.openshift.io/v1alpha1.KubevirtDiskImage }
+###KubevirtDiskImage { #hypershift.openshift.io/v1beta1.KubevirtDiskImage }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtRootVolume">KubevirtRootVolume</a>)
+<a href="#hypershift.openshift.io/v1beta1.KubevirtRootVolume">KubevirtRootVolume</a>)
 </p>
 <p>
 <p>KubevirtDiskImage contains values representing where the rhcos image is located</p>
@@ -5008,10 +4673,10 @@ string
 </tr>
 </tbody>
 </table>
-###KubevirtNodePoolPlatform { #hypershift.openshift.io/v1alpha1.KubevirtNodePoolPlatform }
+###KubevirtNodePoolPlatform { #hypershift.openshift.io/v1beta1.KubevirtNodePoolPlatform }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>)
 </p>
 <p>
 <p>KubevirtNodePoolPlatform specifies the configuration of a NodePool when operating
@@ -5029,7 +4694,7 @@ on KubeVirt platform.</p>
 <td>
 <code>rootVolume</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtRootVolume">
+<a href="#hypershift.openshift.io/v1beta1.KubevirtRootVolume">
 KubevirtRootVolume
 </a>
 </em>
@@ -5042,7 +4707,7 @@ KubevirtRootVolume
 <td>
 <code>compute</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtCompute">
+<a href="#hypershift.openshift.io/v1beta1.KubevirtCompute">
 KubevirtCompute
 </a>
 </em>
@@ -5054,10 +4719,10 @@ KubevirtCompute
 </tr>
 </tbody>
 </table>
-###KubevirtPersistentVolume { #hypershift.openshift.io/v1alpha1.KubevirtPersistentVolume }
+###KubevirtPersistentVolume { #hypershift.openshift.io/v1beta1.KubevirtPersistentVolume }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtVolume">KubevirtVolume</a>)
+<a href="#hypershift.openshift.io/v1beta1.KubevirtVolume">KubevirtVolume</a>)
 </p>
 <p>
 <p>KubevirtPersistentVolume contains the values involved with provisioning persistent storage for a KubeVirt VM.</p>
@@ -5100,7 +4765,7 @@ string
 <td>
 <code>accessModes</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PersistentVolumeAccessMode">
+<a href="#hypershift.openshift.io/v1beta1.PersistentVolumeAccessMode">
 []PersistentVolumeAccessMode
 </a>
 </em>
@@ -5113,10 +4778,10 @@ More info: <a href="https://kubernetes.io/docs/concepts/storage/persistent-volum
 </tr>
 </tbody>
 </table>
-###KubevirtPlatformSpec { #hypershift.openshift.io/v1alpha1.KubevirtPlatformSpec }
+###KubevirtPlatformSpec { #hypershift.openshift.io/v1beta1.KubevirtPlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
 <p>KubevirtPlatformSpec specifies configuration for kubevirt guest cluster installations</p>
@@ -5159,10 +4824,10 @@ Apps: *.apps.guest.apps.mgmt-cluster.example.com</p>
 </tr>
 </tbody>
 </table>
-###KubevirtRootVolume { #hypershift.openshift.io/v1alpha1.KubevirtRootVolume }
+###KubevirtRootVolume { #hypershift.openshift.io/v1beta1.KubevirtRootVolume }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtNodePoolPlatform">KubevirtNodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.KubevirtNodePoolPlatform">KubevirtNodePoolPlatform</a>)
 </p>
 <p>
 <p>KubevirtRootVolume represents the volume that the rhcos disk will be stored and run from.</p>
@@ -5179,7 +4844,7 @@ Apps: *.apps.guest.apps.mgmt-cluster.example.com</p>
 <td>
 <code>diskImage</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtDiskImage">
+<a href="#hypershift.openshift.io/v1beta1.KubevirtDiskImage">
 KubevirtDiskImage
 </a>
 </em>
@@ -5193,7 +4858,7 @@ KubevirtDiskImage
 <td>
 <code>KubevirtVolume</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtVolume">
+<a href="#hypershift.openshift.io/v1beta1.KubevirtVolume">
 KubevirtVolume
 </a>
 </em>
@@ -5207,10 +4872,10 @@ KubevirtVolume
 </tr>
 </tbody>
 </table>
-###KubevirtVolume { #hypershift.openshift.io/v1alpha1.KubevirtVolume }
+###KubevirtVolume { #hypershift.openshift.io/v1beta1.KubevirtVolume }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtRootVolume">KubevirtRootVolume</a>)
+<a href="#hypershift.openshift.io/v1beta1.KubevirtRootVolume">KubevirtRootVolume</a>)
 </p>
 <p>
 <p>KubevirtVolume represents what kind of storage to use for a KubeVirt VM volume</p>
@@ -5227,7 +4892,7 @@ KubevirtVolume
 <td>
 <code>type</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtVolumeType">
+<a href="#hypershift.openshift.io/v1beta1.KubevirtVolumeType">
 KubevirtVolumeType
 </a>
 </em>
@@ -5235,17 +4900,13 @@ KubevirtVolumeType
 <td>
 <em>(Optional)</em>
 <p>Type represents the type of storage to associate with the kubevirt VMs.</p>
-<p>
-Value must be one of:
-&#34;Persistent&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>persistent</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtPersistentVolume">
+<a href="#hypershift.openshift.io/v1beta1.KubevirtPersistentVolume">
 KubevirtPersistentVolume
 </a>
 </em>
@@ -5259,10 +4920,10 @@ This is the default type used when no storage type is defined.</p>
 </tr>
 </tbody>
 </table>
-###KubevirtVolumeType { #hypershift.openshift.io/v1alpha1.KubevirtVolumeType }
+###KubevirtVolumeType { #hypershift.openshift.io/v1beta1.KubevirtVolumeType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtVolume">KubevirtVolume</a>)
+<a href="#hypershift.openshift.io/v1beta1.KubevirtVolume">KubevirtVolume</a>)
 </p>
 <p>
 <p>KubevirtVolumeType is a specific supported KubeVirt volumes</p>
@@ -5279,10 +4940,10 @@ This is the default type used when no storage type is defined.</p>
 </td>
 </tr></tbody>
 </table>
-###LoadBalancerPublishingStrategy { #hypershift.openshift.io/v1alpha1.LoadBalancerPublishingStrategy }
+###LoadBalancerPublishingStrategy { #hypershift.openshift.io/v1beta1.LoadBalancerPublishingStrategy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
 </p>
 <p>
 <p>LoadBalancerPublishingStrategy specifies setting used to expose a service as a LoadBalancer.</p>
@@ -5309,10 +4970,10 @@ string
 </tr>
 </tbody>
 </table>
-###MachineNetworkEntry { #hypershift.openshift.io/v1alpha1.MachineNetworkEntry }
+###MachineNetworkEntry { #hypershift.openshift.io/v1beta1.MachineNetworkEntry }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">ClusterNetworking</a>)
+<a href="#hypershift.openshift.io/v1beta1.ClusterNetworking">ClusterNetworking</a>)
 </p>
 <p>
 <p>MachineNetworkEntry is a single IP address block for node IP blocks.</p>
@@ -5340,10 +5001,10 @@ github.com/openshift/hypershift/api/util/ipnet.IPNet
 </tr>
 </tbody>
 </table>
-###ManagedEtcdSpec { #hypershift.openshift.io/v1alpha1.ManagedEtcdSpec }
+###ManagedEtcdSpec { #hypershift.openshift.io/v1beta1.ManagedEtcdSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">EtcdSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.EtcdSpec">EtcdSpec</a>)
 </p>
 <p>
 <p>ManagedEtcdSpec specifies the behavior of an etcd cluster managed by
@@ -5361,7 +5022,7 @@ HyperShift.</p>
 <td>
 <code>storage</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdStorageSpec">
+<a href="#hypershift.openshift.io/v1beta1.ManagedEtcdStorageSpec">
 ManagedEtcdStorageSpec
 </a>
 </em>
@@ -5372,10 +5033,10 @@ ManagedEtcdStorageSpec
 </tr>
 </tbody>
 </table>
-###ManagedEtcdStorageSpec { #hypershift.openshift.io/v1alpha1.ManagedEtcdStorageSpec }
+###ManagedEtcdStorageSpec { #hypershift.openshift.io/v1beta1.ManagedEtcdStorageSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdSpec">ManagedEtcdSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.ManagedEtcdSpec">ManagedEtcdSpec</a>)
 </p>
 <p>
 <p>ManagedEtcdStorageSpec describes the storage configuration for etcd data.</p>
@@ -5392,24 +5053,20 @@ ManagedEtcdStorageSpec
 <td>
 <code>type</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdStorageType">
+<a href="#hypershift.openshift.io/v1beta1.ManagedEtcdStorageType">
 ManagedEtcdStorageType
 </a>
 </em>
 </td>
 <td>
 <p>Type is the kind of persistent storage implementation to use for etcd.</p>
-<p>
-Value must be one of:
-&#34;PersistentVolume&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>persistentVolume</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PersistentVolumeEtcdStorageSpec">
+<a href="#hypershift.openshift.io/v1beta1.PersistentVolumeEtcdStorageSpec">
 PersistentVolumeEtcdStorageSpec
 </a>
 </em>
@@ -5440,10 +5097,10 @@ is empty.</p>
 </tr>
 </tbody>
 </table>
-###ManagedEtcdStorageType { #hypershift.openshift.io/v1alpha1.ManagedEtcdStorageType }
+###ManagedEtcdStorageType { #hypershift.openshift.io/v1beta1.ManagedEtcdStorageType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdStorageSpec">ManagedEtcdStorageSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.ManagedEtcdStorageSpec">ManagedEtcdStorageSpec</a>)
 </p>
 <p>
 <p>ManagedEtcdStorageType is a storage type for an etcd cluster.</p>
@@ -5460,11 +5117,10 @@ is empty.</p>
 </td>
 </tr></tbody>
 </table>
-###NetworkType { #hypershift.openshift.io/v1alpha1.NetworkType }
+###NetworkType { #hypershift.openshift.io/v1beta1.NetworkType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">ClusterNetworking</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.ClusterNetworking">ClusterNetworking</a>)
 </p>
 <p>
 <p>NetworkType specifies the SDN provider used for cluster networking.</p>
@@ -5490,10 +5146,10 @@ is empty.</p>
 </td>
 </tr></tbody>
 </table>
-###NodePoolAutoScaling { #hypershift.openshift.io/v1alpha1.NodePoolAutoScaling }
+###NodePoolAutoScaling { #hypershift.openshift.io/v1beta1.NodePoolAutoScaling }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">NodePoolSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolSpec">NodePoolSpec</a>)
 </p>
 <p>
 <p>NodePoolAutoScaling specifies auto-scaling behavior for a NodePool.</p>
@@ -5530,10 +5186,10 @@ int32
 </tr>
 </tbody>
 </table>
-###NodePoolCondition { #hypershift.openshift.io/v1alpha1.NodePoolCondition }
+###NodePoolCondition { #hypershift.openshift.io/v1beta1.NodePoolCondition }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolStatus">NodePoolStatus</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolStatus">NodePoolStatus</a>)
 </p>
 <p>
 <p>We define our own condition type since metav1.Condition has validation
@@ -5642,10 +5298,10 @@ int64
 </tr>
 </tbody>
 </table>
-###NodePoolManagement { #hypershift.openshift.io/v1alpha1.NodePoolManagement }
+###NodePoolManagement { #hypershift.openshift.io/v1beta1.NodePoolManagement }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">NodePoolSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolSpec">NodePoolSpec</a>)
 </p>
 <p>
 <p>NodePoolManagement specifies behavior for managing nodes in a NodePool, such
@@ -5663,25 +5319,20 @@ as upgrade strategies and auto-repair behaviors.</p>
 <td>
 <code>upgradeType</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.UpgradeType">
+<a href="#hypershift.openshift.io/v1beta1.UpgradeType">
 UpgradeType
 </a>
 </em>
 </td>
 <td>
 <p>UpgradeType specifies the type of strategy for handling upgrades.</p>
-<p>
-Value must be one of:
-&#34;InPlace&#34;, 
-&#34;Replace&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>replace</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ReplaceUpgrade">
+<a href="#hypershift.openshift.io/v1beta1.ReplaceUpgrade">
 ReplaceUpgrade
 </a>
 </em>
@@ -5694,7 +5345,7 @@ ReplaceUpgrade
 <td>
 <code>inPlace</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.InPlaceUpgrade">
+<a href="#hypershift.openshift.io/v1beta1.InPlaceUpgrade">
 InPlaceUpgrade
 </a>
 </em>
@@ -5718,10 +5369,10 @@ in the NodePool. The default is false.</p>
 </tr>
 </tbody>
 </table>
-###NodePoolPlatform { #hypershift.openshift.io/v1alpha1.NodePoolPlatform }
+###NodePoolPlatform { #hypershift.openshift.io/v1beta1.NodePoolPlatform }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">NodePoolSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolSpec">NodePoolSpec</a>)
 </p>
 <p>
 <p>NodePoolPlatform specifies the underlying infrastructure provider for the
@@ -5739,30 +5390,20 @@ NodePool and is used to configure platform specific behavior.</p>
 <td>
 <code>type</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformType">
+<a href="#hypershift.openshift.io/v1beta1.PlatformType">
 PlatformType
 </a>
 </em>
 </td>
 <td>
 <p>Type specifies the platform name.</p>
-<p>
-Value must be one of:
-&#34;AWS&#34;, 
-&#34;Agent&#34;, 
-&#34;Azure&#34;, 
-&#34;IBMCloud&#34;, 
-&#34;KubeVirt&#34;, 
-&#34;None&#34;, 
-&#34;PowerVS&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>aws</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">
+<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">
 AWSNodePoolPlatform
 </a>
 </em>
@@ -5776,7 +5417,7 @@ AWSNodePoolPlatform
 <td>
 <code>ibmcloud</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudPlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudPlatformSpec">
 IBMCloudPlatformSpec
 </a>
 </em>
@@ -5789,7 +5430,7 @@ IBMCloudPlatformSpec
 <td>
 <code>kubevirt</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtNodePoolPlatform">
+<a href="#hypershift.openshift.io/v1beta1.KubevirtNodePoolPlatform">
 KubevirtNodePoolPlatform
 </a>
 </em>
@@ -5803,7 +5444,7 @@ KubevirtNodePoolPlatform
 <td>
 <code>agent</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AgentNodePoolPlatform">
+<a href="#hypershift.openshift.io/v1beta1.AgentNodePoolPlatform">
 AgentNodePoolPlatform
 </a>
 </em>
@@ -5817,7 +5458,7 @@ AgentNodePoolPlatform
 <td>
 <code>azure</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AzureNodePoolPlatform">
+<a href="#hypershift.openshift.io/v1beta1.AzureNodePoolPlatform">
 AzureNodePoolPlatform
 </a>
 </em>
@@ -5829,7 +5470,7 @@ AzureNodePoolPlatform
 <td>
 <code>powervs</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform">
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">
 PowerVSNodePoolPlatform
 </a>
 </em>
@@ -5841,10 +5482,10 @@ PowerVSNodePoolPlatform
 </tr>
 </tbody>
 </table>
-###NodePoolSpec { #hypershift.openshift.io/v1alpha1.NodePoolSpec }
+###NodePoolSpec { #hypershift.openshift.io/v1beta1.NodePoolSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePool">NodePool</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePool">NodePool</a>)
 </p>
 <p>
 <p>NodePoolSpec is the desired behavior of a NodePool.</p>
@@ -5873,7 +5514,7 @@ string
 <td>
 <code>release</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.Release">
+<a href="#hypershift.openshift.io/v1beta1.Release">
 Release
 </a>
 </em>
@@ -5888,7 +5529,7 @@ machine properties (e.g. an AMI on the AWS platform).</p>
 <td>
 <code>platform</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">
 NodePoolPlatform
 </a>
 </em>
@@ -5896,19 +5537,6 @@ NodePoolPlatform
 <td>
 <p>Platform specifies the underlying infrastructure provider for the NodePool
 and is used to configure platform specific behavior.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodeCount</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: Use Replicas instead. NodeCount will be dropped in the next
-api release.</p>
 </td>
 </tr>
 <tr>
@@ -5928,7 +5556,7 @@ unset, the default value is 0.</p>
 <td>
 <code>management</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">
+<a href="#hypershift.openshift.io/v1beta1.NodePoolManagement">
 NodePoolManagement
 </a>
 </em>
@@ -5942,7 +5570,7 @@ upgrade strategies and auto-repair behaviors.</p>
 <td>
 <code>autoScaling</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolAutoScaling">
+<a href="#hypershift.openshift.io/v1beta1.NodePoolAutoScaling">
 NodePoolAutoScaling
 </a>
 </em>
@@ -6006,7 +5634,7 @@ Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/
 <td>
 <code>taints</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.Taint">
+<a href="#hypershift.openshift.io/v1beta1.Taint">
 []Taint
 </a>
 </em>
@@ -6051,10 +5679,10 @@ JSON or YAML of a serialized Tuned.</p>
 </tr>
 </tbody>
 </table>
-###NodePoolStatus { #hypershift.openshift.io/v1alpha1.NodePoolStatus }
+###NodePoolStatus { #hypershift.openshift.io/v1beta1.NodePoolStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePool">NodePool</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePool">NodePool</a>)
 </p>
 <p>
 <p>NodePoolStatus is the latest observed status of a NodePool.</p>
@@ -6095,7 +5723,7 @@ the NodePool.</p>
 <td>
 <code>conditions</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolCondition">
+<a href="#hypershift.openshift.io/v1beta1.NodePoolCondition">
 []NodePoolCondition
 </a>
 </em>
@@ -6108,10 +5736,10 @@ current state.</p>
 </tr>
 </tbody>
 </table>
-###NodePortPublishingStrategy { #hypershift.openshift.io/v1alpha1.NodePortPublishingStrategy }
+###NodePortPublishingStrategy { #hypershift.openshift.io/v1beta1.NodePortPublishingStrategy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
 </p>
 <p>
 <p>NodePortPublishingStrategy specifies a NodePort used to expose a service.</p>
@@ -6149,11 +5777,11 @@ assigned when the service is created.</p>
 </tr>
 </tbody>
 </table>
-###OLMCatalogPlacement { #hypershift.openshift.io/v1alpha1.OLMCatalogPlacement }
+###OLMCatalogPlacement { #hypershift.openshift.io/v1beta1.OLMCatalogPlacement }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>OLMCatalogPlacement is an enum specifying the placement of OLM catalog components.</p>
@@ -6175,17 +5803,17 @@ the management cluster.</p>
 </td>
 </tr></tbody>
 </table>
-###PersistentVolumeAccessMode { #hypershift.openshift.io/v1alpha1.PersistentVolumeAccessMode }
+###PersistentVolumeAccessMode { #hypershift.openshift.io/v1beta1.PersistentVolumeAccessMode }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtPersistentVolume">KubevirtPersistentVolume</a>)
+<a href="#hypershift.openshift.io/v1beta1.KubevirtPersistentVolume">KubevirtPersistentVolume</a>)
 </p>
 <p>
 </p>
-###PersistentVolumeEtcdStorageSpec { #hypershift.openshift.io/v1alpha1.PersistentVolumeEtcdStorageSpec }
+###PersistentVolumeEtcdStorageSpec { #hypershift.openshift.io/v1beta1.PersistentVolumeEtcdStorageSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ManagedEtcdStorageSpec">ManagedEtcdStorageSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.ManagedEtcdStorageSpec">ManagedEtcdStorageSpec</a>)
 </p>
 <p>
 <p>PersistentVolumeEtcdStorageSpec is the configuration for PersistentVolume
@@ -6228,11 +5856,11 @@ k8s.io/apimachinery/pkg/api/resource.Quantity
 </tr>
 </tbody>
 </table>
-###PlatformSpec { #hypershift.openshift.io/v1alpha1.PlatformSpec }
+###PlatformSpec { #hypershift.openshift.io/v1beta1.PlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>PlatformSpec specifies the underlying infrastructure provider for the cluster
@@ -6250,30 +5878,20 @@ and is used to configure platform specific behavior.</p>
 <td>
 <code>type</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformType">
+<a href="#hypershift.openshift.io/v1beta1.PlatformType">
 PlatformType
 </a>
 </em>
 </td>
 <td>
 <p>Type is the type of infrastructure provider for the cluster.</p>
-<p>
-Value must be one of:
-&#34;AWS&#34;, 
-&#34;Agent&#34;, 
-&#34;Azure&#34;, 
-&#34;IBMCloud&#34;, 
-&#34;KubeVirt&#34;, 
-&#34;None&#34;, 
-&#34;PowerVS&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>aws</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSPlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">
 AWSPlatformSpec
 </a>
 </em>
@@ -6287,7 +5905,7 @@ AWSPlatformSpec
 <td>
 <code>agent</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AgentPlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.AgentPlatformSpec">
 AgentPlatformSpec
 </a>
 </em>
@@ -6301,7 +5919,7 @@ AgentPlatformSpec
 <td>
 <code>ibmcloud</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.IBMCloudPlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.IBMCloudPlatformSpec">
 IBMCloudPlatformSpec
 </a>
 </em>
@@ -6314,7 +5932,7 @@ IBMCloudPlatformSpec
 <td>
 <code>azure</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AzurePlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.AzurePlatformSpec">
 AzurePlatformSpec
 </a>
 </em>
@@ -6327,7 +5945,7 @@ AzurePlatformSpec
 <td>
 <code>powervs</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSPlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.PowerVSPlatformSpec">
 PowerVSPlatformSpec
 </a>
 </em>
@@ -6342,7 +5960,7 @@ This field is immutable. Once set, It can&rsquo;t be changed.</p>
 <td>
 <code>kubevirt</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KubevirtPlatformSpec">
+<a href="#hypershift.openshift.io/v1beta1.KubevirtPlatformSpec">
 KubevirtPlatformSpec
 </a>
 </em>
@@ -6354,11 +5972,11 @@ KubevirtPlatformSpec
 </tr>
 </tbody>
 </table>
-###PlatformType { #hypershift.openshift.io/v1alpha1.PlatformType }
+###PlatformType { #hypershift.openshift.io/v1beta1.PlatformType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
 <p>PlatformType is a specific supported infrastructure provider.</p>
@@ -6393,18 +6011,18 @@ KubevirtPlatformSpec
 </td>
 </tr></tbody>
 </table>
-###PowerVSNodePoolImageDeletePolicy { #hypershift.openshift.io/v1alpha1.PowerVSNodePoolImageDeletePolicy }
+###PowerVSNodePoolImageDeletePolicy { #hypershift.openshift.io/v1beta1.PowerVSNodePoolImageDeletePolicy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>)
 </p>
 <p>
 <p>PowerVSNodePoolImageDeletePolicy defines image delete policy to be used for PowerVSNodePoolPlatform</p>
 </p>
-###PowerVSNodePoolPlatform { #hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform }
+###PowerVSNodePoolPlatform { #hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolPlatform">NodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>)
 </p>
 <p>
 <p>PowerVSNodePoolPlatform specifies the configuration of a NodePool when operating
@@ -6440,7 +6058,7 @@ reasonable default. The current default is s922 which is generally available.</p
 <td>
 <code>processorType</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolProcType">
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolProcType">
 PowerVSNodePoolProcType
 </a>
 </em>
@@ -6455,12 +6073,6 @@ Capped: Shared, but resources do not expand beyond those that are requested, the
 <p>if the processorType is selected as Dedicated, then Processors value cannot be fractional.
 When omitted, this means that the user has no opinion and the platform is left to choose a
 reasonable default. The current default is Shared.</p>
-<p>
-Value must be one of:
-&#34;capped&#34;, 
-&#34;dedicated&#34;, 
-&#34;shared&#34;
-</p>
 </td>
 </tr>
 <tr>
@@ -6511,7 +6123,7 @@ default. The current default is 32.</p>
 <td>
 <code>image</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSResourceReference">
+<a href="#hypershift.openshift.io/v1beta1.PowerVSResourceReference">
 PowerVSResourceReference
 </a>
 </em>
@@ -6526,7 +6138,7 @@ is chosen based on the NodePool release payload image.</p>
 <td>
 <code>storageType</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolStorageType">
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolStorageType">
 PowerVSNodePoolStorageType
 </a>
 </em>
@@ -6544,7 +6156,7 @@ Although, the exact numbers might change over time, the Tier 3 storage is curren
 <td>
 <code>imageDeletePolicy</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolImageDeletePolicy">
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolImageDeletePolicy">
 PowerVSNodePoolImageDeletePolicy
 </a>
 </em>
@@ -6559,10 +6171,10 @@ retain: delete the image from the openshift but retain in the infrastructure.</p
 </tr>
 </tbody>
 </table>
-###PowerVSNodePoolProcType { #hypershift.openshift.io/v1alpha1.PowerVSNodePoolProcType }
+###PowerVSNodePoolProcType { #hypershift.openshift.io/v1beta1.PowerVSNodePoolProcType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>)
 </p>
 <p>
 <p>PowerVSNodePoolProcType defines processor type to be used for PowerVSNodePoolPlatform</p>
@@ -6585,18 +6197,18 @@ retain: delete the image from the openshift but retain in the infrastructure.</p
 </td>
 </tr></tbody>
 </table>
-###PowerVSNodePoolStorageType { #hypershift.openshift.io/v1alpha1.PowerVSNodePoolStorageType }
+###PowerVSNodePoolStorageType { #hypershift.openshift.io/v1beta1.PowerVSNodePoolStorageType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>)
 </p>
 <p>
 <p>PowerVSNodePoolStorageType defines storage type to be used for PowerVSNodePoolPlatform</p>
 </p>
-###PowerVSPlatformSpec { #hypershift.openshift.io/v1alpha1.PowerVSPlatformSpec }
+###PowerVSPlatformSpec { #hypershift.openshift.io/v1beta1.PowerVSPlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PlatformSpec">PlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
 <p>PowerVSPlatformSpec defines IBMCloud PowerVS specific settings for components</p>
@@ -6676,7 +6288,7 @@ This field is immutable. Once set, It can&rsquo;t be changed.</p>
 <td>
 <code>subnet</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSResourceReference">
+<a href="#hypershift.openshift.io/v1beta1.PowerVSResourceReference">
 PowerVSResourceReference
 </a>
 </em>
@@ -6707,7 +6319,7 @@ ServiceInstanceID is the unique identifier that can be obtained from IBM Cloud U
 <td>
 <code>vpc</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSVPC">
+<a href="#hypershift.openshift.io/v1beta1.PowerVSVPC">
 PowerVSVPC
 </a>
 </em>
@@ -6780,11 +6392,11 @@ credentials for storage operator to get authenticated with ibm cloud.</p>
 </tr>
 </tbody>
 </table>
-###PowerVSResourceReference { #hypershift.openshift.io/v1alpha1.PowerVSResourceReference }
+###PowerVSResourceReference { #hypershift.openshift.io/v1beta1.PowerVSResourceReference }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSPlatformSpec">PowerVSPlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.PowerVSPlatformSpec">PowerVSPlatformSpec</a>)
 </p>
 <p>
 <p>PowerVSResourceReference is a reference to a specific IBMCloud PowerVS resource by ID, or Name.
@@ -6825,10 +6437,10 @@ string
 </tr>
 </tbody>
 </table>
-###PowerVSVPC { #hypershift.openshift.io/v1alpha1.PowerVSVPC }
+###PowerVSVPC { #hypershift.openshift.io/v1beta1.PowerVSVPC }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.PowerVSPlatformSpec">PowerVSPlatformSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.PowerVSPlatformSpec">PowerVSPlatformSpec</a>)
 </p>
 <p>
 <p>PowerVSVPC specifies IBM Cloud PowerVS LoadBalancer configuration for the control
@@ -6896,19 +6508,19 @@ This field is immutable. Once set, It can&rsquo;t be changed.</p>
 </tr>
 </tbody>
 </table>
-###PublishingStrategyType { #hypershift.openshift.io/v1alpha1.PublishingStrategyType }
+###PublishingStrategyType { #hypershift.openshift.io/v1beta1.PublishingStrategyType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
 </p>
 <p>
 <p>PublishingStrategyType defines publishing strategies for services.</p>
 </p>
-###Release { #hypershift.openshift.io/v1alpha1.Release }
+###Release { #hypershift.openshift.io/v1beta1.Release }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">NodePoolSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.NodePoolSpec">NodePoolSpec</a>)
 </p>
 <p>
 <p>Release represents the metadata for an OCP release payload image.</p>
@@ -6934,10 +6546,10 @@ string
 </tr>
 </tbody>
 </table>
-###ReplaceUpgrade { #hypershift.openshift.io/v1alpha1.ReplaceUpgrade }
+###ReplaceUpgrade { #hypershift.openshift.io/v1beta1.ReplaceUpgrade }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">NodePoolManagement</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolManagement">NodePoolManagement</a>)
 </p>
 <p>
 <p>ReplaceUpgrade specifies upgrade behavior that replaces existing nodes
@@ -6955,25 +6567,20 @@ according to a given strategy.</p>
 <td>
 <code>strategy</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.UpgradeStrategy">
+<a href="#hypershift.openshift.io/v1beta1.UpgradeStrategy">
 UpgradeStrategy
 </a>
 </em>
 </td>
 <td>
 <p>Strategy is the node replacement strategy for nodes in the pool.</p>
-<p>
-Value must be one of:
-&#34;OnDelete&#34;, 
-&#34;RollingUpdate&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>rollingUpdate</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.RollingUpdate">
+<a href="#hypershift.openshift.io/v1beta1.RollingUpdate">
 RollingUpdate
 </a>
 </em>
@@ -6985,10 +6592,10 @@ creating new nodes and deleting the old ones.</p>
 </tr>
 </tbody>
 </table>
-###RollingUpdate { #hypershift.openshift.io/v1alpha1.RollingUpdate }
+###RollingUpdate { #hypershift.openshift.io/v1beta1.RollingUpdate }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ReplaceUpgrade">ReplaceUpgrade</a>)
+<a href="#hypershift.openshift.io/v1beta1.ReplaceUpgrade">ReplaceUpgrade</a>)
 </p>
 <p>
 <p>RollingUpdate specifies a rolling update strategy which upgrades nodes by
@@ -7054,10 +6661,10 @@ running at any time during the update is at most 130% of desired nodes.</p>
 </tr>
 </tbody>
 </table>
-###RoutePublishingStrategy { #hypershift.openshift.io/v1alpha1.RoutePublishingStrategy }
+###RoutePublishingStrategy { #hypershift.openshift.io/v1beta1.RoutePublishingStrategy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategy">ServicePublishingStrategy</a>)
 </p>
 <p>
 <p>RoutePublishingStrategy specifies options for exposing a service as a Route.</p>
@@ -7084,11 +6691,11 @@ string
 </tr>
 </tbody>
 </table>
-###SecretEncryptionSpec { #hypershift.openshift.io/v1alpha1.SecretEncryptionSpec }
+###SecretEncryptionSpec { #hypershift.openshift.io/v1beta1.SecretEncryptionSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>SecretEncryptionSpec contains metadata about the kubernetes secret encryption strategy being used for the
@@ -7106,25 +6713,20 @@ cluster when applicable.</p>
 <td>
 <code>type</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionType">
+<a href="#hypershift.openshift.io/v1beta1.SecretEncryptionType">
 SecretEncryptionType
 </a>
 </em>
 </td>
 <td>
 <p>Type defines the type of kube secret encryption being used</p>
-<p>
-Value must be one of:
-&#34;aescbc&#34;, 
-&#34;kms&#34;
-</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>kms</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.KMSSpec">
+<a href="#hypershift.openshift.io/v1beta1.KMSSpec">
 KMSSpec
 </a>
 </em>
@@ -7138,7 +6740,7 @@ KMSSpec
 <td>
 <code>aescbc</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.AESCBCSpec">
+<a href="#hypershift.openshift.io/v1beta1.AESCBCSpec">
 AESCBCSpec
 </a>
 </em>
@@ -7150,10 +6752,10 @@ AESCBCSpec
 </tr>
 </tbody>
 </table>
-###SecretEncryptionType { #hypershift.openshift.io/v1alpha1.SecretEncryptionType }
+###SecretEncryptionType { #hypershift.openshift.io/v1beta1.SecretEncryptionType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.SecretEncryptionSpec">SecretEncryptionSpec</a>)
 </p>
 <p>
 <p>SecretEncryptionType defines the type of kube secret encryption being used.</p>
@@ -7173,10 +6775,10 @@ AESCBCSpec
 </td>
 </tr></tbody>
 </table>
-###ServiceNetworkEntry { #hypershift.openshift.io/v1alpha1.ServiceNetworkEntry }
+###ServiceNetworkEntry { #hypershift.openshift.io/v1beta1.ServiceNetworkEntry }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ClusterNetworking">ClusterNetworking</a>)
+<a href="#hypershift.openshift.io/v1beta1.ClusterNetworking">ClusterNetworking</a>)
 </p>
 <p>
 <p>ServiceNetworkEntry is a single IP address block for the service network.</p>
@@ -7204,10 +6806,10 @@ github.com/openshift/hypershift/api/util/ipnet.IPNet
 </tr>
 </tbody>
 </table>
-###ServicePublishingStrategy { #hypershift.openshift.io/v1alpha1.ServicePublishingStrategy }
+###ServicePublishingStrategy { #hypershift.openshift.io/v1beta1.ServicePublishingStrategy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping">ServicePublishingStrategyMapping</a>)
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategyMapping">ServicePublishingStrategyMapping</a>)
 </p>
 <p>
 <p>ServicePublishingStrategy specfies how to publish a ServiceType.</p>
@@ -7224,7 +6826,7 @@ github.com/openshift/hypershift/api/util/ipnet.IPNet
 <td>
 <code>type</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.PublishingStrategyType">
+<a href="#hypershift.openshift.io/v1beta1.PublishingStrategyType">
 PublishingStrategyType
 </a>
 </em>
@@ -7237,7 +6839,7 @@ PublishingStrategyType
 <td>
 <code>nodePort</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePortPublishingStrategy">
+<a href="#hypershift.openshift.io/v1beta1.NodePortPublishingStrategy">
 NodePortPublishingStrategy
 </a>
 </em>
@@ -7250,7 +6852,7 @@ NodePortPublishingStrategy
 <td>
 <code>loadBalancer</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.LoadBalancerPublishingStrategy">
+<a href="#hypershift.openshift.io/v1beta1.LoadBalancerPublishingStrategy">
 LoadBalancerPublishingStrategy
 </a>
 </em>
@@ -7263,7 +6865,7 @@ LoadBalancerPublishingStrategy
 <td>
 <code>route</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.RoutePublishingStrategy">
+<a href="#hypershift.openshift.io/v1beta1.RoutePublishingStrategy">
 RoutePublishingStrategy
 </a>
 </em>
@@ -7274,11 +6876,11 @@ RoutePublishingStrategy
 </tr>
 </tbody>
 </table>
-###ServicePublishingStrategyMapping { #hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping }
+###ServicePublishingStrategyMapping { #hypershift.openshift.io/v1beta1.ServicePublishingStrategyMapping }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.HostedClusterSpec">HostedClusterSpec</a>, 
-<a href="#hypershift.openshift.io/v1alpha1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
 <p>ServicePublishingStrategyMapping specifies how individual control plane
@@ -7296,7 +6898,7 @@ services are published from the hosting cluster of a control plane.</p>
 <td>
 <code>service</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ServiceType">
+<a href="#hypershift.openshift.io/v1beta1.ServiceType">
 ServiceType
 </a>
 </em>
@@ -7309,7 +6911,7 @@ ServiceType
 <td>
 <code>servicePublishingStrategy</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategy">
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategy">
 ServicePublishingStrategy
 </a>
 </em>
@@ -7320,19 +6922,19 @@ ServicePublishingStrategy
 </tr>
 </tbody>
 </table>
-###ServiceType { #hypershift.openshift.io/v1alpha1.ServiceType }
+###ServiceType { #hypershift.openshift.io/v1beta1.ServiceType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ServicePublishingStrategyMapping">ServicePublishingStrategyMapping</a>)
+<a href="#hypershift.openshift.io/v1beta1.ServicePublishingStrategyMapping">ServicePublishingStrategyMapping</a>)
 </p>
 <p>
 <p>ServiceType defines what control plane services can be exposed from the
 management control plane.</p>
 </p>
-###Taint { #hypershift.openshift.io/v1alpha1.Taint }
+###Taint { #hypershift.openshift.io/v1beta1.Taint }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolSpec">NodePoolSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolSpec">NodePoolSpec</a>)
 </p>
 <p>
 <p>Taint is as v1 Core but without TimeAdded.
@@ -7386,10 +6988,10 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.</p>
 </tr>
 </tbody>
 </table>
-###UnmanagedEtcdSpec { #hypershift.openshift.io/v1alpha1.UnmanagedEtcdSpec }
+###UnmanagedEtcdSpec { #hypershift.openshift.io/v1beta1.UnmanagedEtcdSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdSpec">EtcdSpec</a>)
+<a href="#hypershift.openshift.io/v1beta1.EtcdSpec">EtcdSpec</a>)
 </p>
 <p>
 <p>UnmanagedEtcdSpec specifies configuration which enables the control plane to
@@ -7421,7 +7023,7 @@ string
 <td>
 <code>tls</code></br>
 <em>
-<a href="#hypershift.openshift.io/v1alpha1.EtcdTLSConfig">
+<a href="#hypershift.openshift.io/v1beta1.EtcdTLSConfig">
 EtcdTLSConfig
 </a>
 </em>
@@ -7432,10 +7034,10 @@ EtcdTLSConfig
 </tr>
 </tbody>
 </table>
-###UpgradeStrategy { #hypershift.openshift.io/v1alpha1.UpgradeStrategy }
+###UpgradeStrategy { #hypershift.openshift.io/v1beta1.UpgradeStrategy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.ReplaceUpgrade">ReplaceUpgrade</a>)
+<a href="#hypershift.openshift.io/v1beta1.ReplaceUpgrade">ReplaceUpgrade</a>)
 </p>
 <p>
 <p>UpgradeStrategy is a specific strategy for upgrading nodes in a NodePool.</p>
@@ -7456,10 +7058,10 @@ associated node instances are completed.</p>
 </td>
 </tr></tbody>
 </table>
-###UpgradeType { #hypershift.openshift.io/v1alpha1.UpgradeType }
+###UpgradeType { #hypershift.openshift.io/v1beta1.UpgradeType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.NodePoolManagement">NodePoolManagement</a>)
+<a href="#hypershift.openshift.io/v1beta1.NodePoolManagement">NodePoolManagement</a>)
 </p>
 <p>
 <p>UpgradeType is a type of high-level upgrade behavior nodes in a NodePool.</p>
@@ -7481,10 +7083,10 @@ capacity.</p>
 </td>
 </tr></tbody>
 </table>
-###Volume { #hypershift.openshift.io/v1alpha1.Volume }
+###Volume { #hypershift.openshift.io/v1beta1.Volume }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1alpha1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)
+<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)
 </p>
 <p>
 <p>Volume specifies the configuration options for node instance storage devices.</p>

--- a/hack/gen-api-docs.sh
+++ b/hack/gen-api-docs.sh
@@ -24,5 +24,5 @@ export GO111MODULE="off"
 ${GEN_BIN} \
 --config "${FAKE_REPOPATH}/docs/api-doc-gen/config.json" \
 --template-dir "${FAKE_REPOPATH}/docs/api-doc-gen/templates" \
---api-dir ./api/v1alpha1 \
+--api-dir ./api/v1beta1 \
 --out-file "${FAKE_REPOPATH}/docs/content/reference/api.md"


### PR DESCRIPTION
**What this PR does / why we need it**:
Use v1beta1 as the documented API documentation instead of v1alpha1 which is deprecated

**Checklist**
- [x] Subject and description added to both, commit and PR.