### PR TITLE
Kube API server panic: Fix podsecurity annotations on kube-system

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/namespaces.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/namespaces.go
@@ -74,3 +74,9 @@ func NamespaceRouteControllerManager() *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{Name: "openshift-route-controller-manager"},
 	}
 }
+
+func NamespaceKubeSystem() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-system"},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -56,6 +56,7 @@ var initialObjects = []client.Object{
 		},
 	},
 	manifests.NodeTuningClusterOperator(),
+	manifests.NamespaceKubeSystem(),
 }
 
 func shouldNotError(key client.ObjectKey) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit adds pod security annotations to the kube-system namespace before reconciling the konnectivity agent daemonset. This prevents a warning that causes the kube-apiserver to crash.

**Checklist**
- [x] Subject and description added to both, commit and PR.