### PR TITLE
Requeue hostedcontrolplane when waiting for deletion

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -232,7 +232,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 				return ctrl.Result{}, fmt.Errorf("failed to ensure cloud resources are removed")
 			}
 			if !done {
-				return ctrl.Result{}, nil
+				return ctrl.Result{RequeueAfter: time.Minute}, nil
 			}
 		}
 		if controllerutil.ContainsFinalizer(hostedControlPlane, finalizer) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The timeout to proceed with deletion of the hostedcontrolplane is not taking effect because there is nothing requeueing the hcp resource. This adds a requeue time to the resource when waiting for cloud resource deletion.

**Checklist**
- [x] Subject and description added to both, commit and PR.