### PR TITLE
add system:deployer ClusterRole to HCCO

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -137,6 +137,22 @@ func KCMLeaderElectionRoleBinding() *rbacv1.RoleBinding {
 	}
 }
 
+func DeployerClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:deployer",
+		},
+	}
+}
+
+func DeployerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:deployer",
+		},
+	}
+}
+
 func ImageTriggerControllerClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -472,7 +472,6 @@ func ReconcilePodSecurityAdmissionLabelSyncerControllerRoleBinding(r *rbacv1.Clu
 }
 
 func ReconcileImageTriggerControllerClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
-
 	r.RoleRef = rbacv1.RoleRef{
 		APIGroup: rbacv1.SchemeGroupVersion.Group,
 		Kind:     "ClusterRole",
@@ -483,6 +482,66 @@ func ReconcileImageTriggerControllerClusterRoleBinding(r *rbacv1.ClusterRoleBind
 			Kind:      "ServiceAccount",
 			Namespace: "openshift-infra",
 			Name:      "image-trigger-controller",
+		},
+	}
+	return nil
+}
+
+func ReconcileDeployerClusterRole(r *rbacv1.ClusterRole) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"replicationcontrollers"},
+			Verbs:     []string{"get", "list", "watch", "update", "delete"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"replicationcontrollers/scale"},
+			Verbs:     []string{"get", "update"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"create", "get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods/log"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{"create", "list"},
+		},
+		{
+			APIGroups: []string{"image.openshift.io"},
+			Resources: []string{"imagestreamtags", "imagetags"},
+			Verbs:     []string{"create", "update"},
+		},
+	}
+	return nil
+}
+
+func ReconcileDeployerClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:deployer",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "default-rolebindings-controller",
+			Namespace: "openshift-infra",
 		},
 	}
 	return nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -707,6 +707,9 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 
 		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.PodSecurityAdmissionLabelSyncerControllerClusterRole, reconcile: rbac.ReconcilePodSecurityAdmissionLabelSyncerControllerClusterRole},
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.PodSecurityAdmissionLabelSyncerControllerRoleBinding, reconcile: rbac.ReconcilePodSecurityAdmissionLabelSyncerControllerRoleBinding},
+
+		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.DeployerClusterRole, reconcile: rbac.ReconcileDeployerClusterRole},
+		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.DeployerClusterRoleBinding, reconcile: rbac.ReconcileDeployerClusterRoleBinding},
 	}
 	var errs []error
 	for _, m := range rbac {


### PR DESCRIPTION
Creation of this role was moved from the OAS to the OCM operator (which we don't run)

https://github.com/openshift/openshift-apiserver/pull/331
https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/270

We need to create this ClusterRole in the guest cluster.  Lack of this role is causing all `Server-Side apply` conformance tests to fail.