### PR TITLE
Add capa both contract version for consistency

### DIFF
--- a/cmd/install/assets/assets.go
+++ b/cmd/install/assets/assets.go
@@ -31,9 +31,9 @@ const capiLabel = "cluster.x-k8s.io/v1beta1"
 // to satisfy CAPI contracts. There might be a way to achieve this during CRD
 // generation, but for now we're just post-processing at runtime here.
 var capiResources = map[string]string{
-	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclusters.yaml":                      "v1beta2",
-	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachines.yaml":                      "v1beta2",
-	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml":              "v1beta2",
+	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclusters.yaml":                      "v1beta1_v1beta2",
+	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachines.yaml":                      "v1beta1_v1beta2",
+	"cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml":              "v1beta1_v1beta2",
 	"cluster-api-provider-ibmcloud/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml":          "v1beta1",
 	"cluster-api-provider-ibmcloud/infrastructure.cluster.x-k8s.io_ibmpowervsimages.yaml":            "v1beta1",
 	"cluster-api-provider-ibmcloud/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml":          "v1beta1",

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -5580,7 +5580,7 @@ objects:
       controller-gen.kubebuilder.io/version: v0.9.2
     creationTimestamp: null
     labels:
-      cluster.x-k8s.io/v1beta1: v1beta2
+      cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
     name: awsclusters.infrastructure.cluster.x-k8s.io
   spec:
     group: infrastructure.cluster.x-k8s.io
@@ -9835,7 +9835,7 @@ objects:
       controller-gen.kubebuilder.io/version: v0.9.2
     creationTimestamp: null
     labels:
-      cluster.x-k8s.io/v1beta1: v1beta2
+      cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
     name: awsmachines.infrastructure.cluster.x-k8s.io
   spec:
     group: infrastructure.cluster.x-k8s.io
@@ -10808,7 +10808,7 @@ objects:
       controller-gen.kubebuilder.io/version: v0.9.2
     creationTimestamp: null
     labels:
-      cluster.x-k8s.io/v1beta1: v1beta2
+      cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
     name: awsmachinetemplates.infrastructure.cluster.x-k8s.io
   spec:
     group: infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
**What this PR does / why we need it**:
This shouldn't really be needed, but it's consistent with capa repo and might catch edge cases.

https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/8da95554b65f675c11fc3ac02d3e5503407e0090/config/crd/kustomization.yaml#L4

https://github.com/kubernetes-sigs/cluster-api/blob/f784f1e9e93bec81cc9fc60e82549289ca79c6c0/util/conversion/conversion.go#L64

https://github.com/kubernetes-sigs/cluster-api/blob/f784f1e9e93bec81cc9fc60e82549289ca79c6c0/util/conversion/conversion.go#L96

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.