### PR TITLE
Set k8s.io/kubernetes dependency to v0.23.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,6 +183,7 @@ require (
 )
 
 replace (
+	k8s.io/kubernetes => k8s.io/kubernetes v0.23.3
 	kubevirt.io/containerized-data-importer-api => github.com/kubevirt/containerized-data-importer-api v1.41.1-0.20211201033752-05520fb9f18d
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.24
 	sigs.k8s.io/cluster-api-provider-ibmcloud => github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20221007162602-5e3a2bae34bd

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1411,6 +1411,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# k8s.io/kubernetes => k8s.io/kubernetes v0.23.3
 # kubevirt.io/containerized-data-importer-api => github.com/kubevirt/containerized-data-importer-api v1.41.1-0.20211201033752-05520fb9f18d
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.24
 # sigs.k8s.io/cluster-api-provider-ibmcloud => github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20221007162602-5e3a2bae34bd


### PR DESCRIPTION
**What this PR does / why we need it**:
Set k8s.io/kubernetes to v0.23.3 to match the version needed in github.com/openshift/cluster-node-tuning-operator v0.0.0-20220614214129-2c76314fb3cc

**Which issue(s) this PR fixes**
Fixes an art issue with respect to go dependency checks in Cachito.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.