### PR TITLE
HOSTEDCP-603: move CI manifests to core repo

### DIFF
--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -1,0 +1,32 @@
+# Creating a HyperShift CI cluster
+
+## Prerequisites
+
+- OpenShift CLI (oc)
+- An OCP cluster ([ROSA instructions](https://www.rosaworkshop.io/rosa/2-deploy/#automatic-mode))
+
+## Install
+
+Deploy the hypershift-ci-1 manifests:
+
+```shell
+oc apply -f hypershift-ci-1.yaml
+```
+
+After initial installation or as part of a credentials rotation, create a
+kubeconfig from the admin SA token which can be injected into CI jobs:
+
+```shell
+oc serviceaccounts --namespace hypershift-ops create-kubeconfig admin > /tmp/hypershift-ci-1.kubeconfig
+```
+
+Store the kubeconfig in Vault [under the clusters directory](https://vault.ci.openshift.org/ui/vault/secrets/kv/list/selfservice/hypershift-team/ops/clusters/) in a secret named `hypershift-ci-1` with the following schema:
+
+```json
+{
+  "hypershift-ops-admin.kubeconfig": "<kubeconfig contents>",
+  "secretsync/target-name": "hypershift-ci-1",
+  "secretsync/target-namespace": "ci,test-credentials"
+}
+```
+

--- a/contrib/ci/hypershift-ci-1.yaml
+++ b/contrib/ci/hypershift-ci-1.yaml
@@ -1,0 +1,158 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hypershift-ops
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: hypershift-ops
+  name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "hypershift-ops:admin"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  namespace: hypershift-ops
+  name: admin
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-bot
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: object-counts
+  namespace: cluster-bot
+spec:
+  hard:
+    count/hostedclusters.hypershift.openshift.io: "5"
+    count/nodepools.hypershift.openshift.io: "15"
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: object-counts
+  namespace: clusters
+spec:
+  hard:
+    count/hostedclusters.hypershift.openshift.io: "20"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hypershift
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: hypershift-operator
+  namespace: hypershift
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/hypershift/hypershift-operator:latest
+    referencePolicy:
+      type: Local
+    importPolicy:
+      scheduled: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: hypershift
+  name: installer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hypershift-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  namespace: hypershift
+  name: installer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"hypershift-operator:latest"},"fieldPath":"spec.template.spec.containers[?(@.name==\"installer\")].image"}]'
+  name: installer
+  namespace: hypershift
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: installer
+  template:
+    metadata:
+      labels:
+        name: installer
+    spec:
+      initContainers:
+      - args:
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+
+          /usr/bin/oc get istag -n hypershift hypershift-operator:latest -ojsonpath='{.image.dockerImageReference}' > /installer-data/image-ref
+        command:
+        - /bin/bash
+        image: quay.io/openshift/origin-cli:latest
+        name: get-image
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        volumeMounts:
+          - mountPath: /installer-data
+            name: data
+      containers:
+      - args:
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+
+          /usr/bin/hypershift install \
+          --oidc-storage-provider-s3-bucket-name=hypershift-ci-1-oidc \
+          --oidc-storage-provider-s3-region=us-east-1 \
+          --oidc-storage-provider-s3-secret=oidc-s3-creds \
+          --hypershift-image=$(cat /installer-data/image-ref)
+
+          /usr/bin/sleep infinity
+        command:
+        - /bin/bash
+        image: quay.io/hypershift/hypershift-operator:latest
+        name: installer
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        volumeMounts:
+          - mountPath: /installer-data
+            name: data
+      serviceAccountName: installer
+      terminationGracePeriodSeconds: 3
+      volumes:
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
https://issues.redhat.com/browse/HOSTEDCP-603

This moves everything of value out of the https://github.com/openshift/hypershift-ops repo and adds a `hypershift-installer` deployment that will do a full `hypershift install` on the CI cluster on imagestream change, updating both the HO deployment and the manifests.