### PR TITLE
hcco: fix deployer role to include patch for replicationcontrollers

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -496,7 +496,7 @@ func ReconcileDeployerClusterRole(r *rbacv1.ClusterRole) error {
 		{
 			APIGroups: []string{""},
 			Resources: []string{"replicationcontrollers"},
-			Verbs:     []string{"get", "list", "watch", "update", "delete"},
+			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete"},
 		},
 		{
 			APIGroups: []string{""},


### PR DESCRIPTION
Bad copy from https://github.com/openshift/cluster-openshift-controller-manager-operator/blob/master/bindata/v3.11.0/openshift-controller-manager/deployer-clusterrole.yaml#L11-L26

Combined the `delete` but accidentally dropped the `patch` :man_facepalming: 

Causing failures of the `[Feature:DeploymentConfig]` conformance tests.