### PR TITLE
Update internal capk image to match current devel branch

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	hostedClusterAnnotation = "hypershift.openshift.io/cluster"
-	imageCAPK               = "registry.ci.openshift.org/hypershift/cluster-api-kubevirt-controller:0.0.1-prerelease"
+	imageCAPK               = "registry.ci.openshift.org/ocp/4.13:cluster-api-provider-kubevirt"
 )
 
 type Kubevirt struct{}


### PR DESCRIPTION
We're abandoning the pre-release branch in favor of the standard ocp related branches. This updates the capk image to reflect that. 