### PR TITLE
kas token-minter should use localhost kubeconfig

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -791,7 +791,7 @@ func kasVolumeKubeconfig() *corev1.Volume {
 
 func buildKASVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName:  manifests.KASServiceKubeconfigSecret("").Name,
+		SecretName:  manifests.KASLocalhostKubeconfigSecret("").Name,
 		DefaultMode: pointer.Int32Ptr(0640),
 	}
 }


### PR DESCRIPTION
This should be done anyway, but we found it because of https://github.com/openshift/hypershift/pull/2005 combined with an apparent OVN bug that does not allow egress pod traffic to loop back to itself over the service network, even when the egress policy allows same-namespace traffic.