### PR TITLE
Skip destroying cloud resources when cloud creds lost

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3203,6 +3203,16 @@ func (r *HostedControlPlaneReconciler) reconcileMachineApprover(ctx context.Cont
 }
 
 func shouldCleanupCloudResources(hcp *hyperv1.HostedControlPlane) bool {
+	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
+		oidcConfigValid := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidOIDCConfiguration))
+		if oidcConfigValid != nil && oidcConfigValid.Status == metav1.ConditionFalse {
+			return false
+		}
+		validIdentityProvider := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidAWSIdentityProvider))
+		if validIdentityProvider != nil && validIdentityProvider.Status == metav1.ConditionFalse {
+			return false
+		}
+	}
 	return hcp.Annotations[hyperv1.CleanupCloudResourcesAnnotation] == "true"
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When the hosted control plane no longer has access to a cloud account, it should not attempt to cleanup cloud resources since it no longer can communicate with the cloud provider.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-709](https://issues.redhat.com//browse/HOSTEDCP-709)

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.