### PR TITLE
fix etcd ServiceMonitor CA

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -428,7 +428,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 					CA: prometheusoperatorv1.SecretOrConfigMap{
 						ConfigMap: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: manifests.EtcdMetricsSignerCAConfigMap(sm.Namespace).Name,
+								Name: manifests.EtcdSignerCAConfigMap(sm.Namespace).Name,
 							},
 							Key: certs.CASignerCertMapKey,
 						},


### PR DESCRIPTION
The etcd SM CA should be `etcd-signer`, not `etcd-metrics-signer`

This should fix conformance failure `etcd leader changes are not excessive`