### PR TITLE
MULTIARCH-3028: handle PowerVS instance which goes to failed state during infra create and destroy process.

### DIFF
--- a/cmd/infra/powervs/validate.go
+++ b/cmd/infra/powervs/validate.go
@@ -9,8 +9,11 @@ import (
 )
 
 var (
-	cloudConNotFound      = func(cloudConnName string) error { return fmt.Errorf("%s cloud connection not found", cloudConnName) }
-	cloudInstanceNotFound = func(cloudInstance string) error { return fmt.Errorf("%s cloud instance not found", cloudInstance) }
+	cloudConNotFound              = func(cloudConnName string) error { return fmt.Errorf("%s cloud connection not found", cloudConnName) }
+	cloudInstanceNotFound         = func(cloudInstance string) error { return fmt.Errorf("%s cloud instance not found", cloudInstance) }
+	cloudInstanceNotInActiveState = func(state string) error {
+		return fmt.Errorf("provided cloud instance id is not in active state, current state: %s", state)
+	}
 )
 
 // validateCloudInstanceByID
@@ -27,11 +30,11 @@ func validateCloudInstanceByID(ctx context.Context, cloudInstanceID string) (*re
 	}
 
 	if resourceInstance == nil {
-		return nil, fmt.Errorf("%s cloud instance not found", cloudInstanceID)
+		return nil, cloudInstanceNotFound(cloudInstanceID)
 	}
 
 	if *resourceInstance.State != "active" {
-		return nil, fmt.Errorf("provided cloud instance id is not in active state, current state: %s", *resourceInstance.State)
+		return resourceInstance, cloudInstanceNotInActiveState(*resourceInstance.State)
 	}
 
 	return resourceInstance, nil
@@ -87,7 +90,7 @@ func validateCloudInstanceByName(ctx context.Context, cloudInstance string, reso
 	}
 
 	if *resourceInstance.State != "active" {
-		return nil, fmt.Errorf("provided cloud instance id is not in active state, current state: %s", *resourceInstance.State)
+		return resourceInstance, cloudInstanceNotInActiveState(*resourceInstance.State)
 	}
 	return resourceInstance, nil
 }


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Fixes https://issues.redhat.com/browse/MULTIARCH-3028
This PR mainly trying to handle PowerVS instance which goes to failed state during infra create and destroy process.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.