### PR TITLE
Re-revert KAS egress policy

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3229,21 +3229,9 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 	}
 
 	// Reconcile KAS Network Policy
-	// NetworkPolicy egress is broken for 4.11 on OpenShiftSDN, this is a workaround
-	// https://issues.redhat.com/browse/OCPBUGS-2105
-	isOpenShiftSDN := false
-	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityNetworks) {
-		managementClusterNetwork := &configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
-		if err := r.Get(ctx, client.ObjectKeyFromObject(managementClusterNetwork), managementClusterNetwork); err != nil {
-			return fmt.Errorf("failed to get management cluster network config: %w", err)
-		}
-		if managementClusterNetwork.Spec.NetworkType == "OpenShiftSDN" {
-			isOpenShiftSDN = true
-		}
-	}
 	policy = networkpolicy.KASNetworkPolicy(controlPlaneNamespaceName)
 	if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
-		return reconcileKASNetworkPolicy(policy, hcluster, r.ManagementClusterCapabilities.Has(capabilities.CapabilityDNS), !isOpenShiftSDN)
+		return reconcileKASNetworkPolicy(policy, hcluster, r.ManagementClusterCapabilities.Has(capabilities.CapabilityDNS))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile kube-apiserver network policy: %w", err)
 	}
@@ -3593,10 +3581,9 @@ func reconcileSameNamespaceNetworkPolicy(policy *networkingv1.NetworkPolicy) err
 	return nil
 }
 
-func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster, isOpenShiftMgmtCluster bool, specifyEgress bool) error {
+func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster, isOpenShiftMgmtCluster bool) error {
 	port := intstr.FromInt(kas.APIServerListenPort)
 	protocol := corev1.ProtocolTCP
-	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
 	policy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
 		{
 			From: []networkingv1.NetworkPolicyPeer{},
@@ -3623,65 +3610,62 @@ func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyp
 		})
 	}
 
-	if specifyEgress {
-		// Allow traffic to same namespace
-		policy.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
-			{
-				To: []networkingv1.NetworkPolicyPeer{
-					{
-						PodSelector: &metav1.LabelSelector{},
-					},
+	// Allow traffic to same namespace
+	policy.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+		{
+			To: []networkingv1.NetworkPolicyPeer{
+				{
+					PodSelector: &metav1.LabelSelector{},
 				},
 			},
-		}
+		},
+	}
 
-		if isOpenShiftMgmtCluster {
-			// Allow traffic to openshift-dns namespace
-			dnsUDPPort := intstr.FromInt(5353)
-			dnsUDPProtocol := corev1.ProtocolUDP
-			dnsTCPPort := intstr.FromInt(5353)
-			dnsTCPProtocol := corev1.ProtocolTCP
-			policy.Spec.Egress = append(policy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
-				To: []networkingv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": "openshift-dns",
-							},
+	if isOpenShiftMgmtCluster {
+		// Allow traffic to openshift-dns namespace
+		dnsUDPPort := intstr.FromInt(5353)
+		dnsUDPProtocol := corev1.ProtocolUDP
+		dnsTCPPort := intstr.FromInt(5353)
+		dnsTCPProtocol := corev1.ProtocolTCP
+		policy.Spec.Egress = append(policy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+			To: []networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": "openshift-dns",
 						},
 					},
 				},
-				Ports: []networkingv1.NetworkPolicyPort{
-					{
-						Port:     &dnsUDPPort,
-						Protocol: &dnsUDPProtocol,
-					},
-					{
-						Port:     &dnsTCPPort,
-						Protocol: &dnsTCPProtocol,
-					},
+			},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Port:     &dnsUDPPort,
+					Protocol: &dnsUDPProtocol,
 				},
-			})
-		} else {
-			// All traffic to any destination on port 53 for both TCP and UDP
-			dnsUDPPort := intstr.FromInt(53)
-			dnsUDPProtocol := corev1.ProtocolUDP
-			dnsTCPPort := intstr.FromInt(53)
-			dnsTCPProtocol := corev1.ProtocolTCP
-			policy.Spec.Egress = append(policy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
-				Ports: []networkingv1.NetworkPolicyPort{
-					{
-						Port:     &dnsUDPPort,
-						Protocol: &dnsUDPProtocol,
-					},
-					{
-						Port:     &dnsTCPPort,
-						Protocol: &dnsTCPProtocol,
-					},
+				{
+					Port:     &dnsTCPPort,
+					Protocol: &dnsTCPProtocol,
 				},
-			})
-		}
-		policy.Spec.PolicyTypes = append(policy.Spec.PolicyTypes, networkingv1.PolicyTypeEgress)
+			},
+		})
+	} else {
+		// All traffic to any destination on port 53 for both TCP and UDP
+		dnsUDPPort := intstr.FromInt(53)
+		dnsUDPProtocol := corev1.ProtocolUDP
+		dnsTCPPort := intstr.FromInt(53)
+		dnsTCPProtocol := corev1.ProtocolTCP
+		policy.Spec.Egress = append(policy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Port:     &dnsUDPPort,
+					Protocol: &dnsUDPProtocol,
+				},
+				{
+					Port:     &dnsTCPPort,
+					Protocol: &dnsTCPProtocol,
+				},
+			},
+		})
 	}
 
 	policy.Spec.PodSelector = metav1.LabelSelector{
@@ -3689,7 +3673,7 @@ func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyp
 			"app": "kube-apiserver",
 		},
 	}
-
+	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}
 	return nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -844,14 +844,6 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 				".dockerconfigjson": []byte("{}"),
 			},
 		},
-		&configv1.Network{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cluster",
-			},
-			Spec: configv1.NetworkSpec{
-				NetworkType: "OVNKubernetes",
-			},
-		},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "agent-namespace"}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "agent"}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "aws"}},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
@@ -72,14 +72,6 @@ func TestWebhookAllowsHostedClusterReconcilerUpdates(t *testing.T) {
 				},
 				&configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "none-cluster"}},
-				&configv1.Network{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster",
-					},
-					Spec: configv1.NetworkSpec{
-						NetworkType: "OVNKubernetes",
-					},
-				},
 			},
 		},
 	}

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -37,10 +37,6 @@ const (
 	// CapabilityProxy indicates if the cluster supports the
 	// proxies.config.openshift.io api
 	CapabilityProxy
-
-	// CapabilityDNS indicates if the cluster supports the
-	// dnses.config.openshift.io api
-	CapabilityDNS
 )
 
 // ManagementClusterCapabilities holds all information about optional capabilities of
@@ -129,15 +125,6 @@ func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterfa
 	}
 	if hasProxyCap {
 		discoveredCapabilities[CapabilityProxy] = struct{}{}
-	}
-
-	// check for dns capability
-	hasDNSCap, err := isAPIResourceRegistered(client, configv1.GroupVersion, "dnses")
-	if err != nil {
-		return nil, err
-	}
-	if hasDNSCap {
-		discoveredCapabilities[CapabilityDNS] = struct{}{}
 	}
 
 	return &ManagementClusterCapabilities{capabilities: discoveredCapabilities}, nil

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -41,10 +41,6 @@ const (
 	// CapabilityDNS indicates if the cluster supports the
 	// dnses.config.openshift.io api
 	CapabilityDNS
-
-	// CapabilityNetworks indicates if the cluster supports the
-	// networks.config.openshift.io api
-	CapabilityNetworks
 )
 
 // ManagementClusterCapabilities holds all information about optional capabilities of
@@ -142,15 +138,6 @@ func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterfa
 	}
 	if hasDNSCap {
 		discoveredCapabilities[CapabilityDNS] = struct{}{}
-	}
-
-	// check for networks capability
-	hasNetworksCap, err := isAPIResourceRegistered(client, configv1.GroupVersion, "networks")
-	if err != nil {
-		return nil, err
-	}
-	if hasNetworksCap {
-		discoveredCapabilities[CapabilityNetworks] = struct{}{}
 	}
 
 	return &ManagementClusterCapabilities{capabilities: discoveredCapabilities}, nil


### PR DESCRIPTION
tl;dr: Egress policy from the KAS can not be effectively employed because of issues with SDNs, both OpenshiftSDN/ovn-k, and, even more so, because the KAS has controllers that call out to cloud APIs which can not be effectively filtered by any ip/port based rule.

Initial attempt
https://github.com/openshift/hypershift/pull/1905

Revert
https://github.com/openshift/hypershift/pull/2001

New attempt
https://github.com/openshift/hypershift/pull/2005

Took out hypershift CI cluster based on 4.11/OpenShiftSDN

workaround bug OpenShiftSDN egress policy by not deploying policy
https://github.com/openshift/hypershift/pull/2022

KAS unable to mint SA token, breaking conformance tests

workaround bug in ovn-k egress policy but using localhost
https://github.com/openshift/hypershift/pull/2082

Ongoing Issues:
- KMS is broken because KAS access to AWS API is blocked
- conformance failures due to PersistentVolumeLabel admission controller access to AWS API is blocked