### PR TITLE
fix(ibmcloud): Initialize image registry config on creates and bad config

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/reconcile_test.go
@@ -1,0 +1,100 @@
+package registry
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ibmDefaultConfig = &imageregistryv1.Config{
+	ObjectMeta: metav1.ObjectMeta{
+		Generation: 1,
+	},
+	Spec: imageregistryv1.ImageRegistrySpec{
+		OperatorSpec: operatorv1.OperatorSpec{
+			ManagementState: operatorv1.Removed,
+		},
+		Replicas: 1,
+		Storage: imageregistryv1.ImageRegistryConfigStorage{
+			EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
+		},
+	},
+}
+
+func TestReconcileRegistryConfig(t *testing.T) {
+	testsCases := []struct {
+		name                    string
+		inputConfig             *imageregistryv1.Config
+		inputPlatform           hyperv1.PlatformType
+		inputAvailabilityPolicy hyperv1.AvailabilityPolicy
+		expectedConfig          *imageregistryv1.Config
+	}{
+		{
+			name:                    "IBM Cloud default",
+			inputAvailabilityPolicy: hyperv1.HighlyAvailable,
+			inputPlatform:           hyperv1.IBMCloudPlatform,
+			inputConfig:             manifests.Registry(),
+			expectedConfig:          ibmDefaultConfig,
+		},
+		{
+			name:                    "IBM Cloud bad config",
+			inputAvailabilityPolicy: hyperv1.HighlyAvailable,
+			inputPlatform:           hyperv1.IBMCloudPlatform,
+			inputConfig: &imageregistryv1.Config{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+				},
+				Spec: imageregistryv1.ImageRegistrySpec{
+					Storage: imageregistryv1.ImageRegistryConfigStorage{
+						IBMCOS: &imageregistryv1.ImageRegistryConfigStorageIBMCOS{},
+					},
+				},
+			},
+			expectedConfig: ibmDefaultConfig,
+		},
+		{
+			name:                    "IBM Cloud no update",
+			inputAvailabilityPolicy: hyperv1.HighlyAvailable,
+			inputPlatform:           hyperv1.IBMCloudPlatform,
+			inputConfig: &imageregistryv1.Config{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation:      1,
+					ResourceVersion: "v1",
+				},
+				Spec: imageregistryv1.ImageRegistrySpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+					Storage: imageregistryv1.ImageRegistryConfigStorage{
+						PVC: &imageregistryv1.ImageRegistryConfigStoragePVC{},
+					},
+				},
+			},
+			expectedConfig: &imageregistryv1.Config{
+				Spec: imageregistryv1.ImageRegistrySpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+					Storage: imageregistryv1.ImageRegistryConfigStorage{
+						PVC: &imageregistryv1.ImageRegistryConfigStoragePVC{},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			config := tc.inputConfig
+			ReconcileRegistryConfig(config, tc.inputPlatform, tc.inputAvailabilityPolicy)
+			g.Expect(config.Spec.Storage).To(BeEquivalentTo(tc.expectedConfig.Spec.Storage))
+			g.Expect(config.Spec.Replicas).To(BeEquivalentTo(tc.expectedConfig.Spec.Replicas))
+			g.Expect(config.Spec.ManagementState).To(BeEquivalentTo(tc.expectedConfig.Spec.ManagementState))
+		})
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -290,15 +290,11 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 
 	log.Info("reconciling registry config")
 	registryConfig := manifests.Registry()
-	// IBM Cloud platform allows managed service automation to initialize the registry config and then afterwards
-	// the client is in full control of the updates
-	if r.platformType != hyperv1.IBMCloudPlatform {
-		if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
-			registry.ReconcileRegistryConfig(registryConfig, r.platformType, hcp.Spec.InfrastructureAvailabilityPolicy)
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile imageregistry config: %w", err))
-		}
+	if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
+		registry.ReconcileRegistryConfig(registryConfig, r.platformType, hcp.Spec.InfrastructureAvailabilityPolicy)
+		return nil
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile imageregistry config: %w", err))
 	}
 
 	log.Info("reconciling ingress controller")


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates HCCO to initialize image registry config for IBM Cloud platform. With the move of cluster-image-registry-operator to the control plane, a "bad" config is being initialized by the operator (bug: https://issues.redhat.com/browse/OCPBUGS-6797) causing the operator pods to crashloop.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.