### PR TITLE
Route to kubevirt VMs using infra id as service label selector

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -678,6 +678,7 @@ type PlatformSpec struct {
 }
 
 // KubevirtPlatformSpec specifies configuration for kubevirt guest cluster installations
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.generateID) || has(self.generateID)", message="Kubevirt GenerateID is required once set"
 type KubevirtPlatformSpec struct {
 	// BaseDomainPassthrough toggles whether or not an automatically
 	// generated base domain for the guest cluster should be used that
@@ -703,6 +704,14 @@ type KubevirtPlatformSpec struct {
 	// +optional
 	// +immutable
 	BaseDomainPassthrough *bool `json:"baseDomainPassthrough,omitempty"`
+
+	// GenerateID is used to uniquely apply a name suffix to resources associated with
+	// kubevirt infrastructure resources
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Kubevirt GenerateID is immutable once set"
+	// +kubebuilder:validation:MaxLength=11
+	// +optional
+	GenerateID string `json:"generateID,omitempty"`
 }
 
 // AgentPlatformSpec specifies configuration for agent-based installations.

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -133,6 +133,14 @@ const (
 	// SilenceClusterAlertsLabel  is a label that can be used by consumers to indicate
 	// alerts from a cluster can be silenced or ignored
 	SilenceClusterAlertsLabel = "hypershift.openshift.io/silence-cluster-alerts"
+
+	// InfraIDLabel is a label that indicates the hosted cluster's infra id
+	// that the resource is associated with.
+	InfraIDLabel = "hypershift.openshift.io/infra-id"
+
+	// NodePoolNameLabel is a label that indicates the name of the node pool
+	// a resource is associated with
+	NodePoolNameLabel = "hypershift.openshift.io/nodepool-name"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.
@@ -656,6 +664,7 @@ type PlatformSpec struct {
 }
 
 // KubevirtPlatformSpec specifies configuration for kubevirt guest cluster installations
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.generateID) || has(self.generateID)", message="Kubevirt GenerateID is required once set"
 type KubevirtPlatformSpec struct {
 	// BaseDomainPassthrough toggles whether or not an automatically
 	// generated base domain for the guest cluster should be used that
@@ -681,6 +690,14 @@ type KubevirtPlatformSpec struct {
 	// +optional
 	// +immutable
 	BaseDomainPassthrough *bool `json:"baseDomainPassthrough,omitempty"`
+
+	// GenerateID is used to uniquely apply a name suffix to resources associated with
+	// kubevirt infrastructure resources
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Kubevirt GenerateID is immutable once set"
+	// +kubebuilder:validation:MaxLength=11
+	// +optional
+	GenerateID string `json:"generateID,omitempty"`
 }
 
 // AgentPlatformSpec specifies configuration for agent-based installations.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -2675,7 +2675,18 @@ spec:
                           Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                           \n This is possible using OCP wildcard routes"
                         type: boolean
+                      generateID:
+                        description: GenerateID is used to uniquely apply a name suffix
+                          to resources associated with kubevirt infrastructure resources
+                        maxLength: 11
+                        type: string
+                        x-kubernetes-validations:
+                        - message: Kubevirt GenerateID is immutable once set
+                          rule: self == oldSelf
                     type: object
+                    x-kubernetes-validations:
+                    - message: Kubevirt GenerateID is required once set
+                      rule: '!has(oldSelf.generateID) || has(self.generateID)'
                   powervs:
                     description: PowerVS specifies configuration for clusters running
                       on IBMCloud Power VS Service. This field is immutable. Once
@@ -6258,7 +6269,18 @@ spec:
                           Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                           \n This is possible using OCP wildcard routes"
                         type: boolean
+                      generateID:
+                        description: GenerateID is used to uniquely apply a name suffix
+                          to resources associated with kubevirt infrastructure resources
+                        maxLength: 11
+                        type: string
+                        x-kubernetes-validations:
+                        - message: Kubevirt GenerateID is immutable once set
+                          rule: self == oldSelf
                     type: object
+                    x-kubernetes-validations:
+                    - message: Kubevirt GenerateID is required once set
+                      rule: '!has(oldSelf.generateID) || has(self.generateID)'
                   powervs:
                     description: PowerVS specifies configuration for clusters running
                       on IBMCloud Power VS Service. This field is immutable. Once

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -2673,7 +2673,18 @@ spec:
                           Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                           \n This is possible using OCP wildcard routes"
                         type: boolean
+                      generateID:
+                        description: GenerateID is used to uniquely apply a name suffix
+                          to resources associated with kubevirt infrastructure resources
+                        maxLength: 11
+                        type: string
+                        x-kubernetes-validations:
+                        - message: Kubevirt GenerateID is immutable once set
+                          rule: self == oldSelf
                     type: object
+                    x-kubernetes-validations:
+                    - message: Kubevirt GenerateID is required once set
+                      rule: '!has(oldSelf.generateID) || has(self.generateID)'
                   powervs:
                     description: PowerVS specifies configuration for clusters running
                       on IBMCloud Power VS Service. This field is immutable. Once
@@ -6249,7 +6260,18 @@ spec:
                           Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                           \n This is possible using OCP wildcard routes"
                         type: boolean
+                      generateID:
+                        description: GenerateID is used to uniquely apply a name suffix
+                          to resources associated with kubevirt infrastructure resources
+                        maxLength: 11
+                        type: string
+                        x-kubernetes-validations:
+                        - message: Kubevirt GenerateID is immutable once set
+                          rule: self == oldSelf
                     type: object
+                    x-kubernetes-validations:
+                    - message: Kubevirt GenerateID is required once set
+                      rule: '!has(oldSelf.generateID) || has(self.generateID)'
                   powervs:
                     description: PowerVS specifies configuration for clusters running
                       on IBMCloud Power VS Service. This field is immutable. Once

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/providerconfig.go
@@ -1,6 +1,7 @@
 package kubevirt
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"gopkg.in/yaml.v2"
 )
 
@@ -15,6 +16,7 @@ type CloudConfig struct {
 	LoadBalancer LoadBalancerConfig `yaml:"loadBalancer"`
 	InstancesV2  InstancesV2Config  `yaml:"instancesV2"`
 	Namespace    string             `yaml:"namespace"`
+	InfraLabels  map[string]string  `yaml:"infraLabels"`
 }
 
 type LoadBalancerConfig struct {
@@ -39,7 +41,7 @@ func (c *CloudConfig) serialize() (string, error) {
 	return string(out), nil
 }
 
-func cloudConfig(namespace string) CloudConfig {
+func cloudConfig(hcp *hyperv1.HostedControlPlane) CloudConfig {
 	return CloudConfig{
 		LoadBalancer: LoadBalancerConfig{
 			Enabled: true,
@@ -48,6 +50,9 @@ func cloudConfig(namespace string) CloudConfig {
 			Enabled:              true,
 			ZoneAndRegionEnabled: false,
 		},
-		Namespace: namespace,
+		Namespace: hcp.Namespace,
+		InfraLabels: map[string]string{
+			hyperv1.InfraIDLabel: hcp.Spec.InfraID,
+		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
@@ -16,7 +16,7 @@ import (
 )
 
 func ReconcileCloudConfig(cm *corev1.ConfigMap, hcp *hyperv1.HostedControlPlane) error {
-	cfg := cloudConfig(hcp.Namespace)
+	cfg := cloudConfig(hcp)
 	serializedCfg, err := cfg.serialize()
 	if err != nil {
 		return fmt.Errorf("failed to serialize cloudconfig: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -121,10 +121,10 @@ func getContentsOrDie(file string) []byte {
 	return b
 }
 
-func reconcileInfraConfigMap(cm *corev1.ConfigMap) error {
+func reconcileInfraConfigMap(cm *corev1.ConfigMap, infraID string) error {
 	cm.Data = map[string]string{
 		"infraClusterNamespace": cm.Namespace,
-		"infraClusterLabels":    "",
+		"infraClusterLabels":    fmt.Sprintf("%s=%s", hyperv1.InfraIDLabel, infraID),
 	}
 	return nil
 }
@@ -420,7 +420,7 @@ func ReconcileInfra(client crclient.Client, hcp *hyperv1.HostedControlPlane, ctx
 
 	infraConfigMap := manifests.KubevirtCSIDriverInfraConfigMap(infraNamespace)
 	_, err = createOrUpdate(ctx, client, infraConfigMap, func() error {
-		return reconcileInfraConfigMap(infraConfigMap)
+		return reconcileInfraConfigMap(infraConfigMap, hcp.Spec.InfraID)
 	})
 	if err != nil {
 		return err

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
@@ -35,19 +35,21 @@ func IngressDefaultIngressNodePortService() *corev1.Service {
 	}
 }
 
+const IngressDefaultIngressPassthroughServiceName = "default-ingress-passthrough-service"
+
 func IngressDefaultIngressPassthroughService(namespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default-ingress-passthrough-service",
 			Namespace: namespace,
 		},
 	}
 }
 
+const IngressDefaultIngressPassthroughRouteName = "default-ingress-passthrough-route"
+
 func IngressDefaultIngressPassthroughRoute(namespace string) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default-ingress-passthrough-route",
 			Namespace: namespace,
 		},
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -777,8 +777,16 @@ func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv
 		// Manifests for infra/mgmt cluster passthrough service
 		cpService := manifests.IngressDefaultIngressPassthroughService(hcpNamespace)
 
+		cpService.Name = fmt.Sprintf("%s-%s",
+			manifests.IngressDefaultIngressPassthroughServiceName,
+			hcp.Spec.Platform.Kubevirt.GenerateID)
+
 		// Manifests for infra/mgmt cluster passthrough routes
 		cpPassthroughRoute := manifests.IngressDefaultIngressPassthroughRoute(hcpNamespace)
+
+		cpPassthroughRoute.Name = fmt.Sprintf("%s-%s",
+			manifests.IngressDefaultIngressPassthroughRouteName,
+			hcp.Spec.Platform.Kubevirt.GenerateID)
 
 		if _, err := r.CreateOrUpdate(ctx, r.cpClient, cpService, func() error {
 			return ingress.ReconcileDefaultIngressPassthroughService(cpService, defaultIngressNodePortService, hcp)

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -4946,6 +4946,19 @@ Apps: *.apps.guest.apps.mgmt-cluster.example.com</p>
 <p>This is possible using OCP wildcard routes</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>generateID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>GenerateID is used to uniquely apply a name suffix to resources associated with
+kubevirt infrastructure resources</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###KubevirtRootVolume { #hypershift.openshift.io/v1beta1.KubevirtRootVolume }

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -29925,7 +29925,19 @@ objects:
                             Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                             \n This is possible using OCP wildcard routes"
                           type: boolean
+                        generateID:
+                          description: GenerateID is used to uniquely apply a name
+                            suffix to resources associated with kubevirt infrastructure
+                            resources
+                          maxLength: 11
+                          type: string
+                          x-kubernetes-validations:
+                          - message: Kubevirt GenerateID is immutable once set
+                            rule: self == oldSelf
                       type: object
+                      x-kubernetes-validations:
+                      - message: Kubevirt GenerateID is required once set
+                        rule: '!has(oldSelf.generateID) || has(self.generateID)'
                     powervs:
                       description: PowerVS specifies configuration for clusters running
                         on IBMCloud Power VS Service. This field is immutable. Once
@@ -33577,7 +33589,19 @@ objects:
                             Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                             \n This is possible using OCP wildcard routes"
                           type: boolean
+                        generateID:
+                          description: GenerateID is used to uniquely apply a name
+                            suffix to resources associated with kubevirt infrastructure
+                            resources
+                          maxLength: 11
+                          type: string
+                          x-kubernetes-validations:
+                          - message: Kubevirt GenerateID is immutable once set
+                            rule: self == oldSelf
                       type: object
+                      x-kubernetes-validations:
+                      - message: Kubevirt GenerateID is required once set
+                        rule: '!has(oldSelf.generateID) || has(self.generateID)'
                     powervs:
                       description: PowerVS specifies configuration for clusters running
                         on IBMCloud Power VS Service. This field is immutable. Once
@@ -37356,7 +37380,19 @@ objects:
                             Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                             \n This is possible using OCP wildcard routes"
                           type: boolean
+                        generateID:
+                          description: GenerateID is used to uniquely apply a name
+                            suffix to resources associated with kubevirt infrastructure
+                            resources
+                          maxLength: 11
+                          type: string
+                          x-kubernetes-validations:
+                          - message: Kubevirt GenerateID is immutable once set
+                            rule: self == oldSelf
                       type: object
+                      x-kubernetes-validations:
+                      - message: Kubevirt GenerateID is required once set
+                        rule: '!has(oldSelf.generateID) || has(self.generateID)'
                     powervs:
                       description: PowerVS specifies configuration for clusters running
                         on IBMCloud Power VS Service. This field is immutable. Once
@@ -41002,7 +41038,19 @@ objects:
                             Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                             \n This is possible using OCP wildcard routes"
                           type: boolean
+                        generateID:
+                          description: GenerateID is used to uniquely apply a name
+                            suffix to resources associated with kubevirt infrastructure
+                            resources
+                          maxLength: 11
+                          type: string
+                          x-kubernetes-validations:
+                          - message: Kubevirt GenerateID is immutable once set
+                            rule: self == oldSelf
                       type: object
+                      x-kubernetes-validations:
+                      - message: Kubevirt GenerateID is required once set
+                        rule: '!has(oldSelf.generateID) || has(self.generateID)'
                     powervs:
                       description: PowerVS specifies configuration for clusters running
                         on IBMCloud Power VS Service. This field is immutable. Once

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -84,6 +84,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
@@ -4319,7 +4320,11 @@ func (r *HostedClusterReconciler) serviceAccountSigningKeyBytes(ctx context.Cont
 
 func (r *HostedClusterReconciler) reconcileKubevirtPlatformDefaultSettings(ctx context.Context, hc *hyperv1.HostedCluster) error {
 	if hc.Spec.Platform.Kubevirt == nil {
-		return nil
+		hc.Spec.Platform.Kubevirt = &hyperv1.KubevirtPlatformSpec{}
+	}
+
+	if hc.Spec.Platform.Kubevirt.GenerateID == "" {
+		hc.Spec.Platform.Kubevirt.GenerateID = utilrand.String(10)
 	}
 
 	// auto generate the basedomain by retrieving the default ingress *.apps dns.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -827,6 +827,9 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 			Spec: hyperv1.HostedClusterSpec{
 				Platform: hyperv1.PlatformSpec{
 					Type: hyperv1.KubevirtPlatform,
+					Kubevirt: &hyperv1.KubevirtPlatformSpec{
+						GenerateID: "123456789",
+					},
 				},
 				Release: hyperv1.Release{
 					Image: releaseImage.PullSpec,

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -201,8 +201,9 @@ func virtualMachineTemplateBase(image string, kvPlatform *hyperv1.KubevirtNodePo
 	return template
 }
 
-func MachineTemplateSpec(image string, nodePool *hyperv1.NodePool) *capikubevirt.KubevirtMachineTemplateSpec {
-	nodePoolNameLabelKey := "hypershift.kubevirt.io/node-pool-name"
+func MachineTemplateSpec(image string, nodePool *hyperv1.NodePool, hc *hyperv1.HostedCluster) *capikubevirt.KubevirtMachineTemplateSpec {
+	nodePoolNameLabelKey := hyperv1.NodePoolNameLabel
+	infraIDLabelKey := hyperv1.InfraIDLabel
 
 	vmTemplate := virtualMachineTemplateBase(image, nodePool.Spec.Platform.Kubevirt)
 
@@ -236,7 +237,10 @@ func MachineTemplateSpec(image string, nodePool *hyperv1.NodePool) *capikubevirt
 	}
 
 	vmTemplate.Spec.Template.ObjectMeta.Labels[nodePoolNameLabelKey] = nodePool.Name
+	vmTemplate.Spec.Template.ObjectMeta.Labels[infraIDLabelKey] = hc.Spec.InfraID
+
 	vmTemplate.ObjectMeta.Labels[nodePoolNameLabelKey] = nodePool.Name
+	vmTemplate.ObjectMeta.Labels[infraIDLabelKey] = hc.Spec.InfraID
 
 	return &capikubevirt.KubevirtMachineTemplateSpec{
 		Template: capikubevirt.KubevirtMachineTemplateResource{

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2238,7 +2238,7 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 		}
 	case hyperv1.KubevirtPlatform:
 		template = &capikubevirt.KubevirtMachineTemplate{}
-		machineTemplateSpec = kubevirt.MachineTemplateSpec(kubevirtBootImage, nodePool)
+		machineTemplateSpec = kubevirt.MachineTemplateSpec(kubevirtBootImage, nodePool, hcluster)
 		mutateTemplate = func(object client.Object) error {
 			o, _ := object.(*capikubevirt.KubevirtMachineTemplate)
 			o.Spec = *machineTemplateSpec.(*capikubevirt.KubevirtMachineTemplateSpec)


### PR DESCRIPTION
As we're looking to expand the kubevirt platform to manage VMs on external infra (an ocp cluster external to the one hypershift runs on), it's possible that VMs from multiple clusters will get placed in the same namespace. As a result, we need to start labeling the components we place in these namespaces using the unique HostedCluster.Spec.InfraID. 

This serves two purposes for us.
1. We can ensure our ingress passthrough services only route to VMs within a specific cluster
2. We can clearly identify what resources associated with a HostedCluster need to be cleaned up on the external cluster (routes, services, VMs, etc...)