### PR TITLE
fix openshift-route-controller-manager ServiceMonitor regex

### DIFF
--- a/support/metrics/sets.go
+++ b/support/metrics/sets.go
@@ -291,7 +291,7 @@ func OpenShiftRouteControllerManagerRelabelConfigs(set MetricsSet) []*prometheus
 		return []*prometheusoperatorv1.RelabelConfig{
 			{
 				Action:       "drop",
-				Regex:        "*",
+				Regex:        "(.*)",
 				SourceLabels: []prometheusoperatorv1.LabelName{"__name__"},
 			},
 		}


### PR DESCRIPTION
`PrometheusOperatorRejectedResources` alert triggering on ServiceMonitor `openshift-route-controller-manager`

```
level=warn ts=2023-01-31T18:54:46.192269295Z caller=operator.go:2020 component=prometheusoperator msg="skipping servicemonitor" error="invalid regex * for relabel configuration: error parsing regexp: missing argument to repetition operator: `*`" servicemonitor=clusters-sjenning-guest/openshift-route-controller-manager namespace=openshift-monitoring prometheus=k8s
```