### PR TITLE
fix(nto): Disable service account token automount

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -203,6 +203,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
 		}}},
 		{Name: "hosted-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KASServiceKubeconfigSecret("").Name}}},
 	}
+	dep.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)
 
 	params.DeploymentConfig.ApplyTo(dep)
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Components that do not need access to the mgmt cluster should not automount service account tokens.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.