### PR TITLE
test: skip ovnkube-master in crashing pods check

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -352,8 +352,8 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 			t.Fatalf("failed to list pods in namespace %s: %v", namespace, err)
 		}
 		for _, pod := range podList.Items {
-			// TODO: Figure out why KAS becomes unavailable for renewing leader lease
-			if strings.HasPrefix(pod.Name, "capi-provider-") {
+			// TODO: Remove this when https://issues.redhat.com/browse/OCPBUGS-6953 is resolved
+			if strings.HasPrefix(pod.Name, "ovnkube-master-") {
 				continue
 			}
 


### PR DESCRIPTION
Regression: https://github.com/openshift/ovn-kubernetes/pull/1496
Bug filed: https://issues.redhat.com/browse/OCPBUGS-6953
Upstream fix PR: https://github.com/ovn-org/ovn-kubernetes/pull/3395

`ovnkube-master` panics on Node delete

Skip the pod crash check for `ovnkube-master` pods until this fix arrives.

Also, this check is replacing an outdated exclusion for `capi-provider` when we were fighting with etcd cert issues.