### PR TITLE
Update documentation regarding HO release compatibility and CLI support

### DIFF
--- a/docs/content/reference/versioning-support.md
+++ b/docs/content/reference/versioning-support.md
@@ -11,9 +11,9 @@ There are different components that might require independent versioning and sup
 
 ### HO
 
-- A HO is intended to be released for each OCP release.
-- A HO released for OCP N minor release must support N, N-1 and N-2 OCP minor releases.
-- A HO release if anything, will only do best effort to support future OCP versions.
+- A HO is intended to be released for each OCP minor release.
+- A HO released for OCP N minor release must support HostedClusters with a release of N, N-1 and N-2 OCP minor releases.
+- A HO must be updated before future OCP minor release can be deployed or updated. For example, a HO released for OCP N minor release does not support future guest cluster N+1 minor releases. A HO must be updated to match the N+1 release before guest clusters can be deployed or updated to N+1.
 
 ### CPO
 
@@ -21,8 +21,8 @@ There are different components that might require independent versioning and sup
 
 ### CLI
 
-- A CLI is intended to be released as part of any HO release.
-- The CLI is a helper utility for dev purposes. No compatibility policies are guaranteed.
+- A CLI is intended to be released as part of every HO release.
+- A CLI is only guaranteed to be compatible with the HO release it is tied to. For example, CLI compatiblity with N-1 and N+1 HO minor releases are not guaranteed.
 
 ### API
 


### PR DESCRIPTION
This update aims to resolve two docs discrepancies 

1. When speaking about Hypershift Operator (HO) compatibility, we are not clearly stating that the compatibility is in relation to guest cluster support.
2. Our communication around CLI support needs to more accurately reflect what is occurring in our downstream product. The CLI is shipped and is available to our end users. It's being shipped because it's the entry point for people using hypershift to provision KubeVirt and Agent backed guest clusters today. As a result, we should revise how we communicate support expectations for the CLI.