### PR TITLE
Changes autoscalling replica number when the nodepool replica is not set

### DIFF
--- a/hypershift-operator/controllers/nodepool/inplace_test.go
+++ b/hypershift-operator/controllers/nodepool/inplace_test.go
@@ -1,0 +1,82 @@
+package nodepool
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestSetMachineSetReplicas(t *testing.T) {
+	testCases := []struct {
+		name                        string
+		nodePool                    *hyperv1.NodePool
+		machineSet                  *capiv1.MachineSet
+		expectReplicas              int32
+		expectAutoscalerAnnotations map[string]string
+	}{
+		{
+			name: "it sets current replicas to 1 and set annotations when autoscaling is enabled" +
+				" and the MachineSet has nil replicas",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: hyperv1.NodePoolSpec{
+					AutoScaling: &hyperv1.NodePoolAutoScaling{
+						Min: 1,
+						Max: 5,
+					},
+				},
+			},
+			machineSet: &capiv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: capiv1.MachineSetSpec{
+					Replicas: nil,
+				},
+			},
+			expectReplicas: 1,
+			expectAutoscalerAnnotations: map[string]string{
+				autoscalerMinAnnotation: "1",
+				autoscalerMaxAnnotation: "5",
+			},
+		},
+		{
+			name: "it does not set current replicas but set annotations when autoscaling is enabled" +
+				" and the MachineSet has nil replicas",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: hyperv1.NodePoolSpec{
+					AutoScaling: &hyperv1.NodePoolAutoScaling{
+						Min: 2,
+						Max: 5,
+					},
+				},
+			},
+			machineSet: &capiv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: capiv1.MachineSetSpec{
+					Replicas: nil,
+				},
+			},
+			expectReplicas: 2,
+			expectAutoscalerAnnotations: map[string]string{
+				autoscalerMinAnnotation: "2",
+				autoscalerMaxAnnotation: "5",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			setMachineSetReplicas(tc.nodePool, tc.machineSet)
+			g.Expect(*tc.machineSet.Spec.Replicas).To(Equal(tc.expectReplicas))
+			g.Expect(tc.machineSet.Annotations).To(Equal(tc.expectAutoscalerAnnotations))
+		})
+	}
+}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1453,10 +1453,13 @@ func setMachineDeploymentReplicas(nodePool *hyperv1.NodePool, machineDeployment 
 	}
 
 	if isAutoscalingEnabled(nodePool) {
+		// if the MachineSetReplicas is not in the spec will be set as 0, and here will be
+		// evaluated. If autoscaler is activated, the replicas will have the same number as
+		// minimum number of replicas set in the MachineSet spec.
 		if k8sutilspointer.Int32PtrDerefOr(machineDeployment.Spec.Replicas, 0) == 0 {
 			// if autoscaling is enabled and the machineDeployment does not exist yet or it has 0 replicas
-			// we set it to 1 replica as the autoscaler does not support scaling from zero yet.
-			machineDeployment.Spec.Replicas = k8sutilspointer.Int32Ptr(int32(1))
+			// we set the replicas to the Autoscaling minimum value, autoscaler does not support scaling from zero yet.
+			machineDeployment.Spec.Replicas = &nodePool.Spec.AutoScaling.Min
 		}
 		machineDeployment.Annotations[autoscalerMaxAnnotation] = strconv.Itoa(int(nodePool.Spec.AutoScaling.Max))
 		machineDeployment.Annotations[autoscalerMinAnnotation] = strconv.Itoa(int(nodePool.Spec.AutoScaling.Min))

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -1153,6 +1153,32 @@ func TestSetMachineDeploymentReplicas(t *testing.T) {
 				autoscalerMaxAnnotation: "5",
 			},
 		},
+		{
+			name: "it does not set current replicas but set annotations when autoscaling is enabled" +
+				" and the MachineDeployment has nil replicas",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: hyperv1.NodePoolSpec{
+					AutoScaling: &hyperv1.NodePoolAutoScaling{
+						Min: 2,
+						Max: 5,
+					},
+				},
+			},
+			machineDeployment: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: capiv1.MachineDeploymentSpec{
+					Replicas: nil,
+				},
+			},
+			expectReplicas: 2,
+			expectAutoscalerAnnotations: map[string]string{
+				autoscalerMinAnnotation: "2",
+				autoscalerMaxAnnotation: "5",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Before this change, when the NodePool replicas was not set or was nil and the autoscaling was enabled, the number of replicas was fixed to 1. Now it should match the minimum number of replicas set in the 'autoscaling' field of the nodepool spec file

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**Which issue(s) this PR fixes** 
Fixes #[HOSTEDCP-795](https://issues.redhat.com/browse/HOSTEDCP-795)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.