### PR TITLE
fix(cpo): Restart registry operator on annotation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -166,6 +166,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 			},
 		},
 	}
+	params.deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.deploymentConfig.SetDefaults(hcp, selectorLabels(), pointer.Int(1))
 	params.deploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	return params


### PR DESCRIPTION
**What this PR does / why we need it**:
Cluster image registry operator needs to be able to restart on demand.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://github.com/openshift/hypershift/issues/376

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.