### PR TITLE
Fix CAPA crd generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ cluster-api: $(CONTROLLER_GEN)
 .PHONY: cluster-api-provider-aws
 cluster-api-provider-aws: $(CONTROLLER_GEN)
 	rm -rf cmd/install/assets/cluster-api-provider-aws/*.yaml
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="{./vendor/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2, ./vendor/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta1}" output:crd:artifacts:config=cmd/install/assets/cluster-api-provider-aws
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="{./vendor/sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta2, ./vendor/sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/v1beta1}" output:crd:artifacts:config=cmd/install/assets/cluster-api-provider-aws
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./vendor/sigs.k8s.io/cluster-api-provider-aws/v2/api/..." output:crd:artifacts:config=cmd/install/assets/cluster-api-provider-aws
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./vendor/sigs.k8s.io/cluster-api-provider-aws/v2/exp/api/..." output:crd:artifacts:config=cmd/install/assets/cluster-api-provider-aws
 
 .PHONY: cluster-api-provider-ibmcloud
 cluster-api-provider-ibmcloud: $(CONTROLLER_GEN)

--- a/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclustercontrolleridentities.yaml
+++ b/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclustercontrolleridentities.yaml
@@ -104,6 +104,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
             type: object
         type: object

--- a/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
+++ b/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
@@ -103,6 +103,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               durationSeconds:
                 description: The duration, in seconds, of the role session before

--- a/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml
+++ b/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml
@@ -104,6 +104,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               secretRef:
                 description: 'Reference to a secret containing the credentials. The

--- a/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -122,6 +122,9 @@ spec:
                       eksLookupType:
                         description: EKSOptimizedLookupType If specified, will look
                           up an EKS Optimized image in SSM Parameter store
+                        enum:
+                        - AmazonLinux
+                        - AmazonLinuxGPU
                         type: string
                       id:
                         description: ID of resource
@@ -188,6 +191,7 @@ spec:
                           Must be greater than the image snapshot size or 8 (whichever
                           is greater).
                         format: int64
+                        minimum: 8
                         type: integer
                       throughput:
                         description: Throughput to provision in MiB/s supported for

--- a/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/cmd/install/assets/cluster-api-provider-aws/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -129,6 +129,9 @@ spec:
                       eksLookupType:
                         description: EKSOptimizedLookupType If specified, will look
                           up an EKS Optimized image in SSM Parameter store
+                        enum:
+                        - AmazonLinux
+                        - AmazonLinuxGPU
                         type: string
                       id:
                         description: ID of resource
@@ -195,6 +198,7 @@ spec:
                           Must be greater than the image snapshot size or 8 (whichever
                           is greater).
                         format: int64
+                        minimum: 8
                         type: integer
                       throughput:
                         description: Throughput to provision in MiB/s supported for

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -5143,6 +5143,7 @@ objects:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
               type: object
           type: object
@@ -5351,6 +5352,7 @@ objects:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
                 durationSeconds:
                   description: The duration, in seconds, of the role session before
@@ -7424,6 +7426,7 @@ objects:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
                 secretRef:
                   description: 'Reference to a secret containing the credentials.
@@ -8943,6 +8946,9 @@ objects:
                         eksLookupType:
                           description: EKSOptimizedLookupType If specified, will look
                             up an EKS Optimized image in SSM Parameter store
+                          enum:
+                          - AmazonLinux
+                          - AmazonLinuxGPU
                           type: string
                         id:
                           description: ID of resource
@@ -9010,6 +9016,7 @@ objects:
                             device. Must be greater than the image snapshot size or
                             8 (whichever is greater).
                           format: int64
+                          minimum: 8
                           type: integer
                         throughput:
                           description: Throughput to provision in MiB/s supported
@@ -11874,6 +11881,9 @@ objects:
                         eksLookupType:
                           description: EKSOptimizedLookupType If specified, will look
                             up an EKS Optimized image in SSM Parameter store
+                          enum:
+                          - AmazonLinux
+                          - AmazonLinuxGPU
                           type: string
                         id:
                           description: ID of resource
@@ -11941,6 +11951,7 @@ objects:
                             device. Must be greater than the image snapshot size or
                             8 (whichever is greater).
                           format: int64
+                          minimum: 8
                           type: integer
                         throughput:
                           description: Throughput to provision in MiB/s supported


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the command used to generate CRDs for the AWS CAPI provider so that it produces repeatable results every time.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.