### PR TITLE
Add external DNS health condition

### DIFF
--- a/api/v1beta1/hostedcluster_conditions.go
+++ b/api/v1beta1/hostedcluster_conditions.go
@@ -39,6 +39,10 @@ const (
 	// A failure here may require external user intervention to resolve. E.g. cloud provider perms were corrupted. E.g. the guest cluster was broken
 	// and kube resource deletion that affects cloud infra like service type load balancer can't succeed.
 	CloudResourcesDestroyed ConditionType = "CloudResourcesDestroyed"
+	// ExternalDNSReachable bubbles up the same condition from HCP. It signals if the configured external DNS is reachable.
+	// A failure here requires external user intervention to resolve. E.g. changing the external DNS domain or making sure the domain is created
+	// and registered correctly.
+	ExternalDNSReachable ConditionType = "ExternalDNSReachable"
 
 	// Bubble up from HCP which bubbles up from CVO.
 
@@ -155,6 +159,8 @@ const (
 	PlatformCredentialsNotFoundReason     = "PlatformCredentialsNotFound"
 	InvalidImageReason                    = "InvalidImage"
 	InvalidIdentityProvider               = "InvalidIdentityProvider"
+
+	ExternalDNSHostNotReachableReason = "ExternalDNSHostNotReachable"
 
 	ReconciliationPausedConditionReason             = "ReconciliationPaused"
 	ReconciliationInvalidPausedUntilConditionReason = "InvalidPausedUntilValue"

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -470,6 +470,39 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
 	}
 
+	// Reconcile external DNS status
+	{
+		newCondition := metav1.Condition{
+			Type:   string(hyperv1.ExternalDNSReachable),
+			Status: metav1.ConditionUnknown,
+			Reason: hyperv1.StatusUnknownReason,
+		}
+
+		kasExternalHostname := util.ServiceExternalDNSHostname(hostedControlPlane, hyperv1.APIServer)
+		if kasExternalHostname != "" {
+			if err := util.ResolveDNSHostname(ctx, kasExternalHostname); err != nil {
+				newCondition = metav1.Condition{
+					Type:    string(hyperv1.ExternalDNSReachable),
+					Status:  metav1.ConditionFalse,
+					Reason:  hyperv1.ExternalDNSHostNotReachableReason,
+					Message: err.Error(),
+				}
+			} else {
+				newCondition = metav1.Condition{
+					Type:    string(hyperv1.ExternalDNSReachable),
+					Status:  metav1.ConditionTrue,
+					Message: hyperv1.AllIsWellMessage,
+					Reason:  hyperv1.AsExpectedReason,
+				}
+			}
+		} else {
+			newCondition.Message = "External DNS is not configured"
+		}
+
+		newCondition.ObservedGeneration = hostedControlPlane.Generation
+		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
+	}
+
 	// Reconcile hostedcontrolplane availability and Ready flag
 	{
 		infrastructureCondition := meta.FindStatusCondition(hostedControlPlane.Status.Conditions, string(hyperv1.InfrastructureReady))

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2740,6 +2740,11 @@ A failure here often means a software bug or a non-stable cluster.</p>
 </td>
 </tr><tr><td><p>&#34;EtcdSnapshotRestored&#34;</p></td>
 <td></td>
+</tr><tr><td><p>&#34;ExternalDNSReachable&#34;</p></td>
+<td><p>ExternalDNSReachable bubbles up the same condition from HCP. It signals if the configured external DNS is reachable.
+A failure here requires external user intervention to resolve. E.g. changing the external DNS domain or making sure the domain is created
+and registered correctly.</p>
+</td>
 </tr><tr><td><p>&#34;Available&#34;</p></td>
 <td><p>HostedClusterAvailable indicates whether the HostedCluster has a healthy
 control plane.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -594,6 +594,25 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		meta.SetStatusCondition(&hcluster.Status.Conditions, *condition)
 	}
 
+	// Copy the ExternalDNSReachable condition on the hostedcontrolplane.
+	{
+		condition := &metav1.Condition{
+			Type:               string(hyperv1.ExternalDNSReachable),
+			Status:             metav1.ConditionUnknown,
+			Reason:             hyperv1.StatusUnknownReason,
+			Message:            "The hosted control plane is not found",
+			ObservedGeneration: hcluster.Generation,
+		}
+		if hcp != nil {
+			externalDNSReachableCondition := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ExternalDNSReachable))
+			if externalDNSReachableCondition != nil {
+				condition = externalDNSReachableCondition
+			}
+		}
+		condition.ObservedGeneration = hcluster.Generation
+		meta.SetStatusCondition(&hcluster.Status.Conditions, *condition)
+	}
+
 	// Reconcile unmanaged etcd client tls secret validation error status. Note only update status on validation error case to
 	// provide clear status to the user on the resource without having to look at operator logs.
 	{

--- a/support/util/expose.go
+++ b/support/util/expose.go
@@ -42,3 +42,23 @@ func UseDedicatedDNSForKASByHC(hc *hyperv1.HostedCluster) bool {
 		// and later is used to annotate the route so the external DNS controller can watch it.
 		apiServerService.Route != nil && apiServerService.Route.Hostname != ""
 }
+
+func ServiceExternalDNSHostname(hcp *hyperv1.HostedControlPlane, serviceType hyperv1.ServiceType) string {
+	// external DNS hostname can only be set when HCP is Public
+	if !IsPublicHCP(hcp) {
+		return ""
+	}
+
+	service := ServicePublishingStrategyByTypeForHCP(hcp, serviceType)
+	if service == nil {
+		return ""
+	}
+
+	if service.Type == hyperv1.LoadBalancer && service.LoadBalancer != nil {
+		return service.LoadBalancer.Hostname
+	}
+	if service.Type == hyperv1.Route && service.Route != nil {
+		return service.Route.Hostname
+	}
+	return ""
+}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -7,7 +7,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"strings"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -140,4 +142,18 @@ func decompress(r io.Reader) (*bytes.Buffer, error) {
 	}
 
 	return bytes.NewBuffer(data), nil
+}
+
+// ResolveDNSHostname receives a hostname string and tries to resolve it.
+// Returns error if the host can't be resolved.
+func ResolveDNSHostname(ctx context.Context, hostName string) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	ips, err := net.DefaultResolver.LookupIPAddr(timeoutCtx, hostName)
+	if err == nil && len(ips) == 0 {
+		err = fmt.Errorf("couldn't resolve %s", hostName)
+	}
+
+	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new condition to report whether external DNS is working correctly.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-726](https://issues.redhat.com/browse/HOSTEDCP-726)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.