### PR TITLE
Add PodMonitor for ingress-operator pods in HCP namespaces

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2569,6 +2569,14 @@ func (r *HostedControlPlaneReconciler) reconcileIngressOperator(ctx context.Cont
 		return fmt.Errorf("failed to reconcile ingressoperator deployment: %w", err)
 	}
 
+	pm := manifests.IngressOperatorPodMonitor(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, pm, func() error {
+		ingressoperator.ReconcilePodMonitor(pm, hcp.Spec.ClusterID, r.MetricsSet)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ingressoperator pod monitor: %w", err)
+	}
+
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -8,8 +8,10 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/konnectivity"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -20,7 +22,9 @@ import (
 )
 
 const (
+	operatorName                 = "ingress-operator"
 	ingressOperatorContainerName = "ingress-operator"
+	metricsHostname              = "ingress-operator"
 	socks5ProxyContainerName     = "socks-proxy"
 	ingressOperatorMetricsPort   = 60000
 )
@@ -88,7 +92,6 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 }
 
 func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) {
-	operatorName := "ingress-operator"
 	dep.Spec.Replicas = utilpointer.Int32(1)
 	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": operatorName}}
 	dep.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
@@ -182,6 +185,12 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 				{Name: "serviceaccount-token", MountPath: "/var/run/secrets/openshift/serviceaccount"},
 				{Name: "admin-kubeconfig", MountPath: "/etc/kubernetes"},
 			},
+			Ports: []corev1.ContainerPort{
+				{
+					ContainerPort: ingressOperatorMetricsPort,
+					Name:          "metrics",
+				},
+			},
 		})
 		dep.Spec.Template.Spec.Volumes = append(dep.Spec.Template.Spec.Volumes,
 			corev1.Volume{Name: "serviceaccount-token", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}})
@@ -230,4 +239,24 @@ func ingressOperatorSocks5ProxyContainer(socks5ProxyImage string) corev1.Contain
 	}
 	proxy.SetEnvVars(&c.Env)
 	return c
+}
+
+func ReconcilePodMonitor(pm *prometheusoperatorv1.PodMonitor, clusterID string, metricsSet metrics.MetricsSet) {
+	pm.Spec.Selector.MatchLabels = map[string]string{
+		"name": operatorName,
+	}
+	pm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{pm.Namespace},
+	}
+	pm.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{
+		{
+			Interval:             "60s",
+			Port:                 "metrics",
+			Path:                 "/metrics",
+			Scheme:               "http",
+			MetricRelabelConfigs: metrics.RegistryOperatorRelabelConfigs(metricsSet),
+		},
+	}
+
+	util.ApplyClusterIDLabelToPodMonitor(&pm.Spec.PodMetricsEndpoints[0], clusterID)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/ingressoperator.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,15 @@ func IngressOperatorKubeconfig(ns string) *corev1.Secret {
 
 func IngressOperatorDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-operator",
+			Namespace: ns,
+		},
+	}
+}
+
+func IngressOperatorPodMonitor(ns string) *prometheusoperatorv1.PodMonitor {
+	return &prometheusoperatorv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ingress-operator",
 			Namespace: ns,


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, a PodMonitor for ingress-operator pods in HCP namespaces is added to the control-plane-operator reconcile loop. 
This enables scraping of ingress-operator pod metrics, which are needed by SRE-P.

Tested on staging by manually adding an observability operator that looks for PodMonitors on all namespaces.

**Which issue(s) this PR fixes** * 
https://issues.redhat.com/browse/OSD-15101

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.