### PR TITLE
HOSTEDCP-586: E2E Test Disaster Recovery - Migration

### DIFF
--- a/cmd/install/install_render.go
+++ b/cmd/install/install_render.go
@@ -59,7 +59,7 @@ func NewRenderCommand(opts *Options) *cobra.Command {
 			}
 			objects = []crclient.Object{templateObject}
 		} else {
-			objects, err = hyperShiftOperatorManifests(*opts)
+			objects, err = HyperShiftOperatorManifests(*opts)
 			if err != nil {
 				return err
 			}
@@ -154,7 +154,7 @@ func hyperShiftOperatorTemplateManifest(opts *Options) (crclient.Object, error) 
 	}
 
 	// create manifests
-	objects, err := hyperShiftOperatorManifests(*opts)
+	objects, err := HyperShiftOperatorManifests(*opts)
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/api/scheme.go
+++ b/control-plane-operator/hostedclusterconfigoperator/api/scheme.go
@@ -23,6 +23,7 @@ import (
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -64,4 +65,5 @@ func init() {
 	prometheusoperatorv1.AddToScheme(Scheme)
 	imageregistryv1.AddToScheme(Scheme)
 	operatorsv1alpha1.AddToScheme(Scheme)
+	capiaws.AddToScheme(Scheme)
 }

--- a/test/e2e/disaster_recovery_migration_test.go
+++ b/test/e2e/disaster_recovery_migration_test.go
@@ -1,0 +1,888 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DRMigrationPublicAndPrivateTest struct {
+	ctx            context.Context
+	srcMgmtClient  crclient.Client
+	srcMgmtConfig  *rest.Config
+	dstMgmtClient  crclient.Client
+	dstMgmtCluster *hyperv1.HostedCluster
+	etcdVars       map[string]string
+	clusterOpts    core.CreateOptions
+	s3Details      map[string]string
+}
+
+func NewDRMigrationPublicAndPrivateTest(ctx context.Context, srcMgmtClient crclient.Client, srcMgmtConfig *rest.Config, dstMgmtCluster *hyperv1.HostedCluster,
+	dstMgmtClient crclient.Client, etcdVars map[string]string, clusterOpts core.CreateOptions, s3Details map[string]string) *DRMigrationPublicAndPrivateTest {
+	return &DRMigrationPublicAndPrivateTest{
+		ctx:            ctx,
+		srcMgmtClient:  srcMgmtClient,
+		srcMgmtConfig:  srcMgmtConfig,
+		dstMgmtCluster: dstMgmtCluster,
+		dstMgmtClient:  dstMgmtClient,
+		etcdVars:       etcdVars,
+		clusterOpts:    clusterOpts,
+		s3Details:      s3Details,
+	}
+}
+
+func (pr *DRMigrationPublicAndPrivateTest) Setup(t *testing.T) {}
+
+func (pr *DRMigrationPublicAndPrivateTest) BuildHostedClusterManifest() core.CreateOptions {
+	opts := pr.clusterOpts
+
+	opts.AWSPlatform.EndpointAccess = string(hyperv1.PublicAndPrivate)
+	opts.AWSPlatform.InstanceType = "m5.large"
+
+	// Adding Label to avoid ClusterDeletion
+	opts.BeforeApply = func(o crclient.Object) {
+		hostedCluster, isHostedCluster := o.(*hyperv1.HostedCluster)
+		if !isHostedCluster {
+			return
+		}
+		hostedCluster.Labels = map[string]string{e2eutil.AvoidClusterDeletetion: "false"}
+	}
+
+	// This annotation will avoid the cleanup of aws resources in the old HC
+	// located in the srcMgmtCluster, the annotation is enabled on RestoreETCD function
+	opts.Annotations = []string{
+		fmt.Sprintf("%s=false", hyperv1.CleanupCloudResourcesAnnotation),
+	}
+
+	return opts
+}
+
+func (pap *DRMigrationPublicAndPrivateTest) Run(t *testing.T, hostedCluster hyperv1.HostedCluster, hcNodePool hyperv1.NodePool) {
+	g := NewWithT(t)
+	ctx := pap.ctx
+
+	var url string
+	if hostedCluster.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate {
+		for _, service := range hostedCluster.Spec.Services {
+			if service.Service == hyperv1.APIServer {
+				url = service.Route.Hostname
+				break
+			}
+		}
+	}
+	srcDNSIPAddress, err := e2eutil.WaitForDNS(t, ctx, url)
+
+	fmt.Println("Migrating HostedCluster: ", hostedCluster.Name)
+	fmt.Println("Seed: ", pap.s3Details["seedName"])
+
+	var bckManifests []e2eutil.Manifest
+
+	nodepools := &hyperv1.NodePoolList{}
+	err = pap.srcMgmtClient.List(ctx, nodepools, crclient.InNamespace(hostedCluster.Namespace))
+	g.Expect(err).NotTo(HaveOccurred(), "failed to list nodepools in namespace %s: %v", hostedCluster.Namespace, err)
+
+	// Migration process
+	t.Log("Starting Migration")
+	h := &e2eutil.ManifestHandler{
+		Manifests:     bckManifests,
+		SrcClient:     pap.srcMgmtClient,
+		DstClient:     pap.dstMgmtClient,
+		HostedCluster: &hostedCluster,
+		NodePools:     nodepools,
+		Ctx:           ctx,
+		UploadToS3:    false,
+	}
+
+	// Stop HC, NP Reconciliation
+	if err := h.ManageReconciliation(h.HostedCluster, StringTrue); err != nil {
+		t.Fatalf("failed managing reconciliation: %v", err)
+	}
+
+	for _, nodePool := range h.NodePools.Items {
+		if err := h.ManageReconciliation(&nodePool, StringTrue); err != nil {
+			t.Fatalf("failed managing reconciliation: %v", err)
+		}
+	}
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(h.HostedCluster.Namespace, h.HostedCluster.Name).Name
+	etcdMatchLabels := map[string]string{"app": "etcd"}
+
+	// ETCD Backup
+	err = PerformEtcdBackup(t, pap.etcdVars, pap.s3Details, h, pap.srcMgmtConfig)
+	g.Expect(err).NotTo(HaveOccurred(), "failed on etcd backup")
+	defer func() {
+		awsConfig := &aws.Config{
+			Region:      aws.String(pap.s3Details["s3Region"]),
+			Credentials: credentials.NewSharedCredentials(pap.s3Details["s3Creds"], "default"),
+		}
+
+		if hostedCluster.Spec.ControllerAvailabilityPolicy == hyperv1.SingleReplica {
+			err := e2eutil.DeleteS3Object(ctx, awsConfig, pap.s3Details["bucketName"], pap.s3Details["etcd-0"])
+			g.Expect(err).NotTo(HaveOccurred(), "error deleting object %s in S3 bucket: %s", pap.s3Details["etcd-0"], pap.s3Details["bucketName"])
+		} else {
+			etcdPods := &corev1.PodList{}
+
+			if err := h.SrcClient.List(h.Ctx, etcdPods, crclient.InNamespace(hcpNamespace), crclient.MatchingLabels(etcdMatchLabels)); err != nil {
+				t.Fatal("failed to get etcd pods:", err)
+			}
+
+			for _, pod := range etcdPods.Items {
+				err := e2eutil.DeleteS3Object(ctx, awsConfig, pap.s3Details["bucketName"], pap.s3Details[pod.Name])
+				g.Expect(err).NotTo(HaveOccurred(), "error deleting key %s in S3 bucket: %s", pap.s3Details[pod.Name], pap.s3Details["bucketName"])
+			}
+		}
+	}()
+
+	// Manifest backup
+	err = PerformManifestsBackup(t, pap.s3Details, h)
+	g.Expect(err).NotTo(HaveOccurred(), "failed on manifests backup")
+
+	// Clean routes in the srcMgmtCluster HCP NS
+	routes := &routev1.RouteList{}
+	if err := e2eutil.DeleteResource(ctx, h.SrcClient, routes, hcpNamespace, map[string]string{}); err != nil {
+		t.Fatalf("error deleting routes in the HCP Namespace at the source ManagementCluster: %v", err)
+	}
+
+	// Upload to S3
+	if h.UploadToS3 {
+		err = h.UploadManifests(pap.s3Details)
+		g.Expect(err).NotTo(HaveOccurred(), "failed on manifests upload")
+	}
+
+	// Restore Manifests in destination cluster
+	err = RestoreManifestsBackup(t, h, pap.s3Details)
+	g.Expect(err).NotTo(HaveOccurred(), "failed restoring manifests in destination cluster")
+
+	// Recover from migration status
+	for _, nodePool := range nodepools.Items {
+		e2eutil.WaitForXNodePoolReplicas(t, h.Ctx, h.DstClient, *nodePool.Spec.Replicas, &nodePool)
+	}
+
+	// Setting the cleanup for the HostedCluster in the destination MGMT Cluster, It was not created with createCluster function
+	t.Cleanup(func() {
+		e2eutil.Teardown(context.Background(), t, h.DstClient, h.HostedCluster, &pap.clusterOpts, globalOpts.ArtifactDir)
+	})
+	t.Cleanup(func() {
+		e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+	t.Cleanup(func() {
+		e2eutil.EnsureHCPContainersHaveResourceRequests(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+	t.Cleanup(func() {
+		e2eutil.EnsureNoPodsWithTooHighPriority(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+	t.Cleanup(func() {
+		e2eutil.NoticePreemptionOrFailedScheduling(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+	t.Cleanup(func() {
+		e2eutil.EnsureAllRoutesUseHCPRouter(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+
+	// Scaling down the Deps and StatefulSets to allow the migration
+	err = ScaleHCPResources(t, h.Ctx, hostedCluster, h.SrcClient, pap.srcMgmtConfig, zeroReplicas)
+	// Scalling up the CPO Deployment when teardown, to manage the finalizer removal
+	defer func() {
+		fmt.Println("Rescaling CPO in HCP Namespace")
+		cpoDep := &appsv1.Deployment{}
+		cpoDep.Name = "control-plane-operator"
+		cpoDep.Namespace = hcpNamespace
+		if err := h.SrcClient.Get(h.Ctx, crclient.ObjectKeyFromObject(cpoDep), cpoDep); err != nil {
+			t.Logf("failed getting CPO Deployment: %v", err)
+		}
+
+		cpoDepOrig := cpoDep.DeepCopy()
+		cpoDep.Spec.Replicas = &oneReplicas
+		if err := h.SrcClient.Patch(h.Ctx, cpoDep, crclient.MergeFrom(cpoDepOrig)); err != nil {
+			t.Logf("failed scaling up CPO Deployment: %v", err)
+		}
+	}()
+	g.Expect(err).NotTo(HaveOccurred(), "error scalling down the old hosted cluster: %v", err)
+
+	for _, nodePool := range nodepools.Items {
+		e2eutil.WaitForXNodePoolReplicas(t, h.Ctx, h.DstClient, *nodePool.Spec.Replicas, &nodePool)
+	}
+
+	for _, nodePool := range nodepools.Items {
+		e2eutil.WaitForFinishNodePoolUpdate(t, h.Ctx, h.DstClient, &nodePool)
+	}
+
+	// Wait for DNS Propagation
+	for _, service := range h.HostedCluster.Spec.Services {
+		if service.Service == hyperv1.APIServer {
+			url = service.Route.Hostname
+			break
+		}
+	}
+	dstDNSIPAddress, err := e2eutil.WaitForDNS(t, ctx, url)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to reach DNS URL")
+
+	newHostedClient := e2eutil.WaitForGuestClient(t, ctx, h.DstClient, &hostedCluster)
+
+	// Sometimes the DNS's takes more than expected to be propagated, so it causes
+	// unexpected behaviour into the migration.
+	if srcDNSIPAddress.String() == dstDNSIPAddress.String() {
+		// Wait for NodePool to be aware of the API change, expecting 0 replicas in NodePool
+		for _, nodePool := range nodepools.Items {
+			e2eutil.WaitForXNodePoolReplicas(t, h.Ctx, h.DstClient, int32(0), &nodePool)
+		}
+	}
+
+	// Once the OVN pods gets deleted, need to ensure reliablity of the HC API
+	newHostedClient = e2eutil.WaitForGuestClient(t, ctx, h.DstClient, &hostedCluster)
+
+	// Clean Routes in the HCP namespace at the Source Management Cluster
+	routeList := &routev1.RouteList{}
+	err = h.SrcClient.List(ctx, routeList, crclient.InNamespace(hcpNamespace))
+	g.Expect(int32(len(routeList.Items))).NotTo(BeZero(), "route list in the control plane namespace has zero length")
+
+	for _, route := range routeList.Items {
+		err := h.SrcClient.Delete(ctx, &route)
+		g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("couldn't delete route: %s\n", route.Name))
+	}
+
+	// Wait for HC Nodes
+	hcNodes := e2eutil.WaitForNReadyNodesByNodePool(t, ctx, newHostedClient, *hcNodePool.Spec.Replicas, hostedCluster.Spec.Platform.Type, hcNodePool.Name)
+	g.Expect(int32(len(hcNodes))).To(Equal(*hcNodePool.Spec.Replicas))
+
+	// Wait for X replicas in NodePool
+	for _, nodePool := range nodepools.Items {
+		e2eutil.WaitForXNodePoolReplicas(t, h.Ctx, h.DstClient, *nodePool.Spec.Replicas, &nodePool)
+	}
+}
+
+type DRMigrationPrivateTest struct {
+	ctx            context.Context
+	srcMgmtClient  crclient.Client
+	srcMgmtConfig  *rest.Config
+	dstMgmtClient  crclient.Client
+	dstMgmtCluster *hyperv1.HostedCluster
+	etcdVars       map[string]string
+	clusterOpts    core.CreateOptions
+	s3Details      map[string]string
+}
+
+func NewDRMigrationPrivateTest(ctx context.Context, srcMgmtClient crclient.Client, srcMgmtConfig *rest.Config, dstMgmtCluster *hyperv1.HostedCluster,
+	dstMgmtClient crclient.Client, etcdVars map[string]string, clusterOpts core.CreateOptions, s3Details map[string]string) *DRMigrationPublicAndPrivateTest {
+	return &DRMigrationPublicAndPrivateTest{
+		ctx:            ctx,
+		srcMgmtClient:  srcMgmtClient,
+		srcMgmtConfig:  srcMgmtConfig,
+		dstMgmtCluster: dstMgmtCluster,
+		dstMgmtClient:  dstMgmtClient,
+		etcdVars:       etcdVars,
+		clusterOpts:    clusterOpts,
+		s3Details:      s3Details,
+	}
+}
+
+func (pr *DRMigrationPrivateTest) Setup(t *testing.T) {}
+
+func (pr *DRMigrationPrivateTest) BuildHostedClusterManifest() core.CreateOptions {
+	opts := pr.clusterOpts
+
+	opts.AWSPlatform.EndpointAccess = string(hyperv1.Private)
+	opts.AWSPlatform.InstanceType = "m5.large"
+
+	// Adding Label to avoid ClusterDeletion
+	opts.BeforeApply = func(o crclient.Object) {
+		hostedCluster, isHostedCluster := o.(*hyperv1.HostedCluster)
+		if !isHostedCluster {
+			return
+		}
+		hostedCluster.Labels = map[string]string{e2eutil.AvoidClusterDeletetion: "false"}
+	}
+
+	// This annotation will avoid the cleanup of aws resources in the old HC
+	// located in the srcMgmtCluster, the annotation is enabled on RestoreETCD function
+	opts.Annotations = []string{
+		fmt.Sprintf("%s=false", hyperv1.CleanupCloudResourcesAnnotation),
+	}
+
+	return opts
+}
+
+func (pr *DRMigrationPrivateTest) Run(t *testing.T, hostedCluster hyperv1.HostedCluster, hcNodePool hyperv1.NodePool) {
+	g := NewWithT(t)
+	ctx := pr.ctx
+
+	fmt.Println("Migrating HostedCluster: ", hostedCluster.Name)
+	fmt.Println("Seed: ", pr.s3Details["seedName"])
+
+	var bckManifests []e2eutil.Manifest
+
+	nodepools := &hyperv1.NodePoolList{}
+	err := pr.srcMgmtClient.List(ctx, nodepools, crclient.InNamespace(hostedCluster.Namespace))
+	g.Expect(err).NotTo(HaveOccurred(), "failed to list nodepools in namespace %s: %v", hostedCluster.Namespace, err)
+
+	// Migration process
+	t.Log("Starting Migration")
+	h := &e2eutil.ManifestHandler{
+		Manifests:     bckManifests,
+		SrcClient:     pr.srcMgmtClient,
+		DstClient:     pr.dstMgmtClient,
+		HostedCluster: &hostedCluster,
+		NodePools:     nodepools,
+		Ctx:           ctx,
+		UploadToS3:    false,
+	}
+
+	// Stop HC, NP Reconciliation
+	if err := h.ManageReconciliation(h.HostedCluster, StringTrue); err != nil {
+		t.Fatalf("failed managing reconciliation: %v", err)
+	}
+
+	for _, nodePool := range h.NodePools.Items {
+		if err := h.ManageReconciliation(&nodePool, StringTrue); err != nil {
+			t.Fatalf("failed managing reconciliation: %v", err)
+		}
+	}
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(h.HostedCluster.Namespace, h.HostedCluster.Name).Name
+	etcdMatchLabels := map[string]string{"app": "etcd"}
+
+	// ETCD Backup
+	err = PerformEtcdBackup(t, pr.etcdVars, pr.s3Details, h, pr.srcMgmtConfig)
+	g.Expect(err).NotTo(HaveOccurred(), "failed on etcd backup")
+	defer func() {
+		awsConfig := &aws.Config{
+			Region:      aws.String(pr.s3Details["s3Region"]),
+			Credentials: credentials.NewSharedCredentials(pr.s3Details["s3Creds"], "default"),
+		}
+
+		if hostedCluster.Spec.ControllerAvailabilityPolicy == hyperv1.SingleReplica {
+			err := e2eutil.DeleteS3Object(ctx, awsConfig, pr.s3Details["bucketName"], pr.s3Details["etcd-0"])
+			g.Expect(err).NotTo(HaveOccurred(), "error deleting object %s in S3 bucket: %s", pr.s3Details["etcd-0"], pr.s3Details["bucketName"])
+		} else {
+			etcdPods := &corev1.PodList{}
+
+			if err := h.SrcClient.List(h.Ctx, etcdPods, crclient.InNamespace(hcpNamespace), crclient.MatchingLabels(etcdMatchLabels)); err != nil {
+				t.Fatal("failed to get etcd pods:", err)
+			}
+
+			for _, pod := range etcdPods.Items {
+				err := e2eutil.DeleteS3Object(ctx, awsConfig, pr.s3Details["bucketName"], pr.s3Details[pod.Name])
+				g.Expect(err).NotTo(HaveOccurred(), "error deleting key %s in S3 bucket: %s", pr.s3Details[pod.Name], pr.s3Details["bucketName"])
+			}
+		}
+	}()
+
+	// Manifest backup
+	err = PerformManifestsBackup(t, pr.s3Details, h)
+	g.Expect(err).NotTo(HaveOccurred(), "failed on manifests backup")
+
+	// Upload to S3
+	if h.UploadToS3 {
+		err = h.UploadManifests(pr.s3Details)
+		g.Expect(err).NotTo(HaveOccurred(), "failed on manifests upload")
+	}
+
+	// Restore Manifests in destination cluster
+	err = RestoreManifestsBackup(t, h, pr.s3Details)
+	g.Expect(err).NotTo(HaveOccurred(), "failed restoring manifests in destination cluster")
+
+	// Recover from migration status
+	for _, nodePool := range nodepools.Items {
+		e2eutil.WaitForXNodePoolReplicas(t, h.Ctx, h.DstClient, *nodePool.Spec.Replicas, &nodePool)
+	}
+
+	// Setting the cleanup for the HostedCluster in the destination MGMT Cluster, It was not created with createCluster function
+	t.Cleanup(func() {
+		e2eutil.Teardown(context.Background(), t, h.DstClient, h.HostedCluster, &pr.clusterOpts, globalOpts.ArtifactDir)
+	})
+	t.Cleanup(func() {
+		e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+	t.Cleanup(func() {
+		e2eutil.EnsureHCPContainersHaveResourceRequests(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+	t.Cleanup(func() {
+		e2eutil.EnsureNoPodsWithTooHighPriority(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+	t.Cleanup(func() {
+		e2eutil.NoticePreemptionOrFailedScheduling(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+	t.Cleanup(func() {
+		e2eutil.EnsureAllRoutesUseHCPRouter(t, context.Background(), h.DstClient, h.HostedCluster)
+	})
+
+	// Scaling down the Deps and StatefulSets to allow the migration
+	err = ScaleHCPResources(t, h.Ctx, hostedCluster, h.SrcClient, pr.srcMgmtConfig, zeroReplicas)
+	// Scalling up the CPO Deployment when teardown, to manage the finalizer removal
+	defer func() {
+		fmt.Println("Rescaling CPO in HCP Namespace")
+		cpoDep := &appsv1.Deployment{}
+		cpoDep.Name = "control-plane-operator"
+		cpoDep.Namespace = hcpNamespace
+		if err := h.SrcClient.Get(h.Ctx, crclient.ObjectKeyFromObject(cpoDep), cpoDep); err != nil {
+			t.Logf("failed getting CPO Deployment: %v", err)
+		}
+
+		cpoDepOrig := cpoDep.DeepCopy()
+		cpoDep.Spec.Replicas = &oneReplicas
+		if err := h.SrcClient.Patch(h.Ctx, cpoDep, crclient.MergeFrom(cpoDepOrig)); err != nil {
+			t.Logf("failed scaling up CPO Deployment: %v", err)
+		}
+	}()
+	g.Expect(err).NotTo(HaveOccurred(), "error scalling down the old hosted cluster: %v", err)
+
+	for _, nodePool := range nodepools.Items {
+		e2eutil.WaitForXNodePoolReplicas(t, h.Ctx, h.DstClient, *nodePool.Spec.Replicas, &nodePool)
+	}
+
+	for _, nodePool := range nodepools.Items {
+		e2eutil.WaitForFinishNodePoolUpdate(t, h.Ctx, h.DstClient, &nodePool)
+	}
+
+	// Wait for NodePool to be aware of the API change, expecting 0 replicas in NodePool
+	for _, nodePool := range nodepools.Items {
+		e2eutil.WaitForXNodePoolReplicas(t, h.Ctx, h.DstClient, int32(0), &nodePool)
+	}
+
+	// Wait for X replicas in NodePool
+	for _, nodePool := range nodepools.Items {
+		e2eutil.WaitForXNodePoolReplicas(t, h.Ctx, h.DstClient, *nodePool.Spec.Replicas, &nodePool)
+	}
+}
+
+func ScaleHCPResources(t *testing.T, ctx context.Context, hc hyperv1.HostedCluster, mgmtClient crclient.Client, config *rest.Config, replicas int32) error {
+	fmt.Printf("Scaling to %d Deployments and Stateful sets from old HostedCluster: %s\n", replicas, hc.Name)
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name
+
+	// Deployments
+	if err := wait.PollImmediateWithContext(ctx, 10*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
+		deps := &appsv1.DeploymentList{}
+		if err := mgmtClient.List(ctx, deps, &crclient.ListOptions{Namespace: hcpNamespace}); err != nil {
+			if apierrors.IsServiceUnavailable(err) || strings.Contains(err.Error(), "connection refused") {
+				return false, fmt.Errorf("connection refused, retrying...")
+			}
+			return false, fmt.Errorf("error getting deployments from %s: %v", hcpNamespace, err)
+		}
+		if len(deps.Items) > 0 {
+			if err := e2eutil.ScaleResources(ctx, mgmtClient, deps, replicas); err != nil {
+				return false, fmt.Errorf("error scaling deployments to %d: %v", replicas, err)
+			}
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("error scalling deployments %v", err)
+	}
+
+	// StatefulSets
+	if err := wait.PollImmediateWithContext(ctx, 10*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
+		statefulSets := &appsv1.StatefulSetList{}
+		if err := mgmtClient.List(ctx, statefulSets, &crclient.ListOptions{Namespace: hcpNamespace}); err != nil {
+			if apierrors.IsServiceUnavailable(err) || strings.Contains(err.Error(), "connection refused") {
+				return false, fmt.Errorf("connection refused, retrying...")
+			}
+			return false, fmt.Errorf("error getting statefulSets from %s: %v", hcpNamespace, err)
+		}
+		if len(statefulSets.Items) > 0 {
+			if err := e2eutil.ScaleResources(ctx, mgmtClient, statefulSets, replicas); err != nil {
+				return false, fmt.Errorf("error scaling down statefulSets: %v", err)
+			}
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("error scalling stateful sets %v", err)
+	}
+
+	return nil
+}
+
+func PerformEtcdBackup(t *testing.T, etcdVars, s3Details map[string]string, h *e2eutil.ManifestHandler, config *rest.Config) error {
+	t.Log("Executing ETCD backup")
+	etcdMatchLabels := map[string]string{
+		"app": "etcd",
+	}
+	hcpNamespace := manifests.HostedControlPlaneNamespace(h.HostedCluster.Namespace, h.HostedCluster.Name).Name
+
+	date := time.Now()
+	dateQuery := date.Format(time.RFC1123Z)
+
+	etcdPods := &corev1.PodList{}
+	if err := h.SrcClient.List(h.Ctx, etcdPods, crclient.InNamespace(hcpNamespace), crclient.MatchingLabels(etcdMatchLabels)); err != nil {
+		return fmt.Errorf("failed to get etcd pods: %v", err)
+	}
+
+	snapshotSave := fmt.Sprintf("env ETCDCTL_API=3 %s --cacert %s --cert %s --key %s --endpoints=localhost:2379 snapshot save %s",
+		etcdVars["bin"], etcdVars["CAPath"], etcdVars["CertPath"], etcdVars["CertKeyPath"], etcdVars["snapshotPath"])
+
+	snapshotStatus := fmt.Sprintf("env ETCDCTL_API=3 %s -w table snapshot status %s", etcdVars["bin"], etcdVars["snapshotPath"])
+
+	for _, pod := range etcdPods.Items {
+		path := fmt.Sprintf("/%s/hc-backup-%s/etcd/%s-%s-snapshot-%s.db", s3Details["bucketName"], s3Details["seedName"], hcpNamespace, pod.Name, s3Details["seedName"])
+		s3Details[pod.Name] = fmt.Sprintf("hc-backup-%s/etcd/%s-%s-snapshot-%s.db", s3Details["seedName"], hcpNamespace, pod.Name, s3Details["seedName"])
+		postUrl := fmt.Sprintf("https://%s.s3.%s.amazonaws.com", s3Details["bucketName"], s3Details["s3Region"])
+		postUri := fmt.Sprintf("hc-backup-%s/etcd/%s-%s-snapshot-%s.db", s3Details["seedName"], hcpNamespace, pod.Name, s3Details["seedName"])
+		s3Details["s3EtcdSnapshotURL"] = fmt.Sprintf("%s/%s", postUrl, postUri)
+		out := new(bytes.Buffer)
+
+		podExecuter := e2eutil.PodExecOptions{
+			StreamOptions: e2eutil.StreamOptions{
+				IOStreams: genericclioptions.IOStreams{
+					Out:    out,
+					ErrOut: os.Stderr,
+				},
+			},
+			Command:       strings.Split(snapshotSave, " "),
+			Namespace:     hcpNamespace,
+			PodName:       pod.Name,
+			ContainerName: "etcd",
+			Config:        config,
+		}
+
+		t.Logf("Streaming Backup command on %s", pod.Name)
+		if err := podExecuter.Run(); err != nil {
+			return fmt.Errorf("failed to execute etcdctl command: %v", err)
+		}
+
+		fmt.Printf("ETCD Snapshot creation Out: %s", out.String())
+
+		podExecuter.Command = strings.Split(snapshotStatus, " ")
+
+		t.Logf("Streaming Status command on %s", pod.Name)
+		if err := podExecuter.Run(); err != nil {
+			return fmt.Errorf("failed to execute etcdctl command: %v", err)
+		}
+
+		fmt.Printf("ETCD Snapshot status Out: %s", out.String())
+
+		// Configure AWS Client
+		AWSCreds := credentials.NewSharedCredentials(s3Details["s3Creds"], "default")
+		secretAWSK, err := AWSCreds.Get()
+		if err != nil {
+			return fmt.Errorf("failed to recover the AWS Secret: %v", err)
+		}
+
+		signatureString := fmt.Sprintf("PUT\n\n%v\n%v\n%s", etcdVars["queryContentType"], dateQuery, path)
+		authstring, err := presignUrlCreator(signatureString, secretAWSK)
+		if err != nil {
+			t.Fatal("error getting the authstring for S3 upload command:", err)
+		}
+
+		command := []string{
+			"/usr/bin/curl", "-X", "PUT",
+			s3Details["s3EtcdSnapshotURL"], "-H",
+			fmt.Sprintf(`Host: %s.s3.%s.amazonaws.com`, s3Details["bucketName"], s3Details["s3Region"]), "-H",
+			fmt.Sprintf(`Date: %s`, dateQuery), "-H",
+			fmt.Sprintf(`Content-Type: %s`, etcdVars["queryContentType"]), "-H",
+			authstring, "-T", etcdVars["snapshotPath"],
+		}
+
+		fmt.Println("Remote curl command:", command)
+
+		podExecuter.Command = command
+
+		t.Logf("Streaming Curl command on %s", pod.Name)
+		if err := podExecuter.Run(); err != nil {
+			return fmt.Errorf("failed executing curl command: %v", err)
+		}
+
+		if strings.Contains(out.String(), "Error") {
+			fmt.Println("Command: ", command)
+			return fmt.Errorf("error uploading etcd backup to s3: %v", out.String())
+		}
+
+		// Changing folder's permissions in S3
+		sess, err := session.NewSession(&aws.Config{
+			Region:      aws.String(s3Details["s3Region"]),
+			Credentials: credentials.NewSharedCredentials(s3Details["s3Creds"], "default"),
+		})
+		if err != nil {
+			return fmt.Errorf("error creating s3 session: %v", err)
+		}
+
+		svc := s3.New(sess)
+		params := &s3.PutObjectAclInput{
+			Bucket: aws.String(s3Details["bucketName"]),
+			Key:    aws.String(fmt.Sprintf("hc-backup-%s/etcd/%s-%s-snapshot-%s.db", s3Details["seedName"], hcpNamespace, pod.Name, s3Details["seedName"])),
+			ACL:    aws.String("public-read"),
+		}
+		_, err = svc.PutObjectAcl(params)
+		if err != nil {
+			return fmt.Errorf("error setting s3 permissions: %v", err)
+		}
+
+	}
+	fmt.Println()
+
+	return nil
+}
+
+func presignUrlCreator(signatureString string, creds credentials.Value) (string, error) {
+
+	key := []byte(creds.SecretAccessKey)
+	h := hmac.New(sha1.New, key)
+	h.Write([]byte(signatureString))
+	signatureHash := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	authstring := fmt.Sprintf("Authorization: AWS %s:%s", creds.AccessKeyID, signatureHash)
+	if len(creds.AccessKeyID) < 1 || len(signatureHash) < 1 {
+		return "", fmt.Errorf("signature hash or access key id are empty, please check them.")
+	}
+	return authstring, nil
+}
+
+func PerformManifestsBackup(t *testing.T, s3Details map[string]string, h *e2eutil.ManifestHandler) error {
+	hcpNsName := manifests.HostedControlPlaneNamespace(h.HostedCluster.Namespace, h.HostedCluster.Name).Name
+
+	// Manifests on HostedCluster Namespace
+	// HC Namespace
+	hcNs := &corev1.NamespaceList{}
+	if err := h.GetNamespace(hcNs, h.HostedCluster.Namespace); err != nil {
+		return fmt.Errorf("failed getting existant HostedCluster Namespace: %v", err)
+	}
+	if err := h.PackResources(hcNs, e2eutil.HcType); err != nil {
+		return fmt.Errorf("failed packing existant HostedCluster Namespace: %v", err)
+	}
+
+	// HostedClusters
+	hcs := &hyperv1.HostedClusterList{}
+	if err := h.GetResources(hcs, h.HostedCluster.Namespace); err != nil {
+		return fmt.Errorf("failed getting existant HostedClusters: %v", err)
+	}
+	if err := h.PackResources(hcs, e2eutil.HcType); err != nil {
+		return fmt.Errorf("failed packing existant HostedClusters: %v", err)
+	}
+
+	// NodePools
+	nps := &hyperv1.NodePoolList{}
+	if err := h.GetResources(nps, h.HostedCluster.Namespace); err != nil {
+		return fmt.Errorf("failed getting existant NodePools: %v", err)
+	}
+	if err := h.PackResources(nps, e2eutil.HcType); err != nil {
+		return fmt.Errorf("failed packing existant NodePools: %v", err)
+	}
+
+	// Configmaps
+	hcConfigMaps, err := h.GetReferencedConfigMaps()
+	if err != nil {
+		return fmt.Errorf("failed getting existant referenced ConfigMaps in hostedCluster %s: %v", h.HostedCluster.Name, err)
+	}
+	if err := h.PackResources(hcConfigMaps, e2eutil.HcType); err != nil {
+		return fmt.Errorf("failed packing existant ConfigMaps: %v", err)
+	}
+
+	// Secrets
+	hcSecrets, err := h.GetReferencedSecrets()
+	if err != nil {
+		return fmt.Errorf("failed getting existant referenced Secrets in hostedCluster %s: %v", h.HostedCluster.Name, err)
+	}
+	if err := h.PackResources(hcSecrets, e2eutil.HcType); err != nil {
+		return fmt.Errorf("failed packing existant Secrets: %v", err)
+	}
+
+	// HCP Objects backup
+	hcpNs := &corev1.NamespaceList{}
+	if err := h.GetNamespace(hcpNs, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HostedControlPlane Namespace: %v", err)
+	}
+	if err := h.PackResources(hcpNs, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HostedControlPlane Namespace: %v", err)
+	}
+
+	hcpCMs := &corev1.ConfigMapList{}
+	if err := h.GetResources(hcpCMs, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP ConfigMaps: %v", err)
+	}
+	if err := h.PackResources(hcpCMs, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP ConfigMaps: %v", err)
+	}
+
+	hcpSecrets := &corev1.SecretList{}
+	if err := h.GetResources(hcpSecrets, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP Secrets: %v", err)
+	}
+	if err := h.PackResources(hcpSecrets, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP Secrets: %v", err)
+	}
+
+	hcp := &hyperv1.HostedControlPlaneList{}
+	if err := h.GetResources(hcp, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP: %v", err)
+	}
+	if err := h.PackResources(hcp, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP: %v", err)
+	}
+
+	hcpAWSCluster := &capiaws.AWSClusterList{}
+	if err := h.GetResources(hcpAWSCluster, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP AWS Cluster: %v", err)
+	}
+	if err := h.PackResources(hcpAWSCluster, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP AWS Cluster: %v", err)
+	}
+
+	hcpAWSMachineTemplates := &capiaws.AWSMachineTemplateList{}
+	if err := h.GetResources(hcpAWSMachineTemplates, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP AWS Machine Templates: %v", err)
+	}
+	if err := h.PackResources(hcpAWSMachineTemplates, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP AWS Machine Templates: %v", err)
+	}
+
+	hcpAWSMachines := &capiaws.AWSMachineList{}
+	if err := h.GetResources(hcpAWSMachines, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP AWS Machines: %v", err)
+	}
+	if err := h.PackResources(hcpAWSMachines, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP AWS Machines: %v", err)
+	}
+
+	hcpCluster := &capiv1.ClusterList{}
+	if err := h.GetResources(hcpCluster, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP Clusters: %v", err)
+	}
+	if err := h.PackResources(hcpCluster, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP Clusters: %v", err)
+	}
+
+	hcpMachineDeployments := &capiv1.MachineDeploymentList{}
+	if err := h.GetResources(hcpMachineDeployments, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP Machine Deployments: %v", err)
+	}
+	if err := h.PackResources(hcpMachineDeployments, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP Machine Deployments: %v", err)
+	}
+
+	hcpMachineSets := &capiv1.MachineSetList{}
+	if err := h.GetResources(hcpMachineSets, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP Machine Sets: %v", err)
+	}
+	if err := h.PackResources(hcpMachineSets, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP Machine Sets: %v", err)
+	}
+
+	hcpMachines := &capiv1.MachineList{}
+	if err := h.GetResources(hcpMachines, hcpNsName); err != nil {
+		return fmt.Errorf("failed getting existant HCP Machines: %v", err)
+	}
+	if err := h.PackResources(hcpMachines, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("failed packing existant HCP Machines: %v", err)
+	}
+
+	return nil
+}
+
+func RestoreManifestsBackup(t *testing.T, h *e2eutil.ManifestHandler, s3Details map[string]string) error {
+	hcNs := &corev1.Namespace{}
+	hcNs.Kind = "Namespace"
+	if err := h.RestoreResource(hcNs, e2eutil.HcType); err != nil {
+		return fmt.Errorf("error restoring HC Namespace: %v\n", err)
+	}
+
+	hcSecret := &corev1.Secret{}
+	hcSecret.Kind = "Secret"
+	if err := h.RestoreResource(hcSecret, e2eutil.HcType); err != nil {
+		return fmt.Errorf("error restoring HC secrets: %v\n", err)
+	}
+
+	hcConfigMap := &corev1.ConfigMap{}
+	hcConfigMap.Kind = "ConfigMap"
+	if err := h.RestoreResource(hcConfigMap, e2eutil.HcType); err != nil {
+		return fmt.Errorf("error restoring HC ConfigMaps: %v\n", err)
+	}
+
+	hcpNs := &corev1.Namespace{}
+	hcpNs.Kind = "Namespace"
+	if err := h.RestoreResource(hcpNs, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HCP Namespace: %v\n", err)
+	}
+
+	hcpSecrets := &corev1.Secret{}
+	hcpSecrets.Kind = "Secret"
+	if err := h.RestoreResource(hcpSecrets, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HCP Secrets: %v\n", err)
+	}
+
+	hostedControlPlane := &hyperv1.HostedControlPlane{}
+	hostedControlPlane.Kind = "HostedControlPlane"
+	if err := h.RestoreResource(hostedControlPlane, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HostedControlPlane: %v\n", err)
+	}
+
+	hcpAWSCluster := &capiaws.AWSCluster{}
+	hcpAWSCluster.Kind = "AWSCluster"
+	if err := h.RestoreResource(hcpAWSCluster, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HCP AWS Cluster: %v\n", err)
+	}
+
+	hcpAWSMachineTemplate := &capiaws.AWSMachineTemplate{}
+	hcpAWSMachineTemplate.Kind = "AWSMachineTemplate"
+	if err := h.RestoreResource(hcpAWSMachineTemplate, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HCP AWS Machine Template: %v\n", err)
+	}
+
+	hcpAWSMachine := &capiaws.AWSMachine{}
+	hcpAWSMachine.Kind = "AWSMachine"
+	if err := h.RestoreResource(hcpAWSMachine, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HCP AWS Machine: %v\n", err)
+	}
+
+	hcpCluster := &capiv1.Cluster{}
+	hcpCluster.Kind = "Cluster"
+	if err := h.RestoreResource(hcpCluster, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HCP Cluster: %v\n", err)
+	}
+
+	hcpMachineDeployment := &capiv1.MachineDeployment{}
+	hcpMachineDeployment.Kind = "MachineDeployment"
+	if err := h.RestoreResource(hcpMachineDeployment, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HCP MachineDeployment: %v\n", err)
+	}
+
+	hcpMachine := &capiv1.Machine{}
+	hcpMachine.Kind = "Machine"
+	if err := h.RestoreResource(hcpMachine, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HCP Machine: %v\n", err)
+	}
+
+	hcpMachineSet := &capiv1.MachineSet{}
+	hcpMachineSet.Kind = "MachineSet"
+	if err := h.RestoreResource(hcpMachineSet, e2eutil.HcpType); err != nil {
+		return fmt.Errorf("error restoring HCP MachineSet: %v\n", err)
+	}
+
+	hc := &hyperv1.HostedCluster{}
+	hc.Kind = "HostedCluster"
+	if err := h.RestoreETCD(hc, s3Details); err != nil {
+		return fmt.Errorf("error restoring ETCD")
+	}
+
+	np := &hyperv1.NodePool{}
+	np.Kind = "NodePool"
+	if err := h.RestoreResource(np, e2eutil.HcType); err != nil {
+		return fmt.Errorf("error restoring ETCD")
+	}
+
+	return nil
+}

--- a/test/e2e/disaster_recovery_test.go
+++ b/test/e2e/disaster_recovery_test.go
@@ -1,0 +1,261 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/install"
+	"github.com/openshift/hypershift/cmd/version"
+	"github.com/openshift/hypershift/support/metrics"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	tmpDir = "/tmp"
+)
+
+var (
+	StringTrue   string = "true"
+	StringFalse  string = "false"
+	OVNNamespace string = "openshift-ovn-kubernetes"
+)
+
+type DisasterRecoveryTestCase struct {
+	name            string
+	test            DisasterRecoveryTest
+	manifestBuilder HostedClusterManifestBuilder
+}
+
+type DisasterRecoveryTest interface {
+	Setup(t *testing.T)
+	Run(t *testing.T, hostedCluster hyperv1.HostedCluster, hcNodePool hyperv1.NodePool)
+
+	HostedClusterManifestBuilder
+}
+
+type HostedClusterManifestBuilder interface {
+	BuildHostedClusterManifest() core.CreateOptions
+}
+
+func TestDisasterRecovery(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx, cancel := context.WithCancel(testContext)
+	etcdVars := map[string]string{
+		"bin":              "/usr/bin/etcdctl",
+		"CAPath":           "/etc/etcd/tls/etcd-ca/ca.crt",
+		"CertPath":         "/etc/etcd/tls/client/etcd-client.crt",
+		"CertKeyPath":      "/etc/etcd/tls/client/etcd-client.key",
+		"snapshotPath":     "/var/lib/data/snapshot.db",
+		"queryContentType": "application/x-compressed-tar",
+	}
+
+	defer func() {
+		t.Log("Test group: Disaster Recovery finished")
+		cancel()
+	}()
+
+	srcMgmtClient, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get Source MGMT Cluster client")
+	srcMgmtConfig, err := e2eutil.GetConfig()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get Source MGMT Cluster config")
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts.BeforeApply = func(o crclient.Object) {
+		nodePool, isNodepool := o.(*hyperv1.NodePool)
+		if !isNodepool {
+			return
+		}
+		nodePool.Spec.Management.Replace = &hyperv1.ReplaceUpgrade{
+			Strategy: hyperv1.UpgradeStrategyRollingUpdate,
+			RollingUpdate: &hyperv1.RollingUpdate{
+				MaxUnavailable: func(v intstr.IntOrString) *intstr.IntOrString { return &v }(intstr.FromInt(1)),
+				MaxSurge:       func(v intstr.IntOrString) *intstr.IntOrString { return &v }(intstr.FromInt(int(*nodePool.Spec.Replicas))),
+			},
+		}
+	}
+
+	// Create HC with a PublicAndPrivate endpoint access config
+	clusterOpts.AWSPlatform.EndpointAccess = string(hyperv1.PublicAndPrivate)
+	clusterOpts.AWSPlatform.InstanceType = "m5.xlarge"
+
+	// This is our destination Management cluster
+	dstMgmtCluster := e2eutil.CreateCluster(t, ctx, srcMgmtClient, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
+	var url string
+	if dstMgmtCluster.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate {
+		for _, service := range dstMgmtCluster.Spec.Services {
+			if service.Service == hyperv1.APIServer {
+				url = service.Route.Hostname
+				break
+			}
+		}
+	}
+	_, err = e2eutil.WaitForDNS(t, ctx, url)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to reach DNS URL")
+
+	dstMgmtClient := e2eutil.WaitForGuestClient(t, ctx, srcMgmtClient, dstMgmtCluster)
+
+	// Reuse NodePool
+	nodepools := &hyperv1.NodePoolList{}
+	err = srcMgmtClient.List(ctx, nodepools, crclient.InNamespace(dstMgmtCluster.Namespace))
+	g.Expect(err).NotTo(HaveOccurred(), "failed to list nodepools in namespace %s: %v", dstMgmtCluster.Namespace, err)
+	g.Expect(len(nodepools.Items)).Should(Equal(1), "expected exactly one nodepool, got %d", len(nodepools.Items))
+
+	// Wait for nodes to be Ready
+	dstMgmtNodePool := &nodepools.Items[0]
+	dstMgmtNumNodes := clusterOpts.NodePoolReplicas
+	dstMgmtNodes := e2eutil.WaitForNReadyNodesByNodePool(t, ctx, dstMgmtClient, dstMgmtNumNodes, dstMgmtCluster.Spec.Platform.Type, dstMgmtNodePool.Name)
+	t.Logf("Destination Management Cluster %s Nodes Ready: %d", dstMgmtCluster.Name, len(dstMgmtNodes))
+	t.Logf("waiting for Destination MGMT cluster to rollout. Image: %s", globalOpts.LatestReleaseImage)
+	e2eutil.WaitForImageRollout(t, ctx, srcMgmtClient, dstMgmtCluster, globalOpts.LatestReleaseImage)
+
+	// Install Hypershift in the dstMgmtCluster
+	opts := install.Options{
+		AdditionalTrustBundle:                     "",
+		Namespace:                                 "hypershift",
+		HyperShiftImage:                           version.HyperShiftImage,
+		ImageRefsFile:                             "",
+		HyperShiftOperatorReplicas:                2,
+		Development:                               false,
+		EnableValidatingWebhook:                   false,
+		EnableConversionWebhook:                   true,
+		ExcludeEtcdManifests:                      false,
+		PrivatePlatform:                           string(hyperv1.AWSPlatform),
+		AWSPrivateCreds:                           globalOpts.configurableClusterOptions.AWSCredentialsFile,
+		AWSPrivateCredentialsSecret:               "",
+		AWSPrivateCredentialsSecretKey:            "credentials",
+		AWSPrivateRegion:                          globalOpts.configurableClusterOptions.Region,
+		OIDCStorageProviderS3Region:               globalOpts.configurableClusterOptions.Region,
+		OIDCStorageProviderS3BucketName:           "",
+		OIDCStorageProviderS3Credentials:          globalOpts.configurableClusterOptions.AWSCredentialsFile,
+		OIDCStorageProviderS3CredentialsSecret:    "",
+		OIDCStorageProviderS3CredentialsSecretKey: "credentials",
+		ExternalDNSProvider:                       strings.ToLower(string(globalOpts.Platform)),
+		ExternalDNSCredentials:                    globalOpts.configurableClusterOptions.AWSCredentialsFile,
+		ExternalDNSDomainFilter:                   globalOpts.configurableClusterOptions.ExternalDNSDomain,
+		ExternalDNSTxtOwnerId:                     "",
+		EnableAdminRBACGeneration:                 false,
+		MetricsSet:                                metrics.MetricsSetTelemetry,
+		EnableUWMTelemetryRemoteWrite:             true,
+		RHOBSMonitoring:                           false,
+	}
+
+	s3Details := make(map[string]string)
+	s3Details["s3Creds"] = opts.OIDCStorageProviderS3Credentials
+	s3Details["queryContentType"] = etcdVars["queryContentType"]
+	s3Details["s3Region"] = opts.OIDCStorageProviderS3Region
+
+	opts.ApplyDefaults()
+
+	if os.Getenv("CI") == "true" {
+		opts.PlatformMonitoring = metrics.PlatformMonitoringAll
+		opts.EnableCIDebugOutput = true
+	}
+
+	t.Log("Deploying Hypershift")
+	objects, err := install.HyperShiftOperatorManifests(opts)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to object conversion from installation options:", err)
+
+	err = install.Apply(ctx, objects, dstMgmtClient)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to apply hypershift installation manifests:", err)
+
+	err = install.WaitUntilAvailable(ctx, opts, dstMgmtClient)
+	g.Expect(err).NotTo(HaveOccurred(), "failed waiting hypershift installation:", err)
+
+	DisasterRecoveryTests := []DisasterRecoveryTestCase{
+		{
+			name: "TestDRMigrationPublicAndPrivate",
+			test: NewDRMigrationPublicAndPrivateTest(ctx, srcMgmtClient, srcMgmtConfig, dstMgmtCluster, dstMgmtClient, etcdVars, clusterOpts, s3Details),
+		},
+		{
+			name: "TestDRMigrationPrivate",
+			test: NewDRMigrationPrivateTest(ctx, srcMgmtClient, srcMgmtConfig, dstMgmtCluster, dstMgmtClient, etcdVars, clusterOpts, s3Details),
+		},
+	}
+
+	t.Run("Disaster Recovery Tests Group", func(t *testing.T) {
+		for _, testCase := range DisasterRecoveryTests {
+			t.Run(testCase.name, func(t *testing.T) {
+				executeDisasterRecoveryTest(t, ctx, srcMgmtClient, testCase.test, testCase.manifestBuilder, s3Details, opts)
+			})
+		}
+	})
+}
+
+func executeDisasterRecoveryTest(t *testing.T, ctx context.Context, srcMgmtClient crclient.Client, disasterRecoveryTest DisasterRecoveryTest, manifestBuilder HostedClusterManifestBuilder, s3Details map[string]string, opts install.Options) {
+	t.Parallel()
+
+	disasterRecoveryTest.Setup(t)
+	g := NewWithT(t)
+
+	// Customize Cluster Name
+	s3Details["seedName"] = e2eutil.SimpleNameGenerator.GenerateName("")
+
+	// Create Bucket (if necessary) for the testCase
+	if opts.OIDCStorageProviderS3BucketName == "" {
+		awsConfig := &aws.Config{
+			Region:      aws.String(s3Details["s3Region"]),
+			Credentials: credentials.NewSharedCredentials(s3Details["s3Creds"], "default"),
+		}
+		bucket := fmt.Sprintf("%s-%s-%s", "test-disaster-recovery", s3Details["s3Region"], s3Details["seedName"])
+
+		err := e2eutil.CreateS3Bucket(ctx, *awsConfig, bucket)
+		g.Expect(err).NotTo(HaveOccurred(), "error creating S3 bucket:", err)
+		opts.OIDCStorageProviderS3BucketName = bucket
+		defer func() {
+			if err := e2eutil.DeleteS3Bucket(ctx, *awsConfig, bucket); err != nil {
+				t.Errorf("error deleting S3 bucket %s: %v", bucket, err)
+			}
+		}()
+	}
+
+	g.Expect(opts.OIDCStorageProviderS3BucketName).NotTo(BeEmpty(), "S3 bucket name parameter it's empty")
+	s3Details["bucketName"] = opts.OIDCStorageProviderS3BucketName
+
+	if manifestBuilder == nil {
+		manifestBuilder = disasterRecoveryTest
+	}
+	hostedClusterOpts := manifestBuilder.BuildHostedClusterManifest()
+
+	// This is our HostedCluster, which will be migrated to a destination cluster
+	hostedCluster := e2eutil.CreateCluster(t, ctx, srcMgmtClient, &hostedClusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
+	var url string
+	if hostedCluster.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate {
+		for _, service := range hostedCluster.Spec.Services {
+			if service.Service == hyperv1.APIServer {
+				url = service.Route.Hostname
+				break
+			}
+		}
+	}
+	_, err := e2eutil.WaitForDNS(t, ctx, url)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to reach DNS URL")
+	t.Logf("waiting for HostedCluster to rollout. Image: %s", globalOpts.LatestReleaseImage)
+	e2eutil.WaitForImageRollout(t, ctx, srcMgmtClient, hostedCluster, globalOpts.LatestReleaseImage)
+
+	// Grab the HC's NodePool
+	hcNodePools := &hyperv1.NodePoolList{}
+	err = srcMgmtClient.List(ctx, hcNodePools, crclient.InNamespace(hostedCluster.Namespace))
+	g.Expect(err).NotTo(HaveOccurred(), "failed to list nodepools in namespace %s: %v", hostedCluster.Namespace, err)
+	g.Expect(len(hcNodePools.Items)).Should(Equal(1), "expected exactly one nodepool, got %d", len(hcNodePools.Items))
+	hcNodePool := &hcNodePools.Items[0]
+
+	t.Logf("waiting for HostedCluster to rollout. Image: %s", globalOpts.LatestReleaseImage)
+	e2eutil.WaitForImageRollout(t, ctx, srcMgmtClient, hostedCluster, globalOpts.LatestReleaseImage)
+
+	// run test validations
+	disasterRecoveryTest.Run(t, *hostedCluster, *hcNodePool)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -74,6 +74,7 @@ func TestMain(m *testing.M) {
 	flag.Var(&globalOpts.configurableClusterOptions.Zone, "e2e.availability-zones", "Availability zones for clusters")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PullSecretFile, "e2e.pull-secret-file", "", "path to pull secret")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AWSEndpointAccess, "e2e.aws-endpoint-access", "", "endpoint access profile for the cluster")
+	flag.StringVar(&globalOpts.configurableClusterOptions.AWSOIDCBucketName, "e2e.aws-oidc-bucket-name", "hypershift-ci-oidc", "bucket name for OIDC storage")
 	flag.StringVar(&globalOpts.configurableClusterOptions.ExternalDNSDomain, "e2e.external-dns-domain", "", "domain that external-dns will use to create DNS records for HCP endpoints")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "DEPRECATED (ignored will be removed soon)")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtNodeMemory, "e2e.kubevirt-node-memory", "4Gi", "the amount of memory to provide to each workload node")
@@ -146,7 +147,7 @@ func main(m *testing.M) int {
 	defer alertSLOs(testContext)
 
 	if globalOpts.Platform == hyperv1.AWSPlatform {
-		oidcBucketName := "hypershift-ci-oidc"
+		oidcBucketName := globalOpts.configurableClusterOptions.AWSOIDCBucketName
 		iamClient := e2eutil.GetIAMClient(globalOpts.configurableClusterOptions.AWSCredentialsFile, globalOpts.configurableClusterOptions.Region)
 		s3Client := e2eutil.GetS3Client(globalOpts.configurableClusterOptions.AWSCredentialsFile, globalOpts.configurableClusterOptions.Region)
 		if err := setupSharedOIDCProvider(oidcBucketName, iamClient, s3Client); err != nil {
@@ -392,6 +393,7 @@ type configurableClusterOptions struct {
 	AzureCredentialsFile        string
 	AzureLocation               string
 	Region                      string
+	AWSOIDCBucketName           string
 	Zone                        stringSliceVar
 	PullSecretFile              string
 	BaseDomain                  string

--- a/test/e2e/util/manifests.go
+++ b/test/e2e/util/manifests.go
@@ -1,0 +1,296 @@
+package util
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	homanifests "github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/support/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+These utilities will manage the manifests rendering,
+backup and restore against a cluster
+*/
+
+const (
+	e2eSASignKey = "e2e-sa-signing-key"
+)
+
+type Manifest struct {
+	Name string
+	Data []byte
+}
+
+type ManifestHandler struct {
+	Manifests     []Manifest
+	SrcClient     crclient.Client
+	DstClient     crclient.Client
+	HostedCluster *hyperv1.HostedCluster
+	NodePools     *hyperv1.NodePoolList
+	Ctx           context.Context
+	UploadToS3    bool
+}
+
+func (h *ManifestHandler) UploadManifests(s3Details map[string]string) error {
+	fmt.Printf("\nUploading Manifests to S3\n")
+	hcpNs := homanifests.HostedControlPlaneNamespace(h.HostedCluster.Namespace, h.HostedCluster.Name).Name
+	foldPrefix := "/tmp"
+
+	if err := os.MkdirAll(fmt.Sprintf("%s/hc-backup-%s/manifests-%s/", foldPrefix, s3Details["seedName"], hcpNs), os.ModePerm); err != nil {
+		return fmt.Errorf("error creating local folder to backup manifests: %v", err)
+	}
+
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String(s3Details["s3Region"]),
+		Credentials: credentials.NewSharedCredentials(s3Details["s3Creds"], "default"),
+	})
+	if err != nil {
+		return fmt.Errorf("error creating s3 session: %v", err)
+	}
+
+	uploader := s3manager.NewUploader(sess)
+
+	for _, manifest := range h.Manifests {
+		fmt.Println("Uploading Manifest:", manifest.Name)
+		s3Key := fmt.Sprintf("hc-backup-%s/manifests-%s/%s-%s.yaml", s3Details["seedName"], hcpNs, manifest.Name, s3Details["seedName"])
+
+		fileName := foldPrefix + "/" + s3Key
+		if err := ioutil.WriteFile(fileName, manifest.Data, 0644); err != nil {
+			return fmt.Errorf("error writing yaml manifests to filesystem")
+		}
+
+		upParams := &s3manager.UploadInput{
+			Bucket: aws.String(s3Details["bucketName"]),
+			Key:    aws.String(s3Key),
+			Body:   bytes.NewReader(manifest.Data),
+		}
+
+		result, err := uploader.Upload(upParams)
+		if err != nil {
+			fmt.Println("Result:", result)
+			return fmt.Errorf("error uploading file so S3 bucket: %v", err)
+		}
+	}
+	return nil
+}
+
+func (h *ManifestHandler) RestoreResource(object crclient.Object, nsKind string) error {
+	kind := object.GetObjectKind().GroupVersionKind().Kind
+	fmt.Printf("\nRestoring Objects: %s\n", kind)
+	manifestPrefix := strings.ToLower(fmt.Sprintf("%s-%s-", kind, nsKind))
+	for _, manifest := range h.Manifests {
+		if strings.Contains(manifest.Name, manifestPrefix) {
+			obj := object.DeepCopyObject().(crclient.Object)
+			if err := util.DeserializeResource(string(manifest.Data), obj, api.Scheme); err != nil {
+				return fmt.Errorf("error deserializing manifest: %v", err)
+			}
+
+			if obj.GetName() == "" && obj.GetNamespace() == "" {
+				// Sometimes it recovers empty objects.
+				fmt.Println("empty object, bypassing...")
+				continue
+			}
+
+			obj.SetResourceVersion("")
+			obj.SetOwnerReferences([]metav1.OwnerReference{})
+			if kind == "NodePool" {
+				np := obj.(*hyperv1.NodePool)
+				np.Spec.PausedUntil = nil
+				obj = np
+			}
+
+			if err := h.DstClient.Create(h.Ctx, obj); err != nil {
+				if !errors.IsAlreadyExists(err) {
+					return fmt.Errorf("error creating manifest: %v", err)
+				} else {
+					fmt.Println("Object already exists:", manifest.Name)
+				}
+			}
+
+			fmt.Printf("%s created: %v\n", kind, obj.GetName())
+		}
+	}
+	return nil
+}
+
+func (h *ManifestHandler) PackResources(objectList crclient.ObjectList, nsKind string) error {
+	var bckManifest Manifest
+	var bckManifests []Manifest
+
+	if err := meta.EachListItem(objectList, func(item runtime.Object) error {
+		var err error
+		var dataS string
+
+		if dataS, err = util.SerializeResource(item, api.Scheme); err != nil {
+			return fmt.Errorf("error backing up object %T: %v", item, err)
+		}
+
+		bckManifest.Data = []byte(dataS)
+		accessor := meta.NewAccessor()
+		itemName, err := accessor.Name(item)
+		if err != nil {
+			return fmt.Errorf("error backing up object %T: %v", item, err)
+		}
+		fmt.Printf("Backing up %v: %v\n", item.GetObjectKind().GroupVersionKind().Kind, itemName)
+		bckManifest.Name = strings.ToLower(item.GetObjectKind().GroupVersionKind().Kind + "-" + nsKind + "-" + itemName)
+		bckManifests = append(bckManifests, bckManifest)
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error backing up object: %v", err)
+	}
+
+	h.Manifests = append(h.Manifests, bckManifests...)
+	return nil
+}
+
+func (h *ManifestHandler) GetResources(objectList crclient.ObjectList, ns string) error {
+	if err := h.SrcClient.List(h.Ctx, objectList, crclient.InNamespace(ns)); err != nil {
+		return fmt.Errorf("failed getting objectList: %v", err)
+	}
+	return nil
+}
+
+func (h *ManifestHandler) ManageReconciliation(object crclient.Object, stopped string) error {
+	//Flaky stopped param, receive bool and convert to string pointer
+	switch obj := object.(type) {
+	case *hyperv1.HostedCluster:
+		fmt.Printf("Managing HostedCluster reconciliation: %s\n", obj.Name)
+		hcOrig := obj.DeepCopy()
+		obj.Spec.PausedUntil = &stopped
+		if err := h.SrcClient.Patch(h.Ctx, obj, crclient.MergeFrom(hcOrig)); err != nil {
+			return fmt.Errorf("failed pausing hostedcluster %s reconciliation: %v", obj.Name, err)
+		}
+	case *hyperv1.NodePool:
+		fmt.Printf("Stopping NodePool reconciliation: %s\n", obj.Name)
+		npOrig := obj.DeepCopy()
+		obj.Spec.PausedUntil = &stopped
+		if err := h.SrcClient.Patch(h.Ctx, obj, crclient.MergeFrom(npOrig)); err != nil {
+			return fmt.Errorf("failed pausing nodepool %s reconciliation: %v", obj.Name, err)
+		}
+	default:
+		return fmt.Errorf("only HostedCluster and NodePools are allowed to stop reconciliation. Object: %s", object.GetName())
+	}
+	return nil
+}
+
+func (h *ManifestHandler) GetReferencedSecrets() (*corev1.SecretList, error) {
+	secretList := &corev1.SecretList{}
+	tmpList := &corev1.SecretList{}
+
+	if err := h.SrcClient.List(h.Ctx, tmpList, crclient.InNamespace(h.HostedCluster.Namespace)); err != nil {
+		return &corev1.SecretList{}, fmt.Errorf("failed to get the list of secrets from %s namespace: %w", h.HostedCluster.Namespace, err)
+	}
+
+	for _, secretRef := range tmpList.Items {
+		if secretRef.Type == corev1.SecretTypeOpaque {
+			secretList.Items = append(secretList.Items, secretRef)
+		}
+	}
+
+	if len(secretList.Items) <= 0 {
+		return &corev1.SecretList{}, fmt.Errorf("empty secret list recovered from namespace %s namespace", h.HostedCluster.Namespace)
+	}
+
+	return secretList, nil
+}
+
+func (h *ManifestHandler) GetReferencedConfigMaps() (*corev1.ConfigMapList, error) {
+	configMapList := &corev1.ConfigMapList{}
+	configMapRefs := make([]string, 0)
+	nodePoolNames := make([]string, 0)
+
+	for _, nodePool := range h.NodePools.Items {
+		nodePoolNames = append(nodePoolNames, nodePool.Name)
+		if nodePool.Spec.TuningConfig != nil {
+			for _, tuningCM := range nodePool.Spec.TuningConfig {
+				configMapRefs = append(configMapRefs, tuningCM.Name)
+			}
+		}
+
+		if nodePool.Spec.Config != nil {
+			for _, config := range nodePool.Spec.Config {
+				configMapRefs = append(configMapRefs, config.Name)
+			}
+		}
+	}
+
+	// No ConfigMaps to backup
+	if len(configMapRefs) <= 0 {
+		fmt.Printf("there is not configMaps to backup referenced in the nodePools %v at %s namespace\n", nodePoolNames, h.HostedCluster.Namespace)
+		return &corev1.ConfigMapList{}, nil
+	}
+
+	for _, configMapRef := range configMapRefs {
+		sourceCM := &corev1.ConfigMap{}
+		if err := h.SrcClient.Get(h.Ctx, crclient.ObjectKey{Namespace: h.HostedCluster.Namespace, Name: configMapRef}, sourceCM); err != nil {
+			return &corev1.ConfigMapList{}, fmt.Errorf("failed to get referenced configmap %s/%s: %w", h.HostedCluster.Namespace, configMapRef, err)
+		}
+
+		configMapList.Items = append(configMapList.Items, *sourceCM)
+	}
+
+	return configMapList, nil
+}
+
+func (h *ManifestHandler) GetNamespace(object crclient.ObjectList, ns string) error {
+	matchLabel := make(map[string]string)
+	matchLabel[corev1.LabelMetadataName] = ns
+
+	if err := h.SrcClient.List(h.Ctx, object, crclient.MatchingLabels(matchLabel)); err != nil {
+		return fmt.Errorf("failed getting Namespace: %v", err)
+	}
+	return nil
+}
+
+func (h *ManifestHandler) RestoreETCD(hc *hyperv1.HostedCluster, s3Details map[string]string) error {
+	fmt.Printf("\nRestoring ETCD\n")
+	manifestPrefix := strings.ToLower(fmt.Sprintf("%s-%s-%s", hc.Kind, HcType, h.HostedCluster.Name))
+	for _, manifest := range h.Manifests {
+		if strings.Contains(manifest.Name, manifestPrefix) {
+			if err := util.DeserializeResource(string(manifest.Data), hc, api.Scheme); err != nil {
+				return fmt.Errorf("error deserializing manifest: %v", err)
+			}
+			hc.ResourceVersion = ""
+			hc.Spec.PausedUntil = nil
+			hc.Annotations[hyperv1.CleanupCloudResourcesAnnotation] = "true"
+			hc.Spec.Etcd.Managed.Storage.Type = hyperv1.PersistentVolumeEtcdStorage
+			hc.Spec.Etcd.Managed.Storage.RestoreSnapshotURL = append(hc.Spec.Etcd.Managed.Storage.RestoreSnapshotURL, s3Details["s3EtcdSnapshotURL"])
+
+			dataS, err := util.SerializeResource(hc, api.Scheme)
+			if err != nil {
+				return fmt.Errorf("error serializing manifest: %v", err)
+			}
+
+			manifest.Data = []byte(dataS)
+
+			if err := h.DstClient.Create(h.Ctx, hc); err != nil {
+				if !errors.IsAlreadyExists(err) {
+					return fmt.Errorf("error creating manifest: %v", err)
+				} else {
+					fmt.Println("HostedCluster object already exists...")
+				}
+			}
+			fmt.Printf("HostedCluster Restored: %v\n", hc.Name)
+			break
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Added E2E Test which covers the disaster recovery procedure for HostedCluster based on migration among the same AWS Region.

- Exposed some functions to reuse the install package for Hypershift Operator deployment in E2E tests
- Added AWS objects to `api.Scheme` for backup purposes
- Refactored test group to include more Disaster Recovery scenarios in the future
- Included the `Private` and `PublicAndPrivate` endpoint access modes
- Added e2e flag to include the S3 bucket name for OIDC

**Which issue(s) this PR fixes** 
Fixes #[HOSTEDCP-586](https://issues.redhat.com/browse/HOSTEDCP-586)

**E2E Test Steps**
- [x] Stop Reconciliation
- [x] Backup Etcd and Upload to S3
- [x] Backup Manifest and Upload to S3
- [x] Restore HostedCluster
- [ ] Teardown Old HostedCluster (WIP) (This part it's quite unstable)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.