### PR TITLE
expose silence alerts metric

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -129,6 +129,10 @@ const (
 	// a cluster is somehow out of regular support policy.
 	// https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-limited-support_rosa-service-definition.
 	LimitedSupportLabel = "hypershift.openshift.io/limited-support"
+
+	// SilenceClusterAlertsLabel  is a label that can be used by consumers to indicate
+	// alerts from a cluster can be silenced or ignored
+	SilenceClusterAlertsLabel = "hypershift.openshift.io/silence-cluster-alerts"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
This exposes a new metric hypershift_cluster_silence_alerts whose value represents the existence of a label on the HostedCluster CR. We use this metric to communicate to central observability that alerts from a specific HostedCluster should be silenced. This ability to silence clusters is currently present on ROSA.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
https://issues.redhat.com/browse/OSD-15100

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.