### PR TITLE
AUTH-323: konnectivity: split away the rootCA from konnectivity trust

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1573,7 +1573,7 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 
 	konnectivityCACM := manifests.KonnectivityCAConfigMap(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, konnectivityCACM, func() error {
-		return pki.ReconcileConnectivityConfigMap(konnectivityCACM, p.OwnerRef, konnectivitySigner, rootCASecret)
+		return pki.ReconcileKonnectivityConfigMap(konnectivityCACM, p.OwnerRef, konnectivitySigner)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile konnectivity CA config map: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -90,6 +90,6 @@ func ReconcileRootCAConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, ro
 	return reconcileAggregateCA(cm, ownerRef, rootCA)
 }
 
-func ReconcileConnectivityConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, konnectivityCA, rootCA *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, konnectivityCA, rootCA)
+func ReconcileKonnectivityConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, konnectivityCA *corev1.Secret) error {
+	return reconcileAggregateCA(cm, ownerRef, konnectivityCA)
 }


### PR DESCRIPTION
This is a continuation of https://github.com/openshift/hypershift/pull/1891. We do it this way to ensure smooth upgrades of the CI cluster.

/assign @csrwng 