### PR TITLE
fix(cpo): Set restart annotation on multus-admission-controller

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2473,6 +2473,13 @@ func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx conte
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile cluster network operator deployment: %w", err)
 	}
+
+	// CNO manages overall multus-admission-controller deployment. CPO manages restarts.
+	multusDeployment := manifests.MultusAdmissionControllerDeployment(hcp.Namespace)
+	if err := cno.SetRestartAnnotationAndPatch(ctx, r.Client, multusDeployment, p.DeploymentConfig); err != nil {
+		return fmt.Errorf("failed to restart multus admission controller: %w", err)
+	}
+
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
@@ -7,12 +7,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const resourceName = "cluster-network-operator"
+const clusterNetworkOperator = "cluster-network-operator"
+const multusAdmissionController = "multus-admission-controller"
 
 func ClusterNetworkOperatorDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName,
+			Name:      clusterNetworkOperator,
 			Namespace: ns,
 		},
 	}
@@ -22,7 +23,7 @@ func ClusterNetworkOperatorRole(namespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      resourceName,
+			Name:      clusterNetworkOperator,
 		},
 	}
 }
@@ -31,7 +32,7 @@ func ClusterNetworkOperatorRoleBinding(namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      resourceName,
+			Name:      clusterNetworkOperator,
 		},
 	}
 }
@@ -40,7 +41,16 @@ func ClusterNetworkOperatorServiceAccount(namespace string) *corev1.ServiceAccou
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      resourceName,
+			Name:      clusterNetworkOperator,
+		},
+	}
+}
+
+func MultusAdmissionControllerDeployment(namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      multusAdmissionController,
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With `multus-admission-controller` in the CP side for 4.12, it does not cycle when the HC/HCP restart annotation is applied. This change makes it so that CPO will set the restart annotation.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #376

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.