### PR TITLE
test: skip TestCreateClusterKms on non-AWS platforms

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -74,6 +74,9 @@ func TestCreateCluster(t *testing.T) {
 }
 
 func TestCreateClusterKms(t *testing.T) {
+	if globalOpts.Platform != hyperv1.AWSPlatform {
+		t.Skip("test only supported on platform AWS")
+	}
 	t.Parallel()
 	g := NewWithT(t)
 


### PR DESCRIPTION
In powervs e2e periodic, for example
```
=== CONT  TestCreateClusterKms
    create_cluster_test.go:90: 
        failed to retrieve kms key arn
        Unexpected error:
            <*awserr.baseError | 0xc0004b8800>: {
                code: "NoCredentialProviders",
                message: "no valid providers in chain. Deprecated.\n\tFor verbose messaging see aws.Config.CredentialsChainVerboseErrors",
                errs: nil,
            }
            NoCredentialProviders: no valid providers in chain. Deprecated.
            	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
        occurred
--- FAIL: TestCreateClusterKms (6.56s)
```