### PR TITLE
Filtering data recolection only for aws instances running

### DIFF
--- a/test/e2e/util/dump/journals.go
+++ b/test/e2e/util/dump/journals.go
@@ -30,6 +30,7 @@ func DumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 	if len(secretName) == 0 {
 		return fmt.Errorf("no SSH secret specified for cluster, cannot dump journals")
 	}
+
 	sshKeySecret := &corev1.Secret{}
 	sshKeySecret.Name = secretName
 	sshKeySecret.Namespace = hc.Namespace
@@ -120,8 +121,12 @@ func DumpJournals(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluster, 
 			if skip {
 				continue
 			}
-			machineIPs = append(machineIPs, aws.StringValue(instance.PrivateIpAddress))
-			machineInstances = append(machineInstances, instance)
+
+			if *instance.State.Name == "running" {
+				machineIPs = append(machineIPs, aws.StringValue(instance.PrivateIpAddress))
+				machineInstances = append(machineInstances, instance)
+			}
+
 		}
 	}
 


### PR DESCRIPTION
This enables the data recollection only in Nodes which are up and running

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>