### PR TITLE
Give kubevirt csi controller get VMI RBAC

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/infra_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/infra_role.yaml
@@ -9,7 +9,7 @@ rules:
   verbs: ["get", "create", "delete"]
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachineinstances"]
-  verbs: ["list"]
+  verbs: ["list", "get"]
 - apiGroups: ["subresources.kubevirt.io"]
   resources: ["virtualmachineinstances/addvolume", "virtualmachineinstances/removevolume"]
   verbs: ["update"]


### PR DESCRIPTION
In order to properly detect if hotplugged volumes are available the driver needs to inspect the kubevirt VMI the volume was hotplugged into. This gives the controller the ability to get an individual VMI

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Once https://github.com/kubevirt/csi-driver/pull/82 merges, the kubevirt csi driver requires
`get` on VMIs in order to properly function. This PR adds that RBAC

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.