### PR TITLE
Update kubevirt-csi rbac

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/infra_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/infra_role.yaml
@@ -9,7 +9,7 @@ rules:
   verbs: ["get", "create", "delete"]
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachineinstances"]
-  verbs: ["list"]
+  verbs: ["list", "get"]
 - apiGroups: ["subresources.kubevirt.io"]
   resources: ["virtualmachineinstances/addvolume", "virtualmachineinstances/removevolume"]
   verbs: ["update"]


### PR DESCRIPTION
Due to a recent change here [1], kubevirt csi needs rbac to `get` virtual machine instances. 

1. https://github.com/kubevirt/csi-driver/pull/82 