### PR TITLE
Add cli flag to enable root volume encryption

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -505,9 +505,10 @@ func (o ExampleOptions) Resources() *ExampleResources {
 					},
 				},
 				RootVolume: &hyperv1.Volume{
-					Size: o.AWS.RootVolumeSize,
-					Type: o.AWS.RootVolumeType,
-					IOPS: o.AWS.RootVolumeIOPS,
+					Size:          o.AWS.RootVolumeSize,
+					Type:          o.AWS.RootVolumeType,
+					IOPS:          o.AWS.RootVolumeIOPS,
+					EncryptionKey: o.AWS.RootVolumeEncryptionKey,
 				},
 			}
 			nodePools = append(nodePools, nodePool)

--- a/api/fixtures/example_aws.go
+++ b/api/fixtures/example_aws.go
@@ -5,21 +5,22 @@ import (
 )
 
 type ExampleAWSOptions struct {
-	Region             string
-	Zones              []ExampleAWSOptionsZones
-	VPCID              string
-	SecurityGroupID    string
-	InstanceProfile    string
-	InstanceType       string
-	Roles              hyperv1.AWSRolesRef
-	KMSProviderRoleARN string
-	KMSKeyARN          string
-	RootVolumeSize     int64
-	RootVolumeType     string
-	RootVolumeIOPS     int64
-	ResourceTags       []hyperv1.AWSResourceTag
-	EndpointAccess     string
-	ProxyAddress       string
+	Region                  string
+	Zones                   []ExampleAWSOptionsZones
+	VPCID                   string
+	SecurityGroupID         string
+	InstanceProfile         string
+	InstanceType            string
+	Roles                   hyperv1.AWSRolesRef
+	KMSProviderRoleARN      string
+	KMSKeyARN               string
+	RootVolumeSize          int64
+	RootVolumeType          string
+	RootVolumeIOPS          int64
+	RootVolumeEncryptionKey string
+	ResourceTags            []hyperv1.AWSResourceTag
+	EndpointAccess          string
+	ProxyAddress            string
 }
 
 type ExampleAWSOptionsZones struct {

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -40,6 +40,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AWSPlatform.RootVolumeType, "root-volume-type", opts.AWSPlatform.RootVolumeType, "The type of the root volume (e.g. gp3, io2) for machines in the NodePool")
 	cmd.Flags().Int64Var(&opts.AWSPlatform.RootVolumeIOPS, "root-volume-iops", opts.AWSPlatform.RootVolumeIOPS, "The iops of the root volume when specifying type:io1 for machines in the NodePool")
 	cmd.Flags().Int64Var(&opts.AWSPlatform.RootVolumeSize, "root-volume-size", opts.AWSPlatform.RootVolumeSize, "The size of the root volume (min: 8) for machines in the NodePool")
+	cmd.Flags().StringVar(&opts.AWSPlatform.RootVolumeEncryptionKey, "root-volume-kms-key", opts.AWSPlatform.RootVolumeEncryptionKey, "The KMS key ID or ARN to use for root volume encryption for machines in the NodePool")
 	cmd.Flags().StringSliceVar(&opts.AWSPlatform.AdditionalTags, "additional-tags", opts.AWSPlatform.AdditionalTags, "Additional tags to set on AWS resources")
 	cmd.Flags().StringVar(&opts.AWSPlatform.EndpointAccess, "endpoint-access", opts.AWSPlatform.EndpointAccess, "Access for control plane endpoints (Public, PublicAndPrivate, Private)")
 	cmd.Flags().StringVar(&opts.AWSPlatform.EtcdKMSKeyARN, "kms-key-arn", opts.AWSPlatform.EtcdKMSKeyARN, "The ARN of the KMS key to use for Etcd encryption. If not supplied, etcd encryption will default to using a generated AESCBC key.")
@@ -211,21 +212,22 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	}
 
 	exampleOptions.AWS = &apifixtures.ExampleAWSOptions{
-		Region:             infra.Region,
-		Zones:              zones,
-		VPCID:              infra.VPCID,
-		SecurityGroupID:    infra.SecurityGroupID,
-		InstanceProfile:    iamInfo.ProfileName,
-		InstanceType:       opts.AWSPlatform.InstanceType,
-		Roles:              iamInfo.Roles,
-		KMSProviderRoleARN: iamInfo.KMSProviderRoleARN,
-		KMSKeyARN:          iamInfo.KMSKeyARN,
-		RootVolumeSize:     opts.AWSPlatform.RootVolumeSize,
-		RootVolumeType:     opts.AWSPlatform.RootVolumeType,
-		RootVolumeIOPS:     opts.AWSPlatform.RootVolumeIOPS,
-		ResourceTags:       tags,
-		EndpointAccess:     opts.AWSPlatform.EndpointAccess,
-		ProxyAddress:       infra.ProxyAddr,
+		Region:                  infra.Region,
+		Zones:                   zones,
+		VPCID:                   infra.VPCID,
+		SecurityGroupID:         infra.SecurityGroupID,
+		InstanceProfile:         iamInfo.ProfileName,
+		InstanceType:            opts.AWSPlatform.InstanceType,
+		Roles:                   iamInfo.Roles,
+		KMSProviderRoleARN:      iamInfo.KMSProviderRoleARN,
+		KMSKeyARN:               iamInfo.KMSKeyARN,
+		RootVolumeSize:          opts.AWSPlatform.RootVolumeSize,
+		RootVolumeType:          opts.AWSPlatform.RootVolumeType,
+		RootVolumeIOPS:          opts.AWSPlatform.RootVolumeIOPS,
+		RootVolumeEncryptionKey: opts.AWSPlatform.RootVolumeEncryptionKey,
+		ResourceTags:            tags,
+		EndpointAccess:          opts.AWSPlatform.EndpointAccess,
+		ProxyAddress:            infra.ProxyAddr,
 	}
 	return nil
 }

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -120,21 +120,22 @@ type KubevirtPlatformCreateOptions struct {
 }
 
 type AWSPlatformOptions struct {
-	AWSCredentialsFile string
-	AdditionalTags     []string
-	IAMJSON            string
-	InstanceType       string
-	IssuerURL          string
-	PrivateZoneID      string
-	PublicZoneID       string
-	Region             string
-	RootVolumeIOPS     int64
-	RootVolumeSize     int64
-	RootVolumeType     string
-	EndpointAccess     string
-	Zones              []string
-	EtcdKMSKeyARN      string
-	EnableProxy        bool
+	AWSCredentialsFile      string
+	AdditionalTags          []string
+	IAMJSON                 string
+	InstanceType            string
+	IssuerURL               string
+	PrivateZoneID           string
+	PublicZoneID            string
+	Region                  string
+	RootVolumeIOPS          int64
+	RootVolumeSize          int64
+	RootVolumeType          string
+	RootVolumeEncryptionKey string
+	EndpointAccess          string
+	Zones                   []string
+	EtcdKMSKeyARN           string
+	EnableProxy             bool
 }
 
 type AzurePlatformOptions struct {

--- a/cmd/nodepool/aws/create.go
+++ b/cmd/nodepool/aws/create.go
@@ -11,13 +11,14 @@ import (
 )
 
 type AWSPlatformCreateOptions struct {
-	InstanceProfile string
-	SubnetID        string
-	SecurityGroupID string
-	InstanceType    string
-	RootVolumeType  string
-	RootVolumeIOPS  int64
-	RootVolumeSize  int64
+	InstanceProfile         string
+	SubnetID                string
+	SecurityGroupID         string
+	InstanceType            string
+	RootVolumeType          string
+	RootVolumeIOPS          int64
+	RootVolumeSize          int64
+	RootVolumeEncryptionKey string
 }
 
 func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
@@ -40,6 +41,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	cmd.Flags().StringVar(&platformOpts.RootVolumeType, "root-volume-type", platformOpts.RootVolumeType, "The type of the root volume (e.g. gp3, io2) for machines in the NodePool")
 	cmd.Flags().Int64Var(&platformOpts.RootVolumeIOPS, "root-volume-iops", platformOpts.RootVolumeIOPS, "The iops of the root volume for machines in the NodePool")
 	cmd.Flags().Int64Var(&platformOpts.RootVolumeSize, "root-volume-size", platformOpts.RootVolumeSize, "The size of the root volume (min: 8) for machines in the NodePool")
+	cmd.Flags().StringVar(&platformOpts.RootVolumeEncryptionKey, "root-volume-kms-key", platformOpts.RootVolumeEncryptionKey, "The KMS key ID or ARN to use for root volume encryption for machines in the NodePool")
 
 	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
 
@@ -90,9 +92,10 @@ func (o *AWSPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool 
 			},
 		},
 		RootVolume: &hyperv1.Volume{
-			Type: o.RootVolumeType,
-			Size: o.RootVolumeSize,
-			IOPS: o.RootVolumeIOPS,
+			Type:          o.RootVolumeType,
+			Size:          o.RootVolumeSize,
+			IOPS:          o.RootVolumeIOPS,
+			EncryptionKey: o.RootVolumeEncryptionKey,
 		},
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables setting KMS encryption key for nodepool root volume encryption.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.