### PR TITLE
Fix kubevirt how-to doc formatting issues

### DIFF
--- a/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
+++ b/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
@@ -5,20 +5,11 @@ Install a nested OCP cluster running on VMs within a management OCP cluster
 ## Prerequisites
 
 * Admin access to an OpenShift cluster (version 4.12+) specified by the `KUBECONFIG` environment variable.
-* The management OCP cluster must have wildcard dns routes enabled.
-
-       ```
-       oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
-       ```
+* The management OCP cluster must have wildcard dns routes enabled. `oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'`
 * The management OCP cluster must have Openshift Virtualization installed on it. [Instructions for installing Openshift Virtualization](https://docs.openshift.com/container-platform/4.12/virt/install/installing-virt-web.html)
 * The Management OCP cluster must be configured with OVNKubernetes as the default pod network CNI.
 * The Management OCP cluster must have LoadBalancer service support. [Instructions for installing MetalLB](https://docs.openshift.com/container-platform/4.12/networking/metallb/metallb-operator-install.html)
-* The management OCP cluster must have default storage class. [Storage Configuration Documentation](https://docs.openshift.com/container-platform/4.12/post_installation_configuration/storage-configuration.html)
-    Below is an example of how to annotate a storageclass as the default storageclass.
-
-       ```
-       oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-       ```
+* The management OCP cluster must have default storage class. [Storage Configuration Documentation](https://docs.openshift.com/container-platform/4.12/post_installation_configuration/storage-configuration.html) Example of how to set a default storage class: `oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'`
 * The OpenShift CLI (`oc`) or Kubernetes CLI (`kubectl`).
 * A valid [pull secret](https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned) file for the `quay.io/openshift-release-dev` repository.
 


### PR DESCRIPTION
This fixes some of the formatting issues present in the prerequisites section of this doc, https://hypershift-docs.netlify.app/how-to/kubevirt/create-kubevirt-cluster/ 