### PR TITLE
add PSA labels to openshift-infra in guest cluster

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/namespaces.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/namespaces.go
@@ -5,6 +5,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func NamespaceOpenShiftInfra() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-infra",
+		},
+	}
+}
+
 func NamespaceOpenShiftAPIServer() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/namespaces/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/namespaces/reconcile.go
@@ -5,6 +5,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func ReconcileOpenShiftInfraNamespace(ns *corev1.Namespace) error {
+	if ns.Labels == nil {
+		ns.Labels = map[string]string{}
+	}
+	ns.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
+	ns.Labels["pod-security.kubernetes.io/audit"] = "privileged"
+	ns.Labels["pod-security.kubernetes.io/warn"] = "privileged"
+	return nil
+}
+
 func ReconcileKubeAPIServerNamespace(ns *corev1.Namespace) error {
 	ensureLabels(ns, map[string]string{"openshift.io/cluster-monitoring": "true"})
 	return nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -630,6 +630,7 @@ func (r *reconciler) reconcileNamespaces(ctx context.Context) error {
 		reconcile func(*corev1.Namespace) error
 	}{
 		{manifest: manifests.NamespaceOpenShiftAPIServer},
+		{manifest: manifests.NamespaceOpenShiftInfra, reconcile: namespaces.ReconcileOpenShiftInfraNamespace},
 		{manifest: manifests.NamespaceOpenShiftControllerManager},
 		{manifest: manifests.NamespaceKubeAPIServer, reconcile: namespaces.ReconcileKubeAPIServerNamespace},
 		{manifest: manifests.NamespaceKubeControllerManager},


### PR DESCRIPTION
After https://github.com/openshift/hypershift/pull/2097, conformance test `[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted.` began failing.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-conformance-aws-ovn/1625150475412180992

This is because the recycler pod is being blocked by PSA

```
Recycle failed: unexpected error creating recycler pod: pods "recycler-for-nfs-9mqrj" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "pv-recycler" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "pv-recycler" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "vol" uses restricted volume type "nfs"), runAsNonRoot != true (pod or container "pv-recycler" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "pv-recycler" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

Standalone addressed this in https://github.com/openshift/cluster-kube-controller-manager-operator/pull/647