### PR TITLE
add KAS egress network policy

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3271,9 +3271,16 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 	}
 
 	// Reconcile KAS Network Policy
+	var managementClusterNetwork *configv1.Network
+	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityNetworks) {
+		managementClusterNetwork = &configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(managementClusterNetwork), managementClusterNetwork); err != nil {
+			return fmt.Errorf("failed to get management cluster network config: %w", err)
+		}
+	}
 	policy = networkpolicy.KASNetworkPolicy(controlPlaneNamespaceName)
 	if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
-		return reconcileKASNetworkPolicy(policy, hcluster)
+		return reconcileKASNetworkPolicy(policy, hcluster, r.ManagementClusterCapabilities.Has(capabilities.CapabilityDNS), managementClusterNetwork)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile kube-apiserver network policy: %w", err)
 	}
@@ -3623,9 +3630,10 @@ func reconcileSameNamespaceNetworkPolicy(policy *networkingv1.NetworkPolicy) err
 	return nil
 }
 
-func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster) error {
+func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster, isOpenShiftDNS bool, managementClusterNetwork *configv1.Network) error {
 	port := intstr.FromInt(kas.APIServerListenPort)
 	protocol := corev1.ProtocolTCP
+	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
 	policy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
 		{
 			From: []networkingv1.NetworkPolicyPeer{},
@@ -3652,12 +3660,96 @@ func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyp
 		})
 	}
 
+	// NetworkPolicy egress is broken for 4.11 on OpenShiftSDN, this is a workaround
+	// https://issues.redhat.com/browse/OCPBUGS-2105
+	if managementClusterNetwork != nil && managementClusterNetwork.Spec.NetworkType != "OpenShiftSDN" {
+		// Allow traffic to same namespace
+		policy.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{},
+					},
+				},
+			},
+		}
+
+		if len(managementClusterNetwork.Spec.ClusterNetwork) > 0 {
+			clusterNetworks := []string{}
+			for _, network := range managementClusterNetwork.Spec.ClusterNetwork {
+				clusterNetworks = append(clusterNetworks, network.CIDR)
+			}
+
+			// Allow to any destination not on the management cluster service network
+			// i.e. block all inter-namespace egress from KAS not allowed by other rules
+			policy.Spec.Egress = append(policy.Spec.Egress,
+				networkingv1.NetworkPolicyEgressRule{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							IPBlock: &networkingv1.IPBlock{
+								CIDR:   "0.0.0.0/0",
+								Except: clusterNetworks,
+							},
+						},
+					},
+				})
+		}
+
+		if isOpenShiftDNS {
+			// Allow traffic to openshift-dns namespace
+			dnsUDPPort := intstr.FromInt(5353)
+			dnsUDPProtocol := corev1.ProtocolUDP
+			dnsTCPPort := intstr.FromInt(5353)
+			dnsTCPProtocol := corev1.ProtocolTCP
+			policy.Spec.Egress = append(policy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "openshift-dns",
+							},
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Port:     &dnsUDPPort,
+						Protocol: &dnsUDPProtocol,
+					},
+					{
+						Port:     &dnsTCPPort,
+						Protocol: &dnsTCPProtocol,
+					},
+				},
+			})
+		} else {
+			// All traffic to any destination on port 53 for both TCP and UDP
+			dnsUDPPort := intstr.FromInt(53)
+			dnsUDPProtocol := corev1.ProtocolUDP
+			dnsTCPPort := intstr.FromInt(53)
+			dnsTCPProtocol := corev1.ProtocolTCP
+			policy.Spec.Egress = append(policy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Port:     &dnsUDPPort,
+						Protocol: &dnsUDPProtocol,
+					},
+					{
+						Port:     &dnsTCPPort,
+						Protocol: &dnsTCPProtocol,
+					},
+				},
+			})
+		}
+		policy.Spec.PolicyTypes = append(policy.Spec.PolicyTypes, networkingv1.PolicyTypeEgress)
+	}
+
 	policy.Spec.PodSelector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"app": "kube-apiserver",
 		},
 	}
-	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
+
 	return nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -844,6 +844,14 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 				".dockerconfigjson": []byte("{}"),
 			},
 		},
+		&configv1.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster",
+			},
+			Spec: configv1.NetworkSpec{
+				NetworkType: "OVNKubernetes",
+			},
+		},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "agent-namespace"}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "agent"}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "aws"}},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
@@ -72,6 +72,14 @@ func TestWebhookAllowsHostedClusterReconcilerUpdates(t *testing.T) {
 				},
 				&configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "none-cluster"}},
+				&configv1.Network{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.NetworkSpec{
+						NetworkType: "OVNKubernetes",
+					},
+				},
 			},
 		},
 	}

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -37,6 +37,14 @@ const (
 	// CapabilityProxy indicates if the cluster supports the
 	// proxies.config.openshift.io api
 	CapabilityProxy
+
+	// CapabilityDNS indicates if the cluster supports the
+	// dnses.config.openshift.io api
+	CapabilityDNS
+
+	// CapabilityNetworks indicates if the cluster supports the
+	// networks.config.openshift.io api
+	CapabilityNetworks
 )
 
 // ManagementClusterCapabilities holds all information about optional capabilities of
@@ -125,6 +133,24 @@ func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterfa
 	}
 	if hasProxyCap {
 		discoveredCapabilities[CapabilityProxy] = struct{}{}
+	}
+
+	// check for dns capability
+	hasDNSCap, err := isAPIResourceRegistered(client, configv1.GroupVersion, "dnses")
+	if err != nil {
+		return nil, err
+	}
+	if hasDNSCap {
+		discoveredCapabilities[CapabilityDNS] = struct{}{}
+	}
+
+	// check for networks capability
+	hasNetworksCap, err := isAPIResourceRegistered(client, configv1.GroupVersion, "networks")
+	if err != nil {
+		return nil, err
+	}
+	if hasNetworksCap {
+		discoveredCapabilities[CapabilityNetworks] = struct{}{}
 	}
 
 	return &ManagementClusterCapabilities{capabilities: discoveredCapabilities}, nil


### PR DESCRIPTION
Once more!

https://issues.redhat.com/browse/HOSTEDCP-829

The objective of the policy is to block service network egress traffic outside the HCP namespace for the KAS, the one exception being access to DNS in the `openshift-dns` namespace.

Resulting policy on an OCP mgmt cluster

```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: kas
spec:
  egress:
  - to:
    - podSelector: {}
  - to:
    - ipBlock:
        cidr: 0.0.0.0/0
        except:
        - 172.29.0.0/16
  - ports:
    - port: 5353
      protocol: UDP
    - port: 5353
      protocol: TCP
    to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: openshift-dns
  ingress:
  - ports:
    - port: 6443
      protocol: TCP
  - ports:
    - port: 443
      protocol: TCP
  podSelector:
    matchLabels:
      app: kube-apiserver
  policyTypes:
  - Ingress
  - Egress
```