### PR TITLE
cpo: kcm: add nfs pv recycler pod template

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2183,6 +2183,13 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 		return fmt.Errorf("failed to reconcile kcm serving ca: %w", err)
 	}
 
+	recyclerConfig := manifests.RecyclerConfigMap(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, recyclerConfig, func() error {
+		return kcm.ReconcileRecyclerConfig(recyclerConfig, p.OwnerRef)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile kcm recycler config: %w", err)
+	}
+
 	clientCertSecret := manifests.KubeControllerManagerClientCertSecret(hcp.Namespace)
 	if err := r.Get(ctx, client.ObjectKeyFromObject(clientCertSecret), clientCertSecret); err != nil {
 		return fmt.Errorf("failed to get KCM client cert secret: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
@@ -17,6 +17,7 @@ import (
 const (
 	KubeControllerManagerConfigKey = "config.json"
 	ServiceServingCAKey            = "service-ca.crt"
+	RecyclerPodTemplateKey         = "recycler-pod.yaml"
 )
 
 func ReconcileConfig(config, serviceServingCA *corev1.ConfigMap, ownerRef config.OwnerRef) error {
@@ -67,5 +68,46 @@ func ReconcileKCMServiceServingCA(cm, combinedCA *corev1.ConfigMap, ownerRef con
 
 func ReconcileServiceAccount(sa *corev1.ServiceAccount) error {
 	// nothing to reconcile
+	return nil
+}
+
+func ReconcileRecyclerConfig(config *corev1.ConfigMap, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(config)
+	if config.Data == nil {
+		config.Data = map[string]string{}
+	}
+	// https://github.com/openshift/cluster-kube-controller-manager-operator/blob/64b4c1ba/bindata/assets/kube-controller-manager/recycler-cm.yaml
+	config.Data[RecyclerPodTemplateKey] = `apiVersion: v1
+kind: Pod
+metadata:
+  name: recycler-pod
+  namespace: openshift-infra
+  annotations:
+  target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+spec:
+  activeDeadlineSeconds: 60
+  restartPolicy: Never
+  serviceAccountName: pv-recycler-controller
+  containers:
+  - name: recycler-container
+    image: quay.io/openshift/origin-tools:latest
+    command:
+    - "/bin/bash"
+    args:
+    - "-c"
+    - "test -e /scrub && rm -rf /scrub/..?* /scrub/.[!.]* /scrub/*  && test -z \"$(ls -A /scrub)\" || exit 1"
+    volumeMounts:
+    - mountPath: /scrub
+      name: vol
+    securityContext:
+    runAsUser: 0
+    priorityClassName: openshift-user-critical
+    resources:
+    requests:
+      memory: 50Mi
+      cpu: 10m
+  volumes:
+  - name: vol
+`
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kcm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kcm.go
@@ -55,3 +55,12 @@ func KCMService(controlPlaneNamespace string) *corev1.Service {
 func KCMKubeconfigSecret(controlPlaneNamespace string) *corev1.Secret {
 	return secretFor(controlPlaneNamespace, "kube-controller-manager-kubeconfig")
 }
+
+func RecyclerConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recycler-config",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/kcm.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/kcm.go
@@ -1,0 +1,15 @@
+package manifests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func RecyclerServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pv-recycler-controller",
+			Namespace: "openshift-infra",
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -481,6 +481,13 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		}
 	}
 
+	recyclerServiceAccount := manifests.RecyclerServiceAccount()
+	if _, err := r.CreateOrUpdate(ctx, r.client, recyclerServiceAccount, func() error {
+		return nil
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile pv recycler service account: %w", err))
+	}
+
 	log.Info("reconciling observed configuration")
 	errs = append(errs, r.reconcileObservedConfiguration(ctx, hcp)...)
 


### PR DESCRIPTION
Follow on to https://github.com/openshift/hypershift/pull/2180

KCM currently isn't configured with the PV recycle pod template that standalone uses

https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/bindata/assets/config/defaultconfig.yaml#L15

https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/bindata/assets/kube-controller-manager/recycler-cm.yaml

Because of this, the default pv recycler from upstream kube is started in the `default` namespace rather than `openshift-infra`, resulting in a failed in conformance due to PSA policy.

This PR aligns Hypershift KCM with standalone.