### PR TITLE
fix(ibmcloud): Explicitly set HCCO controllers

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -314,6 +314,9 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 			fmt.Sprintf("--oauth-address=%s", oauthAddress),
 			fmt.Sprintf("--oauth-port=%d", oauthPort),
 		}
+		if platformType == hyperv1.IBMCloudPlatform {
+			c.Command = append(c.Command, "--controllers=controller-manager-ca,resources,inplaceupgrader,drainer,hcpstatus")
+		}
 		c.Ports = []corev1.ContainerPort{{Name: "metrics", ContainerPort: 8080}}
 		c.Env = []corev1.EnvVar{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
This disables the node controller on HCCO for IBM Cloud. For IBM Cloud, nodes are not managed through the CAPI system. This will help us ensure that nodes will never be touched by HCCO and reduce control plane load by removing unnecessary watches on resources.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.