### PR TITLE
Add default NodePool name clarification to docs

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -107,7 +107,13 @@ hypershift create cluster aws \
 !!! note
 
     A default NodePool will be created for the cluster with 3 replicas per the
-    `--node-pool-replicas` flag.
+    `--node-pool-replicas` flag. 
+
+!!! note 
+
+    The default NodePool name will be a combination of your cluster name and zone name for 
+    AWS (example, `example-us-east-1a`). For other providers, the default NodePool 
+    name will be the same as the cluster name.
 
 !!! note
 
@@ -119,8 +125,12 @@ namespace and when ready it will look similar to the following:
 
 ```
 oc get --namespace clusters hostedclusters
-NAME      VERSION   KUBECONFIG                 AVAILABLE
-example   4.8.0     example-admin-kubeconfig   True
+NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+example   4.12.0    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
+
+oc get nodepools --namespace clusters
+NAME                 CLUSTER   DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
+example-us-east-1a   example   2               2               False         False        4.12.0
 ```
 
 Eventually the cluster's kubeconfig will become available and can be printed to


### PR DESCRIPTION
**What this PR does / why we need it**:
Add default NodePool name clarification to documentation to explain what the default NodePool name is when creating a cluster with the --node-pool-replicas flag. Also, expanded hosted cluster ready example to show what how the NodePools appear when ready.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.