### PR TITLE
HOSTEDCP-593: Update the pull secret source for ignition payload

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
@@ -31,10 +31,6 @@ func ReconcileMachineConfigServerConfig(cm *corev1.ConfigMap, p *MCSParams) erro
 	if err != nil {
 		return err
 	}
-	serializedPullSecret, err := serialize(p.PullSecret)
-	if err != nil {
-		return err
-	}
 	serializedMasterConfigPool, err := serializeConfigPool(masterConfigPool())
 	if err != nil {
 		return err
@@ -53,13 +49,12 @@ func ReconcileMachineConfigServerConfig(cm *corev1.ConfigMap, p *MCSParams) erro
 	}
 
 	cm.Data["root-ca.crt"] = string(p.RootCA.Data[certs.CASignerCertMapKey])
-	cm.Data["signer-ca.crt"] = string(p.KubeletClientCA.Data[certs.CASignerCertMapKey])
+	cm.Data["signer-ca.crt"] = p.KubeletClientCA.Data[certs.CASignerCertMapKey]
 	cm.Data["cluster-dns-02-config.yaml"] = serializedDNS
 	cm.Data["cluster-infrastructure-02-config.yaml"] = serializedInfra
 	cm.Data["cluster-network-02-config.yaml"] = serializedNetwork
 	cm.Data["cluster-proxy-01-config.yaml"] = serializedProxy
 	cm.Data["install-config.yaml"] = p.InstallConfig.String()
-	cm.Data["pull-secret.yaml"] = serializedPullSecret
 	cm.Data["master.machineconfigpool.yaml"] = serializedMasterConfigPool
 	cm.Data["worker.machineconfigpool.yaml"] = serializedWorkerConfigPool
 	return nil

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,7 +19,7 @@ import (
 	"github.com/openshift/api/operator/v1alpha1"
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
-	api "github.com/openshift/hypershift/api"
+	"github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -82,6 +81,7 @@ const (
 	TokenSecretTokenGenerationTime            = "hypershift.openshift.io/last-token-generation-time"
 	TokenSecretReleaseKey                     = "release"
 	TokenSecretTokenKey                       = "token"
+	TokenSecretPullSecretHashKey              = "pull-secret-hash"
 	TokenSecretConfigKey                      = "config"
 	TokenSecretAnnotation                     = "hypershift.openshift.io/ignition-config"
 	TokenSecretIgnitionReachedAnnotation      = "hypershift.openshift.io/ignition-reached"
@@ -461,7 +461,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	// Validate config input.
-	// 3 generic core config resoures: fips, ssh and haproxy.
+	// 3 generic core config resources: fips, ssh and haproxy.
 	// TODO (alberto): consider moving the expectedCoreConfigResources check
 	// into the token Secret controller so we don't block Machine infra creation on this.
 	expectedCoreConfigResources := 3
@@ -510,7 +510,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	// Check if config needs to be updated.
-	targetConfigHash := hashStruct(config + pullSecretName)
+	targetConfigHash := supportutil.HashStruct(config + pullSecretName)
 	isUpdatingConfig := isUpdatingConfig(nodePool, targetConfigHash)
 	if isUpdatingConfig {
 		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
@@ -545,7 +545,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	// Signal ignition payload generation
-	targetPayloadConfigHash := hashStruct(config + targetVersion + pullSecretName)
+	targetPayloadConfigHash := supportutil.HashStruct(config + targetVersion + pullSecretName)
 	tokenSecret := TokenSecret(controlPlaneNamespace, nodePool.Name, targetPayloadConfigHash)
 	condition, err := r.createValidGeneratedPayloadCondition(ctx, tokenSecret, nodePool.Generation)
 	if err != nil {
@@ -764,8 +764,12 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 
 	tokenSecret = TokenSecret(controlPlaneNamespace, nodePool.Name, targetPayloadConfigHash)
+	pullSecretBytes, err := r.getPullSecretBytes(ctx, hcluster)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get pull secret bytes: %w", err)
+	}
 	if result, err := r.CreateOrUpdate(ctx, r.Client, tokenSecret, func() error {
-		return reconcileTokenSecret(tokenSecret, nodePool, compressedConfig.Bytes())
+		return reconcileTokenSecret(tokenSecret, nodePool, compressedConfig.Bytes(), pullSecretBytes)
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile token Secret: %w", err)
 	} else {
@@ -1175,8 +1179,8 @@ func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.No
 	// The token secret controller deletes expired token Secrets.
 	// When that happens the NodePool controller reconciles and create a new one.
 	// Then it reconciles the userData Secret with the new generated token.
-	// Therefore this secret is mutable.
-	userDataSecret.Immutable = k8sutilspointer.BoolPtr(false)
+	// Therefore, this secret is mutable.
+	userDataSecret.Immutable = k8sutilspointer.Bool(false)
 
 	if userDataSecret.Annotations == nil {
 		userDataSecret.Annotations = make(map[string]string)
@@ -1201,7 +1205,7 @@ func reconcileUserDataSecret(userDataSecret *corev1.Secret, nodePool *hyperv1.No
 // This is used to mirror the Tuned object manifest into the control plane namespace, for the Node
 // Tuning Operator to mirror and reconcile in the hosted cluster.
 func reconcileTuningConfigMap(tuningConfigMap *corev1.ConfigMap, nodePool *hyperv1.NodePool, tuningConfig string) error {
-	tuningConfigMap.Immutable = k8sutilspointer.BoolPtr(false)
+	tuningConfigMap.Immutable = k8sutilspointer.Bool(false)
 	if tuningConfigMap.Annotations == nil {
 		tuningConfigMap.Annotations = make(map[string]string)
 	}
@@ -1221,11 +1225,11 @@ func reconcileTuningConfigMap(tuningConfigMap *corev1.ConfigMap, nodePool *hyper
 	return nil
 }
 
-func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool, compressedConfig []byte) error {
+func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool, compressedConfig []byte, pullSecret []byte) error {
 	// The token secret controller updates expired token IDs for token Secrets.
 	// When that happens the NodePool controller reconciles the userData Secret with the new token ID.
-	// Therefore this secret is mutable.
-	tokenSecret.Immutable = k8sutilspointer.BoolPtr(false)
+	// Therefore, this secret is mutable.
+	tokenSecret.Immutable = k8sutilspointer.Bool(false)
 	if tokenSecret.Annotations == nil {
 		tokenSecret.Annotations = make(map[string]string)
 	}
@@ -1242,6 +1246,7 @@ func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool
 		tokenSecret.Data[TokenSecretTokenKey] = []byte(uuid.New().String())
 		tokenSecret.Data[TokenSecretReleaseKey] = []byte(nodePool.Spec.Release.Image)
 		tokenSecret.Data[TokenSecretConfigKey] = compressedConfig
+		tokenSecret.Data[TokenSecretPullSecretHashKey] = []byte(supportutil.HashStruct(pullSecret))
 	}
 	return nil
 }
@@ -1268,7 +1273,7 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 	machineDeployment.Labels[capiv1.ClusterLabelName] = CAPIClusterName
 
 	resourcesName := generateName(CAPIClusterName, nodePool.Spec.ClusterName, nodePool.GetName())
-	machineDeployment.Spec.MinReadySeconds = k8sutilspointer.Int32Ptr(int32(0))
+	machineDeployment.Spec.MinReadySeconds = k8sutilspointer.Int32(int32(0))
 
 	gvk, err := apiutil.GVKForObject(machineTemplateCR, api.Scheme)
 	if err != nil {
@@ -1278,9 +1283,9 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 	// Set defaults. These are normally set by the CAPI machinedeployment webhook.
 	// However, since we don't run the webhook, CAPI updates the machinedeployment
 	// after it has been created with defaults.
-	machineDeployment.Spec.MinReadySeconds = k8sutilspointer.Int32Ptr(0)
-	machineDeployment.Spec.RevisionHistoryLimit = k8sutilspointer.Int32Ptr(1)
-	machineDeployment.Spec.ProgressDeadlineSeconds = k8sutilspointer.Int32Ptr(600)
+	machineDeployment.Spec.MinReadySeconds = k8sutilspointer.Int32(0)
+	machineDeployment.Spec.RevisionHistoryLimit = k8sutilspointer.Int32(1)
+	machineDeployment.Spec.ProgressDeadlineSeconds = k8sutilspointer.Int32(600)
 
 	// Set selector and template
 	machineDeployment.Spec.ClusterName = CAPIClusterName
@@ -1325,7 +1330,7 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 	// Propagate labels.
 	for k, v := range nodePool.Spec.NodeLabels {
 		// Propagated managed labels down to Machines with a known hardcoded prefix
-		// so the CPO HCCO Node controller can recongnise them and apply them to Nodes.
+		// so the CPO HCCO Node controller can recognize them and apply them to Nodes.
 		labelKey := fmt.Sprintf("%s.%s", labelManagedPrefix, k)
 		machineDeployment.Spec.Template.Labels[labelKey] = v
 	}
@@ -1348,12 +1353,12 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 	}
 
 	// Propagate version and userData Secret to the machineDeployment.
-	if userDataSecret.Name != k8sutilspointer.StringPtrDerefOr(machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName, "") {
+	if userDataSecret.Name != k8sutilspointer.StringDeref(machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName, "") {
 		log.Info("New user data Secret has been generated",
 			"current", machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName,
 			"target", userDataSecret.Name)
 
-		if targetVersion != k8sutilspointer.StringPtrDerefOr(machineDeployment.Spec.Template.Spec.Version, "") {
+		if targetVersion != k8sutilspointer.StringDeref(machineDeployment.Spec.Template.Spec.Version, "") {
 			log.Info("Starting version update: Propagating new version to the MachineDeployment",
 				"releaseImage", nodePool.Spec.Release.Image, "target", targetVersion)
 		}
@@ -1363,7 +1368,7 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 				"current", nodePool.Annotations[nodePoolAnnotationCurrentConfig], "target", targetConfigHash)
 		}
 		machineDeployment.Spec.Template.Spec.Version = &targetVersion
-		machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName = k8sutilspointer.StringPtr(userDataSecret.Name)
+		machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName = k8sutilspointer.String(userDataSecret.Name)
 
 		// We return early here during a version/config update to persist the resource with new user data Secret,
 		// so in the next reconciling loop we get a new MachineDeployment.Generation
@@ -1484,7 +1489,7 @@ func setMachineDeploymentReplicas(nodePool *hyperv1.NodePool, machineDeployment 
 		// if the MachineSetReplicas is not in the spec will be set as 0, and here will be
 		// evaluated. If autoscaler is activated, the replicas will have the same number as
 		// minimum number of replicas set in the MachineSet spec.
-		if k8sutilspointer.Int32PtrDerefOr(machineDeployment.Spec.Replicas, 0) == 0 {
+		if k8sutilspointer.Int32Deref(machineDeployment.Spec.Replicas, 0) == 0 {
 			// if autoscaling is enabled and the machineDeployment does not exist yet or it has 0 replicas
 			// we set the replicas to the Autoscaling minimum value, autoscaler does not support scaling from zero yet.
 			machineDeployment.Spec.Replicas = &nodePool.Spec.AutoScaling.Min
@@ -1497,7 +1502,7 @@ func setMachineDeploymentReplicas(nodePool *hyperv1.NodePool, machineDeployment 
 	if !isAutoscalingEnabled(nodePool) {
 		machineDeployment.Annotations[autoscalerMaxAnnotation] = "0"
 		machineDeployment.Annotations[autoscalerMinAnnotation] = "0"
-		machineDeployment.Spec.Replicas = k8sutilspointer.Int32Ptr(k8sutilspointer.Int32PtrDerefOr(nodePool.Spec.Replicas, 0))
+		machineDeployment.Spec.Replicas = k8sutilspointer.Int32(k8sutilspointer.Int32Deref(nodePool.Spec.Replicas, 0))
 	}
 }
 
@@ -1509,7 +1514,7 @@ func ignConfig(encodedCACert, encodedToken, endpoint, targetConfigVersionHash st
 				TLS: ignitionapi.TLS{
 					CertificateAuthorities: []ignitionapi.Resource{
 						{
-							Source: k8sutilspointer.StringPtr(fmt.Sprintf("data:text/plain;base64,%s", encodedCACert)),
+							Source: k8sutilspointer.String(fmt.Sprintf("data:text/plain;base64,%s", encodedCACert)),
 						},
 					},
 				},
@@ -1683,7 +1688,7 @@ func (r *NodePoolReconciler) getTuningConfig(ctx context.Context,
 		allConfigPlainText = append(allConfigPlainText, string(manifest))
 	}
 
-	// Keep output deterministic to avoid unnecesary no-op changes to Tuned ConfigMap
+	// Keep output deterministic to avoid unnecessary no-op changes to Tuned ConfigMap
 	sort.Strings(allConfigPlainText)
 	return strings.Join(allConfigPlainText, "\n---\n"), utilerrors.NewAggregate(errors)
 }
@@ -2110,13 +2115,6 @@ func (r *NodePoolReconciler) listMachineTemplates(nodePool *hyperv1.NodePool) ([
 	return filtered, nil
 }
 
-func hashStruct(o interface{}) string {
-	hash := fnv.New32a()
-	hash.Write([]byte(fmt.Sprintf("%v", o)))
-	intHash := hash.Sum32()
-	return fmt.Sprintf("%08x", intHash)
-}
-
 // TODO (alberto) drop this deterministic naming logic and get the name for child MachineDeployment from the status/annotation/label?
 func generateName(infraName, clusterName, suffix string) string {
 	return getName(fmt.Sprintf("%s-%s", infraName, clusterName), suffix, 43)
@@ -2143,13 +2141,13 @@ func getName(base, suffix string, maxLength int) string {
 	if baseLength < 1 {
 		prefix := base[0:min(len(base), max(0, maxLength-9))]
 		// Calculate hash on initial base-suffix string
-		shortName := fmt.Sprintf("%s-%s", prefix, hashStruct(name))
+		shortName := fmt.Sprintf("%s-%s", prefix, supportutil.HashStruct(name))
 		return shortName[:min(maxLength, len(shortName))]
 	}
 
 	prefix := base[0:baseLength]
 	// Calculate hash on initial base-suffix string
-	return fmt.Sprintf("%s-%s-%s", prefix, hashStruct(base), suffix)
+	return fmt.Sprintf("%s-%s-%s", prefix, supportutil.HashStruct(base), suffix)
 }
 
 // max returns the greater of its 2 inputs

--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -103,7 +103,7 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 		ImageFileCache:  imageFileCache,
 	}
 
-	payload, err := p.GetPayload(ctx, o.Image, config.String())
+	payload, err := p.GetPayload(ctx, o.Image, config.String(), "")
 	if err != nil {
 		return err
 	}

--- a/ignition-server/controllers/machineconfigserver_ignitionprovider.go
+++ b/ignition-server/controllers/machineconfigserver_ignitionprovider.go
@@ -44,7 +44,7 @@ type MCSIgnitionProvider struct {
 	Namespace       string
 }
 
-func (p *MCSIgnitionProvider) GetPayload(ctx context.Context, releaseImage string, config string) (payload []byte, err error) {
+func (p *MCSIgnitionProvider) GetPayload(ctx context.Context, releaseImage string, config string, pullSecretHash string) (payload []byte, err error) {
 	pullSecret := &corev1.Secret{}
 	if err := p.Client.Get(ctx, client.ObjectKey{Namespace: p.Namespace, Name: pullSecretName}, pullSecret); err != nil {
 		return nil, fmt.Errorf("failed to get pull secret: %w", err)
@@ -65,7 +65,7 @@ func (p *MCSIgnitionProvider) GetPayload(ctx context.Context, releaseImage strin
 
 	// The ConfigMap requires data stored to be a string.
 	// By base64ing the compressed data we ensure all bytes are decodable back.
-	// Otherwise if we'd just string() the bytes, some might not be a valid UTF-8 sequence
+	// Otherwise, if we'd just string() the bytes, some might not be a valid UTF-8 sequence,
 	// and we might lose data.
 	compressedAndEncodedConfig, err := util.CompressAndEncode([]byte(config))
 	if err != nil {
@@ -277,8 +277,8 @@ cat /tmp/custom-config/base64CompressedConfig | base64 -d | gunzip --force --std
 			},
 		},
 		Spec: corev1.PodSpec{
-			TerminationGracePeriodSeconds: k8sutilspointer.Int64Ptr(10),
-			EnableServiceLinks:            k8sutilspointer.BoolPtr(true),
+			TerminationGracePeriodSeconds: k8sutilspointer.Int64(10),
+			EnableServiceLinks:            k8sutilspointer.Bool(true),
 			Subdomain:                     mcsPodSubdomain,
 			Hostname:                      podName,
 			Tolerations: []corev1.Toleration{
@@ -407,7 +407,7 @@ cat /tmp/custom-config/base64CompressedConfig | base64 -d | gunzip --force --std
 					Name: "kubeconfig",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: k8sutilspointer.Int32Ptr(0640),
+							DefaultMode: k8sutilspointer.Int32(0640),
 							SecretName:  "bootstrap-kubeconfig",
 						},
 					},
@@ -416,7 +416,7 @@ cat /tmp/custom-config/base64CompressedConfig | base64 -d | gunzip --force --std
 					Name: "mcs-tls",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: k8sutilspointer.Int32Ptr(0640),
+							DefaultMode: k8sutilspointer.Int32(0640),
 							SecretName:  "mcs-crt",
 						},
 					},
@@ -475,7 +475,7 @@ func machineConfigServerConfigConfigMap(namespace, config string) *corev1.Config
 			Namespace:    namespace,
 			GenerateName: resourceGenerateName,
 		},
-		Immutable: k8sutilspointer.BoolPtr(true),
+		Immutable: k8sutilspointer.Bool(true),
 		Data: map[string]string{
 			TokenSecretConfigKey: config,
 		},

--- a/ignition-server/controllers/tokensecret_controller_test.go
+++ b/ignition-server/controllers/tokensecret_controller_test.go
@@ -25,7 +25,7 @@ var (
 
 type fakeIgnitionProvider struct{}
 
-func (p *fakeIgnitionProvider) GetPayload(ctx context.Context, releaseImage string, config string) (payload []byte, err error) {
+func (p *fakeIgnitionProvider) GetPayload(ctx context.Context, releaseImage string, config string, pullSecretHash string) (payload []byte, err error) {
 	return []byte(fakePayload), nil
 }
 

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"net"
 	"strings"
@@ -165,4 +166,12 @@ func ResolveDNSHostname(ctx context.Context, hostName string) error {
 	}
 
 	return err
+}
+
+// HashStruct takes a value, typically a string, and returns a 32-bit FNV-1a hashed version of the value as a string
+func HashStruct(o interface{}) string {
+	hash := fnv.New32a()
+	hash.Write([]byte(fmt.Sprintf("%v", o)))
+	intHash := hash.Sum32()
+	return fmt.Sprintf("%08x", intHash)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the race condition between the MCS ConfigMap update and ignition payload creation - updates the pull secret source for ignition payload. The NodePool controller will save a hash of the pull secret in every newly created token secret. During creation of an ignition payload, a comparison between the token secret's pull secret hash and a hash of the pull secret will be made to ensure they match. The pull secret will be written to the bootstrap config directory, overwriting the one from the MCS ConfigMap.

**Which issue(s) this PR fixes**:
[HOSTEDCP-593](https://issues.redhat.com/browse/HOSTEDCP-593)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.