### PR TITLE
HOSTEDCP-833: Add Golang check for 'go list' errors in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ deps:
 	$(GO) mod tidy
 	$(GO) mod vendor
 	$(GO) mod verify
+	$(GO) list -m -mod=readonly -json all > /dev/null
 
 # Run staticcheck
 # How to ignore failures https://staticcheck.io/docs/configuration#line-based-linter-directives


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Golang check for 'go list' errors in Makefile within deps section.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-833](https://issues.redhat.com/browse/HOSTEDCP-833)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.