### PR TITLE
HOSTEDCP-833: Set kubevirt.io/client-go version to fix ART Issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,6 +185,7 @@ require (
 replace (
 	k8s.io/client-go => k8s.io/client-go v0.25.2
 	k8s.io/kubernetes => k8s.io/kubernetes v0.23.3
+	kubevirt.io/client-go => kubevirt.io/client-go v0.0.0-00010101000000-000000000000
 	kubevirt.io/containerized-data-importer-api => github.com/kubevirt/containerized-data-importer-api v1.41.1-0.20211201033752-05520fb9f18d
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.24
 	sigs.k8s.io/cluster-api-provider-ibmcloud => github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20221007162602-5e3a2bae34bd

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1415,6 +1415,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # k8s.io/client-go => k8s.io/client-go v0.25.2
 # k8s.io/kubernetes => k8s.io/kubernetes v0.23.3
+# kubevirt.io/client-go => kubevirt.io/client-go v0.0.0-00010101000000-000000000000
 # kubevirt.io/containerized-data-importer-api => github.com/kubevirt/containerized-data-importer-api v1.41.1-0.20211201033752-05520fb9f18d
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.24
 # sigs.k8s.io/cluster-api-provider-ibmcloud => github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20221007162602-5e3a2bae34bd


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an art issue with respect to go dependency checks in Cachito.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-833](https://issues.redhat.com/browse/HOSTEDCP-833)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.