### PR TITLE
ensure reconcilation of apiserver port

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -113,7 +113,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	if util.IsPrivateHCP(hcp) {
 		p.APIServerAddress = fmt.Sprintf("api.%s.hypershift.local", hcp.Name)
-		p.APIServerPort = util.APIPortWithDefault(hcp, config.DefaultAPIServerPort)
+		p.APIServerPort = util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort)
 	} else {
 		p.APIServerAddress = hcp.Status.ControlPlaneEndpoint.Host
 		p.APIServerPort = hcp.Status.ControlPlaneEndpoint.Port

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -114,7 +114,7 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 						KeyFile:  path.Join(volumeMounts.Path(kasContainerMain().Name, kasVolumeServerCert().Name), corev1.TLSPrivateKeyKey),
 					},
 					NamedCertificates: globalconfig.GetConfigNamedCertificates(p.NamedCertificates, kasNamedCertificateMountPathPrefix),
-					BindAddress:       fmt.Sprintf("0.0.0.0:%d", APIServerListenPort),
+					BindAddress:       fmt.Sprintf("0.0.0.0:%d", p.APIServerPort),
 					BindNetwork:       "tcp4",
 					CipherSuites:      hcpconfig.CipherSuites(p.TLSSecurityProfile),
 					MinTLSVersion:     hcpconfig.MinTLSVersion(p.TLSSecurityProfile),

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -41,7 +41,7 @@ func InClusterKASReadyURL(namespace string, securePort *int32) string {
 }
 
 func ReconcileLocalhostKubeconfigSecret(secret, cert *corev1.Secret, ca *corev1.ConfigMap, ownerRef config.OwnerRef, apiServerPort int32) error {
-	localhostURL := fmt.Sprintf("https://localhost:%d", APIServerListenPort)
+	localhostURL := fmt.Sprintf("https://localhost:%d", apiServerPort)
 	return pki.ReconcileKubeConfig(secret, cert, ca, localhostURL, "", manifests.KubeconfigScopeLocal, ownerRef)
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
@@ -15,14 +15,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef config.OwnerRef, clusterID string, metricsSet metrics.MetricsSet) error {
+func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, apiServerPort int, ownerRef config.OwnerRef, clusterID string, metricsSet metrics.MetricsSet) error {
 	ownerRef.ApplyTo(sm)
 
 	sm.Spec.Selector.MatchLabels = kasLabels()
 	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
 		MatchNames: []string{sm.Namespace},
 	}
-	targetPort := intstr.FromInt(APIServerListenPort)
+	targetPort := intstr.FromInt(apiServerPort)
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
 			Interval:   "15s",

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -87,7 +87,7 @@ func ReconcileServiceAccountKubeconfig(secret, csrSigner *corev1.Secret, ca *cor
 	if err := reconcileSignedCert(secret, csrSigner, config.OwnerRef{}, cn, serviceaccount.MakeGroupNames(serviceAccountNamespace), X509UsageClientAuth); err != nil {
 		return fmt.Errorf("failed to reconcile serviceaccount client cert: %w", err)
 	}
-	svcURL := inClusterKASURL(hcp.Namespace, util.APIPortWithDefault(hcp, config.DefaultAPIServerPort))
+	svcURL := inClusterKASURL(hcp.Namespace, util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort))
 
 	return ReconcileKubeConfig(secret, secret, ca, svcURL, "", manifests.KubeconfigScopeLocal, config.OwnerRef{})
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -46,7 +46,6 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/autoscaler"
 	ignitionserverreconciliation "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ignitionserver"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/machineapprover"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform"
 	platformaws "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
@@ -3631,7 +3630,7 @@ func reconcileSameNamespaceNetworkPolicy(policy *networkingv1.NetworkPolicy) err
 }
 
 func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster, isOpenShiftDNS bool, managementClusterNetwork *configv1.Network) error {
-	port := intstr.FromInt(kas.APIServerListenPort)
+	port := intstr.FromInt(int(hyperutil.BindAPIPortWithDefaultFromHostedCluster(hcluster, config.DefaultAPIServerPort)))
 	protocol := corev1.ProtocolTCP
 	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
 	policy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
@@ -3645,19 +3644,20 @@ func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyp
 			},
 		},
 	}
-
 	// We have to keep this in order to support 4.11 clusters where the KAS listen port == the external port
 	if hcluster.Spec.Networking.APIServer != nil && hcluster.Spec.Networking.APIServer.Port != nil {
 		externalPort := intstr.FromInt(int(*hcluster.Spec.Networking.APIServer.Port))
-		policy.Spec.Ingress = append(policy.Spec.Ingress, networkingv1.NetworkPolicyIngressRule{
-			From: []networkingv1.NetworkPolicyPeer{},
-			Ports: []networkingv1.NetworkPolicyPort{
-				{
-					Port:     &externalPort,
-					Protocol: &protocol,
+		if port.IntValue() != externalPort.IntValue() {
+			policy.Spec.Ingress = append(policy.Spec.Ingress, networkingv1.NetworkPolicyIngressRule{
+				From: []networkingv1.NetworkPolicyPeer{},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Port:     &externalPort,
+						Protocol: &protocol,
+					},
 				},
-			},
-		})
+			})
+		}
 	}
 
 	// NetworkPolicy egress is broken for 4.11 on OpenShiftSDN, this is a workaround

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -64,7 +64,7 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 	var apiServerExternalPort int32
 	if util.IsPrivateHC(hcluster) {
 		apiServerExternalAddress = fmt.Sprintf("api.%s.hypershift.local", hcluster.Name)
-		apiServerExternalPort = util.APIPortWithDefaultFromHostedCluster(hcluster, config.DefaultAPIServerPort)
+		apiServerExternalPort = util.InternalAPIPortFromHostedClusterWithDefault(hcluster, config.DefaultAPIServerPort)
 	} else {
 		if hcluster.Status.KubeConfig == nil {
 			return "", true, nil
@@ -98,16 +98,16 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 	}
 
 	apiServerInternalAddress := config.DefaultAdvertiseAddress
-	apiServerInternalPort := int32(config.DefaultAPIServerPort)
+	//TODO: in order to prevent periodic kube-apiserver network blimps in the LoadBalancer
+	//publish strategy this should change.
+	//However: will need API changes for service publishing strategy. Best function to call:
+	//apiServerInternalPort := util.BindAPIPortWithDefaultFromHostedCluster(hcluster, config.DefaultAPIServerPort)
+	apiServerInternalPort := haproxyFrontendListenAddress(hcluster, config.DefaultAPIServerPort)
 	if hcluster.Spec.Networking.APIServer != nil {
 		if hcluster.Spec.Networking.APIServer.AdvertiseAddress != nil {
 			apiServerInternalAddress = *hcluster.Spec.Networking.APIServer.AdvertiseAddress
 		}
-		if hcluster.Spec.Networking.APIServer.Port != nil {
-			apiServerInternalPort = *hcluster.Spec.Networking.APIServer.Port
-		}
 	}
-
 	var apiserverProxy string
 	if hcluster.Spec.Configuration != nil && hcluster.Spec.Configuration.Proxy != nil && hcluster.Spec.Configuration.Proxy.HTTPSProxy != "" && util.ConnectsThroughInternetToControlplane(hcluster.Spec.Platform) {
 		apiserverProxy = hcluster.Spec.Configuration.Proxy.HTTPSProxy
@@ -129,6 +129,14 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 	}
 
 	return buf.String(), false, nil
+}
+
+// TODO: this function can be removed when proper update to service Publish API for load balancer done
+func haproxyFrontendListenAddress(hc *hyperv1.HostedCluster, defaultValue int32) int32 {
+	if hc.Spec.Networking.APIServer != nil && hc.Spec.Networking.APIServer.Port != nil {
+		return *hc.Spec.Networking.APIServer.Port
+	}
+	return defaultValue
 }
 
 func urlPort(u *url.URL) (int32, error) {


### PR DESCRIPTION
This code was not ported when the branch was originally setup and is breaking critical functionality in ibm cloud. This will add the necessary code to reconcile the apiserver port field appropriately in the hostedCluster struct

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.