### PR TITLE
Cleanup default security group only if authorized

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -274,11 +274,15 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Return early if deleted
 	if !hostedControlPlane.DeletionTimestamp.IsZero() {
-		if err := r.destroyAWSDefaultSecurityGroup(ctx, hostedControlPlane); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to destroy default workeer security group: %w", err)
-		}
 
 		if shouldCleanupCloudResources(r.Log, hostedControlPlane) {
+			if err := r.destroyAWSDefaultSecurityGroup(ctx, hostedControlPlane); err != nil {
+				if awsErrorCode(err) == "UnauthorizedOperation" {
+					r.Log.Info("Skipping AWS default security group deletion because the operator is not authorized to delete it.")
+				} else {
+					return ctrl.Result{}, fmt.Errorf("failed to delete AWS default security group: %w", err)
+				}
+			}
 			done, err := r.removeCloudResources(ctx, hostedControlPlane)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to ensure cloud resources are removed: %w", err)
@@ -3767,11 +3771,6 @@ func (r *HostedControlPlaneReconciler) destroyAWSDefaultSecurityGroup(ctx contex
 		return nil
 	}
 
-	logger := ctrl.LoggerFrom(ctx)
-	if msg, isValid := hasValidCloudCredentials(hcp); !isValid {
-		logger.Info("Skipping default SecurityGroup cleanup", "reason", msg)
-		return nil
-	}
 	describeSGResult, err := r.ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{Filters: awsSecurityGroupFilters(hcp.Spec.InfraID)})
 	if err != nil {
 		return fmt.Errorf("cannot list security groups: %w", err)
@@ -3809,7 +3808,8 @@ func (r *HostedControlPlaneReconciler) destroyAWSDefaultSecurityGroup(ctx contex
 }
 
 func awsErrorCode(err error) string {
-	if awsErr, ok := err.(awserr.Error); ok {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
 		return awsErr.Code()
 	}
 	return ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Check the error code of the SG delete operation. If not authorized, skip deletion instead of retrying. Also, only attempt to delete the SG if the cleanup cloud resources annotation is present.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-834](https://issues.redhat.com//browse/HOSTEDCP-834)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.