### PR TITLE
Add condition to NodePool indicating whether a security group for it is available

### DIFF
--- a/api/v1beta1/nodepool_conditions.go
+++ b/api/v1beta1/nodepool_conditions.go
@@ -64,11 +64,12 @@ const (
 
 // Reasons
 const (
-	NodePoolValidationFailedReason     = "ValidationFailed"
-	NodePoolInplaceUpgradeFailedReason = "InplaceUpgradeFailed"
-	NodePoolNotFoundReason             = "NotFound"
-	NodePoolFailedToGetReason          = "FailedToGet"
-	IgnitionEndpointMissingReason      = "IgnitionEndpointMissing"
-	IgnitionCACertMissingReason        = "IgnitionCACertMissing"
-	IgnitionNotReached                 = "ignitionNotReached"
+	NodePoolValidationFailedReason        = "ValidationFailed"
+	NodePoolInplaceUpgradeFailedReason    = "InplaceUpgradeFailed"
+	NodePoolNotFoundReason                = "NotFound"
+	NodePoolFailedToGetReason             = "FailedToGet"
+	IgnitionEndpointMissingReason         = "IgnitionEndpointMissing"
+	IgnitionCACertMissingReason           = "IgnitionCACertMissing"
+	IgnitionNotReached                    = "ignitionNotReached"
+	DefaultAWSSecurityGroupNotReadyReason = "DefaultSGNotReady"
 )

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -397,6 +397,25 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 				ObservedGeneration: nodePool.Generation,
 			})
 		}
+
+		if len(nodePool.Spec.Platform.AWS.SecurityGroups) == 0 &&
+			(hcluster.Status.Platform == nil || hcluster.Status.Platform.AWS == nil || hcluster.Status.Platform.AWS.DefaultWorkerSecurityGroupID == "") {
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+				Type:               hyperv1.NodePoolAWSSecurityGroupAvailableConditionType,
+				Status:             corev1.ConditionFalse,
+				Reason:             hyperv1.DefaultAWSSecurityGroupNotReadyReason,
+				Message:            "Waiting for AWS default security group to be created for hosted cluster",
+				ObservedGeneration: nodePool.Generation,
+			})
+		} else {
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+				Type:               hyperv1.NodePoolAWSSecurityGroupAvailableConditionType,
+				Status:             corev1.ConditionTrue,
+				Reason:             hyperv1.AsExpectedReason,
+				Message:            "NodePool has a security group",
+				ObservedGeneration: nodePool.Generation,
+			})
+		}
 	}
 
 	// Validate PowerVS platform specific input


### PR DESCRIPTION




<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
The condition was added in the original default SG PR but it was not being set by the nodepool controller. It is now computed and set by the nodepool controller.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-841](https://issues.redhat.com//browse/HOSTEDCP-841)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.