### PR TITLE
feat(HCCO): Block DNS operator delete until Cluster Version updated

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -20,6 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -499,23 +500,24 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 	// so we must use the uncached client for this delete call.  To avoid
 	// excessive API calls using the uncached client, the delete call is
 	// guarded using a sync.Once.
-	deleteDNSOperatorDeploymentOnce.Do(func() {
-		dnsOperatorDeployment := manifests.DNSOperatorDeployment()
-		log.Info("removing any existing DNS operator deployment")
-		if err := r.uncachedClient.Delete(ctx, dnsOperatorDeployment); err != nil && !apierrors.IsNotFound(err) {
-			errs = append(errs, err)
-		}
-	})
-
-	deleteCVORemovedResourcesOnce.Do(func() {
-		resources := cvo.ResourcesToRemove(hcp.Spec.Platform.Type)
-		for _, resource := range resources {
-			log.Info("removing existing resources", "resource", resource)
-			if err := r.uncachedClient.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
+	if r.isClusterVersionUpdated(ctx, releaseImage.Version()) {
+		deleteDNSOperatorDeploymentOnce.Do(func() {
+			dnsOperatorDeployment := manifests.DNSOperatorDeployment()
+			log.Info("removing any existing DNS operator deployment")
+			if err := r.uncachedClient.Delete(ctx, dnsOperatorDeployment); err != nil && !apierrors.IsNotFound(err) {
 				errs = append(errs, err)
 			}
-		}
-	})
+		})
+		deleteCVORemovedResourcesOnce.Do(func() {
+			resources := cvo.ResourcesToRemove(hcp.Spec.Platform.Type)
+			for _, resource := range resources {
+				log.Info("removing existing resources", "resource", resource)
+				if err := r.uncachedClient.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
+					errs = append(errs, err)
+				}
+			}
+		})
+	}
 
 	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
 		errs = append(errs, r.reconcileAWSIdentityWebhook(ctx)...)
@@ -1732,6 +1734,21 @@ func (a *genericListAccessor) len() int {
 
 func (a *genericListAccessor) item(i int) client.Object {
 	return (a.items.Index(i).Addr().Interface()).(client.Object)
+}
+
+func (r *reconciler) isClusterVersionUpdated(ctx context.Context, version string) bool {
+	log := ctrl.LoggerFrom(ctx)
+	var clusterVersion configv1.ClusterVersion
+	err := r.client.Get(ctx, types.NamespacedName{Name: "version"}, &clusterVersion)
+	if err != nil {
+		log.Error(err, "unable to retrieve cluster version resource")
+		return false
+	}
+	if clusterVersion.Status.Desired.Version != version {
+		log.Info(fmt.Sprintf("cluster version not yet updated to %s", version))
+		return false
+	}
+	return true
 }
 
 func (r *reconciler) reconcileStorage(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage) []error {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -57,6 +57,7 @@ var initialObjects = []client.Object{
 	},
 	manifests.NodeTuningClusterOperator(),
 	manifests.NamespaceKubeSystem(),
+	&configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}},
 }
 
 func shouldNotError(key client.ObjectKey) bool {


### PR DESCRIPTION
Supersedes #2210 with an amended implementation to block on delete of the incluster dns operator only--to have less of an impact on control plane bring up time.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #2128

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.