### PR TITLE
Destroy cloud resources by default

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -85,10 +85,11 @@ func NewCreateCommands() *cobra.Command {
 func NewDestroyCommands() *cobra.Command {
 
 	opts := &core.DestroyOptions{
-		Namespace:          "clusters",
-		Name:               "",
-		ClusterGracePeriod: 10 * time.Minute,
-		Log:                log.Log,
+		Namespace:             "clusters",
+		Name:                  "",
+		ClusterGracePeriod:    10 * time.Minute,
+		Log:                   log.Log,
+		DestroyCloudResources: true,
 	}
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
Our e2e tests automatically clean up cloud resources by default, but the hypershift cli does not. This has resulted in unexpectedly orphaning cloud resources.

It's possible we should take this a step further and default to always cleaning up cloud resources when defining the HostedCluster at creation time, then provide an option to orphan cloud resources during destruction. 