### PR TITLE
cpo: cno: follow image name change in release payload

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -84,7 +84,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 			WhereaboutsCNI:               images["multus-whereabouts-ipam-cni"],
 			RouteOverrideCNI:             images["multus-route-override-cni"],
 			MultusNetworkPolicy:          images["multus-networkpolicy"],
-			OVN:                          images["ovn-kubernetes"],
+			OVN:                          images["ovn-kubernetes-rhel-9"],
 			EgressRouterCNI:              images["egress-router-cni"],
 			KuryrDaemon:                  images["kuryr-cni"],
 			KuryrController:              images["kuryr-controller"],


### PR DESCRIPTION
The name of the CNO `ovn-kubernetes` image has changed in the release payload

https://github.com/openshift/cluster-network-operator/pull/1712#issuecomment-1442980448

This is causing 4.13 tests to fail.