### PR TITLE
HOSTEDCP-839: Audit log sidecars for openshift-apiserver and openshift-oauth-apiserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2284,14 +2284,14 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.C
 	p := oapi.NewOpenShiftAPIServerParams(hcp, observedConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 	oapicfg := manifests.OpenShiftAPIServerConfig(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, oapicfg, func() error {
-		return oapi.ReconcileConfig(oapicfg, p.OwnerRef, p.EtcdURL, p.IngressDomain(), p.MinTLSVersion(), p.CipherSuites(), p.Image, p.Project)
+		return oapi.ReconcileConfig(oapicfg, p.AuditWebhookRef, p.OwnerRef, p.EtcdURL, p.IngressDomain(), p.MinTLSVersion(), p.CipherSuites(), p.Image, p.Project)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift apiserver config: %w", err)
 	}
 
 	auditCfg := manifests.OpenShiftAPIServerAuditConfig(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, auditCfg, func() error {
-		return oapi.ReconcileAuditConfig(auditCfg, p.OwnerRef)
+		return oapi.ReconcileAuditConfig(auditCfg, p.OwnerRef, p.AuditPolicyConfig())
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift apiserver audit config: %w", err)
 	}
@@ -2316,7 +2316,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.C
 
 	deployment := manifests.OpenShiftAPIServerDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return oapi.ReconcileDeployment(deployment, p.OwnerRef, oapicfg, p.OpenShiftAPIServerDeploymentConfig, p.OpenShiftAPIServerImage, p.ProxyImage, p.EtcdURL, p.AvailabilityProberImage, util.APIPort(hcp))
+		return oapi.ReconcileDeployment(deployment, p.AuditWebhookRef, p.OwnerRef, oapicfg, p.OpenShiftAPIServerDeploymentConfig, p.OpenShiftAPIServerImage, p.ProxyImage, p.EtcdURL, p.AvailabilityProberImage, util.APIPort(hcp))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift apiserver deployment: %w", err)
 	}
@@ -2328,14 +2328,14 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftOAuthAPIServer(ctx cont
 	p := oapi.NewOpenShiftAPIServerParams(hcp, observedConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 	auditCfg := manifests.OpenShiftOAuthAPIServerAuditConfig(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, auditCfg, func() error {
-		return oapi.ReconcileAuditConfig(auditCfg, p.OwnerRef)
+		return oapi.ReconcileAuditConfig(auditCfg, p.OwnerRef, p.AuditPolicyConfig())
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift oauth apiserver audit config: %w", err)
 	}
 
 	pdb := manifests.OpenShiftOAuthAPIServerDisruptionBudget(hcp.Namespace)
 	if result, err := createOrUpdate(ctx, r, pdb, func() error {
-		return oapi.ReconcileOpenShiftOAuthAPIServerPodDisruptionBudget(pdb, p.OAuthAPIServerDeploymentParams())
+		return oapi.ReconcileOpenShiftOAuthAPIServerPodDisruptionBudget(pdb, p.OAuthAPIServerDeploymentParams(hcp))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift oauth apiserver pdb: %w", err)
 	} else {
@@ -2344,7 +2344,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftOAuthAPIServer(ctx cont
 
 	deployment := manifests.OpenShiftOAuthAPIServerDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return oapi.ReconcileOAuthAPIServerDeployment(deployment, p.OwnerRef, p.OAuthAPIServerDeploymentParams(), util.APIPort(hcp))
+		return oapi.ReconcileOAuthAPIServerDeployment(deployment, p.OwnerRef, p.OAuthAPIServerDeploymentParams(hcp), util.APIPort(hcp))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift oauth apiserver deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -155,7 +155,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 						"/usr/bin/tail",
 						"-c+1",
 						"-F",
-						"/var/log/kube-apiserver/audit.log",
+						fmt.Sprintf("%s/%s", volumeMounts.Path(kasContainerMain().Name, kasVolumeWorkLogs().Name), "audit.log"),
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -165,7 +165,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 					},
 					VolumeMounts: []corev1.VolumeMount{{
 						Name:      kasVolumeWorkLogs().Name,
-						MountPath: "/var/log/kube-apiserver",
+						MountPath: volumeMounts.Path(kasContainerMain().Name, kasVolumeWorkLogs().Name),
 					}},
 				},
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/auditcfg.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/auditcfg.go
@@ -1,84 +1,32 @@
 package oapi
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	"fmt"
 
-	oauthv1 "github.com/openshift/api/oauth/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/library-go/pkg/operator/apiserver/audit"
 )
 
 const (
 	auditPolicyConfigMapKey = "policy.yaml"
 )
 
-func ReconcileAuditConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef) error {
+func ReconcileAuditConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef, auditConfig configv1.Audit) error {
 	ownerRef.ApplyTo(cm)
 	if cm.Data == nil {
 		cm.Data = map[string]string{}
 	}
-	policy := defaultAuditPolicy()
+	policy, err := audit.GetAuditPolicy(auditConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get audit policy: %w", err)
+	}
 	policyBytes, err := config.SerializeAuditPolicy(policy)
 	if err != nil {
 		return err
 	}
 	cm.Data[auditPolicyConfigMapKey] = string(policyBytes)
 	return nil
-}
-
-func defaultAuditPolicy() *auditv1.Policy {
-	return &auditv1.Policy{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Policy",
-			APIVersion: auditv1.SchemeGroupVersion.String(),
-		},
-		OmitStages: []auditv1.Stage{
-			auditv1.StageRequestReceived,
-		},
-		Rules: []auditv1.PolicyRule{
-			{
-				Level: auditv1.LevelNone,
-				Resources: []auditv1.GroupResources{
-					{
-						Group: corev1.SchemeGroupVersion.Group,
-						Resources: []string{
-							"events",
-						},
-					},
-				},
-			},
-			{
-				Level: auditv1.LevelNone,
-				Resources: []auditv1.GroupResources{
-					{
-						Group: oauthv1.SchemeGroupVersion.Group,
-						Resources: []string{
-							"oauthaccesstokens",
-							"oauthauthorizetokens",
-						},
-					},
-				},
-			},
-			{
-				Level: auditv1.LevelNone,
-				NonResourceURLs: []string{
-					"/api*",
-					"/version",
-					"/healthz",
-				},
-				UserGroups: []string{
-					"system:authenticated",
-					"system:unauthenticated",
-				},
-			},
-			{
-				Level: auditv1.LevelMetadata,
-				OmitStages: []auditv1.Stage{
-					auditv1.StageRequestReceived,
-				},
-			},
-		},
-	}
 }


### PR DESCRIPTION
This adds a tail sidecar container for the audit logs for the above deployments. It
also plumbs the audit config into the two deployments.

Fixes #[HOSTEDCP-839](https://issues.redhat.com//browse/HOSTEDCP-839)

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.