### PR TITLE
HOSTEDCP-638: Add latest ocp supported info to -v command for cli and operator

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -65,7 +65,7 @@ func main() {
 		},
 	}
 
-	cmd.Version = version.GetRevision()
+	cmd.Version = version.String()
 
 	cmd.AddCommand(NewStartCommand())
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 		},
 	}
 
-	cmd.Version = version.GetRevision()
+	cmd.Version = version.String()
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,6 +3,8 @@ package version
 import (
 	"fmt"
 	"runtime/debug"
+
+	"github.com/openshift/hypershift/support/supportedversion"
 )
 
 // GetRevision returns the overall codebase version. It's for detecting
@@ -22,5 +24,5 @@ func GetRevision() string {
 }
 
 func String() string {
-	return fmt.Sprintf("openshift/hypershift %s", GetRevision())
+	return fmt.Sprintf("openshift/hypershift: %s. Latest supported OCP: %s", GetRevision(), supportedversion.LatestSupportedVersion)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it easier to understand at a glance the latest OCP supported by the Operator / CLI

```
➜  hypershift git:(version-show-latestl-ocp) ✗ ./bin/hypershift -v
hypershift version openshift/hypershift: 42e85b6ed107c4b99a5ef00b886e1943ea896095. Latest supported OCP: 4.13.0
➜  hypershift git:(version-show-latestl-ocp) ✗ ./bin/hypershift-operator -v
hypershift-operator version openshift/hypershift: 42e85b6ed107c4b99a5ef00b886e1943ea896095. Latest supported OCP: 4.13.0
```

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Ref https://issues.redhat.com/browse/HOSTEDCP-638
 

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.