### PR TITLE
Add configuration for automatic labeling and label commands

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,15 @@
+# This file should tell the prow labeler plugin to automatically label PRs
+# that include changes to matching files
+# See: https://github.com/actions/labeler/blob/main/README.md
+area/hypershift-operator:
+- api/**/*
+- hypershift-operator/**/*
+
+area/control-plane-operator:
+- control-plane-operator/**/*
+- availability-prober/**/*
+- dnsresolver/**/*
+- ignition-server/**/*
+- konnectivity-socks5-proxy/**/*
+- kubernetes-default-proxy/**/*
+- token-minter/**/*

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,6 @@
+# This should enable comments such as "/area hypershift-operator" to add
+# the label to a PR/Issue
+# See https://github.com/jpmcb/prow-github-actions/blob/main/docs/labeling.md
+area:
+- 'hypershift-operator'
+- 'control-plane-operator'


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds files that drive automatic labeling of PRs based on files modified and enable commands to label PRs

**Checklist**
- [x] Subject and description added to both, commit and PR.