### PR TITLE
Add configuration for automatic labeling and label commands

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,6 @@
+# This should enable comments such as "/area hypershift-operator" to add
+# the label to a PR/Issue
+# See https://github.com/jpmcb/prow-github-actions/blob/main/docs/labeling.md
+area:
+- 'hypershift-operator'
+- 'control-plane-operator'

--- a/api/OWNERS
+++ b/api/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/hypershift-operator

--- a/availability-prober/OWNERS
+++ b/availability-prober/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/control-plane-operator

--- a/control-plane-operator/OWNERS
+++ b/control-plane-operator/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/control-plane-operator

--- a/dnsresolver/OWNERS
+++ b/dnsresolver/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/control-plane-operator

--- a/hypershift-operator/OWNERS
+++ b/hypershift-operator/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/hypershift-operator

--- a/ignition-server/OWNERS
+++ b/ignition-server/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/control-plane-operator

--- a/konnectivity-socks5-proxy/OWNERS
+++ b/konnectivity-socks5-proxy/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/control-plane-operator

--- a/kubernetes-default-proxy/OWNERS
+++ b/kubernetes-default-proxy/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/control-plane-operator

--- a/token-minter/OWNERS
+++ b/token-minter/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/control-plane-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds OWNERS files in directories to automatically set a label on a PR if a file is changed in that directory.
Adds labels.yaml file that allows /area type of commands on PRs to add the area label.

**Checklist**
- [x] Subject and description added to both, commit and PR.