### PR TITLE
OCPBUGS-8231: Fix cleanup of volumes on cluster deletion

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1416,7 +1416,9 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 		// still in progress.
 		LastTransitionTime: metav1.Now(),
 	}
-	meta.SetStatusCondition(&hcp.Status.Conditions, *resourcesDestroyedCond)
+	// Ensure the LastTransitionTime is updated because the hostedcontrolplane controller relies on that
+	// timestamp to use as a heartbeat.
+	setStatusConditionWithTransitionUpdate(&hcp.Status.Conditions, *resourcesDestroyedCond)
 	if err := r.cpClient.Status().Update(ctx, hcp); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set resources destroyed condition: %w", err)
 	}
@@ -1428,6 +1430,32 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 	} else {
 		return ctrl.Result{}, nil
 	}
+}
+
+func setStatusConditionWithTransitionUpdate(conditions *[]metav1.Condition, newCondition metav1.Condition) {
+	if conditions == nil {
+		return
+	}
+	existingCondition := meta.FindStatusCondition(*conditions, newCondition.Type)
+	if existingCondition == nil {
+		if newCondition.LastTransitionTime.IsZero() {
+			newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		}
+		*conditions = append(*conditions, newCondition)
+		return
+	}
+
+	// Always update the LastTransition time
+	existingCondition.Status = newCondition.Status
+	if !newCondition.LastTransitionTime.IsZero() {
+		existingCondition.LastTransitionTime = newCondition.LastTransitionTime
+	} else {
+		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
+	}
+
+	existingCondition.Reason = newCondition.Reason
+	existingCondition.Message = newCondition.Message
+	existingCondition.ObservedGeneration = newCondition.ObservedGeneration
 }
 
 func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyperv1.HostedControlPlane) (sets.String, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The current code that updates the CloudResourcesDestroyed condition on the hostedcontrolplane resource is not updating the LastTransitionTime. The hostedcontrolplane controller understands this to mean that the hcco is no longer active and proceeds to remove the finalizer from the hostedcontrolplane on the configured timeout. This fix ensures that the LastTransitionTime gets updated on the condition so it can behave as a heartbeat for the hostedcontrolplane controller.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-8231

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.