### PR TITLE
HOSTEDCP-910: Enable pprof in hosted etcd

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -264,6 +264,10 @@ func buildEtcdContainer(p *EtcdParams, namespace string) func(c *corev1.Containe
 				Name:  "QUOTA_BACKEND_BYTES",
 				Value: strconv.FormatInt(p.StorageSpec.PersistentVolume.Size.Value(), 10),
 			},
+			{
+				Name:  "ETCD_ENABLE_PPROF",
+				Value: "true",
+			},
 		}
 		c.Ports = []corev1.ContainerPort{
 			{


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Enables pprof in hosted etcd, similar to self-managed or not-hypershift openshift deployments

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-910](https://issues.redhat.com/browse/HOSTEDCP-910)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.