### PR TITLE
HOSTEDCP-809: Clone CA key/cert to TLS key/cert

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -20,8 +20,11 @@ func reconcileAggregateCA(configMap *corev1.ConfigMap, ownerRef config.OwnerRef,
 	ownerRef.ApplyTo(configMap)
 	combined := &bytes.Buffer{}
 	for _, src := range sources {
-		ca_bytes := src.Data[certs.CASignerCertMapKey]
-		fmt.Fprintf(combined, "%s", string(ca_bytes))
+		caBytes := src.Data[certs.CASignerCertMapKey]
+		_, err := fmt.Fprintf(combined, "%s", string(caBytes))
+		if err != nil {
+			return err
+		}
 	}
 	if configMap.Data == nil {
 		configMap.Data = map[string]string{}
@@ -80,10 +83,6 @@ func ReconcileEtcdMetricsSignerSecret(secret *corev1.Secret, ownerref config.Own
 
 func ReconcileEtcdMetricsSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, etcdMetricsSigner *corev1.Secret) error {
 	return reconcileAggregateCA(cm, ownerRef, etcdMetricsSigner)
-}
-
-func ReconcileClusterSignerCA(secret *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSelfSignedCA(secret, ownerRef, "cluster-signer", "openshift")
 }
 
 func ReconcileRootCAConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, rootCA *corev1.Secret) error {

--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -30,9 +30,17 @@ const (
 	ValidityOneYear  = 365 * ValidityOneDay
 	ValidityTenYears = 10 * ValidityOneYear
 
-	CAHashAnnotation   = "hypershiftlite.openshift.io/ca-hash"
+	CAHashAnnotation = "hypershiftlite.openshift.io/ca-hash"
+	// CASignerCertMapKey is the key value in a CA cert utilized by the control plane operator.
 	CASignerCertMapKey = "ca.crt"
-	CASignerKeyMapKey  = "ca.key"
+	// CASignerKeyMapKey is the key for the private key field in a CA cert utilized by the control plane operator.
+	CASignerKeyMapKey = "ca.key"
+	// TLSSignerCertMapKey is the key value the default k8s cert-manager looks for in a TLS certificate in a TLS secret.
+	//TLSSignerCertMapKey is programmatically enforced to have the same data as CASignerCertMapKey.
+	TLSSignerCertMapKey = "tls.crt"
+	// TLSSignerKeyMapKey is the key the default k8s cert-manager looks for in a private key field in a TLS secret.
+	// TLSSignerKeyMapKey is programmatically enforced to have the same data as CASignerKeyMapKey.
+	TLSSignerKeyMapKey = "tls.key"
 )
 
 // CertCfg contains all needed fields to configure a new certificate
@@ -419,7 +427,9 @@ func ReconcileSelfSignedCA(secret *corev1.Secret, cn, ou string, o ...func(*CAOp
 		secret.Data = map[string][]byte{}
 	}
 	secret.Data[opts.CASignerCertMapKey] = CertToPem(crt)
+	secret.Data[TLSSignerCertMapKey] = secret.Data[opts.CASignerCertMapKey]
 	secret.Data[opts.CASignerKeyMapKey] = PrivateKeyToPem(key)
+	secret.Data[TLSSignerKeyMapKey] = secret.Data[opts.CASignerKeyMapKey]
 	return nil
 }
 

--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -107,7 +107,7 @@ func PrivateKey() (*rsa.PrivateKey, error) {
 	return rsaKey, nil
 }
 
-// SelfSignedCertificate creates a self signed certificate
+// SelfSignedCertificate creates a self-signed certificate
 func SelfSignedCertificate(cfg *CertCfg, key *rsa.PrivateKey) (*x509.Certificate, error) {
 	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
 	if err != nil {
@@ -186,7 +186,7 @@ func rsaPubKeySHA1Hash(pub *rsa.PublicKey) ([]byte, error) {
 	return hash.Sum(nil), nil
 }
 
-// PrivateKeyToPem converts an rsa.PrivateKey object to pem string
+// PrivateKeyToPem converts a rsa.PrivateKey object to pem string
 func PrivateKeyToPem(key *rsa.PrivateKey) []byte {
 	keyInBytes := x509.MarshalPKCS1PrivateKey(key)
 	keyinPem := pem.EncodeToMemory(
@@ -209,18 +209,7 @@ func CertToPem(cert *x509.Certificate) []byte {
 	return certInPem
 }
 
-// CSRToPem converts an x509.CertificateRequest to a pem string
-func CSRToPem(cert *x509.CertificateRequest) []byte {
-	certInPem := pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "CERTIFICATE REQUEST",
-			Bytes: cert.Raw,
-		},
-	)
-	return certInPem
-}
-
-// PublicKeyToPem converts an rsa.PublicKey object to pem string
+// PublicKeyToPem converts a rsa.PublicKey object to pem string
 func PublicKeyToPem(key *rsa.PublicKey) ([]byte, error) {
 	keyInBytes, err := x509.MarshalPKIXPublicKey(key)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Clone CA key/cert to TLS key/cert as some certificate managers expect to use tls.key/tls.crt rather than ca.key/ca.crt.

**Which issue(s) this PR fixes**:
[HOSTEDCP-809](https://issues.redhat.com/browse/HOSTEDCP-809)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.