### PR TITLE
HOSTEDCP-688: E2E Test NodePool Upgrade 

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -88,6 +88,18 @@ func TestNodePool(t *testing.T) {
 				manifestBuilder: NewNTOMachineConfigInPlaceRolloutTestManifest(hostedCluster),
 			},
 		*/
+		{
+			name: "TestNodePoolReplaceUpgrade",
+			test: NewNodePoolUpgradeTest(ctx, mgmtClient, hostedCluster, hostedClusterClient, clusterOpts, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
+		},
+		// TODO: (jparrill) Re-enable when https://issues.redhat.com/browse/OCPBUGS-10218 is fixed
+		/*
+			{
+				name:            "TestNodePoolInPlaceUpgrade",
+				test:            NewNodePoolUpgradeTest(ctx, mgmtClient, hostedCluster, hostedClusterClient, clusterOpts, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
+				manifestBuilder: NewNodePoolInPlaceUpgradeTestManifest(hostedCluster, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
+			},
+		*/
 	}
 
 	t.Run("NodePool Tests Group", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactored the E2E NodePool Upgrade tests following the same principles then before, it follows the 2 ways of upgrade 'Replace' and 'InPlace'.

**Which issue(s) this PR fixes**
Fixes #[HOSTEDCP-688](https://issues.redhat.com/browse/HOSTEDCP-688)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.