### PR TITLE
create external Routes for Private clusters

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -187,17 +187,13 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			for i, svc := range services {
 				switch svc.Service {
 				case hyperv1.APIServer:
-					if endpointAccess != hyperv1.Private {
-						services[i].Route = &hyperv1.RoutePublishingStrategy{
-							Hostname: fmt.Sprintf("api-%s.%s", o.Name, o.ExternalDNSDomain),
-						}
+					services[i].Route = &hyperv1.RoutePublishingStrategy{
+						Hostname: fmt.Sprintf("api-%s.%s", o.Name, o.ExternalDNSDomain),
 					}
 
 				case hyperv1.OAuthServer:
-					if endpointAccess != hyperv1.Private {
-						services[i].Route = &hyperv1.RoutePublishingStrategy{
-							Hostname: fmt.Sprintf("oauth-%s.%s", o.Name, o.ExternalDNSDomain),
-						}
+					services[i].Route = &hyperv1.RoutePublishingStrategy{
+						Hostname: fmt.Sprintf("oauth-%s.%s", o.Name, o.ExternalDNSDomain),
 					}
 
 				case hyperv1.Konnectivity:

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -133,6 +133,14 @@ const (
 	// SilenceClusterAlertsLabel  is a label that can be used by consumers to indicate
 	// alerts from a cluster can be silenced or ignored
 	SilenceClusterAlertsLabel = "hypershift.openshift.io/silence-cluster-alerts"
+
+	// RouteVisibilityLabel is a label that can be used by external-dns to filter routes
+	// it should not consider for name registration
+	RouteVisibilityLabel = "hypershift.openshift.io/route-visibility"
+
+	// RouteVisibilityPrivate is a value for RouteVisibilityLabel that will result
+	// in the labeled route being ignored by external-dns
+	RouteVisibilityPrivate = "private"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -191,6 +191,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								"--registry=txt",
 								"--txt-suffix=-external-dns",
 								fmt.Sprintf("--txt-owner-id=%s", txtOwnerId),
+								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
 							LivenessProbe: &corev1.Probe{

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1037,28 +1037,51 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Con
 	}
 
 	if serviceStrategy.Type == hyperv1.Route {
-		externalRoute := manifests.KubeAPIServerExternalRoute(hcp.Namespace)
+		externalPublicRoute := manifests.KubeAPIServerExternalPublicRoute(hcp.Namespace)
+		externalPrivateRoute := manifests.KubeAPIServerExternalPrivateRoute(hcp.Namespace)
 		if util.IsPublicHCP(hcp) {
-			if _, err := createOrUpdate(ctx, r.Client, externalRoute, func() error {
+			// Remove the external private route if it exists
+			err := r.Get(ctx, client.ObjectKeyFromObject(externalPrivateRoute), externalPrivateRoute)
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed to check whether apiserver external private route exists: %w", err)
+				}
+			} else {
+				if err := r.Delete(ctx, externalPrivateRoute); err != nil {
+					return fmt.Errorf("failed to delete apiserver external private route: %w", err)
+				}
+			}
+			// Reconcile the external public route
+			if _, err := createOrUpdate(ctx, r.Client, externalPublicRoute, func() error {
 				hostname := ""
 				if serviceStrategy.Route != nil {
 					hostname = serviceStrategy.Route.Hostname
 				}
-				return kas.ReconcileExternalRoute(externalRoute, p.OwnerReference, hostname)
+				return kas.ReconcileExternalPublicRoute(externalPublicRoute, p.OwnerReference, hostname)
 			}); err != nil {
-				return fmt.Errorf("failed to reconcile apiserver external route %s: %w", externalRoute.Name, err)
+				return fmt.Errorf("failed to reconcile apiserver external public route %s: %w", externalPublicRoute.Name, err)
 			}
 		} else {
-			// Remove the external route if it exists
-			err := r.Get(ctx, client.ObjectKeyFromObject(externalRoute), externalRoute)
+			// Remove the external public route if it exists
+			err := r.Get(ctx, client.ObjectKeyFromObject(externalPublicRoute), externalPublicRoute)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
-					return fmt.Errorf("failed to check whether apiserver external route exists: %w", err)
+					return fmt.Errorf("failed to check whether apiserver external public route exists: %w", err)
 				}
 			} else {
-				if err := r.Delete(ctx, externalRoute); err != nil {
-					return fmt.Errorf("failed to delete apiserver external route: %w", err)
+				if err := r.Delete(ctx, externalPublicRoute); err != nil {
+					return fmt.Errorf("failed to delete apiserver external public route: %w", err)
 				}
+			}
+			// Reconcile the external private route
+			if _, err := createOrUpdate(ctx, r.Client, externalPrivateRoute, func() error {
+				hostname := ""
+				if serviceStrategy.Route != nil {
+					hostname = serviceStrategy.Route.Hostname
+				}
+				return kas.ReconcileExternalPrivateRoute(externalPrivateRoute, p.OwnerReference, hostname)
+			}); err != nil {
+				return fmt.Errorf("failed to reconcile apiserver external private route %s: %w", externalPrivateRoute.Name, err)
 			}
 		}
 		// The private KAS route is always present as it is the default
@@ -1133,28 +1156,51 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServerService(ctx context.C
 	if serviceStrategy.Type != hyperv1.Route {
 		return nil
 	}
-	oauthExternalRoute := manifests.OauthServerExternalRoute(hcp.Namespace)
+	oauthExternalPublicRoute := manifests.OauthServerExternalPublicRoute(hcp.Namespace)
+	oauthExternalPrivateRoute := manifests.OauthServerExternalPrivateRoute(hcp.Namespace)
 	if util.IsPublicHCP(hcp) {
-		if _, err := createOrUpdate(ctx, r.Client, oauthExternalRoute, func() error {
+		// Remove the external private route if it exists
+		err := r.Get(ctx, client.ObjectKeyFromObject(oauthExternalPrivateRoute), oauthExternalPrivateRoute)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to check whether OAuth external private route exists: %w", err)
+			}
+		} else {
+			if err := r.Delete(ctx, oauthExternalPrivateRoute); err != nil {
+				return fmt.Errorf("failed to delete OAuth external private route: %w", err)
+			}
+		}
+		// Reconcile the external public route
+		if _, err := createOrUpdate(ctx, r.Client, oauthExternalPublicRoute, func() error {
 			hostname := ""
 			if serviceStrategy.Route != nil {
 				hostname = serviceStrategy.Route.Hostname
 			}
-			return oauth.ReconcileExternalRoute(oauthExternalRoute, p.OwnerRef, hostname, r.DefaultIngressDomain)
+			return oauth.ReconcileExternalPublicRoute(oauthExternalPublicRoute, p.OwnerRef, hostname, r.DefaultIngressDomain)
 		}); err != nil {
-			return fmt.Errorf("failed to reconcile OAuth external route: %w", err)
+			return fmt.Errorf("failed to reconcile OAuth external public route: %w", err)
 		}
 	} else {
 		// Remove the external route if it exists
-		err := r.Get(ctx, client.ObjectKeyFromObject(oauthExternalRoute), oauthExternalRoute)
+		err := r.Get(ctx, client.ObjectKeyFromObject(oauthExternalPublicRoute), oauthExternalPublicRoute)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to check whether OAuth external route exists: %w", err)
+				return fmt.Errorf("failed to check whether OAuth external public route exists: %w", err)
 			}
 		} else {
-			if err := r.Delete(ctx, oauthExternalRoute); err != nil {
-				return fmt.Errorf("failed to delete OAuth external route: %w", err)
+			if err := r.Delete(ctx, oauthExternalPublicRoute); err != nil {
+				return fmt.Errorf("failed to delete OAuth external public route: %w", err)
 			}
+		}
+		// Reconcile the external private route
+		if _, err := createOrUpdate(ctx, r.Client, oauthExternalPrivateRoute, func() error {
+			hostname := ""
+			if serviceStrategy.Route != nil {
+				hostname = serviceStrategy.Route.Hostname
+			}
+			return oauth.ReconcileExternalPrivateRoute(oauthExternalPrivateRoute, p.OwnerRef, hostname, r.DefaultIngressDomain)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile OAuth external private route: %w", err)
 		}
 	}
 	if util.IsPrivateHCP(hcp) {
@@ -1438,7 +1484,7 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServiceStatus(ctx context.C
 	}
 	if serviceStrategy.Type == hyperv1.Route {
 		if util.IsPublicHCP(hcp) {
-			route = manifests.OauthServerExternalRoute(hcp.Namespace)
+			route = manifests.OauthServerExternalPublicRoute(hcp.Namespace)
 			if err = r.Get(ctx, client.ObjectKeyFromObject(route), route); err != nil {
 				if apierrors.IsNotFound(err) {
 					err = nil
@@ -1448,6 +1494,8 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServiceStatus(ctx context.C
 				return
 			}
 		} else {
+			// TODO: sjenning: This should be switched to OauthServerExternalPrivateRoute
+			// once end-to-end DNS connectivity is added over PrivateLink
 			route = manifests.OauthServerInternalRoute(hcp.Namespace)
 			if err = r.Get(ctx, client.ObjectKeyFromObject(route), route); err != nil {
 				if apierrors.IsNotFound(err) {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
@@ -7,17 +7,19 @@ import (
 )
 
 const (
-	KubeAPIServerServiceName        = "kube-apiserver"
-	KubeAPIServerPrivateServiceName = "kube-apiserver-private"
-	kubeAPIServerExternalRouteName  = "kube-apiserver"
-	kubeAPIServerInternalRouteName  = "kube-apiserver-internal"
-	oauthServiceName                = "oauth-openshift"
-	oauthExternalRouteName          = "oauth"
-	oauthInternalRouteName          = "oauth-internal"
-	konnectivityServerServiceName   = "konnectivity-server"
-	openshiftAPIServerServiceName   = "openshift-apiserver"
-	oauthAPIServerName              = "openshift-oauth-apiserver"
-	packageServerServiceName        = "packageserver"
+	KubeAPIServerServiceName              = "kube-apiserver"
+	KubeAPIServerPrivateServiceName       = "kube-apiserver-private"
+	kubeAPIServerExternalPublicRouteName  = "kube-apiserver"
+	kubeAPIServerExternalPrivateRouteName = "kube-apiserver-private"
+	kubeAPIServerInternalRouteName        = "kube-apiserver-internal"
+	oauthServiceName                      = "oauth-openshift"
+	oauthExternalRoutePublicName          = "oauth"
+	oauthExternalRoutePrivateName         = "oauth-private"
+	oauthInternalRouteName                = "oauth-internal"
+	konnectivityServerServiceName         = "konnectivity-server"
+	openshiftAPIServerServiceName         = "openshift-apiserver"
+	oauthAPIServerName                    = "openshift-oauth-apiserver"
+	packageServerServiceName              = "packageserver"
 )
 
 func KubeAPIServerService(hostedClusterNamespace string) *corev1.Service {
@@ -38,10 +40,19 @@ func KubeAPIServerPrivateService(hostedClusterNamespace string) *corev1.Service 
 	}
 }
 
-func KubeAPIServerExternalRoute(hostedClusterNamespace string) *routev1.Route {
+func KubeAPIServerExternalPublicRoute(hostedClusterNamespace string) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubeAPIServerExternalRouteName,
+			Name:      kubeAPIServerExternalPublicRouteName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
+func KubeAPIServerExternalPrivateRoute(hostedClusterNamespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeAPIServerExternalPrivateRouteName,
 			Namespace: hostedClusterNamespace,
 		},
 	}
@@ -65,11 +76,20 @@ func OauthServerService(hostedClusterNamespace string) *corev1.Service {
 	}
 }
 
-func OauthServerExternalRoute(hostedClusterNamespace string) *routev1.Route {
+func OauthServerExternalPublicRoute(hostedClusterNamespace string) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedClusterNamespace,
-			Name:      oauthExternalRouteName,
+			Name:      oauthExternalRoutePublicName,
+		},
+	}
+}
+
+func OauthServerExternalPrivateRoute(hostedClusterNamespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hostedClusterNamespace,
+			Name:      oauthExternalRoutePrivateName,
 		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -1,6 +1,8 @@
 package oauth
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+
 	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -8,9 +10,21 @@ import (
 	"github.com/openshift/hypershift/support/util"
 )
 
-func ReconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
+func ReconcileExternalPublicRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
 	ownerRef.ApplyTo(route)
 	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.OauthServerService(route.Namespace).Name)
+}
+
+func ReconcileExternalPrivateRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
+	ownerRef.ApplyTo(route)
+	if err := util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.OauthServerService(route.Namespace).Name); err != nil {
+		return err
+	}
+	if route.Labels == nil {
+		route.Labels = map[string]string{}
+	}
+	route.Labels[hyperv1.RouteVisibilityLabel] = hyperv1.RouteVisibilityPrivate
+	return nil
 }
 
 func ReconcileInternalRoute(route *routev1.Route, ownerRef config.OwnerRef) error {

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -373,6 +373,7 @@ objects:
           - --registry=txt
           - --txt-suffix=-external-dns
           - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
+          - --label-filter=hypershift.openshift.io/route-visibility!=private
           - --aws-zone-type=public
           - --aws-batch-change-interval=10s
           command:

--- a/support/util/route.go
+++ b/support/util/route.go
@@ -89,10 +89,6 @@ func hash(s string) string {
 func ReconcileExternalRoute(route *routev1.Route, hostname string, defaultIngressDomain string, serviceName string) error {
 	if hostname != "" {
 		AddHCPRouteLabel(route)
-		if route.Annotations == nil {
-			route.Annotations = map[string]string{}
-		}
-		route.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = hostname
 		route.Spec.Host = hostname
 	} else {
 		if route.Spec.Host == "" {
@@ -108,6 +104,8 @@ func ReconcileExternalRoute(route *routev1.Route, hostname string, defaultIngres
 		Termination:                   routev1.TLSTerminationPassthrough,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 	}
+	// remove annotation as external-dns will register the name if host is within the zone
+	delete(route.Annotations, hyperv1.ExternalDNSHostnameAnnotation)
 	return nil
 }
 

--- a/test/e2e/util/oauth.go
+++ b/test/e2e/util/oauth.go
@@ -138,7 +138,7 @@ func WaitForOAuthRouteReady(t *testing.T, ctx context.Context, client crclient.C
 	g := NewWithT(t)
 
 	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
-	route := hcpmanifests.OauthServerExternalRoute(hcpNamespace)
+	route := hcpmanifests.OauthServerExternalPublicRoute(hcpNamespace)
 
 	err := wait.PollImmediateWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (done bool, err error) {
 		err = client.Get(context.Background(), crclient.ObjectKeyFromObject(route), route)


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/HOSTEDCP-801

We need to maintain the routes for the external KAS and OAuth names even when the cluster is `Private` so that traffic coming across the PrivateLink using those name are properly routed.

Strictly speaking, this isn't required for the KAS because it is the default service for the HCP router, but we should make it explicit.