### PR TITLE
OCPBUGS-8421: fix API documentation for audit webhook field

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -270,8 +270,6 @@ type HostedClusterSpec struct {
 	// keys. The kubeconfig needs to be stored in the secret with a secret key
 	// name that corresponds to the constant AuditWebhookKubeconfigKey.
 	//
-	// This field is currently only supported on the IBMCloud platform.
-	//
 	// +optional
 	// +immutable
 	AuditWebhook *corev1.LocalObjectReference `json:"auditWebhook,omitempty"`

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -278,8 +278,6 @@ type HostedClusterSpec struct {
 	// keys. The kubeconfig needs to be stored in the secret with a secret key
 	// name that corresponds to the constant AuditWebhookKubeconfigKey.
 	//
-	// This field is currently only supported on the IBMCloud platform.
-	//
 	// +optional
 	// +immutable
 	AuditWebhook *corev1.LocalObjectReference `json:"auditWebhook,omitempty"`

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -81,14 +81,13 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               auditWebhook:
-                description: "AuditWebhook contains metadata for configuring an audit
+                description: AuditWebhook contains metadata for configuring an audit
                   webhook endpoint for a cluster to process cluster audit events.
                   It references a secret that contains the webhook information for
                   the audit webhook endpoint. It is a secret because if the endpoint
                   has mTLS the kubeconfig will contain client keys. The kubeconfig
                   needs to be stored in the secret with a secret key name that corresponds
-                  to the constant AuditWebhookKubeconfigKey. \n This field is currently
-                  only supported on the IBMCloud platform."
+                  to the constant AuditWebhookKubeconfigKey.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -3769,14 +3768,13 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               auditWebhook:
-                description: "AuditWebhook contains metadata for configuring an audit
+                description: AuditWebhook contains metadata for configuring an audit
                   webhook endpoint for a cluster to process cluster audit events.
                   It references a secret that contains the webhook information for
                   the audit webhook endpoint. It is a secret because if the endpoint
                   has mTLS the kubeconfig will contain client keys. The kubeconfig
                   needs to be stored in the secret with a secret key name that corresponds
-                  to the constant AuditWebhookKubeconfigKey. \n This field is currently
-                  only supported on the IBMCloud platform."
+                  to the constant AuditWebhookKubeconfigKey.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -359,7 +359,6 @@ contains the webhook information for the audit webhook endpoint. It is a
 secret because if the endpoint has mTLS the kubeconfig will contain client
 keys. The kubeconfig needs to be stored in the secret with a secret key
 name that corresponds to the constant AuditWebhookKubeconfigKey.</p>
-<p>This field is currently only supported on the IBMCloud platform.</p>
 </td>
 </tr>
 <tr>
@@ -3447,7 +3446,6 @@ contains the webhook information for the audit webhook endpoint. It is a
 secret because if the endpoint has mTLS the kubeconfig will contain client
 keys. The kubeconfig needs to be stored in the secret with a secret key
 name that corresponds to the constant AuditWebhookKubeconfigKey.</p>
-<p>This field is currently only supported on the IBMCloud platform.</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -27269,14 +27269,13 @@ objects:
                   type: object
                   x-kubernetes-map-type: atomic
                 auditWebhook:
-                  description: "AuditWebhook contains metadata for configuring an
-                    audit webhook endpoint for a cluster to process cluster audit
-                    events. It references a secret that contains the webhook information
-                    for the audit webhook endpoint. It is a secret because if the
-                    endpoint has mTLS the kubeconfig will contain client keys. The
-                    kubeconfig needs to be stored in the secret with a secret key
-                    name that corresponds to the constant AuditWebhookKubeconfigKey.
-                    \n This field is currently only supported on the IBMCloud platform."
+                  description: AuditWebhook contains metadata for configuring an audit
+                    webhook endpoint for a cluster to process cluster audit events.
+                    It references a secret that contains the webhook information for
+                    the audit webhook endpoint. It is a secret because if the endpoint
+                    has mTLS the kubeconfig will contain client keys. The kubeconfig
+                    needs to be stored in the secret with a secret key name that corresponds
+                    to the constant AuditWebhookKubeconfigKey.
                   properties:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -31029,14 +31028,13 @@ objects:
                   type: object
                   x-kubernetes-map-type: atomic
                 auditWebhook:
-                  description: "AuditWebhook contains metadata for configuring an
-                    audit webhook endpoint for a cluster to process cluster audit
-                    events. It references a secret that contains the webhook information
-                    for the audit webhook endpoint. It is a secret because if the
-                    endpoint has mTLS the kubeconfig will contain client keys. The
-                    kubeconfig needs to be stored in the secret with a secret key
-                    name that corresponds to the constant AuditWebhookKubeconfigKey.
-                    \n This field is currently only supported on the IBMCloud platform."
+                  description: AuditWebhook contains metadata for configuring an audit
+                    webhook endpoint for a cluster to process cluster audit events.
+                    It references a secret that contains the webhook information for
+                    the audit webhook endpoint. It is a secret because if the endpoint
+                    has mTLS the kubeconfig will contain client keys. The kubeconfig
+                    needs to be stored in the secret with a secret key name that corresponds
+                    to the constant AuditWebhookKubeconfigKey.
                   properties:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names


### PR DESCRIPTION
**What this PR does / why we need it**:
The current API documentation states that the audit webhook field is only supported for IBM Cloud. It should be supported for all platforms.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-8421

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 