### PR TITLE
Fixes HCCO reconcile error for kubevirt csi driver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -303,7 +303,7 @@ func ReconcileTenant(client crclient.Client, hcp *hyperv1.HostedControlPlane, ct
 		return err
 	}
 
-	tenantNodeClusterRole := manifests.KubevirtCSIDriverTenantNodeClusterRole(tenantNamespace)
+	tenantNodeClusterRole := manifests.KubevirtCSIDriverTenantNodeClusterRole()
 	_, err = createOrUpdate(ctx, client, tenantNodeClusterRole, func() error {
 		return reconcileTenantNodeClusterRole(tenantNodeClusterRole)
 	})
@@ -311,7 +311,7 @@ func ReconcileTenant(client crclient.Client, hcp *hyperv1.HostedControlPlane, ct
 		return err
 	}
 
-	tenantNodeClusterRoleBinding := manifests.KubevirtCSIDriverTenantNodeClusterRoleBinding(tenantNamespace)
+	tenantNodeClusterRoleBinding := manifests.KubevirtCSIDriverTenantNodeClusterRoleBinding()
 	_, err = createOrUpdate(ctx, client, tenantNodeClusterRoleBinding, func() error {
 		return reconcileTenantNodeClusterRoleBinding(tenantNodeClusterRoleBinding, tenantNamespace)
 	})
@@ -319,7 +319,7 @@ func ReconcileTenant(client crclient.Client, hcp *hyperv1.HostedControlPlane, ct
 		return err
 	}
 
-	tenantControllerClusterRoleBinding := manifests.KubevirtCSIDriverTenantControllerClusterRoleBinding(tenantNamespace)
+	tenantControllerClusterRoleBinding := manifests.KubevirtCSIDriverTenantControllerClusterRoleBinding()
 	_, err = createOrUpdate(ctx, client, tenantControllerClusterRoleBinding, func() error {
 		return reconcileTenantControllerClusterRoleBinding(tenantControllerClusterRoleBinding, tenantNamespace)
 	})
@@ -327,7 +327,7 @@ func ReconcileTenant(client crclient.Client, hcp *hyperv1.HostedControlPlane, ct
 		return err
 	}
 
-	tenantControllerClusterRole := manifests.KubevirtCSIDriverTenantControllerClusterRole(tenantNamespace)
+	tenantControllerClusterRole := manifests.KubevirtCSIDriverTenantControllerClusterRole()
 	_, err = createOrUpdate(ctx, client, tenantControllerClusterRole, func() error {
 		return reconcileTenantControllerClusterRole(tenantControllerClusterRole)
 	})

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kubevirt.go
@@ -73,20 +73,18 @@ func KubevirtCSIDriverTenantControllerSA(ns string) *corev1.ServiceAccount {
 	}
 }
 
-func KubevirtCSIDriverTenantControllerClusterRole(ns string) *rbacv1.ClusterRole {
+func KubevirtCSIDriverTenantControllerClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubevirt-csi-controller-cr",
-			Namespace: ns,
+			Name: "kubevirt-csi-controller-cr",
 		},
 	}
 }
 
-func KubevirtCSIDriverTenantControllerClusterRoleBinding(ns string) *rbacv1.ClusterRoleBinding {
+func KubevirtCSIDriverTenantControllerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubevirt-csi-controller-binding",
-			Namespace: ns,
+			Name: "kubevirt-csi-controller-binding",
 		},
 	}
 }
@@ -100,20 +98,18 @@ func KubevirtCSIDriverTenantNodeSA(ns string) *corev1.ServiceAccount {
 	}
 }
 
-func KubevirtCSIDriverTenantNodeClusterRole(ns string) *rbacv1.ClusterRole {
+func KubevirtCSIDriverTenantNodeClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubevirt-csi-node-cr",
-			Namespace: ns,
+			Name: "kubevirt-csi-node-cr",
 		},
 	}
 }
 
-func KubevirtCSIDriverTenantNodeClusterRoleBinding(ns string) *rbacv1.ClusterRoleBinding {
+func KubevirtCSIDriverTenantNodeClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubevirt-csi-node-binding",
-			Namespace: ns,
+			Name: "kubevirt-csi-node-binding",
 		},
 	}
 }


### PR DESCRIPTION
ClusterRoles and ClusterRoleBindings are cluster scoped, and do not need namespaces.  Trying to set the namespace during reconciliation results in errors like the one below.

```{"level":"error","ts":"2023-03-06T20:38:30Z","msg":"Reconciler error","controller":"resources","object":{"name":""},"namespace":"","name":"","reconcileID":"8e7c2ab5-e628-412e-9419-fb889e766185","error":"MutateFn cannot mutate object name and/or object namespace","errorCauses":[{"error":"MutateFn cannot mutate object name and/or object namespace"}],"stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234"}
```