### PR TITLE
HOSTEDCP-807: Check KAS loadbalancer health

### DIFF
--- a/api/v1beta1/hostedcluster_conditions.go
+++ b/api/v1beta1/hostedcluster_conditions.go
@@ -174,6 +174,8 @@ const (
 
 	ExternalDNSHostNotReachableReason = "ExternalDNSHostNotReachable"
 
+	KASLoadBalancerNotReachableReason = "KASLoadBalancerNotReachable"
+
 	ReconciliationPausedConditionReason             = "ReconciliationPaused"
 	ReconciliationInvalidPausedUntilConditionReason = "InvalidPausedUntilValue"
 )

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"hash/fnv"
 	"io"
 	"net"
+	"net/http"
 	"strings"
 	"time"
 
@@ -166,6 +168,17 @@ func ResolveDNSHostname(ctx context.Context, hostName string) error {
 	}
 
 	return err
+}
+
+// InsecureHTTPClient return an http.Client which skips server certificate verification
+func InsecureHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
 }
 
 // HashStruct takes a value, typically a string, and returns a 32-bit FNV-1a hashed version of the value as a string

--- a/test/e2e/util/oauth.go
+++ b/test/e2e/util/oauth.go
@@ -106,7 +106,7 @@ func WaitForOAuthToken(t *testing.T, ctx context.Context, oauthRoute *routev1.Ro
 	}
 
 	var access_token string
-	err = wait.PollImmediateWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollImmediateWithContext(ctx, time.Second, time.Minute*2, func(ctx context.Context) (done bool, err error) {
 		resp, err := httpClient.Do(request)
 		if err != nil {
 			t.Logf("Waiting for OAuth token request to succeed")


### PR DESCRIPTION
**What this PR does / why we need it**:
This enhances HCAvailable condition to better represent day2 state

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-807](https://issues.redhat.com/browse/HOSTEDCP-807)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.