### PR TITLE
WIP: add CCM to HCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/manifests.go
@@ -1,0 +1,86 @@
+package aws
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CCMServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMRole(ns string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMRoleBinding(ns string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMCloudConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-cloud-config",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMControllerCredsSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cloud-controller-creds",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMContainer() *corev1.Container {
+	return &corev1.Container{
+		Name: "cloud-controller-manager",
+	}
+}
+
+func ccmVolumeKubeconfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "kubeconfig",
+	}
+}
+
+func ccmCloudConfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cloud-config",
+	}
+}
+
+func ccmCloudControllerCreds() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cloud-controller-creds",
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
@@ -1,0 +1,149 @@
+package aws
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ReconcileCCMServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sa)
+	util.EnsurePullSecret(sa, controlplaneoperator.PullSecret("").Name)
+	return nil
+}
+
+func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, serviceAccountName string, releaseImage *releaseinfo.ReleaseImage) error {
+	deploymentConfig := newDeploymentConfig()
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: ccmLabels(),
+		},
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: ccmLabels(),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					util.BuildContainer(CCMContainer(), buildCCMContainer(releaseImage.ComponentImages()["aws-cloud-controller-manager"])),
+				},
+				Volumes:            []corev1.Volume{},
+				ServiceAccountName: serviceAccountName,
+			},
+		},
+	}
+
+	addVolumes(deployment)
+
+	util.ApplyCloudProviderCreds(&deployment.Spec.Template.Spec, Provider, &corev1.LocalObjectReference{Name: KubeCloudControllerCredsSecret("").Name}, releaseImage.ComponentImages()["token-minter"], CCMContainer().Name)
+
+	config.OwnerRefFrom(hcp).ApplyTo(deployment)
+	deploymentConfig.ApplyTo(deployment)
+	return nil
+}
+
+func addVolumes(deployment *appsv1.Deployment) {
+
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmVolumeKubeconfig(), buildCCMVolumeKubeconfig),
+	)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmCloudConfig(), buildCCMCloudConfig),
+	)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmCloudControllerCreds(), buildCCMControllerCreds),
+	)
+}
+
+func podVolumeMounts() util.PodVolumeMounts {
+	return util.PodVolumeMounts{
+		CCMContainer().Name: util.ContainerVolumeMounts{
+			ccmVolumeKubeconfig().Name:     "/etc/kubernetes/kubeconfig",
+			ccmCloudConfig().Name:          "/etc/cloud",
+			ccmCloudControllerCreds().Name: "/etc/aws",
+		},
+	}
+}
+
+func buildCCMContainer(controllerManagerImage string) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = controllerManagerImage
+		c.ImagePullPolicy = corev1.PullIfNotPresent
+		c.Command = []string{"/bin/aws-cloud-controller-manager"}
+		c.Args = []string{
+			"--cloud-provider=aws",
+			"--use-service-account-credentials=false",
+			"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+			"--cloud-config=/etc/cloud/aws.conf",
+			"--configure-cloud-routes=false",
+			"--leader-elect=true",
+			"--leader-elect-lease-duration=137s",
+			"--leader-elect-renew-deadline=107s",
+			"--leader-elect-retry-period=26s",
+			"--leader-elect-resource-namespace=openshift-cloud-controller-manager",
+		}
+		c.VolumeMounts = podVolumeMounts().ContainerMounts(c.Name)
+	}
+}
+
+func buildCCMVolumeKubeconfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+	}
+}
+
+func buildCCMControllerCreds(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: CCMControllerCredsSecret("").Name,
+	}
+}
+
+func buildCCMCloudConfig(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: CCMCloudConfigMap("").Name,
+		},
+	}
+}
+
+func newDeploymentConfig() config.DeploymentConfig {
+	result := config.DeploymentConfig{}
+	result.Resources = config.ResourcesSpec{
+		CCMContainer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+				corev1.ResourceCPU:    resource.MustParse("75m"),
+			},
+		},
+	}
+	result.AdditionalLabels = additionalLabels()
+	result.Scheduling.PriorityClass = config.DefaultPriorityClass
+
+	result.Replicas = 1
+
+	return result
+}
+
+func ccmLabels() map[string]string {
+	return map[string]string{
+		"app": "cloud-controller-manager",
+	}
+}
+
+func additionalLabels() map[string]string {
+	return map[string]string{
+		hyperv1.ControlPlaneComponent: "cloud-controller-manager",
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -6,7 +6,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
@@ -276,10 +275,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 
 	switch hcp.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		params.CloudProvider = aws.Provider
-		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AWSProviderConfig("").Name}
-		params.CloudProviderCreds = &corev1.LocalObjectReference{Name: aws.KubeCloudControllerCredsSecret("").Name}
 	case hyperv1.AzurePlatform:
 		params.CloudProvider = azure.Provider
 		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -9,7 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
@@ -103,10 +102,6 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	switch hcp.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		params.CloudProvider = aws.Provider
-		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AWSProviderConfig("").Name}
-		params.CloudProviderCreds = &corev1.LocalObjectReference{Name: aws.KubeCloudControllerCredsSecret("").Name}
 	case hyperv1.AzurePlatform:
 		params.CloudProvider = azure.Provider
 		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/namespaces.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/namespaces.go
@@ -13,6 +13,14 @@ func NamespaceOpenShiftInfra() *corev1.Namespace {
 	}
 }
 
+func NamespaceOpenshiftCloudControllerManager() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-cloud-controller-manager",
+		},
+	}
+}
+
 func NamespaceOpenShiftAPIServer() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -640,6 +640,7 @@ func (r *reconciler) reconcileNamespaces(ctx context.Context) error {
 	}{
 		{manifest: manifests.NamespaceOpenShiftAPIServer},
 		{manifest: manifests.NamespaceOpenShiftInfra, reconcile: namespaces.ReconcileOpenShiftInfraNamespace},
+		{manifest: manifests.NamespaceOpenshiftCloudControllerManager},
 		{manifest: manifests.NamespaceOpenShiftControllerManager},
 		{manifest: manifests.NamespaceKubeAPIServer, reconcile: namespaces.ReconcileKubeAPIServerNamespace},
 		{manifest: manifests.NamespaceKubeControllerManager},


### PR DESCRIPTION
This adds the AWS CCM to the HCP.

This is required to get CI back online after `--cloud-provider=external` was set in the kubelet flags as part of the OCP transition away from the long deprecated in-tree provider.

WIP: The `cloud-controller-creds` role requires additional privileges over what the in-tree provider required.  Those changes haven't been made yet.