### PR TITLE
HOSTEDCP-919: Add AWS cloud controller manager

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1110,6 +1110,10 @@ type AWSRolesRef struct {
 	//  "Statement": [
 	//    {
 	//      "Action": [
+	//        "autoscaling:DescribeAutoScalingGroups",
+	//        "autoscaling:DescribeLaunchConfigurations",
+	//        "autoscaling:DescribeTags",
+	//        "ec2:DescribeAvailabilityZones",
 	//        "ec2:DescribeInstances",
 	//        "ec2:DescribeImages",
 	//        "ec2:DescribeRegions",
@@ -1152,6 +1156,7 @@ type AWSRolesRef struct {
 	//        "elasticloadbalancing:CreateTargetGroup",
 	//        "elasticloadbalancing:DeleteListener",
 	//        "elasticloadbalancing:DeleteTargetGroup",
+	//        "elasticloadbalancing:DeregisterTargets",
 	//        "elasticloadbalancing:DescribeListeners",
 	//        "elasticloadbalancing:DescribeLoadBalancerPolicies",
 	//        "elasticloadbalancing:DescribeTargetGroups",

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -102,6 +102,10 @@ const (
   "Statement": [
     {
       "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DescribeTags",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeImages",
         "ec2:DescribeRegions",
@@ -144,6 +148,7 @@ const (
         "elasticloadbalancing:CreateTargetGroup",
         "elasticloadbalancing:DeleteListener",
         "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DeregisterTargets",
         "elasticloadbalancing:DescribeListeners",
         "elasticloadbalancing:DescribeLoadBalancerPolicies",
         "elasticloadbalancing:DescribeTargetGroups",

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -6056,7 +6056,9 @@ spec:
                             description: "KubeCloudControllerARN is an ARN value referencing
                               a role appropriate for the KCM/KCC. \n The following
                               is an example of a valid policy document: \n { \"Version\":
-                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"ec2:DescribeInstances\",
+                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
+                              \"autoscaling:DescribeLaunchConfigurations\", \"autoscaling:DescribeTags\",
+                              \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeInstances\",
                               \"ec2:DescribeImages\", \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",
                               \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
                               \"ec2:DescribeVolumes\", \"ec2:CreateSecurityGroup\",
@@ -6079,8 +6081,8 @@ spec:
                               \"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer\",
                               \"elasticloadbalancing:AddTags\", \"elasticloadbalancing:CreateListener\",
                               \"elasticloadbalancing:CreateTargetGroup\", \"elasticloadbalancing:DeleteListener\",
-                              \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DescribeListeners\",
-                              \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
+                              \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DeregisterTargets\",
+                              \"elasticloadbalancing:DescribeListeners\", \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
                               \"elasticloadbalancing:DescribeTargetGroups\", \"elasticloadbalancing:DescribeTargetHealth\",
                               \"elasticloadbalancing:ModifyListener\", \"elasticloadbalancing:ModifyTargetGroup\",
                               \"elasticloadbalancing:RegisterTargets\", \"elasticloadbalancing:SetLoadBalancerPoliciesOfListener\",

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -6047,7 +6047,9 @@ spec:
                             description: "KubeCloudControllerARN is an ARN value referencing
                               a role appropriate for the KCM/KCC. \n The following
                               is an example of a valid policy document: \n { \"Version\":
-                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"ec2:DescribeInstances\",
+                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
+                              \"autoscaling:DescribeLaunchConfigurations\", \"autoscaling:DescribeTags\",
+                              \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeInstances\",
                               \"ec2:DescribeImages\", \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",
                               \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
                               \"ec2:DescribeVolumes\", \"ec2:CreateSecurityGroup\",
@@ -6070,8 +6072,8 @@ spec:
                               \"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer\",
                               \"elasticloadbalancing:AddTags\", \"elasticloadbalancing:CreateListener\",
                               \"elasticloadbalancing:CreateTargetGroup\", \"elasticloadbalancing:DeleteListener\",
-                              \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DescribeListeners\",
-                              \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
+                              \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DeregisterTargets\",
+                              \"elasticloadbalancing:DescribeListeners\", \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
                               \"elasticloadbalancing:DescribeTargetGroups\", \"elasticloadbalancing:DescribeTargetHealth\",
                               \"elasticloadbalancing:ModifyListener\", \"elasticloadbalancing:ModifyTargetGroup\",
                               \"elasticloadbalancing:RegisterTargets\", \"elasticloadbalancing:SetLoadBalancerPoliciesOfListener\",

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/manifests.go
@@ -1,0 +1,68 @@
+package aws
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CCMServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMRole(ns string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMRoleBinding(ns string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func ccmContainer() *corev1.Container {
+	return &corev1.Container{
+		Name: "cloud-controller-manager",
+	}
+}
+
+func ccmVolumeKubeconfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "kubeconfig",
+	}
+}
+
+func ccmCloudConfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cloud-config",
+	}
+}
+
+func ccmCloudControllerCreds() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cloud-controller-creds",
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ReconcileCCMServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sa)
+	util.EnsurePullSecret(sa, controlplaneoperator.PullSecret("").Name)
+	return nil
+}
+
+func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, serviceAccountName string, releaseImage *releaseinfo.ReleaseImage) error {
+	deploymentConfig := newDeploymentConfig()
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: ccmLabels(),
+		},
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: ccmLabels(),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					util.BuildContainer(ccmContainer(), buildCCMContainer(releaseImage.ComponentImages()["aws-cloud-controller-manager"])),
+				},
+				Volumes:            []corev1.Volume{},
+				ServiceAccountName: serviceAccountName,
+			},
+		},
+	}
+
+	addVolumes(deployment)
+
+	util.ApplyCloudProviderCreds(&deployment.Spec.Template.Spec, Provider, &corev1.LocalObjectReference{Name: KubeCloudControllerCredsSecret("").Name}, releaseImage.ComponentImages()["token-minter"], ccmContainer().Name)
+
+	config.OwnerRefFrom(hcp).ApplyTo(deployment)
+	deploymentConfig.ApplyTo(deployment)
+	return nil
+}
+
+func addVolumes(deployment *appsv1.Deployment) {
+
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmVolumeKubeconfig(), buildCCMVolumeKubeconfig),
+	)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmCloudConfig(), buildCCMCloudConfig),
+	)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmCloudControllerCreds(), buildCCMControllerCreds),
+	)
+}
+
+func podVolumeMounts() util.PodVolumeMounts {
+	return util.PodVolumeMounts{
+		ccmContainer().Name: util.ContainerVolumeMounts{
+			ccmVolumeKubeconfig().Name:     "/etc/kubernetes/kubeconfig",
+			ccmCloudConfig().Name:          "/etc/cloud",
+			ccmCloudControllerCreds().Name: "/etc/aws",
+		},
+	}
+}
+
+func buildCCMContainer(controllerManagerImage string) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = controllerManagerImage
+		c.ImagePullPolicy = corev1.PullIfNotPresent
+		c.Command = []string{"/bin/aws-cloud-controller-manager"}
+		c.Args = []string{
+			"--cloud-provider=aws",
+			"--use-service-account-credentials=false",
+			"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+			"--cloud-config=/etc/cloud/aws.conf",
+			"--configure-cloud-routes=false",
+			"--leader-elect=true",
+			fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),
+			fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
+			fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
+			"--leader-elect-resource-namespace=openshift-cloud-controller-manager",
+		}
+		c.VolumeMounts = podVolumeMounts().ContainerMounts(c.Name)
+	}
+}
+
+func buildCCMVolumeKubeconfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+	}
+}
+
+func buildCCMControllerCreds(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: KubeCloudControllerCredsSecret("").Name,
+	}
+}
+
+func buildCCMCloudConfig(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: manifests.AWSProviderConfig("").Name,
+		},
+	}
+}
+
+func newDeploymentConfig() config.DeploymentConfig {
+	result := config.DeploymentConfig{}
+	result.Resources = config.ResourcesSpec{
+		ccmContainer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+				corev1.ResourceCPU:    resource.MustParse("75m"),
+			},
+		},
+	}
+	result.AdditionalLabels = additionalLabels()
+	result.Scheduling.PriorityClass = config.DefaultPriorityClass
+
+	result.Replicas = 1
+
+	return result
+}
+
+func ccmLabels() map[string]string {
+	return map[string]string{
+		"app": "cloud-controller-manager",
+	}
+}
+
+func additionalLabels() map[string]string {
+	return map[string]string{
+		hyperv1.ControlPlaneComponent: "cloud-controller-manager",
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -6,7 +6,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
@@ -276,10 +275,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 
 	switch hcp.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		params.CloudProvider = aws.Provider
-		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AWSProviderConfig("").Name}
-		params.CloudProviderCreds = &corev1.LocalObjectReference{Name: aws.KubeCloudControllerCredsSecret("").Name}
 	case hyperv1.AzurePlatform:
 		params.CloudProvider = azure.Provider
 		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -9,7 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
@@ -103,10 +102,6 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	switch hcp.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
-		params.CloudProvider = aws.Provider
-		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AWSProviderConfig("").Name}
-		params.CloudProviderCreds = &corev1.LocalObjectReference{Name: aws.KubeCloudControllerCredsSecret("").Name}
 	case hyperv1.AzurePlatform:
 		params.CloudProvider = azure.Provider
 		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/namespaces.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/namespaces.go
@@ -13,6 +13,14 @@ func NamespaceOpenShiftInfra() *corev1.Namespace {
 	}
 }
 
+func NamespaceOpenshiftCloudControllerManager() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-cloud-controller-manager",
+		},
+	}
+}
+
 func NamespaceOpenShiftAPIServer() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -640,6 +640,7 @@ func (r *reconciler) reconcileNamespaces(ctx context.Context) error {
 	}{
 		{manifest: manifests.NamespaceOpenShiftAPIServer},
 		{manifest: manifests.NamespaceOpenShiftInfra, reconcile: namespaces.ReconcileOpenShiftInfraNamespace},
+		{manifest: manifests.NamespaceOpenshiftCloudControllerManager},
 		{manifest: manifests.NamespaceOpenShiftControllerManager},
 		{manifest: manifests.NamespaceKubeAPIServer, reconcile: namespaces.ReconcileKubeAPIServerNamespace},
 		{manifest: manifests.NamespaceKubeControllerManager},

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1711,6 +1711,10 @@ string
 &ldquo;Statement&rdquo;: [
 {
 &ldquo;Action&rdquo;: [
+&ldquo;autoscaling:DescribeAutoScalingGroups&rdquo;,
+&ldquo;autoscaling:DescribeLaunchConfigurations&rdquo;,
+&ldquo;autoscaling:DescribeTags&rdquo;,
+&ldquo;ec2:DescribeAvailabilityZones&rdquo;,
 &ldquo;ec2:DescribeInstances&rdquo;,
 &ldquo;ec2:DescribeImages&rdquo;,
 &ldquo;ec2:DescribeRegions&rdquo;,
@@ -1753,6 +1757,7 @@ string
 &ldquo;elasticloadbalancing:CreateTargetGroup&rdquo;,
 &ldquo;elasticloadbalancing:DeleteListener&rdquo;,
 &ldquo;elasticloadbalancing:DeleteTargetGroup&rdquo;,
+&ldquo;elasticloadbalancing:DeregisterTargets&rdquo;,
 &ldquo;elasticloadbalancing:DescribeListeners&rdquo;,
 &ldquo;elasticloadbalancing:DescribeLoadBalancerPolicies&rdquo;,
 &ldquo;elasticloadbalancing:DescribeTargetGroups&rdquo;,

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -33370,8 +33370,10 @@ objects:
                                 referencing a role appropriate for the KCM/KCC. \n
                                 The following is an example of a valid policy document:
                                 \n { \"Version\": \"2012-10-17\", \"Statement\": [
-                                { \"Action\": [ \"ec2:DescribeInstances\", \"ec2:DescribeImages\",
-                                \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",
+                                { \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
+                                \"autoscaling:DescribeLaunchConfigurations\", \"autoscaling:DescribeTags\",
+                                \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeInstances\",
+                                \"ec2:DescribeImages\", \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",
                                 \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
                                 \"ec2:DescribeVolumes\", \"ec2:CreateSecurityGroup\",
                                 \"ec2:CreateTags\", \"ec2:CreateVolume\", \"ec2:ModifyInstanceAttribute\",
@@ -33393,8 +33395,8 @@ objects:
                                 \"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer\",
                                 \"elasticloadbalancing:AddTags\", \"elasticloadbalancing:CreateListener\",
                                 \"elasticloadbalancing:CreateTargetGroup\", \"elasticloadbalancing:DeleteListener\",
-                                \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DescribeListeners\",
-                                \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
+                                \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DeregisterTargets\",
+                                \"elasticloadbalancing:DescribeListeners\", \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
                                 \"elasticloadbalancing:DescribeTargetGroups\", \"elasticloadbalancing:DescribeTargetHealth\",
                                 \"elasticloadbalancing:ModifyListener\", \"elasticloadbalancing:ModifyTargetGroup\",
                                 \"elasticloadbalancing:RegisterTargets\", \"elasticloadbalancing:SetLoadBalancerPoliciesOfListener\",
@@ -40795,8 +40797,10 @@ objects:
                                 referencing a role appropriate for the KCM/KCC. \n
                                 The following is an example of a valid policy document:
                                 \n { \"Version\": \"2012-10-17\", \"Statement\": [
-                                { \"Action\": [ \"ec2:DescribeInstances\", \"ec2:DescribeImages\",
-                                \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",
+                                { \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
+                                \"autoscaling:DescribeLaunchConfigurations\", \"autoscaling:DescribeTags\",
+                                \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeInstances\",
+                                \"ec2:DescribeImages\", \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",
                                 \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
                                 \"ec2:DescribeVolumes\", \"ec2:CreateSecurityGroup\",
                                 \"ec2:CreateTags\", \"ec2:CreateVolume\", \"ec2:ModifyInstanceAttribute\",
@@ -40818,8 +40822,8 @@ objects:
                                 \"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer\",
                                 \"elasticloadbalancing:AddTags\", \"elasticloadbalancing:CreateListener\",
                                 \"elasticloadbalancing:CreateTargetGroup\", \"elasticloadbalancing:DeleteListener\",
-                                \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DescribeListeners\",
-                                \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
+                                \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DeregisterTargets\",
+                                \"elasticloadbalancing:DescribeListeners\", \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
                                 \"elasticloadbalancing:DescribeTargetGroups\", \"elasticloadbalancing:DescribeTargetHealth\",
                                 \"elasticloadbalancing:ModifyListener\", \"elasticloadbalancing:ModifyTargetGroup\",
                                 \"elasticloadbalancing:RegisterTargets\", \"elasticloadbalancing:SetLoadBalancerPoliciesOfListener\",

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -63,6 +63,7 @@ func TestNodePool(t *testing.T) {
 	// Set of tests
 	// Each test should have their own NodePool
 	nodePoolTests := []NodePoolTestCase{
+
 		{
 			name: "TestKMSRootVolumeEncryption",
 			test: NewKMSRootVolumeTest(hostedCluster, clusterOpts),
@@ -79,11 +80,14 @@ func TestNodePool(t *testing.T) {
 			name: "TestNTOMachineConfigGetsRolledOut",
 			test: NewNTOMachineConfigRolloutTest(ctx, mgmtClient, hostedCluster, hostedClusterClient),
 		},
-		{
-			name:            "TestNTOMachineConfigAppliedInPlace",
-			test:            NewNTOMachineConfigRolloutTest(ctx, mgmtClient, hostedCluster, hostedClusterClient),
-			manifestBuilder: NewNTOMachineConfigInPlaceRolloutTestManifest(hostedCluster),
-		},
+		/*
+			// TODO: (csrwng) Re-enable when https://issues.redhat.com/browse/OCPBUGS-10218 is fixed
+			{
+				name:            "TestNTOMachineConfigAppliedInPlace",
+				test:            NewNTOMachineConfigRolloutTest(ctx, mgmtClient, hostedCluster, hostedClusterClient),
+				manifestBuilder: NewNTOMachineConfigInPlaceRolloutTestManifest(hostedCluster),
+			},
+		*/
 	}
 
 	t.Run("NodePool Tests Group", func(t *testing.T) {

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -159,6 +159,8 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 }
 
 func TestInPlaceUpgradeNodePool(t *testing.T) {
+	// TODO: (csrwng) Re-enable when https://issues.redhat.com/browse/OCPBUGS-10218 is fixed
+	t.Skip("Skipping due to https://issues.redhat.com/browse/OCPBUGS-10218")
 	t.Parallel()
 	g := NewWithT(t)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a new deployment for the AWS cloud controller manager. This is required because in 4.14 kubelets are initialized with an external cloud manager.

Updates the kube cloud controller manager AWS role with additional permissions.


**Checklist**
- [x] Subject and description added to both, commit and PR.