### PR TITLE
OCPBUGS-8381: Use appropriate serving certificate for OAuth

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -92,6 +92,15 @@ func KonnectivityCAConfigMap(ns string) *corev1.ConfigMap {
 	}
 }
 
+func OpenShiftOAuthMasterCABundle(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oauth-master-ca-bundle",
+			Namespace: ns,
+		},
+	}
+}
+
 func EtcdSignerSecret(ns string) *corev1.Secret {
 	return secretFor(ns, "etcd-signer")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/config.go
@@ -62,11 +62,7 @@ func generateOAuthConfig(ctx context.Context, client crclient.Client, namespace 
 		return path.Join(dir, file)
 	}
 
-	caCertPath := ""
-	if _, hasCA := params.ServingCert.Data[certs.CASignerCertMapKey]; hasCA {
-		caCertPath = cpath(oauthVolumeServingCert().Name, certs.CASignerCertMapKey)
-	}
-
+	caCertPath := cpath(oauthVolumeMasterCABundle().Name, certs.CASignerCertMapKey)
 	serverConfig := &osinv1.OsinServerConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "OsinServerConfig",

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -41,6 +41,7 @@ var (
 			oauthVolumeLoginTemplate().Name:     "/etc/kubernetes/secrets/templates/login",
 			oauthVolumeProvidersTemplate().Name: "/etc/kubernetes/secrets/templates/providers",
 			oauthVolumeWorkLogs().Name:          "/var/run/kubernetes",
+			oauthVolumeMasterCABundle().Name:    "/etc/kubernetes/certs/master-ca",
 		},
 	}
 )
@@ -101,6 +102,7 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 			util.BuildVolume(oauthVolumeLoginTemplate(), buildOAuthVolumeLoginTemplate),
 			util.BuildVolume(oauthVolumeProvidersTemplate(), buildOAuthVolumeProvidersTemplate),
 			util.BuildVolume(oauthVolumeWorkLogs(), buildOAuthVolumeWorkLogs),
+			util.BuildVolume(oauthVolumeMasterCABundle(), buildOAuthVolumeMasterCABundle),
 			{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: utilpointer.Int32Ptr(0640)}}},
 			{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: utilpointer.Int32Ptr(0640)}}},
 			{Name: "konnectivity-proxy-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: manifests.KonnectivityCAConfigMap("").Name}, DefaultMode: utilpointer.Int32Ptr(0640)}}},
@@ -252,6 +254,17 @@ func buildOAuthVolumeProvidersTemplate(v *corev1.Volume) {
 		DefaultMode: utilpointer.Int32Ptr(0640),
 		SecretName:  manifests.OAuthServerDefaultProviderSelectionTemplateSecret("").Name,
 	}
+}
+
+func oauthVolumeMasterCABundle() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "master-ca-bundle",
+	}
+}
+
+func buildOAuthVolumeMasterCABundle(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+	v.ConfigMap.Name = manifests.OpenShiftOAuthMasterCABundle("").Name
 }
 
 func socks5ProxyContainer(socks5ProxyImage string) corev1.Container {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/oauth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/oauth.go
@@ -3,6 +3,7 @@ package pki
 import (
 	"net"
 
+	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -16,4 +17,21 @@ func ReconcileOAuthServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRe
 		dnsNames = append(dnsNames, externalOAuthAddress)
 	}
 	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-oauth", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, ips)
+}
+
+func ReconcileOAuthMasterCABundle(caBundle *corev1.ConfigMap, ownerRef config.OwnerRef, sourceCerts []*corev1.Secret) error {
+	var sources []*corev1.Secret
+	// Collect all sources and use the same key (ca.crt) whether original is ca.crt or tls.crt
+	for _, cert := range sourceCerts {
+		if _, hasKey := cert.Data[certs.CASignerCertMapKey]; hasKey {
+			sources = append(sources, cert.DeepCopy())
+			continue
+		}
+		sources = append(sources, &corev1.Secret{
+			Data: map[string][]byte{
+				certs.CASignerCertMapKey: cert.Data[corev1.TLSCertKey],
+			},
+		})
+	}
+	return reconcileAggregateCA(caBundle, ownerRef, sources...)
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/oauth/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/oauth/reconcile.go
@@ -4,7 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/support/certs"
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,12 +14,9 @@ import (
 	oauthv1 "github.com/openshift/api/oauth/v1"
 )
 
-func ReconcileOAuthServerCertCABundle(cm *corev1.ConfigMap, sourceSecret *corev1.Secret) error {
-	if _, hasCertKey := sourceSecret.Data[corev1.TLSCertKey]; !hasCertKey {
-		return fmt.Errorf("source secret %s/%s does not have a cert key", sourceSecret.Namespace, sourceSecret.Name)
-	}
+func ReconcileOAuthServerCertCABundle(cm *corev1.ConfigMap, sourceBundle *corev1.ConfigMap) error {
 	cm.Data = map[string]string{}
-	cm.Data["ca-bundle.crt"] = string(sourceSecret.Data[corev1.TLSCertKey])
+	cm.Data["ca-bundle.crt"] = string(sourceBundle.Data[certs.CASignerCertMapKey])
 	return nil
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -89,7 +89,7 @@ var cpObjects = []client.Object{
 	fakeOpenShiftAPIServerService(),
 	fakeOpenShiftOAuthAPIServerService(),
 	fakeKubeadminPasswordSecret(),
-	fakeOAuthServingCert(),
+	fakeOAuthMasterCABundle(),
 	fakePackageServerService(),
 }
 
@@ -233,9 +233,9 @@ func fakeKubeadminPasswordSecret() *corev1.Secret {
 	return s
 }
 
-func fakeOAuthServingCert() *corev1.Secret {
-	s := cpomanifests.OpenShiftOAuthServerCert("bar")
-	s.Data = map[string][]byte{"tls.crt": []byte("test")}
+func fakeOAuthMasterCABundle() *corev1.ConfigMap {
+	s := cpomanifests.OpenShiftOAuthMasterCABundle("bar")
+	s.Data = map[string]string{"ca.crt": "test"}
 	return s
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For oauth, we currently only copy the self-signed cert to openshift-config-managed
of the hosted cluster. However, if a certificate has been specified for
the oauth endpoint via spec.config.apiServer, the bundle that we copy
over should contain the additional certificate.

Adds CA bundle to the oauth server configuration that contains certs
specified through apiserver namedcerts and the self-signed cert that we
normally generate.

**Which issue(s) this PR fixes**:
Fixes #OCPBUGS-8381

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.