### PR TITLE
HOSTEDCP-919: Clean up and API doc

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1102,6 +1102,7 @@ type AWSRolesRef struct {
 	NetworkARN string `json:"networkARN"`
 
 	// KubeCloudControllerARN is an ARN value referencing a role appropriate for the KCM/KCC.
+	// Source: https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies
 	//
 	// The following is an example of a valid policy document:
 	//

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -6054,9 +6054,10 @@ spec:
                             type: string
                           kubeCloudControllerARN:
                             description: "KubeCloudControllerARN is an ARN value referencing
-                              a role appropriate for the KCM/KCC. \n The following
-                              is an example of a valid policy document: \n { \"Version\":
-                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
+                              a role appropriate for the KCM/KCC. Source: https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies
+                              \n The following is an example of a valid policy document:
+                              \n { \"Version\": \"2012-10-17\", \"Statement\": [ {
+                              \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
                               \"autoscaling:DescribeLaunchConfigurations\", \"autoscaling:DescribeTags\",
                               \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeInstances\",
                               \"ec2:DescribeImages\", \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -6045,9 +6045,10 @@ spec:
                             type: string
                           kubeCloudControllerARN:
                             description: "KubeCloudControllerARN is an ARN value referencing
-                              a role appropriate for the KCM/KCC. \n The following
-                              is an example of a valid policy document: \n { \"Version\":
-                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
+                              a role appropriate for the KCM/KCC. Source: https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies
+                              \n The following is an example of a valid policy document:
+                              \n { \"Version\": \"2012-10-17\", \"Statement\": [ {
+                              \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
                               \"autoscaling:DescribeLaunchConfigurations\", \"autoscaling:DescribeTags\",
                               \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeInstances\",
                               \"ec2:DescribeImages\", \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/manifests.go
@@ -3,30 +3,11 @@ package aws
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func CCMServiceAccount(ns string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "aws-cloud-controller-manager",
-			Namespace: ns,
-		},
-	}
-}
-
-func CCMRole(ns string) *rbacv1.Role {
-	return &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "aws-cloud-controller-manager",
-			Namespace: ns,
-		},
-	}
-}
-
-func CCMRoleBinding(ns string) *rbacv1.RoleBinding {
-	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "aws-cloud-controller-manager",
 			Namespace: ns,

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1704,7 +1704,8 @@ string
 </em>
 </td>
 <td>
-<p>KubeCloudControllerARN is an ARN value referencing a role appropriate for the KCM/KCC.</p>
+<p>KubeCloudControllerARN is an ARN value referencing a role appropriate for the KCM/KCC.
+Source: <a href="https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies">https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies</a></p>
 <p>The following is an example of a valid policy document:</p>
 <p>{
 &ldquo;Version&rdquo;: &ldquo;2012-10-17&rdquo;,

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -33367,8 +33367,9 @@ objects:
                               type: string
                             kubeCloudControllerARN:
                               description: "KubeCloudControllerARN is an ARN value
-                                referencing a role appropriate for the KCM/KCC. \n
-                                The following is an example of a valid policy document:
+                                referencing a role appropriate for the KCM/KCC. Source:
+                                https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies
+                                \n The following is an example of a valid policy document:
                                 \n { \"Version\": \"2012-10-17\", \"Statement\": [
                                 { \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
                                 \"autoscaling:DescribeLaunchConfigurations\", \"autoscaling:DescribeTags\",
@@ -40794,8 +40795,9 @@ objects:
                               type: string
                             kubeCloudControllerARN:
                               description: "KubeCloudControllerARN is an ARN value
-                                referencing a role appropriate for the KCM/KCC. \n
-                                The following is an example of a valid policy document:
+                                referencing a role appropriate for the KCM/KCC. Source:
+                                https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies
+                                \n The following is an example of a valid policy document:
                                 \n { \"Version\": \"2012-10-17\", \"Statement\": [
                                 { \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
                                 \"autoscaling:DescribeLaunchConfigurations\", \"autoscaling:DescribeTags\",


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up to #2271
Removes unnecessary manifest functions and adds a comment with the source of the policy used for the cloud controller manager.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 