### PR TITLE
OCPBUGS-10227: Ensure identity provider health check condition is persisted and remove awsendpoint control plane finalizer if invalid aws creds

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -277,6 +277,11 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// This is a best effort ping to the identity provider
 	// that enables access from the operator to the cloud provider resources.
 	healthCheckIdentityProvider(ctx, hostedControlPlane, r.ec2Client)
+	// We want to ensure the healthCheckIdentityProvider condition is in status before we go through the deletion timestamp path.
+	if err := r.Client.Status().Patch(ctx, hostedControlPlane, client.MergeFromWithOptions(originalHostedControlPlane, client.MergeFromWithOptimisticLock{})); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+	}
+	originalHostedControlPlane = hostedControlPlane.DeepCopy()
 
 	// Return early if deleted
 	if !hostedControlPlane.DeletionTimestamp.IsZero() {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2934,24 +2934,44 @@ func (r *HostedClusterReconciler) deleteNodePools(ctx context.Context, c client.
 	return nil
 }
 
-func deleteAWSEndpointServices(ctx context.Context, c client.Client, namespace string) (bool, error) {
+// deleteAWSEndpointServices loops over AWSEndpointServiceList items and sends a delete request for each.
+// If the HC has no valid aws credentials it removes the CPO finalizer for each AWSEndpointService.
+// It returns true if len(awsEndpointServiceList.Items) != 0.
+func deleteAWSEndpointServices(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, namespace string) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
 	var awsEndpointServiceList hyperv1.AWSEndpointServiceList
 	if err := c.List(ctx, &awsEndpointServiceList, &client.ListOptions{Namespace: namespace}); err != nil && !apierrors.IsNotFound(err) {
 		return false, fmt.Errorf("error listing awsendpointservices in namespace %s: %w", namespace, err)
 	}
 	for _, ep := range awsEndpointServiceList.Items {
 		if ep.DeletionTimestamp != nil {
+			if platformaws.ValidCredentials(hc) {
+				continue
+			}
+
+			// We remove the CPO finalizer if there's no valid credentials so deletion can proceed.
+			cpoFinalizer := "hypershift.openshift.io/control-plane-operator-finalizer"
+			if controllerutil.ContainsFinalizer(&ep, cpoFinalizer) {
+				controllerutil.RemoveFinalizer(&ep, cpoFinalizer)
+				if err := c.Update(ctx, &ep); err != nil {
+					return false, fmt.Errorf("failed to remove finalizer from awsendpointservice: %w", err)
+				}
+			}
+			log.Info("Removed finalizer for awsendpointservice because the HC has no valid aws credentials", "name", ep.Name)
 			continue
 		}
+
 		if err := c.Delete(ctx, &ep); err != nil && !apierrors.IsNotFound(err) {
 			return false, fmt.Errorf("error deleting awsendpointservices %s in namespace %s: %w", ep.Name, namespace, err)
 		}
 	}
+
 	if len(awsEndpointServiceList.Items) != 0 {
 		// The CPO puts a finalizer on AWSEndpointService resources and should
 		// not be terminated until the resources are removed from the API server
 		return true, nil
 	}
+
 	return false, nil
 }
 
@@ -3027,7 +3047,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		return false, err
 	}
 
-	exists, err := deleteAWSEndpointServices(ctx, r.Client, controlPlaneNamespace)
+	exists, err := deleteAWSEndpointServices(ctx, r.Client, hc, controlPlaneNamespace)
 	if err != nil {
 		return false, err
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -290,7 +290,7 @@ func (AWS) ReconcileSecretEncryption(ctx context.Context, c client.Client, creat
 	return nil
 }
 
-func validCredentials(hc *hyperv1.HostedCluster) bool {
+func ValidCredentials(hc *hyperv1.HostedCluster) bool {
 	oidcConfigValid := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidOIDCConfiguration))
 	if oidcConfigValid != nil && oidcConfigValid.Status == metav1.ConditionFalse {
 		return false
@@ -303,7 +303,7 @@ func validCredentials(hc *hyperv1.HostedCluster) bool {
 }
 
 func (AWS) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, controlPlaneNamespace string) error {
-	if validCredentials(hc) {
+	if ValidCredentials(hc) {
 		return nil
 	}
 	awsMachineList := capiaws.AWSMachineList{}


### PR DESCRIPTION

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Without this additional logic cluster might get stuck deleting when either the CPO didn't have the chance to set the valid identity provider condition or when the credentials are invalid.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Ref OCPBUGS-10227

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.