### PR TITLE
HOSTEDCP-801: Expose external DNS for private cluster endpoints

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -187,17 +187,13 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			for i, svc := range services {
 				switch svc.Service {
 				case hyperv1.APIServer:
-					if endpointAccess != hyperv1.Private {
-						services[i].Route = &hyperv1.RoutePublishingStrategy{
-							Hostname: fmt.Sprintf("api-%s.%s", o.Name, o.ExternalDNSDomain),
-						}
+					services[i].Route = &hyperv1.RoutePublishingStrategy{
+						Hostname: fmt.Sprintf("api-%s.%s", o.Name, o.ExternalDNSDomain),
 					}
 
 				case hyperv1.OAuthServer:
-					if endpointAccess != hyperv1.Private {
-						services[i].Route = &hyperv1.RoutePublishingStrategy{
-							Hostname: fmt.Sprintf("oauth-%s.%s", o.Name, o.ExternalDNSDomain),
-						}
+					services[i].Route = &hyperv1.RoutePublishingStrategy{
+						Hostname: fmt.Sprintf("oauth-%s.%s", o.Name, o.ExternalDNSDomain),
 					}
 
 				case hyperv1.Konnectivity:

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -141,6 +141,14 @@ const (
 	// NodePoolNameLabel is a label that indicates the name of the node pool
 	// a resource is associated with
 	NodePoolNameLabel = "hypershift.openshift.io/nodepool-name"
+
+	// RouteVisibilityLabel is a label that can be used by external-dns to filter routes
+	// it should not consider for name registration
+	RouteVisibilityLabel = "hypershift.openshift.io/route-visibility"
+
+	// RouteVisibilityPrivate is a value for RouteVisibilityLabel that will result
+	// in the labeled route being ignored by external-dns
+	RouteVisibilityPrivate = "private"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -192,6 +192,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								"--txt-suffix=-external-dns",
 								fmt.Sprintf("--txt-owner-id=%s", txtOwnerId),
 								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
+								"--events",
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
 							LivenessProbe: &corev1.Probe{

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -191,6 +191,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								"--registry=txt",
 								"--txt-suffix=-external-dns",
 								fmt.Sprintf("--txt-owner-id=%s", txtOwnerId),
+								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
 							LivenessProbe: &corev1.Probe{

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -16,11 +16,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes"
@@ -30,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -38,12 +41,14 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 )
 
 const (
-	defaultResync = 10 * time.Hour
+	defaultResync               = 10 * time.Hour
+	externalPrivateServiceLabel = "hypershift.openshift.io/external-private-service"
 )
 
 // PrivateServiceObserver watches a given Service type LB and reconciles
@@ -179,6 +184,7 @@ type AWSEndpointServiceReconciler struct {
 	client.Client
 	ec2Client     ec2iface.EC2API
 	route53Client route53iface.Route53API
+	upsert.CreateOrUpdateProvider
 }
 
 func (r *AWSEndpointServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -188,11 +194,11 @@ func (r *AWSEndpointServiceReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			RateLimiter:             workqueue.NewItemExponentialFailureRateLimiter(3*time.Second, 30*time.Second),
 			MaxConcurrentReconciles: 10,
 		}).
+		Watches(&source.Kind{Type: &hyperv1.HostedControlPlane{}}, handler.Funcs{UpdateFunc: r.enqueueOnAccessChange(mgr)}).
 		Build(r)
 	if err != nil {
 		return fmt.Errorf("failed setting up with a controller manager: %w", err)
 	}
-
 	r.Client = mgr.GetClient()
 
 	// AWS_SHARED_CREDENTIALS_FILE and AWS_REGION envvar should be set in operator deployment
@@ -205,6 +211,33 @@ func (r *AWSEndpointServiceReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	r.route53Client = route53.New(awsSession, route53Config)
 
 	return nil
+}
+
+func (r *AWSEndpointServiceReconciler) enqueueOnAccessChange(mgr ctrl.Manager) func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+	return func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+		logger := mgr.GetLogger()
+		newHCP, isOk := e.ObjectNew.(*hyperv1.HostedControlPlane)
+		if !isOk {
+			logger.Info("WARNING: enqueueOnAccessChange: new resource is not of type HostedControlPlane")
+			return
+		}
+		oldHCP, isOk := e.ObjectOld.(*hyperv1.HostedControlPlane)
+		if !isOk {
+			logger.Info("WARNING: enqueueOnAccessChange: old resource is not of type HostedControlPlane")
+			return
+		}
+		// Only enqueue awsendpointservices when there is a change in the endpointaccess value, otherwise ignore changes
+		if newHCP.Spec.Platform.AWS != nil && oldHCP.Spec.Platform.AWS != nil && newHCP.Spec.Platform.AWS.EndpointAccess != oldHCP.Spec.Platform.AWS.EndpointAccess {
+			awsEndpointServiceList := &hyperv1.AWSEndpointServiceList{}
+			if err := r.List(context.Background(), awsEndpointServiceList, client.InNamespace(newHCP.Namespace)); err != nil {
+				logger.Error(err, "enqueueOnAccessChange: cannot list awsendpointservices")
+				return
+			}
+			for i := range awsEndpointServiceList.Items {
+				q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&awsEndpointServiceList.Items[i])})
+			}
+		}
+	}
 }
 
 func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -293,7 +326,7 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Reconcile the AWSEndpointService
 	oldStatus := awsEndpointService.Status.DeepCopy()
-	if err := reconcileAWSEndpointService(ctx, awsEndpointService, hcp, r.ec2Client, r.route53Client); err != nil {
+	if err := r.reconcileAWSEndpointService(ctx, awsEndpointService, hcp, r.ec2Client, r.route53Client); err != nil {
 		meta.SetStatusCondition(&awsEndpointService.Status.Conditions, metav1.Condition{
 			Type:    string(hyperv1.AWSEndpointAvailable),
 			Status:  metav1.ConditionFalse,
@@ -359,7 +392,7 @@ func diffSubnetIDs(desired []string, existing []*string) (added, removed []*stri
 	return
 }
 
-func reconcileAWSEndpointService(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, hcp *hyperv1.HostedControlPlane, ec2Client ec2iface.EC2API, route53Client route53iface.Route53API) error {
+func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointService(ctx context.Context, awsEndpointService *hyperv1.AWSEndpointService, hcp *hyperv1.HostedControlPlane, ec2Client ec2iface.EC2API, route53Client route53iface.Route53API) error {
 	log, err := logr.FromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("logger not found: %w", err)
@@ -510,7 +543,80 @@ func reconcileAWSEndpointService(ctx context.Context, awsEndpointService *hyperv
 	awsEndpointService.Status.DNSNames = fqdns
 	awsEndpointService.Status.DNSZoneID = zoneID
 
+	if isPublic, externalNames := util.IsPublicHCP(hcp), hcpExternalNames(hcp); !isPublic && len(externalNames) > 0 {
+		// only if not public and external names are configured, create services of type ExternalName so external-dns
+		// can create records for them
+		var errs []error
+		for svcType, externalName := range externalNames {
+			var svc *corev1.Service
+			switch svcType {
+			case "api":
+				svc = manifests.KubeAPIServerExternalPrivateService(hcp.Namespace)
+			case "oauth":
+				svc = manifests.OauthServerExternalPrivateService(hcp.Namespace)
+			}
+			if _, err := r.CreateOrUpdate(ctx, r, svc, func() error {
+				log.Info("Reconciling external name service", "service", svc.Name, "externalName", externalName)
+				return reconcileExternalService(svc, hcp, externalName, aws.StringValue(endpointDNSEntries[0].DnsName))
+			}); err != nil {
+				errs = append(errs, fmt.Errorf("failed to reconcile %s external service: %w", svcType, err))
+			}
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("failed to create external services for private endpoints: %w", utilerrors.NewAggregate(errs))
+		}
+	} else {
+		// if the cluster is public, ensure that any ExternalName services are removed
+		privateExternalServices := &corev1.ServiceList{}
+		if err := r.List(ctx, privateExternalServices, client.HasLabels{externalPrivateServiceLabel}); err != nil {
+			return fmt.Errorf("cannot list private external services: %w", err)
+		}
+		if len(privateExternalServices.Items) > 0 {
+			log.Info("Removing private external services", "count", len(privateExternalServices.Items))
+			var errs []error
+			for i := range privateExternalServices.Items {
+				svc := &privateExternalServices.Items[i]
+				if err := r.Delete(ctx, svc); err != nil {
+					errs = append(errs, fmt.Errorf("failed to delete private external service %s: %w", svc.Name, err))
+				}
+			}
+			if len(errs) > 0 {
+				return utilerrors.NewAggregate(errs)
+			}
+		}
+	}
+
 	return nil
+}
+
+func reconcileExternalService(svc *corev1.Service, hcp *hyperv1.HostedControlPlane, hostName, targetCName string) error {
+	ownerRef := config.OwnerRefFrom(hcp)
+	ownerRef.ApplyTo(svc)
+	if svc.Labels == nil {
+		svc.Labels = map[string]string{}
+	}
+	if svc.Annotations == nil {
+		svc.Annotations = map[string]string{}
+	}
+	svc.Labels[externalPrivateServiceLabel] = "true"
+	svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = hostName
+	svc.Spec.Type = corev1.ServiceTypeExternalName
+	svc.Spec.ExternalName = targetCName
+	return nil
+}
+
+func hcpExternalNames(hcp *hyperv1.HostedControlPlane) map[string]string {
+	result := map[string]string{}
+	apiStrategy := util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.APIServer)
+	if apiStrategy != nil && apiStrategy.Type == hyperv1.Route && apiStrategy.Route != nil && apiStrategy.Route.Hostname != "" {
+		result["api"] = apiStrategy.Route.Hostname
+	}
+
+	oauthStrategy := util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.OAuthServer)
+	if oauthStrategy != nil && oauthStrategy.Type == hyperv1.Route && oauthStrategy.Route != nil && oauthStrategy.Route.Hostname != "" {
+		result["oauth"] = oauthStrategy.Route.Hostname
+	}
+	return result
 }
 
 func zoneName(hcpName string) string {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1042,28 +1042,51 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Con
 	}
 
 	if serviceStrategy.Type == hyperv1.Route {
-		externalRoute := manifests.KubeAPIServerExternalRoute(hcp.Namespace)
+		externalPublicRoute := manifests.KubeAPIServerExternalPublicRoute(hcp.Namespace)
+		externalPrivateRoute := manifests.KubeAPIServerExternalPrivateRoute(hcp.Namespace)
 		if util.IsPublicHCP(hcp) {
-			if _, err := createOrUpdate(ctx, r.Client, externalRoute, func() error {
+			// Remove the external private route if it exists
+			err := r.Get(ctx, client.ObjectKeyFromObject(externalPrivateRoute), externalPrivateRoute)
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed to check whether apiserver external private route exists: %w", err)
+				}
+			} else {
+				if err := r.Delete(ctx, externalPrivateRoute); err != nil {
+					return fmt.Errorf("failed to delete apiserver external private route: %w", err)
+				}
+			}
+			// Reconcile the external public route
+			if _, err := createOrUpdate(ctx, r.Client, externalPublicRoute, func() error {
 				hostname := ""
 				if serviceStrategy.Route != nil {
 					hostname = serviceStrategy.Route.Hostname
 				}
-				return kas.ReconcileExternalRoute(externalRoute, p.OwnerReference, hostname)
+				return kas.ReconcileExternalPublicRoute(externalPublicRoute, p.OwnerReference, hostname)
 			}); err != nil {
-				return fmt.Errorf("failed to reconcile apiserver external route %s: %w", externalRoute.Name, err)
+				return fmt.Errorf("failed to reconcile apiserver external public route %s: %w", externalPublicRoute.Name, err)
 			}
 		} else {
-			// Remove the external route if it exists
-			err := r.Get(ctx, client.ObjectKeyFromObject(externalRoute), externalRoute)
+			// Remove the external public route if it exists
+			err := r.Get(ctx, client.ObjectKeyFromObject(externalPublicRoute), externalPublicRoute)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
-					return fmt.Errorf("failed to check whether apiserver external route exists: %w", err)
+					return fmt.Errorf("failed to check whether apiserver external public route exists: %w", err)
 				}
 			} else {
-				if err := r.Delete(ctx, externalRoute); err != nil {
-					return fmt.Errorf("failed to delete apiserver external route: %w", err)
+				if err := r.Delete(ctx, externalPublicRoute); err != nil {
+					return fmt.Errorf("failed to delete apiserver external public route: %w", err)
 				}
+			}
+			// Reconcile the external private route
+			if _, err := createOrUpdate(ctx, r.Client, externalPrivateRoute, func() error {
+				hostname := ""
+				if serviceStrategy.Route != nil {
+					hostname = serviceStrategy.Route.Hostname
+				}
+				return kas.ReconcileExternalPrivateRoute(externalPrivateRoute, p.OwnerReference, hostname)
+			}); err != nil {
+				return fmt.Errorf("failed to reconcile apiserver external private route %s: %w", externalPrivateRoute.Name, err)
 			}
 		}
 		// The private KAS route is always present as it is the default
@@ -1138,28 +1161,51 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServerService(ctx context.C
 	if serviceStrategy.Type != hyperv1.Route {
 		return nil
 	}
-	oauthExternalRoute := manifests.OauthServerExternalRoute(hcp.Namespace)
+	oauthExternalPublicRoute := manifests.OauthServerExternalPublicRoute(hcp.Namespace)
+	oauthExternalPrivateRoute := manifests.OauthServerExternalPrivateRoute(hcp.Namespace)
 	if util.IsPublicHCP(hcp) {
-		if _, err := createOrUpdate(ctx, r.Client, oauthExternalRoute, func() error {
+		// Remove the external private route if it exists
+		err := r.Get(ctx, client.ObjectKeyFromObject(oauthExternalPrivateRoute), oauthExternalPrivateRoute)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to check whether OAuth external private route exists: %w", err)
+			}
+		} else {
+			if err := r.Delete(ctx, oauthExternalPrivateRoute); err != nil {
+				return fmt.Errorf("failed to delete OAuth external private route: %w", err)
+			}
+		}
+		// Reconcile the external public route
+		if _, err := createOrUpdate(ctx, r.Client, oauthExternalPublicRoute, func() error {
 			hostname := ""
 			if serviceStrategy.Route != nil {
 				hostname = serviceStrategy.Route.Hostname
 			}
-			return oauth.ReconcileExternalRoute(oauthExternalRoute, p.OwnerRef, hostname, r.DefaultIngressDomain)
+			return oauth.ReconcileExternalPublicRoute(oauthExternalPublicRoute, p.OwnerRef, hostname, r.DefaultIngressDomain)
 		}); err != nil {
-			return fmt.Errorf("failed to reconcile OAuth external route: %w", err)
+			return fmt.Errorf("failed to reconcile OAuth external public route: %w", err)
 		}
 	} else {
 		// Remove the external route if it exists
-		err := r.Get(ctx, client.ObjectKeyFromObject(oauthExternalRoute), oauthExternalRoute)
+		err := r.Get(ctx, client.ObjectKeyFromObject(oauthExternalPublicRoute), oauthExternalPublicRoute)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to check whether OAuth external route exists: %w", err)
+				return fmt.Errorf("failed to check whether OAuth external public route exists: %w", err)
 			}
 		} else {
-			if err := r.Delete(ctx, oauthExternalRoute); err != nil {
-				return fmt.Errorf("failed to delete OAuth external route: %w", err)
+			if err := r.Delete(ctx, oauthExternalPublicRoute); err != nil {
+				return fmt.Errorf("failed to delete OAuth external public route: %w", err)
 			}
+		}
+		// Reconcile the external private route
+		if _, err := createOrUpdate(ctx, r.Client, oauthExternalPrivateRoute, func() error {
+			hostname := ""
+			if serviceStrategy.Route != nil {
+				hostname = serviceStrategy.Route.Hostname
+			}
+			return oauth.ReconcileExternalPrivateRoute(oauthExternalPrivateRoute, p.OwnerRef, hostname, r.DefaultIngressDomain)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile OAuth external private route: %w", err)
 		}
 	}
 	if util.IsPrivateHCP(hcp) {
@@ -1443,7 +1489,7 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServiceStatus(ctx context.C
 	}
 	if serviceStrategy.Type == hyperv1.Route {
 		if util.IsPublicHCP(hcp) {
-			route = manifests.OauthServerExternalRoute(hcp.Namespace)
+			route = manifests.OauthServerExternalPublicRoute(hcp.Namespace)
 			if err = r.Get(ctx, client.ObjectKeyFromObject(route), route); err != nil {
 				if apierrors.IsNotFound(err) {
 					err = nil
@@ -1453,6 +1499,8 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServiceStatus(ctx context.C
 				return
 			}
 		} else {
+			// TODO: sjenning: This should be switched to OauthServerExternalPrivateRoute
+			// once end-to-end DNS connectivity is added over PrivateLink
 			route = manifests.OauthServerInternalRoute(hcp.Namespace)
 			if err = r.Get(ctx, client.ObjectKeyFromObject(route), route); err != nil {
 				if apierrors.IsNotFound(err) {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/hypershift/support/releaseinfo"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/support/util"
 	"go.uber.org/zap/zaptest"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -236,6 +237,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 			Labels: map[string]string{
 				"hypershift.openshift.io/hosted-control-plane": targetNamespace,
 				hyperv1.RouteVisibilityLabel:                   string(hyperv1.RouteVisibilityPrivate),
+				util.InternalRouteLabel:                        "true",
 			},
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -154,6 +154,7 @@ func ReconcileExternalPrivateRoute(route *routev1.Route, owner *metav1.OwnerRefe
 		route.Labels = map[string]string{}
 	}
 	route.Labels[hyperv1.RouteVisibilityLabel] = hyperv1.RouteVisibilityPrivate
+	util.AddInternalRouteLabel(route)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
@@ -7,19 +7,21 @@ import (
 )
 
 const (
-	KubeAPIServerServiceName              = "kube-apiserver"
-	KubeAPIServerPrivateServiceName       = "kube-apiserver-private"
-	kubeAPIServerExternalPublicRouteName  = "kube-apiserver"
-	kubeAPIServerExternalPrivateRouteName = "kube-apiserver-private"
-	kubeAPIServerInternalRouteName        = "kube-apiserver-internal"
-	oauthServiceName                      = "oauth-openshift"
-	oauthExternalRoutePublicName          = "oauth"
-	oauthExternalRoutePrivateName         = "oauth-private"
-	oauthInternalRouteName                = "oauth-internal"
-	konnectivityServerServiceName         = "konnectivity-server"
-	openshiftAPIServerServiceName         = "openshift-apiserver"
-	oauthAPIServerName                    = "openshift-oauth-apiserver"
-	packageServerServiceName              = "packageserver"
+	KubeAPIServerServiceName                = "kube-apiserver"
+	KubeAPIServerPrivateServiceName         = "kube-apiserver-private"
+	kubeAPIServerExternalPublicRouteName    = "kube-apiserver"
+	kubeAPIServerExternalPrivateRouteName   = "kube-apiserver-private"
+	kubeAPIServerInternalRouteName          = "kube-apiserver-internal"
+	kubeAPIServerExternalPrivateServiceName = "kube-apiserver-private-external"
+	oauthServiceName                        = "oauth-openshift"
+	oauthExternalRoutePublicName            = "oauth"
+	oauthExternalRoutePrivateName           = "oauth-private"
+	oauthInternalRouteName                  = "oauth-internal"
+	oauthExternalPrivateServiceName         = "oauth-private-external"
+	konnectivityServerServiceName           = "konnectivity-server"
+	openshiftAPIServerServiceName           = "openshift-apiserver"
+	oauthAPIServerName                      = "openshift-oauth-apiserver"
+	packageServerServiceName                = "packageserver"
 )
 
 func KubeAPIServerService(hostedClusterNamespace string) *corev1.Service {
@@ -67,6 +69,15 @@ func KubeAPIServerInternalRoute(hostedClusterNamespace string) *routev1.Route {
 	}
 }
 
+func KubeAPIServerExternalPrivateService(hostedClusterNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeAPIServerExternalPrivateServiceName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
 func OauthServerService(hostedClusterNamespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -99,6 +110,15 @@ func OauthServerInternalRoute(hostedClusterNamespace string) *routev1.Route {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedClusterNamespace,
 			Name:      oauthInternalRouteName,
+		},
+	}
+}
+
+func OauthServerExternalPrivateService(hostedClusterNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oauthExternalPrivateServiceName,
+			Namespace: hostedClusterNamespace,
 		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
@@ -7,17 +7,19 @@ import (
 )
 
 const (
-	KubeAPIServerServiceName        = "kube-apiserver"
-	KubeAPIServerPrivateServiceName = "kube-apiserver-private"
-	kubeAPIServerExternalRouteName  = "kube-apiserver"
-	kubeAPIServerInternalRouteName  = "kube-apiserver-internal"
-	oauthServiceName                = "oauth-openshift"
-	oauthExternalRouteName          = "oauth"
-	oauthInternalRouteName          = "oauth-internal"
-	konnectivityServerServiceName   = "konnectivity-server"
-	openshiftAPIServerServiceName   = "openshift-apiserver"
-	oauthAPIServerName              = "openshift-oauth-apiserver"
-	packageServerServiceName        = "packageserver"
+	KubeAPIServerServiceName              = "kube-apiserver"
+	KubeAPIServerPrivateServiceName       = "kube-apiserver-private"
+	kubeAPIServerExternalPublicRouteName  = "kube-apiserver"
+	kubeAPIServerExternalPrivateRouteName = "kube-apiserver-private"
+	kubeAPIServerInternalRouteName        = "kube-apiserver-internal"
+	oauthServiceName                      = "oauth-openshift"
+	oauthExternalRoutePublicName          = "oauth"
+	oauthExternalRoutePrivateName         = "oauth-private"
+	oauthInternalRouteName                = "oauth-internal"
+	konnectivityServerServiceName         = "konnectivity-server"
+	openshiftAPIServerServiceName         = "openshift-apiserver"
+	oauthAPIServerName                    = "openshift-oauth-apiserver"
+	packageServerServiceName              = "packageserver"
 )
 
 func KubeAPIServerService(hostedClusterNamespace string) *corev1.Service {
@@ -38,10 +40,19 @@ func KubeAPIServerPrivateService(hostedClusterNamespace string) *corev1.Service 
 	}
 }
 
-func KubeAPIServerExternalRoute(hostedClusterNamespace string) *routev1.Route {
+func KubeAPIServerExternalPublicRoute(hostedClusterNamespace string) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubeAPIServerExternalRouteName,
+			Name:      kubeAPIServerExternalPublicRouteName,
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
+func KubeAPIServerExternalPrivateRoute(hostedClusterNamespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeAPIServerExternalPrivateRouteName,
 			Namespace: hostedClusterNamespace,
 		},
 	}
@@ -65,11 +76,20 @@ func OauthServerService(hostedClusterNamespace string) *corev1.Service {
 	}
 }
 
-func OauthServerExternalRoute(hostedClusterNamespace string) *routev1.Route {
+func OauthServerExternalPublicRoute(hostedClusterNamespace string) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostedClusterNamespace,
-			Name:      oauthExternalRouteName,
+			Name:      oauthExternalRoutePublicName,
+		},
+	}
+}
+
+func OauthServerExternalPrivateRoute(hostedClusterNamespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hostedClusterNamespace,
+			Name:      oauthExternalRoutePrivateName,
 		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -1,6 +1,8 @@
 package oauth
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+
 	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -8,9 +10,21 @@ import (
 	"github.com/openshift/hypershift/support/util"
 )
 
-func ReconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
+func ReconcileExternalPublicRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
 	ownerRef.ApplyTo(route)
 	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.OauthServerService(route.Namespace).Name)
+}
+
+func ReconcileExternalPrivateRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
+	ownerRef.ApplyTo(route)
+	if err := util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.OauthServerService(route.Namespace).Name); err != nil {
+		return err
+	}
+	if route.Labels == nil {
+		route.Labels = map[string]string{}
+	}
+	route.Labels[hyperv1.RouteVisibilityLabel] = hyperv1.RouteVisibilityPrivate
+	return nil
 }
 
 func ReconcileInternalRoute(route *routev1.Route, ownerRef config.OwnerRef) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -24,6 +24,7 @@ func ReconcileExternalPrivateRoute(route *routev1.Route, ownerRef config.OwnerRe
 		route.Labels = map[string]string{}
 	}
 	route.Labels[hyperv1.RouteVisibilityLabel] = hyperv1.RouteVisibilityPrivate
+	util.AddInternalRouteLabel(route)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -36,7 +36,6 @@ func ReconcileKASServerCertSecret(secret, ca *corev1.Secret, ownerRef config.Own
 		"kubernetes.default",
 		"kubernetes.default.svc",
 		"kubernetes.default.svc.cluster.local",
-		// TODO: add private KAS endpoint name
 		svc.Name,
 		fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace),
 		fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace),

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -403,7 +403,9 @@ func NewStartCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			if err := (&awsprivatelink.AWSEndpointServiceReconciler{}).SetupWithManager(mgr); err != nil {
+			if err := (&awsprivatelink.AWSEndpointServiceReconciler{
+				CreateOrUpdateProvider: upsert.New(enableCIDebugOutput),
+			}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "aws-endpoint-service")
 				os.Exit(1)
 			}

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -374,6 +374,7 @@ objects:
           - --txt-suffix=-external-dns
           - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
           - --label-filter=hypershift.openshift.io/route-visibility!=private
+          - --events
           - --aws-zone-type=public
           - --aws-batch-change-interval=10s
           command:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -373,6 +373,7 @@ objects:
           - --registry=txt
           - --txt-suffix=-external-dns
           - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
+          - --label-filter=hypershift.openshift.io/route-visibility!=private
           - --aws-zone-type=public
           - --aws-batch-change-interval=10s
           command:

--- a/support/util/route.go
+++ b/support/util/route.go
@@ -89,10 +89,6 @@ func hash(s string) string {
 func ReconcileExternalRoute(route *routev1.Route, hostname string, defaultIngressDomain string, serviceName string) error {
 	if hostname != "" {
 		AddHCPRouteLabel(route)
-		if route.Annotations == nil {
-			route.Annotations = map[string]string{}
-		}
-		route.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = hostname
 		route.Spec.Host = hostname
 	} else {
 		if route.Spec.Host == "" {
@@ -108,6 +104,8 @@ func ReconcileExternalRoute(route *routev1.Route, hostname string, defaultIngres
 		Termination:                   routev1.TLSTerminationPassthrough,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 	}
+	// remove annotation as external-dns will register the name if host is within the zone
+	delete(route.Annotations, hyperv1.ExternalDNSHostnameAnnotation)
 	return nil
 }
 

--- a/test/e2e/util/oauth.go
+++ b/test/e2e/util/oauth.go
@@ -138,7 +138,7 @@ func WaitForOAuthRouteReady(t *testing.T, ctx context.Context, client crclient.C
 	g := NewWithT(t)
 
 	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
-	route := hcpmanifests.OauthServerExternalRoute(hcpNamespace)
+	route := hcpmanifests.OauthServerExternalPublicRoute(hcpNamespace)
 
 	err := wait.PollImmediateWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (done bool, err error) {
 		err = client.Get(context.Background(), crclient.ObjectKeyFromObject(route), route)


### PR DESCRIPTION
**What this PR does / why we need it**:
For clusters with an endpoint access of type Private, that use route as
a publishing strategy and specify a hostname, the hostname is exposed
externally via external-dns using a service of type ExternalName.

Clusters can be switched back and forth between Private and
PublicAndPrivate and the external-dns records are adjusted as needed.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-801](https://issues.redhat.com//browse/HOSTEDCP-801)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.