### PR TITLE
Create a second scheme that always registers `prometheusoperatorv1` GVKs

### DIFF
--- a/api/scheme.go
+++ b/api/scheme.go
@@ -29,7 +29,12 @@ import (
 )
 
 var (
-	Scheme = runtime.NewScheme()
+	// InstallScheme only should be used when installing the HyperShift Operator.
+	// The only current difference is that prometheusoperatorv1's GVKs must always be used, regardless of whether
+	// RHOBS monitoring is enabled.
+	// Ref: https://issues.redhat.com/browse/OCPBUGS-8713
+	InstallScheme = runtime.NewScheme()
+	Scheme        = runtime.NewScheme()
 	// TODO: Even though an object typer is specified here, serialized objects
 	// are not always getting their TypeMeta set unless explicitly initialized
 	// on the variable declarations.
@@ -47,6 +52,27 @@ var (
 )
 
 func init() {
+	capiaws.AddToScheme(InstallScheme)
+	capiibm.AddToScheme(InstallScheme)
+	clientgoscheme.AddToScheme(InstallScheme)
+	hyperv1alpha1.AddToScheme(InstallScheme)
+	hyperv1beta1.AddToScheme(InstallScheme)
+	capiv1.AddToScheme(InstallScheme)
+	configv1.AddToScheme(InstallScheme)
+	operatorv1.AddToScheme(InstallScheme)
+	securityv1.AddToScheme(InstallScheme)
+	routev1.AddToScheme(InstallScheme)
+	rbacv1.AddToScheme(InstallScheme)
+	corev1.AddToScheme(InstallScheme)
+	apiextensionsv1.AddToScheme(InstallScheme)
+	kasv1beta1.AddToScheme(InstallScheme)
+	prometheusoperatorv1.AddToScheme(InstallScheme)
+	agentv1.AddToScheme(InstallScheme)
+	capikubevirt.AddToScheme(InstallScheme)
+	capiazure.AddToScheme(InstallScheme)
+	snapshotv1.AddToScheme(InstallScheme)
+	imagev1.AddToScheme(InstallScheme)
+
 	capiaws.AddToScheme(Scheme)
 	capiibm.AddToScheme(Scheme)
 	clientgoscheme.AddToScheme(Scheme)

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -646,11 +646,11 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	}
 
 	for idx := range objects {
-		gvk, err := apiutil.GVKForObject(objects[idx], hyperapi.Scheme)
+		gvk, err := apiutil.GVKForObject(objects[idx], hyperapi.InstallScheme)
 		if err != nil {
 			return nil, fmt.Errorf("failed to look up gvk for %T: %w", objects[idx], err)
 		}
-		// Everything that embedds metav1.TypeMeta implements this
+		// Everything that embeds metav1.TypeMeta implements this
 		objects[idx].(interface {
 			SetGroupVersionKind(gvk schema.GroupVersionKind)
 		}).SetGroupVersionKind(gvk)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates a second scheme, InstallScheme

This second scheme is needed because the [ServiceMonitor for the hypershift operator itself](https://github.com/openshift/hypershift/blob/05b97dea8201cd43954cf854a9dab05e83a54570/cmd/install/assets/hypershift_operator.go#L1108-L1133) currently must always use the prometheus operator's GVKs, not the RHOBS fork, while the other controllers should use the RHOBS fork when configured to do so.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-8713](https://issues.redhat.com/browse/OCPBUGS-8713)