### PR TITLE
HOSTEDCP-924: Exposing LastCompletedVersion as a new status.condition

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -40,6 +40,9 @@ const (
 	ClusterVersionAvailable ConditionType = "ClusterVersionAvailable"
 	// ClusterVersionReleaseAccepted bubbles up Failing ReleaseAccepted from the CVO.
 	ClusterVersionReleaseAccepted ConditionType = "ClusterVersionReleaseAccepted"
+	// LastCompletedClusterVersion exposes the last HostedCluster completed version as a condition.
+	// It's mostly the same as .status.version.history but consumable from outside.
+	LastCompletedClusterVersion ConditionType = "LastCompletedClusterVersion"
 
 	// UnmanagedEtcdAvailable indicates whether a user-managed etcd cluster is
 	// healthy.

--- a/api/v1beta1/hostedcluster_conditions.go
+++ b/api/v1beta1/hostedcluster_conditions.go
@@ -61,6 +61,9 @@ const (
 	ClusterVersionAvailable ConditionType = "ClusterVersionAvailable"
 	// ClusterVersionReleaseAccepted bubbles up Failing ReleaseAccepted from the CVO.
 	ClusterVersionReleaseAccepted ConditionType = "ClusterVersionReleaseAccepted"
+	// LastCompletedClusterVersion exposes the last HostedCluster completed version as a condition.
+	// It's mostly the same as .status.version.history but consumable from outside.
+	LastCompletedClusterVersion ConditionType = "LastCompletedClusterVersion"
 
 	// UnmanagedEtcdAvailable indicates whether a user-managed etcd cluster is
 	// healthy.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2858,6 +2858,10 @@ A failure here may require external user intervention to resolve. E.g. hitting q
 <td><p>KubeAPIServerAvailable bubbles up the same condition from HCP. It signals if the kube API server is available.
 A failure here often means a software bug or a non-stable cluster.</p>
 </td>
+</tr><tr><td><p>&#34;LastCompletedClusterVersion&#34;</p></td>
+<td><p>LastCompletedClusterVersion exposes the last HostedCluster completed version as a condition.
+It&rsquo;s mostly the same as .status.version.history but consumable from outside.</p>
+</td>
 </tr><tr><td><p>&#34;PlatformCredentialsFound&#34;</p></td>
 <td><p>PlatformCredentialsFound indicates that credentials required for the
 desired platform are valid.


### PR DESCRIPTION
The status field is set as True and the reason AsExpected, once the HostedCluster reaches the Completed state in the cluster. Meanwhile the HostedCluster does not reaches that state, it will keep the False status and Unknown reason.

- Completed
```json
{
  "lastTransitionTime": "2023-03-21T11:21:41Z",
  "message": "4.13.0-ec.4",
  "observedGeneration": 3,
  "reason": "AsExpected",
  "status": "True",
  "type": "LastCompletedClusterVersion"
}
```

- No Previous Version
```json
{
  "lastTransitionTime": "2023-03-21T11:32:51Z",
  "message": "",
  "observedGeneration": 1,
  "reason": "StatusUnknown",
  "status": "False",
  "type": "LastCompletedClusterVersion"
}
```

- Partial
```json
{
  "lastTransitionTime": "2023-03-21T11:32:51Z",
  "message": "4.13.0-0.nightly-2023-03-19-052243",
  "observedGeneration": 3,
  "reason": "StatusUnknown",
  "status": "False",
  "type": "LastCompletedClusterVersion"
}
```

**What this PR does / why we need it**:
Adding a new HostedCluster condition to expose that information in a way that ManifestWork can consume. More info in the associated Jira

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-924](https://issues.redhat.com/browse/HOSTEDCP-924)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.