### PR TITLE
OCPBUGS-8691: Add storage operators perms. to watch HostedControlPlane

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/05_operator_role-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/05_operator_role-hypershift.yaml
@@ -67,3 +67,11 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedcontrolplanes
+  verbs:
+  - watch
+  - list
+  - get

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/role.yaml
@@ -56,3 +56,11 @@ rules:
       - delete
       - patch
       - update
+  - apiGroups:
+      - hypershift.openshift.io
+    resources:
+      - hostedcontrolplanes
+    verbs:
+      - watch
+      - list
+      - get


### PR DESCRIPTION
**What this PR does / why we need it**:
cluster-storage-operator and csi-snapshot-controller-operators should be able to list/watch HostedControlPlanes to get its nodeSelector.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.