### PR TITLE
[release-4.13] Disable inplace upgrade e2e tests

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -81,7 +81,10 @@ func TestNodePool(t *testing.T) {
 		t.Run("TestNodePoolAutoRepair", testNodePoolAutoRepair(ctx, mgmtClient, hostedCluster, guestClient, clusterOpts))
 		t.Run("TestNodepoolMachineconfigGetsRolledout", testNodepoolMachineconfigGetsRolledout(ctx, mgmtClient, hostedCluster, guestClient, clusterOpts))
 		t.Run("TestNTOMachineConfigGetsRolledOut", testNTOMachineConfigGetsRolledOut(ctx, mgmtClient, hostedCluster, guestClient, clusterOpts))
-		t.Run("TestNTOMachineConfigAppliedInPlace", testNTOMachineConfigAppliedInPlace(ctx, mgmtClient, hostedCluster, guestClient, clusterOpts))
+		/*
+			 		// TODO: (csrwng) Re-enable when https://issues.redhat.com/browse/OCPBUGS-10218 is fixed
+					t.Run("TestNTOMachineConfigAppliedInPlace", testNTOMachineConfigAppliedInPlace(ctx, mgmtClient, hostedCluster, guestClient, clusterOpts))
+		*/
 
 		for _, testCase := range nodePoolTests {
 			t.Run(testCase.name, func(t *testing.T) {

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -159,6 +159,8 @@ func TestReplaceUpgradeNodePool(t *testing.T) {
 }
 
 func TestInPlaceUpgradeNodePool(t *testing.T) {
+	// TODO: (csrwng) Re-enable when https://issues.redhat.com/browse/OCPBUGS-10218 is fixed
+	t.Skip("Skipping due to https://issues.redhat.com/browse/OCPBUGS-10218")
 	t.Parallel()
 	g := NewWithT(t)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable inplace upgrade tests until OCPBUGS-10218 is fixed

https://issues.redhat.com/browse/OCPBUGS-10218

**Checklist**
- [x] Subject and description added to both, commit and PR.