### PR TITLE
OCPBUGS-10823 ensure well known public domains do not get proxied on image imports

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -245,6 +245,8 @@ func buildOASContainerMain(image string, etcdHostname string, port int32) func(c
 			"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 			fmt.Sprintf("--client-ca-file=%s", cpath(common.VolumeTotalClientCA().Name, certs.CASignerCertMapKey)),
 		}
+		// this list can be gathered from firewall docs: https://docs.openshift.com/container-platform/4.12/installing/install_config/configuring-firewall.html
+		defaultSampleImportContainerRegistries := "quay.io,cdn03.quay.io,cdn02.quay.io,cdn01.quay.io,cdn.quay.io,registry.redhat.io,registry.access.redhat.com,access.redhat.com,sso.redhat.com"
 		c.Env = []corev1.EnvVar{
 			{
 				Name:  "HTTP_PROXY",
@@ -256,7 +258,7 @@ func buildOASContainerMain(image string, etcdHostname string, port int32) func(c
 			},
 			{
 				Name:  "NO_PROXY",
-				Value: fmt.Sprintf("%s,%s", manifests.KubeAPIServerService("").Name, etcdHostname),
+				Value: fmt.Sprintf("%s,%s,%s", manifests.KubeAPIServerService("").Name, etcdHostname, defaultSampleImportContainerRegistries),
 			},
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)


### PR DESCRIPTION
In client environments that run with a HTTP_PROXY: that proxy information is lost when the image import is done on the openshift-apiserver side and sent through the konnectivity-sidecar. There are a set of well known domains that are necessary for the MVP set of samples that get deployed in an openshift cluster. These well known public domains should not have to be proxied into the client environment and instead can go direct from the management cluster. Any other defined domains do need to proxy into the cluster network for the ability to access on prem registries.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.