### PR TITLE
HOSTEDCP-806: Fix ValidAWSKMSConfig condition

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3975,7 +3975,15 @@ func hasValidCloudCredentials(hcp *hyperv1.HostedControlPlane) (string, bool) {
 
 func (r *HostedControlPlaneReconciler) validateAWSKMSConfig(ctx context.Context, hcp *hyperv1.HostedControlPlane) {
 	if hcp.Spec.SecretEncryption == nil || hcp.Spec.SecretEncryption.KMS == nil || hcp.Spec.SecretEncryption.KMS.AWS == nil {
-		// AWS KMS not configured, skip
+		// AWS KMS not configured
+		condition := metav1.Condition{
+			Type:               string(hyperv1.ValidAWSKMSConfig),
+			ObservedGeneration: hcp.Generation,
+			Status:             metav1.ConditionUnknown,
+			Message:            "AWS KMS is not configured",
+			Reason:             hyperv1.StatusUnknownReason,
+		}
+		meta.SetStatusCondition(&hcp.Status.Conditions, condition)
 		return
 	}
 	log := ctrl.LoggerFrom(ctx)
@@ -3989,8 +3997,15 @@ func (r *HostedControlPlaneReconciler) validateAWSKMSConfig(ctx context.Context,
 
 	token, err := util.CreateTokenForServiceAccount(ctx, manifests.KASContainerAWSKMSProviderServiceAccount(), guestClient)
 	if err != nil {
-		// service account might not be created in the guest cluster yet.
-		log.Error(err, "failed to create token for KMS provider service account")
+		// service account might not be created in the guest cluster or KAS is not operational.
+		condition := metav1.Condition{
+			Type:               string(hyperv1.ValidAWSKMSConfig),
+			ObservedGeneration: hcp.Generation,
+			Status:             metav1.ConditionUnknown,
+			Message:            fmt.Sprintf("failed to create token for KMS provider service account: %v", err),
+			Reason:             hyperv1.StatusUnknownReason,
+		}
+		meta.SetStatusCondition(&hcp.Status.Conditions, condition)
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes `ValidAWSKMSConfig` condition not being set when KAS is not operational or KMS is not configured

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-806](https://issues.redhat.com/browse/HOSTEDCP-806)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.