### PR TITLE
SDA-8609: Making sure that servicemonitors & podmonitors are created with at least a 30s scrape interval

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -449,7 +449,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("https")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
+			Interval:   "30s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -405,7 +405,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	}
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval: "15s",
+			Interval: "30s",
 			Port:     "metrics",
 			Scheme:   "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3259,7 +3259,7 @@ func (r *HostedControlPlaneReconciler) reconcileHostedClusterConfigOperator(ctx 
 	if _, err := createOrUpdate(ctx, r.Client, podMonitor, func() error {
 		podMonitor.Spec.Selector = *deployment.Spec.Selector
 		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
-			Interval:             "15s",
+			Interval:             "30s",
 			Port:                 "metrics",
 			MetricRelabelConfigs: metrics.HostedClusterConfigOperatorRelabelConfigs(r.MetricsSet),
 		}}

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -375,7 +375,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 	if result, err := createOrUpdate(ctx, c, podMonitor, func() error {
 		podMonitor.Spec.Selector = *ignitionServerDeployment.Spec.Selector
 		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
-			Interval: "15s",
+			Interval: "30s",
 			Port:     "metrics",
 		}}
 		podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{controlPlaneNamespace}}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
@@ -25,7 +25,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, apiServerP
 	targetPort := intstr.FromInt(apiServerPort)
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
+			Interval:   "30s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
@@ -21,7 +21,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("client")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
+			Interval:   "30s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -92,7 +92,7 @@ func ReconcileClusterNodeTuningOperatorServiceMonitor(sm *prometheusoperatorv1.S
 	targetPort := intstr.FromInt(60000)
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
+			Interval:   "30s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			Path:       "/metrics",

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/servicemonitor.go
@@ -21,7 +21,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("https")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
+			Interval:   "30s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/servicemonitor.go
@@ -21,7 +21,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("https")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
+			Interval:   "30s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -198,7 +198,7 @@ func ReconcileCatalogServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, own
 	targetPort := intstr.FromString("metrics")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
+			Interval:   "30s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -147,7 +147,7 @@ func ReconcileOLMOperatorServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor,
 	targetPort := intstr.FromString("metrics")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
+			Interval:   "30s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/servicemonitor.go
@@ -21,7 +21,7 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("https")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
+			Interval:   "30s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1886,7 +1886,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	if _, err := createOrUpdate(ctx, r.Client, podMonitor, func() error {
 		podMonitor.Spec.Selector = *controlPlaneOperatorDeployment.Spec.Selector
 		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
-			Interval:             "15s",
+			Interval:             "30s",
 			Port:                 "metrics",
 			MetricRelabelConfigs: metrics.ControlPlaneOperatorRelabelConfigs(r.MetricsSet),
 		}}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the scrape interval from **15 sec** to **30 sec** on the `servicemonitor`s and `podmonitor`s configs created by the `hypershift-operator` and by the `control-plane-operator` operators.
The `ingress-operator` `service-monitor` for which the scrape interval was already set to 60 sec is not impacted by this change.
This PR is needed lo lower the memory and CPU consumption of the [OBO operator](https://github.com/rhobs/observability-operator) on the MC clusters. This will also indirectly reduce the traffic sent to RHOBS by the OBO Prometheus instances.

**Which issue(s) this PR fixes**
Fixes [SDA-8609](https://issues.redhat.com/browse/SDA-8609)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.