### PR TITLE
HOSTEDCP-934: Validate PublishingStrategyMapping

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -25,13 +25,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/client-go/tools/clientcmd"
 	"net"
 	"os"
 	"reflect"
 	"sort"
 	"strings"
 	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -3395,6 +3396,10 @@ func (r *HostedClusterReconciler) validateConfigAndClusterCapabilities(ctx conte
 		errs = append(errs, err)
 	}
 
+	if err := r.validatePublishingStrategyMapping(hc); err != nil {
+		errs = append(errs, err)
+	}
+
 	// TODO(IBM): Revisit after fleets no longer use conflicting network CIDRs
 	if hc.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
 		if err := r.validateNetworks(hc); err != nil {
@@ -3529,16 +3534,43 @@ func (r *HostedClusterReconciler) validateAWSConfig(hc *hyperv1.HostedCluster) e
 
 	if hc.Spec.Platform.AWS.EndpointAccess == hyperv1.Private {
 		if servicePublishingStrategy != nil && servicePublishingStrategy.Type != hyperv1.Route && servicePublishingStrategy.Type != hyperv1.LoadBalancer {
-			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v", hyperv1.APIServer, servicePublishingStrategy.Type))
+			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route", hyperv1.APIServer, servicePublishingStrategy.Type))
 		}
 
 	} else {
 		if !hyperutil.UseDedicatedDNSForKASByHC(hc) && servicePublishingStrategy.Type != hyperv1.LoadBalancer {
-			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route", hyperv1.APIServer, servicePublishingStrategy.Type))
+			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route or Loadbalancer", hyperv1.APIServer, servicePublishingStrategy.Type))
 		}
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+// validatePublishingStrategyMapping validates that each published serviceType has a unique hostname.
+func (r *HostedClusterReconciler) validatePublishingStrategyMapping(hc *hyperv1.HostedCluster) error {
+	hostnameServiceMap := make(map[string]string, len(hc.Spec.Services))
+	for _, svc := range hc.Spec.Services {
+		hostname := ""
+		if svc.Type == hyperv1.LoadBalancer && svc.LoadBalancer != nil {
+			hostname = svc.LoadBalancer.Hostname
+		}
+		if svc.Type == hyperv1.Route && svc.Route != nil {
+			hostname = svc.Route.Hostname
+		}
+
+		if hostname == "" {
+			continue
+		}
+
+		serviceType, exists := hostnameServiceMap[hostname]
+		if exists {
+			return fmt.Errorf("service type %s can't be published with the same hostname %s as service type %s", svc.Service, hostname, serviceType)
+		}
+
+		hostnameServiceMap[hostname] = string(svc.Service)
+	}
+
+	return nil
 }
 
 func (r *HostedClusterReconciler) validateAzureConfig(ctx context.Context, hc *hyperv1.HostedCluster) error {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1020,6 +1020,29 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 			},
 			expectedResult: errors.New(`spec.networking.MachineNetwork: Invalid value: "172.16.1.0/24": spec.networking.MachineNetwork and spec.networking.ServiceNetwork overlap: 172.16.1.0/24 and 172.16.1.252/32`),
 		},
+		{
+			name: "multiple published services use the same hostname, error",
+			hostedCluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{
+				Services: []hyperv1.ServicePublishingStrategyMapping{
+					{
+						Service: hyperv1.APIServer,
+						ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+							Type:  hyperv1.Route,
+							Route: &hyperv1.RoutePublishingStrategy{Hostname: "api.example.com"},
+						},
+					},
+					{
+						Service: hyperv1.OAuthServer,
+						ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+							Type:  hyperv1.Route,
+							Route: &hyperv1.RoutePublishingStrategy{Hostname: "api.example.com"},
+						},
+					},
+				},
+			}},
+			expectedResult:                errors.New(`service type OAuthServer can't be published with the same hostname api.example.com as service type APIServer`),
+			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
Validates and reports conflicting services published hostnames

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-934](https://issues.redhat.com/browse/HOSTEDCP-934)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.