### PR TITLE
SDA-8609: No more specifying the scrape interval at servicemonitors & podmonitors level 

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -449,7 +449,6 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("https")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -405,9 +405,8 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	}
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval: "15s",
-			Port:     "metrics",
-			Scheme:   "https",
+			Port:   "metrics",
+			Scheme: "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{
 				SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
 					ServerName: "etcd-client",

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3259,7 +3259,6 @@ func (r *HostedControlPlaneReconciler) reconcileHostedClusterConfigOperator(ctx 
 	if _, err := createOrUpdate(ctx, r.Client, podMonitor, func() error {
 		podMonitor.Spec.Selector = *deployment.Spec.Selector
 		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
-			Interval:             "15s",
 			Port:                 "metrics",
 			MetricRelabelConfigs: metrics.HostedClusterConfigOperatorRelabelConfigs(r.MetricsSet),
 		}}

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -375,8 +375,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 	if result, err := createOrUpdate(ctx, c, podMonitor, func() error {
 		podMonitor.Spec.Selector = *ignitionServerDeployment.Spec.Selector
 		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
-			Interval: "15s",
-			Port:     "metrics",
+			Port: "metrics",
 		}}
 		podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{controlPlaneNamespace}}
 		if podMonitor.Annotations == nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/servicemonitor.go
@@ -25,7 +25,6 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, apiServerP
 	targetPort := intstr.FromInt(apiServerPort)
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/servicemonitor.go
@@ -21,7 +21,6 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("client")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -92,7 +92,6 @@ func ReconcileClusterNodeTuningOperatorServiceMonitor(sm *prometheusoperatorv1.S
 	targetPort := intstr.FromInt(60000)
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			Path:       "/metrics",

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/servicemonitor.go
@@ -21,7 +21,6 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("https")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/servicemonitor.go
@@ -21,7 +21,6 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("https")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -198,7 +198,6 @@ func ReconcileCatalogServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, own
 	targetPort := intstr.FromString("metrics")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -147,7 +147,6 @@ func ReconcileOLMOperatorServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor,
 	targetPort := intstr.FromString("metrics")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/servicemonitor.go
@@ -21,7 +21,6 @@ func ReconcileServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, ownerRef c
 	targetPort := intstr.FromString("https")
 	sm.Spec.Endpoints = []prometheusoperatorv1.Endpoint{
 		{
-			Interval:   "15s",
 			TargetPort: &targetPort,
 			Scheme:     "https",
 			TLSConfig: &prometheusoperatorv1.TLSConfig{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/monitoring/servicemonitor.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/monitoring/servicemonitor.go
@@ -25,7 +25,6 @@ func ReconcileKubeAPIServerServiceMonitor(serviceMonitor *prometheusoperatorv1.S
 				},
 				CAFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 			},
-			Interval:             "30s",
 			Scheme:               "https",
 			Port:                 "https",
 			Path:                 "/metrics",

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1886,7 +1886,6 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	if _, err := createOrUpdate(ctx, r.Client, podMonitor, func() error {
 		podMonitor.Spec.Selector = *controlPlaneOperatorDeployment.Spec.Selector
 		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
-			Interval:             "15s",
 			Port:                 "metrics",
 			MetricRelabelConfigs: metrics.ControlPlaneOperatorRelabelConfigs(r.MetricsSet),
 		}}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR no more specifies the scrape interval at `servicemonitors` & `podmonitors` level when the global scrape interval specified at Prometheus root config level can be used instead.
The `ingress-operator` `service-monitor` for which the scrape interval is set to 60 sec is not impacted by this change; indeed this value is much higher than the value you could expect at Prometheus root config level.
This PR is needed lo lower the memory and CPU consumption of the [OBO operator](https://github.com/rhobs/observability-operator) on the MC clusters. This will also indirectly reduce the traffic sent to RHOBS by the OBO Prometheus instances.
This PR replaces https://github.com/openshift/hypershift/pull/2323 which was still hardcoding a value into the code.

**Which issue(s) this PR fixes**
Fixes [SDA-8609](https://issues.redhat.com/browse/SDA-8609)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.