### PR TITLE
support/supportedversion: Include the problematic version strings in error messages

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1129,7 +1129,7 @@ func TestValidateReleaseImage(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: errors.New("releases before 4.8 are not supported"),
+			expectedResult: errors.New(`releases before 4.8 are not supported. Attempting to use: "4.7.0"`),
 		},
 		{
 			name: "unsupported y-stream downgrade, error",
@@ -1161,7 +1161,7 @@ func TestValidateReleaseImage(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: errors.New("y-stream downgrade is not supported"),
+			expectedResult: errors.New(`y-stream downgrade from "4.13.0" to "4.12.0" is not supported`),
 		},
 		{
 			name: "unsupported y-stream upgrade, error",
@@ -1193,7 +1193,7 @@ func TestValidateReleaseImage(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: errors.New("y-stream upgrade is not for OpenShiftSDN"),
+			expectedResult: errors.New(`y-stream upgrade from "4.11.0" to "4.13.0" is not for OpenShiftSDN`),
 		},
 		{
 			name: "supported y-stream upgrade, success",

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -46,24 +46,24 @@ func maxInt64(a, b uint64) uint64 {
 
 func IsValidReleaseVersion(version, currentVersion, latestVersionSupported, minSupportedVersion *semver.Version, networkType hyperv1.NetworkType, platformType hyperv1.PlatformType) error {
 	if version.LT(semver.MustParse("4.8.0")) {
-		return fmt.Errorf("releases before 4.8 are not supported")
+		return fmt.Errorf("releases before 4.8 are not supported. Attempting to use: %q", version)
 	}
 
 	if currentVersion != nil && currentVersion.Minor > version.Minor {
-		return fmt.Errorf("y-stream downgrade is not supported")
+		return fmt.Errorf("y-stream downgrade from %q to %q is not supported", currentVersion, version)
 	}
 
 	if networkType == hyperv1.OpenShiftSDN && currentVersion != nil && currentVersion.Minor < version.Minor {
-		return fmt.Errorf("y-stream upgrade is not for OpenShiftSDN")
+		return fmt.Errorf("y-stream upgrade from %q to %q is not for OpenShiftSDN", currentVersion, version)
 	}
 
 	versionMinorOnly := &semver.Version{Major: version.Major, Minor: version.Minor}
 	if networkType == hyperv1.OpenShiftSDN && currentVersion == nil && versionMinorOnly.GT(semver.MustParse("4.10.0")) && platformType != hyperv1.PowerVSPlatform {
-		return fmt.Errorf("cannot use OpenShiftSDN with OCP version > 4.10")
+		return fmt.Errorf("cannot use OpenShiftSDN with OCP version %q > 4.10", version)
 	}
 
 	if networkType == hyperv1.OVNKubernetes && currentVersion == nil && versionMinorOnly.LTE(semver.MustParse("4.10.0")) {
-		return fmt.Errorf("cannot use OVNKubernetes with OCP version < 4.11")
+		return fmt.Errorf("cannot use OVNKubernetes with OCP version %q < 4.11", version)
 	}
 
 	if (version.Major == latestVersionSupported.Major && version.Minor > latestVersionSupported.Minor) || version.Major > latestVersionSupported.Major {


### PR DESCRIPTION
Because `releases before 4.8 are not supported` and similar are helpful, but folks may not know which release they'd requested.  By including the version inline, they can distinguish between "makes sense, I'll request a different version" and "hrm, why was I requesting `0.0.1-0.test-2023-03-27-200807-ci-ln-wl9g9xk-latest` ? Maybe cluster-bot or ci-controller needs a patch".