### PR TITLE
HOSTEDCP-939: Setup shared OIDC provider for e2e clusters

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -46,6 +46,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AWSPlatform.EtcdKMSKeyARN, "kms-key-arn", opts.AWSPlatform.EtcdKMSKeyARN, "The ARN of the KMS key to use for Etcd encryption. If not supplied, etcd encryption will default to using a generated AESCBC key.")
 	cmd.Flags().BoolVar(&opts.AWSPlatform.EnableProxy, "enable-proxy", opts.AWSPlatform.EnableProxy, "If a proxy should be set up, rather than allowing direct internet access from the nodes")
 	cmd.Flags().StringVar(&opts.CredentialSecretName, "secret-creds", opts.CredentialSecretName, "A Kubernetes secret with a platform credential (--aws-creds), --pull-secret and --base-domain value. The secret must exist in the supplied \"--namespace\"")
+	cmd.Flags().StringVar(&opts.AWSPlatform.IssuerURL, "oidc-issuer-url", "", "The OIDC provider issuer URL")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -68,6 +68,7 @@ func NewCreateIAMCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Infrastructure ID to use for AWS resources.")
 	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3BucketName, "oidc-storage-provider-s3-bucket-name", "", "The name of the bucket in which the OIDC discovery document is stored")
 	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3Region, "oidc-storage-provider-s3-region", "", "The region of the bucket in which the OIDC discovery document is stored")
+	cmd.Flags().StringVar(&opts.IssuerURL, "oidc-issuer-url", "", "The OIDC provider issuer URL")
 	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "Region where cluster infra should be created")
 	cmd.Flags().StringVar(&opts.OutputFile, "output-file", opts.OutputFile, "Path to file that will contain output information from infra resources (optional)")
 	cmd.Flags().StringVar(&opts.PublicZoneID, "public-zone-id", opts.PublicZoneID, "The id of the clusters public route53 zone")
@@ -153,9 +154,6 @@ func (o *CreateIAMOptions) CreateIAM(ctx context.Context, client crclient.Client
 	if err := utilerrors.NewAggregate(errs); err != nil {
 		return nil, err
 	}
-
-	o.IssuerURL = oidcDiscoveryURL(o.OIDCStorageProviderS3BucketName, o.OIDCStorageProviderS3Region, o.InfraID)
-	log.Log.Info("Detected Issuer URL", "issuer", o.IssuerURL)
 
 	awsSession := awsutil.NewSession("cli-create-iam", o.AWSCredentialsFile, o.AWSKey, o.AWSSecretKey, o.Region)
 	awsConfig := awsutil.NewConfig()

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -15,16 +15,10 @@ package hostedcluster
 import (
 	"bytes"
 	"context"
-	"crypto"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"reflect"
@@ -65,6 +59,7 @@ import (
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/infraid"
 	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/oidc"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
@@ -73,7 +68,6 @@ import (
 	hyperutil "github.com/openshift/hypershift/support/util"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	ini "gopkg.in/ini.v1"
-	jose "gopkg.in/square/go-jose.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -4002,76 +3996,12 @@ const (
 	oidcDocumentsFinalizer         = "hypershift.io/aws-oidc-discovery"
 	serviceAccountSigningKeySecret = "sa-signing-key"
 	serviceSignerPublicKey         = "service-account.pub"
-	jwksURI                        = "/openid/v1/jwks"
-	discoveryTemplate              = `{
-	"issuer": "%s",
-	"jwks_uri": "%s%s",
-	"response_types_supported": [
-		"id_token"
-	],
-	"subject_types_supported": [
-		"public"
-	],
-	"id_token_signing_alg_values_supported": [
-		"RS256"
-	]
-}`
 )
 
-type oidcGeneratorParams struct {
-	issuerURL string
-	pubKey    []byte
-}
-
-type oidcDocumentGeneratorFunc func(params oidcGeneratorParams) (io.ReadSeeker, error)
-
-func generateConfigurationDocument(params oidcGeneratorParams) (io.ReadSeeker, error) {
-	return strings.NewReader(fmt.Sprintf(discoveryTemplate, params.issuerURL, params.issuerURL, jwksURI)), nil
-}
-
-type KeyResponse struct {
-	Keys []jose.JSONWebKey `json:"keys"`
-}
-
-func generateJWKSDocument(params oidcGeneratorParams) (io.ReadSeeker, error) {
-	block, _ := pem.Decode(params.pubKey)
-	if block == nil || block.Type != "RSA PUBLIC KEY" {
-		return nil, fmt.Errorf("failed to decode PEM block containing RSA public key")
-	}
-	pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key: %w", err)
-	}
-	rsaPubKey, ok := pubKey.(*rsa.PublicKey)
-	if !ok {
-		return nil, fmt.Errorf("public key is not RSA")
-	}
-
-	hasher := crypto.SHA256.New()
-	hasher.Write(block.Bytes)
-	hash := hasher.Sum(nil)
-	kid := base64.RawURLEncoding.EncodeToString(hash)
-
-	var keys []jose.JSONWebKey
-	keys = append(keys, jose.JSONWebKey{
-		Key:       rsaPubKey,
-		KeyID:     kid,
-		Algorithm: string(jose.RS256),
-		Use:       "sig",
-	})
-
-	jwks, err := json.MarshalIndent(KeyResponse{Keys: keys}, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-
-	return bytes.NewReader(jwks), nil
-}
-
-func oidcDocumentGenerators() map[string]oidcDocumentGeneratorFunc {
-	return map[string]oidcDocumentGeneratorFunc{
-		"/.well-known/openid-configuration": generateConfigurationDocument,
-		jwksURI:                             generateJWKSDocument,
+func oidcDocumentGenerators() map[string]oidc.OIDCDocumentGeneratorFunc {
+	return map[string]oidc.OIDCDocumentGeneratorFunc{
+		"/.well-known/openid-configuration": oidc.GenerateConfigurationDocument,
+		oidc.JWKSURI:                        oidc.GenerateJWKSDocument,
 	}
 }
 
@@ -4111,9 +4041,9 @@ func (r *HostedClusterReconciler) reconcileAWSOIDCDocuments(ctx context.Context,
 		return fmt.Errorf("controlplane service account signing key secret %q missing required key %s", client.ObjectKeyFromObject(secret), serviceSignerPublicKey)
 	}
 
-	params := oidcGeneratorParams{
-		issuerURL: hcp.Spec.IssuerURL,
-		pubKey:    secret.Data[serviceSignerPublicKey],
+	params := oidc.ODICGeneratorParams{
+		IssuerURL: hcp.Spec.IssuerURL,
+		PubKey:    secret.Data[serviceSignerPublicKey],
 	}
 
 	for path, generator := range oidcDocumentGenerators() {

--- a/support/oidc/oidc.go
+++ b/support/oidc/oidc.go
@@ -1,0 +1,83 @@
+package oidc
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"strings"
+
+	jose "gopkg.in/square/go-jose.v2"
+)
+
+type ODICGeneratorParams struct {
+	IssuerURL string
+	PubKey    []byte
+}
+
+type KeyResponse struct {
+	Keys []jose.JSONWebKey `json:"keys"`
+}
+
+type OIDCDocumentGeneratorFunc func(params ODICGeneratorParams) (io.ReadSeeker, error)
+
+func GenerateJWKSDocument(params ODICGeneratorParams) (io.ReadSeeker, error) {
+	block, _ := pem.Decode(params.PubKey)
+	if block == nil || block.Type != "RSA PUBLIC KEY" {
+		return nil, fmt.Errorf("failed to decode PEM block containing RSA public key")
+	}
+	pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
+	}
+	rsaPubKey, ok := pubKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("public key is not RSA")
+	}
+
+	hasher := crypto.SHA256.New()
+	hasher.Write(block.Bytes)
+	hash := hasher.Sum(nil)
+	kid := base64.RawURLEncoding.EncodeToString(hash)
+
+	var keys []jose.JSONWebKey
+	keys = append(keys, jose.JSONWebKey{
+		Key:       rsaPubKey,
+		KeyID:     kid,
+		Algorithm: string(jose.RS256),
+		Use:       "sig",
+	})
+
+	jwks, err := json.MarshalIndent(KeyResponse{Keys: keys}, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes.NewReader(jwks), nil
+}
+
+const (
+	JWKSURI           = "/openid/v1/jwks"
+	discoveryTemplate = `{
+	"issuer": "%s",
+	"jwks_uri": "%s%s",
+	"response_types_supported": [
+		"id_token"
+	],
+	"subject_types_supported": [
+		"public"
+	],
+	"id_token_signing_alg_values_supported": [
+		"RS256"
+	]
+}`
+)
+
+func GenerateConfigurationDocument(params ODICGeneratorParams) (io.ReadSeeker, error) {
+	return strings.NewReader(fmt.Sprintf(discoveryTemplate, params.IssuerURL, params.IssuerURL, JWKSURI)), nil
+}

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -31,7 +31,7 @@ func TestAutoscaling(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	// Get the newly created NodePool
 	nodepools := &hyperv1.NodePoolList{}

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -41,7 +41,7 @@ func TestHAEtcdChaos(t *testing.T) {
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.NodePoolReplicas = 0
 
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	t.Run("KillRandomMembers", testKillRandomMembers(ctx, client, cluster))
 	t.Run("KillAllMembers", testKillAllMembers(ctx, client, cluster))
@@ -63,7 +63,7 @@ func TestEtcdChaos(t *testing.T) {
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.NodePoolReplicas = 0
 
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	t.Run("KillAllMembers", testKillAllMembers(ctx, client, cluster))
 }

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -29,7 +29,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	// Sanity check the cluster by waiting for the nodes to report ready
 	t.Logf("Waiting for guest client to become available")

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -39,7 +39,7 @@ func TestCreateCluster(t *testing.T) {
 		clusterOpts.NodePoolReplicas = 1
 	}
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	// Sanity check the cluster by waiting for the nodes to report ready
 	t.Logf("Waiting for guest client to become available")
@@ -92,7 +92,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 	g.Expect(kmsKeyArn).NotTo(BeNil(), "failed to retrieve kms key arn")
 
 	clusterOpts.AWSPlatform.EtcdKMSKeyARN = *kmsKeyArn
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	g.Expect(hostedCluster.Spec.SecretEncryption.KMS.AWS.ActiveKey.ARN).To(Equal(*kmsKeyArn))
 	g.Expect(hostedCluster.Spec.SecretEncryption.KMS.AWS.Auth.AWSKMSRoleARN).ToNot(BeEmpty())
@@ -132,7 +132,7 @@ func TestNoneCreateCluster(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	// Wait for the rollout to be reported complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
@@ -162,7 +162,7 @@ func TestCreateClusterPrivate(t *testing.T) {
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.AWSPlatform.EndpointAccess = string(hyperv1.Private)
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	_, err = e2eutil.WaitForGuestKubeConfig(t, ctx, client, hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "couldn't get kubeconfig")
@@ -207,7 +207,7 @@ func TestCreateClusterProxy(t *testing.T) {
 	clusterOpts.AWSPlatform.EnableProxy = true
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	// Sanity check the cluster by waiting for the nodes to report ready
 	t.Logf("Waiting for guest client to become available")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,11 +18,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/go-logr/logr"
 	routev1client "github.com/openshift/client-go/route/clientset/versioned"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
+	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
 	"github.com/openshift/hypershift/cmd/version"
 	"github.com/openshift/hypershift/test/e2e/podtimingcontroller"
 	"github.com/openshift/hypershift/test/e2e/util"
@@ -38,6 +43,9 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/oidc"
 )
 
 var (
@@ -137,9 +145,84 @@ func main(m *testing.M) int {
 	}
 	defer alertSLOs(testContext)
 
+	oidcBucketName := "hypershift-ci-oidc"
+	iamClient := e2eutil.GetIAMClient(globalOpts.configurableClusterOptions.AWSCredentialsFile, globalOpts.configurableClusterOptions.Region)
+	s3Client := e2eutil.GetS3Client(globalOpts.configurableClusterOptions.AWSCredentialsFile, globalOpts.configurableClusterOptions.Region)
+	if err := setupSharedOIDCProvider(oidcBucketName, iamClient, s3Client); err != nil {
+		log.Error(err, "failed to setup shared OIDC provider")
+		return -1
+	}
+	defer e2eutil.DestroyOIDCProvider(log, iamClient, globalOpts.IssuerURL)
+	defer e2eutil.CleanupOIDCBucketObjects(log, s3Client, oidcBucketName, globalOpts.IssuerURL)
+
 	// Everything's okay to run tests
 	log.Info("executing e2e tests", "options", globalOpts)
 	return m.Run()
+}
+
+// setup a shared OIDC provider to be used by all HostedClusters
+func setupSharedOIDCProvider(oidcBucketName string, iamClient iamiface.IAMAPI, s3Client *s3.S3) error {
+	providerID := e2eutil.SimpleNameGenerator.GenerateName("e2e-oidc-provider-")
+	issuerURL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", oidcBucketName, globalOpts.configurableClusterOptions.Region, providerID)
+
+	iamOptions := awsinfra.CreateIAMOptions{
+		IssuerURL:      issuerURL,
+		AdditionalTags: globalOpts.additionalTags,
+	}
+
+	if _, err := iamOptions.CreateOIDCProvider(iamClient); err != nil {
+		return fmt.Errorf("failed to create OIDC provider: %w", err)
+	}
+
+	key, err := certs.PrivateKey()
+	if err != nil {
+		return fmt.Errorf("failed generating a private key: %w", err)
+	}
+
+	keyBytes := certs.PrivateKeyToPem(key)
+	publicKeyBytes, err := certs.PublicKeyToPem(&key.PublicKey)
+	if err != nil {
+		return fmt.Errorf("failed to generate public key from private key: %w", err)
+	}
+
+	// create openid configuration
+	params := oidc.ODICGeneratorParams{
+		IssuerURL: issuerURL,
+		PubKey:    publicKeyBytes,
+	}
+
+	oidcGenerators := map[string]oidc.OIDCDocumentGeneratorFunc{
+		"/.well-known/openid-configuration": oidc.GenerateConfigurationDocument,
+		oidc.JWKSURI:                        oidc.GenerateJWKSDocument,
+	}
+
+	for path, generator := range oidcGenerators {
+		bodyReader, err := generator(params)
+		if err != nil {
+			return fmt.Errorf("failed to generate OIDC document %s: %w", path, err)
+		}
+		_, err = s3Client.PutObject(&s3.PutObjectInput{
+			ACL:    aws.String("public-read"),
+			Body:   bodyReader,
+			Bucket: aws.String(oidcBucketName),
+			Key:    aws.String(providerID + path),
+		})
+		if err != nil {
+			wrapped := fmt.Errorf("failed to upload %s to the %s s3 bucket", path, oidcBucketName)
+			if awsErr, ok := err.(awserr.Error); ok {
+				// Generally, the underlying message from AWS has unique per-request
+				// info not suitable for publishing as condition messages, so just
+				// return the code.
+				wrapped = fmt.Errorf("%w: aws returned an error: %s", wrapped, awsErr.Code())
+			}
+			return wrapped
+		}
+	}
+
+	globalOpts.IssuerURL = issuerURL
+	globalOpts.ServiceAccountSigningKey = keyBytes
+
+	return nil
 }
 
 // alertSLOs creates alert for our SLO/SLIs and log when firing.
@@ -294,6 +377,9 @@ type options struct {
 	configurableClusterOptions configurableClusterOptions
 	additionalTags             stringSliceVar
 
+	IssuerURL                string
+	ServiceAccountSigningKey []byte
+
 	// SkipAPIBudgetVerification implies that you are executing the e2e tests
 	// from local to verify that them works fine before push
 	SkipAPIBudgetVerification bool
@@ -347,6 +433,7 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 			AWSCredentialsFile: o.configurableClusterOptions.AWSCredentialsFile,
 			Region:             o.configurableClusterOptions.Region,
 			EndpointAccess:     o.configurableClusterOptions.AWSEndpointAccess,
+			IssuerURL:          o.IssuerURL,
 		},
 		KubevirtPlatform: core.KubevirtPlatformCreateOptions{
 			ServicePublishingStrategy: kubevirt.IngressServicePublishingStrategy,

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -49,7 +49,7 @@ func TestNodePool(t *testing.T) {
 	// We set replicas to 0 in order to allow the inner tests to
 	// create their own NodePools with the proper replicas
 	clusterOpts.NodePoolReplicas = 0
-	hostedCluster := e2eutil.CreateCluster(t, ctx, mgmtClient, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	hostedCluster := e2eutil.CreateCluster(t, ctx, mgmtClient, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 	hostedClusterClient := e2eutil.WaitForGuestClient(t, ctx, mgmtClient, hostedCluster)
 
 	// Get the newly created defautlt NodePool

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -48,7 +48,7 @@ func TestOLM(t *testing.T) {
 
 	// Create a cluster
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir)
+	cluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	// Get guest client
 	t.Logf("Waiting for guest client to become available")

--- a/test/e2e/util/aws.go
+++ b/test/e2e/util/aws.go
@@ -1,11 +1,19 @@
 package util
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/go-logr/logr"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
+	"github.com/openshift/hypershift/support/oidc"
 )
 
 const (
@@ -29,4 +37,70 @@ func GetKMSKeyArn(awsCreds, awsRegion string) (*string, error) {
 	}
 
 	return out.KeyMetadata.Arn, nil
+}
+
+func GetS3Client(awsCreds, awsRegion string) *s3.S3 {
+	awsSession := awsutil.NewSession("e2e-s3", awsCreds, "", "", awsRegion)
+	awsConfig := awsutil.NewConfig()
+	return s3.New(awsSession, awsConfig)
+}
+
+func GetIAMClient(awsCreds, awsRegion string) iamiface.IAMAPI {
+	awsSession := awsutil.NewSession("e2e-iam", awsCreds, "", "", awsRegion)
+	awsConfig := awsutil.NewConfig()
+	return iam.New(awsSession, awsConfig)
+}
+
+func DestroyOIDCProvider(log logr.Logger, iamClient iamiface.IAMAPI, issuerURL string) {
+	oidcProviderList, err := iamClient.ListOpenIDConnectProviders(&iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		log.Error(err, "failed to list OIDC providers")
+		return
+	}
+
+	providerName := strings.TrimPrefix(issuerURL, "https://")
+	for _, provider := range oidcProviderList.OpenIDConnectProviderList {
+		if strings.Contains(*provider.Arn, providerName) {
+			_, err := iamClient.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{
+				OpenIDConnectProviderArn: provider.Arn,
+			})
+			if err != nil {
+				if aerr, ok := err.(awserr.Error); ok {
+					if aerr.Code() != iam.ErrCodeNoSuchEntityException {
+						log.Error(aerr, "Error deleting OIDC provider", "providerARN", provider.Arn)
+						return
+					}
+				} else {
+					log.Error(err, "Error deleting OIDC provider", "providerARN", provider.Arn)
+					return
+				}
+			} else {
+				log.Info("Deleted OIDC provider", "providerARN", provider.Arn)
+			}
+			break
+		}
+	}
+
+}
+
+func CleanupOIDCBucketObjects(log logr.Logger, s3Client *s3.S3, bucketName, issuerURL string) {
+	providerID := issuerURL[strings.LastIndex(issuerURL, "/")+1:]
+
+	objectsToDelete := []*s3.ObjectIdentifier{
+		{
+			Key: aws.String(providerID + "/.well-known/openid-configuration"),
+		},
+		{
+			Key: aws.String(providerID + oidc.JWKSURI),
+		},
+	}
+
+	if _, err := s3Client.DeleteObjects(&s3.DeleteObjectsInput{
+		Bucket: aws.String(bucketName),
+		Delete: &s3.Delete{Objects: objectsToDelete},
+	}); err != nil {
+		if awsErr := awserr.Error(nil); !errors.As(err, &awsErr) || awsErr.Code() != s3.ErrCodeNoSuchBucket {
+			log.Error(awsErr, "failed to delete OIDC objects from S3 bucket", "bucketName", bucketName)
+		}
+	}
 }

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -41,7 +41,7 @@ import (
 //
 // This function is intended (for now) to be the preferred default way of
 // creating a hosted cluster during a test.
-func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, opts *core.CreateOptions, platform hyperv1.PlatformType, artifactDir string) *hyperv1.HostedCluster {
+func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, opts *core.CreateOptions, platform hyperv1.PlatformType, artifactDir string, serviceAccountSigningKey []byte) *hyperv1.HostedCluster {
 	g := NewWithT(t)
 	start := time.Now()
 
@@ -56,6 +56,34 @@ func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, op
 	}
 	err := client.Create(ctx, namespace)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to create namespace")
+
+	// create serviceAccount signing key secret
+	serviceAccountSigningKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "e2e-sa-signing-key",
+			Namespace: namespace.Name,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			hyperv1.ServiceAccountSigningKeySecretKey: serviceAccountSigningKey,
+		},
+	}
+	err = client.Create(ctx, serviceAccountSigningKeySecret)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create serviceAccountSigningKeySecret")
+
+	originalBeforeApply := opts.BeforeApply
+	opts.BeforeApply = func(o crclient.Object) {
+		if originalBeforeApply != nil {
+			originalBeforeApply(o)
+		}
+
+		switch v := o.(type) {
+		case *hyperv1.HostedCluster:
+			v.Spec.ServiceAccountSigningKey = &corev1.LocalObjectReference{
+				Name: serviceAccountSigningKeySecret.Name,
+			}
+		}
+	}
 
 	// Build the skeletal HostedCluster based on the provided platform.
 	hc := &hyperv1.HostedCluster{


### PR DESCRIPTION
**What this PR does / why we need it**:
Only a single OIDC provider will be created and shared between all e2e HostedClusters. 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-939](https://issues.redhat.com/browse/HOSTEDCP-939)

**Checklist**
- [x] Relevant issues have been referenced.