### PR TITLE
ACM-4615 get pull secret instead of dockerconfigjson from mce credentials

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -178,7 +178,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 	var pullSecret []byte
 	var err error
 	if len(opts.CredentialSecretName) > 0 {
-		pullSecret, err = util.GetDockerConfigJSON(opts.CredentialSecretName, opts.Namespace)
+		pullSecret, err = util.GetPullSecret(opts.CredentialSecretName, opts.Namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func getReleaseSemanticVersion(ctx context.Context, opts *CreateOptions, provide
 	var pullSecretBytes []byte
 	var err error
 	if len(opts.CredentialSecretName) > 0 {
-		pullSecretBytes, err = util.GetDockerConfigJSON(opts.CredentialSecretName, opts.Namespace)
+		pullSecretBytes, err = util.GetPullSecret(opts.CredentialSecretName, opts.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/util/secrets.go
+++ b/cmd/util/secrets.go
@@ -68,3 +68,15 @@ func GetDockerConfigJSON(name string, namespace string) ([]byte, error) {
 	}
 	return dockerConfigJSON, nil
 }
+
+func GetPullSecret(name string, namespace string) ([]byte, error) {
+	secret, err := GetSecret(name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	pullSecret := secret.Data["pullSecret"]
+	if len(pullSecret) == 0 {
+		return nil, fmt.Errorf("the pull secret is invalid, {namespace: %s, secret: %s}", namespace, name)
+	}
+	return []byte(pullSecret), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**: 
get pull secret instead of dockerconfigjson from mce credentials to make consistent with https://github.com/openshift/hypershift/blob/main/docs/content/how-to/aws/create-aws-hosted-cluster-secret-credentials.md. This allows for successful cluster creation when following the docs

**Which issue(s) this PR fixes**:
Fixes https://github.com/openshift/hypershift/issues/2179 & https://issues.redhat.com/browse/ACM-4615

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

Before:
```
2023-03-28T14:53:44-04:00	INFO	Retreiving credentials secret	{"namespace": "clusters", "name": "aws-secret-test"}
2023-03-28T14:53:51-04:00	ERROR	Failed to create cluster	{"error": "failed to default network: failed to get version for release image quay.io/openshift-release-dev/ocp-release:4.13.0-rc.0-x86_64: the .dockerconfigjson key is invalid, {namespace: clusters, secret: aws-secret-test}"}
```
After:
```
2023-03-28T16:03:49-04:00       INFO    Retreiving credentials secret   {"namespace": "clusters", "name": "aws-secret-test"}
Using baseDomain from the --base-domain flag
2023-03-28T16:03:54-04:00       INFO    Creating infrastructure {"id": "dockercfg-xtf6p"}
2023-03-28T16:03:54-04:00       INFO    Using zone      {"zone": "us-east-1a"}
2023-03-28T16:03:55-04:00       INFO    Created VPC     {"id": "vpc-06773e8e4cab02449"}
.
.
... to completion
```