### PR TITLE
OCPBUGS-10227: Preserve false status of ValidAWSIdentityProvider condition

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -337,6 +337,11 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		oldCondition := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.ValidAWSIdentityProvider))
+
+		// Preserve previous false status if we can no longer determine the status (for example when the hostedcontrolplane has been deleted)
+		if oldCondition != nil && oldCondition.Status == metav1.ConditionFalse && freshCondition.Status == metav1.ConditionUnknown {
+			freshCondition.Status = metav1.ConditionFalse
+		}
 		if oldCondition == nil || oldCondition.Status != freshCondition.Status {
 			freshCondition.ObservedGeneration = hcluster.Generation
 			meta.SetStatusCondition(&hcluster.Status.Conditions, *freshCondition)


### PR DESCRIPTION
**What this PR does / why we need it**:
When the hostedcontrolplane has been removed, we may still depend on the ValidAWSIdentityProvider condition to determine whether to abandon the AWSEndpointService. Current behavior is that the condition status reverts to Unknown. This prevents the AWSEndpointService controller from abandoning the cleanup of the VPC endpoint.

This change preserves the value of the condition if it was false and can no longer be determined via the hostedcontrolplane resource.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-10227

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.