### PR TITLE
Revert "cpo: cno: follow image name change in release payload"

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -85,7 +85,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 			WhereaboutsCNI:               images["multus-whereabouts-ipam-cni"],
 			RouteOverrideCNI:             images["multus-route-override-cni"],
 			MultusNetworkPolicy:          images["multus-networkpolicy"],
-			OVN:                          images["ovn-kubernetes-rhel-9"],
+			OVN:                          images["ovn-kubernetes"],
 			EgressRouterCNI:              images["egress-router-cni"],
 			KuryrDaemon:                  images["kuryr-cni"],
 			KuryrController:              images["kuryr-controller"],


### PR DESCRIPTION
This reverts commit 956d0936625c4f76dbe306af6c537d890c3a1ab6.

CNO changed the OVN image name in the payload again
https://github.com/openshift/cluster-network-operator/pull/1747