### PR TITLE
HOSTEDCP-850: Fix nodepool autoscaler logic

### DIFF
--- a/hypershift-operator/controllers/nodepool/inplace_test.go
+++ b/hypershift-operator/controllers/nodepool/inplace_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sutilspointer "k8s.io/utils/pointer"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -64,6 +65,58 @@ func TestSetMachineSetReplicas(t *testing.T) {
 				},
 			},
 			expectReplicas: 2,
+			expectAutoscalerAnnotations: map[string]string{
+				autoscalerMinAnnotation: "2",
+				autoscalerMaxAnnotation: "5",
+			},
+		},
+		{
+			name: "it sets current replicas to autoScaling.min and set annotations when autoscaling is enabled" +
+				" and the MachineSet has replicas < autoScaling.min",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: hyperv1.NodePoolSpec{
+					AutoScaling: &hyperv1.NodePoolAutoScaling{
+						Min: 2,
+						Max: 5,
+					},
+				},
+			},
+			machineSet: &capiv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: capiv1.MachineSetSpec{
+					Replicas: k8sutilspointer.Int32Ptr(1),
+				},
+			},
+			expectReplicas: 2,
+			expectAutoscalerAnnotations: map[string]string{
+				autoscalerMinAnnotation: "2",
+				autoscalerMaxAnnotation: "5",
+			},
+		},
+		{
+			name: "it sets current replicas to autoScaling.max and set annotations when autoscaling is enabled" +
+				" and the MachineSet has replicas > autoScaling.max",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: hyperv1.NodePoolSpec{
+					AutoScaling: &hyperv1.NodePoolAutoScaling{
+						Min: 2,
+						Max: 5,
+					},
+				},
+			},
+			machineSet: &capiv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: capiv1.MachineSetSpec{
+					Replicas: k8sutilspointer.Int32Ptr(10),
+				},
+			},
+			expectReplicas: 5,
 			expectAutoscalerAnnotations: map[string]string{
 				autoscalerMinAnnotation: "2",
 				autoscalerMaxAnnotation: "5",

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -1179,6 +1179,58 @@ func TestSetMachineDeploymentReplicas(t *testing.T) {
 				autoscalerMaxAnnotation: "5",
 			},
 		},
+		{
+			name: "it sets current replicas to autoScaling.min and set annotations when autoscaling is enabled" +
+				" and the MachineDeployment has replicas < autoScaling.min",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: hyperv1.NodePoolSpec{
+					AutoScaling: &hyperv1.NodePoolAutoScaling{
+						Min: 2,
+						Max: 5,
+					},
+				},
+			},
+			machineDeployment: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: capiv1.MachineDeploymentSpec{
+					Replicas: k8sutilspointer.Int32Ptr(1),
+				},
+			},
+			expectReplicas: 2,
+			expectAutoscalerAnnotations: map[string]string{
+				autoscalerMinAnnotation: "2",
+				autoscalerMaxAnnotation: "5",
+			},
+		},
+		{
+			name: "it sets current replicas to autoScaling.max and set annotations when autoscaling is enabled" +
+				" and the MachineDeployment has replicas > autoScaling.max",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: hyperv1.NodePoolSpec{
+					AutoScaling: &hyperv1.NodePoolAutoScaling{
+						Min: 2,
+						Max: 5,
+					},
+				},
+			},
+			machineDeployment: &capiv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: capiv1.MachineDeploymentSpec{
+					Replicas: k8sutilspointer.Int32Ptr(10),
+				},
+			},
+			expectReplicas: 5,
+			expectAutoscalerAnnotations: map[string]string{
+				autoscalerMinAnnotation: "2",
+				autoscalerMaxAnnotation: "5",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures MachineDeployment/MachineSet has correct replicas count corresponding to autoscaler min/max values

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-850](https://issues.redhat.com/browse/HOSTEDCP-850)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.