### PR TITLE
Add option to set kubevirt core count in e2e tests

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -64,6 +64,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.ExternalDNSDomain, "e2e.external-dns-domain", "", "domain that external-dns will use to create DNS records for HCP endpoints")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "DEPRECATED (ignored will be removed soon)")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtNodeMemory, "e2e.kubevirt-node-memory", "4Gi", "the amount of memory to provide to each workload node")
+	flag.UintVar(&globalOpts.configurableClusterOptions.KubeVirtNodeCores, "e2e.kubevirt-node-cores", 4, "The number of cores provided to each workload node")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtInfraKubeconfigFile, "e2e.kubevirt-infra-kubeconfig", "", "path to the kubeconfig file of the external infra cluster")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtInfraNamespace, "e2e.kubevirt-infra-namespace", "", "the namespace on the infra cluster the workers will be created on")
 	flag.IntVar(&globalOpts.configurableClusterOptions.NodePoolReplicas, "e2e.node-pool-replicas", 2, "the number of replicas for each node pool in the cluster")
@@ -233,6 +234,7 @@ type configurableClusterOptions struct {
 	ExternalDNSDomain           string
 	KubeVirtContainerDiskImage  string
 	KubeVirtNodeMemory          string
+	KubeVirtNodeCores           uint
 	KubeVirtInfraKubeconfigFile string
 	KubeVirtInfraNamespace      string
 	NodePoolReplicas            int
@@ -271,7 +273,7 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		},
 		KubevirtPlatform: core.KubevirtPlatformCreateOptions{
 			ServicePublishingStrategy: kubevirt.IngressServicePublishingStrategy,
-			Cores:                     2,
+			Cores:                     uint32(o.configurableClusterOptions.KubeVirtNodeCores),
 			Memory:                    o.configurableClusterOptions.KubeVirtNodeMemory,
 			InfraKubeConfigFile:       o.configurableClusterOptions.KubeVirtInfraKubeconfigFile,
 			InfraNamespace:            o.configurableClusterOptions.KubeVirtInfraNamespace,


### PR DESCRIPTION
We're hitting this ovs bug, https://bugzilla.redhat.com/show_bug.cgi?id=2180460

The workaround is to increase the core count, so we need the ability to influence the core count used in our e2e tests. We default to 4 cores now because that reduces the likelihood of encountering the bug.