### PR TITLE
Fix nodepool upgrade e2e test

### DIFF
--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -156,12 +156,7 @@ func (ru *NodePoolUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, node
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get release info for latest image")
 
 	t.Logf("Validating all Nodes have the synced labels and taints")
-	for _, node := range nodes {
-		g.Expect(node.Labels).To(HaveKeyWithValue(syncedLabelsKey, syncedLabelsValue))
-		g.Expect(node.Spec.Taints[0].Key).To(Equal(nodePool.Spec.Taints[0].Key))
-		g.Expect(node.Spec.Taints[0].Value).To(Equal(nodePool.Spec.Taints[0].Value))
-		g.Expect(node.Spec.Taints[0].Effect).To(Equal(nodePool.Spec.Taints[0].Effect))
-	}
+	e2eutil.EnsureNodesLabelsAndTaints(t, nodePool, nodes)
 
 	// Update NodePool images to the latest.
 	err = ru.mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)

--- a/test/e2e/util/node.go
+++ b/test/e2e/util/node.go
@@ -31,3 +31,25 @@ func EnsureNodeCommunication(t *testing.T, ctx context.Context, client crclient.
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 }
+
+func EnsureNodesLabelsAndTaints(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
+	g := NewWithT(t)
+
+	var taintTransformer = func(taint corev1.Taint) hyperv1.Taint {
+		return hyperv1.Taint{
+			Key:    taint.Key,
+			Value:  taint.Value,
+			Effect: taint.Effect,
+		}
+	}
+
+	for _, node := range nodes {
+		for key, value := range nodePool.Spec.NodeLabels {
+			g.Expect(node.Labels).To(HaveKeyWithValue(key, value))
+		}
+
+		for _, taint := range nodePool.Spec.Taints {
+			g.Expect(node.Spec.Taints).To(ContainElement(WithTransform(taintTransformer, Equal(taint))))
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix nodepool upgrade e2e test labels and taints validation logic

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
