### PR TITLE
HOSTEDCP-568: Update Konnectiviy socks5 proxy for IBM exception

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -102,8 +102,6 @@ const (
 	resourceDeletionTimeout = 2 * time.Minute
 )
 
-var NoopReconcile controllerutil.MutateFn = func() error { return nil }
-
 type InfrastructureStatus struct {
 	APIHost                 string
 	APIPort                 int32
@@ -280,7 +278,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	originalHostedControlPlane := hostedControlPlane.DeepCopy()
-	// This is a best effort ping to the identity provider
+	// This is the best effort ping to the identity provider
 	// that enables access from the operator to the cloud provider resources.
 	healthCheckIdentityProvider(ctx, hostedControlPlane)
 	// We want to ensure the healthCheckIdentityProvider condition is in status before we go through the deletion timestamp path.
@@ -610,7 +608,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 			message = ""
 			status = metav1.ConditionTrue
 		}
-		hostedControlPlane.Status.Ready = (status == metav1.ConditionTrue)
+		hostedControlPlane.Status.Ready = status == metav1.ConditionTrue
 		condition := metav1.Condition{
 			Type:               string(hyperv1.HostedControlPlaneAvailable),
 			Status:             status,
@@ -795,7 +793,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 		releaseImage.ComponentImages()[util.CPOImageName],
 		hostedControlPlane,
 		r.DefaultIngressDomain,
-		// The healthz handler was added before the CPO started to mange te ignition server and its the same binary,
+		// The healthz handler was added before the CPO started to manage the ignition server, and it's the same binary,
 		// so we know it always exists here.
 		true,
 		r.ReleaseProvider.GetRegistryOverrides(),
@@ -884,7 +882,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 
 	// Reconcile openshift apiserver
 	r.Log.Info("Reconciling OpenShift API Server")
-	if err := r.reconcileOpenShiftAPIServer(ctx, hostedControlPlane, observedConfig, releaseImage, infraStatus.OpenShiftAPIHost, createOrUpdate); err != nil {
+	if err := r.reconcileOpenShiftAPIServer(ctx, hostedControlPlane, observedConfig, releaseImage, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile openshift apiserver: %w", err)
 	}
 
@@ -901,7 +899,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 
 	// Reconcile openshift oauth apiserver
 	r.Log.Info("Reconciling OpenShift OAuth API Server")
-	if err := r.reconcileOpenShiftOAuthAPIServer(ctx, hostedControlPlane, observedConfig, releaseImage, infraStatus.OauthAPIServerHost, createOrUpdate); err != nil {
+	if err := r.reconcileOpenShiftOAuthAPIServer(ctx, hostedControlPlane, observedConfig, releaseImage, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile openshift oauth apiserver: %w", err)
 	}
 
@@ -969,7 +967,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 
 	// Reconcile OLM
 	r.Log.Info("Reconciling OLM")
-	if err = r.reconcileOperatorLifecycleManager(ctx, hostedControlPlane, releaseImage, infraStatus.PackageServerAPIAddress, createOrUpdate); err != nil {
+	if err = r.reconcileOperatorLifecycleManager(ctx, hostedControlPlane, releaseImage, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile olm: %w", err)
 	}
 
@@ -993,7 +991,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 		return fmt.Errorf("failed to reconcile ignition: %w", err)
 	}
 
-	// Reconcle machine config server config
+	// Reconcile machine config server config
 	r.Log.Info("Reconciling machine config server config")
 	if err = r.reconcileMachineConfigServerConfig(ctx, hostedControlPlane, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile mcs config: %w", err)
@@ -1795,8 +1793,11 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 	// Cluster Node Tuning Operator metrics Serving Cert
 	NodeTuningOperatorServingCert := manifests.ClusterNodeTuningOperatorServingCertSecret(hcp.Namespace)
 	NodeTuningOperatorService := manifests.ClusterNodeTuningOperatorMetricsService(hcp.Namespace)
-	removeServiceCAAnnotationAndSecret(ctx, r.Client, NodeTuningOperatorService, NodeTuningOperatorServingCert)
-	if _, err := createOrUpdate(ctx, r, NodeTuningOperatorServingCert, func() error {
+	err := removeServiceCAAnnotationAndSecret(ctx, r.Client, NodeTuningOperatorService, NodeTuningOperatorServingCert)
+	if err != nil {
+		r.Log.Error(err, "failed to remove service ca annotation and secret: %w")
+	}
+	if _, err = createOrUpdate(ctx, r, NodeTuningOperatorServingCert, func() error {
 		return pki.ReconcileNodeTuningOperatorServingCertSecret(NodeTuningOperatorServingCert, rootCASecret, p.OwnerRef)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile node tuning operator serving cert: %w", err)
@@ -2376,7 +2377,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeScheduler(ctx context.Contex
 	return nil
 }
 
-func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.Context, hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, releaseImage *releaseinfo.ReleaseImage, serviceClusterIP string, createOrUpdate upsert.CreateOrUpdateFN) error {
+func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.Context, hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, releaseImage *releaseinfo.ReleaseImage, createOrUpdate upsert.CreateOrUpdateFN) error {
 	p := oapi.NewOpenShiftAPIServerParams(hcp, observedConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 	oapicfg := manifests.OpenShiftAPIServerConfig(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, oapicfg, func() error {
@@ -2420,7 +2421,7 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.C
 	return nil
 }
 
-func (r *HostedControlPlaneReconciler) reconcileOpenShiftOAuthAPIServer(ctx context.Context, hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, releaseImage *releaseinfo.ReleaseImage, serviceClusterIP string, createOrUpdate upsert.CreateOrUpdateFN) error {
+func (r *HostedControlPlaneReconciler) reconcileOpenShiftOAuthAPIServer(ctx context.Context, hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, releaseImage *releaseinfo.ReleaseImage, createOrUpdate upsert.CreateOrUpdateFN) error {
 	p := oapi.NewOpenShiftAPIServerParams(hcp, observedConfig, releaseImage.ComponentImages(), r.SetDefaultSecurityContext)
 	auditCfg := manifests.OpenShiftOAuthAPIServerAuditConfig(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, auditCfg, func() error {
@@ -2773,7 +2774,7 @@ func (r *HostedControlPlaneReconciler) reconcileIngressOperator(ctx context.Cont
 	return nil
 }
 
-func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage, packageServerAddress string, createOrUpdate upsert.CreateOrUpdateFN) error {
+func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage, createOrUpdate upsert.CreateOrUpdateFN) error {
 	p := olm.NewOperatorLifecycleManagerParams(hcp, releaseImage.ComponentImages(), releaseImage.Version(), r.SetDefaultSecurityContext)
 
 	if hcp.Spec.OLMCatalogPlacement == hyperv1.ManagementOLMCatalogPlacement {
@@ -3704,7 +3705,7 @@ func healthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControl
 	// We try to interact with cloud provider to see validate is operational.
 	if _, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{}); err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			// When awsErr.Code() is WebIdentityErr it's likely to be an external issue, e.g the idp resource was deleted.
+			// When awsErr.Code() is WebIdentityErr it's likely to be an external issue, e.g. the idp resource was deleted.
 			// We don't set awsErr.Message() in the condition as it might contain aws requests IDs that would make the condition be updated in loop.
 			if awsErr.Code() == "WebIdentityErr" {
 				condition := metav1.Condition{

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2501,7 +2501,7 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServer(ctx context.Context,
 
 	deployment := manifests.OAuthServerDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return oauth.ReconcileDeployment(ctx, r, deployment, p.OwnerRef, oauthConfig, p.OAuthServerImage, p.DeploymentConfig, p.IdentityProviders(), p.OauthConfigOverrides, p.AvailabilityProberImage, util.APIPort(hcp), p.NamedCertificates(), p.Socks5ProxyImage, p.NoProxy)
+		return oauth.ReconcileDeployment(ctx, r, deployment, p.OwnerRef, oauthConfig, p.OAuthServerImage, p.DeploymentConfig, p.IdentityProviders(), p.OauthConfigOverrides, p.AvailabilityProberImage, util.APIPort(hcp), p.NamedCertificates(), p.Socks5ProxyImage)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile oauth deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -867,6 +867,19 @@ func TestEventHandling(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: "etcd-encryption-key"},
 		Data:       map[string][]byte{"key": []byte("very-secret")},
 	}
+	fakeNodeTuningOperator := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-tuning-operator",
+			Namespace: "bar",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+		},
+	}
+	fakeNodeTuningOperatorTLS := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: "node-tuning-operator-tls"},
+		Data:       map[string][]byte{"key": []byte("very-secret")},
+	}
 
 	hcpGVK, err := apiutil.GVKForObject(hcp, api.Scheme)
 	if err != nil {
@@ -876,7 +889,7 @@ func TestEventHandling(t *testing.T) {
 	restMapper.Add(hcpGVK, meta.RESTScopeNamespace)
 	c := &createTrackingClient{Client: fake.NewClientBuilder().
 		WithScheme(api.Scheme).
-		WithObjects(hcp, pullSecret, etcdEncryptionKey).
+		WithObjects(hcp, pullSecret, etcdEncryptionKey, fakeNodeTuningOperator, fakeNodeTuningOperatorTLS).
 		WithRESTMapper(restMapper).
 		Build(),
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -86,7 +86,7 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 	}
 	deployment.Spec.Template.ObjectMeta.Annotations[configHashAnnotation] = util.ComputeHash(configBytes)
 	deployment.Spec.Template.Spec = corev1.PodSpec{
-		AutomountServiceAccountToken: utilpointer.BoolPtr(false),
+		AutomountServiceAccountToken: utilpointer.Bool(false),
 		Containers: []corev1.Container{
 			util.BuildContainer(oauthContainerMain(), buildOAuthContainerMain(image)),
 			socks5ProxyContainer(socks5ProxyImage),
@@ -101,9 +101,9 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 			util.BuildVolume(oauthVolumeProvidersTemplate(), buildOAuthVolumeProvidersTemplate),
 			util.BuildVolume(oauthVolumeWorkLogs(), buildOAuthVolumeWorkLogs),
 			util.BuildVolume(oauthVolumeMasterCABundle(), buildOAuthVolumeMasterCABundle),
-			{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: utilpointer.Int32Ptr(0640)}}},
-			{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: utilpointer.Int32Ptr(0640)}}},
-			{Name: "konnectivity-proxy-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: manifests.KonnectivityCAConfigMap("").Name}, DefaultMode: utilpointer.Int32Ptr(0640)}}},
+			{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: utilpointer.Int32(0640)}}},
+			{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: utilpointer.Int32(0640)}}},
+			{Name: "konnectivity-proxy-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: manifests.KonnectivityCAConfigMap("").Name}, DefaultMode: utilpointer.Int32(0640)}}},
 		},
 	}
 	deploymentConfig.ApplyTo(deployment)
@@ -188,7 +188,7 @@ func oauthVolumeKubeconfig() *corev1.Volume {
 
 func buildOAuthVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		DefaultMode: utilpointer.Int32Ptr(0640),
+		DefaultMode: utilpointer.Int32(0640),
 		SecretName:  manifests.KASServiceKubeconfigSecret("").Name,
 	}
 }
@@ -200,7 +200,7 @@ func oauthVolumeServingCert() *corev1.Volume {
 
 func buildOAuthVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		DefaultMode: utilpointer.Int32Ptr(0640),
+		DefaultMode: utilpointer.Int32(0640),
 		SecretName:  manifests.OpenShiftOAuthServerCert("").Name,
 	}
 }
@@ -211,7 +211,7 @@ func oauthVolumeSessionSecret() *corev1.Volume {
 }
 func buildOAuthVolumeSessionSecret(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		DefaultMode: utilpointer.Int32Ptr(0640),
+		DefaultMode: utilpointer.Int32(0640),
 		SecretName:  manifests.OAuthServerServiceSessionSecret("").Name,
 	}
 }
@@ -223,7 +223,7 @@ func oauthVolumeErrorTemplate() *corev1.Volume {
 
 func buildOAuthVolumeErrorTemplate(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		DefaultMode: utilpointer.Int32Ptr(0640),
+		DefaultMode: utilpointer.Int32(0640),
 		SecretName:  manifests.OAuthServerDefaultErrorTemplateSecret("").Name,
 	}
 }
@@ -236,7 +236,7 @@ func oauthVolumeLoginTemplate() *corev1.Volume {
 
 func buildOAuthVolumeLoginTemplate(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		DefaultMode: utilpointer.Int32Ptr(0640),
+		DefaultMode: utilpointer.Int32(0640),
 		SecretName:  manifests.OAuthServerDefaultLoginTemplateSecret("").Name,
 	}
 }
@@ -249,7 +249,7 @@ func oauthVolumeProvidersTemplate() *corev1.Volume {
 
 func buildOAuthVolumeProvidersTemplate(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		DefaultMode: utilpointer.Int32Ptr(0640),
+		DefaultMode: utilpointer.Int32(0640),
 		SecretName:  manifests.OAuthServerDefaultProviderSelectionTemplateSecret("").Name,
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -62,9 +62,9 @@ type OAuthConfigParams struct {
 	LoginURLOverride string
 }
 
-// ConfigOverride defines the oauth parameters that can be overriden in special use cases. The only supported
+// ConfigOverride defines the oauth parameters that can be overridden in special use cases. The only supported
 // use case for this currently is the IBMCloud IAM OIDC provider. These parameters are necessary since the public
-// OpenID api does not support some of the customizations used in the IBMCloud IAM OIDC provider. This can be removed
+// OpenID api does not support some customizations used in the IBMCloud IAM OIDC provider. This can be removed
 // if the public API is adjusted to allow specifying these customizations.
 type ConfigOverride struct {
 	URLs      osinv1.OpenIDURLs   `json:"urls,omitempty"`
@@ -104,7 +104,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, images map[string]str
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Scheme: corev1.URISchemeHTTPS,
-					Port:   intstr.FromInt(int(OAuthServerPort)),
+					Port:   intstr.FromInt(OAuthServerPort),
 					Path:   "healthz",
 				},
 			},
@@ -120,7 +120,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, images map[string]str
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Scheme: corev1.URISchemeHTTPS,
-					Port:   intstr.FromInt(int(OAuthServerPort)),
+					Port:   intstr.FromInt(OAuthServerPort),
 					Path:   "healthz",
 				},
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -12,7 +12,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 )
@@ -41,7 +40,6 @@ type OAuthServerParams struct {
 	AvailabilityProberImage string `json:"availabilityProberImage"`
 	Availability            hyperv1.AvailabilityPolicy
 	Socks5ProxyImage        string
-	NoProxy                 []string
 }
 
 type OAuthConfigParams struct {
@@ -85,7 +83,6 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, images map[string]str
 		AvailabilityProberImage: images[util.AvailabilityProberImageName],
 		Availability:            hcp.Spec.ControllerAvailabilityPolicy,
 		Socks5ProxyImage:        images["socks5-proxy"],
-		NoProxy:                 []string{manifests.KubeAPIServerService("").Name},
 	}
 	if hcp.Spec.Configuration != nil {
 		p.APIServer = hcp.Spec.Configuration.APIServer
@@ -155,10 +152,6 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, images map[string]str
 	}
 
 	p.SetDefaultSecurityContext = setDefaultSecurityContext
-
-	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-		p.NoProxy = append(p.NoProxy, "iam.cloud.ibm.com", "iam.test.cloud.ibm.com")
-	}
 
 	return p
 }

--- a/konnectivity-socks5-proxy/main.go
+++ b/konnectivity-socks5-proxy/main.go
@@ -328,5 +328,8 @@ func (d proxyResolver) ResolveK8sService(ctx context.Context, l logr.Logger, nam
 // AZURE: https://docs.microsoft.com/en-us/rest/api/azure/#how-to-call-azure-rest-apis-with-curl
 // IBMCLOUD: https://cloud.ibm.com/apidocs/iam-identity-token-api#endpoints
 func isCloudAPI(host string) bool {
-	return strings.HasSuffix(host, ".amazonaws.com") || strings.HasSuffix(host, ".microsoftonline.com") || strings.HasSuffix(host, "azure.com") || strings.HasSuffix(host, "cloud.ibm.com")
+	return strings.HasSuffix(host, ".amazonaws.com") ||
+		strings.HasSuffix(host, ".microsoftonline.com") ||
+		strings.HasSuffix(host, "azure.com") ||
+		strings.HasSuffix(host, "cloud.ibm.com")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* Consolidates #1741 and #1722.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-568](https://issues.redhat.com/browse/HOSTEDCP-568)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.