### PR TITLE
HOSTEDCP-802: add cli flag to enable upgrade type

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -83,6 +83,7 @@ type ExampleOptions struct {
 	NetworkType                      hyperv1.NetworkType
 	ControlPlaneAvailabilityPolicy   hyperv1.AvailabilityPolicy
 	InfrastructureAvailabilityPolicy hyperv1.AvailabilityPolicy
+	UpgradeType                      hyperv1.UpgradeType
 }
 
 func (o ExampleOptions) Resources() *ExampleResources {
@@ -507,7 +508,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			Spec: hyperv1.NodePoolSpec{
 				Management: hyperv1.NodePoolManagement{
 					AutoRepair:  o.AutoRepair,
-					UpgradeType: hyperv1.UpgradeTypeReplace,
+					UpgradeType: o.UpgradeType,
 				},
 				Replicas:    &o.NodePoolReplicas,
 				ClusterName: o.Name,

--- a/api/v1beta1/nodepool_types.go
+++ b/api/v1beta1/nodepool_types.go
@@ -2,11 +2,11 @@ package v1beta1
 
 import (
 	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"strings"
 )
 
 const (
@@ -184,6 +184,26 @@ const (
 	// additional node capacity requirements.
 	UpgradeTypeInPlace = UpgradeType("InPlace")
 )
+
+func (p *UpgradeType) String() string {
+	return string(*p)
+}
+
+func (p *UpgradeType) Set(s string) error {
+	switch strings.ToLower(s) {
+	case "replace":
+		*p = UpgradeTypeReplace
+	case "inplace":
+		*p = UpgradeTypeInPlace
+	default:
+		return fmt.Errorf("unknown upgrade type used '%s'", s)
+	}
+	return nil
+}
+
+func (p *UpgradeType) Type() string {
+	return "UpgradeType"
+}
 
 // UpgradeStrategy is a specific strategy for upgrading nodes in a NodePool.
 type UpgradeStrategy string

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"github.com/openshift/hypershift/api/v1beta1"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -35,6 +36,7 @@ func NewCreateCommands() *cobra.Command {
 		NodeSelector:                   nil,
 		Log:                            log.Log,
 		NodeDrainTimeout:               0,
+		NodeUpgradeType:                v1beta1.UpgradeTypeReplace,
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -71,6 +73,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringToStringVar(&opts.NodeSelector, "node-selector", opts.NodeSelector, "A comma separated list of key=value to use as node selector for the Hosted Control Plane pods to stick to. E.g. role=cp,disk=fast")
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
+	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
 
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(none.NewCreateCommand(opts))

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -73,6 +73,7 @@ type CreateOptions struct {
 	Log                              logr.Logger
 	SkipAPIBudgetVerification        bool
 	CredentialSecretName             string
+	NodeUpgradeType                  hyperv1.UpgradeType
 
 	// BeforeApply is called immediately before resources are applied to the
 	// server, giving the user an opportunity to inspect or mutate the resources.
@@ -267,6 +268,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		ServiceCIDR:                      opts.ServiceCIDR,
 		ClusterCIDR:                      opts.ClusterCIDR,
 		NodeSelector:                     opts.NodeSelector,
+		UpgradeType:                      opts.NodeUpgradeType,
 	}, nil
 }
 

--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -16,12 +16,13 @@ import (
 )
 
 type CreateNodePoolOptions struct {
-	Name         string
-	Namespace    string
-	ClusterName  string
-	NodeCount    int32
-	ReleaseImage string
-	Render       bool
+	Name            string
+	Namespace       string
+	ClusterName     string
+	NodeCount       int32
+	ReleaseImage    string
+	Render          bool
+	NodeUpgradeType hyperv1.UpgradeType
 }
 
 type PlatformOptions interface {
@@ -81,7 +82,7 @@ func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts
 		},
 		Spec: hyperv1.NodePoolSpec{
 			Management: hyperv1.NodePoolManagement{
-				UpgradeType: hyperv1.UpgradeTypeReplace,
+				UpgradeType: o.NodeUpgradeType,
 			},
 			ClusterName: o.ClusterName,
 			Replicas:    &o.NodeCount,

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -1,6 +1,7 @@
 package nodepool
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hypershift/cmd/nodepool/agent"
@@ -24,11 +25,12 @@ func NewCreateCommand() *cobra.Command {
 	}
 
 	opts := &core.CreateNodePoolOptions{
-		Name:         "example",
-		Namespace:    "clusters",
-		ClusterName:  "example",
-		NodeCount:    2,
-		ReleaseImage: "",
+		Name:            "example",
+		Namespace:       "clusters",
+		ClusterName:     "example",
+		NodeCount:       2,
+		ReleaseImage:    "",
+		NodeUpgradeType: hyperv1.UpgradeTypeReplace,
 	}
 
 	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The name of the NodePool")
@@ -36,6 +38,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.PersistentFlags().Int32Var(&opts.NodeCount, "node-count", opts.NodeCount, "The number of nodes to create in the NodePool")
 	cmd.PersistentFlags().StringVar(&opts.ClusterName, "cluster-name", opts.ClusterName, "The name of the HostedCluster nodes in this pool will join")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes. If empty, defaults to the same release image as the HostedCluster.")
+	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
 
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying")
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -428,6 +428,7 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		PullSecretFile:                   o.configurableClusterOptions.PullSecretFile,
 		ControlPlaneOperatorImage:        o.configurableClusterOptions.ControlPlaneOperatorImage,
 		ExternalDNSDomain:                o.configurableClusterOptions.ExternalDNSDomain,
+		NodeUpgradeType:                  hyperv1.UpgradeTypeReplace,
 		AWSPlatform: core.AWSPlatformOptions{
 			InstanceType:       "m5.large",
 			RootVolumeSize:     64,


### PR DESCRIPTION
**What this PR does / why we need it**:
Nodepool upgrade has two different upgrade methods, Replace and InPlace.
I think our CI upgrade test should cover both. So I add one flag in our CLI to support the completion of the Replace upgrade and InPlace upgrade in the prow.
```
Flag: 
   --upgrade-type string    The upgrade type is a type of high-level upgrade behavior nodes in a NodePool. Supported options: Replace, InPlace (default "Replace")
```
example:
```
bin/hypershift create cluster aws --aws-creds xxx --pull-secret xxx --upgrade-type InPlace  --base-domain xxx --render
```
**Which issue(s) this PR fixes**
Fixes [HOSTEDCP-802](https://issues.redhat.com/browse/HOSTEDCP-802)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.