### PR TITLE
W/A for KubeVirt provider with RHCOS 9.2

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -86,7 +86,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, images map[strin
 			WhereaboutsCNI:               images["multus-whereabouts-ipam-cni"],
 			RouteOverrideCNI:             images["multus-route-override-cni"],
 			MultusNetworkPolicy:          images["multus-networkpolicy"],
-			OVN:                          images["ovn-kubernetes"],
+			OVN:                          images["ovn-kubernetes-rhel-9"],
 			EgressRouterCNI:              images["egress-router-cni"],
 			KuryrDaemon:                  images["kuryr-cni"],
 			KuryrController:              images["kuryr-controller"],

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -148,6 +148,8 @@ func WaitForNReadyNodes(t *testing.T, ctx context.Context, client crclient.Clien
 	switch platform {
 	case hyperv1.PowerVSPlatform:
 		waitTimeout = 60 * time.Minute
+	case hyperv1.KubevirtPlatform:
+		waitTimeout = 60 * time.Minute
 	}
 
 	t.Logf("Waiting for nodes to become ready. Want: %v", n)


### PR DESCRIPTION
Due to changes in RHCOS 9.2, the ignition config is not able to be fetched with the openstack provider. However, it works with kubevirt ignition provider. Adding a workaround that uses a modified RHCOS containerdisk that sets the kernel command line parameter of `ignition.platform.id=kubevirt` instead of `ignition.platform.id=openstack`

This is needed until https://github.com/coreos/fedora-coreos-tracker/issues/1126 is resolved and we'll have our kubevirt artifact shipped with RHCOS.
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.