### PR TITLE
Revert "Create a second scheme that always registers prometheusoperatorv1 GVKs"

### DIFF
--- a/api/scheme.go
+++ b/api/scheme.go
@@ -29,12 +29,7 @@ import (
 )
 
 var (
-	// InstallScheme only should be used when installing the HyperShift Operator.
-	// The only current difference is that prometheusoperatorv1's GVKs must always be used, regardless of whether
-	// RHOBS monitoring is enabled.
-	// Ref: https://issues.redhat.com/browse/OCPBUGS-8713
-	InstallScheme = runtime.NewScheme()
-	Scheme        = runtime.NewScheme()
+	Scheme = runtime.NewScheme()
 	// TODO: Even though an object typer is specified here, serialized objects
 	// are not always getting their TypeMeta set unless explicitly initialized
 	// on the variable declarations.
@@ -52,27 +47,6 @@ var (
 )
 
 func init() {
-	capiaws.AddToScheme(InstallScheme)
-	capiibm.AddToScheme(InstallScheme)
-	clientgoscheme.AddToScheme(InstallScheme)
-	hyperv1alpha1.AddToScheme(InstallScheme)
-	hyperv1beta1.AddToScheme(InstallScheme)
-	capiv1.AddToScheme(InstallScheme)
-	configv1.AddToScheme(InstallScheme)
-	operatorv1.AddToScheme(InstallScheme)
-	securityv1.AddToScheme(InstallScheme)
-	routev1.AddToScheme(InstallScheme)
-	rbacv1.AddToScheme(InstallScheme)
-	corev1.AddToScheme(InstallScheme)
-	apiextensionsv1.AddToScheme(InstallScheme)
-	kasv1beta1.AddToScheme(InstallScheme)
-	prometheusoperatorv1.AddToScheme(InstallScheme)
-	agentv1.AddToScheme(InstallScheme)
-	capikubevirt.AddToScheme(InstallScheme)
-	capiazure.AddToScheme(InstallScheme)
-	snapshotv1.AddToScheme(InstallScheme)
-	imagev1.AddToScheme(InstallScheme)
-
 	capiaws.AddToScheme(Scheme)
 	capiibm.AddToScheme(Scheme)
 	clientgoscheme.AddToScheme(Scheme)

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -655,11 +655,11 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	}
 
 	for idx := range objects {
-		gvk, err := apiutil.GVKForObject(objects[idx], hyperapi.InstallScheme)
+		gvk, err := apiutil.GVKForObject(objects[idx], hyperapi.Scheme)
 		if err != nil {
 			return nil, fmt.Errorf("failed to look up gvk for %T: %w", objects[idx], err)
 		}
-		// Everything that embeds metav1.TypeMeta implements this
+		// Everything that embedds metav1.TypeMeta implements this
 		objects[idx].(interface {
 			SetGroupVersionKind(gvk schema.GroupVersionKind)
 		}).SetGroupVersionKind(gvk)


### PR DESCRIPTION
Reverts openshift/hypershift#2292
We will use OBO to ship hypershift metrics, so no need to register this version group, and we are seeing this error in the installer pod:
```
 oc logs -n open-cluster-management-agent-addon hypershift-install-job-25cr8-nnlvw
already exists: PriorityClass /hypershift-control-plane
already exists: PriorityClass /hypershift-etcd
already exists: PriorityClass /hypershift-api-critical
already exists: PriorityClass /hypershift-operator
applied Namespace /hypershift
applied ServiceAccount hypershift/operator
applied ClusterRole /hypershift-operator
applied ClusterRoleBinding /hypershift-operator
applied Role hypershift/hypershift-operator
applied RoleBinding hypershift/hypershift-operator
applied ServiceAccount hypershift/external-dns
applied ClusterRole /external-dns
applied ClusterRoleBinding /external-dns
applied Deployment hypershift/external-dns
applied Deployment hypershift/operator
applied Service hypershift/operator
applied Role hypershift/prometheus
applied RoleBinding hypershift/prometheus
Error: Incorrect version specified in apply patch. Specified patch version: monitoring.coreos.com/v1, expected: monitoring.rhobs/v1
Incorrect version specified in apply patch. Specified patch version: monitoring.coreos.com/v1, expected: monitoring.rhobs/v1
```