### PR TITLE
HOSTEDCP-954: Remove ec2:ReleaseAddress

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1244,7 +1244,6 @@ type AWSRolesRef struct {
 	//  "Statement": [
 	//    {
 	//      "Action": [
-	//        "ec2:AllocateAddress",
 	//        "ec2:AssociateRouteTable",
 	//        "ec2:AttachInternetGateway",
 	//        "ec2:AuthorizeSecurityGroupIngress",
@@ -1282,7 +1281,6 @@ type AWSRolesRef struct {
 	//        "ec2:ModifyInstanceAttribute",
 	//        "ec2:ModifyNetworkInterfaceAttribute",
 	//        "ec2:ModifySubnetAttribute",
-	//        "ec2:ReleaseAddress",
 	//        "ec2:RevokeSecurityGroupIngress",
 	//        "ec2:RunInstances",
 	//        "ec2:TerminateInstances",

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -211,7 +211,6 @@ const (
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:ModifySubnetAttribute",
-        "ec2:ReleaseAddress",
         "ec2:RevokeSecurityGroupIngress",
         "ec2:RunInstances",
         "ec2:TerminateInstances",

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -173,7 +173,6 @@ const (
   "Statement": [
     {
       "Action": [
-        "ec2:AllocateAddress",
         "ec2:AssociateRouteTable",
         "ec2:AttachInternetGateway",
         "ec2:AuthorizeSecurityGroupIngress",

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -6153,16 +6153,16 @@ spec:
                             description: "NodePoolManagementARN is an ARN value referencing
                               a role appropriate for the CAPI Controller. \n The following
                               is an example of a valid policy document: \n { \"Version\":
-                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"ec2:AllocateAddress\",
-                              \"ec2:AssociateRouteTable\", \"ec2:AttachInternetGateway\",
-                              \"ec2:AuthorizeSecurityGroupIngress\", \"ec2:CreateInternetGateway\",
-                              \"ec2:CreateNatGateway\", \"ec2:CreateRoute\", \"ec2:CreateRouteTable\",
-                              \"ec2:CreateSecurityGroup\", \"ec2:CreateSubnet\", \"ec2:CreateTags\",
-                              \"ec2:DeleteInternetGateway\", \"ec2:DeleteNatGateway\",
-                              \"ec2:DeleteRouteTable\", \"ec2:DeleteSecurityGroup\",
-                              \"ec2:DeleteSubnet\", \"ec2:DeleteTags\", \"ec2:DescribeAccountAttributes\",
-                              \"ec2:DescribeAddresses\", \"ec2:DescribeAvailabilityZones\",
-                              \"ec2:DescribeImages\", \"ec2:DescribeInstances\", \"ec2:DescribeInternetGateways\",
+                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"ec2:AssociateRouteTable\",
+                              \"ec2:AttachInternetGateway\", \"ec2:AuthorizeSecurityGroupIngress\",
+                              \"ec2:CreateInternetGateway\", \"ec2:CreateNatGateway\",
+                              \"ec2:CreateRoute\", \"ec2:CreateRouteTable\", \"ec2:CreateSecurityGroup\",
+                              \"ec2:CreateSubnet\", \"ec2:CreateTags\", \"ec2:DeleteInternetGateway\",
+                              \"ec2:DeleteNatGateway\", \"ec2:DeleteRouteTable\",
+                              \"ec2:DeleteSecurityGroup\", \"ec2:DeleteSubnet\", \"ec2:DeleteTags\",
+                              \"ec2:DescribeAccountAttributes\", \"ec2:DescribeAddresses\",
+                              \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeImages\",
+                              \"ec2:DescribeInstances\", \"ec2:DescribeInternetGateways\",
                               \"ec2:DescribeNatGateways\", \"ec2:DescribeNetworkInterfaces\",
                               \"ec2:DescribeNetworkInterfaceAttribute\", \"ec2:DescribeRouteTables\",
                               \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
@@ -6170,16 +6170,16 @@ spec:
                               \"ec2:DescribeVolumes\", \"ec2:DetachInternetGateway\",
                               \"ec2:DisassociateRouteTable\", \"ec2:DisassociateAddress\",
                               \"ec2:ModifyInstanceAttribute\", \"ec2:ModifyNetworkInterfaceAttribute\",
-                              \"ec2:ModifySubnetAttribute\", \"ec2:ReleaseAddress\",
-                              \"ec2:RevokeSecurityGroupIngress\", \"ec2:RunInstances\",
-                              \"ec2:TerminateInstances\", \"tag:GetResources\", \"ec2:CreateLaunchTemplate\",
-                              \"ec2:CreateLaunchTemplateVersion\", \"ec2:DescribeLaunchTemplates\",
-                              \"ec2:DescribeLaunchTemplateVersions\", \"ec2:DeleteLaunchTemplate\",
-                              \"ec2:DeleteLaunchTemplateVersions\" ], \"Resource\":
-                              [ \"*\" ], \"Effect\": \"Allow\" }, { \"Condition\":
-                              { \"StringLike\": { \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"
-                              } }, \"Action\": [ \"iam:CreateServiceLinkedRole\" ],
-                              \"Resource\": [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                              \"ec2:ModifySubnetAttribute\", \"ec2:RevokeSecurityGroupIngress\",
+                              \"ec2:RunInstances\", \"ec2:TerminateInstances\", \"tag:GetResources\",
+                              \"ec2:CreateLaunchTemplate\", \"ec2:CreateLaunchTemplateVersion\",
+                              \"ec2:DescribeLaunchTemplates\", \"ec2:DescribeLaunchTemplateVersions\",
+                              \"ec2:DeleteLaunchTemplate\", \"ec2:DeleteLaunchTemplateVersions\"
+                              ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\" },
+                              { \"Condition\": { \"StringLike\": { \"iam:AWSServiceName\":
+                              \"elasticloadbalancing.amazonaws.com\" } }, \"Action\":
+                              [ \"iam:CreateServiceLinkedRole\" ], \"Resource\": [
+                              \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
                               ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                               ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                               ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -6144,16 +6144,16 @@ spec:
                             description: "NodePoolManagementARN is an ARN value referencing
                               a role appropriate for the CAPI Controller. \n The following
                               is an example of a valid policy document: \n { \"Version\":
-                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"ec2:AllocateAddress\",
-                              \"ec2:AssociateRouteTable\", \"ec2:AttachInternetGateway\",
-                              \"ec2:AuthorizeSecurityGroupIngress\", \"ec2:CreateInternetGateway\",
-                              \"ec2:CreateNatGateway\", \"ec2:CreateRoute\", \"ec2:CreateRouteTable\",
-                              \"ec2:CreateSecurityGroup\", \"ec2:CreateSubnet\", \"ec2:CreateTags\",
-                              \"ec2:DeleteInternetGateway\", \"ec2:DeleteNatGateway\",
-                              \"ec2:DeleteRouteTable\", \"ec2:DeleteSecurityGroup\",
-                              \"ec2:DeleteSubnet\", \"ec2:DeleteTags\", \"ec2:DescribeAccountAttributes\",
-                              \"ec2:DescribeAddresses\", \"ec2:DescribeAvailabilityZones\",
-                              \"ec2:DescribeImages\", \"ec2:DescribeInstances\", \"ec2:DescribeInternetGateways\",
+                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"ec2:AssociateRouteTable\",
+                              \"ec2:AttachInternetGateway\", \"ec2:AuthorizeSecurityGroupIngress\",
+                              \"ec2:CreateInternetGateway\", \"ec2:CreateNatGateway\",
+                              \"ec2:CreateRoute\", \"ec2:CreateRouteTable\", \"ec2:CreateSecurityGroup\",
+                              \"ec2:CreateSubnet\", \"ec2:CreateTags\", \"ec2:DeleteInternetGateway\",
+                              \"ec2:DeleteNatGateway\", \"ec2:DeleteRouteTable\",
+                              \"ec2:DeleteSecurityGroup\", \"ec2:DeleteSubnet\", \"ec2:DeleteTags\",
+                              \"ec2:DescribeAccountAttributes\", \"ec2:DescribeAddresses\",
+                              \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeImages\",
+                              \"ec2:DescribeInstances\", \"ec2:DescribeInternetGateways\",
                               \"ec2:DescribeNatGateways\", \"ec2:DescribeNetworkInterfaces\",
                               \"ec2:DescribeNetworkInterfaceAttribute\", \"ec2:DescribeRouteTables\",
                               \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
@@ -6161,16 +6161,16 @@ spec:
                               \"ec2:DescribeVolumes\", \"ec2:DetachInternetGateway\",
                               \"ec2:DisassociateRouteTable\", \"ec2:DisassociateAddress\",
                               \"ec2:ModifyInstanceAttribute\", \"ec2:ModifyNetworkInterfaceAttribute\",
-                              \"ec2:ModifySubnetAttribute\", \"ec2:ReleaseAddress\",
-                              \"ec2:RevokeSecurityGroupIngress\", \"ec2:RunInstances\",
-                              \"ec2:TerminateInstances\", \"tag:GetResources\", \"ec2:CreateLaunchTemplate\",
-                              \"ec2:CreateLaunchTemplateVersion\", \"ec2:DescribeLaunchTemplates\",
-                              \"ec2:DescribeLaunchTemplateVersions\", \"ec2:DeleteLaunchTemplate\",
-                              \"ec2:DeleteLaunchTemplateVersions\" ], \"Resource\":
-                              [ \"*\" ], \"Effect\": \"Allow\" }, { \"Condition\":
-                              { \"StringLike\": { \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"
-                              } }, \"Action\": [ \"iam:CreateServiceLinkedRole\" ],
-                              \"Resource\": [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                              \"ec2:ModifySubnetAttribute\", \"ec2:RevokeSecurityGroupIngress\",
+                              \"ec2:RunInstances\", \"ec2:TerminateInstances\", \"tag:GetResources\",
+                              \"ec2:CreateLaunchTemplate\", \"ec2:CreateLaunchTemplateVersion\",
+                              \"ec2:DescribeLaunchTemplates\", \"ec2:DescribeLaunchTemplateVersions\",
+                              \"ec2:DeleteLaunchTemplate\", \"ec2:DeleteLaunchTemplateVersions\"
+                              ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\" },
+                              { \"Condition\": { \"StringLike\": { \"iam:AWSServiceName\":
+                              \"elasticloadbalancing.amazonaws.com\" } }, \"Action\":
+                              [ \"iam:CreateServiceLinkedRole\" ], \"Resource\": [
+                              \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
                               ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                               ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                               ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1794,7 +1794,6 @@ string
 &ldquo;Statement&rdquo;: [
 {
 &ldquo;Action&rdquo;: [
-&ldquo;ec2:AllocateAddress&rdquo;,
 &ldquo;ec2:AssociateRouteTable&rdquo;,
 &ldquo;ec2:AttachInternetGateway&rdquo;,
 &ldquo;ec2:AuthorizeSecurityGroupIngress&rdquo;,
@@ -1832,7 +1831,6 @@ string
 &ldquo;ec2:ModifyInstanceAttribute&rdquo;,
 &ldquo;ec2:ModifyNetworkInterfaceAttribute&rdquo;,
 &ldquo;ec2:ModifySubnetAttribute&rdquo;,
-&ldquo;ec2:ReleaseAddress&rdquo;,
 &ldquo;ec2:RevokeSecurityGroupIngress&rdquo;,
 &ldquo;ec2:RunInstances&rdquo;,
 &ldquo;ec2:TerminateInstances&rdquo;,

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -33478,11 +33478,11 @@ objects:
                                 referencing a role appropriate for the CAPI Controller.
                                 \n The following is an example of a valid policy document:
                                 \n { \"Version\": \"2012-10-17\", \"Statement\": [
-                                { \"Action\": [ \"ec2:AllocateAddress\", \"ec2:AssociateRouteTable\",
-                                \"ec2:AttachInternetGateway\", \"ec2:AuthorizeSecurityGroupIngress\",
-                                \"ec2:CreateInternetGateway\", \"ec2:CreateNatGateway\",
-                                \"ec2:CreateRoute\", \"ec2:CreateRouteTable\", \"ec2:CreateSecurityGroup\",
-                                \"ec2:CreateSubnet\", \"ec2:CreateTags\", \"ec2:DeleteInternetGateway\",
+                                { \"Action\": [ \"ec2:AssociateRouteTable\", \"ec2:AttachInternetGateway\",
+                                \"ec2:AuthorizeSecurityGroupIngress\", \"ec2:CreateInternetGateway\",
+                                \"ec2:CreateNatGateway\", \"ec2:CreateRoute\", \"ec2:CreateRouteTable\",
+                                \"ec2:CreateSecurityGroup\", \"ec2:CreateSubnet\",
+                                \"ec2:CreateTags\", \"ec2:DeleteInternetGateway\",
                                 \"ec2:DeleteNatGateway\", \"ec2:DeleteRouteTable\",
                                 \"ec2:DeleteSecurityGroup\", \"ec2:DeleteSubnet\",
                                 \"ec2:DeleteTags\", \"ec2:DescribeAccountAttributes\",
@@ -33495,17 +33495,16 @@ objects:
                                 \"ec2:DescribeVolumes\", \"ec2:DetachInternetGateway\",
                                 \"ec2:DisassociateRouteTable\", \"ec2:DisassociateAddress\",
                                 \"ec2:ModifyInstanceAttribute\", \"ec2:ModifyNetworkInterfaceAttribute\",
-                                \"ec2:ModifySubnetAttribute\", \"ec2:ReleaseAddress\",
-                                \"ec2:RevokeSecurityGroupIngress\", \"ec2:RunInstances\",
-                                \"ec2:TerminateInstances\", \"tag:GetResources\",
-                                \"ec2:CreateLaunchTemplate\", \"ec2:CreateLaunchTemplateVersion\",
-                                \"ec2:DescribeLaunchTemplates\", \"ec2:DescribeLaunchTemplateVersions\",
-                                \"ec2:DeleteLaunchTemplate\", \"ec2:DeleteLaunchTemplateVersions\"
-                                ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\"
-                                }, { \"Condition\": { \"StringLike\": { \"iam:AWSServiceName\":
-                                \"elasticloadbalancing.amazonaws.com\" } }, \"Action\":
-                                [ \"iam:CreateServiceLinkedRole\" ], \"Resource\":
-                                [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                                \"ec2:ModifySubnetAttribute\", \"ec2:RevokeSecurityGroupIngress\",
+                                \"ec2:RunInstances\", \"ec2:TerminateInstances\",
+                                \"tag:GetResources\", \"ec2:CreateLaunchTemplate\",
+                                \"ec2:CreateLaunchTemplateVersion\", \"ec2:DescribeLaunchTemplates\",
+                                \"ec2:DescribeLaunchTemplateVersions\", \"ec2:DeleteLaunchTemplate\",
+                                \"ec2:DeleteLaunchTemplateVersions\" ], \"Resource\":
+                                [ \"*\" ], \"Effect\": \"Allow\" }, { \"Condition\":
+                                { \"StringLike\": { \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"
+                                } }, \"Action\": [ \"iam:CreateServiceLinkedRole\"
+                                ], \"Resource\": [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
                                 ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                                 ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                                 ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",
@@ -41002,11 +41001,11 @@ objects:
                                 referencing a role appropriate for the CAPI Controller.
                                 \n The following is an example of a valid policy document:
                                 \n { \"Version\": \"2012-10-17\", \"Statement\": [
-                                { \"Action\": [ \"ec2:AllocateAddress\", \"ec2:AssociateRouteTable\",
-                                \"ec2:AttachInternetGateway\", \"ec2:AuthorizeSecurityGroupIngress\",
-                                \"ec2:CreateInternetGateway\", \"ec2:CreateNatGateway\",
-                                \"ec2:CreateRoute\", \"ec2:CreateRouteTable\", \"ec2:CreateSecurityGroup\",
-                                \"ec2:CreateSubnet\", \"ec2:CreateTags\", \"ec2:DeleteInternetGateway\",
+                                { \"Action\": [ \"ec2:AssociateRouteTable\", \"ec2:AttachInternetGateway\",
+                                \"ec2:AuthorizeSecurityGroupIngress\", \"ec2:CreateInternetGateway\",
+                                \"ec2:CreateNatGateway\", \"ec2:CreateRoute\", \"ec2:CreateRouteTable\",
+                                \"ec2:CreateSecurityGroup\", \"ec2:CreateSubnet\",
+                                \"ec2:CreateTags\", \"ec2:DeleteInternetGateway\",
                                 \"ec2:DeleteNatGateway\", \"ec2:DeleteRouteTable\",
                                 \"ec2:DeleteSecurityGroup\", \"ec2:DeleteSubnet\",
                                 \"ec2:DeleteTags\", \"ec2:DescribeAccountAttributes\",
@@ -41019,17 +41018,16 @@ objects:
                                 \"ec2:DescribeVolumes\", \"ec2:DetachInternetGateway\",
                                 \"ec2:DisassociateRouteTable\", \"ec2:DisassociateAddress\",
                                 \"ec2:ModifyInstanceAttribute\", \"ec2:ModifyNetworkInterfaceAttribute\",
-                                \"ec2:ModifySubnetAttribute\", \"ec2:ReleaseAddress\",
-                                \"ec2:RevokeSecurityGroupIngress\", \"ec2:RunInstances\",
-                                \"ec2:TerminateInstances\", \"tag:GetResources\",
-                                \"ec2:CreateLaunchTemplate\", \"ec2:CreateLaunchTemplateVersion\",
-                                \"ec2:DescribeLaunchTemplates\", \"ec2:DescribeLaunchTemplateVersions\",
-                                \"ec2:DeleteLaunchTemplate\", \"ec2:DeleteLaunchTemplateVersions\"
-                                ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\"
-                                }, { \"Condition\": { \"StringLike\": { \"iam:AWSServiceName\":
-                                \"elasticloadbalancing.amazonaws.com\" } }, \"Action\":
-                                [ \"iam:CreateServiceLinkedRole\" ], \"Resource\":
-                                [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                                \"ec2:ModifySubnetAttribute\", \"ec2:RevokeSecurityGroupIngress\",
+                                \"ec2:RunInstances\", \"ec2:TerminateInstances\",
+                                \"tag:GetResources\", \"ec2:CreateLaunchTemplate\",
+                                \"ec2:CreateLaunchTemplateVersion\", \"ec2:DescribeLaunchTemplates\",
+                                \"ec2:DescribeLaunchTemplateVersions\", \"ec2:DeleteLaunchTemplate\",
+                                \"ec2:DeleteLaunchTemplateVersions\" ], \"Resource\":
+                                [ \"*\" ], \"Effect\": \"Allow\" }, { \"Condition\":
+                                { \"StringLike\": { \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"
+                                } }, \"Action\": [ \"iam:CreateServiceLinkedRole\"
+                                ], \"Resource\": [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
                                 ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                                 ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                                 ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",


### PR DESCRIPTION

**What this PR does / why we need it**:

Checking if ec2:ReleaseAddress is needed for NodePool management polcy or not 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/HOSTEDCP-954

**Checklist**
- [x ] Subject and description added to both, commit and PR.
- [ x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.