### PR TITLE
OCPBUGS-11442: properly reconcile with user specified changes for in proxy configuration

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -621,7 +621,7 @@ func (r *reconciler) reconcileConfig(ctx context.Context, hcp *hyperv1.HostedCon
 
 	proxy := globalconfig.ProxyConfig()
 	if _, err := r.CreateOrUpdate(ctx, r.client, proxy, func() error {
-		globalconfig.ReconcileProxyConfig(proxy, hcp.Spec.Configuration)
+		globalconfig.ReconcileInClusterProxyConfig(proxy, hcp.Spec.Configuration)
 		return nil
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile proxy config: %w", err))


### PR DESCRIPTION
**What this PR does / why we need it**:

Users are able to and directed to configure the cluster-wide proxy directly in the guest cluster when needing to setup local proxying in the guest cluster network: https://docs.openshift.com/container-platform/4.10/networking/enable-cluster-wide-proxy.html. Currently: even when the proxy configuration in the hosted cluster is nil: we are squashing all these changes and revoking what they are doing locally. This makes it impossible for them to configure the proxy within their network (they should not need to have to proxy these configurations to the hostedcluster resource each time and get it to propogate as that can be controlled by a separate entity like a managed cloud provider). This allows the user to create those changes and have them persist


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/projects/OCPBUGS/issues/OCPBUGS-11442

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.