### PR TITLE
HOSTEDCP-917: Add publicAndPrivate <-> Private e2e test

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -7,13 +7,12 @@ import (
 	"context"
 	"strings"
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/support/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -41,34 +40,7 @@ func TestCreateCluster(t *testing.T) {
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
-	// Sanity check the cluster by waiting for the nodes to report ready
-	t.Logf("Waiting for guest client to become available")
-	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
-
-	// Wait for Nodes to be Ready
-	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
-
-	// TODO (alberto): move into WaitForNReadyNodes after this PR github.com/openshift/hypershift/pull/1702 gets merged so it's validated by any call to the function in any test.
-	// It's has to wait for the PR to merged otherwise the control_plane_upgrade_test would fail.
-	t.Logf("Validating all Nodes have the NodePool label")
-	nodes := &corev1.NodeList{}
-	if err := guestClient.List(ctx, nodes); err != nil {
-		t.Fatalf("failed to list nodes in guest cluster: %v", err)
-	}
-	for _, node := range nodes.Items {
-		g.Expect(node.Labels[hyperv1.NodePoolLabel]).NotTo(BeEmpty())
-	}
-
-	// Wait for the rollout to be complete
-	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
-	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
-
-	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
-	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-	e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
+	validatePublicCluster(t, ctx, client, hostedCluster, &clusterOpts)
 }
 
 func TestCreateClusterCustomConfig(t *testing.T) {
@@ -97,26 +69,10 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 	g.Expect(hostedCluster.Spec.SecretEncryption.KMS.AWS.ActiveKey.ARN).To(Equal(*kmsKeyArn))
 	g.Expect(hostedCluster.Spec.SecretEncryption.KMS.AWS.Auth.AWSKMSRoleARN).ToNot(BeEmpty())
 
-	// Sanity check the cluster by waiting for the nodes to report ready
-	t.Logf("Waiting for guest client to become available")
+	validatePublicCluster(t, ctx, client, hostedCluster, &clusterOpts)
+
 	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
-
-	// Wait for Nodes to be Ready
-	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
-	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
-
-	// Wait for the rollout to be complete
-	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
-	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
-
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
-
-	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-	e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
-
 	e2eutil.EnsureSecretEncryptedUsingKMS(t, ctx, hostedCluster, guestClient)
-
 	// test oauth with identity provider
 	e2eutil.EnsureOAuthWithIdentityProvider(t, ctx, client, hostedCluster)
 }
@@ -145,6 +101,26 @@ func TestNoneCreateCluster(t *testing.T) {
 	// e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 }
 
+// TestCreateClusterProxy implements a test that creates a cluster behind a proxy with the code under test.
+func TestCreateClusterProxy(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts.AWSPlatform.EnableProxy = true
+	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
+
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
+
+	validatePublicCluster(t, ctx, client, hostedCluster, &clusterOpts)
+}
+
 // TestCreateClusterPrivate implements a smoke test that creates a private cluster.
 // Validations requiring guest cluster client are dropped here since the kas is not accessible when private.
 // In the future we might want to leverage https://issues.redhat.com/browse/HOSTEDCP-697 to access guest cluster.
@@ -164,50 +140,41 @@ func TestCreateClusterPrivate(t *testing.T) {
 
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
-	_, err = e2eutil.WaitForGuestKubeConfig(t, ctx, client, hostedCluster)
-	g.Expect(err).NotTo(HaveOccurred(), "couldn't get kubeconfig")
+	validatePrivateCluster(t, ctx, client, hostedCluster)
 
-	// Ensure NodePools have all Nodes ready.
-	waitTimeout := 30 * time.Minute
-	err = wait.PollImmediateWithContext(ctx, 5*time.Second, waitTimeout, func(ctx context.Context) (done bool, err error) {
-		var nodePoolList hyperv1.NodePoolList
-		if err := client.List(ctx, &nodePoolList, &crclient.ListOptions{Namespace: hostedCluster.Namespace}); err != nil {
-			t.Fatalf("failed to list nodepools: %v", err)
-		}
-		for _, nodePool := range nodePoolList.Items {
-			if *nodePool.Spec.Replicas != nodePool.Status.Replicas {
-				t.Logf("Waiting. NodePool %q wants %v replicas but has %v", nodePool.Name, *nodePool.Spec.Replicas, nodePool.Status.Replicas)
-				return false, nil
-			}
-		}
-		return true, nil
-	})
-
-	// Wait for the rollout to be complete
-	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
-	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
-
-	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
-	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+	// Private -> publicAndPrivate
+	t.Run("SwitchFromPrivateToPublic", testSwitchFromPrivateToPublic(ctx, client, hostedCluster, &clusterOpts))
+	// publicAndPrivate -> Private
+	t.Run("SwitchFromPublicToPrivate", testSwitchFromPublicToPrivate(ctx, client, hostedCluster))
 }
 
-// TestCreateClusterProxy implements a test that creates a cluster behind a proxy with the code under test.
-func TestCreateClusterProxy(t *testing.T) {
-	t.Parallel()
+func testSwitchFromPrivateToPublic(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *core.CreateOptions) func(t *testing.T) {
+	return func(t *testing.T) {
+		g := NewWithT(t)
+
+		err := e2eutil.UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
+			obj.Spec.Platform.AWS.EndpointAccess = hyperv1.PublicAndPrivate
+		})
+		g.Expect(err).ToNot(HaveOccurred(), "failed to update hostedcluster EndpointAccess")
+
+		validatePublicCluster(t, ctx, client, hostedCluster, clusterOpts)
+	}
+}
+
+func testSwitchFromPublicToPrivate(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) func(t *testing.T) {
+	return func(t *testing.T) {
+		g := NewWithT(t)
+		err := e2eutil.UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
+			obj.Spec.Platform.AWS.EndpointAccess = hyperv1.Private
+		})
+		g.Expect(err).ToNot(HaveOccurred(), "failed to update hostedcluster EndpointAccess")
+
+		validatePrivateCluster(t, ctx, client, hostedCluster)
+	}
+}
+
+func validatePublicCluster(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *core.CreateOptions) {
 	g := NewWithT(t)
-
-	ctx, cancel := context.WithCancel(testContext)
-	defer cancel()
-
-	client, err := e2eutil.GetClient()
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
-
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	clusterOpts.AWSPlatform.EnableProxy = true
-	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
-
-	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	// Sanity check the cluster by waiting for the nodes to report ready
 	t.Logf("Waiting for guest client to become available")
@@ -217,24 +184,53 @@ func TestCreateClusterProxy(t *testing.T) {
 	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
 	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
-	// TODO (alberto): move into WaitForNReadyNodes after this PR github.com/openshift/hypershift/pull/1702 gets merged so it's validated by any call to the function in any test.
-	// It's has to wait for the PR to merged otherwise the control_plane_upgrade_test would fail.
-	t.Logf("Validating all Nodes have the NodePool label")
-	nodes := &corev1.NodeList{}
-	if err := guestClient.List(ctx, nodes); err != nil {
-		t.Fatalf("failed to list nodes in guest cluster: %v", err)
+	// Wait for the rollout to be complete
+	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
+	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
+
+	err := client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+
+	serviceStrategy := util.ServicePublishingStrategyByTypeByHC(hostedCluster, hyperv1.APIServer)
+	g.Expect(serviceStrategy).ToNot(BeNil())
+	if serviceStrategy.Type == hyperv1.Route && serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
+		g.Expect(hostedCluster.Status.ControlPlaneEndpoint.Host).To(Equal(serviceStrategy.Route.Hostname))
+	} else {
+		// sanity check
+		g.Expect(hostedCluster.Status.ControlPlaneEndpoint.Host).ToNot(ContainSubstring("hypershift.local"))
 	}
-	for _, node := range nodes.Items {
-		g.Expect(node.Labels[hyperv1.NodePoolLabel]).NotTo(BeEmpty())
-	}
+
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
+	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+	e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
+}
+
+func validatePrivateCluster(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+
+	_, err := e2eutil.WaitForGuestKubeConfig(t, ctx, client, hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "couldn't get kubeconfig")
+
+	// Ensure NodePools have all Nodes ready.
+	e2eutil.WaitForNodePoolDesiredNodes(t, ctx, client, hostedCluster)
 
 	// Wait for the rollout to be complete
 	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
 	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
+
 	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
-	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
+	serviceStrategy := util.ServicePublishingStrategyByTypeByHC(hostedCluster, hyperv1.APIServer)
+	g.Expect(serviceStrategy).ToNot(BeNil())
+	// Private clusters should always use Route
+	g.Expect(serviceStrategy.Type).To(Equal(hyperv1.Route))
+	if serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
+		g.Expect(hostedCluster.Status.ControlPlaneEndpoint.Host).To(Equal(serviceStrategy.Route.Hostname))
+	} else {
+		// sanity check
+		g.Expect(hostedCluster.Status.ControlPlaneEndpoint.Host).ToNot(ContainSubstring("hypershift.local"))
+	}
+
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-	e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
 }

--- a/test/e2e/util/node.go
+++ b/test/e2e/util/node.go
@@ -3,11 +3,13 @@ package util
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,10 +26,21 @@ func EnsureNodeCommunication(t *testing.T, ctx context.Context, client crclient.
 		g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
 		guestClient := kubeclient.NewForConfigOrDie(guestConfig)
 
-		podList, err := guestClient.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{LabelSelector: "app=konnectivity-agent"})
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(podList.Items).ToNot(BeEmpty())
-		_, err = guestClient.CoreV1().Pods("kube-system").GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{Container: "konnectivity-agent"}).DoRaw(ctx)
+		// Mulham: konnectivity-agent pod is not available immediately after switching from private to public.
+		// This simply adds retries to solve that.
+		err = wait.PollImmediateWithContext(ctx, 10*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
+			podList, err := guestClient.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{LabelSelector: "app=konnectivity-agent"})
+			if err != nil || len(podList.Items) == 0 {
+				return false, nil
+			}
+
+			_, err = guestClient.CoreV1().Pods("kube-system").GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{Container: "konnectivity-agent"}).DoRaw(ctx)
+			if err != nil {
+				return false, nil
+			}
+
+			return true, nil
+		})
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -38,14 +38,18 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func PatchObject[T crclient.Object](ctx context.Context, client crclient.Client, obj T) error {
+func UpdateObject[T crclient.Object](t *testing.T, ctx context.Context, client crclient.Client, original T, mutate func(obj T)) error {
 	return wait.PollImmediateWithContext(ctx, time.Second, time.Minute*1, func(ctx context.Context) (done bool, err error) {
-		original := obj.DeepCopyObject().(T)
-		if err := client.Get(ctx, crclient.ObjectKeyFromObject(obj), original); err != nil {
+		if err := client.Get(ctx, crclient.ObjectKeyFromObject(original), original); err != nil {
+			t.Logf("failed to retrieve object %s, will retry: %v", original.GetName(), err)
 			return false, nil
 		}
 
+		obj := original.DeepCopyObject().(T)
+		mutate(obj)
+
 		if err := client.Patch(ctx, obj, crclient.MergeFrom(original)); err != nil {
+			t.Logf("failed to patch object %s, will retry: %v", original.GetName(), err)
 			if errors.IsConflict(err) {
 				return false, nil
 			}
@@ -139,7 +143,8 @@ func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Clien
 
 	t.Logf("Waiting for a successful connection to the guest apiserver")
 	var guestClient crclient.Client
-	waitForGuestClientCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	// Mulham: increased timeout from 5m to 15m as guest kubeconfig/API server takes longer to report available after switching from private to public
+	waitForGuestClientCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
 	defer cancel()
 	// SOA TTL is 60s. If DNS lookup fails on the api-* name, it is unlikely to succeed in less than 60s.
 	err = wait.PollImmediateWithContext(waitForGuestClientCtx, 35*time.Second, 30*time.Minute, func(ctx context.Context) (done bool, err error) {
@@ -184,6 +189,7 @@ func WaitForNReadyNodes(t *testing.T, ctx context.Context, client crclient.Clien
 			for _, cond := range node.Status.Conditions {
 				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
 					readyNodes = append(readyNodes, node.Name)
+					g.Expect(node.Labels[hyperv1.NodePoolLabel]).NotTo(BeEmpty())
 				}
 			}
 		}
@@ -363,6 +369,26 @@ func WaitForNodePoolVersion(t *testing.T, ctx context.Context, client crclient.C
 	g.Expect(err).NotTo(HaveOccurred(), "failed waiting for nodepool version")
 
 	t.Logf("Observed nodepool %s/%s to report version %s in %s", nodePool.Namespace, nodePool.Name, version, time.Since(start).Round(time.Second))
+}
+
+func WaitForNodePoolDesiredNodes(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+
+	waitTimeout := 30 * time.Minute
+	err := wait.PollImmediateWithContext(ctx, 5*time.Second, waitTimeout, func(ctx context.Context) (done bool, err error) {
+		var nodePoolList hyperv1.NodePoolList
+		if err := client.List(ctx, &nodePoolList, &crclient.ListOptions{Namespace: hostedCluster.Namespace}); err != nil {
+			t.Fatalf("failed to list nodepools: %v", err)
+		}
+		for _, nodePool := range nodePoolList.Items {
+			if *nodePool.Spec.Replicas != nodePool.Status.Replicas {
+				t.Logf("Waiting. NodePool %q wants %v replicas but has %v", nodePool.Name, *nodePool.Spec.Replicas, nodePool.Status.Replicas)
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	g.Expect(err).NotTo(HaveOccurred(), "failed to ensure all NodePools' nodes ready")
 }
 
 func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Validates switching a cluster from `PublicAndPrivate` to `Private` and vice versa to be working .

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-917](https://issues.redhat.com/browse/HOSTEDCP-917)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.