### PR TITLE
OCPBUGS-11450: Pass OPENSHIFT_RELEASE_IMAGE env variable to CNO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -482,6 +482,7 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 			{Name: "TOKEN_MINTER_IMAGE", Value: params.Images.TokenMinter},
 			{Name: "CLI_IMAGE", Value: params.Images.CLI},
 			{Name: "SOCKS5_PROXY_IMAGE", Value: params.Images.Socks5Proxy},
+			{Name: "OPENSHIFT_RELEASE_IMAGE", Value: params.DeploymentConfig.AdditionalAnnotations[hyperv1.ReleaseImageAnnotation]},
 		}...),
 		Name:            operatorName,
 		Image:           params.Images.NetworkOperator,


### PR DESCRIPTION
When CNO is managed by Hypershift, it's deployment has "hypershift.openshift.io/release-image" template metadata annotation. The annotation's value is used to track progress of cluster control plane version upgrades. But multus-admission-controller created and managed by CNO does not have that annotation so service providers are not able to track its version upgrades.

The proposed solution is for CNO to propagate its "hypershift.openshift.io/release-image" annotation down to the multus-admission-controller deployment. For that CNO need to have "get" access to its own deployment manifest to be able to read the deployment template metadata annotations. 

This PR grants CNO `get` permission to read its own deployment object.

Corresponding [CNO PR](https://github.com/openshift/cluster-network-operator/pull/1770) is submitted.

Update:
The CNO team preferred passing hypershift.openshift.io/release-image annotation with an additional env variable "OPENSHIFT_RELEASE_IMAGE" because of performance implications of reading not-changing Kubernetes objects.

The code changed to pass OPENSHIFT_RELEASE_IMAGE variable to CNO.