### PR TITLE
Add monitoring label to HCP namespace

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -114,6 +114,10 @@ const (
 	controlplaneOperatorManagesIgnitionServerLabel = "io.openshift.hypershift.control-plane-operator-manages-ignition-server"
 	controlPlaneOperatorManagesMachineApprover     = "io.openshift.hypershift.control-plane-operator-manages.cluster-machine-approver"
 	controlPlaneOperatorManagesMachineAutoscaler   = "io.openshift.hypershift.control-plane-operator-manages.cluster-autoscaler"
+
+	// The common label for monitoring in HyperShift
+	// Namespaces with this label will be actively monitored by the observability operator
+	hyperShiftMonitoringLabel = "hypershift.openshift.io/monitoring"
 )
 
 // NoopReconcile is just a default mutation function that does nothing.
@@ -918,7 +922,10 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			controlPlaneNamespace.Labels = make(map[string]string)
 		}
 		controlPlaneNamespace.Labels["hypershift.openshift.io/hosted-control-plane"] = "true"
-		controlPlaneNamespace.Labels["hypershift.openshift.io/monitoring"] = "true"
+
+		// Enable monitoring for hosted control plane namespaces
+		controlPlaneNamespace.Labels[hyperShiftMonitoringLabel] = "true"
+
 		if r.EnableOCPClusterMonitoring {
 			controlPlaneNamespace.Labels["openshift.io/cluster-monitoring"] = "true"
 		}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -918,6 +918,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			controlPlaneNamespace.Labels = make(map[string]string)
 		}
 		controlPlaneNamespace.Labels["hypershift.openshift.io/hosted-control-plane"] = "true"
+		controlPlaneNamespace.Labels["hypershift.openshift.io/monitoring"] = "true"
 		if r.EnableOCPClusterMonitoring {
 			controlPlaneNamespace.Labels["openshift.io/cluster-monitoring"] = "true"
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
For HyperShift, we are currently scraping hosted control plane metrics via the Observability Operator. The [namespaceSelector](https://github.com/rhobs/observability-operator/blob/main/docs/api.md#monitoringstackspecnamespaceselector) field of the operator's MonitoringStack CR does not support multiple labels. With Management Cluster metrics soon to be forwarded by the Observability Operator, we need a common label that acts as an identifier that the namespace should be monitored by Observability Operator. 
This PR adds the `hypershift.openshift.io/monitoring` label to the hosted control plane namespace to achieve this goal.

**Which issue(s) this PR fixes**
Resolves: [OSD-15905](https://issues.redhat.com/browse/OSD-15905)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.