### PR TITLE
OCPBUGS-11640: Update HostedCluster oauthCallbackURLTemplate

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -529,7 +529,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 					Message: hyperv1.AllIsWellMessage,
 					Reason:  hyperv1.AsExpectedReason,
 				}
-				hostedControlPlane.Status.OAuthCallbackURLTemplate = fmt.Sprintf("https://%s:%d/oauthcallback/[identity-provider-name]", infraStatus.OAuthHost, infraStatus.OAuthPort)
+				hostedControlPlane.Status.OAuthCallbackURLTemplate = fmt.Sprintf("https://%s:%d/oauth2callback/[identity-provider-name]", infraStatus.OAuthHost, infraStatus.OAuthPort)
 			} else {
 				message := "Cluster infrastructure is still provisioning"
 				if len(infraStatus.Message) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Update HostedCluster oauthCallbackURLTemplate to use 'oauth2callback' in URL, not 'oauthcallback'.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-11640](https://issues.redhat.com/browse/OCPBUGS-11640)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.