### PR TITLE
OCPBUGS-11654: [release-4.12] Create new EC2 client for AWS identity provider health check

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -277,6 +277,11 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// This is a best effort ping to the identity provider
 	// that enables access from the operator to the cloud provider resources.
 	healthCheckIdentityProvider(ctx, hostedControlPlane, r.ec2Client)
+	// We want to ensure the healthCheckIdentityProvider condition is in status before we go through the deletion timestamp path.
+	if err := r.Client.Status().Patch(ctx, hostedControlPlane, client.MergeFromWithOptions(originalHostedControlPlane, client.MergeFromWithOptimisticLock{})); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+	}
+	originalHostedControlPlane = hostedControlPlane.DeepCopy()
 
 	// Return early if deleted
 	if !hostedControlPlane.DeletionTimestamp.IsZero() {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -180,15 +180,21 @@ func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager, create
 
 	r.reconcileInfrastructureStatus = r.defaultReconcileInfrastructureStatus
 
+	r.ec2Client, r.awsSession = getEC2Client()
+
+	return nil
+}
+
+func getEC2Client() (ec2iface.EC2API, *session.Session) {
 	// AWS_SHARED_CREDENTIALS_FILE and AWS_REGION envvar should be set in operator deployment
 	// when reconciling an AWS hosted control plane
 	if os.Getenv("AWS_SHARED_CREDENTIALS_FILE") != "" {
 		awsSession := awsutil.NewSession("control-plane-operator", "", "", "", "")
 		awsConfig := awssdk.NewConfig()
-		r.ec2Client = ec2.New(awsSession, awsConfig)
-		r.awsSession = awsSession
+		ec2Client := ec2.New(awsSession, awsConfig)
+		return ec2Client, awsSession
 	}
-	return nil
+	return nil, nil
 }
 
 func isScrapeConfig(obj client.Object) bool {
@@ -276,7 +282,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	originalHostedControlPlane := hostedControlPlane.DeepCopy()
 	// This is a best effort ping to the identity provider
 	// that enables access from the operator to the cloud provider resources.
-	healthCheckIdentityProvider(ctx, hostedControlPlane, r.ec2Client)
+	healthCheckIdentityProvider(ctx, hostedControlPlane)
 	// We want to ensure the healthCheckIdentityProvider condition is in status before we go through the deletion timestamp path.
 	if err := r.Client.Status().Patch(ctx, hostedControlPlane, client.MergeFromWithOptions(originalHostedControlPlane, client.MergeFromWithOptimisticLock{})); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
@@ -3613,12 +3619,17 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 	return nil
 }
 
-func healthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane, ec2Client ec2iface.EC2API) {
+func healthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane) {
 	if hcp.Spec.Platform.AWS == nil {
 		return
 	}
 
 	log := ctrl.LoggerFrom(ctx)
+
+	ec2Client, _ := getEC2Client()
+	if ec2Client == nil {
+		return
+	}
 
 	// We try to interact with cloud provider to see validate is operational.
 	if _, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{}); err != nil {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2926,24 +2926,44 @@ func (r *HostedClusterReconciler) deleteNodePools(ctx context.Context, c client.
 	return nil
 }
 
-func deleteAWSEndpointServices(ctx context.Context, c client.Client, namespace string) (bool, error) {
+// deleteAWSEndpointServices loops over AWSEndpointServiceList items and sends a delete request for each.
+// If the HC has no valid aws credentials it removes the CPO finalizer for each AWSEndpointService.
+// It returns true if len(awsEndpointServiceList.Items) != 0.
+func deleteAWSEndpointServices(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, namespace string) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
 	var awsEndpointServiceList hyperv1.AWSEndpointServiceList
 	if err := c.List(ctx, &awsEndpointServiceList, &client.ListOptions{Namespace: namespace}); err != nil && !apierrors.IsNotFound(err) {
 		return false, fmt.Errorf("error listing awsendpointservices in namespace %s: %w", namespace, err)
 	}
 	for _, ep := range awsEndpointServiceList.Items {
 		if ep.DeletionTimestamp != nil {
+			if platformaws.ValidCredentials(hc) {
+				continue
+			}
+
+			// We remove the CPO finalizer if there's no valid credentials so deletion can proceed.
+			cpoFinalizer := "hypershift.openshift.io/control-plane-operator-finalizer"
+			if controllerutil.ContainsFinalizer(&ep, cpoFinalizer) {
+				controllerutil.RemoveFinalizer(&ep, cpoFinalizer)
+				if err := c.Update(ctx, &ep); err != nil {
+					return false, fmt.Errorf("failed to remove finalizer from awsendpointservice: %w", err)
+				}
+			}
+			log.Info("Removed finalizer for awsendpointservice because the HC has no valid aws credentials", "name", ep.Name)
 			continue
 		}
+
 		if err := c.Delete(ctx, &ep); err != nil && !apierrors.IsNotFound(err) {
 			return false, fmt.Errorf("error deleting awsendpointservices %s in namespace %s: %w", ep.Name, namespace, err)
 		}
 	}
+
 	if len(awsEndpointServiceList.Items) != 0 {
 		// The CPO puts a finalizer on AWSEndpointService resources and should
 		// not be terminated until the resources are removed from the API server
 		return true, nil
 	}
+
 	return false, nil
 }
 
@@ -3012,7 +3032,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		return false, err
 	}
 
-	exists, err := deleteAWSEndpointServices(ctx, r.Client, controlPlaneNamespace)
+	exists, err := deleteAWSEndpointServices(ctx, r.Client, hc, controlPlaneNamespace)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The health check will incorrectly report a healthy condition for the
AWSIdentityProvider when reusing the same client. This change fixes that
by creating a new client every time the health check is executed.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.