### PR TITLE
OCPBUGS-11749: Add pod security labels to hcp namespace

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -919,6 +919,12 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 		controlPlaneNamespace.Labels["hypershift.openshift.io/hosted-control-plane"] = "true"
 
+		// Set pod security labels on HCP namespace
+		controlPlaneNamespace.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
+		controlPlaneNamespace.Labels["pod-security.kubernetes.io/audit"] = "privileged"
+		controlPlaneNamespace.Labels["pod-security.kubernetes.io/warn"] = "privileged"
+
+		// Enable monitoring for hosted control plane namespaces
 		if r.EnableOCPClusterMonitoring {
 			controlPlaneNamespace.Labels["openshift.io/cluster-monitoring"] = "true"
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Pod security restrictions do not allow a private router to be created. The hosted control plane namespace must be labeled appropriately so that pod security admission can allow the private router.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-11749

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.