### PR TITLE
Enable monitoring for hypershift namespace

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -59,11 +59,16 @@ func (o HyperShiftNamespace) Build() *corev1.Namespace {
 			Name: o.Name,
 		},
 	}
+
 	if o.EnableOCPClusterMonitoring {
 		namespace.Labels = map[string]string{
 			"openshift.io/cluster-monitoring": "true",
 		}
 	}
+
+	// Enable observability operator monitoring
+	metrics.EnableOBOMonitoring(namespace)
+
 	return namespace
 }
 

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -37,6 +37,8 @@ objects:
   kind: Namespace
   metadata:
     creationTimestamp: null
+    labels:
+      hypershift.openshift.io/monitoring: "true"
     name: ${NAMESPACE}
   spec: {}
   status: {}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -114,10 +114,6 @@ const (
 	controlplaneOperatorManagesIgnitionServerLabel = "io.openshift.hypershift.control-plane-operator-manages-ignition-server"
 	controlPlaneOperatorManagesMachineApprover     = "io.openshift.hypershift.control-plane-operator-manages.cluster-machine-approver"
 	controlPlaneOperatorManagesMachineAutoscaler   = "io.openshift.hypershift.control-plane-operator-manages.cluster-autoscaler"
-
-	// The common label for monitoring in HyperShift
-	// Namespaces with this label will be actively monitored by the observability operator
-	hyperShiftMonitoringLabel = "hypershift.openshift.io/monitoring"
 )
 
 // NoopReconcile is just a default mutation function that does nothing.
@@ -923,12 +919,13 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 		controlPlaneNamespace.Labels["hypershift.openshift.io/hosted-control-plane"] = "true"
 
-		// Enable monitoring for hosted control plane namespaces
-		controlPlaneNamespace.Labels[hyperShiftMonitoringLabel] = "true"
-
 		if r.EnableOCPClusterMonitoring {
 			controlPlaneNamespace.Labels["openshift.io/cluster-monitoring"] = "true"
 		}
+
+		// Enable observability operator monitoring
+		metrics.EnableOBOMonitoring(controlPlaneNamespace)
+
 		return nil
 	})
 	if err != nil {

--- a/support/metrics/labels.go
+++ b/support/metrics/labels.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// The common label for monitoring in HyperShift
+	// Namespaces with this label will be actively monitored by the observability operator
+	HyperShiftMonitoringLabel = "hypershift.openshift.io/monitoring"
+)
+
+// EnableOBOMonitoring enforces observability operator monitoring on the given namespace
+func EnableOBOMonitoring(namespace *corev1.Namespace) {
+	if namespace.Labels == nil {
+		namespace.Labels = make(map[string]string)
+	}
+
+	namespace.Labels[HyperShiftMonitoringLabel] = "true"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
For HyperShift, the Observability Operator will be scraping HCP and Management Cluster platform metrics via a common label; `hypershift.openshift.io/monitoring`. This is because [namespaceSelector](https://github.com/rhobs/observability-operator/blob/main/docs/api.md#monitoringstackspecnamespaceselector) field of the operator's MonitoringStack CR does not support multiple labels.
As we need the HyperShift Operator metrics to be forwarded to RHOBS for effective monitoring, this PR adds the common monitoring label to the `hypershift` namespace to achieve this functional goal.

**Which issue(s) this PR fixes**
Resolves: [OSD-15973](https://issues.redhat.com/browse/OSD-15973)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.