### PR TITLE
OCPBUGS-11649: Always requeue AWSEndpointService controllers

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -355,7 +355,9 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	log.Info("reconcilation complete")
-	return ctrl.Result{}, nil
+	// always requeue to catch and report out of band changes in AWS
+	// NOTICE: if the RequeueAfter interval is short enough, it could result in hitting some AWS request limits.
+	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 }
 
 func hasAWSConfig(platform *hyperv1.PlatformSpec) bool {

--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -252,7 +252,9 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	log.Info("reconcilation complete")
-	return ctrl.Result{}, nil
+	// always requeue to catch and report out of band changes in AWS
+	// NOTICE: if the RequeueAfter interval is short enough, it could result in hitting some AWS request limits.
+	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 }
 
 func reconcileAWSEndpointServiceSpec(ctx context.Context, c client.Client, awsEndpointService *hyperv1.AWSEndpointService, hc *hyperv1.HostedCluster) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This ensure that the controllers can detect and report out of band changes on aws endpoint/service.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-11649](https://issues.redhat.com/browse/OCPBUGS-11649)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.