### PR TITLE
docs: update OIDC s3 bucket creation procedure

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -49,16 +49,18 @@ you should adjust to your own environment.
     To create the bucket (in us-east-1):
         ```shell linenums="1"
         BUCKET_NAME=your-bucket-name
-        aws s3api create-bucket --acl public-read --bucket $BUCKET_NAME
+        aws s3api create-bucket --bucket $BUCKET_NAME
+        aws s3api delete-public-access-block --bucket $BUCKET_NAME
         ```
 
     To create the bucket in a region other than us-east-1:
         ```shell linenums="1"
         BUCKET_NAME=your-bucket-name
         REGION=us-east-2
-        aws s3api create-bucket --acl public-read --bucket $BUCKET_NAME \
+        aws s3api create-bucket --bucket $BUCKET_NAME \
           --create-bucket-configuration LocationConstraint=$REGION \
           --region $REGION
+        aws s3api delete-public-access-block --bucket $BUCKET_NAME
         ```
 
 ## Before you begin


### PR DESCRIPTION
AWS has changed how s3 public buckets work
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

We need to update our docs to remove the ACL and add a command to remove the public access block.