### PR TITLE
OCPBUGS-11773: remove s3 object ACL for OIDC

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -4067,7 +4067,6 @@ func (r *HostedClusterReconciler) reconcileAWSOIDCDocuments(ctx context.Context,
 			return fmt.Errorf("failed to generate OIDC document %s: %w", path, err)
 		}
 		_, err = r.S3Client.PutObject(&s3.PutObjectInput{
-			ACL:    aws.String("public-read"),
 			Body:   bodyReader,
 			Bucket: aws.String(r.OIDCStorageProviderS3BucketName),
 			Key:    aws.String(hcluster.Spec.InfraID + path),


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-11773

AWS has recently disabled ACL support by default.
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

OCP installer fixed in the same way https://github.com/openshift/installer/pull/7085

Docs update was https://github.com/openshift/hypershift/pull/2425