### PR TITLE
Relax MCO API strict decoding

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1783,7 +1783,7 @@ func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
 
 	YamlSerializer := serializer.NewSerializerWithOptions(
 		serializer.DefaultMetaFactory, scheme, scheme,
-		serializer.SerializerOptions{Yaml: true, Pretty: true, Strict: true},
+		serializer.SerializerOptions{Yaml: true, Pretty: true, Strict: false},
 	)
 
 	cr, _, err := YamlSerializer.Decode(manifest, nil, nil)


### PR DESCRIPTION
NTOMachineConfigRolloutTest got transparently broken in CI NodePool show error [1]
```
 - lastTransitionTime: "2023-04-14T15:43:46Z" message: 'configmap "nto-mc-example-7tldp-test-ntomachineconfig-replace" failed validation: error decoding config: strict decoding error: unknown field "spec.baseOSExtensionsContainerImage"' observedGeneration: 2 reason: ValidationFailed status: "False" type: ValidMachineConfig
```

The NTO generate MachineConfig has a field that our strict decoding doesn't like [2]

This seems to be caused because the NTO just recently bumped their vendored MCO API [3]

Relaxing the strict decoding should prevent NTO from breaking us transparenrly. Actual use of a new field by NTO requires concious bump of the MCO API in Hypershift as well.

[1] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_hypershift/2426/pull-ci-openshift-hypershift-main-e2e-aws/1646891104265572352/artifacts/e2e-aws/run-e2e/artifacts/TestNodePool_PreTeardownClusterDump/namespaces/e2e-clusters-5kd66/hypershift.openshift.io/nodepools/example-7tldp-test-ntomachineconfig-replace.yaml

[2] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_hypershift/2426/pull-ci-openshift-hypershift-main-e2e-aws/1646891104265572352/artifacts/e2e-aws/run-e2e/artifacts/TestNodePool_PreTeardownClusterDump/namespaces/e2e-clusters-5kd66-example-7tldp/core/configmaps/nto-mc-example-7tldp-test-ntomachineconfig-replace.yaml

[3] https://github.com/openshift/cluster-node-tuning-operator/commit/799473afef5c028b93d459e76a4ad6a5d7b2c7ac#diff-1d76cebdf359151e0af837c1b0d9aa096720b8fe97a2d09d6a4ba4cbdfb386f8R79

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.