### PR TITLE
e2e: Cleanup shared OIDC provider on SIGTERM

### DIFF
--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -129,7 +129,7 @@ func (o *CreateIAMOptions) Run(ctx context.Context, client crclient.Client) erro
 
 func (o *CreateIAMOptions) CreateIAM(ctx context.Context, client crclient.Client) (*CreateIAMOutput, error) {
 	var err error
-	if err = o.parseAdditionalTags(); err != nil {
+	if err = o.ParseAdditionalTags(); err != nil {
 		return nil, err
 	}
 	if o.OIDCStorageProviderS3BucketName == "" || o.OIDCStorageProviderS3Region == "" {
@@ -175,7 +175,7 @@ func (o *CreateIAMOptions) CreateIAM(ctx context.Context, client crclient.Client
 	return results, nil
 }
 
-func (o *CreateIAMOptions) parseAdditionalTags() error {
+func (o *CreateIAMOptions) ParseAdditionalTags() error {
 	parsed, err := util.ParseAWSTags(o.AdditionalTags)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
some OIDC providers created by the CI are not cleaned up properly because the run was terminated abnormally.
I am assuming the reason is that the deferred functions are not called when the test is terminated abnormally (for some reason). This adds the cleanup logic for that case when we detect a SIGTERM.
I also moved the actual creation of the provider to the end of the setupSharedOIDCProvider function, so that if we fail before that, the provider will not be created. Before this change, we could create the provider, fail at the next step and then return in main without calling the cleanup.