### PR TITLE
Add IBMers as reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,4 +8,6 @@ reviewers:
 - enxebre
 - csrwng
 - sjenning
+- hasueki
+- isco-rodriguez
 component: hypershift


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Hide and Francisco as reviewers to the repo so they are able to lgtm PRs