### PR TITLE
OCPBUGS-11939: Initialize RegistryOverrides w/ mgmt cluster ICSP

### DIFF
--- a/api/scheme.go
+++ b/api/scheme.go
@@ -7,6 +7,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
@@ -56,6 +57,7 @@ func init() {
 	hyperv1beta1.AddToScheme(Scheme)
 	capiv1.AddToScheme(Scheme)
 	configv1.AddToScheme(Scheme)
+	operatorv1alpha1.AddToScheme(Scheme)
 	operatorv1.AddToScheme(Scheme)
 	securityv1.AddToScheme(Scheme)
 	routev1.AddToScheme(Scheme)

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -471,6 +471,17 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 		objects = append(objects, userCABundleCM)
 	}
 
+	trustedCABundle := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "hypershift",
+			Name:      "openshift-config-managed-trusted-ca-bundle",
+			Labels: map[string]string{
+				"config.openshift.io/inject-trusted-cabundle": "true",
+			},
+		},
+	}
+	objects = append(objects, trustedCABundle)
+
 	if len(opts.ExternalDNSProvider) > 0 {
 		externalDNSServiceAccount := assets.ExternalDNSServiceAccount{
 			Namespace: operatorNamespace,
@@ -522,6 +533,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 
 	operatorDeployment := assets.HyperShiftOperatorDeployment{
 		AdditionalTrustBundle:          userCABundleCM,
+		OpenShiftTrustBundle:           trustedCABundle,
 		Namespace:                      operatorNamespace,
 		OperatorImage:                  opts.HyperShiftImage,
 		ServiceAccount:                 operatorServiceAccount,

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -152,7 +152,7 @@ type HostedControlPlaneReconciler struct {
 	SetDefaultSecurityContext bool
 
 	Log                           logr.Logger
-	ReleaseProvider               releaseinfo.ProviderWithRegistryOverrides
+	ReleaseProvider               releaseinfo.ProviderWithOpenShiftImageRegistryOverrides
 	createOrUpdate                func(hcp *hyperv1.HostedControlPlane) upsert.CreateOrUpdateFN
 	EnableCIDebugOutput           bool
 	OperateOnReleaseImage         string
@@ -907,6 +907,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 		// so we know it always exists here.
 		true,
 		r.ReleaseProvider.GetRegistryOverrides(),
+		util.ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetOpenShiftImageRegistryOverrides()),
 		r.ManagementClusterCapabilities.Has(capabilities.CapabilitySecurityContextConstraint),
 		config.OwnerRefFrom(hostedControlPlane),
 	); err != nil {
@@ -3229,29 +3230,29 @@ func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.C
 		return fmt.Errorf("failed to reconcile ssh key ignition config: %w", err)
 	}
 
-	imageContentSourceIgnitionConfig := manifests.ImageContentSourcePolicyIgnitionConfig(hcp.GetNamespace())
-	if !p.HasImageContentSourcePolicy {
-		// ensure the icsp configmap has been removed if no longer needed
-		err := r.Get(ctx, client.ObjectKeyFromObject(imageContentSourceIgnitionConfig), imageContentSourceIgnitionConfig)
+	imageSourceMirrorsIgnitionConfig := manifests.ImageContentPolicyIgnitionConfig(hcp.GetNamespace())
+	if !p.HasImageMirrorPolicies {
+		// ensure the imageDigestMirrorSet configmap has been removed if no longer needed
+		err := r.Get(ctx, client.ObjectKeyFromObject(imageSourceMirrorsIgnitionConfig), imageSourceMirrorsIgnitionConfig)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("failed to check whether image content source policy configuration configmap exists: %w", err)
 			}
 		} else {
-			if err := r.Delete(ctx, imageContentSourceIgnitionConfig); err != nil {
+			if err := r.Delete(ctx, imageSourceMirrorsIgnitionConfig); err != nil {
 				return fmt.Errorf("failed to delete image content source policy configuration configmap: %w", err)
 			}
 		}
 		return nil
 	}
 
-	icsp := globalconfig.ImageContentSourcePolicy()
-	if err := globalconfig.ReconcileImageContentSourcePolicy(icsp, hcp); err != nil {
-		return fmt.Errorf("failed to reconcile image content source policy: %w", err)
+	imageDigestMirrorSet := globalconfig.ImageDigestMirrorSet()
+	if err := globalconfig.ReconcileImageDigestMirrors(imageDigestMirrorSet, hcp); err != nil {
+		return fmt.Errorf("failed to reconcile image content policy: %w", err)
 	}
 
-	if _, err := createOrUpdate(ctx, r, imageContentSourceIgnitionConfig, func() error {
-		return ignition.ReconcileImageContentSourcePolicyIgnitionConfig(imageContentSourceIgnitionConfig, p.OwnerRef, icsp)
+	if _, err := createOrUpdate(ctx, r, imageSourceMirrorsIgnitionConfig, func() error {
+		return ignition.ReconcileImageSourceMirrorsIgnitionConfig(imageSourceMirrorsIgnitionConfig, p.OwnerRef, imageDigestMirrorSet)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile image content source policy ignition config: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ignition/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignition/params.go
@@ -6,18 +6,18 @@ import (
 )
 
 type IgnitionConfigParams struct {
-	OwnerRef                    config.OwnerRef
-	FIPSEnabled                 bool
-	SSHKey                      string
-	HasImageContentSourcePolicy bool
+	OwnerRef               config.OwnerRef
+	FIPSEnabled            bool
+	SSHKey                 string
+	HasImageMirrorPolicies bool
 }
 
 func NewIgnitionConfigParams(hcp *hyperv1.HostedControlPlane, sshKey string) *IgnitionConfigParams {
 	params := &IgnitionConfigParams{
-		OwnerRef:                    config.OwnerRefFrom(hcp),
-		FIPSEnabled:                 hcp.Spec.FIPS,
-		SSHKey:                      sshKey,
-		HasImageContentSourcePolicy: len(hcp.Spec.ImageContentSources) > 0,
+		OwnerRef:               config.OwnerRefFrom(hcp),
+		FIPSEnabled:            hcp.Spec.FIPS,
+		SSHKey:                 sshKey,
+		HasImageMirrorPolicies: len(hcp.Spec.ImageContentSources) > 0,
 	}
 
 	return params

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/ignition.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/ignition.go
@@ -41,7 +41,7 @@ func IgnitionFIPSConfig(ns string) *corev1.ConfigMap {
 	}
 }
 
-func ImageContentSourcePolicyIgnitionConfig(ns string) *corev1.ConfigMap {
+func ImageContentPolicyIgnitionConfig(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ignition-config-40-image-content-source",

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -631,11 +631,11 @@ func (r *reconciler) reconcileConfig(ctx context.Context, hcp *hyperv1.HostedCon
 		errs = append(errs, fmt.Errorf("failed to reconcile proxy config: %w", err))
 	}
 
-	icsp := globalconfig.ImageContentSourcePolicy()
+	icsp := globalconfig.ImageDigestMirrorSet()
 	if _, err := r.CreateOrUpdate(ctx, r.client, icsp, func() error {
-		return globalconfig.ReconcileImageContentSourcePolicy(icsp, hcp)
+		return globalconfig.ReconcileImageDigestMirrors(icsp, hcp)
 	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile image content source policy: %w", err))
+		errs = append(errs, fmt.Errorf("failed to reconcile image digest mirror set: %w", err))
 	}
 
 	installConfigCM := manifests.InstallConfigConfigMap()

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -342,15 +342,20 @@ func NewStartCommand() *cobra.Command {
 			componentImages[name] = image
 		}
 
-		releaseProvider := &releaseinfo.RegistryMirrorProviderDecorator{
-			Delegate: &releaseinfo.StaticProviderDecorator{
-				Delegate: &releaseinfo.CachedProvider{
-					Inner: &releaseinfo.RegistryClientProvider{},
-					Cache: map[string]*releaseinfo.ReleaseImage{},
+		imageRegistryOverrides := util.ConvertImageRegistryOverrideStringToMap(os.Getenv("OPENSHIFT_IMG_OVERRIDES"))
+
+		releaseProvider := &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
+			Delegate: &releaseinfo.RegistryMirrorProviderDecorator{
+				Delegate: &releaseinfo.StaticProviderDecorator{
+					Delegate: &releaseinfo.CachedProvider{
+						Inner: &releaseinfo.RegistryClientProvider{},
+						Cache: map[string]*releaseinfo.ReleaseImage{},
+					},
+					ComponentImages: componentImages,
 				},
-				ComponentImages: componentImages,
+				RegistryOverrides: registryOverrides,
 			},
-			RegistryOverrides: registryOverrides,
+			OpenShiftImageRegistryOverrides: imageRegistryOverrides,
 		}
 
 		defaultIngressDomain := os.Getenv(config.DefaultIngressDomainEnvVar)

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -309,6 +309,14 @@ objects:
     name: operator
     namespace: ${NAMESPACE}
 - apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      config.openshift.io/inject-trusted-cabundle: "true"
+    name: openshift-config-managed-trusted-ca-bundle
+    namespace: hypershift
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     creationTimestamp: null
@@ -535,7 +543,7 @@ objects:
           - mountPath: /var/run/secrets/openshift/serviceaccount
             name: token
           - mountPath: /etc/pki/ca-trust/extracted/pem
-            name: ocm-trusted-ca-bundle
+            name: openshift-config-managed-trusted-ca-bundle
             readOnly: true
         priorityClassName: hypershift-operator
         serviceAccountName: operator
@@ -559,8 +567,8 @@ objects:
             items:
             - key: ca-bundle.crt
               path: tls-ca-bundle.pem
-            name: ocm-trusted-ca-bundle
-          name: ocm-trusted-ca-bundle
+            name: openshift-config-managed-trusted-ca-bundle
+          name: openshift-config-managed-trusted-ca-bundle
   status: {}
 - apiVersion: v1
   kind: Service

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -534,6 +534,9 @@ objects:
             name: credentials
           - mountPath: /var/run/secrets/openshift/serviceaccount
             name: token
+          - mountPath: /etc/pki/ca-trust/extracted/pem
+            name: ocm-trusted-ca-bundle
+            readOnly: true
         priorityClassName: hypershift-operator
         serviceAccountName: operator
         volumes:
@@ -552,6 +555,12 @@ objects:
             - serviceAccountToken:
                 audience: openshift
                 path: token
+        - configMap:
+            items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+            name: ocm-trusted-ca-bundle
+          name: ocm-trusted-ca-bundle
   status: {}
 - apiVersion: v1
   kind: Service

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -138,7 +138,7 @@ type HostedClusterReconciler struct {
 	HypershiftOperatorImage string
 
 	// ReleaseProvider looks up the OCP version for the release images in HostedClusters
-	ReleaseProvider releaseinfo.ProviderWithRegistryOverrides
+	ReleaseProvider releaseinfo.ProviderWithOpenShiftImageRegistryOverrides
 
 	// SetDefaultSecurityContext is used to configure Security Context for containers
 	SetDefaultSecurityContext bool
@@ -1505,6 +1505,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			defaultIngressDomain,
 			ignitionServerHasHealthzHandler,
 			r.ReleaseProvider.GetRegistryOverrides(),
+			hyperutil.ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetOpenShiftImageRegistryOverrides()),
 			r.ManagementClusterCapabilities.Has(capabilities.CapabilitySecurityContextConstraint),
 			config.MutatingOwnerRefFromHCP(hcp, releaseImageVersion),
 		); err != nil {
@@ -1938,7 +1939,20 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	// Reconcile operator deployment
 	controlPlaneOperatorDeployment := controlplaneoperator.OperatorDeployment(controlPlaneNamespace.Name)
 	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
-		return reconcileControlPlaneOperatorDeployment(controlPlaneOperatorDeployment, hcluster, hostedControlPlane, controlPlaneOperatorImage, utilitiesImage, r.SetDefaultSecurityContext, controlPlaneOperatorServiceAccount, r.EnableCIDebugOutput, convertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()), defaultIngressDomain, cpoHasUtilities, r.MetricsSet)
+		return reconcileControlPlaneOperatorDeployment(
+			controlPlaneOperatorDeployment,
+			hcluster,
+			hostedControlPlane,
+			controlPlaneOperatorImage,
+			utilitiesImage,
+			r.SetDefaultSecurityContext,
+			controlPlaneOperatorServiceAccount,
+			r.EnableCIDebugOutput,
+			hyperutil.ConvertRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetRegistryOverrides()),
+			hyperutil.ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(r.ReleaseProvider.GetOpenShiftImageRegistryOverrides()),
+			defaultIngressDomain,
+			cpoHasUtilities,
+			r.MetricsSet)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane operator deployment: %w", err)
@@ -1970,18 +1984,6 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	}
 
 	return nil
-}
-
-func convertRegistryOverridesToCommandLineFlag(registryOverrides map[string]string) string {
-	commandLineFlagArray := []string{}
-	for registrySource, registryReplacement := range registryOverrides {
-		commandLineFlagArray = append(commandLineFlagArray, fmt.Sprintf("%s=%s", registrySource, registryReplacement))
-	}
-	if len(commandLineFlagArray) > 0 {
-		return strings.Join(commandLineFlagArray, ",")
-	}
-	// this is the equivalent of null on a StringToString command line variable.
-	return "="
 }
 
 func servicePublishingStrategyByType(hcp *hyperv1.HostedCluster, svcType hyperv1.ServiceType) *hyperv1.ServicePublishingStrategy {
@@ -2045,7 +2047,21 @@ func GetControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 	return hypershiftOperatorImage, nil
 }
 
-func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, cpoImage, utilitiesImage string, setDefaultSecurityContext bool, sa *corev1.ServiceAccount, enableCIDebugOutput bool, registryOverrideCommandLine, defaultIngressDomain string, cpoHasUtilities bool, metricsSet metrics.MetricsSet) error {
+func reconcileControlPlaneOperatorDeployment(
+	deployment *appsv1.Deployment,
+	hc *hyperv1.HostedCluster,
+	hcp *hyperv1.HostedControlPlane,
+	cpoImage,
+	utilitiesImage string,
+	setDefaultSecurityContext bool,
+	sa *corev1.ServiceAccount,
+	enableCIDebugOutput bool,
+	registryOverrideCommandLine string,
+	openShiftRegistryOverrides string,
+	defaultIngressDomain string,
+	cpoHasUtilities bool,
+	metricsSet metrics.MetricsSet) error {
+
 	cpoResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("80Mi"),
@@ -2122,6 +2138,10 @@ func reconcileControlPlaneOperatorDeployment(deployment *appsv1.Deployment, hc *
 							{
 								Name:  "OPERATE_ON_RELEASE_IMAGE",
 								Value: hc.Spec.Release.Image,
+							},
+							{
+								Name:  "OPENSHIFT_IMG_OVERRIDES",
+								Value: openShiftRegistryOverrides,
 							},
 							metrics.MetricsSetToEnv(metricsSet),
 						},

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/hypershift/support/globalconfig"
 	"os"
 	"strings"
 	"time"
@@ -253,16 +254,38 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		}
 	}
 
+	// The mgr and therefore the cache is not started yet, thus we have to construct a client that
+	// directly reads from the api.
+	apiReadingClient, err := crclient.NewDelegatingClient(crclient.NewDelegatingClientInput{
+		CacheReader: mgr.GetAPIReader(),
+		Client:      mgr.GetClient(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to construct api reading client: %w", err)
+	}
+
+	// Populate registry overrides with any ICSP and IDMS from a OpenShift management cluster
+	var imageRegistryOverrides map[string][]string
+	if mgmtClusterCaps.Has(capabilities.CapabilityICSP) || mgmtClusterCaps.Has(capabilities.CapabilityIDMS) {
+		imageRegistryOverrides, err = globalconfig.GetAllImageRegistryMirrors(ctx, apiReadingClient)
+		if err != nil {
+			return fmt.Errorf("failed to populate image registry overrides: %w", err)
+		}
+	}
+
 	hostedClusterReconciler := &hostedcluster.HostedClusterReconciler{
 		Client:                        mgr.GetClient(),
 		ManagementClusterCapabilities: mgmtClusterCaps,
 		HypershiftOperatorImage:       operatorImage,
-		ReleaseProvider: &releaseinfo.RegistryMirrorProviderDecorator{
-			Delegate: &releaseinfo.CachedProvider{
-				Inner: &releaseinfo.RegistryClientProvider{},
-				Cache: map[string]*releaseinfo.ReleaseImage{},
+		ReleaseProvider: &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
+			Delegate: &releaseinfo.RegistryMirrorProviderDecorator{
+				Delegate: &releaseinfo.CachedProvider{
+					Inner: &releaseinfo.RegistryClientProvider{},
+					Cache: map[string]*releaseinfo.ReleaseImage{},
+				},
+				RegistryOverrides: opts.RegistryOverrides,
 			},
-			RegistryOverrides: opts.RegistryOverrides,
+			OpenShiftImageRegistryOverrides: imageRegistryOverrides,
 		},
 		EnableOCPClusterMonitoring: opts.EnableOCPClusterMonitoring,
 		EnableCIDebugOutput:        opts.EnableCIDebugOutput,
@@ -309,12 +332,15 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 
 	if err := (&nodepool.NodePoolReconciler{
 		Client: mgr.GetClient(),
-		ReleaseProvider: &releaseinfo.RegistryMirrorProviderDecorator{
-			Delegate: &releaseinfo.CachedProvider{
-				Inner: &releaseinfo.RegistryClientProvider{},
-				Cache: map[string]*releaseinfo.ReleaseImage{},
+		ReleaseProvider: &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
+			Delegate: &releaseinfo.RegistryMirrorProviderDecorator{
+				Delegate: &releaseinfo.CachedProvider{
+					Inner: &releaseinfo.RegistryClientProvider{},
+					Cache: map[string]*releaseinfo.ReleaseImage{},
+				},
+				RegistryOverrides: opts.RegistryOverrides,
 			},
-			RegistryOverrides: opts.RegistryOverrides,
+			OpenShiftImageRegistryOverrides: imageRegistryOverrides,
 		},
 		CreateOrUpdateProvider:  createOrUpdate,
 		HypershiftOperatorImage: operatorImage,
@@ -357,16 +383,6 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		}).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create uwm telemetry controller: %w", err)
 		}
-	}
-
-	// The mgr and therefore the cache is not started yet, thus we have to construct a client that
-	// directly reads from the api.
-	apiReadingClient, err := crclient.NewDelegatingClient(crclient.NewDelegatingClientInput{
-		CacheReader: mgr.GetAPIReader(),
-		Client:      mgr.GetClient(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to construct api reading client: %w", err)
 	}
 
 	// If it exists, block default ingress controller from admitting HCP private routes

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -143,12 +143,15 @@ func setUpPayloadStoreReconciler(ctx context.Context, registryOverrides map[stri
 		Client:       mgr.GetClient(),
 		PayloadStore: payloadStore,
 		IgnitionProvider: &controllers.LocalIgnitionProvider{
-			ReleaseProvider: &releaseinfo.RegistryMirrorProviderDecorator{
-				Delegate: &releaseinfo.CachedProvider{
-					Inner: &releaseinfo.RegistryClientProvider{},
-					Cache: map[string]*releaseinfo.ReleaseImage{},
+			ReleaseProvider: &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
+				Delegate: &releaseinfo.RegistryMirrorProviderDecorator{
+					Delegate: &releaseinfo.CachedProvider{
+						Inner: &releaseinfo.RegistryClientProvider{},
+						Cache: map[string]*releaseinfo.ReleaseImage{},
+					},
+					RegistryOverrides: registryOverrides,
 				},
-				RegistryOverrides: registryOverrides,
+				OpenShiftImageRegistryOverrides: util.ConvertImageRegistryOverrideStringToMap(os.Getenv("OPENSHIFT_IMG_OVERRIDES")),
 			},
 			Client:         mgr.GetClient(),
 			Namespace:      os.Getenv(namespaceEnvVariableName),

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 
@@ -45,6 +46,12 @@ const (
 	// CapabilityNetworks indicates if the cluster supports the
 	// networks.config.openshift.io api
 	CapabilityNetworks
+
+	// CapabilityICSP indicates if the cluster supports ImageContentSourcePolicy CRDs
+	CapabilityICSP
+
+	// CapabilityIDMS indicates if the cluster supports ImageDigestMirrorSet CRDs
+	CapabilityIDMS
 )
 
 // ManagementClusterCapabilities holds all information about optional capabilities of
@@ -151,6 +158,18 @@ func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterfa
 	}
 	if hasNetworksCap {
 		discoveredCapabilities[CapabilityNetworks] = struct{}{}
+	}
+
+	// check for ImageContentSourcePolicy capability
+	hasICSPCap, err := isAPIResourceRegistered(client, operatorv1alpha1.GroupVersion, "imagecontentsourcepolicies")
+	if hasICSPCap {
+		discoveredCapabilities[CapabilityICSP] = struct{}{}
+	}
+
+	// check for ImageDigestMirrorSet capability
+	hasIDMSCap, err := isAPIResourceRegistered(client, configv1.GroupVersion, "imagedigestmirrorsets")
+	if hasIDMSCap {
+		discoveredCapabilities[CapabilityIDMS] = struct{}{}
 	}
 
 	return &ManagementClusterCapabilities{capabilities: discoveredCapabilities}, nil

--- a/support/globalconfig/imagecontentsource.go
+++ b/support/globalconfig/imagecontentsource.go
@@ -1,17 +1,31 @@
 package globalconfig
 
 import (
-	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"context"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ImageContentSourcePolicy() *operatorv1alpha1.ImageContentSourcePolicy {
-	return &operatorv1alpha1.ImageContentSourcePolicy{
+// ImageContentSourcePolicyList returns an initialized ImageContentSourcePolicyList pointer
+func ImageContentSourcePolicyList() *operatorv1alpha1.ImageContentSourcePolicyList {
+	return &operatorv1alpha1.ImageContentSourcePolicyList{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ImageContentSourcePolicy",
-			APIVersion: operatorv1alpha1.GroupVersion.String(),
+			Kind:       "ImageContentSourcePolicyList",
+			APIVersion: configv1.GroupVersion.String(),
+		},
+	}
+}
+
+func ImageDigestMirrorSet() *configv1.ImageDigestMirrorSet {
+	return &configv1.ImageDigestMirrorSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ImageDigestMirrorSet",
+			APIVersion: configv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
@@ -19,17 +33,81 @@ func ImageContentSourcePolicy() *operatorv1alpha1.ImageContentSourcePolicy {
 	}
 }
 
-func ReconcileImageContentSourcePolicy(icsp *operatorv1alpha1.ImageContentSourcePolicy, hcp *hyperv1.HostedControlPlane) error {
-	if icsp.Labels == nil {
-		icsp.Labels = map[string]string{}
+func ImageDigestMirrorSetList() *configv1.ImageDigestMirrorSetList {
+	return &configv1.ImageDigestMirrorSetList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ImageDigestMirrorSetList",
+			APIVersion: configv1.GroupVersion.String(),
+		},
 	}
-	icsp.Labels["machineconfiguration.openshift.io/role"] = "worker"
-	icsp.Spec.RepositoryDigestMirrors = []operatorv1alpha1.RepositoryDigestMirrors{}
-	for _, imageContentSourceEntry := range hcp.Spec.ImageContentSources {
-		icsp.Spec.RepositoryDigestMirrors = append(icsp.Spec.RepositoryDigestMirrors, operatorv1alpha1.RepositoryDigestMirrors{
-			Source:  imageContentSourceEntry.Source,
-			Mirrors: imageContentSourceEntry.Mirrors,
+}
+
+func ReconcileImageDigestMirrors(idms *configv1.ImageDigestMirrorSet, hcp *hyperv1.HostedControlPlane) error {
+	if idms.Labels == nil {
+		idms.Labels = map[string]string{}
+	}
+	idms.Labels["machineconfiguration.openshift.io/role"] = "worker"
+	idms.Spec.ImageDigestMirrors = []configv1.ImageDigestMirrors{}
+	for _, source := range hcp.Spec.ImageContentSources {
+		var mirrors []configv1.ImageMirror
+
+		for _, mirror := range source.Mirrors {
+			mirrors = append(mirrors, configv1.ImageMirror(mirror))
+		}
+
+		idms.Spec.ImageDigestMirrors = append(idms.Spec.ImageDigestMirrors, configv1.ImageDigestMirrors{
+			Source:  source.Source,
+			Mirrors: mirrors,
 		})
 	}
 	return nil
+}
+
+// GetAllImageRegistryMirrors returns all image registry mirrors from any ImageContentSourcePolicy and
+// ImageDigestMirrorSet in an OpenShift management cluster (other management cluster types will not have these policies)
+// ImageContentSourcePolicy will be deprecated and removed in 4.17 according to the following Jira ticket and PR
+// description in favor of ImageDigestMirrorSet. We will need to look for both policy types in the cluster.
+//
+//		https://issues.redhat.com/browse/OCPNODE-1258
+//	    https://github.com/openshift/hypershift/pull/1776
+func GetAllImageRegistryMirrors(ctx context.Context, client client.Client) (map[string][]string, error) {
+	var mgmtClusterRegistryOverrides = make(map[string][]string)
+
+	// Retrieve any ImageContentSourcePolicy from the management cluster
+	var imageContentSourcePolicies = ImageContentSourcePolicyList()
+	err := client.List(ctx, imageContentSourcePolicies)
+	if err != nil {
+		return nil, err
+	}
+
+	// For each image content source policy in the management cluster, map the source with each of its mirrors
+	for _, item := range imageContentSourcePolicies.Items {
+		for _, mirror := range item.Spec.RepositoryDigestMirrors {
+			source := mirror.Source
+
+			for n := range mirror.Mirrors {
+				mgmtClusterRegistryOverrides[source] = append(mgmtClusterRegistryOverrides[source], mirror.Mirrors[n])
+			}
+		}
+	}
+
+	// Retrieve any ImageDigestMirrorSet from the management cluster
+	var imageDigestMirrorSets = ImageDigestMirrorSetList()
+	err = client.List(ctx, imageDigestMirrorSets)
+	if err != nil {
+		return nil, err
+	}
+
+	// For each image digest mirror set in the management cluster, map the source with each of its mirrors
+	for _, item := range imageDigestMirrorSets.Items {
+		for _, imageDigestMirror := range item.Spec.ImageDigestMirrors {
+			source := imageDigestMirror.Source
+
+			for n := range imageDigestMirror.Mirrors {
+				mgmtClusterRegistryOverrides[source] = append(mgmtClusterRegistryOverrides[source], string(imageDigestMirror.Mirrors[n]))
+			}
+		}
+	}
+
+	return mgmtClusterRegistryOverrides, nil
 }

--- a/support/releaseinfo/fake/fake.go
+++ b/support/releaseinfo/fake/fake.go
@@ -105,6 +105,10 @@ func (*FakeReleaseProvider) GetRegistryOverrides() map[string]string {
 	return nil
 }
 
+func (*FakeReleaseProvider) GetOpenShiftImageRegistryOverrides() map[string][]string {
+	return nil
+}
+
 func GetReleaseImage(ctx context.Context, hc *hyperv1.HostedCluster, client crclient.WithWatch, releaseProvider *FakeReleaseProvider) *releaseinfo.ReleaseImage {
 	var pullSecret corev1.Secret
 	if err := client.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hc.Spec.PullSecret.Name}, &pullSecret); err != nil {

--- a/support/releaseinfo/registry_image_content_policies.go
+++ b/support/releaseinfo/registry_image_content_policies.go
@@ -1,0 +1,50 @@
+package releaseinfo
+
+import (
+	"context"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"strings"
+	"sync"
+)
+
+var _ ProviderWithOpenShiftImageRegistryOverrides = (*ProviderWithOpenShiftImageRegistryOverridesDecorator)(nil)
+
+type ProviderWithOpenShiftImageRegistryOverridesDecorator struct {
+	Delegate                        ProviderWithRegistryOverrides
+	OpenShiftImageRegistryOverrides map[string][]string
+
+	lock sync.Mutex
+}
+
+func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) Lookup(ctx context.Context, image string, pullSecret []byte) (*ReleaseImage, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	logger := ctrl.LoggerFrom(ctx)
+
+	for registrySource, registryDest := range p.OpenShiftImageRegistryOverrides {
+		if strings.Contains(image, registrySource) {
+			for _, registryReplacement := range registryDest {
+				image = strings.Replace(image, registrySource, registryReplacement, 1)
+
+				// Attempt to lookup image with mirror registry destination
+				releaseImage, err := p.Delegate.Lookup(ctx, image, pullSecret)
+				if releaseImage != nil {
+					return releaseImage, nil
+				}
+
+				logger.Error(err, "Failed to look up release image using registry mirror", "registry mirror", registryReplacement)
+			}
+		}
+	}
+
+	return p.Delegate.Lookup(ctx, image, pullSecret)
+}
+
+func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) GetRegistryOverrides() map[string]string {
+	return p.Delegate.GetRegistryOverrides()
+}
+
+func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) GetOpenShiftImageRegistryOverrides() map[string][]string {
+	return p.OpenShiftImageRegistryOverrides
+}

--- a/support/releaseinfo/releaseinfo.go
+++ b/support/releaseinfo/releaseinfo.go
@@ -25,6 +25,11 @@ type ProviderWithRegistryOverrides interface {
 	GetRegistryOverrides() map[string]string
 }
 
+type ProviderWithOpenShiftImageRegistryOverrides interface {
+	ProviderWithRegistryOverrides
+	GetOpenShiftImageRegistryOverrides() map[string][]string
+}
+
 // ReleaseImage wraps an ImageStream with some utilities that help the user
 // discover constituent component image information.
 type ReleaseImage struct {

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -197,6 +197,7 @@ func ConvertRegistryOverridesToCommandLineFlag(registryOverrides map[string]stri
 		commandLineFlagArray = append(commandLineFlagArray, fmt.Sprintf("%s=%s", registrySource, registryReplacement))
 	}
 	if len(commandLineFlagArray) > 0 {
+		sort.Strings(commandLineFlagArray)
 		return strings.Join(commandLineFlagArray, ",")
 	}
 	// this is the equivalent of null on a StringToString command line variable.

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -187,4 +188,59 @@ func HashStruct(o interface{}) string {
 	_, _ = hash.Write([]byte(fmt.Sprintf("%v", o)))
 	intHash := hash.Sum32()
 	return fmt.Sprintf("%08x", intHash)
+}
+
+// ConvertRegistryOverridesToCommandLineFlag converts a map of registry sources and their mirrors into a string
+func ConvertRegistryOverridesToCommandLineFlag(registryOverrides map[string]string) string {
+	var commandLineFlagArray []string
+	for registrySource, registryReplacement := range registryOverrides {
+		commandLineFlagArray = append(commandLineFlagArray, fmt.Sprintf("%s=%s", registrySource, registryReplacement))
+	}
+	if len(commandLineFlagArray) > 0 {
+		return strings.Join(commandLineFlagArray, ",")
+	}
+	// this is the equivalent of null on a StringToString command line variable.
+	return "="
+}
+
+// ConvertOpenShiftImageRegistryOverridesToCommandLineFlag converts a map of image registry sources and their mirrors into a string
+func ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(registryOverrides map[string][]string) string {
+	var commandLineFlagArray []string
+	for registrySource, registryReplacements := range registryOverrides {
+		for _, registryReplacement := range registryReplacements {
+			commandLineFlagArray = append(commandLineFlagArray, fmt.Sprintf("%s=%s", registrySource, registryReplacement))
+		}
+	}
+	if len(commandLineFlagArray) > 0 {
+		sort.Strings(commandLineFlagArray)
+		return strings.Join(commandLineFlagArray, ",")
+	}
+	// this is the equivalent of null on a StringToString command line variable.
+	return "="
+}
+
+// ConvertImageRegistryOverrideStringToMap translates the environment variable containing registry source to mirror
+// mappings back to a map[string]string structure that can be ingested by the registry image content policies release provider
+func ConvertImageRegistryOverrideStringToMap(envVar string) map[string][]string {
+	registryMirrorPair := strings.Split(envVar, ",")
+
+	if len(registryMirrorPair) == 0 || envVar == "=" {
+		return nil
+	}
+
+	imageRegistryOverrides := make(map[string][]string)
+
+	for _, pair := range registryMirrorPair {
+		registryMirror := strings.Split(pair, "=")
+		registry := registryMirror[0]
+		mirror := registryMirror[1]
+
+		if _, ok := imageRegistryOverrides[registry]; ok {
+			imageRegistryOverrides[registry] = append(imageRegistryOverrides[registry], mirror)
+		} else {
+			imageRegistryOverrides[registry] = []string{mirror}
+		}
+	}
+
+	return imageRegistryOverrides
 }

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -49,6 +49,155 @@ func TestCompressDecompress(t *testing.T) {
 	}
 }
 
+func TestConvertRegistryOverridesToCommandLineFlag(t *testing.T) {
+	testCases := []struct {
+		name              string
+		registryOverrides map[string]string
+		expectedFlag      string
+	}{
+		{
+			name:         "No registry overrides",
+			expectedFlag: "=",
+		},
+		{
+			name: "Registry overrides with single mirrors",
+			registryOverrides: map[string]string{
+				"registry1": "mirror1.1",
+				"registry2": "mirror2.1",
+				"registry3": "mirror3.1",
+			},
+			expectedFlag: "registry1=mirror1.1,registry2=mirror2.1,registry3=mirror3.1",
+		},
+	}
+
+	t.Parallel()
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			result := ConvertRegistryOverridesToCommandLineFlag(testCase.registryOverrides)
+			g.Expect(result).To(Equal(testCase.expectedFlag))
+		})
+	}
+}
+
+func TestConvertOpenShiftImageRegistryOverridesToCommandLineFlag(t *testing.T) {
+	testCases := []struct {
+		name              string
+		registryOverrides map[string][]string
+		expectedFlag      string
+	}{
+		{
+			name:         "No registry overrides",
+			expectedFlag: "=",
+		},
+		{
+			name: "Registry overrides with single mirrors",
+			registryOverrides: map[string][]string{
+				"registry1": {
+					"mirror1.1",
+				},
+				"registry2": {
+					"mirror2.1",
+				},
+				"registry3": {
+					"mirror3.1",
+				},
+			},
+			expectedFlag: "registry1=mirror1.1,registry2=mirror2.1,registry3=mirror3.1",
+		},
+		{
+			name: "Registry overrides with multiple mirrors",
+			registryOverrides: map[string][]string{
+				"registry1": {
+					"mirror1.1",
+					"mirror1.2",
+					"mirror1.3",
+				},
+				"registry2": {
+					"mirror2.1",
+					"mirror2.2",
+				},
+				"registry3": {
+					"mirror3.1",
+				},
+			},
+			expectedFlag: "registry1=mirror1.1,registry1=mirror1.2,registry1=mirror1.3,registry2=mirror2.1,registry2=mirror2.2,registry3=mirror3.1",
+		},
+	}
+
+	t.Parallel()
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			result := ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(testCase.registryOverrides)
+			g.Expect(result).To(Equal(testCase.expectedFlag))
+		})
+	}
+}
+
+func TestConvertImageRegistryOverrideStringToMap(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedOutput map[string][]string
+		input          string
+	}{
+		{
+			name:  "No registry overrides",
+			input: "=",
+			//expectedOutput: make(map[string][]string),
+		},
+		{
+			name: "Registry overrides with single mirrors",
+			expectedOutput: map[string][]string{
+				"registry1": {
+					"mirror1.1",
+				},
+				"registry2": {
+					"mirror2.1",
+				},
+				"registry3": {
+					"mirror3.1",
+				},
+			},
+
+			input: "registry-proxy.engineering.redhat.com=registry.example.com,registry-proxy.engineering.redhat.com=registry.example2.com,registry.redhat.io=registry.example.com",
+		},
+		{
+			name: "Registry overrides with multiple mirrors",
+			expectedOutput: map[string][]string{
+				"registry1": {
+					"mirror1.1",
+					"mirror1.2",
+					"mirror1.3",
+				},
+				"registry2": {
+					"mirror2.1",
+					"mirror2.2",
+				},
+				"registry3": {
+					"mirror3.1",
+				},
+			},
+			input: "registry1=mirror1.1,registry1=mirror1.2,registry1=mirror1.3,registry2=mirror2.1,registry2=mirror2.2,registry3=mirror3.1",
+		},
+	}
+
+	t.Parallel()
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			result := ConvertImageRegistryOverrideStringToMap(testCase.input)
+			g.Expect(result).To(Equal(testCase.expectedOutput))
+		})
+	}
+}
+
 // Tests that a given input can be expected and encoded without errors.
 func testCompressFunc(t *testing.T, payload, expected []byte) {
 	t.Helper()

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -164,7 +164,7 @@ func TestConvertImageRegistryOverrideStringToMap(t *testing.T) {
 				},
 			},
 
-			input: "registry-proxy.engineering.redhat.com=registry.example.com,registry-proxy.engineering.redhat.com=registry.example2.com,registry.redhat.io=registry.example.com",
+			input: "registry1=mirror1.1,registry2=mirror2.1,registry3=mirror3.1",
 		},
 		{
 			name: "Registry overrides with multiple mirrors",


### PR DESCRIPTION
**What this PR does / why we need it**:
Includes any registry mirrors from ImageContentSourcePolicy (ICSP) and ImageDigestMirrorSet (IDMS) policies from the management cluster. Registry mirrors from these policies provide the cluster with alternatives to the default Operator Hub and image registries in disconnected environments.

Injects the trusted CA bundle from the openshift-config-managed pod into the HyperShift Operator pod. These additional CAs are needed in disconnected environments utilizing an OpenShift management cluster.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-11939](https://issues.redhat.com/browse/OCPBUGS-11939)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.