### PR TITLE
HOSTEDCP-937: New metric to expose Hypershift operator info

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -76,6 +76,8 @@ const (
 	awsCredsSecretName            = "hypershift-operator-aws-credentials"
 	oidcProviderS3CredsSecretName = "hypershift-operator-oidc-provider-s3-credentials"
 	externaDNSCredsSecretName     = "external-dns-credentials"
+
+	HypershiftOperatorName = "operator"
 )
 
 type HyperShiftOperatorCredentialsSecret struct {
@@ -454,22 +456,22 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "operator",
+			Name:      HypershiftOperatorName,
 			Namespace: o.Namespace.Name,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &o.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"name": "operator",
+					"name": HypershiftOperatorName,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"name":                    "operator",
-						hyperv1.OperatorComponent: "operator",
-						"app":                     "operator",
+						"name":                    HypershiftOperatorName,
+						hyperv1.OperatorComponent: HypershiftOperatorName,
+						"app":                     HypershiftOperatorName,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -482,7 +484,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 											{
 												Key:      "name",
 												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"operator"},
+												Values:   []string{HypershiftOperatorName},
 											},
 										},
 									},
@@ -495,7 +497,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 					ServiceAccountName: o.ServiceAccount.Name,
 					Containers: []corev1.Container{
 						{
-							Name: "operator",
+							Name: HypershiftOperatorName,
 							// needed since hypershift operator runs with anyuuid scc
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
@@ -595,9 +597,9 @@ func (o HyperShiftOperatorService) Build() *corev1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: o.Namespace.Name,
-			Name:      "operator",
+			Name:      HypershiftOperatorName,
 			Labels: map[string]string{
-				"name": "operator",
+				"name": HypershiftOperatorName,
 			},
 			Annotations: map[string]string{
 				"service.beta.openshift.io/serving-cert-secret-name": "manager-serving-cert",
@@ -606,7 +608,7 @@ func (o HyperShiftOperatorService) Build() *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
-				"name": "operator",
+				"name": HypershiftOperatorName,
 			},
 			Ports: []corev1.ServicePort{
 				{
@@ -718,7 +720,7 @@ func (o HyperShiftOperatorServiceAccount) Build() *corev1.ServiceAccount {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: o.Namespace.Name,
-			Name:      "operator",
+			Name:      HypershiftOperatorName,
 		},
 	}
 	return sa
@@ -1140,13 +1142,13 @@ func (o HyperShiftServiceMonitor) Build() *prometheusoperatorv1.ServiceMonitor {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: o.Namespace.Name,
-			Name:      "operator",
+			Name:      HypershiftOperatorName,
 		},
 		Spec: prometheusoperatorv1.ServiceMonitorSpec{
 			JobLabel: "component",
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"name": "operator",
+					"name": HypershiftOperatorName,
 				},
 			},
 			Endpoints: []prometheusoperatorv1.Endpoint{

--- a/hypershift-operator/metrics_test.go
+++ b/hypershift-operator/metrics_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/openshift/hypershift/api"
+	"github.com/openshift/hypershift/cmd/install/assets"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	fakePodName = "operator-fakepod"
+)
+
+func TestGetOperatorImage(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name            string
+		hypershiftPod   *corev1.Pod
+		expectedImage   string
+		expectedImageID string
+		expectedError   bool
+	}{
+		{
+			name: "When the pod is running it should get details from it",
+			hypershiftPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakePodName,
+					Namespace: "hypershift",
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: time.Time{}.Add(10 * time.Minute)},
+						},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:    assets.HypershiftOperatorName,
+							Image:   "quay.io/hypershift/hypershift:latest",
+							ImageID: "quay.io/hypershift/hypershift@sha256:746dc6b979cd6d42d4e6f3214e20eb5a2e0a2b4d1c1345f6914e5492e69d9afe",
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{
+									StartedAt: metav1.Time{Time: time.Time{}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedImage:   "quay.io/hypershift/hypershift:latest",
+			expectedImageID: "quay.io/hypershift/hypershift@sha256:746dc6b979cd6d42d4e6f3214e20eb5a2e0a2b4d1c1345f6914e5492e69d9afe",
+		},
+		{
+			name:            "When the pod is not running it should return strings with 'not found' and an error",
+			hypershiftPod:   &corev1.Pod{},
+			expectedImage:   "not found",
+			expectedImageID: "not found",
+			expectedError:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MY_NAMESPACE", "hypershift")
+			t.Setenv("MY_NAME", fakePodName)
+			g := NewWithT(t)
+			client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tc.hypershiftPod).Build()
+			image, imageId, err := getOperatorImage(client)
+			if tc.expectedError {
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}
+			g.Expect(image).To(BeIdenticalTo(tc.expectedImage))
+			g.Expect(imageId).To(BeIdenticalTo(tc.expectedImageID))
+		})
+	}
+}


### PR DESCRIPTION
Added new metric with 4 fields to expose:
- The Hypershift version
- The container image
- The container image id
- Latest Supported Version
- The GoVersion which is executing the operator. 
- The GoArch (This could be useful in the future)

All these markers will help the users and consumers to identify and debug possible issues in some scenarios

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-937](https://issues.redhat.com/browse/HOSTEDCP-937)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.