### PR TITLE
OCPBUGS-11719: Ensure ingress controllers are removed before load balancers

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1501,6 +1501,8 @@ func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyp
 	}
 	if !removed {
 		remaining.Insert("image-registry")
+	} else {
+		log.Info("Image registry is removed")
 	}
 	log.Info("Ensuring ingress controllers are removed")
 	removed, err = r.ensureIngressControllersRemoved(ctx, hcp)
@@ -1509,6 +1511,8 @@ func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyp
 	}
 	if !removed {
 		remaining.Insert("ingress-controllers")
+	} else {
+		log.Info("Ingress controllers are removed")
 	}
 	log.Info("Ensuring load balancers are removed")
 	removed, err = r.ensureServiceLoadBalancersRemoved(ctx)
@@ -1517,6 +1521,8 @@ func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyp
 	}
 	if !removed {
 		remaining.Insert("loadbalancers")
+	} else {
+		log.Info("Load balancers are removed")
 	}
 	log.Info("Ensuring persistent volumes are removed")
 	removed, err = r.ensurePersistentVolumesRemoved(ctx)
@@ -1525,6 +1531,8 @@ func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyp
 	}
 	if !removed {
 		remaining.Insert("persistent-volumes")
+	} else {
+		log.Info("Persistent volumes are removed")
 	}
 
 	return remaining, errors.NewAggregate(errs)
@@ -1712,7 +1720,13 @@ func (r *reconciler) ensureImageRegistryStorageRemoved(ctx context.Context) (boo
 func (r *reconciler) ensureServiceLoadBalancersRemoved(ctx context.Context) (bool, error) {
 	found, err := cleanupResources(ctx, r.client, &corev1.ServiceList{}, func(obj client.Object) bool {
 		svc := obj.(*corev1.Service)
-		return svc.Spec.Type == corev1.ServiceTypeLoadBalancer
+		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			return false
+		}
+		if _, hasAnnotation := svc.Annotations["ingresscontroller.operator.openshift.io/owning-ingresscontroller"]; hasAnnotation {
+			return false
+		}
+		return true
 	}, false)
 	if err != nil {
 		return false, fmt.Errorf("failed to remove load balancer services: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleaning up load balancers and ingress controllers concurrently can lead to a race condition that causes deletion to be stuck on a hosted cluster. This commit prevents load balancer cleanup from happening until all ingress controllers have been removed.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-10400

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.