### PR TITLE
OCPBUGS-11946: Add new OCP 4.13 storage admission plugin

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -292,6 +292,7 @@ func admissionPlugins() []string {
 		"security.openshift.io/SCCExecRestrictions",
 		"security.openshift.io/SecurityContextConstraint",
 		"security.openshift.io/ValidateSecurityContextConstraints",
+		"storage.openshift.io/CSIInlineVolumeSecurity",
 	}
 }
 


### PR DESCRIPTION
This PR adds storage admission plugin "storage.openshift.io/CSIInlineVolumeSecurity" to KAS config.

Reference: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1385

