### PR TITLE
OCPBUGS-11738: Delete kubeadmin secret when an idp is defined

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -643,14 +643,19 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	kubeadminPassword := common.KubeadminPasswordSecret(hostedControlPlane.Namespace)
-	if err := r.Get(ctx, client.ObjectKeyFromObject(kubeadminPassword), kubeadminPassword); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return reconcile.Result{}, fmt.Errorf("failed to get kubeadmin password: %w", err)
-		}
+	explicitOauthConfig := hostedControlPlane.Spec.Configuration != nil && hostedControlPlane.Spec.Configuration.OAuth != nil
+	if explicitOauthConfig {
+		hostedControlPlane.Status.KubeadminPassword = nil
 	} else {
-		hostedControlPlane.Status.KubeadminPassword = &corev1.LocalObjectReference{
-			Name: kubeadminPassword.Name,
+		kubeadminPassword := common.KubeadminPasswordSecret(hostedControlPlane.Namespace)
+		if err := r.Get(ctx, client.ObjectKeyFromObject(kubeadminPassword), kubeadminPassword); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return reconcile.Result{}, fmt.Errorf("failed to get kubeadmin password: %w", err)
+			}
+		} else {
+			hostedControlPlane.Status.KubeadminPassword = &corev1.LocalObjectReference{
+				Name: kubeadminPassword.Name,
+			}
 		}
 	}
 
@@ -1655,11 +1660,20 @@ func (r *HostedControlPlaneReconciler) reconcileClusterIPServiceStatus(ctx conte
 }
 
 func (r *HostedControlPlaneReconciler) reconcileKubeadminPassword(ctx context.Context, hcp *hyperv1.HostedControlPlane, explicitOauthConfig bool, createOrUpdate upsert.CreateOrUpdateFN) error {
-	if explicitOauthConfig {
-		return nil
-	}
-	var kubeadminPassword string
 	kubeadminPasswordSecret := common.KubeadminPasswordSecret(hcp.Namespace)
+	if explicitOauthConfig {
+		// delete kubeadminPasswordSecret if it exist
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		return r.Client.Delete(ctx, kubeadminPasswordSecret)
+	}
+
+	var kubeadminPassword string
 	if _, err := createOrUpdate(ctx, r, kubeadminPasswordSecret, func() error {
 		return reconcileKubeadminPasswordSecret(kubeadminPasswordSecret, hcp, &kubeadminPassword)
 	}); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -975,11 +975,13 @@ func (r *reconciler) reconcileKubeadminPasswordHashSecret(ctx context.Context, h
 	kubeadminPasswordSecret := manifests.KubeadminPasswordSecret(hcp.Namespace)
 	if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret); err != nil {
 		if apierrors.IsNotFound(err) {
-			// kubeAdminPasswordHash will not exist when a user specifies an explicit oauth config
-			return nil
+			// kubeAdminPasswordHash should not exist when a user specifies an explicit oauth config
+			// delete kubeAdminPasswordHash if it exist
+			return r.deleteKubeadminPasswordHashSecret(ctx, hcp)
 		}
 		return fmt.Errorf("failed to get kubeadmin password secret: %w", err)
 	}
+
 	kubeadminPasswordHashSecret := manifests.KubeadminPasswordHashSecret()
 	if _, err := r.CreateOrUpdate(ctx, r.client, kubeadminPasswordHashSecret, func() error {
 		return kubeadminpassword.ReconcileKubeadminPasswordHashSecret(kubeadminPasswordHashSecret, kubeadminPasswordSecret)
@@ -992,6 +994,29 @@ func (r *reconciler) reconcileKubeadminPasswordHashSecret(ctx context.Context, h
 			oauthDeployment.Spec.Template.ObjectMeta.Annotations = map[string]string{}
 		}
 		oauthDeployment.Spec.Template.ObjectMeta.Annotations[SecretHashAnnotation] = secretHash(kubeadminPasswordHashSecret.Data["kubeadmin"])
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *reconciler) deleteKubeadminPasswordHashSecret(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	kubeadminPasswordHashSecret := manifests.KubeadminPasswordHashSecret()
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(kubeadminPasswordHashSecret), kubeadminPasswordHashSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if err := r.client.Delete(ctx, kubeadminPasswordHashSecret); err != nil {
+		return err
+	}
+
+	oauthDeployment := manifests.OAuthDeployment(hcp.Namespace)
+	if _, err := r.CreateOrUpdate(ctx, r.cpClient, oauthDeployment, func() error {
+		delete(oauthDeployment.Spec.Template.ObjectMeta.Annotations, SecretHashAnnotation)
 		return nil
 	}); err != nil {
 		return err

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -454,14 +454,19 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 	// Set kubeadminPassword status
 	{
-		kubeadminPasswordSecret := manifests.KubeadminPasswordSecret(hcluster.Namespace, hcluster.Name)
-		err := r.Client.Get(ctx, client.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret)
-		if err != nil {
-			if !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("failed to reconcile kubeadmin password secret: %w", err)
-			}
+		explicitOauthConfig := hcluster.Spec.Configuration != nil && hcluster.Spec.Configuration.OAuth != nil
+		if explicitOauthConfig {
+			hcluster.Status.KubeadminPassword = nil
 		} else {
-			hcluster.Status.KubeadminPassword = &corev1.LocalObjectReference{Name: kubeadminPasswordSecret.Name}
+			kubeadminPasswordSecret := manifests.KubeadminPasswordSecret(hcluster.Namespace, hcluster.Name)
+			err := r.Client.Get(ctx, client.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret)
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, fmt.Errorf("failed to reconcile kubeadmin password secret: %w", err)
+				}
+			} else {
+				hcluster.Status.KubeadminPassword = &corev1.LocalObjectReference{Name: kubeadminPasswordSecret.Name}
+			}
 		}
 	}
 
@@ -1404,6 +1409,17 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		})
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile hostedcluster kubeconfig secret: %w", err)
+		}
+	} else {
+		KubeadminPasswordSecret := manifests.KubeadminPasswordSecret(hcluster.Namespace, hcluster.Name)
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(KubeadminPasswordSecret), KubeadminPasswordSecret); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to get hostedcluster kubeadmin password secret %q: %w", client.ObjectKeyFromObject(KubeadminPasswordSecret), err)
+			}
+		} else {
+			if err := r.Client.Delete(ctx, KubeadminPasswordSecret); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to delete hostedcluster kubeadmin password secret %q: %w", client.ObjectKeyFromObject(KubeadminPasswordSecret), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
this removes "kube:admin" IdP as an available option when an explicit idp is defined

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-11738](https://issues.redhat.com/browse/OCPBUGS-11738)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.