### PR TITLE
Removed unused KMS permissions for nodePool role

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1324,8 +1324,7 @@ type AWSRolesRef struct {
 	// 	  	"Effect": "Allow",
 	// 	  	"Action": [
 	// 	  		"kms:Decrypt",
-	// 	  		"kms:Encrypt",
-	// 	  		"kms:GenerateDataKey",
+	// 	  		"kms:ReEncrypt",
 	// 	  		"kms:GenerateDataKeyWithoutPlainText",
 	// 	  		"kms:DescribeKey"
 	// 	  	],
@@ -1334,9 +1333,7 @@ type AWSRolesRef struct {
 	// 	  {
 	// 	  	"Effect": "Allow",
 	// 	  	"Action": [
-	// 	  		"kms:RevokeGrant",
-	// 	  		"kms:CreateGrant",
-	// 	  		"kms:ListGrants"
+	// 	  		"kms:CreateGrant"
 	// 	  	],
 	// 	  	"Resource": "*",
 	// 	  	"Condition": {

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -253,8 +253,7 @@ const (
 		"Effect": "Allow",
 		"Action": [
 			"kms:Decrypt",
-			"kms:Encrypt",
-			"kms:GenerateDataKey",
+			"kms:ReEncrypt",
 			"kms:GenerateDataKeyWithoutPlainText",
 			"kms:DescribeKey"
 		],
@@ -263,9 +262,7 @@ const (
 	{
 		"Effect": "Allow",
 		"Action": [
-			"kms:RevokeGrant",
-			"kms:CreateGrant",
-			"kms:ListGrants"
+			"kms:CreateGrant"
 		],
 		"Resource": "*",
 		"Condition": {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -6183,12 +6183,11 @@ spec:
                               ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                               ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                               ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",
-                              \"Action\": [ \"kms:Decrypt\", \"kms:Encrypt\", \"kms:GenerateDataKey\",
-                              \"kms:GenerateDataKeyWithoutPlainText\", \"kms:DescribeKey\"
-                              ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
-                              [ \"kms:RevokeGrant\", \"kms:CreateGrant\", \"kms:ListGrants\"
-                              ], \"Resource\": \"*\", \"Condition\": { \"Bool\": {
-                              \"kms:GrantIsForAWSResource\": true } } } ] }"
+                              \"Action\": [ \"kms:Decrypt\", \"kms:ReEncrypt\", \"kms:GenerateDataKeyWithoutPlainText\",
+                              \"kms:DescribeKey\" ], \"Resource\": \"*\" }, { \"Effect\":
+                              \"Allow\", \"Action\": [ \"kms:CreateGrant\" ], \"Resource\":
+                              \"*\", \"Condition\": { \"Bool\": { \"kms:GrantIsForAWSResource\":
+                              true } } } ] }"
                             type: string
                           storageARN:
                             description: "StorageARN is an ARN value referencing a

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -6174,12 +6174,11 @@ spec:
                               ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                               ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                               ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",
-                              \"Action\": [ \"kms:Decrypt\", \"kms:Encrypt\", \"kms:GenerateDataKey\",
-                              \"kms:GenerateDataKeyWithoutPlainText\", \"kms:DescribeKey\"
-                              ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
-                              [ \"kms:RevokeGrant\", \"kms:CreateGrant\", \"kms:ListGrants\"
-                              ], \"Resource\": \"*\", \"Condition\": { \"Bool\": {
-                              \"kms:GrantIsForAWSResource\": true } } } ] }"
+                              \"Action\": [ \"kms:Decrypt\", \"kms:ReEncrypt\", \"kms:GenerateDataKeyWithoutPlainText\",
+                              \"kms:DescribeKey\" ], \"Resource\": \"*\" }, { \"Effect\":
+                              \"Allow\", \"Action\": [ \"kms:CreateGrant\" ], \"Resource\":
+                              \"*\", \"Condition\": { \"Bool\": { \"kms:GrantIsForAWSResource\":
+                              true } } } ] }"
                             type: string
                           storageARN:
                             description: "StorageARN is an ARN value referencing a

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1874,8 +1874,7 @@ string
 &ldquo;Effect&rdquo;: &ldquo;Allow&rdquo;,
 &ldquo;Action&rdquo;: [
 &ldquo;kms:Decrypt&rdquo;,
-&ldquo;kms:Encrypt&rdquo;,
-&ldquo;kms:GenerateDataKey&rdquo;,
+&ldquo;kms:ReEncrypt&rdquo;,
 &ldquo;kms:GenerateDataKeyWithoutPlainText&rdquo;,
 &ldquo;kms:DescribeKey&rdquo;
 ],
@@ -1884,9 +1883,7 @@ string
 {
 &ldquo;Effect&rdquo;: &ldquo;Allow&rdquo;,
 &ldquo;Action&rdquo;: [
-&ldquo;kms:RevokeGrant&rdquo;,
-&ldquo;kms:CreateGrant&rdquo;,
-&ldquo;kms:ListGrants&rdquo;
+&ldquo;kms:CreateGrant&rdquo;
 ],
 &ldquo;Resource&rdquo;: &ldquo;</em>&rdquo;,
 &ldquo;Condition&rdquo;: {

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -33516,13 +33516,12 @@ objects:
                                 ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                                 ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                                 ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",
-                                \"Action\": [ \"kms:Decrypt\", \"kms:Encrypt\", \"kms:GenerateDataKey\",
+                                \"Action\": [ \"kms:Decrypt\", \"kms:ReEncrypt\",
                                 \"kms:GenerateDataKeyWithoutPlainText\", \"kms:DescribeKey\"
                                 ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\",
-                                \"Action\": [ \"kms:RevokeGrant\", \"kms:CreateGrant\",
-                                \"kms:ListGrants\" ], \"Resource\": \"*\", \"Condition\":
-                                { \"Bool\": { \"kms:GrantIsForAWSResource\": true
-                                } } } ] }"
+                                \"Action\": [ \"kms:CreateGrant\" ], \"Resource\":
+                                \"*\", \"Condition\": { \"Bool\": { \"kms:GrantIsForAWSResource\":
+                                true } } } ] }"
                               type: string
                             storageARN:
                               description: "StorageARN is an ARN value referencing
@@ -41039,13 +41038,12 @@ objects:
                                 ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                                 ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                                 ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",
-                                \"Action\": [ \"kms:Decrypt\", \"kms:Encrypt\", \"kms:GenerateDataKey\",
+                                \"Action\": [ \"kms:Decrypt\", \"kms:ReEncrypt\",
                                 \"kms:GenerateDataKeyWithoutPlainText\", \"kms:DescribeKey\"
                                 ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\",
-                                \"Action\": [ \"kms:RevokeGrant\", \"kms:CreateGrant\",
-                                \"kms:ListGrants\" ], \"Resource\": \"*\", \"Condition\":
-                                { \"Bool\": { \"kms:GrantIsForAWSResource\": true
-                                } } } ] }"
+                                \"Action\": [ \"kms:CreateGrant\" ], \"Resource\":
+                                \"*\", \"Condition\": { \"Bool\": { \"kms:GrantIsForAWSResource\":
+                                true } } } ] }"
                               type: string
                             storageARN:
                               description: "StorageARN is an ARN value referencing


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed KMS permissions not required to encrypt EC2 root volumes (ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#ebs-encryption-permissions)

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.