### PR TITLE
HOSTEDCP-969: Move cluster deletion duration metric into controller

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -402,6 +402,10 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from hostedcluster: %w", err)
 			}
 		}
+
+		deletionDuration := time.Since(hcluster.DeletionTimestamp.Time).Seconds()
+		clusterDeletionTime.WithLabelValues(hcluster.Name).Set(deletionDuration)
+
 		log.Info("Deleted hostedcluster", "name", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}

--- a/hypershift-operator/controllers/hostedcluster/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics.go
@@ -1,0 +1,20 @@
+package hostedcluster
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	ClusterDeletionTimeMetricName = "hypershift_cluster_deletion_duration_seconds"
+	clusterDeletionTime           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Time in seconds it took from initial cluster deletion to the resource all hypershift finalizers being removed",
+		Name: ClusterDeletionTimeMetricName,
+	}, []string{"name"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		clusterDeletionTime,
+	)
+}


### PR DESCRIPTION
Atm we have high frequency reconciliation loop where we constantly review the over all state of the world by looping over all clusters. It's worth noting that With this particular change we'll be capturing something different i.e. "when we remove all finalisers we own", which doesn't necessarily is the same than "when the HC is removed from etcd".

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.