### PR TITLE
Fixes loop between HC controller and pod security label syncer

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -934,6 +934,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		controlPlaneNamespace.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
 		controlPlaneNamespace.Labels["pod-security.kubernetes.io/audit"] = "privileged"
 		controlPlaneNamespace.Labels["pod-security.kubernetes.io/warn"] = "privileged"
+		controlPlaneNamespace.Labels["security.openshift.io/scc.podSecurityLabelSync"] = "false"
 
 		// Enable monitoring for hosted control plane namespaces
 		if r.EnableOCPClusterMonitoring {


### PR DESCRIPTION
We're seeing a lot of the errors below in our kubevirt e2e tests. It appears the pod security label syncer is battling the hosted cluster to set some pod-security related labels. 

```
{"level":"info","ts":"2023-04-20T20:04:51Z","msg":"WARNING: Object got updated more than one time without a no-op update, this indicates hypershift incorrectly reverting defaulted values","type":"*v1.Namespace","name":"/clusters-vossel1","diff":"  &v1.Namespace{\n  \tTypeMeta: {Kind: \"Namespace\", APIVersion: \"v1\"},\n  \tObjectMeta: v1.ObjectMeta{\n  \t\t... // 8 identical fields\n  \t\tDeletionTimestamp:          nil,\n  \t\tDeletionGracePeriodSeconds: nil,\n  \t\tLabels: map[string]string{\n  \t\t\t\"hypershift.openshift.io/hosted-control-plane\": \"true\",\n  \t\t\t\"hypershift.openshift.io/monitoring\":           \"true\",\n  \t\t\t\"kubernetes.io/metadata.name\":                  \"clusters-vossel1\",\n+ \t\t\t\"pod-security.kubernetes.io/audit\":             \"privileged\",\n  \t\t\t\"pod-security.kubernetes.io/enforce\":           \"privileged\",\n  \t\t\t\"pod-security.kubernetes.io/enforce-version\":   \"v1.24\",\n+ \t\t\t\"pod-security.kubernetes.io/warn\":              \"privileged\",\n  \t\t},\n  \t\tAnnotations:     {\"openshift.io/sa.scc.mcs\": \"s0:c28,c22\", \"openshift.io/sa.scc.supplemental-groups\": \"1000800000/10000\", \"openshift.io/sa.scc.uid-range\": \"1000800000/10000\"},\n  \t\tOwnerReferences: nil,\n  \t\t... // 2 identical fields\n  \t},\n  \tSpec:   {Finalizers: {\"kubernetes\"}},\n  \tStatus: {Phase: \"Active\"},\n  }\n","semanticDeepEqual":false,"updateCount":78}
```