### PR TITLE
docs: update OIDC bucket create with bucket policy

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -51,6 +51,18 @@ you should adjust to your own environment.
         BUCKET_NAME=your-bucket-name
         aws s3api create-bucket --bucket $BUCKET_NAME
         aws s3api delete-public-access-block --bucket $BUCKET_NAME
+        echo '{
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": "s3:GetObject",
+              "Resource": "arn:aws:s3:::${BUCKET_NAME}/*"
+            }
+          ]
+        }' | envsubst > policy.json
+        aws s3api put-bucket-policy --bucket $BUCKET_NAME --policy file://policy.json
         ```
 
     To create the bucket in a region other than us-east-1:
@@ -61,6 +73,18 @@ you should adjust to your own environment.
           --create-bucket-configuration LocationConstraint=$REGION \
           --region $REGION
         aws s3api delete-public-access-block --bucket $BUCKET_NAME
+        echo '{
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": "s3:GetObject",
+              "Resource": "arn:aws:s3:::${BUCKET_NAME}/*"
+            }
+          ]
+        }' | envsubst > policy.json
+        aws s3api put-bucket-policy --bucket $BUCKET_NAME --policy file://policy.json
         ```
 
 ## Before you begin


### PR DESCRIPTION
Follow on to https://github.com/openshift/hypershift/pull/2425 and https://github.com/openshift/hypershift/pull/2423

Following the current procedure results in a bucket that _can_ have public access but does not allow `GetObject` on a public basis.

Adding this bucket policy allows public access to objects in the OIDC bucket.