### PR TITLE
Hosted cluster created metric

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -402,6 +402,10 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from hostedcluster: %w", err)
 			}
 		}
+
+		deletionDuration := time.Since(hcluster.DeletionTimestamp.Time).Seconds()
+		clusterDeletionTime.WithLabelValues(hcluster.Name).Set(deletionDuration)
+
 		log.Info("Deleted hostedcluster", "name", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}

--- a/hypershift-operator/controllers/hostedcluster/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics.go
@@ -6,14 +6,19 @@ import (
 )
 
 var (
-	clusterDeletionTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Help: "Time in seconds it took from initial cluster deletion to the resource all hypershift finalizers being removed",
+	hostedClusterDeletionDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Time in seconds it took from HostedCluster having a deletion timestamp to all hypershift finalizers being removed",
 		Name: "hypershift_cluster_deletion_duration_seconds",
+	}, []string{"name"})
+	hostedClusterGuestCloudResourcesDeletionDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Time in seconds it took from HostedCluster having a deletion timestamp to the CloudResourcesDestroyed being true",
+		Name: "hypershift_cluster_guest_cloud_resources_deletion_duration_seconds",
 	}, []string{"name"})
 )
 
 func init() {
 	metrics.Registry.MustRegister(
-		clusterDeletionTime,
+		hostedClusterDeletionDuration,
+		hostedClusterGuestCloudResourcesDeletionDuration,
 	)
 }

--- a/hypershift-operator/controllers/hostedcluster/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics.go
@@ -1,0 +1,19 @@
+package hostedcluster
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	clusterDeletionTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Time in seconds it took from initial cluster deletion to the resource all hypershift finalizers being removed",
+		Name: "hypershift_cluster_deletion_duration_seconds",
+	}, []string{"name"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		clusterDeletionTime,
+	)
+}

--- a/hypershift-operator/controllers/hostedcluster/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics.go
@@ -14,6 +14,10 @@ var (
 		Help: "Time in seconds it took from HostedCluster having a deletion timestamp to the CloudResourcesDestroyed being true",
 		Name: "hypershift_cluster_guest_cloud_resources_deletion_duration_seconds",
 	}, []string{"name"})
+	hostedClusterCreated = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Timestamp of the Hosted Cluster creation time. This metric allows to identify Hosted Clusters that have not gone available in a given time frame and count them as failures",
+		Name: "hypershift_cluster_created_timestamp_seconds",
+	}, []string{"name", "desiredImage", "completedImage", "available"})
 )
 
 func init() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Timestamp of the Hosted Cluster creation time. This metric allows to identify Hosted Clusters that have not gone available in a given time frame and count them as failures

/hold
Needs https://github.com/openshift/hypershift/pull/2463

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.