### PR TITLE
Fix kubevirt csi daemonset reconcile loop

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/daemonset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/daemonset.yaml
@@ -4,20 +4,30 @@ apiVersion: apps/v1
 metadata:
   name: kubevirt-csi-node
 spec:
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: kubevirt-csi-driver
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:
         app: kubevirt-csi-driver
     spec:
-      serviceAccount: kubevirt-csi-node-sa
+      dnsPolicy: ClusterFirst
       priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: kubevirt-csi-node-sa
+      serviceAccountName: kubevirt-csi-node-sa
+      terminationGracePeriodSeconds: 30
       tolerations:
-        - operator: Exists
+      - operator: Exists
       containers:
         - name: csi-driver
           securityContext:
@@ -58,10 +68,13 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+            successThreshold: 1
           resources:
             requests:
               memory: 50Mi
               cpu: 10m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
         - name: csi-node-driver-registrar
           securityContext:
             privileged: true
@@ -88,6 +101,8 @@ spec:
             requests:
               memory: 20Mi
               cpu: 5m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
         - name: csi-liveness-probe
           image: quay.io/openshift/origin-csi-livenessprobe:latest
           args:
@@ -101,6 +116,8 @@ spec:
             requests:
               memory: 20Mi
               cpu: 5m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       volumes:
         - name: kubelet-dir
           hostPath:
@@ -120,4 +137,5 @@ spec:
             type: Directory
         - name: udev
           hostPath:
+            type: ""
             path: /run/udev


### PR DESCRIPTION
The HCCO was clobbering some daemonset default values for the kubevirt-csi driver within the guest cluster. The result was that the HCCO would define the daemonset, some default values would get applied server side, then we'd detect those changes and remove them, then they'd get added back and so on the loop goes.

This PR fixes the reconcile loop by ensuring that we explicitly set the default values we were clobbering. Now there's no loop.