### PR TITLE
Remove e2e build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PROMTOOL=GO111MODULE=on GOFLAGS=-mod=vendor go run github.com/prometheus/prometh
 GO_GCFLAGS ?= -gcflags=all='-N -l'
 GO=GO111MODULE=on GOFLAGS=-mod=vendor go
 GO_BUILD_RECIPE=CGO_ENABLED=0 $(GO) build $(GO_GCFLAGS)
-GO_E2E_RECIPE=CGO_ENABLED=0 $(GO) test $(GO_GCFLAGS) -tags e2e -c
+GO_E2E_RECIPE=CGO_ENABLED=0 $(GO) test $(GO_GCFLAGS) -c
 
 CI_TESTS_RUN ?= ""
 
@@ -154,7 +154,7 @@ app-sre-saas-template: hypershift
 # Run tests
 .PHONY: test
 test:
-	$(GO) test -race -count=25 -timeout=30m ./... -coverprofile cover.out
+	$(GO) test -race -count=25 -timeout=30m $(shell go list ./... | grep -v e2e) -coverprofile cover.out
 
 .PHONY: e2e
 e2e:

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/nodepool_autorepair_test.go
+++ b/test/e2e/nodepool_autorepair_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/nodepool_kms_root_volume_test.go
+++ b/test/e2e/nodepool_kms_root_volume_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/podtimingcontroller/podtimingcontroller.go
+++ b/test/e2e/podtimingcontroller/podtimingcontroller.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package podtimingcontroller
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
I question the e2e build tags are giving us anything today and they get my IDE confused when navigating through symbols.
/hold
For others to have the chance to prove its value.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.