### PR TITLE
ACM-4277: docs: Add L2Advertisement CR to the Handling Ingress section in the agent docs

### DIFF
--- a/docs/content/how-to/agent/create-agent-cluster.md
+++ b/docs/content/how-to/agent/create-agent-cluster.md
@@ -554,9 +554,9 @@ EOF
 
 #### Step 2 - Get the MetalLB Operator Configured
 
-We will create an `IPAddressPool` with a single IP address. This IP address must be on the same subnet as the network used by the cluster nodes.
-
-
+We will create an `IPAddressPool` with a single IP address and L2Advertisement to advertise the LoadBalancer IPs provided by the `IPAddressPool` via L2. 
+Since layer 2 mode relies on ARP and NDP, the IP address must be on the same subnet as the network used by the cluster nodes in order for the MetalLB to work.
+more information about metalLB configuration options is available [here](https://metallb.universe.tf/configuration/).
 > **WARN:** Change `INGRESS_IP` env var to match your environments addressing.
 
 ~~~sh
@@ -573,6 +573,13 @@ spec:
   autoAssign: false
   addresses:
     - ${INGRESS_IP}-${INGRESS_IP}
+---
+
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: ingress-public-ip
+  namespace: metallb
 EOF
 ~~~
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix docs
The last update to `Handling Ingress` section in create agent cluster (#1836) replaced AddressPool with IPAddressPool, unlike AddressPool IPAddressPool is used only for the ip assignement part. In order advertise the IP we should create L2Advertisement.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
https://issues.redhat.com/browse/ACM-4277

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.