### PR TITLE
ACM-5116: Increase KubeVirt default Mem and Root Volume Sizes

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -521,7 +521,7 @@ type KubevirtCompute struct {
 	// Memory represents how much guest memory the VM should have
 	//
 	// +optional
-	// +kubebuilder:default="4Gi"
+	// +kubebuilder:default="8Gi"
 	Memory *resource.Quantity `json:"memory"`
 
 	// Cores represents how many cores the guest VM should have
@@ -539,7 +539,7 @@ type KubevirtPersistentVolume struct {
 	// Size is the size of the persistent storage volume
 	//
 	// +optional
-	// +kubebuilder:default="16Gi"
+	// +kubebuilder:default="32Gi"
 	Size *resource.Quantity `json:"size"`
 	// StorageClass is the storageClass used for the underlying PVC that hosts the volume
 	//

--- a/api/v1beta1/nodepool_types.go
+++ b/api/v1beta1/nodepool_types.go
@@ -2,11 +2,12 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strings"
 )
 
 const (
@@ -514,7 +515,7 @@ type KubevirtCompute struct {
 	// Memory represents how much guest memory the VM should have
 	//
 	// +optional
-	// +kubebuilder:default="4Gi"
+	// +kubebuilder:default="8Gi"
 	Memory *resource.Quantity `json:"memory"`
 
 	// Cores represents how many cores the guest VM should have
@@ -532,7 +533,7 @@ type KubevirtPersistentVolume struct {
 	// Size is the size of the persistent storage volume
 	//
 	// +optional
-	// +kubebuilder:default="16Gi"
+	// +kubebuilder:default="32Gi"
 	Size *resource.Quantity `json:"size"`
 	// StorageClass is the storageClass used for the underlying PVC that hosts the volume
 	//

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -28,10 +28,10 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	opts.KubevirtPlatform = core.KubevirtPlatformCreateOptions{
 		ServicePublishingStrategy: IngressServicePublishingStrategy,
 		APIServerAddress:          "",
-		Memory:                    "4Gi",
+		Memory:                    "8Gi",
 		Cores:                     2,
 		ContainerDiskImage:        "",
-		RootVolumeSize:            16,
+		RootVolumeSize:            32,
 		InfraKubeConfigFile:       "",
 	}
 
@@ -87,8 +87,8 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		return errors.New("the number of cores inside the machine must be a value greater than or equal to 1")
 	}
 
-	if opts.KubevirtPlatform.RootVolumeSize < 8 {
-		return fmt.Errorf("the root volume size [%d] must be greater than or equal to 8", opts.KubevirtPlatform.RootVolumeSize)
+	if opts.KubevirtPlatform.RootVolumeSize < 16 {
+		return fmt.Errorf("the root volume size [%d] must be greater than or equal to 16", opts.KubevirtPlatform.RootVolumeSize)
 	}
 
 	infraID := opts.InfraID

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -529,7 +529,7 @@ spec:
                             anyOf:
                             - type: integer
                             - type: string
-                            default: 4Gi
+                            default: 8Gi
                             description: Memory represents how much guest memory the
                               VM should have
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -571,7 +571,7 @@ spec:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                default: 16Gi
+                                default: 32Gi
                                 description: Size is the size of the persistent storage
                                   volume
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -1361,7 +1361,7 @@ spec:
                             anyOf:
                             - type: integer
                             - type: string
-                            default: 4Gi
+                            default: 8Gi
                             description: Memory represents how much guest memory the
                               VM should have
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -1403,7 +1403,7 @@ spec:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                default: 16Gi
+                                default: 32Gi
                                 description: Size is the size of the persistent storage
                                   volume
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -42823,7 +42823,7 @@ objects:
                               anyOf:
                               - type: integer
                               - type: string
-                              default: 4Gi
+                              default: 8Gi
                               description: Memory represents how much guest memory
                                 the VM should have
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -42865,7 +42865,7 @@ objects:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  default: 16Gi
+                                  default: 32Gi
                                   description: Size is the size of the persistent
                                     storage volume
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -43664,7 +43664,7 @@ objects:
                               anyOf:
                               - type: integer
                               - type: string
-                              default: 4Gi
+                              default: 8Gi
                               description: Memory represents how much guest memory
                                 the VM should have
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -43706,7 +43706,7 @@ objects:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  default: 16Gi
+                                  default: 32Gi
                                   description: Size is the size of the persistent
                                     storage volume
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -74,7 +74,9 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.AWSEndpointAccess, "e2e.aws-endpoint-access", "", "endpoint access profile for the cluster")
 	flag.StringVar(&globalOpts.configurableClusterOptions.ExternalDNSDomain, "e2e.external-dns-domain", "", "domain that external-dns will use to create DNS records for HCP endpoints")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "DEPRECATED (ignored will be removed soon)")
-	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtNodeMemory, "e2e.kubevirt-node-memory", "4Gi", "the amount of memory to provide to each workload node")
+	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtNodeMemory, "e2e.kubevirt-node-memory", "8Gi", "the amount of memory to provide to each workload node")
+	flag.UintVar(&globalOpts.configurableClusterOptions.KubeVirtNodeCores, "e2e.kubevirt-node-cores", 2, "The number of cores provided to each workload node")
+	flag.UintVar(&globalOpts.configurableClusterOptions.KubeVirtRootVolumeSize, "e2e.kubevirt-root-volume-size", 32, "The root volume size in Gi")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtInfraKubeconfigFile, "e2e.kubevirt-infra-kubeconfig", "", "path to the kubeconfig file of the external infra cluster")
 	flag.StringVar(&globalOpts.configurableClusterOptions.KubeVirtInfraNamespace, "e2e.kubevirt-infra-namespace", "", "the namespace on the infra cluster the workers will be created on")
 	flag.IntVar(&globalOpts.configurableClusterOptions.NodePoolReplicas, "e2e.node-pool-replicas", 2, "the number of replicas for each node pool in the cluster")
@@ -361,6 +363,8 @@ type configurableClusterOptions struct {
 	ExternalDNSDomain           string
 	KubeVirtContainerDiskImage  string
 	KubeVirtNodeMemory          string
+	KubeVirtRootVolumeSize      uint
+	KubeVirtNodeCores           uint
 	KubeVirtInfraKubeconfigFile string
 	KubeVirtInfraNamespace      string
 	NodePoolReplicas            int
@@ -401,10 +405,11 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		},
 		KubevirtPlatform: core.KubevirtPlatformCreateOptions{
 			ServicePublishingStrategy: kubevirt.IngressServicePublishingStrategy,
-			Cores:                     2,
+			Cores:                     uint32(o.configurableClusterOptions.KubeVirtNodeCores),
 			Memory:                    o.configurableClusterOptions.KubeVirtNodeMemory,
 			InfraKubeConfigFile:       o.configurableClusterOptions.KubeVirtInfraKubeconfigFile,
 			InfraNamespace:            o.configurableClusterOptions.KubeVirtInfraNamespace,
+			RootVolumeSize:            uint32(o.configurableClusterOptions.KubeVirtRootVolumeSize),
 		},
 		AzurePlatform: core.AzurePlatformOptions{
 			CredentialsFile: o.configurableClusterOptions.AzureCredentialsFile,


### PR DESCRIPTION
Increases Mem defaults to 8gi
Increases Root Volume defaults to 32 Gi
Adds option to e2e tests to configure cpu counts and root volume size.

This aligns closer with the requirements set here, https://docs.openshift.com/container-platform/4.12/post_installation_configuration/node-tasks.html#rhel-compute-requirements_post-install-node-tasks 

We're erroring on the side of overshooting the minimal root volume size by default in order to provide a more usable default experience. In practice, we've seen that the container images can fill up the root volume quickly depending on the workloads installed. 