### PR TITLE
add hyperv1.SilenceClusterAlertsLabel to HostedCluster on deletion

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3081,6 +3081,16 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name
 	log := ctrl.LoggerFrom(ctx)
 
+	// add `hyperv1.SilenceClusterAlertsLabel` label to the HostedCluster when it is deleting
+	// this will ensure that alerts triggered because of the deletion process aren't forwarded
+	if _, ok := hc.Labels[hyperv1.SilenceClusterAlertsLabel]; !ok {
+		original := hc.DeepCopy()
+		hc.Labels[hyperv1.SilenceClusterAlertsLabel] = "clusterDeleting"
+		if err := r.Patch(ctx, hc, client.MergeFromWithOptions(original)); err != nil {
+			return false, fmt.Errorf("cannot patch hosted cluster with silence label: %w", err)
+		}
+	}
+
 	// ensure that the cleanup annotation has been propagated to the hcp if it is set
 	if hc.Annotations[hyperv1.CleanupCloudResourcesAnnotation] == "true" {
 		hcp := controlplaneoperator.HostedControlPlane(controlPlaneNamespace, hc.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the hyperv1.SilenceClusterAlertsLabel label to a HostedCluster CR during the deletion process. It will facilitate silencing alerts triggered during the uninstall process.

**Which issue(s) this PR fixes**:
[OSD-15598](https://issues.redhat.com/browse/OSD-15598)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.