### PR TITLE
HOSTEDCP-969: Only track available metric once

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -103,8 +103,11 @@ import (
 )
 
 const (
-	finalizer                      = "hypershift.openshift.io/finalizer"
-	HostedClusterAnnotation        = "hypershift.openshift.io/cluster"
+	finalizer               = "hypershift.openshift.io/finalizer"
+	HostedClusterAnnotation = "hypershift.openshift.io/cluster"
+	// HasBeenAvailableAnnotation is an implementation detail to check if HC has ever been available.
+	// This is useful for e.g. monitor duration from creation to available and avoid noise from condition flipping.
+	HasBeenAvailableAnnotation     = "hypershift.openshift.io/HasBeenAvailable"
 	clusterDeletionRequeueDuration = 5 * time.Second
 
 	ImageStreamCAPI                        = "cluster-capi-controllers"
@@ -647,12 +650,13 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		meta.SetStatusCondition(&hcluster.Status.Conditions, computeHostedClusterAvailability(hcluster, hcp))
 
 		// SLI: Hosted Cluster available duration.
-		// TODO (alberto): If the available condition flips from true -> false -> true, then atm this metric
-		// counts availableTime as the duration until the latest transition.
-		// We might want to prevent this from happening and only count first transition by checking the hc.Status.Version.History.
 		availableTime := clusterAvailableTime(hcluster)
 		if availableTime != nil {
 			hostedClusterAvailableDuration.WithLabelValues(hcluster.Name).Set(*availableTime)
+			if hcluster.Annotations == nil {
+				hcluster.Annotations = make(map[string]string)
+			}
+			hcluster.Annotations[HasBeenAvailableAnnotation] = "true"
 		}
 	}
 
@@ -4679,4 +4683,9 @@ func (r *HostedClusterReconciler) discoverKubevirtClusterClient(ctx context.Cont
 	cluster.namespace = hc.Spec.Platform.Kubevirt.Credentials.InfraNamespace
 	r.kubevirtInfraClients.LoadOrStore(hc.Spec.InfraID, cluster)
 	return cluster, nil
+}
+
+func HasBeenAvailable(hc *hyperv1.HostedCluster) bool {
+	_, ok := hc.Annotations[HasBeenAvailableAnnotation]
+	return ok
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -2240,3 +2240,35 @@ func TestComputeAWSEndpointServiceCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestHasBeenAvailable(t *testing.T) {
+	testCases := []struct {
+		name     string
+		hc       *hyperv1.HostedCluster
+		expected bool
+	}{
+		{
+			name: "When it has HasBeenAvailable Annotation it should return true",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						HasBeenAvailableAnnotation: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:     "When it has no HasBeenAvailable Annotation it should return false",
+			hc:       &hyperv1.HostedCluster{},
+			expected: false,
+		},
+	}
+
+	g := NewGomegaWithT(t)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g.Expect(HasBeenAvailable(tc.hc)).To(Equal(tc.expected))
+		})
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics.go
@@ -44,8 +44,12 @@ func init() {
 	)
 }
 
-// clusterAvailableTime returns LastTransitionTime
+// clusterAvailableTime returns the time in seconds from cluster creation to first available transition.
+// If the condition is nil, false or the cluster has already been available it returns nil.
 func clusterAvailableTime(hc *hyperv1.HostedCluster) *float64 {
+	if HasBeenAvailable(hc) {
+		return nil
+	}
 	condition := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.HostedClusterAvailable))
 	if condition == nil {
 		return nil

--- a/hypershift-operator/controllers/hostedcluster/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/prometheus/client_golang/prometheus"
@@ -138,6 +139,33 @@ func TestMetrics(t *testing.T) {
 			if diff := cmp.Diff(result, tc.expected); diff != "" {
 				t.Errorf("result differs from actual: %s", diff)
 			}
+		})
+	}
+}
+
+func TestClusterAvailableTime(t *testing.T) {
+	testCases := []struct {
+		name     string
+		hc       *hyperv1.HostedCluster
+		expected *float64
+	}{
+		{
+			name: "When HostedCluster has been available it should return nil",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						HasBeenAvailableAnnotation: "true",
+					},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	g := NewGomegaWithT(t)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g.Expect(clusterAvailableTime(tc.hc)).To(BeEquivalentTo(tc.expected))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
/hold
needs https://github.com/openshift/hypershift/pull/2477

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.