### PR TITLE
HOSTEDCP-960: Add e2e to validate HC/NP conditions expected status

### DIFF
--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -1,0 +1,69 @@
+package conditions
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ExpectedHCConditions() map[hyperv1.ConditionType]metav1.ConditionStatus {
+	return map[hyperv1.ConditionType]metav1.ConditionStatus{
+		hyperv1.HostedClusterAvailable:               metav1.ConditionTrue,
+		hyperv1.InfrastructureReady:                  metav1.ConditionTrue,
+		hyperv1.KubeAPIServerAvailable:               metav1.ConditionTrue,
+		hyperv1.IgnitionEndpointAvailable:            metav1.ConditionTrue,
+		hyperv1.EtcdAvailable:                        metav1.ConditionTrue,
+		hyperv1.ValidReleaseInfo:                     metav1.ConditionTrue,
+		hyperv1.ValidHostedClusterConfiguration:      metav1.ConditionTrue,
+		hyperv1.SupportedHostedCluster:               metav1.ConditionTrue,
+		hyperv1.ClusterVersionSucceeding:             metav1.ConditionTrue,
+		hyperv1.ClusterVersionAvailable:              metav1.ConditionTrue,
+		hyperv1.ClusterVersionReleaseAccepted:        metav1.ConditionTrue,
+		hyperv1.ReconciliationActive:                 metav1.ConditionTrue,
+		hyperv1.ReconciliationSucceeded:              metav1.ConditionTrue,
+		hyperv1.ValidOIDCConfiguration:               metav1.ConditionTrue,
+		hyperv1.ValidAWSIdentityProvider:             metav1.ConditionTrue,
+		hyperv1.AWSDefaultSecurityGroupCreated:       metav1.ConditionTrue,
+		hyperv1.ValidHostedControlPlaneConfiguration: metav1.ConditionTrue,
+		hyperv1.ValidReleaseImage:                    metav1.ConditionTrue,
+		hyperv1.PlatformCredentialsFound:             metav1.ConditionTrue,
+		hyperv1.AWSEndpointAvailable:                 metav1.ConditionTrue,
+		hyperv1.AWSEndpointServiceAvailable:          metav1.ConditionTrue,
+
+		hyperv1.HostedClusterProgressing:  metav1.ConditionFalse,
+		hyperv1.HostedClusterDegraded:     metav1.ConditionFalse,
+		hyperv1.ClusterVersionFailing:     metav1.ConditionFalse,
+		hyperv1.ClusterVersionProgressing: metav1.ConditionFalse,
+
+		// conditions with no strong gurantees
+		//
+		// UnmanagedEtcdAvailable is only set if hcluster.Spec.Etcd.ManagementType == hyperv1.Unmanaged.
+		hyperv1.UnmanagedEtcdAvailable: metav1.ConditionTrue,
+		// ClusterVersionUpgradeable is not always guranteed to be true.
+		hyperv1.ClusterVersionUpgradeable: metav1.ConditionTrue,
+		// ExternalDNSReachable could be set to ConditionUnknown if external DNS is not configured or HC is private.
+		hyperv1.ExternalDNSReachable: metav1.ConditionTrue,
+		// ValidAWSKMSConfig could be set to ConditionUnknown if KMS key/role are not configured.
+		hyperv1.ValidAWSKMSConfig: metav1.ConditionTrue,
+	}
+}
+
+func ExpectedNodePoolConditions() map[string]corev1.ConditionStatus {
+	return map[string]corev1.ConditionStatus{
+		hyperv1.NodePoolReadyConditionType:                     corev1.ConditionTrue,
+		hyperv1.NodePoolValidReleaseImageConditionType:         corev1.ConditionTrue,
+		hyperv1.NodePoolValidGeneratedPayloadConditionType:     corev1.ConditionTrue,
+		hyperv1.NodePoolValidPlatformImageType:                 corev1.ConditionTrue,
+		hyperv1.NodePoolValidMachineConfigConditionType:        corev1.ConditionTrue,
+		hyperv1.NodePoolValidTuningConfigConditionType:         corev1.ConditionTrue,
+		hyperv1.NodePoolAllMachinesReadyConditionType:          corev1.ConditionTrue,
+		hyperv1.NodePoolAllNodesHealthyConditionType:           corev1.ConditionTrue,
+		hyperv1.NodePoolReconciliationActiveConditionType:      corev1.ConditionTrue,
+		hyperv1.NodePoolReachedIgnitionEndpoint:                corev1.ConditionTrue,
+		hyperv1.NodePoolAWSSecurityGroupAvailableConditionType: corev1.ConditionTrue,
+		hyperv1.NodePoolUpdateManagementEnabledConditionType:   corev1.ConditionTrue,
+
+		hyperv1.NodePoolUpdatingVersionConditionType: corev1.ConditionFalse,
+		hyperv1.NodePoolUpdatingConfigConditionType:  corev1.ConditionFalse,
+	}
+}

--- a/support/util/expose.go
+++ b/support/util/expose.go
@@ -44,12 +44,32 @@ func UseDedicatedDNSForKASByHC(hc *hyperv1.HostedCluster) bool {
 }
 
 func ServiceExternalDNSHostname(hcp *hyperv1.HostedControlPlane, serviceType hyperv1.ServiceType) string {
-	// external DNS hostname can only be set when HCP is Public
+	// external DNS hostname can only be reached when HCP is Public
 	if !IsPublicHCP(hcp) {
 		return ""
 	}
 
 	service := ServicePublishingStrategyByTypeForHCP(hcp, serviceType)
+	if service == nil {
+		return ""
+	}
+
+	if service.Type == hyperv1.LoadBalancer && service.LoadBalancer != nil {
+		return service.LoadBalancer.Hostname
+	}
+	if service.Type == hyperv1.Route && service.Route != nil {
+		return service.Route.Hostname
+	}
+	return ""
+}
+
+func ServiceExternalDNSHostnameByHC(hc *hyperv1.HostedCluster, serviceType hyperv1.ServiceType) string {
+	// external DNS hostname can only be reached when HC is Public
+	if !IsPublicHC(hc) {
+		return ""
+	}
+
+	service := ServicePublishingStrategyByTypeByHC(hc, serviceType)
 	if service == nil {
 		return ""
 	}

--- a/support/util/visibility.go
+++ b/support/util/visibility.go
@@ -24,6 +24,14 @@ func IsPrivateHC(hc *hyperv1.HostedCluster) bool {
 			hc.Spec.Platform.AWS.EndpointAccess == hyperv1.Private)
 }
 
+func IsPublicHC(hc *hyperv1.HostedCluster) bool {
+	if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
+		return true
+	}
+	return hc.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate ||
+		hc.Spec.Platform.AWS.EndpointAccess == hyperv1.Public
+}
+
 func IsPublicKASWithDNS(hostedControlPlane *hyperv1.HostedControlPlane) bool {
 	return IsPublicHCP(hostedControlPlane) && UseDedicatedDNSforKAS(hostedControlPlane)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Validates that all HostedCluster and NodePool conditions match their execrated status (true / false)

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-960](https://issues.redhat.com/browse/HOSTEDCP-960)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.