### PR TITLE
ACM-5173 [backport 4.13] get pull secret instead of dockerconfigjson from mce credentials

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -177,7 +177,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 	var pullSecret []byte
 	var err error
 	if len(opts.CredentialSecretName) > 0 {
-		pullSecret, err = util.GetDockerConfigJSON(opts.CredentialSecretName, opts.Namespace)
+		pullSecret, err = util.GetPullSecret(opts.CredentialSecretName, opts.Namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func getReleaseSemanticVersion(ctx context.Context, opts *CreateOptions, provide
 	var pullSecretBytes []byte
 	var err error
 	if len(opts.CredentialSecretName) > 0 {
-		pullSecretBytes, err = util.GetDockerConfigJSON(opts.CredentialSecretName, opts.Namespace)
+		pullSecretBytes, err = util.GetPullSecret(opts.CredentialSecretName, opts.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/util/secrets.go
+++ b/cmd/util/secrets.go
@@ -68,3 +68,15 @@ func GetDockerConfigJSON(name string, namespace string) ([]byte, error) {
 	}
 	return dockerConfigJSON, nil
 }
+
+func GetPullSecret(name string, namespace string) ([]byte, error) {
+	secret, err := GetSecret(name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	pullSecret := secret.Data["pullSecret"]
+	if len(pullSecret) == 0 {
+		return nil, fmt.Errorf("the pull secret is invalid, {namespace: %s, secret: %s}", namespace, name)
+	}
+	return []byte(pullSecret), nil
+}


### PR DESCRIPTION
Backport of https://github.com/openshift/hypershift/commit/142d91e6b81858adbfd50907674c59d9f016c447
Issue: https://issues.redhat.com/browse/ACM-5173