### PR TITLE
OCPBUGS-12689: hosted clusters default KAS PDA config should be consistent with OCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -90,7 +90,7 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 									Kind:       "PodSecurityConfiguration",
 								},
 								Defaults: podsecurityadmissionv1beta1.PodSecurityDefaults{
-									Enforce:        "restricted",
+									Enforce:        "privileged",
 									EnforceVersion: "latest",
 									Audit:          "restricted",
 									AuditVersion:   "latest",


### PR DESCRIPTION
**What this PR does / why we need it**:
Set hosted cluster KAS config pod security enforcement to privileged.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-12689](https://issues.redhat.com/browse/OCPBUGS-12689)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.