### PR TITLE
HOSTEDCP-788: Configurable SRE MetricsSet

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -361,6 +361,7 @@ func NewStartCommand() *cobra.Command {
 			os.Exit(1)
 		}
 		setupLog.Info("Using metrics set", "set", metricsSet.String())
+
 		if err := (&hostedcontrolplane.HostedControlPlaneReconciler{
 			Client:                        mgr.GetClient(),
 			ManagementClusterCapabilities: mgmtClusterCaps,

--- a/docs/content/how-to/metrics-sets.md
+++ b/docs/content/how-to/metrics-sets.md
@@ -13,9 +13,8 @@ The following metrics sets are supported:
 
 * `Telemetry` - metrics needed for telemetry. This is the default and the smallest
    set of metrics.
-* `SRE` - metrics in `Telemetry` plus those needed for service reliability monitoring of HyperShift control planes.
-   Includes metrics necessary to produce alerts and allow troubleshooting of control plane
-   components.
+* `SRE` - Configurable metrics set, intended to include necessary metrics to produce alerts and 
+   allow troubleshooting of control plane components.
 * `All` - all the metrics produced by standalone OCP control plane components.
 
 The metrics set is configured by setting the `METRICS_SET` environment variable in the HyperShift
@@ -24,3 +23,26 @@ operator deployment:
 ```
 oc set env -n hypershift deployment/operator METRICS_SET=All
 ```
+
+## Configuring the SRE Metrics Set
+
+When the SRE metrics set is specified, the HyperShift operator looks for a ConfigMap named
+`sre-metric-set` with a single key: `config`. The value of the `config` key should contain a set
+of RelabelConfigs organized by control plane component. An example of this configuration can be
+found in `support/metrics/testdata/sreconfig.yaml` in this repository.
+
+The following components can be specified:
+
+* etcd
+* kubeAPIServer
+* kubeControllerManager
+* openshiftAPIServer
+* openshiftControllerManager
+* openshiftRouteControllerManager
+* cvo
+* olm
+* catalogOperator
+* registryOperator
+* nodeTuningOperator
+* controlPlaneOperator
+* hostedClusterConfigOperator

--- a/support/metrics/sets_test.go
+++ b/support/metrics/sets_test.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	_ "embed"
+	"testing"
+)
+
+//go:embed testdata/sreconfig.yaml
+var sampleSREConfigYAML string
+
+func TestLoadMetricsConfig(t *testing.T) {
+	config := MetricsSetConfig{}
+	err := config.LoadFromString(sampleSREConfigYAML)
+	if err != nil {
+		t.Fatalf("Unexpected: %v", err)
+	}
+	if len(config.KubeAPIServer) == 0 {
+		t.Errorf("Kube APIServer configuration not loaded")
+	}
+}

--- a/support/metrics/testdata/sreconfig.yaml
+++ b/support/metrics/testdata/sreconfig.yaml
@@ -1,0 +1,77 @@
+kubeAPIServer:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_controller_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_step_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "transformation_(transformation_latencies_microseconds|failures_total)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "network_plugin_operations_latency_microseconds|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)"
+    sourceLabels: ["__name__", "le"]
+kubeControllerManager:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|request|server).*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "rest_client_request_latency_seconds_(bucket|count|sum)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)"
+    sourceLabels: ["__name__"]
+openshiftAPIServer:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_controller_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_step_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)"
+    sourceLabels: ["__name__", "le"]
+openshiftControllerManager:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|request|server).*"
+    sourceLabels: ["__name__"]
+openshiftRouteControllerManager:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|request|server).*"
+    sourceLabels: ["__name__"]
+olm:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+catalogOperator:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+cvo:
+  - action: drop
+    regex: "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces the use of a ConfigMap to configure the metrics relabelings to use in control plane ServiceMonitors. The ConfigMap should live in the hypershift operator namespace, be named 'sre-metric-set' and have a single key named 'config'. The contents of the config should be a YAML file with keys for each of the control plane components that produces a service monitor. An example is included in support/metrics/testdata.

Changes to the configuration ConfigMap result in the ConfigMap getting copied to all hosted control planes and the Control Plane Operator pod in those namespaces to be restarted. For the CPO pod, the configuration is only read once during startup and used by the service monitor reconciliation functions.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-788](https://issues.redhat.com//browse/HOSTEDCP-788)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.