### PR TITLE
Add new --featuregate-manifest to /usr/bin/cluster-config-operator render

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -664,11 +664,23 @@ func applyCloudConfigVolumeMount(configRef *corev1.LocalObjectReference, podSpec
 func invokeBootstrapRenderScript(workDir string) string {
 	var script = `#!/bin/sh
 cd /tmp
-mkdir input output
+mkdir input output manifests
+
+touch /tmp/manifests/99_feature-gate.yaml
+cat <<EOF >/tmp/manifests/99_feature-gate.yaml
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec: {}
+EOF
+
 /usr/bin/cluster-config-operator render \
    --config-output-file config \
    --asset-input-dir /tmp/input \
-   --asset-output-dir /tmp/output
+   --asset-output-dir /tmp/output \
+   --rendered-manifest-files=/tmp/manifests \
+   --featuregate-manifest=/tmp/manifests/99_feature-gate.yaml
 cp /tmp/output/manifests/* %[1]s
 `
 	return fmt.Sprintf(script, workDir)


### PR DESCRIPTION
CI is currently borken https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn/1653511338548269056/artifacts/e2e-aws-ovn/run-e2e/artifacts/TestCreateCluster_PreTeardownClusterDump/namespaces/e2e-clusters-glkxm-example-qmb9l/core/pods/logs/kube-apiserver-79b6c48d7-mzv44-init-bootstrap-previous.log.

This introduced a new command which is effectively required https://github.com/openshift/cluster-config-operator/pull/288

This introduced new status in featureGate CRD https://github.com/openshift/api/pull/1405

Here it was added to the installer github.com/openshift/installer/pull/6990

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.