### PR TITLE
Fixed assignment to entry in nil map

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3158,6 +3158,9 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	// this will ensure that alerts triggered because of the deletion process aren't forwarded
 	if _, ok := hc.Labels[hyperv1.SilenceClusterAlertsLabel]; !ok {
 		original := hc.DeepCopy()
+		if hc.Labels == nil {
+			hc.Labels = make(map[string]string)
+		}
 		hc.Labels[hyperv1.SilenceClusterAlertsLabel] = "clusterDeleting"
 		if err := r.Patch(ctx, hc, client.MergeFromWithOptions(original)); err != nil {
 			return false, fmt.Errorf("cannot patch hosted cluster with silence label: %w", err)


### PR DESCRIPTION
fixes hypershift-operator crash on deletion:
```
panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map

goroutine 1202 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:118 +0x2d9
panic({0x2fd2360, 0x3980de0})
        /usr/local/go/src/runtime/panic.go:890 +0x267
github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster.(*HostedClusterReconciler).delete(0xc000152e00, {0x39a89e8, 0xc001a07bf0}, 0xc001353000)
        /hypershift/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go:3161 +0x19e
github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster.(*HostedClusterReconciler).reconcile(0xc000152e00, {0x39a89e8, 0xc001a07bf0}, {{{0xc0002b76c8, 0x8}, {0xc0002b76d1, 0xc}}}, {{0x39ab810, 0xc001a07c20}, 0x0}, ...)
```