### PR TITLE
Add audit-log-maxbackup setting for openshift-api-server

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/config.go
@@ -59,6 +59,7 @@ func reconcileConfigObject(cfg *openshiftcpv1.OpenShiftAPIServerConfig, auditWeb
 		"shutdown-delay-duration": {"3s"},
 		"audit-log-format":        {"json"},
 		"audit-log-maxsize":       {"100"},
+		"audit-log-maxbackup":     {"10"},
 		"audit-policy-file":       {cpath(oasVolumeAuditConfig().Name, auditPolicyConfigMapKey)},
 		"audit-log-path":          {cpath(oasVolumeWorkLogs().Name, "audit.log")},
 	}


### PR DESCRIPTION



**What this PR does / why we need it**:

In order to meet CIS and PCI-DSS compliance, we need to have an audit-log-max backup set to 10 or any appropriate value, we should add this as a default so that no additional configuration is needed after the installation.

**Which issue(s) this PR fixes** *
Jira #https://issues.redhat.com/browse/OSD-15157

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.