### PR TITLE
Updated secrets permissions 4.12

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -234,7 +234,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
 		},
 	}}
 	dep.Spec.Template.Spec.Volumes = []corev1.Volume{
-		{Name: "node-tuning-operator-tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "node-tuning-operator-tls"}}},
+		{Name: "node-tuning-operator-tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "node-tuning-operator-tls", DefaultMode: utilpointer.Int32Ptr(416)}}},
 		{Name: "trusted-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 			Optional:             utilpointer.Bool(true),
 			LocalObjectReference: corev1.LocalObjectReference{Name: "trusted-ca"},
@@ -242,7 +242,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
 				{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"},
 			},
 		}}},
-		{Name: "hosted-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KASServiceKubeconfigSecret("").Name}}},
+		{Name: "hosted-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KASServiceKubeconfigSecret("").Name, DefaultMode: utilpointer.Int32Ptr(416)}}},
 	}
 
 	params.DeploymentConfig.ApplyTo(dep)

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
@@ -142,4 +142,5 @@ func routeOCMVolumeServingCert() *corev1.Volume {
 func buildRouteOCMVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.OpenShiftRouteControllerManagerCertSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32Ptr(416)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated some more secret permissions to 416 specifically those mounted by

cluster-node-tuning-operator
openshift-route-controller-manager

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #1031

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.