### PR TITLE
remove flags set by CI env var

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -148,10 +148,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	var opts Options
-	if os.Getenv("CI") == "true" {
-		opts.PlatformMonitoring = metrics.PlatformMonitoringAll
-		opts.EnableCIDebugOutput = true
-	}
 	opts.PrivatePlatform = string(hyperv1.NonePlatform)
 	opts.MetricsSet = metrics.DefaultMetricsSet
 	opts.EnableConversionWebhook = true // default to enabling the conversion webhook


### PR DESCRIPTION
Follow on to https://github.com/openshift/release/pull/39012

Remove magic flag setting when running in CI.  Workflow in o/r now explicitly sets these flags.