### PR TITLE
OCPBUGS-13112: Add timeout to KAS health check client

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -745,7 +745,9 @@ func healthCheckKASEndpoint(hostname string, hcp *hyperv1.HostedControlPlane) er
 	port := util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort)
 	healthEndpoint := fmt.Sprintf("https://%s:%d/healthz", hostname, port)
 
-	resp, err := util.InsecureHTTPClient().Get(healthEndpoint)
+	httpClient := util.InsecureHTTPClient()
+	httpClient.Timeout = 10 * time.Second
+	resp, err := httpClient.Get(healthEndpoint)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The current health check HTTP client can block reconciliation for a long time if it cannot access the destination endpoint. This commit adds a timeout to the client so that reconciliation can proceed.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-13112

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.