### PR TITLE
Lock down kubevirt csi storageclass mappings

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/controller.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/controller.yaml
@@ -44,6 +44,11 @@ spec:
                 configMapKeyRef:
                   name: driver-config
                   key: infraClusterLabels
+            - name: INFRA_STORAGE_CLASS_ENFORCEMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: driver-config
+                  key: infraStorageClassEnforcement
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -123,9 +123,12 @@ func getContentsOrDie(file string) []byte {
 }
 
 func reconcileInfraConfigMap(cm *corev1.ConfigMap, infraID string) error {
+	storageClassEnforcement := "allowDefault: true\nallowAll: false\n"
+
 	cm.Data = map[string]string{
-		"infraClusterNamespace": cm.Namespace,
-		"infraClusterLabels":    fmt.Sprintf("%s=%s", hyperv1.InfraIDLabel, infraID),
+		"infraClusterNamespace":        cm.Namespace,
+		"infraClusterLabels":           fmt.Sprintf("%s=%s", hyperv1.InfraIDLabel, infraID),
+		"infraStorageClassEnforcement": storageClassEnforcement,
 	}
 	return nil
 }


### PR DESCRIPTION
This PR integrates [work completed recently](https://github.com/kubevirt/csi-driver/pull/62) in the kubevirt-csi driver to enforce what infra cluster storageclasses can be used by guest clusters.

Right now, we only want to allow the default mapping of the default infra sc to a guest sc. In the future, we'll expand this to [allow users creating HostedClusters to define this storageclass mapping](https://github.com/openshift/hypershift/pull/2528) in greater detail.