### PR TITLE
Updated secrets to read only for CNO and OCM

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -237,7 +237,10 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
 		},
 	}}
 	dep.Spec.Template.Spec.Volumes = []corev1.Volume{
-		{Name: "node-tuning-operator-tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "node-tuning-operator-tls"}}},
+		{Name: "node-tuning-operator-tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+			SecretName:  "node-tuning-operator-tls",
+			DefaultMode: utilpointer.Int32Ptr(416),
+		}}},
 		{Name: "metrics-client-ca", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "metrics-client"}}},
 		{Name: "trusted-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 			Optional:             utilpointer.Bool(true),
@@ -246,7 +249,10 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
 				{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"},
 			},
 		}}},
-		{Name: "hosted-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KASServiceKubeconfigSecret("").Name}}},
+		{Name: "hosted-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+			SecretName:  manifests.KASServiceKubeconfigSecret("").Name,
+			DefaultMode: utilpointer.Int32Ptr(416),
+		}}},
 	}
 
 	params.DeploymentConfig.ApplyTo(dep)

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -71,7 +71,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image string, config *co
 	deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
 		configHashAnnotation: configHash,
 	}
-	deployment.Spec.Template.Spec.AutomountServiceAccountToken = pointer.Bool(false)
+	deployment.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.Bool(false)
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{
 		util.BuildContainer(routeOCMContainerMain(), buildRouteOCMContainerMain(image)),
 	}
@@ -131,6 +131,7 @@ func routeOCMVolumeKubeconfig() *corev1.Volume {
 func buildRouteOCMVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.KASServiceKubeconfigSecret("").Name
+	utilpointer.Int32Ptr(416)
 }
 
 func routeOCMVolumeServingCert() *corev1.Volume {
@@ -142,4 +143,5 @@ func routeOCMVolumeServingCert() *corev1.Volume {
 func buildRouteOCMVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.OpenShiftRouteControllerManagerCertSecret("").Name
+	utilpointer.Int32Ptr(416)
 }


### PR DESCRIPTION
What this PR does / why we need it:
Updated some more secret permissions to 416 specifically those mounted by

cluster-node-tuning-operator
openshift-route-controller-manager

Which issue(s) this PR fixes (optional, use fixes #<issue_number>(, fixes #<issue_number>, ...) format, where issue_number might be a GitHub issue, or a Jira story:
Fixes #1031

**Checklist**
- [x ] Subject and description added to both, commit and PR.
- [x ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.