### PR TITLE
[release-4.12] Configurable SRE MetricsSet

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -152,6 +152,7 @@ type HostedControlPlaneReconciler struct {
 	OperateOnReleaseImage         string
 	DefaultIngressDomain          string
 	MetricsSet                    metrics.MetricsSet
+	SREConfigHash                 string
 	ec2Client                     ec2iface.EC2API
 	awsSession                    *session.Session
 	reconcileInfrastructureStatus func(ctx context.Context, hcp *hyperv1.HostedControlPlane) (InfrastructureStatus, error)
@@ -784,6 +785,11 @@ func IsStorageAndCSIManaged(hostedControlPlane *hyperv1.HostedControlPlane) bool
 }
 
 func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedControlPlane *hyperv1.HostedControlPlane, createOrUpdate upsert.CreateOrUpdateFN, releaseImage *releaseinfo.ReleaseImage, infraStatus InfrastructureStatus) error {
+
+	if err := r.reconcileSREMetricsConfig(ctx, createOrUpdate, hostedControlPlane.Namespace); err != nil {
+		return fmt.Errorf("failed to reconcile metrics config: %w", err)
+	}
+
 	if useHCPRouter(hostedControlPlane) {
 		r.Log.Info("Reconciling router")
 		if err := r.reconcileRouter(ctx, hostedControlPlane, releaseImage, createOrUpdate, util.IsRouteKAS(hostedControlPlane), infraStatus.InternalHCPRouterHost, infraStatus.ExternalHCPRouterHost); err != nil {
@@ -4069,4 +4075,31 @@ func (r *HostedControlPlaneReconciler) GetGuestClusterClient(ctx context.Context
 	}
 
 	return clientset, nil
+}
+
+// reconcileSREMetricsConfig ensures that if using the SRE metrics set that the loaded configuration
+// is the latest from the ConfigMap.
+func (r *HostedControlPlaneReconciler) reconcileSREMetricsConfig(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, cpNamespace string) error {
+	log := ctrl.LoggerFrom(ctx)
+	if r.MetricsSet != metrics.MetricsSetSRE {
+		return nil
+	}
+	log.Info("Reconciling SRE metrics configuration")
+	cm := metrics.SREMetricsSetConfigurationConfigMap(cpNamespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("SRE configuration does not exist")
+			return nil
+		}
+		return fmt.Errorf("failed to get SRE configuration configmap: %w", err)
+	}
+	currentMetricsSetConfigHash := metrics.SREMetricsSetConfigHash(cm)
+	if currentMetricsSetConfigHash != r.SREConfigHash {
+		// Only load a new config if configuration content has changed
+		if err := metrics.LoadSREMetricsSetConfigurationFromConfigMap(cm); err != nil {
+			return fmt.Errorf("failed to load SRE configuration: %w", err)
+		}
+		r.SREConfigHash = currentMetricsSetConfigHash
+	}
+	return nil
 }

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -361,6 +361,7 @@ func NewStartCommand() *cobra.Command {
 			os.Exit(1)
 		}
 		setupLog.Info("Using metrics set", "set", metricsSet.String())
+
 		if err := (&hostedcontrolplane.HostedControlPlaneReconciler{
 			Client:                        mgr.GetClient(),
 			ManagementClusterCapabilities: mgmtClusterCaps,

--- a/docs/content/how-to/metrics-sets.md
+++ b/docs/content/how-to/metrics-sets.md
@@ -13,9 +13,8 @@ The following metrics sets are supported:
 
 * `Telemetry` - metrics needed for telemetry. This is the default and the smallest
    set of metrics.
-* `SRE` - metrics in `Telemetry` plus those needed for service reliability monitoring of HyperShift control planes.
-   Includes metrics necessary to produce alerts and allow troubleshooting of control plane
-   components.
+* `SRE` - Configurable metrics set, intended to include necessary metrics to produce alerts and 
+   allow troubleshooting of control plane components.
 * `All` - all the metrics produced by standalone OCP control plane components.
 
 The metrics set is configured by setting the `METRICS_SET` environment variable in the HyperShift
@@ -24,3 +23,26 @@ operator deployment:
 ```
 oc set env -n hypershift deployment/operator METRICS_SET=All
 ```
+
+## Configuring the SRE Metrics Set
+
+When the SRE metrics set is specified, the HyperShift operator looks for a ConfigMap named
+`sre-metric-set` with a single key: `config`. The value of the `config` key should contain a set
+of RelabelConfigs organized by control plane component. An example of this configuration can be
+found in `support/metrics/testdata/sreconfig.yaml` in this repository.
+
+The following components can be specified:
+
+* etcd
+* kubeAPIServer
+* kubeControllerManager
+* openshiftAPIServer
+* openshiftControllerManager
+* openshiftRouteControllerManager
+* cvo
+* olm
+* catalogOperator
+* registryOperator
+* nodeTuningOperator
+* controlPlaneOperator
+* hostedClusterConfigOperator

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -89,6 +89,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -147,7 +148,10 @@ type HostedClusterReconciler struct {
 
 	ImageMetadataProvider hyperutil.ImageMetadataProvider
 
-	MetricsSet metrics.MetricsSet
+	MetricsSet    metrics.MetricsSet
+	SREConfigHash string
+
+	OperatorNamespace string
 
 	overwriteReconcile func(ctx context.Context, req ctrl.Request, log logr.Logger, hcluster *hyperv1.HostedCluster) (ctrl.Result, error)
 	now                func() metav1.Time
@@ -156,7 +160,7 @@ type HostedClusterReconciler struct {
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters/status,verbs=get;update;patch
 
-func (r *HostedClusterReconciler) SetupWithManager(mgr ctrl.Manager, createOrUpdate upsert.CreateOrUpdateProvider) error {
+func (r *HostedClusterReconciler) SetupWithManager(mgr ctrl.Manager, createOrUpdate upsert.CreateOrUpdateProvider, metricsSet metrics.MetricsSet, operatorNamespace string) error {
 	if r.Clock == nil {
 		r.Clock = clock.RealClock{}
 	}
@@ -176,7 +180,7 @@ func (r *HostedClusterReconciler) SetupWithManager(mgr ctrl.Manager, createOrUpd
 			MaxConcurrentReconciles: 10,
 		})
 	for _, managedResource := range r.managedResources() {
-		builder.Watches(&source.Kind{Type: managedResource}, handler.EnqueueRequestsFromMapFunc(enqueueParentHostedCluster))
+		builder.Watches(&source.Kind{Type: managedResource}, handler.EnqueueRequestsFromMapFunc(enqueueHostedClustersFunc(metricsSet, operatorNamespace, mgr.GetClient())))
 	}
 
 	// Set based on SCC capability
@@ -1411,6 +1415,11 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	defaultIngressDomain, err := r.defaultIngressDomain(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to determine default ingress domain: %w", err)
+	}
+
+	// Reconcile SRE metrics config
+	if err := r.reconcileSREMetricsConfig(ctx, createOrUpdate, hcp); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile SRE metrics config: %w", err)
 	}
 
 	// Reconcile the control plane operator
@@ -3107,16 +3116,36 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	return true, nil
 }
 
-func enqueueParentHostedCluster(obj client.Object) []reconcile.Request {
-	var hostedClusterName string
-	if obj.GetAnnotations() != nil {
-		hostedClusterName = obj.GetAnnotations()[HostedClusterAnnotation]
-	}
-	if hostedClusterName == "" {
-		return []reconcile.Request{}
-	}
-	return []reconcile.Request{
-		{NamespacedName: hyperutil.ParseNamespacedName(hostedClusterName)},
+func enqueueHostedClustersFunc(metricsSet metrics.MetricsSet, operatorNamespace string, c client.Client) func(client.Object) []reconcile.Request {
+	return func(obj client.Object) []reconcile.Request {
+		log := ctrllog.Log
+		if metricsSet == metrics.MetricsSetSRE {
+			if _, isCM := obj.(*corev1.ConfigMap); isCM {
+				if obj.GetName() == metrics.SREConfigurationConfigMapName && obj.GetNamespace() == operatorNamespace {
+					// A change has occurred to the SRE metrics set configuration. We should requeue all HostedClusters
+					hcList := &hyperv1.HostedClusterList{}
+					if err := c.List(context.Background(), hcList); err != nil {
+						// An error occurred, report it.
+						log.Error(err, "failed to list hosted clusters while processing SRE config event")
+					}
+					requests := make([]reconcile.Request, 0, len(hcList.Items))
+					for _, hc := range hcList.Items {
+						requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: hc.Name, Namespace: hc.Namespace}})
+					}
+					return requests
+				}
+			}
+		}
+		var hostedClusterName string
+		if obj.GetAnnotations() != nil {
+			hostedClusterName = obj.GetAnnotations()[HostedClusterAnnotation]
+		}
+		if hostedClusterName == "" {
+			return []reconcile.Request{}
+		}
+		return []reconcile.Request{
+			{NamespacedName: hyperutil.ParseNamespacedName(hostedClusterName)},
+		}
 	}
 }
 
@@ -4215,5 +4244,41 @@ func (r *HostedClusterReconciler) dereferenceAWSRoles(ctx context.Context, roles
 		rolesRef.KubeCloudControllerARN = arn
 	}
 
+	return nil
+}
+
+// reconcileSREMetricsConfig loads the SRE metrics configuration (avoids parsing if the content is the same)
+// and ensures that it is synced to the hosted control plane
+func (r *HostedClusterReconciler) reconcileSREMetricsConfig(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcp *hyperv1.HostedControlPlane) error {
+	log := ctrl.LoggerFrom(ctx)
+	if r.MetricsSet != metrics.MetricsSetSRE {
+		return nil
+	}
+	log.Info("Reconciling SRE metrics configuration")
+	cm := metrics.SREMetricsSetConfigurationConfigMap(r.OperatorNamespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("SRE configuration does not exist")
+			return nil
+		}
+		return fmt.Errorf("failed to get SRE configuration configmap: %w", err)
+	}
+	currentMetricsSetConfigHash := metrics.SREMetricsSetConfigHash(cm)
+	if currentMetricsSetConfigHash != r.SREConfigHash {
+		// Only load a new config if configuration content has changed
+		if err := metrics.LoadSREMetricsSetConfigurationFromConfigMap(cm); err != nil {
+			return fmt.Errorf("failed to load SRE configuration: %w", err)
+		}
+		r.SREConfigHash = currentMetricsSetConfigHash
+	}
+	destinationCM := metrics.SREMetricsSetConfigurationConfigMap(hcp.Namespace)
+	ownerRef := config.OwnerRefFrom(hcp)
+	if _, err := createOrUpdate(ctx, r.Client, destinationCM, func() error {
+		ownerRef.ApplyTo(destinationCM)
+		destinationCM.Data = cm.Data
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to update hosted cluster SRE metrics configuration: %w", err)
+	}
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
@@ -11,6 +11,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	version "github.com/openshift/hypershift/cmd/version"
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
+	"github.com/openshift/hypershift/support/metrics"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/upsert"
@@ -111,7 +112,7 @@ func TestWebhookAllowsHostedClusterReconcilerUpdates(t *testing.T) {
 				}),
 				ReleaseProvider: &fakereleaseprovider.FakeReleaseProvider{},
 			}
-			if err := hostedClusterReconciler.SetupWithManager(mgr, upsert.New(true)); err != nil {
+			if err := hostedClusterReconciler.SetupWithManager(mgr, upsert.New(true), metrics.MetricsSetAll, "hypershift"); err != nil {
 				t.Fatalf("failed to set up hostedClusterReconciler: %v", err)
 			}
 

--- a/support/metrics/sets_test.go
+++ b/support/metrics/sets_test.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	_ "embed"
+	"testing"
+)
+
+//go:embed testdata/sreconfig.yaml
+var sampleSREConfigYAML string
+
+func TestLoadMetricsConfig(t *testing.T) {
+	config := MetricsSetConfig{}
+	err := config.LoadFromString(sampleSREConfigYAML)
+	if err != nil {
+		t.Fatalf("Unexpected: %v", err)
+	}
+	if len(config.KubeAPIServer) == 0 {
+		t.Errorf("Kube APIServer configuration not loaded")
+	}
+}

--- a/support/metrics/testdata/sreconfig.yaml
+++ b/support/metrics/testdata/sreconfig.yaml
@@ -1,0 +1,77 @@
+kubeAPIServer:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_controller_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_step_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "transformation_(transformation_latencies_microseconds|failures_total)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "network_plugin_operations_latency_microseconds|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)"
+    sourceLabels: ["__name__", "le"]
+kubeControllerManager:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|request|server).*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "rest_client_request_latency_seconds_(bucket|count|sum)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)"
+    sourceLabels: ["__name__"]
+openshiftAPIServer:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_controller_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_step_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)"
+    sourceLabels: ["__name__", "le"]
+openshiftControllerManager:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|request|server).*"
+    sourceLabels: ["__name__"]
+openshiftRouteControllerManager:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|request|server).*"
+    sourceLabels: ["__name__"]
+olm:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+catalogOperator:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+cvo:
+  - action: drop
+    regex: "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces the use of a ConfigMap to configure the metrics relabelings to use in control plane ServiceMonitors. The ConfigMap should live in the hypershift operator namespace, be named 'sre-metric-set' and have a single key named 'config'. The contents of the config should be a YAML file with keys for each of the control plane components that produces a service monitor. An example is included in support/metrics/testdata.

Changes to the configuration ConfigMap result in the ConfigMap getting copied to all hosted control planes and the Control Plane Operator pod in those namespaces to be restarted. For the CPO pod, the configuration is only read once during startup and used by the service monitor reconciliation functions.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.