### PR TITLE
HOSTEDCP-947: Maxed the QUOTA_BACKEND_BYTES to the recommended limit

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -11,6 +11,10 @@ import (
 	"github.com/openshift/hypershift/support/config"
 )
 
+const (
+	EtcdSTSQuotaBackendSize = 8 * 1024 * 1024 * 1024
+)
+
 type EtcdParams struct {
 	EtcdImage string
 	CPOImage  string

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -262,7 +262,7 @@ func buildEtcdContainer(p *EtcdParams, namespace string) func(c *corev1.Containe
 			},
 			{
 				Name:  "QUOTA_BACKEND_BYTES",
-				Value: strconv.FormatInt(p.StorageSpec.PersistentVolume.Size.Value(), 10),
+				Value: strconv.FormatInt(EtcdSTSQuotaBackendSize, 10),
 			},
 		}
 		c.Ports = []corev1.ContainerPort{


### PR DESCRIPTION
As the ETCD mentioned in the documentation, the max size for this quota is 8G, above that they will raise a performance warning.

This limit will only prevent the ETCD to write over 8G in the PV, but the PV default size is not modified, because the PVC size could be raised directly.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**Which issue(s) this PR fixes**
Fixes #[HOSTEDCP-947](https://issues.redhat.com/browse/HOSTEDCP-947)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.