### PR TITLE
contrib: ci: increase HC quota in clusters namespace

### DIFF
--- a/contrib/ci/hypershift-ci-1.yaml
+++ b/contrib/ci/hypershift-ci-1.yaml
@@ -45,7 +45,7 @@ metadata:
   namespace: clusters
 spec:
   hard:
-    count/hostedclusters.hypershift.openshift.io: "20"
+    count/hostedclusters.hypershift.openshift.io: "30"
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
We are hitting HC quota in the root CI cluster.  This was originally set conservatively to avoid overload issues in the root cluster.  Time has shown it to be stable at this load and worker memory utilization is low at around 50% on 64Gi nodes.

Lets push it from 20 to 30.