### PR TITLE
OCPBUGS-11383: Sync proxy TrustedCA to guest cluster

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -60,6 +60,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/storage"
 	supportawsutil "github.com/openshift/hypershift/support/awsutil"
 	"github.com/openshift/hypershift/support/capabilities"
+	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/globalconfig"
@@ -1872,6 +1873,21 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		return fmt.Errorf("failed to reconcile ingress cert secret: %w", err)
 	}
 
+	var userCABundles []client.ObjectKey
+	if hcp.Spec.AdditionalTrustBundle != nil {
+		userCABundles = append(userCABundles, client.ObjectKey{Namespace: hcp.Namespace, Name: hcp.Spec.AdditionalTrustBundle.Name})
+	}
+	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.Proxy != nil && hcp.Spec.Configuration.Proxy.TrustedCA.Name != "" {
+		userCABundles = append(userCABundles, client.ObjectKey{Namespace: hcp.Namespace, Name: hcp.Spec.Configuration.Proxy.TrustedCA.Name})
+	}
+
+	trustedCABundle := manifests.TrustedCABundleConfigMap(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, trustedCABundle, func() error {
+		return r.reconcileManagedTrustedCABundle(ctx, trustedCABundle, userCABundles)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile managed UserCA configMap: %w", err)
+	}
+
 	// OAuth server Cert
 	oauthServerCert := manifests.OpenShiftOAuthServerCert(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, oauthServerCert, func() error {
@@ -1894,6 +1910,15 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 			bundleSources = append(bundleSources, certSecret)
 		}
 	}
+
+	if trustedCABundle.Data[certs.UserCABundleMapKey] != "" {
+		bundleSources = append(bundleSources, &corev1.Secret{
+			Data: map[string][]byte{
+				certs.CASignerCertMapKey: []byte(trustedCABundle.Data[certs.UserCABundleMapKey]),
+			},
+		})
+	}
+
 	oauthMasterCABundle := manifests.OpenShiftOAuthMasterCABundle(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, oauthMasterCABundle, func() error {
 		return pki.ReconcileOAuthMasterCABundle(oauthMasterCABundle, p.OwnerRef, bundleSources)
@@ -3131,12 +3156,9 @@ func (r *HostedControlPlaneReconciler) reconcileMachineConfigServerConfig(ctx co
 		return fmt.Errorf("failed to get pull secret: %w", err)
 	}
 
-	var userCA *corev1.ConfigMap
-	if hcp.Spec.AdditionalTrustBundle != nil {
-		userCA = manifests.UserCAConfigMap(hcp.Namespace)
-		if err := r.Get(ctx, client.ObjectKeyFromObject(userCA), userCA); err != nil {
-			return fmt.Errorf("failed to get user ca: %w", err)
-		}
+	trustedCABundle := manifests.TrustedCABundleConfigMap(hcp.Namespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(trustedCABundle), trustedCABundle); err != nil {
+		return fmt.Errorf("failed to get trustedCABundle: %w", err)
 	}
 
 	kubeletClientCA := manifests.KubeletClientCABundle(hcp.Namespace)
@@ -3144,7 +3166,7 @@ func (r *HostedControlPlaneReconciler) reconcileMachineConfigServerConfig(ctx co
 		return fmt.Errorf("failed to get root kubelet client CA: %w", err)
 	}
 
-	p := mcs.NewMCSParams(hcp, rootCA, pullSecret, userCA, kubeletClientCA)
+	p := mcs.NewMCSParams(hcp, rootCA, pullSecret, trustedCABundle, kubeletClientCA)
 
 	cm := manifests.MachineConfigServerConfig(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, cm, func() error {
@@ -3152,6 +3174,27 @@ func (r *HostedControlPlaneReconciler) reconcileMachineConfigServerConfig(ctx co
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile machine config server config: %w", err)
 	}
+	return nil
+}
+
+func (r *HostedControlPlaneReconciler) reconcileManagedTrustedCABundle(ctx context.Context, trustedCABundle *corev1.ConfigMap, caBundleConfigMaps []client.ObjectKey) error {
+	caBundles := make([]string, len(caBundleConfigMaps))
+	for _, key := range caBundleConfigMaps {
+		cm := &corev1.ConfigMap{}
+		if err := r.Get(ctx, key, cm); err != nil {
+			return fmt.Errorf("failed to get configMap %s: %w", key.Name, err)
+		}
+		data, hasData := cm.Data[certs.UserCABundleMapKey]
+		if !hasData {
+			return fmt.Errorf("configMap %s must have a %s key", cm.Name, certs.UserCABundleMapKey)
+		}
+
+		caBundles = append(caBundles, data)
+	}
+
+	trustedCABundle.Data = make(map[string]string)
+	trustedCABundle.Data[certs.UserCABundleMapKey] = strings.Join(caBundles, "")
+
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -83,6 +83,15 @@ func UserCAConfigMap(ns string) *corev1.ConfigMap {
 	}
 }
 
+func TrustedCABundleConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "trusted-ca-bundle-managed",
+			Namespace: ns,
+		},
+	}
+}
+
 func KonnectivityCAConfigMap(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/pki.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/pki.go
@@ -5,20 +5,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func RootCASecret(ns string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "root-ca",
-			Namespace: ns,
-		},
-	}
-}
-
-func ControlPlaneUserCABundle(ns string) *corev1.ConfigMap {
+func ProxyTrustedCAConfigMap(name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-ca-bundle",
-			Namespace: ns,
+			Name:      name,
+			Namespace: "openshift-config",
 		},
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -48,6 +48,7 @@ var initialObjects = []client.Object{
 	globalconfig.ImageConfig(),
 	globalconfig.ProjectConfig(),
 	globalconfig.BuildConfig(),
+	globalconfig.ProxyConfig(),
 	// Not running bcrypt hashing for the kubeadmin secret massively speeds up the tests, 4s vs 0.1s (and for -race its ~10x that)
 	&corev1.Secret{
 		ObjectMeta: manifests.KubeadminPasswordHashSecret().ObjectMeta,
@@ -207,7 +208,7 @@ func fakeKonnectivityAgentSecret() *corev1.Secret {
 }
 
 func fakeRootCASecret() *corev1.Secret {
-	s := manifests.RootCASecret("bar")
+	s := cpomanifests.RootCASecret("bar")
 	s.Data = map[string][]byte{
 		"ca.crt": []byte("12345"),
 		"ca.key": []byte("12345"),
@@ -355,13 +356,13 @@ func TestReconcileUserCertCABundle(t *testing.T) {
 				},
 				Spec: hyperv1.HostedControlPlaneSpec{
 					AdditionalTrustBundle: &corev1.LocalObjectReference{
-						Name: manifests.ControlPlaneUserCABundle(testNamespace).Name,
+						Name: cpomanifests.UserCAConfigMap(testNamespace).Name,
 					},
 				},
 			},
 			inputObjects: []client.Object{
 				&corev1.ConfigMap{
-					ObjectMeta: manifests.ControlPlaneUserCABundle(testNamespace).ObjectMeta,
+					ObjectMeta: cpomanifests.UserCAConfigMap(testNamespace).ObjectMeta,
 					Data: map[string]string{
 						"ca-bundle.crt": "acertxyz",
 					},

--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -41,6 +41,8 @@ const (
 	// TLSSignerKeyMapKey is the key the default k8s cert-manager looks for in a private key field in a TLS secret.
 	// TLSSignerKeyMapKey is programmatically enforced to have the same data as CASignerKeyMapKey.
 	TLSSignerKeyMapKey = "tls.key"
+	// UserCABundleMapKeyis the key value in a user-provided CA configMap.
+	UserCABundleMapKey = "ca-bundle.crt"
 )
 
 // CertCfg contains all needed fields to configure a new certificate


### PR DESCRIPTION
**What this PR does / why we need it**:
- Sync Proxy TrustedCA ConfigMap to guest cluster
- Add proxy TrustedCA to MachineConfigServer trusted bundle
- Append proxy TrustedCA to oauth master CA bundle

This PR is a split from https://github.com/openshift/hypershift/pull/2240, but without the e2e test which was failing due to an incorrect configuration of the test proxy server.
This should be followed up by a new PR with an e2e to validate proxy setup works with a TrustedCA once a solution is found.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-11383](https://issues.redhat.com/browse/OCPBUGS-11383)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.