### PR TITLE
HOSTEDCP-975: Add NodePool DeletionDuration and InitialRolloutDuration metrics

### DIFF
--- a/hypershift-operator/controllers/nodepool/inplace.go
+++ b/hypershift-operator/controllers/nodepool/inplace.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sutilspointer "k8s.io/utils/pointer"
@@ -148,6 +149,10 @@ func (r *NodePoolReconciler) reconcileMachineSet(ctx context.Context,
 
 	if machineSetInPlaceRolloutIsComplete(machineSet) {
 		if nodePool.Status.Version != targetVersion {
+			if nodePool.Status.Version == "" {
+				metrics.RecordNodePoolInitialRolloutDuration(nodePool)
+			}
+
 			log.Info("Version upgrade complete",
 				"previous", nodePool.Status.Version, "new", targetVersion)
 			nodePool.Status.Version = targetVersion

--- a/hypershift-operator/controllers/nodepool/metrics/metrics.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"time"
+
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -20,12 +22,26 @@ var (
 		Help: "Number of available replicas associated with a given NodePool",
 		Name: NodePoolAvailableReplicasMetricName,
 	}, labelNames)
+
+	NodePoolDeletionDurationMetricName = "hypershift_nodepools_deletion_duration_seconds"
+	nodePoolDeletionDuration           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Time in seconds it took for NodePool to be deleted",
+		Name: NodePoolDeletionDurationMetricName,
+	}, labelNames)
+
+	NodePoolInitialRolloutDurationMetricName = "hypershift_nodepools_initial_rollout_duration_seconds"
+	nodePoolInitialRolloutDuration           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Time in seconds it took from initial NodePool creation and rollout of initial version",
+		Name: NodePoolInitialRolloutDurationMetricName,
+	}, labelNames)
 )
 
 func init() {
 	metrics.Registry.MustRegister(
 		nodePoolSize,
 		nodePoolAvailableReplicas,
+		nodePoolDeletionDuration,
+		nodePoolInitialRolloutDuration,
 	)
 }
 
@@ -43,4 +59,14 @@ func RecordNodePoolSize(nodePool *hyperv1.NodePool, size float64) {
 
 func RecordNodePoolAvailableReplicas(nodePool *hyperv1.NodePool) {
 	nodePoolAvailableReplicas.WithLabelValues(labelValues(nodePool)...).Set(float64(nodePool.Status.Replicas))
+}
+
+func RecordNodePoolDeletionDuration(nodePool *hyperv1.NodePool) {
+	duration := time.Since(nodePool.DeletionTimestamp.Time).Seconds()
+	nodePoolDeletionDuration.WithLabelValues(labelValues(nodePool)...).Set(duration)
+}
+
+func RecordNodePoolInitialRolloutDuration(nodePool *hyperv1.NodePool) {
+	duration := time.Since(nodePool.CreationTimestamp.Time).Seconds()
+	nodePoolInitialRolloutDuration.WithLabelValues(labelValues(nodePool)...).Set(duration)
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -181,6 +181,8 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 		}
 
+		metrics.RecordNodePoolDeletionDuration(nodePool)
+
 		log.Info("Deleted nodepool", "name", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
@@ -1525,6 +1527,10 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 	// is at the expected version (spec.version) and config (userData Secret) so we reconcile status and annotation.
 	if MachineDeploymentComplete(machineDeployment) {
 		if nodePool.Status.Version != targetVersion {
+			if nodePool.Status.Version == "" {
+				metrics.RecordNodePoolInitialRolloutDuration(nodePool)
+			}
+
 			log.Info("Version update complete",
 				"previous", nodePool.Status.Version, "new", targetVersion)
 			nodePool.Status.Version = targetVersion

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -247,6 +247,8 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 				HypershiftOperatorInfoName,
 				nodepoolmetrics.NodePoolSizeMetricName,
 				nodepoolmetrics.NodePoolAvailableReplicasMetricName,
+				nodepoolmetrics.NodePoolDeletionDurationMetricName,
+				nodepoolmetrics.NodePoolInitialRolloutDurationMetricName,
 			} {
 				// Query fo HC specific metrics by hc.name.
 				query := fmt.Sprintf("%v{name=\"%s\"}", metricName, hc.Name)
@@ -254,8 +256,8 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 					// Query HO info metric
 					query = HypershiftOperatorInfoName
 				}
-				if metricName == nodepoolmetrics.NodePoolSizeMetricName || metricName == nodepoolmetrics.NodePoolAvailableReplicasMetricName {
-					// Mulham: `namespace`` label is used and overrwriten by prometheus relabeling configs.
+				if strings.HasPrefix(metricName, "hypershift_nodepools") {
+					// Mulham: `namespace` label is used and overrwriten by prometheus relabeling configs.
 					// Therfore, the `namespace` label we set in our metrics is renamed as `exported_namespace`
 					query = fmt.Sprintf("%v{exported_namespace=\"%s\"}", metricName, hc.Namespace)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `hypershift_nodepools_deletion_duration_seconds` and `hypershift_nodepools_initial_rollout_duration_seconds` metrics

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-975](https://issues.redhat.com/browse/HOSTEDCP-975)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.