### PR TITLE
Add a new e2e option for the ETCD storage class

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -100,6 +100,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSProcessors, "e2e.powervs-processors", "0.5", "Number of processors allocated. Default is 0.5")
 	flag.IntVar(&globalOpts.configurableClusterOptions.PowerVSMemory, "e2e.powervs-memory", 32, "Amount of memory allocated (in GB). Default is 32")
 	flag.BoolVar(&globalOpts.SkipAPIBudgetVerification, "e2e.skip-api-budget", false, "Bool to avoid send metrics to E2E Server on local test execution.")
+	flag.StringVar(&globalOpts.configurableClusterOptions.EtcdStorageClass, "e2e.etcd-storage-class", "", "The persistent volume storage class for etcd data volumes")
 
 	flag.Parse()
 
@@ -378,6 +379,7 @@ type configurableClusterOptions struct {
 	PowerVSProcType             hyperv1.PowerVSNodePoolProcType
 	PowerVSProcessors           string
 	PowerVSMemory               int
+	EtcdStorageClass            string
 }
 
 var nextAWSZoneIndex = 0
@@ -435,6 +437,7 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 			fmt.Sprintf("%s=true", hyperv1.CleanupCloudResourcesAnnotation),
 		},
 		SkipAPIBudgetVerification: o.SkipAPIBudgetVerification,
+		EtcdStorageClass:          o.configurableClusterOptions.EtcdStorageClass,
 	}
 	createOption.AWSPlatform.AdditionalTags = append(createOption.AWSPlatform.AdditionalTags, o.additionalTags...)
 	if len(o.configurableClusterOptions.Zone) == 0 {


### PR DESCRIPTION
Add the `e2e.etcd-storage-class` e2e CLI flag to get the storage class for ETCD, if needed. By default, this flag is empty.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.