### PR TITLE
CNV-24818: Add fsGroup support to kubevirt-csi-driver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/tenant_csidriver.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/tenant_csidriver.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.kubevirt.io
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+  fsGroupPolicy: ReadWriteOnceWithFSType

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/tenant_csidriver.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/tenant_csidriver.yaml
@@ -1,8 +1,0 @@
-apiVersion: storage.k8s.io/v1
-kind: CSIDriver
-metadata:
-  name: csi.kubevirt.io
-spec:
-  attachRequired: true
-  podInfoOnMount: true
-  fsGroupPolicy: ReadWriteOnceWithFSType

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -36,7 +36,6 @@ var (
 
 	tenantNodeClusterRole        = mustClusterRole("tenant_node_clusterrole.yaml")
 	tenantNodeClusterRoleBinding = mustClusterRoleBinding("tenant_node_clusterrolebinding.yaml")
-	tenantCSIDriver              = mustCSIDriver("tenant_csidriver.yaml")
 
 	daemonset = mustDaemonSet("daemonset.yaml")
 
@@ -100,16 +99,6 @@ func mustRole(file string) *rbacv1.Role {
 func mustRoleBinding(file string) *rbacv1.RoleBinding {
 	b := getContentsOrDie(file)
 	obj := &rbacv1.RoleBinding{}
-	if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(b), 500).Decode(&obj); err != nil {
-		panic(err)
-	}
-
-	return obj
-}
-
-func mustCSIDriver(file string) *storagev1.CSIDriver {
-	b := getContentsOrDie(file)
-	obj := &storagev1.CSIDriver{}
 	if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(b), 500).Decode(&obj); err != nil {
 		panic(err)
 	}
@@ -289,7 +278,10 @@ func reconcileDefaultTenantStorageClass(sc *storagev1.StorageClass) error {
 }
 
 func reconcileDefaultTenantCSIDriverResource(csiDriver *storagev1.CSIDriver) error {
-	csiDriver.Spec = *tenantCSIDriver.Spec.DeepCopy()
+	csiDriver.Spec.AttachRequired = utilpointer.Bool(true)
+	csiDriver.Spec.PodInfoOnMount = utilpointer.Bool(true)
+	fsPolicy := storagev1.ReadWriteOnceWithFSTypeFSGroupPolicy
+	csiDriver.Spec.FSGroupPolicy = &fsPolicy
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kubevirt.go
@@ -122,6 +122,14 @@ func KubevirtCSIDriverDefaultTenantStorageClass() *storagev1.StorageClass {
 	}
 }
 
+func KubevirtCSIDriverResource() *storagev1.CSIDriver {
+	return &storagev1.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "csi.kubevirt.io",
+		},
+	}
+}
+
 func KubevirtCSIDriverDaemonSet(ns string) *appsv1.DaemonSet {
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
Add FSGroup support to kubevirt-csi-driver deployment. Add CSI driver resource because it was missing in hypershift deployments.

Source of CSIDriver:
https://github.com/kubevirt/csi-driver/pull/87

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.