### PR TITLE
OCPBUGS-13034: Cluster-api SA can't create events

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2733,6 +2733,11 @@ func reconcileCAPIManagerClusterRole(role *rbacv1.ClusterRole) error {
 			Resources: []string{"customresourcedefinitions"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{"update", "create", "patch"},
+		},
 	}
 	return nil
 }
@@ -2785,6 +2790,11 @@ func reconcileCAPIManagerRole(role *rbacv1.Role) error {
 				"secrets",
 			},
 			Verbs: []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{"create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"coordination.k8s.io"},


### PR DESCRIPTION
**Which issue(s) this PR fixes**
Fixes #[OCPBUGS-13034](https://issues.redhat.com/browse/OCPBUGS-13034)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.