### PR TITLE
OCPBUGS-13113: Add ClusterUpgradeDuration metric

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -482,6 +482,9 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	// Set version status
 	hcluster.Status.Version = computeClusterVersionStatus(r.Clock, hcluster, hcp)
 
+	// compute ClusterUpgradeDuration and record metric if there were any upgrades
+	hcmetrics.ReportClusterUpgradeDuration(hcluster)
+
 	// Copy the CVO conditions from the HCP.
 	hcpCVOConditions := map[hyperv1.ConditionType]*metav1.Condition{
 		hyperv1.ClusterVersionSucceeding:      nil,

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -241,6 +241,7 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 				hcmetrics.GuestCloudResourcesDeletionDurationMetricName,
 				hcmetrics.AvailableDurationName,
 				hcmetrics.InitialRolloutDurationName,
+				hcmetrics.ClusterUpgradeDurationMetricName,
 				hcmetrics.ProxyName,
 				hcmetrics.SilenceAlertsName,
 				hcmetrics.LimitedSupportEnabledName,
@@ -258,6 +259,10 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 				}
 				if strings.HasPrefix(metricName, "hypershift_nodepools") {
 					query = fmt.Sprintf("%v{cluster_name=\"%s\"}", metricName, hc.Name)
+				}
+				// upgrade metric is only available for TestUpgradeControlPlane
+				if metricName == hcmetrics.ClusterUpgradeDurationMetricName && !strings.HasPrefix("TestUpgradeControlPlane", t.Name()) {
+					continue
 				}
 
 				result, err := RunQueryAtTime(ctx, NewLogr(t), prometheusClient, query, time.Now())


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-13113](https://issues.redhat.com/browse/OCPBUGS-13113)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.