### PR TITLE
OCPBUGS-13547: Pass release image version to MCO bootstrap via --payload-version

### DIFF
--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -296,6 +296,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 			fmt.Sprintf("--pull-secret=%s/pull-secret.yaml", configDir),
 			fmt.Sprintf("--dest-dir=%s", destDir),
 			fmt.Sprintf("--additional-trust-bundle-config-file=%s/user-ca-bundle-config.yaml", configDir),
+			fmt.Sprintf("--payload-version=%s", imageProvider.Version()),
 		}
 		if image, exists := imageProvider.ImageExist("mdns-publisher"); exists {
 			args = append(args, fmt.Sprintf("--mdns-publisher-image=%s", image))

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/docker/distribution/manifest/manifestlist"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
@@ -283,11 +284,15 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 			return fmt.Errorf("failed to write pull secret to config dir: %w", err)
 		}
 
+		payloadVersion, err := semver.Parse(imageProvider.Version())
+		if err != nil {
+			return fmt.Errorf("failed to parse payload version: %w", err)
+		}
+
+		// args contains the base args that have not changed over time.
 		args := []string{
 			"bootstrap",
-			fmt.Sprintf("--image-references=%s", path.Join(configDir, "release-manifests", "image-references")),
 			fmt.Sprintf("--root-ca=%s/root-ca.crt", configDir),
-			fmt.Sprintf("--kube-ca=%s/signer-ca.crt", configDir),
 			fmt.Sprintf("--infra-config-file=%s/cluster-infrastructure-02-config.yaml", configDir),
 			fmt.Sprintf("--network-config-file=%s/cluster-network-02-config.yaml", configDir),
 			fmt.Sprintf("--proxy-config-file=%s/cluster-proxy-01-config.yaml", configDir),
@@ -296,8 +301,37 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 			fmt.Sprintf("--pull-secret=%s/pull-secret.yaml", configDir),
 			fmt.Sprintf("--dest-dir=%s", destDir),
 			fmt.Sprintf("--additional-trust-bundle-config-file=%s/user-ca-bundle-config.yaml", configDir),
-			fmt.Sprintf("--payload-version=%s", imageProvider.Version()),
 		}
+
+		// Depending on the version, we need different args.
+		switch y := payloadVersion.Minor; {
+		case y >= 14:
+			args = append(args,
+				fmt.Sprintf("--payload-version=%s", imageProvider.Version()),
+			)
+			// We need to include 4.13 plus args here too.
+			fallthrough
+		case y >= 13:
+			args = append(args,
+				fmt.Sprintf("--image-references=%s", path.Join(configDir, "release-manifests", "image-references")),
+				fmt.Sprintf("--kube-ca=%s/signer-ca.crt", configDir),
+			)
+		case y <= 12:
+			// when the CPO is at N and the NodePool.spec.release at N-1
+			// we fail to render ignition payload because https://github.com/openshift/machine-config-operator/pull/3286
+			// broke backward compatibility.
+			args = append(args,
+				fmt.Sprintf("--machine-config-operator-image=%s", imageProvider.GetImage("machine-config-operator")),
+				fmt.Sprintf("--machine-config-oscontent-image=%s", imageProvider.GetImage("machine-os-content")),
+				fmt.Sprintf("--infra-image=%s", imageProvider.GetImage("pod")),
+				fmt.Sprintf("--keepalived-image=%s", imageProvider.GetImage("keepalived-ipfailover")),
+				fmt.Sprintf("--coredns-image=%s", imageProvider.GetImage("codedns")),
+				fmt.Sprintf("--haproxy-image=%s", imageProvider.GetImage("haproxy")),
+				fmt.Sprintf("--baremetal-runtimecfg-image=%s", imageProvider.GetImage("baremetal-runtimecfg")),
+				fmt.Sprintf("--kube-ca=%s/root-ca.crt", configDir),
+			)
+		}
+
 		if image, exists := imageProvider.ImageExist("mdns-publisher"); exists {
 			args = append(args, fmt.Sprintf("--mdns-publisher-image=%s", image))
 		}
@@ -313,48 +347,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 		out, err := cmd.CombinedOutput()
 		log.Info("machine-config-operator process completed", "time", time.Since(start).Round(time.Second).String(), "output", string(out))
 		if err != nil {
-			// when the CPO is at N and the NodePool.spec.release at N-1
-			// we fail to render ignition payload because https://github.com/openshift/machine-config-operator/pull/3286
-			// broke backward compatibility.
-			// We fall back to MCO previously supported flags.
-			args := []string{
-				"bootstrap",
-				fmt.Sprintf("--machine-config-operator-image=%s", imageProvider.GetImage("machine-config-operator")),
-				fmt.Sprintf("--machine-config-oscontent-image=%s", imageProvider.GetImage("machine-os-content")),
-				fmt.Sprintf("--infra-image=%s", imageProvider.GetImage("pod")),
-				fmt.Sprintf("--keepalived-image=%s", imageProvider.GetImage("keepalived-ipfailover")),
-				fmt.Sprintf("--coredns-image=%s", imageProvider.GetImage("codedns")),
-				fmt.Sprintf("--haproxy-image=%s", imageProvider.GetImage("haproxy")),
-				fmt.Sprintf("--baremetal-runtimecfg-image=%s", imageProvider.GetImage("baremetal-runtimecfg")),
-				fmt.Sprintf("--root-ca=%s/root-ca.crt", configDir),
-				fmt.Sprintf("--kube-ca=%s/root-ca.crt", configDir),
-				fmt.Sprintf("--infra-config-file=%s/cluster-infrastructure-02-config.yaml", configDir),
-				fmt.Sprintf("--network-config-file=%s/cluster-network-02-config.yaml", configDir),
-				fmt.Sprintf("--proxy-config-file=%s/cluster-proxy-01-config.yaml", configDir),
-				fmt.Sprintf("--config-file=%s/install-config.yaml", configDir),
-				fmt.Sprintf("--dns-config-file=%s/cluster-dns-02-config.yaml", configDir),
-				fmt.Sprintf("--pull-secret=%s/pull-secret.yaml", configDir),
-				fmt.Sprintf("--dest-dir=%s", destDir),
-				fmt.Sprintf("--additional-trust-bundle-config-file=%s/user-ca-bundle-config.yaml", configDir),
-			}
-
-			if image, exists := imageProvider.ImageExist("mdns-publisher"); exists {
-				args = append(args, fmt.Sprintf("--mdns-publisher-image=%s", image))
-			}
-			if mcsConfig.Data["user-ca-bundle-config.yaml"] != "" {
-				args = append(args, fmt.Sprintf("--additional-trust-bundle-config-file=%s/user-ca-bundle-config.yaml", configDir))
-			}
-			if p.CloudProvider == hyperv1.AzurePlatform {
-				args = append(args, fmt.Sprintf("--cloud-config-file=%s/cloud.conf.configmap.yaml", mcoBaseDir))
-			}
-
-			start = time.Now()
-			cmd = exec.CommandContext(ctx, filepath.Join(binDir, "machine-config-operator"), args...)
-			out, err = cmd.CombinedOutput()
-			log.Info("machine-config-operator process completed", "time", time.Since(start).Round(time.Second).String(), "output", string(out))
-			if err != nil {
-				return fmt.Errorf("machine-config-operator process failed: %w", err)
-			}
+			return fmt.Errorf("machine-config-operator process failed: %w", err)
 		}
 
 		// set missing images condition on the HCP

--- a/ignition-server/controllers/machineconfigserver_ignitionprovider.go
+++ b/ignition-server/controllers/machineconfigserver_ignitionprovider.go
@@ -213,7 +213,8 @@ machine-config-operator bootstrap \
 {{ if .isAzure -}}
 --cloud-config-file=/tmp/cloud.conf.configmap.yaml \
 {{ end -}}
---pull-secret=/assets/manifests/pull-secret.yaml
+--pull-secret=/assets/manifests/pull-secret.yaml \
+--payload-version={{ .payloadVersion }}
 # Use our own version of configpools that swap master and workers
 mv /mcc-manifests/bootstrap/manifests /mcc-manifests/bootstrap/manifests.tmp
 mkdir /mcc-manifests/bootstrap/manifests
@@ -234,6 +235,7 @@ func machineConfigServerPod(namespace string, releaseImage *releaseinfo.ReleaseI
 		"haproxyImage":             images["haproxy-router"],
 		"baremetalRuntimeCfgImage": images["baremetal-runtimecfg"],
 		"isAzure":                  provider == hyperv1.AzurePlatform,
+		"payloadVersion":           releaseImage.Version(),
 	}
 	bootstrapScriptBytes := &bytes.Buffer{}
 	if err := mcoBootstrapScriptTemplate.Execute(bootstrapScriptBytes, scriptArgs); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

MCO recently introduced a new flag `--payload-version` that expects to take the payload release version as a value. This is currently inert but will be required once openshift/machine-config-operator#3688 is merged.
This was added to the installer in openshift/installer#7160.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.