### PR TITLE
fix nil deref in DefaultWorkerSecurityGroupID check

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -510,7 +510,7 @@ func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointService(ctx context.C
 				subnetIDs = append(subnetIDs, &awsEndpointService.Spec.SubnetIDs[i])
 			}
 
-			if hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID == "" {
+			if hcp.Status.Platform == nil || hcp.Status.Platform.AWS == nil || hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID == "" {
 				return fmt.Errorf("DefaultWorkerSecurityGroupID doesn't exist yet for the endpoint to use")
 			}
 			output, err := ec2Client.CreateVpcEndpointWithContext(ctx, &ec2.CreateVpcEndpointInput{


### PR DESCRIPTION
Seen in 4.14
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn/1658789482020737024/artifacts/e2e-aws-ovn/run-e2e/artifacts/TestCreateClusterCustomConfig_PreTeardownClusterDump/namespaces/e2e-clusters-vlb54-example-zcndx/core/pods/logs/control-plane-operator-7cbb5b4964-mnfzz-control-plane-operator-previous.log

Seen in 4.13
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn/1658804612850782208/artifacts/e2e-aws-ovn/run-e2e/artifacts/TestCreateCluster_PreTeardownClusterDump/namespaces/e2e-clusters-j9wqg-example-frpkt/core/pods/logs/control-plane-operator-8596978568-6v4sp-control-plane-operator-previous.log

Introduced by https://github.com/openshift/hypershift/pull/2475

Needs backport to 4.13 https://github.com/openshift/hypershift/pull/2529
Hold on 4.12 https://github.com/openshift/hypershift/pull/2559