### PR TITLE
Updated secret permissions for openshift-route-controller-manager

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
@@ -131,6 +131,7 @@ func routeOCMVolumeKubeconfig() *corev1.Volume {
 func buildRouteOCMVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.KASServiceKubeconfigSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32(0640)
 }
 
 func routeOCMVolumeServingCert() *corev1.Volume {
@@ -142,4 +143,5 @@ func routeOCMVolumeServingCert() *corev1.Volume {
 func buildRouteOCMVolumeServingCert(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{}
 	v.Secret.SecretName = manifests.OpenShiftRouteControllerManagerCertSecret("").Name
+	v.Secret.DefaultMode = pointer.Int32(0640)
 }


### PR DESCRIPTION
What this PR does / why we need it:
Updated some more secret permissions to 416 specifically those mounted by
openshift-route-controller-manager

Which issue(s) this PR fixes (optional, use fixes #<issue_number>(, fixes #<issue_number>, ...) format, where issue_number might be a GitHub issue, or a Jira story:
Fixes #1031

**Checklist**
- [x ] Subject and description added to both, commit and PR.
- [x ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.