### PR TITLE
Use newly introduced KubeVirt Platform rhcos Image

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -85,7 +85,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 
 			g.Expect(PlatformValidation(tc.nodePool)).To(Succeed())
 
-			bootImage := newCachedQCOWBootImage(bootImageName, imageHash, hostedClusterNamespace)
+			bootImage := newCachedContainerBootImage(bootImageName, imageHash, hostedClusterNamespace)
 			bootImage.dvName = bootImageNamePrefix + "12345"
 			result := MachineTemplateSpec(tc.nodePool, bootImage, tc.hcluster)
 			g.Expect(result).To(Equal(tc.expected), "Comparison failed\n%v", cmp.Diff(tc.expected, result))
@@ -117,7 +117,7 @@ func TestCacheImage(t *testing.T) {
 		name              string
 		nodePool          *hyperv1.NodePool
 		existingResources []client.Object
-		asserFunc         func(Gomega, []v1beta1.DataVolume, string, *cachedQCOWImage)
+		asserFunc         func(Gomega, []v1beta1.DataVolume, string, *cachedContainerBootImage)
 		errExpected       bool
 		dvNamePrefix      string
 	}{
@@ -196,7 +196,7 @@ func TestCacheImage(t *testing.T) {
 				},
 			},
 			dvNamePrefix: bootImageNamePrefix,
-			asserFunc: func(g Gomega, dvs []v1beta1.DataVolume, expectedDVNamePrefix string, bootImage *cachedQCOWImage) {
+			asserFunc: func(g Gomega, dvs []v1beta1.DataVolume, expectedDVNamePrefix string, bootImage *cachedContainerBootImage) {
 				g.ExpectWithOffset(1, dvs).Should(HaveLen(2), "should not clear the other DV")
 				for _, dv := range dvs {
 					if dv.Name != bootImageNamePrefix+"another-one" {
@@ -217,7 +217,7 @@ func TestCacheImage(t *testing.T) {
 			_ = v1beta1.AddToScheme(scheme)
 			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.existingResources...).Build()
 
-			bootImage := newCachedQCOWBootImage(bootImageName, imageHash, hostedClusterNamespace)
+			bootImage := newCachedContainerBootImage(bootImageName, imageHash, hostedClusterNamespace)
 			err := bootImage.CacheImage(ctx, cl, tc.nodePool, infraId)
 
 			if tc.errExpected != (err != nil) {
@@ -235,7 +235,7 @@ func TestCacheImage(t *testing.T) {
 	}
 }
 
-func assertDV(g Gomega, dvs []v1beta1.DataVolume, expectedDVNamePrefix string, bootImage *cachedQCOWImage) {
+func assertDV(g Gomega, dvs []v1beta1.DataVolume, expectedDVNamePrefix string, bootImage *cachedContainerBootImage) {
 	g.ExpectWithOffset(1, dvs).Should(HaveLen(1), "failed to read the DataVolume back; No matched DataVolume")
 	g.ExpectWithOffset(1, dvs[0].Name).Should(HavePrefix(expectedDVNamePrefix))
 	g.ExpectWithOffset(1, bootImage.dvName).Should(Equal(dvs[0].Name), "failed to set the dvName filed in the cacheImage object")

--- a/support/releaseinfo/fixtures/4.10-installer-coreos-bootimages.yaml
+++ b/support/releaseinfo/fixtures/4.10-installer-coreos-bootimages.yaml
@@ -607,6 +607,11 @@ data:
               "release": "410.84.202111111322-0",
               "project": "rhcos-cloud",
               "name": "rhcos-410-84-202111111322-0-gcp-x86-64"
+            },
+            "kubevirt": {
+              "release": "414.92.202305090606-0",
+              "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.14-9.2-kubevirt",
+              "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5ba2d624b78fff140a255baa17c5713b07316a1c809f922717ed014128d6ac85"
             }
           },
           "rhel-coreos-extensions": {

--- a/support/releaseinfo/releaseinfo.go
+++ b/support/releaseinfo/releaseinfo.go
@@ -56,8 +56,9 @@ type CoreOSFormat struct {
 }
 
 type CoreOSImages struct {
-	AWS     CoreOSAWSImages     `json:"aws"`
-	PowerVS CoreOSPowerVSImages `json:"powervs"`
+	AWS      CoreOSAWSImages      `json:"aws"`
+	PowerVS  CoreOSPowerVSImages  `json:"powervs"`
+	Kubevirt CoreOSKubevirtImages `json:"kubevirt"`
 }
 
 type CoreOSAWSImages struct {
@@ -67,6 +68,12 @@ type CoreOSAWSImages struct {
 type CoreOSAWSImage struct {
 	Release string `json:"release"`
 	Image   string `json:"image"`
+}
+
+type CoreOSKubevirtImages struct {
+	Release   string `json:"release"`
+	Image     string `json:"image"`
+	DigestRef string `json:"digest-ref"`
 }
 
 type CoreOSPowerVSImages struct {

--- a/support/releaseinfo/releaseinfo_test.go
+++ b/support/releaseinfo/releaseinfo_test.go
@@ -25,3 +25,18 @@ func TestReleaseInfoPowerVS(t *testing.T) {
 		}
 	}
 }
+
+// TestReleaseInfoKubeVirt tests validates the presence of the kubevirt images
+func TestReleaseInfoKubeVirt(t *testing.T) {
+	metadata, err := DeserializeImageMetadata(fixtures.CoreOSBootImagesYAML_4_10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	arch, ok := metadata.Architectures["x86_64"]
+	if !ok {
+		t.Fatal("metadata does not contain the x86_64 architecture")
+	}
+	if arch.Images.Kubevirt.DigestRef == "" {
+		t.Fatal("metadata does not contain a digest ref for kubevirt")
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -396,7 +396,6 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		ControlPlaneOperatorImage:        o.configurableClusterOptions.ControlPlaneOperatorImage,
 		ExternalDNSDomain:                o.configurableClusterOptions.ExternalDNSDomain,
 		NodeUpgradeType:                  hyperv1.UpgradeTypeReplace,
-		Arch:                             "amd64",
 		AWSPlatform: core.AWSPlatformOptions{
 			RootVolumeSize:     64,
 			RootVolumeType:     "gp3",
@@ -439,6 +438,12 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		SkipAPIBudgetVerification: o.SkipAPIBudgetVerification,
 		EtcdStorageClass:          o.configurableClusterOptions.EtcdStorageClass,
 	}
+
+	// Arch is only currently valid for aws platform
+	if o.Platform == hyperv1.AWSPlatform {
+		createOption.Arch = "amd64"
+	}
+
 	createOption.AWSPlatform.AdditionalTags = append(createOption.AWSPlatform.AdditionalTags, o.additionalTags...)
 	if len(o.configurableClusterOptions.Zone) == 0 {
 		// align with default for e2e.aws-region flag

--- a/test/e2e/nodepool_kv_cache_image_test.go
+++ b/test/e2e/nodepool_kv_cache_image_test.go
@@ -5,13 +5,14 @@ package e2e
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
-	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -90,7 +91,7 @@ func (k KubeVirtCacheTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePoo
 		}
 	}
 
-	nodePool.Spec.Replicas = pointer.Int32(2)
+	nodePool.Spec.Replicas = pointer.Int32(1)
 
 	return nodePool, nil
 }

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -52,10 +52,6 @@ func NewNodePoolMachineconfigRolloutTest(ctx context.Context, mgmtClient crclien
 }
 
 func (mc *NodePoolMachineconfigRolloutTest) Setup(t *testing.T) {
-	if globalOpts.Platform == hyperv1.KubevirtPlatform {
-		t.Skip("test can't run for the platform KubeVirt")
-	}
-
 	t.Log("Starting test NodePoolMachineconfigRolloutTest")
 }
 

--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -67,10 +67,6 @@ func NewNTOMachineConfigRolloutTest(ctx context.Context, mgmtClient crclient.Cli
 }
 
 func (mc *NTOMachineConfigRolloutTest) Setup(t *testing.T) {
-	if globalOpts.Platform == hyperv1.KubevirtPlatform {
-		t.Skip("test can't run for the platform KubeVirt")
-	}
-
 	t.Log("Starting test NTOMachineConfigRolloutTest")
 }
 

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -96,7 +96,16 @@ func NewNodePoolUpgradeTest(ctx context.Context, mgmtClient crclient.Client, hos
 	}
 }
 
-func (ru *NodePoolUpgradeTest) Setup(t *testing.T) {}
+func (ru *NodePoolUpgradeTest) Setup(t *testing.T) {
+
+	// TODO re-enable this for KubeVirt platform once the new KubeVirt rhcos
+	// image is available in a previous release. Right now we can't test updating
+	// because the KubeVirt rhcos variant is only in latest.
+	// Tracking this here, https://issues.redhat.com/browse/CNV-29003
+	if globalOpts.Platform == hyperv1.KubevirtPlatform {
+		t.Skip("test can't run for the platform KubeVirt")
+	}
+}
 
 func (ru *NodePoolUpgradeTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
 	nodePool := &hyperv1.NodePool{

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -221,6 +221,8 @@ func WaitForNReadyNodesByNodePool(t *testing.T, ctx context.Context, client crcl
 	// waitTimeout for nodes to become Ready
 	waitTimeout := 30 * time.Minute
 	switch platform {
+	case hyperv1.KubevirtPlatform:
+		waitTimeout = 45 * time.Minute
 	case hyperv1.PowerVSPlatform:
 		waitTimeout = 60 * time.Minute
 	}


### PR DESCRIPTION
This PR introduces the ability to use the new kubevirt platform rhcos image as detected from the release image. This entirely replaces the old usage of the openstack image. Moving forward, we will only allow guest clusters to be created with kubevirt platform when the guest cluster contains a reference to the kubevirt rhcos image (ocp >= 4.14)

I also re-enabled some of the nodepool tests which appear to be working when given a longer timeout period. 