### PR TITLE
HOSTEDCP-975: Add cluster_name label to nodepools metrics

### DIFF
--- a/hypershift-operator/controllers/nodepool/metrics/metrics.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	labelNames = []string{"namespace", "name", "platform"}
+	labelNames = []string{"namespace", "name", "cluster_name", "platform"}
 
 	NodePoolSizeMetricName = "hypershift_nodepools_size"
 	nodePoolSize           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -45,28 +45,29 @@ func init() {
 	)
 }
 
-func labelValues(nodePool *hyperv1.NodePool) []string {
-	return []string{
-		nodePool.Namespace,
-		nodePool.Name,
-		string(nodePool.Spec.Platform.Type),
+func labels(nodePool *hyperv1.NodePool) prometheus.Labels {
+	return prometheus.Labels{
+		"namespace":    nodePool.Namespace,
+		"name":         nodePool.Name,
+		"cluster_name": nodePool.Spec.ClusterName,
+		"platform":     string(nodePool.Spec.Platform.Type),
 	}
 }
 
 func RecordNodePoolSize(nodePool *hyperv1.NodePool, size float64) {
-	nodePoolSize.WithLabelValues(labelValues(nodePool)...).Set(size)
+	nodePoolSize.With(labels(nodePool)).Set(size)
 }
 
 func RecordNodePoolAvailableReplicas(nodePool *hyperv1.NodePool) {
-	nodePoolAvailableReplicas.WithLabelValues(labelValues(nodePool)...).Set(float64(nodePool.Status.Replicas))
+	nodePoolAvailableReplicas.With(labels(nodePool)).Set(float64(nodePool.Status.Replicas))
 }
 
 func RecordNodePoolDeletionDuration(nodePool *hyperv1.NodePool) {
 	duration := time.Since(nodePool.DeletionTimestamp.Time).Seconds()
-	nodePoolDeletionDuration.WithLabelValues(labelValues(nodePool)...).Set(duration)
+	nodePoolDeletionDuration.With(labels(nodePool)).Set(duration)
 }
 
 func RecordNodePoolInitialRolloutDuration(nodePool *hyperv1.NodePool) {
 	duration := time.Since(nodePool.CreationTimestamp.Time).Seconds()
-	nodePoolInitialRolloutDuration.WithLabelValues(labelValues(nodePool)...).Set(duration)
+	nodePoolInitialRolloutDuration.With(labels(nodePool)).Set(duration)
 }

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -257,9 +257,7 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 					query = HypershiftOperatorInfoName
 				}
 				if strings.HasPrefix(metricName, "hypershift_nodepools") {
-					// Mulham: `namespace` label is used and overrwriten by prometheus relabeling configs.
-					// Therfore, the `namespace` label we set in our metrics is renamed as `exported_namespace`
-					query = fmt.Sprintf("%v{exported_namespace=\"%s\"}", metricName, hc.Namespace)
+					query = fmt.Sprintf("%v{cluster_name=\"%s\"}", metricName, hc.Name)
 				}
 
 				result, err := RunQueryAtTime(ctx, NewLogr(t), prometheusClient, query, time.Now())


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a `cluster_name` label to all nodepools metrics, which is needed to map nodepools to their HostedCluster
context: https://redhat-internal.slack.com/archives/C01C8502FMM/p1684256556058189

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-975](https://issues.redhat.com/browse/HOSTEDCP-975)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.