### PR TITLE
CNV-27353: Add port 80 to the default ingress

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
@@ -1,14 +1,16 @@
 package ingress
 
 import (
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"testing"
 
 	. "github.com/onsi/gomega"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 )
 
 func TestReconcileDefaultIngressController(t *testing.T) {
@@ -227,6 +229,166 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 			err := ReconcileDefaultIngressController(tc.inputIngressController, tc.inputIngressDomain, tc.inputPlatformType, tc.inputReplicas, tc.inputIsIBMCloudUPI, tc.inputIsPrivate)
 			g.Expect(err).To(BeNil())
 			g.Expect(tc.inputIngressController).To(BeEquivalentTo(tc.expectedIngressController))
+		})
+	}
+}
+
+func TestReconcileDefaultIngressPassthroughService(t *testing.T) {
+	const (
+		infraId        = "12345678"
+		nodePort       = 8080
+		secureNodePort = 6443
+	)
+
+	hcp := &hyperv1.HostedControlPlane{
+		Spec: hyperv1.HostedControlPlaneSpec{
+			InfraID: infraId,
+		},
+	}
+
+	for _, tc := range []struct {
+		name          string
+		defSvc        func() *corev1.Service
+		shouldSucceed bool
+	}{
+		{
+			name: "valid use case",
+			defSvc: func() *corev1.Service {
+				defSvs := manifests.IngressDefaultIngressNodePortService()
+				defSvs.Spec.Ports = []corev1.ServicePort{
+					{
+						Port:     443,
+						NodePort: secureNodePort,
+					},
+					{
+						Port:     80,
+						NodePort: nodePort,
+					},
+				}
+				return defSvs
+			},
+			shouldSucceed: true,
+		},
+		{
+			name: "valid use case with additional ports",
+			defSvc: func() *corev1.Service {
+				defSvs := manifests.IngressDefaultIngressNodePortService()
+				defSvs.Spec.Ports = []corev1.ServicePort{
+					{
+						Port:     22,
+						NodePort: 2222,
+					},
+					{
+						Port:     443,
+						NodePort: secureNodePort,
+					},
+					{
+						Port:     80,
+						NodePort: nodePort,
+					},
+					{
+						Port:     9999,
+						NodePort: 9999,
+					},
+				}
+				return defSvs
+			},
+			shouldSucceed: true,
+		},
+		{
+			name: "error: missing secure node port",
+			defSvc: func() *corev1.Service {
+				defSvs := manifests.IngressDefaultIngressNodePortService()
+				defSvs.Spec.Ports = []corev1.ServicePort{
+					{
+						Port: 443,
+					},
+					{
+						Port:     80,
+						NodePort: nodePort,
+					},
+				}
+				return defSvs
+			},
+			shouldSucceed: false,
+		},
+		{
+			name: "error: missing node port",
+			defSvc: func() *corev1.Service {
+				defSvs := manifests.IngressDefaultIngressNodePortService()
+				defSvs.Spec.Ports = []corev1.ServicePort{
+					{
+						Port:     443,
+						NodePort: secureNodePort,
+					},
+					{
+						Port: 80,
+					},
+				}
+				return defSvs
+			},
+			shouldSucceed: false,
+		},
+		{
+			name: "error: missing secure port",
+			defSvc: func() *corev1.Service {
+				defSvs := manifests.IngressDefaultIngressNodePortService()
+				defSvs.Spec.Ports = []corev1.ServicePort{
+					{
+						Port:     80,
+						NodePort: nodePort,
+					},
+				}
+				return defSvs
+			},
+			shouldSucceed: false,
+		},
+		{
+			name: "error: missing port",
+			defSvc: func() *corev1.Service {
+				defSvs := manifests.IngressDefaultIngressNodePortService()
+				defSvs.Spec.Ports = []corev1.ServicePort{
+					{
+						Port:     443,
+						NodePort: secureNodePort,
+					},
+				}
+				return defSvs
+			},
+			shouldSucceed: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			resSvc := &corev1.Service{}
+			err := ReconcileDefaultIngressPassthroughService(resSvc, tc.defSvc(), hcp)
+
+			if tc.shouldSucceed {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(resSvc.Spec.Selector).To(HaveKeyWithValue("kubevirt.io", "virt-launcher"))
+				g.Expect(resSvc.Spec.Selector).To(HaveKeyWithValue(hyperv1.InfraIDLabel, infraId))
+				g.Expect(resSvc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+				g.Expect(resSvc.Labels).To(HaveKeyWithValue(hyperv1.InfraIDLabel, infraId))
+				g.Expect(resSvc.Spec.Ports).To(HaveLen(2))
+				g.Expect(resSvc.Spec.Ports).To(ContainElements(
+					corev1.ServicePort{
+						Port:       80,
+						Name:       "http-80",
+						Protocol:   corev1.ProtocolTCP,
+						TargetPort: intstr.FromInt(nodePort),
+					},
+					corev1.ServicePort{
+						Port:       443,
+						Name:       "https-443",
+						Protocol:   corev1.ProtocolTCP,
+						TargetPort: intstr.FromInt(secureNodePort),
+					}),
+				)
+			} else {
+				g.Expect(err).To(HaveOccurred())
+			}
+
 		})
 	}
 }


### PR DESCRIPTION

## What this PR does / why we need it
The default ingress for hypershift kubevirt guest clusters does not forward port 80. This is due to the default ingress service and route only forwarding 443 traffic at the moment. The service needs to also forward port 80 to the guest cluster nodes.

## Which issue(s) this PR fixes
Address https://issues.redhat.com/browse/CNV-27353

### Checklist
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.