### PR TITLE
HOSTEDCP-979: Re-enable InPlace NodePool tests

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -270,7 +270,7 @@ func validateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 
 		for _, condition := range hostedCluster.Status.Conditions {
 			if condition.Type == string(hyperv1.ClusterVersionUpgradeable) {
-				// ClusterVersionUpgradeable condition status is not always guranteed to be true, skip.
+				// ClusterVersionUpgradeable condition status is not always guaranteed to be true, skip.
 				t.Logf("observed condition %s status [%s]", condition.Type, condition.Status)
 				continue
 			}
@@ -284,7 +284,7 @@ func validateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 				t.Logf("condition %s status [%s] doesn't match the expected status [%s]", condition.Type, condition.Status, expectedStatus)
 				return false, nil
 			}
-			t.Logf("observed condition %s status to match expected stauts [%s]", condition.Type, expectedStatus)
+			t.Logf("observed condition %s status to match expected status [%s]", condition.Type, expectedStatus)
 		}
 
 		return true, nil

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -222,7 +222,7 @@ func validateNodePoolConditions(t *testing.T, ctx context.Context, client crclie
 	}
 
 	start := time.Now()
-	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 10*time.Minute, func(ctx context.Context) (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 20*time.Minute, func(ctx context.Context) (bool, error) {
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(nodePool), nodePool); err != nil {
 			t.Logf("Failed to get nodepool: %v", err)
 			return false, nil

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -81,26 +81,20 @@ func TestNodePool(t *testing.T) {
 			name: "TestNTOMachineConfigGetsRolledOut",
 			test: NewNTOMachineConfigRolloutTest(ctx, mgmtClient, hostedCluster, hostedClusterClient),
 		},
-		/*
-			// TODO: (csrwng) Re-enable when https://issues.redhat.com/browse/OCPBUGS-10218 is fixed
-			{
-				name:            "TestNTOMachineConfigAppliedInPlace",
-				test:            NewNTOMachineConfigRolloutTest(ctx, mgmtClient, hostedCluster, hostedClusterClient),
-				manifestBuilder: NewNTOMachineConfigInPlaceRolloutTestManifest(hostedCluster),
-			},
-		*/
+		{
+			name:            "TestNTOMachineConfigAppliedInPlace",
+			test:            NewNTOMachineConfigRolloutTest(ctx, mgmtClient, hostedCluster, hostedClusterClient),
+			manifestBuilder: NewNTOMachineConfigInPlaceRolloutTestManifest(hostedCluster),
+		},
 		{
 			name: "TestNodePoolReplaceUpgrade",
 			test: NewNodePoolUpgradeTest(ctx, mgmtClient, hostedCluster, hostedClusterClient, clusterOpts, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
 		},
-		// TODO: (jparrill) Re-enable when https://issues.redhat.com/browse/OCPBUGS-10218 is fixed
-		/*
-			{
-				name:            "TestNodePoolInPlaceUpgrade",
-				test:            NewNodePoolUpgradeTest(ctx, mgmtClient, hostedCluster, hostedClusterClient, clusterOpts, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
-				manifestBuilder: NewNodePoolInPlaceUpgradeTestManifest(hostedCluster, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
-			},
-		*/
+		{
+			name:            "TestNodePoolInPlaceUpgrade",
+			test:            NewNodePoolUpgradeTest(ctx, mgmtClient, hostedCluster, hostedClusterClient, clusterOpts, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
+			manifestBuilder: NewNodePoolInPlaceUpgradeTestManifest(hostedCluster, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
+		},
 		{
 			name: "KubeVirtCacheTest",
 			test: NewKubeVirtCacheTest(ctx, mgmtClient, hostedCluster),
@@ -244,7 +238,7 @@ func validateNodePoolConditions(t *testing.T, ctx context.Context, client crclie
 				t.Logf("condition %s status [%s] doesn't match the expected status [%s]", condition.Type, condition.Status, expectedStatus)
 				return false, nil
 			}
-			t.Logf("observed condition %s status to match expected stauts [%s]", condition.Type, expectedStatus)
+			t.Logf("observed condition %s status to match expected status [%s]", condition.Type, expectedStatus)
 		}
 
 		return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-enable NTOMachineConfigAppliedInPlace & NodePoolInPlaceUpgrade tests

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-979](https://issues.redhat.com/browse/HOSTEDCP-979)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- N/A This change includes docs. 
- N/A This change includes unit tests.