### PR TITLE
OCPBUGS-13168: Include default ingress CA in root CA bundle

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1689,9 +1689,17 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		return fmt.Errorf("failed to reconcile root CA: %w", err)
 	}
 
+	observedDefaultIngressCert := manifests.IngressObservedDefaultIngressCertCA(hcp.Namespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(observedDefaultIngressCert), observedDefaultIngressCert); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get observed default ingress cert: %w", err)
+		}
+		observedDefaultIngressCert = nil
+	}
+
 	rootCAConfigMap := manifests.RootCAConfigMap(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, rootCAConfigMap, func() error {
-		return pki.ReconcileRootCAConfigMap(rootCAConfigMap, p.OwnerRef, rootCASecret)
+		return pki.ReconcileRootCAConfigMap(rootCAConfigMap, p.OwnerRef, rootCASecret, observedDefaultIngressCert)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile root CA configmap: %w", err)
 	}
@@ -2418,13 +2426,13 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 		return fmt.Errorf("failed to fetch combined ca configmap: %w", err)
 	}
 
-	// TODO: the following is weird, it adds the rootCA to the service-ca configmap
-	//       why would anyone want that?
 	serviceServingCA := manifests.ServiceServingCA(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, serviceServingCA, func() error {
-		return kcm.ReconcileKCMServiceServingCA(serviceServingCA, rootCAConfigMap, p.OwnerRef)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile kcm serving ca: %w", err)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(serviceServingCA), serviceServingCA); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get service serving CA")
+		} else {
+			serviceServingCA = nil
+		}
 	}
 
 	recyclerConfig := manifests.RecyclerConfigMap(hcp.Namespace)
@@ -2470,7 +2478,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 
 	kcmDeployment := manifests.KCMDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, kcmDeployment, func() error {
-		return kcm.ReconcileDeployment(kcmDeployment, kcmConfig, serviceServingCA, p, util.APIPort(hcp))
+		return kcm.ReconcileDeployment(kcmDeployment, kcmConfig, rootCAConfigMap, serviceServingCA, p, util.APIPort(hcp))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile kcm deployment: %w", err)
 	}
@@ -2554,9 +2562,18 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftAPIServer(ctx context.C
 		r.Log.Info("reconciled openshift apiserver servicemonitor", "result", result)
 	}
 
+	serviceServingCA := manifests.ServiceServingCA(hcp.Namespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(serviceServingCA), serviceServingCA); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get service serving CA")
+		} else {
+			serviceServingCA = nil
+		}
+	}
+
 	deployment := manifests.OpenShiftAPIServerDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return oapi.ReconcileDeployment(deployment, p.AuditWebhookRef, p.OwnerRef, oapicfg, p.OpenShiftAPIServerDeploymentConfig, p.OpenShiftAPIServerImage, p.ProxyImage, p.EtcdURL, p.AvailabilityProberImage, util.APIPort(hcp))
+		return oapi.ReconcileDeployment(deployment, p.AuditWebhookRef, p.OwnerRef, oapicfg, serviceServingCA, p.OpenShiftAPIServerDeploymentConfig, p.OpenShiftAPIServerImage, p.ProxyImage, p.EtcdURL, p.AvailabilityProberImage, util.APIPort(hcp))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile openshift apiserver deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -25,6 +25,8 @@ import (
 const (
 	AWSCloudProviderCredsKey = "credentials"
 	configHashAnnotation     = "kube-controller-manager.hypershift.openshift.io/config-hash"
+	serviceCAHashAnnotation  = "kube-controller-manager.hypershift.openshift.io/service-ca-hash"
+	rootCAHashAnnotation     = "kube-controller-manager.hypershift.openshift.io/root-ca-hash"
 )
 
 var (
@@ -60,7 +62,7 @@ func kcmLabels() map[string]string {
 	}
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev1.ConfigMap, p *KubeControllerManagerParams, apiPort *int32) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceServingCA *corev1.ConfigMap, p *KubeControllerManagerParams, apiPort *int32) error {
 	// preserve existing resource requirements for main KCM container
 	mainContainer := util.FindContainer(kcmContainerMain().Name, deployment.Spec.Template.Spec.Containers)
 	if mainContainer != nil {
@@ -95,6 +97,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev
 		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{}
 	}
 	deployment.Spec.Template.ObjectMeta.Annotations[configHashAnnotation] = util.ComputeHash(configBytes)
+	deployment.Spec.Template.ObjectMeta.Annotations[rootCAHashAnnotation] = util.HashStruct(rootCA.Data)
 
 	deployment.Spec.Template.Spec = corev1.PodSpec{
 		AutomountServiceAccountToken: pointer.Bool(false),
@@ -114,8 +117,11 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, servingCA *corev
 		},
 	}
 	p.DeploymentConfig.ApplyTo(deployment)
-	if servingCA != nil {
-		applyServingCAVolume(&deployment.Spec.Template.Spec, servingCA)
+	if serviceServingCA != nil {
+		deployment.Spec.Template.ObjectMeta.Annotations[serviceCAHashAnnotation] = util.HashStruct(serviceServingCA.Data)
+		applyServingCAVolume(&deployment.Spec.Template.Spec, serviceServingCA)
+	} else {
+		deployment.Spec.Template.ObjectMeta.Annotations[serviceCAHashAnnotation] = ""
 	}
 	applyCloudConfigVolumeMount(&deployment.Spec.Template.Spec, p.CloudProviderConfig, p.CloudProvider)
 	util.ApplyCloudProviderCreds(&deployment.Spec.Template.Spec, p.CloudProvider, p.CloudProviderCreds, p.TokenMinterImage, kcmContainerMain().Name)
@@ -291,13 +297,8 @@ func (name serviceCAVolumeBuilder) buildKCMVolumeServiceServingCA(v *corev1.Volu
 func applyServingCAVolume(ps *corev1.PodSpec, cm *corev1.ConfigMap) {
 	builder := serviceCAVolumeBuilder(cm.Name)
 	ps.Volumes = append(ps.Volumes, util.BuildVolume(kcmVolumeServiceServingCA(), builder.buildKCMVolumeServiceServingCA))
-	var container *corev1.Container
-	for i, c := range ps.Containers {
-		if c.Name == kcmContainerMain().Name {
-			container = &ps.Containers[i]
-			break
-		}
-	}
+
+	container := util.FindContainer(kcmContainerMain().Name, ps.Containers)
 	if container == nil {
 		panic("did not find the main kcm container in pod spec")
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/ingress.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/ingress.go
@@ -125,3 +125,21 @@ func IngressDefaultIngressControllerCert() *corev1.Secret {
 		},
 	}
 }
+
+func IngressDefaultIngressCertCA() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-ingress-cert",
+			Namespace: "openshift-config-managed",
+		},
+	}
+}
+
+func IngressObservedDefaultIngressCertCA(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "observed-default-ingress-cert",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -85,8 +85,16 @@ func ReconcileEtcdMetricsSignerConfigMap(cm *corev1.ConfigMap, ownerRef config.O
 	return reconcileAggregateCA(cm, ownerRef, etcdMetricsSigner)
 }
 
-func ReconcileRootCAConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, rootCA *corev1.Secret) error {
-	return reconcileAggregateCA(cm, ownerRef, rootCA)
+func ReconcileRootCAConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, rootCA *corev1.Secret, observedDefaultIngressCert *corev1.ConfigMap) error {
+	sources := []*corev1.Secret{rootCA}
+	if observedDefaultIngressCert != nil {
+		sources = append(sources, &corev1.Secret{
+			Data: map[string][]byte{
+				certs.CASignerCertMapKey: []byte(observedDefaultIngressCert.Data[certs.CASignerCertMapKey]),
+			},
+		})
+	}
+	return reconcileAggregateCA(cm, ownerRef, sources...)
 }
 
 func ReconcileKonnectivityConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, konnectivityCA *corev1.Secret) error {

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -16,8 +16,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"k8s.io/client-go/rest"
 	"os"
+
+	"k8s.io/client-go/rest"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
@@ -257,6 +258,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		OAuthAddress:          o.OAuthAddress,
 		OAuthPort:             o.OAuthPort,
 		OperateOnReleaseImage: os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
+		EnableCIDebugOutput:   o.enableCIDebugOutput,
 	}
 	configmetrics.Register(mgr.GetCache())
 	return operatorConfig.Start(ctx)

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -66,6 +66,7 @@ type HostedClusterConfigOperatorConfig struct {
 	OAuthAddress                 string
 	OAuthPort                    int32
 	OperateOnReleaseImage        string
+	EnableCIDebugOutput          bool
 
 	kubeClient kubeclient.Interface
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleans up code of the CMCA controller in the HCCO. It watches configmaps that we are interested in in the guest cluster's
openshift-config-managed namespace and syncs them to target configmaps on the control plane side. The CMCA controller not longer updates deployments directly, rather the recocile function of each deployment updates the hash annotation for itself.

The 'router-ca' configmap no longer exists, so it was removed. Instead the 'default-ingress-cert' configmap is what is now synced.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-13168

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.