### PR TITLE
OCPBUGS-13034: Fixed revoking some permissions to CAPI Manager Clusterrole

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2733,11 +2733,6 @@ func reconcileCAPIManagerClusterRole(role *rbacv1.ClusterRole) error {
 			Resources: []string{"customresourcedefinitions"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"events"},
-			Verbs:     []string{"update", "create", "patch"},
-		},
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

I the previous [PR](https://github.com/openshift/hypershift/pull/2565) on this topic, I've added non necessary permissions, this PR fixes that.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-13034](https://issues.redhat.com/browse/OCPBUGS-13034)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
