### PR TITLE
HOSTEDCP-947: Set ETCD Storage Size as immutable field and equalised the default size among both api versions

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1585,7 +1585,9 @@ type PersistentVolumeEtcdStorageSpec struct {
 	// Size is the minimum size of the data volume for each etcd member.
 	//
 	// +optional
-	// +kubebuilder:default="4Gi"
+	// +kubebuilder:default="8Gi"
+	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Etcd PV storage size is immutable"
 	Size *resource.Quantity `json:"size,omitempty"`
 }
 

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1563,6 +1563,8 @@ type PersistentVolumeEtcdStorageSpec struct {
 	//
 	// +optional
 	// +kubebuilder:default="8Gi"
+	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Etcd PV storage size is immutable"
 	Size *resource.Quantity `json:"size,omitempty"`
 }
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -1990,11 +1990,14 @@ spec:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                default: 4Gi
+                                default: 8Gi
                                 description: Size is the minimum size of the data
                                   volume for each etcd member.
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
                               storageClassName:
                                 description: "StorageClassName is the StorageClass
                                   of the data volume for each etcd member. \n See
@@ -5708,6 +5711,9 @@ spec:
                                   volume for each etcd member.
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
                               storageClassName:
                                 description: "StorageClassName is the StorageClass
                                   of the data volume for each etcd member. \n See

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -1968,11 +1968,14 @@ spec:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                default: 4Gi
+                                default: 8Gi
                                 description: Size is the minimum size of the data
                                   volume for each etcd member.
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
                               storageClassName:
                                 description: "StorageClassName is the StorageClass
                                   of the data volume for each etcd member. \n See
@@ -5691,6 +5694,9 @@ spec:
                                   volume for each etcd member.
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
                               storageClassName:
                                 description: "StorageClassName is the StorageClass
                                   of the data volume for each etcd member. \n See

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -29241,11 +29241,14 @@ objects:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  default: 4Gi
+                                  default: 8Gi
                                   description: Size is the minimum size of the data
                                     volume for each etcd member.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                  x-kubernetes-validations:
+                                  - message: Etcd PV storage size is immutable
+                                    rule: self == oldSelf
                                 storageClassName:
                                   description: "StorageClassName is the StorageClass
                                     of the data volume for each etcd member. \n See
@@ -33031,6 +33034,9 @@ objects:
                                     volume for each etcd member.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                  x-kubernetes-validations:
+                                  - message: Etcd PV storage size is immutable
+                                    rule: self == oldSelf
                                 storageClassName:
                                   description: "StorageClassName is the StorageClass
                                     of the data volume for each etcd member. \n See
@@ -36789,11 +36795,14 @@ objects:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  default: 4Gi
+                                  default: 8Gi
                                   description: Size is the minimum size of the data
                                     volume for each etcd member.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                  x-kubernetes-validations:
+                                  - message: Etcd PV storage size is immutable
+                                    rule: self == oldSelf
                                 storageClassName:
                                   description: "StorageClassName is the StorageClass
                                     of the data volume for each etcd member. \n See
@@ -40585,6 +40594,9 @@ objects:
                                     volume for each etcd member.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                  x-kubernetes-validations:
+                                  - message: Etcd PV storage size is immutable
+                                    rule: self == oldSelf
                                 storageClassName:
                                   description: "StorageClassName is the StorageClass
                                     of the data volume for each etcd member. \n See


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up PR from https://github.com/openshift/hypershift/pull/2549. 

This PR contains 2 changes:

- Make immutable the Etcd storage size in alpha and beta APIs
- Equalised the default storage size on alpha API

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-947](https://issues.redhat.com/browse/HOSTEDCP-947)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.