### PR TITLE
Fix dump for Kubevirt

### DIFF
--- a/api/scheme.go
+++ b/api/scheme.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	kasv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -73,4 +74,5 @@ func init() {
 	snapshotv1.AddToScheme(Scheme)
 	imagev1.AddToScheme(Scheme)
 	cdiv1beta1.AddToScheme(Scheme)
+	kubevirtv1.AddToScheme(Scheme)
 }

--- a/support/api/scheme.go
+++ b/support/api/scheme.go
@@ -27,6 +27,7 @@ import (
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiibm "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta1"
@@ -81,4 +82,5 @@ func init() {
 	}
 	mcfgv1.AddToScheme(Scheme)
 	cdiv1beta1.AddToScheme(Scheme)
+	kubevirtv1.AddToScheme(Scheme)
 }


### PR DESCRIPTION
1. fixed wrong namespace
2. only request kubevirt resources if kubevirt is in use, to avoid error of resource type unknown.

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.