### PR TITLE
OCPBUGS-13970: Reconcile oauthDeployment annotations even if kubeadmin secret is not found

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1059,14 +1059,13 @@ func (r *reconciler) reconcileKubeadminPasswordHashSecret(ctx context.Context, h
 func (r *reconciler) deleteKubeadminPasswordHashSecret(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	kubeadminPasswordHashSecret := manifests.KubeadminPasswordHashSecret()
 	if err := r.client.Get(ctx, client.ObjectKeyFromObject(kubeadminPasswordHashSecret), kubeadminPasswordHashSecret); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
+		if !apierrors.IsNotFound(err) {
+			return err
 		}
-		return err
-	}
-
-	if err := r.client.Delete(ctx, kubeadminPasswordHashSecret); err != nil {
-		return err
+	} else {
+		if err := r.client.Delete(ctx, kubeadminPasswordHashSecret); err != nil {
+			return err
+		}
 	}
 
 	oauthDeployment := manifests.OAuthDeployment(hcp.Namespace)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -249,6 +249,14 @@ func fakePackageServerService() *corev1.Service {
 func TestReconcileKubeadminPasswordHashSecret(t *testing.T) {
 	testNamespace := "master-cluster1"
 	testHCPName := "cluster1"
+
+	annotatedOauthDeployment := &appsv1.Deployment{
+		ObjectMeta: manifests.OAuthDeployment(testNamespace).ObjectMeta,
+	}
+	annotatedOauthDeployment.Spec.Template.Annotations = map[string]string{
+		SecretHashAnnotation: "fake-hash",
+	}
+
 	tests := map[string]struct {
 		inputHCP                                 *hyperv1.HostedControlPlane
 		inputObjects                             []client.Object
@@ -289,6 +297,19 @@ func TestReconcileKubeadminPasswordHashSecret(t *testing.T) {
 				&appsv1.Deployment{
 					ObjectMeta: manifests.OAuthDeployment(testNamespace).ObjectMeta,
 				},
+			},
+			expectedOauthServerAnnotations:           nil,
+			expectKubeadminPasswordHashSecretToExist: false,
+		},
+		"when kubeadminPasswordSecret doesn't exist the oauth server SecretHashAnnotation annotation is deleted and the hash secret is not created": {
+			inputHCP: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testHCPName,
+					Namespace: testNamespace,
+				},
+			},
+			inputObjects: []client.Object{
+				annotatedOauthDeployment,
 			},
 			expectedOauthServerAnnotations:           nil,
 			expectKubeadminPasswordHashSecretToExist: false,


### PR DESCRIPTION
fixes the case where the kubeadmin secret deletion succeeded but removing the annotation from oauthDeployment failed, which will make it not possible to reconcile again because we are retuning early if the secret is not found.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.