### PR TITLE
Expose annotation to allow release image overrides

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -158,6 +158,11 @@ const (
 	// allows the creation of guest clusters <= 4.13, which are before the rhcos kubevirt
 	// variant was released.
 	AllowUnsupportedKubeVirtRHCOSVariantsAnnotation = "hypershift.openshift.io/allow-unsupported-kubevirt-rhcos-variants"
+
+	// ImageOverridesAnnotation is passed as a flag to the CPO to allow overriding release images.
+	// The format of the annotation value is a commma-separated list of image=ref pairs like:
+	// cluster-network-operator=example.com/cno:latest,ovn-kubernetes=example.com/ovnkube:latest
+	ImageOverridesAnnotation = "hypershift.openshift.io/image-overrides"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2114,6 +2114,11 @@ func reconcileControlPlaneOperatorDeployment(
 			"--token-minter-image", utilitiesImage,
 		)
 	}
+	if imageOverrides := hc.Annotations[hyperv1.ImageOverridesAnnotation]; imageOverrides != "" {
+		args = append(args,
+			"--image-overrides", imageOverrides,
+		)
+	}
 
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows creating a HostedCluster with alternate images for the different components included in the release.

**Checklist**
- [x] Subject and description added to both, commit and PR.