### PR TITLE
HOSTEDCP-967: Disable v1alpha1 and conversion webhook by default

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -150,14 +150,13 @@ func NewCommand() *cobra.Command {
 	var opts Options
 	opts.PrivatePlatform = string(hyperv1.NonePlatform)
 	opts.MetricsSet = metrics.DefaultMetricsSet
-	opts.EnableConversionWebhook = true // default to enabling the conversion webhook
 
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", "hypershift", "The namespace in which to install HyperShift")
 	cmd.PersistentFlags().StringVar(&opts.HyperShiftImage, "hypershift-image", version.HyperShiftImage, "The HyperShift image to deploy")
 	cmd.PersistentFlags().BoolVar(&opts.Development, "development", false, "Enable tweaks to facilitate local development")
 	cmd.PersistentFlags().BoolVar(&opts.EnableValidatingWebhook, "enable-validating-webhook", false, "Enable webhook for validating hypershift API types")
 	cmd.PersistentFlags().MarkDeprecated("enable-validating-webhook", "This field is deprecated and has no effect")
-	cmd.PersistentFlags().BoolVar(&opts.EnableConversionWebhook, "enable-conversion-webhook", true, "Enable webhook for converting hypershift API types")
+	cmd.PersistentFlags().BoolVar(&opts.EnableConversionWebhook, "enable-conversion-webhook", false, "Enable webhook for converting hypershift API types")
 	cmd.PersistentFlags().BoolVar(&opts.ExcludeEtcdManifests, "exclude-etcd", false, "Leave out etcd manifests")
 	cmd.PersistentFlags().Var(&opts.PlatformMonitoring, "platform-monitoring", "Select an option for enabling platform cluster monitoring. Valid values are: None, OperatorOnly, All")
 	cmd.PersistentFlags().BoolVar(&opts.EnableCIDebugOutput, "enable-ci-debug-output", opts.EnableCIDebugOutput, "If extra CI debug output should be enabled")
@@ -197,7 +196,7 @@ func NewCommand() *cobra.Command {
 			return err
 		}
 
-		err = apply(cmd.Context(), objects)
+		err = apply(cmd.Context(), opts, objects)
 		if err != nil {
 			return err
 		}
@@ -216,7 +215,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func apply(ctx context.Context, objects []crclient.Object) error {
+func apply(ctx context.Context, opts Options, objects []crclient.Object) error {
 	client, err := util.GetClient()
 	if err != nil {
 		return err
@@ -240,15 +239,59 @@ func apply(ctx context.Context, objects []crclient.Object) error {
 			} else {
 				fmt.Printf("created %s %s/%s\n", "PriorityClass", object.GetNamespace(), object.GetName())
 			}
-		} else {
-			if err := client.Patch(ctx, object, crclient.RawPatch(types.ApplyPatchType, objectBytes.Bytes()), crclient.ForceOwnership, crclient.FieldOwner("hypershift")); err != nil {
-				errs = append(errs, err)
-			}
-			fmt.Printf("applied %s %s/%s\n", object.GetObjectKind().GroupVersionKind().Kind, object.GetNamespace(), object.GetName())
+			continue
 		}
+
+		// if the CRD already installed and have converion webhook enabled, server-side apply will fail to remove spec.conversion.webhook.clientConfig field
+		// which is injected with the annotation service.beta.openshift.io/inject-cabundle, we need to maunally remove and patch it first.
+		if !opts.EnableConversionWebhook {
+			if err := patchHyperShiftCRDManagedFields(object, client, ctx); err != nil {
+				return err
+			}
+		}
+
+		if err := client.Patch(ctx, object, crclient.RawPatch(types.ApplyPatchType, objectBytes.Bytes()), crclient.ForceOwnership, crclient.FieldOwner("hypershift")); err != nil {
+			errs = append(errs, err)
+		}
+		fmt.Printf("applied %s %s/%s\n", object.GetObjectKind().GroupVersionKind().Kind, object.GetNamespace(), object.GetName())
 	}
 
 	return errors.NewAggregate(errs)
+}
+
+func patchHyperShiftCRDManagedFields(object crclient.Object, client crclient.Client, ctx context.Context) error {
+	if object.GetObjectKind().GroupVersionKind().Kind != "CustomResourceDefinition" || !strings.Contains(object.GetName(), "hypershift.openshift.io") {
+		return nil
+	}
+
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := client.Get(ctx, crclient.ObjectKeyFromObject(object), crd); err != nil {
+		// CRD is not installed, return
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if crd.Spec.Conversion != nil && crd.Spec.Conversion.Strategy == apiextensionsv1.WebhookConverter {
+		original := crd.DeepCopy()
+
+		// remove fields managed by `service-ca-operator` or `cainjector` (i.e. spec.conversion.webhook.clientConfig)
+		var managedFields []metav1.ManagedFieldsEntry
+		for _, field := range crd.ObjectMeta.ManagedFields {
+			if field.Manager == "service-ca-operator" || field.Manager == "cainjector" {
+				continue
+			}
+			managedFields = append(managedFields, field)
+		}
+
+		crd.ObjectMeta.ManagedFields = managedFields
+		if err := client.Patch(ctx, crd, crclient.MergeFrom(original)); err != nil {
+			return fmt.Errorf("failed to patch CRD %s: %v", crd.Name, err)
+		}
+	}
+
+	return nil
 }
 
 func waitUntilAvailable(ctx context.Context, opts Options) error {
@@ -587,6 +630,15 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	}, func(crd *apiextensionsv1.CustomResourceDefinition) {
 		if crd.Spec.Group == "hypershift.openshift.io" {
 			if !opts.EnableConversionWebhook {
+				var versions []apiextensionsv1.CustomResourceDefinitionVersion
+				for _, version := range crd.Spec.Versions {
+					// disable v1alpha1 version
+					if version.Name == "v1alpha1" {
+						version.Served = false
+					}
+					versions = append(versions, version)
+				}
+				crd.Spec.Versions = versions
 				return
 			}
 			if crd.Annotations != nil {

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -460,7 +460,6 @@ objects:
           - --enable-ocp-cluster-monitoring=false
           - --enable-ci-debug-output=false
           - --private-platform=AWS
-          - --cert-dir=/var/run/secrets/serving-cert
           - --oidc-storage-provider-s3-bucket-name=${OIDC_S3_NAME}
           - --oidc-storage-provider-s3-region=${OIDC_S3_REGION}
           - --oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/${OIDC_S3_CREDS_SECRET_KEY}
@@ -526,8 +525,6 @@ objects:
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
-          - mountPath: /var/run/secrets/serving-cert
-            name: serving-cert
           - mountPath: /etc/oidc-storage-provider-s3-creds
             name: oidc-storage-provider-s3-creds
           - mountPath: /etc/provider
@@ -537,9 +534,6 @@ objects:
         priorityClassName: hypershift-operator
         serviceAccountName: operator
         volumes:
-        - name: serving-cert
-          secret:
-            secretName: manager-serving-cert
         - name: oidc-storage-provider-s3-creds
           secret:
             secretName: ${OIDC_S3_CREDS_SECRET}
@@ -26837,23 +26831,10 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      service.beta.openshift.io/inject-cabundle: "true"
+      controller-gen.kubebuilder.io/version: v0.12.0
     creationTimestamp: null
     name: awsendpointservices.hypershift.openshift.io
   spec:
-    conversion:
-      strategy: Webhook
-      webhook:
-        clientConfig:
-          service:
-            name: operator
-            namespace: ${NAMESPACE}
-            path: /convert
-            port: 443
-        conversionReviewVersions:
-        - v1beta2
-        - v1beta1
-        - v1alpha1
     group: hypershift.openshift.io
     names:
       kind: AWSEndpointService
@@ -27024,7 +27005,7 @@ objects:
                   type: string
               type: object
           type: object
-      served: true
+      served: false
       storage: false
       subresources:
         status: {}
@@ -27201,23 +27182,10 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      service.beta.openshift.io/inject-cabundle: "true"
+      controller-gen.kubebuilder.io/version: v0.12.0
     creationTimestamp: null
     name: hostedclusters.hypershift.openshift.io
   spec:
-    conversion:
-      strategy: Webhook
-      webhook:
-        clientConfig:
-          service:
-            name: operator
-            namespace: ${NAMESPACE}
-            path: /convert
-            port: 443
-        conversionReviewVersions:
-        - v1beta2
-        - v1beta1
-        - v1alpha1
     group: hypershift.openshift.io
     names:
       kind: HostedCluster
@@ -31054,7 +31022,7 @@ objects:
                   type: object
               type: object
           type: object
-      served: true
+      served: false
       storage: false
       subresources:
         status: {}
@@ -34769,25 +34737,12 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      service.beta.openshift.io/inject-cabundle: "true"
+      controller-gen.kubebuilder.io/version: v0.12.0
     creationTimestamp: null
     labels:
       cluster.x-k8s.io/v1beta1: v1beta1
     name: hostedcontrolplanes.hypershift.openshift.io
   spec:
-    conversion:
-      strategy: Webhook
-      webhook:
-        clientConfig:
-          service:
-            name: operator
-            namespace: ${NAMESPACE}
-            path: /convert
-            port: 443
-        conversionReviewVersions:
-        - v1beta2
-        - v1beta1
-        - v1alpha1
     group: hypershift.openshift.io
     names:
       categories:
@@ -38650,7 +38605,7 @@ objects:
               - ready
               type: object
           type: object
-      served: true
+      served: false
       storage: false
       subresources:
         status: {}
@@ -42353,23 +42308,10 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      service.beta.openshift.io/inject-cabundle: "true"
+      controller-gen.kubebuilder.io/version: v0.12.0
     creationTimestamp: null
     name: nodepools.hypershift.openshift.io
   spec:
-    conversion:
-      strategy: Webhook
-      webhook:
-        clientConfig:
-          service:
-            name: operator
-            namespace: ${NAMESPACE}
-            path: /convert
-            port: 443
-        conversionReviewVersions:
-        - v1beta2
-        - v1beta1
-        - v1alpha1
     group: hypershift.openshift.io
     names:
       kind: NodePool
@@ -43266,7 +43208,7 @@ objects:
                   type: string
               type: object
           type: object
-      served: true
+      served: false
       storage: false
       subresources:
         scale:


### PR DESCRIPTION
**What this PR does / why we need it**:
Disables `v1alpha1` and the conversion webhook by default when installing hypershift.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-967](https://issues.redhat.com/browse/HOSTEDCP-967)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.