### PR TITLE
OCPBUGS-11882: CPO now annotates HCP pods with safe-to-evict CA annotation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
@@ -1,6 +1,9 @@
 package common
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +52,12 @@ func VolumeAggregatorCA() *corev1.Volume {
 		Name: "aggregator-ca",
 	}
 }
+
 func BuildVolumeAggregatorCA(v *corev1.Volume) {
 	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
 	v.ConfigMap.Name = manifests.AggregatorClientCAConfigMap("").Name
+}
+
+func EmptyDirVolumeAggregator(volumes ...string) string {
+	return fmt.Sprintf("\"%s\"", strings.Join(volumes[:], ","))
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/common/manifests_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/common/manifests_test.go
@@ -1,0 +1,45 @@
+package common
+
+import "testing"
+
+func TestEmptyDirVolumeAggregator(t *testing.T) {
+	type args struct {
+		volumes []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Sending an slice of strings, it should return string with the same content separated by comma",
+			args: args{
+				volumes: []string{
+					"test1",
+					"test2",
+					"test3",
+				},
+			},
+			want: `"test1,test2,test3"`,
+		},
+		{
+			name: "Sending a slice with one string, it should return a string with the same content wihout commas",
+			args: args{
+				volumes: []string{"test1"},
+			},
+			want: `"test1"`,
+		},
+		{
+			name: "Sending an empty string, it should return another empty string",
+			args: args{},
+			want: `""`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EmptyDirVolumeAggregator(tt.args.volumes...); got != tt.want {
+				t.Errorf("EmptyDirVolumeAggregator() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	cpotypes "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/types"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/proxy"
@@ -215,6 +216,18 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 			},
 		},
 	}
+
+	emptyDirVols := common.EmptyDirVolumeAggregator(
+		kasVolumeBootstrapManifests().Name,
+		kasVolumeWorkLogs().Name,
+		kasVolumeKMSSocket().Name,
+	)
+
+	if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+		deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	deployment.Spec.Template.ObjectMeta.Annotations[cpotypes.PodSafeToEvictLocalVolumesKey] = emptyDirVols
 
 	// With managed etcd, we should wait for the known etcd client service name to
 	// at least resolve before starting up to avoid futile connection attempts and

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -14,9 +14,11 @@ import (
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
+	cpotypes "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/types"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
@@ -116,6 +118,13 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceS
 			util.BuildVolume(kcmVolumeRecyclerConfig(), buildKCMVolumeRecyclerConfigMap),
 		},
 	}
+	emptyDirVols := common.EmptyDirVolumeAggregator(
+		kcmVolumeWorkLogs().Name,
+		kcmVolumeCertDir().Name,
+	)
+
+	deployment.Spec.Template.ObjectMeta.Annotations[cpotypes.PodSafeToEvictLocalVolumesKey] = emptyDirVols
+
 	p.DeploymentConfig.ApplyTo(deployment)
 	if serviceServingCA != nil {
 		deployment.Spec.Template.ObjectMeta.Annotations[serviceCAHashAnnotation] = util.HashStruct(serviceServingCA.Data)

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/konnectivity"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	cpotypes "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/types"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
@@ -166,6 +167,17 @@ func ReconcileDeployment(deployment *appsv1.Deployment, auditWebhookRef *corev1.
 			}),
 		},
 	}
+
+	emptyDirVols := common.EmptyDirVolumeAggregator(
+		oasTrustAnchorVolume().Name,
+		oasVolumeWorkLogs().Name,
+	)
+
+	if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+		deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	deployment.Spec.Template.ObjectMeta.Annotations[cpotypes.PodSafeToEvictLocalVolumesKey] = emptyDirVols
 
 	if serviceServingCA != nil {
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, util.BuildVolume(serviceCASignerVolume(), buildServiceCASignerVolume))

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
+	cpotypes "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/types"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
@@ -75,6 +76,15 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 		}
 	}
 	deployment.Spec.Template.ObjectMeta.Labels = openShiftOAuthAPIServerLabels()
+	emptyDirVols := common.EmptyDirVolumeAggregator(
+		oauthVolumeWorkLogs().Name,
+	)
+
+	if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+		deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	deployment.Spec.Template.ObjectMeta.Annotations[cpotypes.PodSafeToEvictLocalVolumesKey] = emptyDirVols
+
 	deployment.Spec.Template.Spec = corev1.PodSpec{
 		AutomountServiceAccountToken: pointer.Bool(false),
 		Containers: []corev1.Container{

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/packageserver-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: packageserver
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "tmpfs"
 spec:
   progressDeadlineSeconds: 600
   replicas: 2

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: '"client-token,web-identity-token"'
         hypershift.openshift.io/release-image: quay.io/ocp-dev/test-release-image:latest
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/types/types.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/types/types.go
@@ -1,0 +1,11 @@
+package types
+
+const (
+	// PodSafeToEvictKey is an annotation used by the CA operator which makes sure
+	// all the pods annotated with it, could be drained properly.
+	// source https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
+	PodSafeToEvictKey = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+	// PodSafeToEvictLocalVolumesKey is an annotation used by the CA operator which makes sure
+	// all the pods annotated with it and the picking the desired local volumes that are safe to evict, could be drained properly.
+	PodSafeToEvictLocalVolumesKey = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
+)

--- a/hypershift-operator/controllers/manifests/manifests.go
+++ b/hypershift-operator/controllers/manifests/manifests.go
@@ -2,9 +2,10 @@ package manifests
 
 import (
 	"fmt"
+	"strings"
+
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strings"
 
 	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -76,4 +77,8 @@ func ReconcileKubevirtInfraTempRoute(route *routev1.Route) error {
 		},
 	}
 	return nil
+}
+
+func EmptyDirVolumeAggregator(volumes ...string) string {
+	return fmt.Sprintf("\"%s\"", strings.Join(volumes[:], ","))
 }

--- a/hypershift-operator/controllers/manifests/manifests_test.go
+++ b/hypershift-operator/controllers/manifests/manifests_test.go
@@ -1,0 +1,45 @@
+package manifests
+
+import "testing"
+
+func TestEmptyDirVolumeAggregator(t *testing.T) {
+	type args struct {
+		volumes []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Sending an slice of strings, it should return string with the same content separated by comma",
+			args: args{
+				volumes: []string{
+					"test1",
+					"test2",
+					"test3",
+				},
+			},
+			want: `"test1,test2,test3"`,
+		},
+		{
+			name: "Sending a slice with one string, it should return a string with the same content wihout commas",
+			args: args{
+				volumes: []string{"test1"},
+			},
+			want: `"test1"`,
+		},
+		{
+			name: "Sending an empty string, it should return another empty string",
+			args: args{},
+			want: `""`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EmptyDirVolumeAggregator(tt.args.volumes...); got != tt.want {
+				t.Errorf("EmptyDirVolumeAggregator() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/powervs"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	nodepoolmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics"
 	"github.com/openshift/hypershift/test/e2e/util/dump"
 	corev1 "k8s.io/api/core/v1"
@@ -129,12 +130,16 @@ func CreateCluster(t *testing.T, ctx context.Context, client crclient.Client, op
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 	}
 
+	hcpNs := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name
+
 	// Everything went well, so register the async cleanup handler and allow tests
 	// to proceed.
 	t.Logf("Successfully created hostedcluster %s/%s in %s", hc.Namespace, hc.Name, time.Since(start).Round(time.Second))
 
 	t.Cleanup(func() { teardown(context.Background(), t, client, hc, opts, artifactDir) })
-
+	t.Cleanup(func() {
+		EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t, context.Background(), client, hcpNs)
+	})
 	t.Cleanup(func() { EnsureAllContainersHavePullPolicyIfNotPresent(t, context.Background(), client, hc) })
 	t.Cleanup(func() { EnsureHCPContainersHaveResourceRequests(t, context.Background(), client, hc) })
 	t.Cleanup(func() { EnsureNoPodsWithTooHighPriority(t, context.Background(), client, hc) })


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-11882](https://issues.redhat.com/browse/OCPBUGS-11882)

Depend on:
- https://github.com/openshift/aws-ebs-csi-driver-operator/pull/231
- https://github.com/openshift/cluster-network-operator/pull/1822

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes e2e and unit tests.