### PR TITLE
[release-4.13] HOSTEDCP-975: Backport nodepools metrics

### DIFF
--- a/hypershift-operator/controllers/nodepool/inplace.go
+++ b/hypershift-operator/controllers/nodepool/inplace.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/hypershift/api"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sutilspointer "k8s.io/utils/pointer"
@@ -148,6 +149,10 @@ func (r *NodePoolReconciler) reconcileMachineSet(ctx context.Context,
 
 	if machineSetInPlaceRolloutIsComplete(machineSet) {
 		if nodePool.Status.Version != targetVersion {
+			if nodePool.Status.Version == "" {
+				metrics.RecordNodePoolInitialRolloutDuration(nodePool)
+			}
+
 			log.Info("Version upgrade complete",
 				"previous", nodePool.Status.Version, "new", targetVersion)
 			nodePool.Status.Version = targetVersion

--- a/hypershift-operator/controllers/nodepool/metrics/metrics.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics.go
@@ -1,0 +1,46 @@
+package metrics
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	labelNames = []string{"namespace", "name", "platform"}
+
+	NodePoolSizeMetricName = "hypershift_nodepools_size"
+	nodePoolSize           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Number of desired replicas associated with a given NodePool",
+		Name: NodePoolSizeMetricName,
+	}, labelNames)
+
+	NodePoolAvailableReplicasMetricName = "hypershift_nodepools_available_replicas"
+	nodePoolAvailableReplicas           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Number of available replicas associated with a given NodePool",
+		Name: NodePoolAvailableReplicasMetricName,
+	}, labelNames)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		nodePoolSize,
+		nodePoolAvailableReplicas,
+	)
+}
+
+func labelValues(nodePool *hyperv1.NodePool) []string {
+	return []string{
+		nodePool.Namespace,
+		nodePool.Name,
+		string(nodePool.Spec.Platform.Type),
+	}
+}
+
+func RecordNodePoolSize(nodePool *hyperv1.NodePool, size float64) {
+	nodePoolSize.WithLabelValues(labelValues(nodePool)...).Set(size)
+}
+
+func RecordNodePoolAvailableReplicas(nodePool *hyperv1.NodePool) {
+	nodePoolAvailableReplicas.WithLabelValues(labelValues(nodePool)...).Set(float64(nodePool.Status.Replicas))
+}

--- a/hypershift-operator/controllers/nodepool/metrics/metrics.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"time"
+
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -20,12 +22,26 @@ var (
 		Help: "Number of available replicas associated with a given NodePool",
 		Name: NodePoolAvailableReplicasMetricName,
 	}, labelNames)
+
+	NodePoolDeletionDurationMetricName = "hypershift_nodepools_deletion_duration_seconds"
+	nodePoolDeletionDuration           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Time in seconds it took for NodePool to be deleted",
+		Name: NodePoolDeletionDurationMetricName,
+	}, labelNames)
+
+	NodePoolInitialRolloutDurationMetricName = "hypershift_nodepools_initial_rollout_duration_seconds"
+	nodePoolInitialRolloutDuration           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help: "Time in seconds it took from initial NodePool creation and rollout of initial version",
+		Name: NodePoolInitialRolloutDurationMetricName,
+	}, labelNames)
 )
 
 func init() {
 	metrics.Registry.MustRegister(
 		nodePoolSize,
 		nodePoolAvailableReplicas,
+		nodePoolDeletionDuration,
+		nodePoolInitialRolloutDuration,
 	)
 }
 
@@ -43,4 +59,14 @@ func RecordNodePoolSize(nodePool *hyperv1.NodePool, size float64) {
 
 func RecordNodePoolAvailableReplicas(nodePool *hyperv1.NodePool) {
 	nodePoolAvailableReplicas.WithLabelValues(labelValues(nodePool)...).Set(float64(nodePool.Status.Replicas))
+}
+
+func RecordNodePoolDeletionDuration(nodePool *hyperv1.NodePool) {
+	duration := time.Since(nodePool.DeletionTimestamp.Time).Seconds()
+	nodePoolDeletionDuration.WithLabelValues(labelValues(nodePool)...).Set(duration)
+}
+
+func RecordNodePoolInitialRolloutDuration(nodePool *hyperv1.NodePool) {
+	duration := time.Since(nodePool.CreationTimestamp.Time).Seconds()
+	nodePoolInitialRolloutDuration.WithLabelValues(labelValues(nodePool)...).Set(duration)
 }

--- a/hypershift-operator/controllers/nodepool/metrics/metrics.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	labelNames = []string{"namespace", "name", "platform"}
+	labelNames = []string{"namespace", "name", "cluster_name", "platform"}
 
 	NodePoolSizeMetricName = "hypershift_nodepools_size"
 	nodePoolSize           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -45,28 +45,29 @@ func init() {
 	)
 }
 
-func labelValues(nodePool *hyperv1.NodePool) []string {
-	return []string{
-		nodePool.Namespace,
-		nodePool.Name,
-		string(nodePool.Spec.Platform.Type),
+func labels(nodePool *hyperv1.NodePool) prometheus.Labels {
+	return prometheus.Labels{
+		"namespace":    nodePool.Namespace,
+		"name":         nodePool.Name,
+		"cluster_name": nodePool.Spec.ClusterName,
+		"platform":     string(nodePool.Spec.Platform.Type),
 	}
 }
 
 func RecordNodePoolSize(nodePool *hyperv1.NodePool, size float64) {
-	nodePoolSize.WithLabelValues(labelValues(nodePool)...).Set(size)
+	nodePoolSize.With(labels(nodePool)).Set(size)
 }
 
 func RecordNodePoolAvailableReplicas(nodePool *hyperv1.NodePool) {
-	nodePoolAvailableReplicas.WithLabelValues(labelValues(nodePool)...).Set(float64(nodePool.Status.Replicas))
+	nodePoolAvailableReplicas.With(labels(nodePool)).Set(float64(nodePool.Status.Replicas))
 }
 
 func RecordNodePoolDeletionDuration(nodePool *hyperv1.NodePool) {
 	duration := time.Since(nodePool.DeletionTimestamp.Time).Seconds()
-	nodePoolDeletionDuration.WithLabelValues(labelValues(nodePool)...).Set(duration)
+	nodePoolDeletionDuration.With(labels(nodePool)).Set(duration)
 }
 
 func RecordNodePoolInitialRolloutDuration(nodePool *hyperv1.NodePool) {
 	duration := time.Since(nodePool.CreationTimestamp.Time).Seconds()
-	nodePoolInitialRolloutDuration.WithLabelValues(labelValues(nodePool)...).Set(duration)
+	nodePoolInitialRolloutDuration.With(labels(nodePool)).Set(duration)
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/kubevirt"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics"
 	ignserver "github.com/openshift/hypershift/ignition-server/controllers"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/releaseinfo"
@@ -874,6 +875,8 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		} else {
 			log.Info("Reconciled MachineSet", "result", result)
 		}
+		// we use machineSet.Spec.Replicas because .Spec.Replicas will not be set if autoscaling is enabled
+		metrics.RecordNodePoolSize(nodePool, float64(*ms.Spec.Replicas))
 	}
 
 	if nodePool.Spec.Management.UpgradeType == hyperv1.UpgradeTypeReplace {
@@ -892,7 +895,12 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		} else {
 			log.Info("Reconciled MachineDeployment", "result", result)
 		}
+		// we use machineDeployment.Spec.Replicas because .Spec.Replicas will not be set if autoscaling is enabled
+		metrics.RecordNodePoolSize(nodePool, float64(*md.Spec.Replicas))
 	}
+
+	// .Status.Replicas is updated at this point, record metric
+	metrics.RecordNodePoolAvailableReplicas(nodePool)
 
 	mhc := machineHealthCheck(nodePool, controlPlaneNamespace)
 	if nodePool.Spec.Management.AutoRepair {

--- a/hypershift-operator/metrics.go
+++ b/hypershift-operator/metrics.go
@@ -48,7 +48,6 @@ type hypershiftMetrics struct {
 	hostedClustersNodePools            *prometheus.GaugeVec
 	nodePools                          *prometheus.GaugeVec
 	nodePoolsWithFailureCondition      *prometheus.GaugeVec
-	nodePoolSize                       *prometheus.GaugeVec
 	hypershiftOperatorInfo             prometheus.GaugeFunc
 	hostedClusterTransitionSeconds     *prometheus.HistogramVec
 
@@ -91,10 +90,6 @@ func newMetrics(client crclient.Client, log logr.Logger, hypershiftImage ImageIn
 			Name: "hypershift_nodepools_failure_conditions",
 			Help: "Total number of NodePools by platform with conditions in undesired state",
 		}, []string{"platform", "condition"}),
-		nodePoolSize: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "hypershift_nodepools_size",
-			Help: "Number of replicas associated with a given NodePool",
-		}, []string{"name", "platform"}),
 		// hypershiftOperatorInfo is a metric to capture the current operator details of the management cluster
 		hypershiftOperatorInfo: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 			Name: HypershiftOperatorInfoName,
@@ -184,9 +179,6 @@ func setupMetrics(mgr manager.Manager) error {
 	}
 	if err := crmetrics.Registry.Register(metrics.nodePools); err != nil {
 		return fmt.Errorf("failed to register nodePools metric: %w", err)
-	}
-	if err := crmetrics.Registry.Register(metrics.nodePoolSize); err != nil {
-		return fmt.Errorf("failed to register nodePoolSize metric: %w", err)
 	}
 	if err := crmetrics.Registry.Register(metrics.hostedClusterTransitionSeconds); err != nil {
 		return fmt.Errorf("failed to register hostedClusterTransitionSeconds metric: %w", err)
@@ -373,7 +365,6 @@ func (m *hypershiftMetrics) observeNodePools(ctx context.Context, nodePools *hyp
 				}
 			}
 		}
-		m.nodePoolSize.WithLabelValues(crclient.ObjectKeyFromObject(&np).String(), platform).Set(float64(np.Status.Replicas))
 	}
 	for key, count := range npByCluster.Counts() {
 		labels := counterKeyToLabels(key)

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -247,6 +247,8 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 				HypershiftOperatorInfoName,
 				nodepoolmetrics.NodePoolSizeMetricName,
 				nodepoolmetrics.NodePoolAvailableReplicasMetricName,
+				nodepoolmetrics.NodePoolDeletionDurationMetricName,
+				nodepoolmetrics.NodePoolInitialRolloutDurationMetricName,
 			} {
 				// Query fo HC specific metrics by hc.name.
 				query := fmt.Sprintf("%v{name=\"%s\"}", metricName, hc.Name)
@@ -254,8 +256,8 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 					// Query HO info metric
 					query = HypershiftOperatorInfoName
 				}
-				if metricName == nodepoolmetrics.NodePoolSizeMetricName || metricName == nodepoolmetrics.NodePoolAvailableReplicasMetricName {
-					// Mulham: `namespace`` label is used and overrwriten by prometheus relabeling configs.
+				if strings.HasPrefix(metricName, "hypershift_nodepools") {
+					// Mulham: `namespace` label is used and overrwriten by prometheus relabeling configs.
 					// Therfore, the `namespace` label we set in our metrics is renamed as `exported_namespace`
 					query = fmt.Sprintf("%v{exported_namespace=\"%s\"}", metricName, hc.Namespace)
 				}

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -257,9 +257,7 @@ func teardown(ctx context.Context, t *testing.T, client crclient.Client, hc *hyp
 					query = HypershiftOperatorInfoName
 				}
 				if strings.HasPrefix(metricName, "hypershift_nodepools") {
-					// Mulham: `namespace` label is used and overrwriten by prometheus relabeling configs.
-					// Therfore, the `namespace` label we set in our metrics is renamed as `exported_namespace`
-					query = fmt.Sprintf("%v{exported_namespace=\"%s\"}", metricName, hc.Namespace)
+					query = fmt.Sprintf("%v{cluster_name=\"%s\"}", metricName, hc.Name)
 				}
 
 				result, err := RunQueryAtTime(ctx, NewLogr(t), prometheusClient, query, time.Now())


### PR DESCRIPTION
backport of https://github.com/openshift/hypershift/pull/2532, https://github.com/openshift/hypershift/pull/2558 and https://github.com/openshift/hypershift/pull/2580