### PR TITLE
Only set AWS conditions when Platform == AWS

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -206,9 +206,8 @@ func validatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 		g.Expect(hostedCluster.Status.ControlPlaneEndpoint.Host).ToNot(ContainSubstring("hypershift.local"))
 	}
 
-	if hostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform {
-		validateHostedClusterAWSConditions(t, ctx, client, hostedCluster)
-	}
+	validateHostedClusterConditions(t, ctx, client, hostedCluster)
+
 	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 	e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
@@ -241,14 +240,12 @@ func validatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 		g.Expect(hostedCluster.Status.ControlPlaneEndpoint.Host).ToNot(ContainSubstring("hypershift.local"))
 	}
 
-	if hostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform {
-		validateHostedClusterAWSConditions(t, ctx, client, hostedCluster)
-	}
+	validateHostedClusterConditions(t, ctx, client, hostedCluster)
 
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 }
 
-func validateHostedClusterAWSConditions(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func validateHostedClusterConditions(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	expectedConditions := conditions.ExpectedHCConditions()
 
 	if hostedCluster.Spec.SecretEncryption == nil || hostedCluster.Spec.SecretEncryption.KMS == nil || hostedCluster.Spec.SecretEncryption.KMS.AWS == nil {


### PR DESCRIPTION
Previously, we had to disable some condition checks in our e2e tests because AWS specific conditions were leaking into the other Platforms which caused e2e test failures.

This PR isolates setting the AWS related conditions to the AWS platform, which allows us to re-enable the condition checking for all platforms again in the e2e tests