### PR TITLE
[release-4.13] OCPBUGS-13735: Cluster-api SA can't create events and fix permissions wrongly included

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2683,6 +2683,11 @@ func reconcileCAPIManagerClusterRole(role *rbacv1.ClusterRole) error {
 			Resources: []string{"customresourcedefinitions"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{"update", "create", "patch"},
+		},
 	}
 	return nil
 }


### PR DESCRIPTION
Backport for release-4.13 version which includes

- https://github.com/openshift/hypershift/pull/2565
- https://github.com/openshift/hypershift/pull/2586

**Which issue(s) this PR fixes**:

- Fixes #[OCPBUGS-13034](https://issues.redhat.com/browse/OCPBUGS-13034) (main)
- Fixes #[OCPBUGS-13735](https://issues.redhat.com/browse/OCPBUGS-13735) (backport for 4.13)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.