### PR TITLE
[release-4.13] HOSTEDCP-1010: Set ETCD Storage Size as immutable field and equalised the default size among both api versions

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1544,7 +1544,9 @@ type PersistentVolumeEtcdStorageSpec struct {
 	// Size is the minimum size of the data volume for each etcd member.
 	//
 	// +optional
-	// +kubebuilder:default="4Gi"
+	// +kubebuilder:default="8Gi"
+	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Etcd PV storage size is immutable"
 	Size *resource.Quantity `json:"size,omitempty"`
 }
 

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1518,6 +1518,8 @@ type PersistentVolumeEtcdStorageSpec struct {
 	//
 	// +optional
 	// +kubebuilder:default="8Gi"
+	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Etcd PV storage size is immutable"
 	Size *resource.Quantity `json:"size,omitempty"`
 }
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -1984,11 +1984,14 @@ spec:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                default: 4Gi
+                                default: 8Gi
                                 description: Size is the minimum size of the data
                                   volume for each etcd member.
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
                               storageClassName:
                                 description: "StorageClassName is the StorageClass
                                   of the data volume for each etcd member. \n See
@@ -5638,6 +5641,9 @@ spec:
                                   volume for each etcd member.
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
                               storageClassName:
                                 description: "StorageClassName is the StorageClass
                                   of the data volume for each etcd member. \n See

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -1961,11 +1961,14 @@ spec:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                default: 4Gi
+                                default: 8Gi
                                 description: Size is the minimum size of the data
                                   volume for each etcd member.
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
                               storageClassName:
                                 description: "StorageClassName is the StorageClass
                                   of the data volume for each etcd member. \n See
@@ -5619,6 +5622,9 @@ spec:
                                   volume for each etcd member.
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
                               storageClassName:
                                 description: "StorageClassName is the StorageClass
                                   of the data volume for each etcd member. \n See

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -29220,11 +29220,14 @@ objects:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  default: 4Gi
+                                  default: 8Gi
                                   description: Size is the minimum size of the data
                                     volume for each etcd member.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                  x-kubernetes-validations:
+                                  - message: Etcd PV storage size is immutable
+                                    rule: self == oldSelf
                                 storageClassName:
                                   description: "StorageClassName is the StorageClass
                                     of the data volume for each etcd member. \n See
@@ -32944,6 +32947,9 @@ objects:
                                     volume for each etcd member.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                  x-kubernetes-validations:
+                                  - message: Etcd PV storage size is immutable
+                                    rule: self == oldSelf
                                 storageClassName:
                                   description: "StorageClassName is the StorageClass
                                     of the data volume for each etcd member. \n See
@@ -36633,11 +36639,14 @@ objects:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  default: 4Gi
+                                  default: 8Gi
                                   description: Size is the minimum size of the data
                                     volume for each etcd member.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                  x-kubernetes-validations:
+                                  - message: Etcd PV storage size is immutable
+                                    rule: self == oldSelf
                                 storageClassName:
                                   description: "StorageClassName is the StorageClass
                                     of the data volume for each etcd member. \n See
@@ -40362,6 +40371,9 @@ objects:
                                     volume for each etcd member.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                  x-kubernetes-validations:
+                                  - message: Etcd PV storage size is immutable
+                                    rule: self == oldSelf
                                 storageClassName:
                                   description: "StorageClassName is the StorageClass
                                     of the data volume for each etcd member. \n See


### PR DESCRIPTION
Manual cherry-pick from https://github.com/openshift/hypershift/pull/2588

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-1010](https://issues.redhat.com/browse/HOSTEDCP-1010)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.