### PR TITLE
OCPBUGS-14169: Remove external-dns --events flag

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -205,7 +205,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								"--txt-suffix=-external-dns",
 								fmt.Sprintf("--txt-owner-id=%s", txtOwnerId),
 								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
-								"--events",
+								"--interval=1m",
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
 							LivenessProbe: &corev1.Probe{

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -382,7 +382,7 @@ objects:
           - --txt-suffix=-external-dns
           - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
           - --label-filter=hypershift.openshift.io/route-visibility!=private
-          - --events
+          - --interval=1m
           - --aws-zone-type=public
           - --aws-batch-change-interval=10s
           command:


### PR DESCRIPTION
**What this PR does / why we need it**:
The events flag causes the external-dns controller to ignore route events for extended periods of time in some circumstances. For now, removing the flag and replacing with the interval flag.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-14169

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.