### PR TITLE
CLI sets update channel to stable release

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -76,6 +76,7 @@ type ExampleOptions struct {
 	EtcdStorageClass                 string
 	ExternalDNSDomain                string
 	Arch                             string
+	UpgradeChannel                   string
 	AWS                              *ExampleAWSOptions
 	None                             *ExampleNoneOptions
 	Agent                            *ExampleAgentOptions
@@ -457,6 +458,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			ControllerAvailabilityPolicy:     o.ControlPlaneAvailabilityPolicy,
 			InfrastructureAvailabilityPolicy: o.InfrastructureAvailabilityPolicy,
 			Platform:                         platformSpec,
+			Channel:                          o.UpgradeChannel,
 		},
 	}
 

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -1,8 +1,9 @@
 package cluster
 
 import (
-	"github.com/openshift/hypershift/api/v1beta1"
 	"time"
+
+	"github.com/openshift/hypershift/api/v1beta1"
 
 	"github.com/spf13/cobra"
 
@@ -38,6 +39,7 @@ func NewCreateCommands() *cobra.Command {
 		NodeDrainTimeout:               0,
 		NodeUpgradeType:                v1beta1.UpgradeTypeReplace,
 		Arch:                           "amd64",
+		UpgradeChannel:                 "",
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -76,6 +78,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
 	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The default processor architecture for the NodePool (e.g. arm64, amd64)")
+	cmd.PersistentFlags().StringVar(&opts.UpgradeChannel, "upgrade-channel", opts.UpgradeChannel, "The OpenShift upgrade channel to use to track update paths. This will default to the minor release's stable channel")
 
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(none.NewCreateCommand(opts))


### PR DESCRIPTION
Previously, the update channel would remain empty after creating a guest cluster using the hypershift CLI, and there was no way to configure the channel up front. A user would instead need to edit the HostedCluster object's hc.Spec.Channel variable to the desired value.

This PR introduces the ability to both define and default the upgrade channel during `hypershift cluster create` command. If no upgrade channel is set, a default of `stable-<major>.<minor>` is used.