### PR TITLE
HOSTEDCP-1305: Simplify HostedControlPlaneNamespace().Name

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -150,7 +150,7 @@ func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 	if err := c.Get(ctx, client.ObjectKeyFromObject(hostedCluster), hostedCluster); err != nil {
 		return fmt.Errorf("failed to get hosted cluster %s/%s: %w", opts.Namespace, opts.Name, err)
 	}
-	cpNamespace := manifests.HostedControlPlaneNamespace(opts.Namespace, opts.Name).Name
+	cpNamespace := manifests.HostedControlPlaneNamespace(opts.Namespace, opts.Name)
 	localPort := rand.Intn(45000-32767) + 32767
 	kubeconfigFileName, err := createGuestKubeconfig(ctx, c, cpNamespace, localPort, opts.Log)
 	if err != nil {
@@ -321,7 +321,7 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 
 	cmd.Run(ctx, objectType(&corev1.Node{}))
 
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(opts.Namespace, opts.Name).Name
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(opts.Namespace, opts.Name)
 
 	kubevirtExternalInfraClusters, localKubevirtInUse := shouldDumpKubevirt(nodePools)
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -322,7 +322,7 @@ func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Request, log logr.Logger, hcluster *hyperv1.HostedCluster) (ctrl.Result, error) {
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespaceObject(hcluster.Namespace, hcluster.Name)
 	hcp := controlplaneoperator.HostedControlPlane(controlPlaneNamespace.Name, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(hcp), hcp)
 	if err != nil {
@@ -728,7 +728,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 	// Copy AWSEndpointAvailable and AWSEndpointServiceAvailable conditions from the AWSEndpointServices.
 	if hcluster.Spec.Platform.Type == hyperv1.AWSPlatform {
-		hcpNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
+		hcpNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 		var awsEndpointServiceList hyperv1.AWSEndpointServiceList
 		if err := r.List(ctx, &awsEndpointServiceList, &client.ListOptions{Namespace: hcpNamespace}); err != nil {
 			condition := metav1.Condition{
@@ -1782,7 +1782,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 
 // reconcileCAPIManager orchestrates orchestrates of  all CAPI manager components.
 func (r *HostedClusterReconciler) reconcileCAPIManager(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, pullSecretBytes []byte) error {
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespaceObject(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get control plane namespace: %w", err)
@@ -1910,7 +1910,7 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, cre
 		return nil
 	}
 
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespaceObject(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get control plane namespace: %w", err)
@@ -1959,7 +1959,7 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, cre
 // reconcileControlPlaneOperator orchestrates reconciliation of the control plane
 // operator components.
 func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane, controlPlaneOperatorImage, utilitiesImage, defaultIngressDomain string, cpoHasUtilities bool, openShiftTrustedCABundleConfigMapExists bool) error {
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespaceObject(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get control plane namespace: %w", err)
@@ -3369,7 +3369,7 @@ func deleteControlPlaneOperatorRBAC(ctx context.Context, c client.Client, rbacNa
 }
 
 func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.HostedCluster) (bool, error) {
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
 	log := ctrl.LoggerFrom(ctx)
 
 	// ensure that the cleanup annotation has been propagated to the hcp if it is set
@@ -4511,7 +4511,7 @@ func (r *HostedClusterReconciler) validateServiceAccountSigningKey(ctx context.C
 	if err != nil {
 		return err
 	}
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
 	cpSigningKeySecret := controlplaneoperator.ServiceAccountSigningKeySecret(controlPlaneNamespace)
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(cpSigningKeySecret), cpSigningKeySecret); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -4740,7 +4740,7 @@ func (r *HostedClusterReconciler) reconcileMonitoringDashboard(ctx context.Conte
 	varsToReplace := map[string]string{
 		"__NAME__":                    hc.Name,
 		"__NAMESPACE__":               hc.Namespace,
-		"__CONTROL_PLANE_NAMESPACE__": manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name,
+		"__CONTROL_PLANE_NAMESPACE__": manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name),
 		"__CLUSTER_ID__":              hc.Spec.ClusterID,
 	}
 	for k, v := range varsToReplace {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -127,7 +127,7 @@ func TestHasBeenAvailable(t *testing.T) {
 				},
 			}
 
-			hcpNs := hcpmanifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
+			hcpNs := hcpmanifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 			hcp := controlplaneoperator.HostedControlPlane(hcpNs, hcluster.Name)
 
 			hcp.Status = hyperv1.HostedControlPlaneStatus{

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -197,7 +197,7 @@ func (v kubevirtClusterValidator) validate(ctx context.Context, cli client.Clien
 		return nil, fmt.Errorf("the spec.platform.kubevirt field is missing in the HostedCluster resource")
 	}
 
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
 	cl, err := v.clientMap.DiscoverKubevirtClusterClient(ctx, cli, hc.Spec.InfraID, hc.Spec.Platform.Kubevirt.Credentials, controlPlaneNamespace, hc.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect external infra cluster; %w", err)

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
@@ -107,7 +107,7 @@ func TestDeleteCredentials(t *testing.T) {
 func TestReconcileCAPIInfraCR(t *testing.T) {
 	hostedClusterNamespace := "clusters"
 	hostedClusterName := "hc1"
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName).Name
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName)
 
 	ignitionEndpoint := "ign"
 	caSecret := ignitionserver.IgnitionCACertSecret(controlPlaneNamespace)

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -28,7 +28,7 @@ const (
 )
 
 func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, version semver.Version, controlPlaneOperatorAppliesManagementKASNetworkPolicyLabel bool) error {
-	controlPlaneNamespaceName := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
+	controlPlaneNamespaceName := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 
 	// Reconcile openshift-ingress Network Policy
 	policy := networkpolicy.OpenshiftIngressNetworkPolicy(controlPlaneNamespaceName)

--- a/hypershift-operator/controllers/manifests/manifests.go
+++ b/hypershift-operator/controllers/manifests/manifests.go
@@ -13,12 +13,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName string) *corev1.Namespace {
+func HostedControlPlaneNamespaceObject(hostedClusterNamespace, hostedClusterName string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s", hostedClusterNamespace, strings.ReplaceAll(hostedClusterName, ".", "-")),
+			Name: HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName),
 		},
 	}
+}
+
+func HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName string) string {
+	return fmt.Sprintf("%s-%s", hostedClusterNamespace, strings.ReplaceAll(hostedClusterName, ".", "-"))
 }
 
 func KubeConfigSecret(hostedClusterNamespace string, hostedClusterName string) *corev1.Secret {

--- a/hypershift-operator/controllers/nodepool/metrics/metrics.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics.go
@@ -325,7 +325,7 @@ func (c *nodePoolsMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 				}
 
 				if pathToReplicasCount != nil {
-					hcpNs := manifests.HostedControlPlaneNamespace(nodePool.Namespace, nodePool.Spec.ClusterName).Name
+					hcpNs := manifests.HostedControlPlaneNamespace(nodePool.Namespace, nodePool.Spec.ClusterName)
 					wishedReplicas := float64((*pathToReplicasCount)[hcpNs+"/"+nodePool.Name])
 
 					ch <- prometheus.MustNewConstMetric(

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -168,7 +168,7 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(nodePool.Namespace, nodePool.Spec.ClusterName).Name
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(nodePool.Namespace, nodePool.Spec.ClusterName)
 
 	// If deleted, clean up and return early.
 	if !nodePool.DeletionTimestamp.IsZero() {
@@ -239,7 +239,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	})
 
 	// Get HostedCluster deps.
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	ignEndpoint := hcluster.Status.IgnitionEndpoint
 	infraID := hcluster.Spec.InfraID
 	if err := validateInfraID(infraID); err != nil {
@@ -2534,7 +2534,7 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 		// TODO(alberto): Consider signal in a condition.
 		return nil, nil, "", fmt.Errorf("unsupported platform type: %s", nodePool.Spec.Platform.Type)
 	}
-	template.SetNamespace(manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name)
+	template.SetNamespace(manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name))
 
 	machineTemplateSpecJSON, err := json.Marshal(machineTemplateSpec)
 	if err != nil {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -1440,7 +1440,7 @@ func RunTestMachineTemplateBuilders(t *testing.T, preCreateMachineTemplate bool)
 		preCreatedMachineTemplate := &capiaws.AWSMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nodePool.GetName(),
-				Namespace: manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name,
+				Namespace: manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name),
 			},
 			Spec: capiaws.AWSMachineTemplateSpec{
 				Template: capiaws.AWSMachineTemplateResource{
@@ -1462,7 +1462,7 @@ func RunTestMachineTemplateBuilders(t *testing.T, preCreateMachineTemplate bool)
 	expectedMachineTemplate := &capiaws.AWSMachineTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nodePool.GetName(),
-			Namespace:   manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name,
+			Namespace:   manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name),
 			Annotations: map[string]string{nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String()},
 		},
 		Spec: capiaws.AWSMachineTemplateSpec{

--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -54,7 +54,7 @@ func testKillRandomMembers(parentCtx context.Context, client crclient.Client, cl
 		ctx, cancel := context.WithCancel(parentCtx)
 		defer cancel()
 
-		guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name
+		guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name)
 		t.Logf("Hosted control plane namespace is %s", guestNamespace)
 
 		// Get a client for the cluster
@@ -85,7 +85,7 @@ func testKillRandomMembers(parentCtx context.Context, client crclient.Client, cl
 
 		etcdPods := &corev1.PodList{}
 		err = client.List(ctx, etcdPods, &crclient.ListOptions{
-			Namespace:     manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name,
+			Namespace:     guestNamespace,
 			LabelSelector: labels.Set(etcdSts.Spec.Selector.MatchLabels).AsSelector(),
 		})
 		g.Expect(err).NotTo(HaveOccurred(), "failed to list etcd pods")
@@ -147,7 +147,7 @@ func testKillAllMembers(parentCtx context.Context, client crclient.Client, clust
 		ctx, cancel := context.WithCancel(parentCtx)
 		defer cancel()
 
-		guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name
+		guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name)
 		t.Logf("Hosted control plane namespace is %s", guestNamespace)
 
 		// Get a client for the cluster
@@ -178,7 +178,7 @@ func testKillAllMembers(parentCtx context.Context, client crclient.Client, clust
 
 		etcdPods := &corev1.PodList{}
 		err = client.List(ctx, etcdPods, &crclient.ListOptions{
-			Namespace:     manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name,
+			Namespace:     guestNamespace,
 			LabelSelector: labels.Set(etcdSts.Spec.Selector.MatchLabels).AsSelector(),
 		})
 		g.Expect(err).NotTo(HaveOccurred(), "failed to list etcd pods")
@@ -257,7 +257,7 @@ func testSingleMemberRecovery(parentCtx context.Context, client crclient.Client,
 		ctx, cancel := context.WithCancel(parentCtx)
 		defer cancel()
 
-		guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name
+		guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name)
 		t.Logf("Hosted control plane namespace is %s", guestNamespace)
 
 		// Wait for a guest client to become available
@@ -271,7 +271,7 @@ func testSingleMemberRecovery(parentCtx context.Context, client crclient.Client,
 
 		etcdPods := &corev1.PodList{}
 		err = client.List(ctx, etcdPods, &crclient.ListOptions{
-			Namespace:     manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name,
+			Namespace:     manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name),
 			LabelSelector: labels.Set(etcdSts.Spec.Selector.MatchLabels).AsSelector(),
 		})
 

--- a/test/e2e/nodepool_kv_cache_image_test.go
+++ b/test/e2e/nodepool_kv_cache_image_test.go
@@ -54,7 +54,7 @@ func (k KubeVirtCacheTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []core
 		gg.Expect(np.Status.Platform.KubeVirt.CacheName).ToNot(BeEmpty(), "cache DataVolume name should be populated")
 	}).Within(5 * time.Minute).WithPolling(time.Second).Should(Succeed())
 
-	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name).Name
+	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
 	var guestNamespace string
 	if np.Status.Platform.KubeVirt.Credentials != nil &&
 		len(np.Status.Platform.KubeVirt.Credentials.InfraNamespace) > 0 {

--- a/test/e2e/nodepool_kv_jsonpatch_test.go
+++ b/test/e2e/nodepool_kv_jsonpatch_test.go
@@ -55,7 +55,7 @@ func (k KubeVirtJsonPatchTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []
 		gg.Expect(np.Spec.Platform.Kubevirt).ToNot(BeNil())
 	}).Within(5 * time.Minute).WithPolling(time.Second).Should(Succeed())
 
-	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name).Name
+	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
 	var guestNamespace string
 	if np.Status.Platform != nil &&
 		np.Status.Platform.KubeVirt != nil &&

--- a/test/e2e/nodepool_kv_qos_guaranteed_test.go
+++ b/test/e2e/nodepool_kv_qos_guaranteed_test.go
@@ -58,7 +58,7 @@ func (k KubeVirtQoSClassGuaranteedTest) Run(t *testing.T, nodePool hyperv1.NodeP
 		gg.Expect(np.Spec.Platform.Kubevirt.Compute.QosClass).To(HaveValue(Equal(hyperv1.QoSClassGuaranteed)))
 	}).Within(5 * time.Minute).WithPolling(time.Second).Should(Succeed())
 
-	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name).Name
+	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
 	var guestNamespace string
 	if np.Status.Platform != nil &&
 		np.Status.Platform.KubeVirt != nil &&

--- a/test/e2e/nodepool_rolling_upgrade_test.go
+++ b/test/e2e/nodepool_rolling_upgrade_test.go
@@ -99,7 +99,7 @@ func (k *RollingUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes 
 	g.Expect(err).ToNot(HaveOccurred(), "failed waiting for the rolling upgrade to complete")
 
 	// check all aws machines have the new instance type
-	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name).Name
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
 	awsMachines := &capiaws.AWSMachineList{}
 	err = k.mgmtClient.List(k.ctx, awsMachines, crclient.InNamespace(controlPlaneNamespace), crclient.MatchingLabels{capiv1.MachineDeploymentNameLabel: nodePool.Name})
 	g.Expect(err).ToNot(HaveOccurred(), "failed to list aws machines")

--- a/test/e2e/olm_test.go
+++ b/test/e2e/olm_test.go
@@ -48,7 +48,7 @@ func TestOLM(t *testing.T) {
 		t.Logf("Waiting for guest client to become available")
 		guestClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
 
-		guestNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		guestNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		t.Logf("Hosted control plane namespace is %s", guestNamespace)
 
 		waitCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -101,7 +101,7 @@ func (h *hypershiftTest) after(hostedCluster *hyperv1.HostedCluster, opts *core.
 		return
 	}
 	h.Run("EnsureHostedCluster", func(t *testing.T) {
-		hcpNs := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		hcpNs := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 		EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t, context.Background(), h.client, hcpNs)
 		EnsureAllContainersHavePullPolicyIfNotPresent(t, context.Background(), h.client, hostedCluster)

--- a/test/e2e/util/oauth.go
+++ b/test/e2e/util/oauth.go
@@ -145,7 +145,7 @@ func WaitForOAuthToken(t *testing.T, ctx context.Context, oauthRoute *routev1.Ro
 func WaitForOAuthRouteReady(t *testing.T, ctx context.Context, client crclient.Client, restConfig *restclient.Config, hostedCluster *hyperv1.HostedCluster) *routev1.Route {
 	g := NewWithT(t)
 
-	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 	route := hcpmanifests.OauthServerExternalPublicRoute(hcpNamespace)
 
 	err := wait.PollImmediateWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (done bool, err error) {
@@ -225,7 +225,7 @@ const OAuthServerConfigKey = "config.yaml"
 func WaitForOauthConfig(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	g := NewWithT(t)
 
-	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 	oauthConfigCM := hcpmanifests.OAuthServerConfig(hcpNamespace)
 
 	err := wait.PollImmediateWithContext(ctx, time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
@@ -256,7 +256,7 @@ func validateClusterPreIDP(t *testing.T, ctx context.Context, client crclient.Cl
 
 	g.Expect(hostedCluster.Status.KubeadminPassword).ToNot(BeNil())
 
-	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 	kubeadminPasswordSecret := configmanifests.KubeadminPasswordSecret(hcpNamespace)
 	// validate kubeadmin secret exist
 	err := client.Get(ctx, crclient.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret)
@@ -277,7 +277,7 @@ func validateClusterPostIDP(t *testing.T, ctx context.Context, client crclient.C
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(hostedCluster.Status.KubeadminPassword).To(BeNil())
 
-	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 	kubeadminPasswordSecret := configmanifests.KubeadminPasswordSecret(hcpNamespace)
 	// validate kubeadmin secret is deleted
 	err = client.Get(ctx, crclient.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -330,7 +330,7 @@ func WaitForConditionsOnHostedControlPlane(t *testing.T, ctx context.Context, cl
 		hyperv1.ValidHostedControlPlaneConfiguration,
 	}
 	var rolloutIncompleteReasons []string
-	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 	t.Logf("Waiting for hostedcontrolplane to rollout image. Namespace: %s, name: %s, image: %s", namespace, hostedCluster.Name, image)
 	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 30*time.Minute, func(ctx context.Context) (done bool, err error) {
@@ -409,7 +409,7 @@ func WaitForNodePoolDesiredNodes(t *testing.T, ctx context.Context, client crcli
 
 func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureNoCrashingPods", func(t *testing.T) {
-		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 		var podList corev1.PodList
 		if err := client.List(ctx, &podList, crclient.InNamespace(namespace)); err != nil {
@@ -444,7 +444,7 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 
 func NoticePreemptionOrFailedScheduling(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("NoticePreemptionOrFailedScheduling", func(t *testing.T) {
-		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 		var eventList corev1.EventList
 		if err := client.List(ctx, &eventList, crclient.InNamespace(namespace)); err != nil {
@@ -463,7 +463,7 @@ func EnsureNoPodsWithTooHighPriority(t *testing.T, ctx context.Context, client c
 	// Priority of the etcd priority class, nothing should ever exceed this.
 	const maxAllowedPriority = 100002000
 	t.Run("EnsureNoPodsWithTooHighPriority", func(t *testing.T) {
-		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 		var podList corev1.PodList
 		if err := client.List(ctx, &podList, crclient.InNamespace(namespace)); err != nil {
@@ -483,7 +483,7 @@ func EnsureNoPodsWithTooHighPriority(t *testing.T, ctx context.Context, client c
 
 func EnsureAllContainersHavePullPolicyIfNotPresent(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureAllContainersHavePullPolicyIfNotPresent", func(t *testing.T) {
-		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 
 		var podList corev1.PodList
 		if err := client.List(ctx, &podList, crclient.InNamespace(namespace)); err != nil {
@@ -528,7 +528,7 @@ func EnsureNodeCountMatchesNodePoolReplicas(t *testing.T, ctx context.Context, h
 
 func EnsureMachineDeploymentGeneration(t *testing.T, ctx context.Context, hostClient crclient.Client, hostedCluster *hyperv1.HostedCluster, expectedGeneration int64) {
 	t.Run("EnsureMachineDeploymentGeneration", func(t *testing.T) {
-		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		var machineDeploymentList capiv1.MachineDeploymentList
 		if err := hostClient.List(ctx, &machineDeploymentList, crclient.InNamespace(namespace)); err != nil {
 			t.Fatalf("failed to list machinedeployments: %v", err)
@@ -642,7 +642,7 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 		v1api := promv1.NewAPI(promClient)
 
 		// Compare metrics against budgets
-		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		clusterAgeMinutes := int32(time.Since(hostedCluster.CreationTimestamp.Time).Round(time.Minute).Minutes())
 		budgets := []struct {
 			name   string
@@ -731,7 +731,7 @@ func EnsureAllRoutesUseHCPRouter(t *testing.T, ctx context.Context, hostClient c
 			}
 		}
 		var routes routev1.RouteList
-		if err := hostClient.List(ctx, &routes, crclient.InNamespace(manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name)); err != nil {
+		if err := hostClient.List(ctx, &routes, crclient.InNamespace(manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name))); err != nil {
 			t.Fatalf("failed to list routes: %v", err)
 		}
 		for _, route := range routes.Items {
@@ -750,7 +750,7 @@ func EnsureNetworkPolicies(t *testing.T, ctx context.Context, c crclient.Client,
 			t.Skip()
 		}
 
-		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		t.Run("EnsureComponentsHaveNeedManagementKASAccessLabel", func(t *testing.T) {
 			// Check for all components expected to have NeedManagementKASAccessLabel.
 			want := []string{
@@ -971,7 +971,7 @@ func getTokenFromSecret(ctx context.Context, secretName string, client crclient.
 
 func EnsureHCPContainersHaveResourceRequests(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureHCPContainersHaveResourceRequests", func(t *testing.T) {
-		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		var podList corev1.PodList
 		if err := client.List(ctx, &podList, &crclient.ListOptions{Namespace: namespace}); err != nil {
 			t.Fatalf("failed to list pods: %v", err)
@@ -1029,7 +1029,7 @@ func EnsureSecretEncryptedUsingKMS(t *testing.T, ctx context.Context, hostedClus
 			secretEtcdKey,
 		}
 
-		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		out := new(bytes.Buffer)
 
 		podExecuter := PodExecOptions{
@@ -1514,7 +1514,7 @@ func validateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 
 func EnsureHCPPodsAffinitiesAndTolerations(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureHCPPodsAffinitiesAndTolerations", func(t *testing.T) {
-		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		awsEbsCsiDriverOperatorPodSubstring := "aws-ebs-csi-driver-operator"
 		controlPlaneLabelTolerationKey := "hypershift.openshift.io/control-plane"
 		clusterNodeSchedulingAffinityWeight := 100


### PR DESCRIPTION
## What this PR does / why we need it
32 out of 38 calls to `HostedControlPlaneNamespace` are only to get the
   controlPlane namespace name. These cases are actually creating a namespace object only to take its `Name` field.

This PR renames the `HostedControlPlaneNamespace` function, to `HostedControlPlaneNamespaceObject`, and add a new   `HostedControlPlaneNamespace` function to only return the namespace name. Then use this new function anywhere we only want the namespace name, to simplify the code by avoiding the creation of the namespace object just to then take the `Name` field.

## Checklist
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.