### PR TITLE
OCPBUGS-12972: Use different ports for MCS in the ignition provider

### DIFF
--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -456,8 +456,8 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 			fmt.Sprintf("--bootstrap-kubeconfig=%s/kubeconfig", mcsBaseDir),
 			fmt.Sprintf("--cert=%s/tls.crt", mcsBaseDir),
 			fmt.Sprintf("--key=%s/tls.key", mcsBaseDir),
-			"--secure-port=22623",
-			"--insecure-port=22624",
+			"--secure-port=22625",
+			"--insecure-port=22626",
 		)
 		go func() {
 			out, err := cmd.CombinedOutput()
@@ -471,7 +471,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 		}
 		var payload []byte
 		err = wait.PollUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
-			req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost:22624/config/master", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost:22626/config/master", nil)
 			if err != nil {
 				return false, fmt.Errorf("error building http request: %w", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a restriction on querying ports 22623 and 22624 on the
cluster's supported ip families everywhere in the cluster. This lead to
every request to MCS resulting in `connection refused` in a dual-stack
cluster.

An IPv4-only cluster got around this issue because the temp MCS server
bound to the ports on both IPv4 and IPv6 and the request resolved
`localhost` to `::1`. This allowed the request to get past the blocks on
the ports on the IPv4 familiy.

On a dual-stack cluster the ports are blocked for both IPv4 and IPv6 so
the request could never succeed.

Resolves https://issues.redhat.com/browse/OCPBUGS-12972

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.