### PR TITLE
KubeVirt Openstack image annotation override

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -577,6 +577,13 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		nodePool := defaultNodePool(cluster.Name)
 		nodePool.Spec.Platform.Kubevirt = ExampleKubeVirtTemplate(o.Kubevirt)
 		nodePools = append(nodePools, nodePool)
+		val, exists := o.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation]
+		if exists {
+			if nodePool.Annotations == nil {
+				nodePool.Annotations = map[string]string{}
+			}
+			nodePool.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation] = val
+		}
 	case hyperv1.NonePlatform, hyperv1.AgentPlatform:
 		nodePools = append(nodePools, defaultNodePool(cluster.Name))
 	case hyperv1.AzurePlatform:

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -152,6 +152,12 @@ const (
 	// RouteVisibilityPrivate is a value for RouteVisibilityLabel that will result
 	// in the labeled route being ignored by external-dns
 	RouteVisibilityPrivate = "private"
+
+	// AllowUnsupportedKubeVirtRHCOSVariantsAnnotation allows a NodePool to use image sources
+	// other than the official rhcos kubevirt variant, such as the openstack variant. This
+	// allows the creation of guest clusters <= 4.13, which are before the rhcos kubevirt
+	// variant was released.
+	AllowUnsupportedKubeVirtRHCOSVariantsAnnotation = "hypershift.openshift.io/allow-unsupported-kubevirt-rhcos-variants"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/hypershift-operator/controllers/nodepool/kubevirt/imagecacher.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/imagecacher.go
@@ -3,6 +3,7 @@ package kubevirt
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +39,7 @@ type BootImage interface {
 	// CacheImage creates a PVC to cache the node image.
 	CacheImage(context.Context, client.Client, *hyperv1.NodePool, string) error
 	getDVSourceForVMTemplate() *v1beta1.DataVolumeSource
+	String() string
 }
 
 type BootImageNamer interface {
@@ -59,6 +61,10 @@ func newBootImage(imageName string, isHTTP bool) *bootImage {
 		bi.name = containerImagePrefix + imageName
 	}
 	return bi
+}
+
+func (bi bootImage) String() string {
+	return strings.TrimPrefix(bi.name, containerImagePrefix)
 }
 
 func (bootImage) CacheImage(_ context.Context, _ client.Client, _ *hyperv1.NodePool, _ string) error {
@@ -106,6 +112,10 @@ func newCachedBootImage(name, hash, namespace string, isHTTP bool) *cachedBootIm
 	}
 
 	return cbi
+}
+
+func (cbi cachedBootImage) String() string {
+	return strings.TrimPrefix(cbi.name, containerImagePrefix)
 }
 
 func (qi *cachedBootImage) CacheImage(ctx context.Context, cl client.Client, nodePool *hyperv1.NodePool, uid string) error {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -369,7 +369,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			Type:               hyperv1.NodePoolValidPlatformImageType,
 			Status:             corev1.ConditionTrue,
 			Reason:             hyperv1.AsExpectedReason,
-			Message:            fmt.Sprintf("Bootstrap KubeVirt Image is %q", kubevirtBootImage),
+			Message:            fmt.Sprintf("Bootstrap KubeVirt Image is %s", kubevirtBootImage.String()),
 			ObservedGeneration: nodePool.Generation,
 		})
 


### PR DESCRIPTION
This allows the unsupported openstack rhcos variant to be used with kubevirt when a special annotation is used. We need this for internal testing of tenant clusters <= 4.13

example hypershift cli command to enable this functionality

```
hypershift create cluster kubevirt \
        --name $CLUSTER_NAME \
        --annotations "hypershift.openshift.io/allow-unsupported-kubevirt-rhcos-variants=true"
        --pull-secret $PULL_SECRET_PATH \
        --ssh-key $SSH_KEY_PATH  \
        --node-pool-replicas $REPLICAS \
        --release-image $RELEASE_IMAGE \
        --memory $MEM \
        --cores $CPU
```