### PR TITLE
HOSTEDCP-1008: Add NodePoolTransitionSeconds metric

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -624,11 +624,14 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	}
 	SetStatusCondition(&nodePool.Status.Conditions, *condition)
 
+	oldReachedIgnitionEndpointCondition := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolReachedIgnitionEndpoint)
 	reachedIgnitionEndpointCondition, err := r.createReachedIgnitionEndpointCondition(ctx, tokenSecret, nodePool.Generation)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error setting IgnitionReached condition: %w", err)
 	}
 	SetStatusCondition(&nodePool.Status.Conditions, *reachedIgnitionEndpointCondition)
+
+	metrics.ObserveConditionTransitionDuration(nodePool, reachedIgnitionEndpointCondition, oldReachedIgnitionEndpointCondition)
 
 	// Validate tuningConfig input.
 	tuningConfig, err := r.getTuningConfig(ctx, nodePool)
@@ -743,13 +746,17 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		message = hyperv1.AllIsWellMessage
 	}
 
-	SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+	oldAllMachinesReadyCondition := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolAllMachinesReadyConditionType)
+	allMachinesReadyCondition := &hyperv1.NodePoolCondition{
 		Type:               hyperv1.NodePoolAllMachinesReadyConditionType,
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
 		ObservedGeneration: nodePool.Generation,
-	})
+	}
+	SetStatusCondition(&nodePool.Status.Conditions, *allMachinesReadyCondition)
+
+	metrics.ObserveConditionTransitionDuration(nodePool, allMachinesReadyCondition, oldAllMachinesReadyCondition)
 
 	// Set AllNodesHealthyCondition.
 	status = corev1.ConditionTrue
@@ -775,13 +782,17 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		message = hyperv1.AllIsWellMessage
 	}
 
-	SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+	oldAllMachinesHealthyCondition := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolAllNodesHealthyConditionType)
+	allMachinesHealthyCondition := &hyperv1.NodePoolCondition{
 		Type:               hyperv1.NodePoolAllNodesHealthyConditionType,
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
 		ObservedGeneration: nodePool.Generation,
-	})
+	}
+	SetStatusCondition(&nodePool.Status.Conditions, *allMachinesHealthyCondition)
+
+	metrics.ObserveConditionTransitionDuration(nodePool, allMachinesHealthyCondition, oldAllMachinesHealthyCondition)
 
 	// 2. - Reconcile towards expected state of the world.
 	compressedConfig, err := supportutil.CompressAndEncode([]byte(config))


### PR DESCRIPTION
**What this PR does / why we need it**:
records time in seconds it took from NodePool creation until a given condition transitions to true, for the following conditions:
- NodePoolReachedIgnitionEndpoint
- NodePoolAllMachinesReadyConditionType
- NodePoolAllNodesHealthyConditionType

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://issues.redhat.com/browse/HOSTEDCP-1008

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.