### PR TITLE
OCPBUGS-14087: Enable HCCO to reconcile over the OperatorHub's disableAllDefaultSources object

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -192,6 +192,7 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 		&configv1.Image{},
 		&configv1.Project{},
 		&configv1.ClusterOperator{},
+		&configv1.OperatorHub{},
 		&appsv1.DaemonSet{},
 		&configv1.ClusterOperator{},
 		&configv1.ClusterVersion{},
@@ -1286,6 +1287,18 @@ func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedContro
 
 	p := olm.NewOperatorLifecycleManagerParams(hcp)
 
+	// Check if the defaultSources are disabled
+	operatorHub := &configv1.OperatorHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	}
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(operatorHub), operatorHub); err != nil {
+		if !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("failed to get OperatorHub %s: %w", client.ObjectKeyFromObject(operatorHub).String(), err))
+		}
+	}
+
 	catalogs := []struct {
 		manifest  func() *operatorsv1alpha1.CatalogSource
 		reconcile func(*operatorsv1alpha1.CatalogSource, *olm.OperatorLifecycleManagerParams)
@@ -1298,11 +1311,19 @@ func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedContro
 
 	for _, catalog := range catalogs {
 		cs := catalog.manifest()
-		if _, err := r.CreateOrUpdate(ctx, r.client, cs, func() error {
-			catalog.reconcile(cs, p)
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile catalog source %s/%s: %w", cs.Namespace, cs.Name, err))
+		if operatorHub.Spec.DisableAllDefaultSources {
+			if err := r.client.Delete(ctx, cs); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errs = append(errs, fmt.Errorf("failed to delete catalogSource %s/%s: %w", cs.Namespace, cs.Name, err))
+				}
+			}
+		} else {
+			if _, err := r.CreateOrUpdate(ctx, r.client, cs, func() error {
+				catalog.reconcile(cs, p)
+				return nil
+			}); err != nil {
+				errs = append(errs, fmt.Errorf("failed to reconcile catalog source %s/%s: %w", cs.Namespace, cs.Name, err))
+			}
 		}
 	}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -59,6 +59,7 @@ var initialObjects = []client.Object{
 	manifests.NodeTuningClusterOperator(),
 	manifests.NamespaceKubeSystem(),
 	&configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}},
+	fakeOperatorHub(),
 }
 
 func shouldNotError(key client.ObjectKey) bool {
@@ -244,6 +245,14 @@ func fakePackageServerService() *corev1.Service {
 	s := manifests.OLMPackageServerControlPlaneService("bar")
 	s.Spec.ClusterIP = "1.1.1.1"
 	return s
+}
+
+func fakeOperatorHub() *configv1.OperatorHub {
+	return &configv1.OperatorHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	}
 }
 
 func TestReconcileKubeadminPasswordHashSecret(t *testing.T) {

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -117,6 +117,7 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 				&configv1.ClusterVersion{}:  allSelector,
 				&configv1.FeatureGate{}:     allSelector,
 				&configv1.ClusterOperator{}: allSelector,
+				&configv1.OperatorHub{}:     allSelector,
 
 				// Needed for inplace upgrader.
 				&corev1.Node{}: allSelector,


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-14087](https://issues.redhat.com/browse/OCPBUGS-14087)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.