### PR TITLE
HOSTEDCP-1036: Create Makefile path to create productized CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ all: build e2e
 
 pre-commit: all verify test
 
-build: hypershift-operator control-plane-operator hypershift
+build: hypershift-operator control-plane-operator hypershift product-cli
 
 .PHONY: update
 update: deps api api-docs app-sre-saas-template
@@ -78,6 +78,10 @@ control-plane-operator:
 .PHONY: hypershift
 hypershift:
 	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift .
+
+.PHONY: product-cli
+product-cli:
+	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/hcp ./product-cli
 
 # Run this when updating any of the types in the api package to regenerate the
 # deepcopy code and CRD manifest files.

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -1,0 +1,43 @@
+package cluster
+
+import (
+	"github.com/openshift/hypershift/api/v1beta1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/hypershift/cmd/cluster/agent"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/log"
+)
+
+func NewCreateCommands() *cobra.Command {
+	opts := &core.CreateOptions{
+		Namespace:                      "clusters",
+		Name:                           "example",
+		ReleaseImage:                   "",
+		PullSecretFile:                 "",
+		ControlPlaneAvailabilityPolicy: "HighlyAvailable",
+		Render:                         false,
+		InfraID:                        "",
+		ServiceCIDR:                    "172.31.0.0/16",
+		ClusterCIDR:                    "10.132.0.0/14",
+		Wait:                           false,
+		Timeout:                        0,
+		ExternalDNSDomain:              "",
+		AdditionalTrustBundle:          "",
+		ImageContentSources:            "",
+		NodeSelector:                   nil,
+		Log:                            log.Log,
+		NodeDrainTimeout:               0,
+		NodeUpgradeType:                v1beta1.UpgradeTypeReplace,
+		Arch:                           "amd64",
+	}
+	cmd := &cobra.Command{
+		Use:          "cluster",
+		Short:        "Creates basic functional HostedCluster resources",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(agent.NewCreateCommand(opts))
+
+	return cmd
+}

--- a/product-cli/cmd/create/create.go
+++ b/product-cli/cmd/create/create.go
@@ -1,0 +1,18 @@
+package create
+
+import (
+	"github.com/openshift/hypershift/product-cli/cmd/cluster"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "create",
+		Short:        "Commands for creating HostedClusters",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(cluster.NewCreateCommands())
+
+	return cmd
+}

--- a/product-cli/main.go
+++ b/product-cli/main.go
@@ -1,0 +1,61 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift/hypershift/product-cli/cmd/create"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/openshift/hypershift/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	cmd := &cobra.Command{
+		Use:              "hcp",
+		SilenceUsage:     true,
+		TraverseChildren: true,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	cmd.Version = version.String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer cancel()
+
+	cmd.AddCommand(create.NewCommand())
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT)
+	go func() {
+		<-sigs
+		fmt.Fprintln(os.Stderr, "\nAborted...")
+		cancel()
+	}()
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a Makefile build command to create a productized version of the HyperShift CLI and adds the beginning source code directory structure for the productized CLI commands.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1036](https://issues.redhat.com/browse/HOSTEDCP-1036)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.