### PR TITLE
cli: Add release-stream flag

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -1,8 +1,9 @@
 package cluster
 
 import (
-	"github.com/openshift/hypershift/api/v1beta1"
 	"time"
+
+	"github.com/openshift/hypershift/api/v1beta1"
 
 	"github.com/spf13/cobra"
 
@@ -21,6 +22,7 @@ func NewCreateCommands() *cobra.Command {
 		Namespace:                      "clusters",
 		Name:                           "example",
 		ReleaseImage:                   "",
+		ReleaseStream:                  "",
 		PullSecretFile:                 "",
 		ControlPlaneAvailabilityPolicy: "SingleReplica",
 		Render:                         false,
@@ -52,6 +54,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSDomain, "external-dns-domain", opts.ExternalDNSDomain, "Sets hostname to opinionated values in the specificed domain for services with publishing type LoadBalancer or Route.")
 	cmd.PersistentFlags().StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the cluster")
+	cmd.PersistentFlags().StringVar(&opts.ReleaseStream, "release-stream", opts.ReleaseStream, "The OCP release stream for the cluster (e.g. 4.14.0-0.nightly), this flag is ignored if release-image is set")
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Path to a pull secret (required)")
 	cmd.PersistentFlags().StringVar(&opts.ControlPlaneAvailabilityPolicy, "control-plane-availability-policy", opts.ControlPlaneAvailabilityPolicy, "Availability policy for hosted cluster components. Supported options: SingleReplica, HighlyAvailable")
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", opts.Render, "Render output as YAML to stdout instead of applying")

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -56,6 +56,7 @@ type CreateOptions struct {
 	NodeDrainTimeout                 time.Duration
 	PullSecretFile                   string
 	ReleaseImage                     string
+	ReleaseStream                    string
 	Render                           bool
 	SSHKeyFile                       string
 	ServiceCIDR                      string
@@ -155,7 +156,7 @@ type AzurePlatformOptions struct {
 
 func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures.ExampleOptions, error) {
 	if len(opts.ReleaseImage) == 0 {
-		defaultVersion, err := version.LookupDefaultOCPVersion()
+		defaultVersion, err := version.LookupDefaultOCPVersion(opts.ReleaseStream)
 		if err != nil {
 			return nil, fmt.Errorf("release image is required when unable to lookup default OCP version: %w", err)
 		}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -824,7 +824,7 @@ func expectedRules(addRules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
 }
 
 func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
-	releaseImage, _ := version.LookupDefaultOCPVersion()
+	releaseImage, _ := version.LookupDefaultOCPVersion("")
 	hostedClusters := []*hyperv1.HostedCluster{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "agent"},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -476,7 +476,7 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 // up additional contextual defaulting.
 func (o *options) Complete() error {
 	if len(o.LatestReleaseImage) == 0 {
-		defaultVersion, err := version.LookupDefaultOCPVersion()
+		defaultVersion, err := version.LookupDefaultOCPVersion("")
 		if err != nil {
 			return fmt.Errorf("couldn't look up default OCP version: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow to specify a `release-stream` like 4.14.0-0.nightly instead of a full pull-spec release-image