### PR TITLE
OCPBUGS-11882: Annotate HCP pods with the safe-to-evict-local-volume CA annotation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: client-token,web-identity-token
         hypershift.openshift.io/release-image: quay.io/ocp-dev/test-release-image:latest
       creationTimestamp: null
       labels:

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -12,7 +12,21 @@ import (
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	suppconfig "github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/releaseinfo"
+)
+
+var (
+	LocalStorageVolumes = []string{
+		"private",
+		"public",
+		"sockets",
+		"virt-bin-share-dir",
+		"libvirt-runtime",
+		"ephemeral-disks",
+		"container-disks",
+		"hotplug-disks",
+	}
 )
 
 func defaultImage(releaseImage *releaseinfo.ReleaseImage) (string, string, error) {
@@ -230,6 +244,15 @@ func MachineTemplateSpec(nodePool *hyperv1.NodePool, bootImage BootImage, hclust
 
 	vmTemplate.ObjectMeta.Labels[hyperv1.NodePoolNameLabel] = nodePool.Name
 	vmTemplate.ObjectMeta.Labels[hyperv1.InfraIDLabel] = hcluster.Spec.InfraID
+
+	// Adding volumes for safe-eviction by clusterAutoscaler when it comes in action.
+	// The volumes that should be included in the annotation are the emptyDir and hostPath ones
+
+	if vmTemplate.Spec.Template.ObjectMeta.Annotations == nil {
+		vmTemplate.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	vmTemplate.Spec.Template.ObjectMeta.Annotations[suppconfig.PodSafeToEvictLocalVolumesKey] = strings.Join(LocalStorageVolumes, ",")
 
 	if hcluster.Spec.Platform.Kubevirt != nil && hcluster.Spec.Platform.Kubevirt.Credentials != nil {
 		vmTemplate.ObjectMeta.Namespace = hcluster.Spec.Platform.Kubevirt.Credentials.InfraNamespace

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -3,12 +3,14 @@ package kubevirt
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
+	suppconfig "github.com/openshift/hypershift/support/config"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
@@ -308,6 +310,9 @@ func generateNodeTemplate(memory string, cpu uint32, volumeSize string) *capikub
 					Labels: map[string]string{
 						hyperv1.NodePoolNameLabel: "my-pool",
 						hyperv1.InfraIDLabel:      "1234",
+					},
+					Annotations: map[string]string{
+						suppconfig.PodSafeToEvictLocalVolumesKey: strings.Join(LocalStorageVolumes, ","),
 					},
 				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{

--- a/support/config/deployment_test.go
+++ b/support/config/deployment_test.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -389,6 +391,105 @@ func TestResourceRequestOverrides(t *testing.T) {
 			hcp.Annotations = test.annotations
 			actual := resourceRequestOverrides(hcp)
 			g.Expect(actual).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestApplyTo(t *testing.T) {
+	tests := []struct {
+		name     string
+		volumes  []corev1.Volume
+		expected string
+	}{
+		{
+			name: "if 3 volumes provided and 2 valids for safe annotation, it should only annotate the deployment with these 2 volume names",
+			volumes: []corev1.Volume{
+				corev1.Volume{
+					Name: "test-hostpath",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "test",
+						},
+					},
+				},
+				corev1.Volume{
+					Name: "test-emptydir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMedium("Memory"),
+						},
+					},
+				},
+				corev1.Volume{
+					Name: "test-volume",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "test",
+						},
+					},
+				},
+			},
+			expected: "test-hostpath,test-emptydir",
+		},
+		{
+			name: "no hostpath or emptydir volumes provided, no safe eviction annotation",
+			volumes: []corev1.Volume{
+				corev1.Volume{
+					Name: "test-volume",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "test",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			deployment := &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-deployment",
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-container",
+								},
+							},
+							Volumes: tc.volumes,
+						},
+					},
+				},
+			}
+			dc := &DeploymentConfig{}
+			dc.ApplyTo(deployment)
+
+			localVolumeList := make([]string, 0)
+			for _, volume := range deployment.Spec.Template.Spec.Volumes {
+				// Check the volumes, if they are emptyDir or hostPath, should be annotated
+				if volume.EmptyDir != nil || volume.HostPath != nil {
+					localVolumeList = append(localVolumeList, volume.Name)
+				}
+			}
+
+			// After going through all the volumes in the deployment, validates if
+			// the annotation value makes sense with the expectations.
+			if _, exists := deployment.Spec.Template.ObjectMeta.Annotations[PodSafeToEvictLocalVolumesKey]; exists {
+				g.Expect(deployment.Spec.Template.ObjectMeta.Annotations).To(HaveKeyWithValue(PodSafeToEvictLocalVolumesKey, strings.Join(localVolumeList, ",")))
+			}
 		})
 	}
 }

--- a/support/config/types.go
+++ b/support/config/types.go
@@ -1,0 +1,7 @@
+package config
+
+const (
+	// PodSafeToEvictLocalVolumesKey is an annotation used by the CA operator which makes sure
+	// all the pods annotated with it and the picking the desired local volumes that are safe to evict, could be drained properly.
+	PodSafeToEvictLocalVolumesKey = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
+)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
@@ -13,6 +18,7 @@ import (
 	routev1client "github.com/openshift/client-go/route/clientset/versioned"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	suppconfig "github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 	"github.com/openshift/library-go/test/library/metrics"
 	promapi "github.com/prometheus/client_golang/api"
@@ -34,12 +40,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"testing"
-	"time"
 )
 
 func UpdateObject[T crclient.Object](t *testing.T, ctx context.Context, client crclient.Client, original T, mutate func(obj T)) error {
@@ -982,4 +985,76 @@ func RunQueryAtTime(ctx context.Context, log logr.Logger, prometheusClient prome
 			Result: result.(model.Vector),
 		},
 	}, nil
+}
+
+func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx context.Context, hostClient crclient.Client, hcpNs string) {
+	t.Run("EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations", func(t *testing.T) {
+		g := NewWithT(t)
+
+		auditedAppList := map[string]string{
+			"cloud-controller-manager":         "app",
+			"aws-ebs-csi-driver-controller":    "app",
+			"capi-provider-controller-manager": "app",
+			"cloud-network-config-controller":  "app",
+			"cluster-network-operator":         "app",
+			"cluster-version-operator":         "app",
+			"control-plane-operator":           "app",
+			"ignition-server":                  "app",
+			"ingress-operator":                 "app",
+			"kube-apiserver":                   "app",
+			"kube-controller-manager":          "app",
+			"kube-scheduler":                   "app",
+			"multus-admission-controller":      "app",
+			"oauth-openshift":                  "app",
+			"openshift-apiserver":              "app",
+			"openshift-oauth-apiserver":        "app",
+			"packageserver":                    "app",
+			"ovnkube-master":                   "app",
+			"kubevirt-csi-driver":              "app",
+			"cluster-image-registry-operator":  "name",
+			"virt-launcher":                    "kubevirt.io",
+		}
+
+		hcpPods := &corev1.PodList{}
+		if err := hostClient.List(ctx, hcpPods, &client.ListOptions{
+			Namespace: hcpNs,
+		}); err != nil {
+			t.Fatalf("cannot list hostedControlPlane pods: %v", err)
+		}
+
+		// Check if the pod's volumes are hostPath or emptyDir, if so, the deployment
+		// should annotate the pods with the safe-to-evict-local-volumes, with all the volumes
+		// involved as an string  and separated by comma, to satisfy CA operator contract.
+		// more info here: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
+		for _, pod := range hcpPods.Items {
+			var labelKey, labelValue string
+			// Go through our audited list looking for the label that matches the pod Labels
+			// Get the key and value and delete the entry from the audited list.
+			for appName, prefix := range auditedAppList {
+				if pod.Labels[prefix] == appName {
+					labelKey = prefix
+					labelValue = appName
+					delete(auditedAppList, prefix)
+					break
+				}
+			}
+
+			if labelKey == "" || labelValue == "" {
+				// if the Key/Value are empty we asume that the pod is not in the auditedList,
+				// if that's the case the annotation should not exists in that pod.
+				// Then continue to the next pod
+				g.Expect(pod.Annotations[suppconfig.PodSafeToEvictLocalVolumesKey]).To(BeEmpty(), "the pod  %s is not in the audited list for safe-eviction and should not contain the safe-to-evict-local-volume annotation", pod.Name)
+				continue
+			}
+
+			annotationValue := pod.ObjectMeta.Annotations[suppconfig.PodSafeToEvictLocalVolumesKey]
+			for _, volume := range pod.Spec.Volumes {
+				// Check the pod's volumes, if they are emptyDir or hostPath,
+				// they should include that volume in the annotation
+				if volume.EmptyDir != nil || volume.HostPath != nil {
+					g.Expect(strings.Contains(annotationValue, volume.Name)).To(BeTrue(), "pod with name %s do not have the right volumes set in the safe-to-evict-local-volume annotation: \nCurrent: %s, Expected to be included in: %s", pod.Name, volume.Name, annotationValue)
+				}
+			}
+		}
+	})
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-11882](https://issues.redhat.com/browse/OCPBUGS-11882)

Depend on:
- https://github.com/openshift/aws-ebs-csi-driver-operator/pull/231
- https://github.com/openshift/cluster-network-operator/pull/1822
- https://github.com/openshift/aws-ebs-csi-driver-operator/pull/232
- https://github.com/openshift/cluster-network-operator/pull/1830

This is a second approach from https://github.com/openshift/hypershift/pull/2597. This makes more sense.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes e2e and unit tests.