### PR TITLE
Remove alsologtostderr flag form CAP*

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2638,7 +2638,6 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 							},
 						},
 						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--alsologtostderr",
 							"--v=4",
 							"--leader-elect=true",
 							fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -170,7 +170,6 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 							},
 						},
 						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--alsologtostderr",
 							"--v=4",
 							"--leader-elect=true",
 							"--feature-gates=EKS=false",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -127,7 +127,6 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 						Command: []string{"/manager"},
 						Args: []string{
 							"--namespace", "$(MY_NAMESPACE)",
-							"--alsologtostderr",
 							"--v=4",
 							"--leader-elect=true",
 						},

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/powervs/powervs.go
@@ -146,7 +146,6 @@ func (p PowerVS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *
 						},
 						Command: []string{"/bin/cluster-api-provider-ibmcloud-controller-manager"},
 						Args: []string{"--namespace", "$(MY_NAMESPACE)",
-							"--alsologtostderr",
 							"--v=4",
 							"--leader-elect=true",
 							"--powervs-provider-id-fmt=v2",


### PR DESCRIPTION
This is needed to accomodate CAPI 1.4 coming in 4.14 payload https://main.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.3-to-v1.4.html, https://github.com/kubernetes/enhancements/issues/2845, https://github.com/kubernetes/kubernetes/pull/112120

This is currently breaking CAPI/CAPA rebases:
See https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-api/175/pull-ci-openshift-cluster-api-master-e2e-hypershift/1661096357663870976/artifacts/e2e-hypershift/run-e2e/artifacts/TestCreateCluster_PreTeardownClusterDump/namespaces/e2e-clusters-cdnlw-example-6pcmz/core/pods/logs/cluster-api-7bfdd5447-qc5xt-manager.log

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.