### PR TITLE
OCPBUGS-14575: Check for IDMS only if mgmt cluster has req API

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -267,7 +267,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	// Populate registry overrides with any ICSP and IDMS from a OpenShift management cluster
 	var imageRegistryOverrides map[string][]string
 	if mgmtClusterCaps.Has(capabilities.CapabilityICSP) || mgmtClusterCaps.Has(capabilities.CapabilityIDMS) {
-		imageRegistryOverrides, err = globalconfig.GetAllImageRegistryMirrors(ctx, apiReadingClient)
+		imageRegistryOverrides, err = globalconfig.GetAllImageRegistryMirrors(ctx, apiReadingClient, mgmtClusterCaps.Has(capabilities.CapabilityIDMS))
 		if err != nil {
 			return fmt.Errorf("failed to populate image registry overrides: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Only check for IDMS CRs only if the management cluster has the required API

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-14575](https://issues.redhat.com/browse/OCPBUGS-14575)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.