### PR TITLE
HOSTEDCP-1016: Validate publishing strategies

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -937,7 +937,10 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 	}
 	for _, cluster := range hostedClusters {
 		cluster.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
-			{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
+			{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: "api.example.com"}},
+			},
 			{Service: hyperv1.Konnectivity, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
 			{Service: hyperv1.OAuthServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
 			{Service: hyperv1.Ignition, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
@@ -1115,6 +1118,22 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 				},
 			}},
 			expectedResult:                errors.New(`service type OAuthServer can't be published with the same hostname api.example.com as service type APIServer`),
+			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
+		},
+		{
+			name: "APIServer service with publishing strategy Route doen't have hostname field set, error",
+			hostedCluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{
+				Services: []hyperv1.ServicePublishingStrategyMapping{
+					{
+						Service: hyperv1.APIServer,
+						ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+							Type:  hyperv1.Route,
+							Route: &hyperv1.RoutePublishingStrategy{},
+						},
+					},
+				},
+			}},
+			expectedResult:                errors.New(`hostname field is required for service type APIServer with publishing strategy Route`),
 			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. validate hostname required for APIServer service when type is `Route`
2. validate hostname is not set for all services except APIServer and OAuth if endpoint access is not `Public`
3. validate APIServer is published as `Route` if endpoint access is `Public`

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1016](https://issues.redhat.com/browse/HOSTEDCP-1016)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.