### PR TITLE
Enforce Immutability of some KubeVirt Platform Values

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -684,6 +684,7 @@ type KubevirtPlatformCredentials struct {
 	// +immutable
 	// +kubebuilder:validation:Required
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="infraKubeConfigSecret is immutable"
 	InfraKubeConfigSecret *KubeconfigSecretRef `json:"infraKubeConfigSecret,omitempty"`
 
 	// InfraNamespace defines the namespace on the external infra cluster that is used to host the KubeVirt
@@ -694,6 +695,7 @@ type KubevirtPlatformCredentials struct {
 	// +immutable
 	// +kubebuilder:validation:Required
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="infraNamespace is immutable"
 	InfraNamespace string `json:"infraNamespace"`
 }
 
@@ -723,6 +725,7 @@ type KubevirtPlatformSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="baseDomainPassthrough is immutable"
 	BaseDomainPassthrough *bool `json:"baseDomainPassthrough,omitempty"`
 
 	// GenerateID is used to uniquely apply a name suffix to resources associated with

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -687,6 +687,7 @@ type KubevirtPlatformCredentials struct {
 	// +immutable
 	// +kubebuilder:validation:Required
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="infraKubeConfigSecret is immutable"
 	InfraKubeConfigSecret *KubeconfigSecretRef `json:"infraKubeConfigSecret,omitempty"`
 
 	// InfraNamespace defines the namespace on the external infra cluster that is used to host the KubeVirt
@@ -697,6 +698,7 @@ type KubevirtPlatformCredentials struct {
 	// +immutable
 	// +kubebuilder:validation:Required
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="infraNamespace is immutable"
 	InfraNamespace string `json:"infraNamespace"`
 }
 
@@ -726,6 +728,7 @@ type KubevirtPlatformSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="baseDomainPassthrough is immutable"
 	BaseDomainPassthrough *bool `json:"baseDomainPassthrough,omitempty"`
 
 	// GenerateID is used to uniquely apply a name suffix to resources associated with

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -2685,6 +2685,9 @@ spec:
                           Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                           \n This is possible using OCP wildcard routes"
                         type: boolean
+                        x-kubernetes-validations:
+                        - message: baseDomainPassthrough is immutable
+                          rule: self == oldSelf
                       credentials:
                         description: "Credentials defines the client credentials used
                           when creating KubeVirt virtual machines. Defining credentials
@@ -2709,6 +2712,9 @@ spec:
                             - key
                             - name
                             type: object
+                            x-kubernetes-validations:
+                            - message: infraKubeConfigSecret is immutable
+                              rule: self == oldSelf
                           infraNamespace:
                             description: InfraNamespace defines the namespace on the
                               external infra cluster that is used to host the KubeVirt
@@ -2717,6 +2723,9 @@ spec:
                               referenced in the InfraKubeConfigSecret must have access
                               to manage the required resources within this namespace.
                             type: string
+                            x-kubernetes-validations:
+                            - message: infraNamespace is immutable
+                              rule: self == oldSelf
                         required:
                         - infraNamespace
                         type: object
@@ -6395,6 +6404,9 @@ spec:
                           Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                           \n This is possible using OCP wildcard routes"
                         type: boolean
+                        x-kubernetes-validations:
+                        - message: baseDomainPassthrough is immutable
+                          rule: self == oldSelf
                       credentials:
                         description: "Credentials defines the client credentials used
                           when creating KubeVirt virtual machines. Defining credentials
@@ -6419,6 +6431,9 @@ spec:
                             - key
                             - name
                             type: object
+                            x-kubernetes-validations:
+                            - message: infraKubeConfigSecret is immutable
+                              rule: self == oldSelf
                           infraNamespace:
                             description: InfraNamespace defines the namespace on the
                               external infra cluster that is used to host the KubeVirt
@@ -6427,6 +6442,9 @@ spec:
                               referenced in the InfraKubeConfigSecret must have access
                               to manage the required resources within this namespace.
                             type: string
+                            x-kubernetes-validations:
+                            - message: infraNamespace is immutable
+                              rule: self == oldSelf
                         required:
                         - infraNamespace
                         type: object

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -2683,6 +2683,9 @@ spec:
                           Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                           \n This is possible using OCP wildcard routes"
                         type: boolean
+                        x-kubernetes-validations:
+                        - message: baseDomainPassthrough is immutable
+                          rule: self == oldSelf
                       credentials:
                         description: "Credentials defines the client credentials used
                           when creating KubeVirt virtual machines. Defining credentials
@@ -2707,6 +2710,9 @@ spec:
                             - key
                             - name
                             type: object
+                            x-kubernetes-validations:
+                            - message: infraKubeConfigSecret is immutable
+                              rule: self == oldSelf
                           infraNamespace:
                             description: InfraNamespace defines the namespace on the
                               external infra cluster that is used to host the KubeVirt
@@ -2715,6 +2721,9 @@ spec:
                               referenced in the InfraKubeConfigSecret must have access
                               to manage the required resources within this namespace.
                             type: string
+                            x-kubernetes-validations:
+                            - message: infraNamespace is immutable
+                              rule: self == oldSelf
                         required:
                         - infraNamespace
                         type: object
@@ -6386,6 +6395,9 @@ spec:
                           Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                           \n This is possible using OCP wildcard routes"
                         type: boolean
+                        x-kubernetes-validations:
+                        - message: baseDomainPassthrough is immutable
+                          rule: self == oldSelf
                       credentials:
                         description: "Credentials defines the client credentials used
                           when creating KubeVirt virtual machines. Defining credentials
@@ -6410,6 +6422,9 @@ spec:
                             - key
                             - name
                             type: object
+                            x-kubernetes-validations:
+                            - message: infraKubeConfigSecret is immutable
+                              rule: self == oldSelf
                           infraNamespace:
                             description: InfraNamespace defines the namespace on the
                               external infra cluster that is used to host the KubeVirt
@@ -6418,6 +6433,9 @@ spec:
                               referenced in the InfraKubeConfigSecret must have access
                               to manage the required resources within this namespace.
                             type: string
+                            x-kubernetes-validations:
+                            - message: infraNamespace is immutable
+                              rule: self == oldSelf
                         required:
                         - infraNamespace
                         type: object

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -899,6 +899,9 @@ spec:
                             - key
                             - name
                             type: object
+                            x-kubernetes-validations:
+                            - message: infraKubeConfigSecret is immutable
+                              rule: self == oldSelf
                           infraNamespace:
                             description: InfraNamespace defines the namespace on the
                               external infra cluster that is used to host the KubeVirt
@@ -907,6 +910,9 @@ spec:
                               referenced in the InfraKubeConfigSecret must have access
                               to manage the required resources within this namespace.
                             type: string
+                            x-kubernetes-validations:
+                            - message: infraNamespace is immutable
+                              rule: self == oldSelf
                         required:
                         - infraNamespace
                         type: object
@@ -1801,6 +1807,9 @@ spec:
                             - key
                             - name
                             type: object
+                            x-kubernetes-validations:
+                            - message: infraKubeConfigSecret is immutable
+                              rule: self == oldSelf
                           infraNamespace:
                             description: InfraNamespace defines the namespace on the
                               external infra cluster that is used to host the KubeVirt
@@ -1809,6 +1818,9 @@ spec:
                               referenced in the InfraKubeConfigSecret must have access
                               to manage the required resources within this namespace.
                             type: string
+                            x-kubernetes-validations:
+                            - message: infraNamespace is immutable
+                              rule: self == oldSelf
                         required:
                         - infraNamespace
                         type: object

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -29969,6 +29969,9 @@ objects:
                             Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                             \n This is possible using OCP wildcard routes"
                           type: boolean
+                          x-kubernetes-validations:
+                          - message: baseDomainPassthrough is immutable
+                            rule: self == oldSelf
                         credentials:
                           description: "Credentials defines the client credentials
                             used when creating KubeVirt virtual machines. Defining
@@ -29993,6 +29996,9 @@ objects:
                               - key
                               - name
                               type: object
+                              x-kubernetes-validations:
+                              - message: infraKubeConfigSecret is immutable
+                                rule: self == oldSelf
                             infraNamespace:
                               description: InfraNamespace defines the namespace on
                                 the external infra cluster that is used to host the
@@ -30002,6 +30008,9 @@ objects:
                                 access to manage the required resources within this
                                 namespace.
                               type: string
+                              x-kubernetes-validations:
+                              - message: infraNamespace is immutable
+                                rule: self == oldSelf
                           required:
                           - infraNamespace
                           type: object
@@ -33749,6 +33758,9 @@ objects:
                             Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                             \n This is possible using OCP wildcard routes"
                           type: boolean
+                          x-kubernetes-validations:
+                          - message: baseDomainPassthrough is immutable
+                            rule: self == oldSelf
                         credentials:
                           description: "Credentials defines the client credentials
                             used when creating KubeVirt virtual machines. Defining
@@ -33773,6 +33785,9 @@ objects:
                               - key
                               - name
                               type: object
+                              x-kubernetes-validations:
+                              - message: infraKubeConfigSecret is immutable
+                                rule: self == oldSelf
                             infraNamespace:
                               description: InfraNamespace defines the namespace on
                                 the external infra cluster that is used to host the
@@ -33782,6 +33797,9 @@ objects:
                                 access to manage the required resources within this
                                 namespace.
                               type: string
+                              x-kubernetes-validations:
+                              - message: infraNamespace is immutable
+                                rule: self == oldSelf
                           required:
                           - infraNamespace
                           type: object
@@ -37656,6 +37674,9 @@ objects:
                             Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                             \n This is possible using OCP wildcard routes"
                           type: boolean
+                          x-kubernetes-validations:
+                          - message: baseDomainPassthrough is immutable
+                            rule: self == oldSelf
                         credentials:
                           description: "Credentials defines the client credentials
                             used when creating KubeVirt virtual machines. Defining
@@ -37680,6 +37701,9 @@ objects:
                               - key
                               - name
                               type: object
+                              x-kubernetes-validations:
+                              - message: infraKubeConfigSecret is immutable
+                                rule: self == oldSelf
                             infraNamespace:
                               description: InfraNamespace defines the namespace on
                                 the external infra cluster that is used to host the
@@ -37689,6 +37713,9 @@ objects:
                                 access to manage the required resources within this
                                 namespace.
                               type: string
+                              x-kubernetes-validations:
+                              - message: infraNamespace is immutable
+                                rule: self == oldSelf
                           required:
                           - infraNamespace
                           type: object
@@ -41430,6 +41457,9 @@ objects:
                             Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
                             \n This is possible using OCP wildcard routes"
                           type: boolean
+                          x-kubernetes-validations:
+                          - message: baseDomainPassthrough is immutable
+                            rule: self == oldSelf
                         credentials:
                           description: "Credentials defines the client credentials
                             used when creating KubeVirt virtual machines. Defining
@@ -41454,6 +41484,9 @@ objects:
                               - key
                               - name
                               type: object
+                              x-kubernetes-validations:
+                              - message: infraKubeConfigSecret is immutable
+                                rule: self == oldSelf
                             infraNamespace:
                               description: InfraNamespace defines the namespace on
                                 the external infra cluster that is used to host the
@@ -41463,6 +41496,9 @@ objects:
                                 access to manage the required resources within this
                                 namespace.
                               type: string
+                              x-kubernetes-validations:
+                              - message: infraNamespace is immutable
+                                rule: self == oldSelf
                           required:
                           - infraNamespace
                           type: object
@@ -43530,6 +43566,9 @@ objects:
                               - key
                               - name
                               type: object
+                              x-kubernetes-validations:
+                              - message: infraKubeConfigSecret is immutable
+                                rule: self == oldSelf
                             infraNamespace:
                               description: InfraNamespace defines the namespace on
                                 the external infra cluster that is used to host the
@@ -43539,6 +43578,9 @@ objects:
                                 access to manage the required resources within this
                                 namespace.
                               type: string
+                              x-kubernetes-validations:
+                              - message: infraNamespace is immutable
+                                rule: self == oldSelf
                           required:
                           - infraNamespace
                           type: object
@@ -44443,6 +44485,9 @@ objects:
                               - key
                               - name
                               type: object
+                              x-kubernetes-validations:
+                              - message: infraKubeConfigSecret is immutable
+                                rule: self == oldSelf
                             infraNamespace:
                               description: InfraNamespace defines the namespace on
                                 the external infra cluster that is used to host the
@@ -44452,6 +44497,9 @@ objects:
                                 access to manage the required resources within this
                                 namespace.
                               type: string
+                              x-kubernetes-validations:
+                              - message: infraNamespace is immutable
+                                rule: self == oldSelf
                           required:
                           - infraNamespace
                           type: object


### PR DESCRIPTION
Some KubeVirt platform values were meant to be immutable, but immutability was not being enforced. This fixes that by adding validation rules to enforce immutability on those values. 