### PR TITLE
Extend np test timeout for KubeVirt platform

### DIFF
--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -139,8 +139,13 @@ func (mc *NodePoolMachineconfigRolloutTest) Run(t *testing.T, nodePool hyperv1.N
 		t.Fatalf("failed to create %s DaemonSet in guestcluster: %v", ds.Name, err)
 	}
 
+	timeout := time.Duration(15 * time.Minute)
+	if np.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+		timeout = time.Duration(25 * time.Minute)
+	}
+
 	t.Logf("waiting for rollout of updated nodepools")
-	err = wait.PollImmediateWithContext(ctx, 10*time.Second, 15*time.Minute, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateWithContext(ctx, 10*time.Second, timeout, func(ctx context.Context) (bool, error) {
 		if ctx.Err() != nil {
 			return false, ctx.Err()
 		}

--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -126,8 +126,13 @@ func (mc *NTOMachineConfigRolloutTest) Run(t *testing.T, nodePool hyperv1.NodePo
 		}
 	}
 
+	timeout := time.Duration(15 * time.Minute)
+	if np.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+		timeout = time.Duration(25 * time.Minute)
+	}
+
 	t.Logf("waiting for rollout of NodePools with NTO-generated config")
-	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 15*time.Minute, func(ctx context.Context) (bool, error) {
+	err := wait.PollImmediateWithContext(ctx, 10*time.Second, timeout, func(ctx context.Context) (bool, error) {
 		if ctx.Err() != nil {
 			return false, ctx.Err()
 		}


### PR DESCRIPTION
Sometimes it takes the networking stack awhile to come online for new nodes with the KubeVirt platform. This likely has to do more with our CI environment than anything else. We're running the KubeVirt VMs very lean in order to be able to run so many tests in parallel. 

If we increase time timeout for the NTO and MachineConfig node pool tests, i have been able to confirm that they will pass with better consistency. 