### PR TITLE
OCPBUGS-14620: Set `DisableStrictZoneCheck = true` in the AWS Cloud Provider config

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
@@ -16,6 +16,7 @@ const (
 )
 
 const configTemplate = `[Global]
+DisableStrictZoneCheck = true
 Zone = %s
 VPC = %s
 KubernetesClusterID = %s


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit sets this value to always be true, otherwise we rely on an explicit list of valid AWS regions in the upstream cloud-provider https://github.com/openshift/kubernetes/blob/release-4.12/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go#L19-L41 which may become out-of-date. This addresses the bug found in OCPBUGS-14620 where ap-southeast-3 became supported starting in OCP 4.11, but was not in this explicit upstream list until OCP 4.13.


**Which issue(s) this PR fixes**:
Fixes OCPBUGS-14620

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.