### PR TITLE
OCPBUGS-14633: Check for OPENSHIFT_IMG_OVERRIDES before using

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -342,7 +342,12 @@ func NewStartCommand() *cobra.Command {
 			componentImages[name] = image
 		}
 
-		imageRegistryOverrides := util.ConvertImageRegistryOverrideStringToMap(os.Getenv("OPENSHIFT_IMG_OVERRIDES"))
+		var imageRegistryOverrides map[string][]string
+
+		openShiftImgOverrides, ok := os.LookupEnv("OPENSHIFT_IMG_OVERRIDES")
+		if ok {
+			imageRegistryOverrides = util.ConvertImageRegistryOverrideStringToMap(openShiftImgOverrides)
+		}
 
 		releaseProvider := &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
 			Delegate: &releaseinfo.RegistryMirrorProviderDecorator{


### PR DESCRIPTION
**What this PR does / why we need it**:
Check for the existence of OPENSHIFT_IMG_OVERRIDES before using the environment variable to create registry overrides.

https://github.com/openshift/hypershift/pull/2437 created a binding between HO and CPO as a CPO that contains this PR crashes when deployed by an HO that does not.

The reason appears to be related to the absence of the OPENSHIFT_IMG_OVERRIDES envvar on the CPO deployment.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-14633](https://issues.redhat.com/browse/OCPBUGS-14633)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.