### PR TITLE
Update autocaler RBAC to accomodate machinepools support added upstream

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -204,6 +204,8 @@ func ReconcileAutoscalerRole(role *rbacv1.Role, owner config.OwnerRef) error {
 				"machines",
 				"machinesets",
 				"machinesets/scale",
+				"machinepools",
+				"machinepools/scale",
 			},
 			Verbs: []string{"*"},
 		},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2451,6 +2451,8 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role) error {
 				"machines",
 				"machinesets",
 				"machinesets/scale",
+				"machinepools",
+				"machinepools/scale",
 			},
 			Verbs: []string{"*"},
 		},


### PR DESCRIPTION
This is needed to let the autoscaler to operate https://github.com/openshift/kubernetes-autoscaler/pull/256#issuecomment-1582621901 https://github.com/kubernetes/autoscaler/pull/4676

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.