### PR TITLE
OCPBUGS-14784: Honor global ingress configuration LoadBalancer type on AWS

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
@@ -12,12 +12,14 @@ type IngressParams struct {
 	PlatformType     hyperv1.PlatformType
 	IsPrivate        bool
 	IBMCloudUPI      bool
+	AWSNLB           bool
 }
 
 func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 	var replicas int32 = 1
 	isPrivate := false
 	ibmCloudUPI := false
+	nlb := false
 	if hcp.Spec.Platform.IBMCloud != nil && hcp.Spec.Platform.IBMCloud.ProviderType == configv1.IBMCloudProviderTypeUPI {
 		ibmCloudUPI = true
 	}
@@ -27,6 +29,9 @@ func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 	if hcp.Spec.InfrastructureAvailabilityPolicy == hyperv1.HighlyAvailable {
 		replicas = 2
 	}
+	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.Ingress != nil && hcp.Spec.Configuration.Ingress.LoadBalancer.Platform.AWS != nil {
+		nlb = hcp.Spec.Configuration.Ingress.LoadBalancer.Platform.AWS.Type == configv1.NLB
+	}
 
 	return &IngressParams{
 		IngressSubdomain: globalconfig.IngressDomain(hcp),
@@ -34,6 +39,7 @@ func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 		PlatformType:     hcp.Spec.Platform.Type,
 		IsPrivate:        isPrivate,
 		IBMCloudUPI:      ibmCloudUPI,
+		AWSNLB:           nlb,
 	}
 
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 )
 
-func ReconcileDefaultIngressController(ingressController *operatorv1.IngressController, ingressSubdomain string, platformType hyperv1.PlatformType, replicas int32, isIBMCloudUPI bool, isPrivate bool) error {
+func ReconcileDefaultIngressController(ingressController *operatorv1.IngressController, ingressSubdomain string, platformType hyperv1.PlatformType, replicas int32, isIBMCloudUPI bool, isPrivate bool, useNLB bool) error {
 	// If ingress controller already exists, skip reconciliation to allow day-2 configuration
 	if ingressController.ResourceVersion != "" {
 		return nil
@@ -36,6 +36,22 @@ func ReconcileDefaultIngressController(ingressController *operatorv1.IngressCont
 	case hyperv1.KubevirtPlatform:
 		ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
 			Type: operatorv1.NodePortServiceStrategyType,
+		}
+		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
+			Name: manifests.IngressDefaultIngressControllerCert().Name,
+		}
+	case hyperv1.AWSPlatform:
+		if useNLB {
+			ingressController.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
+				Scope: operatorv1.ExternalLoadBalancer,
+				ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
+					Type: operatorv1.AWSLoadBalancerProvider,
+					AWS: &operatorv1.AWSLoadBalancerParameters{
+						Type:                          operatorv1.AWSNetworkLoadBalancer,
+						NetworkLoadBalancerParameters: &operatorv1.AWSNetworkLoadBalancerParameters{},
+					},
+				},
+			}
 		}
 		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
 			Name: manifests.IngressDefaultIngressControllerCert().Name,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -803,7 +803,7 @@ func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv
 	p := ingress.NewIngressParams(hcp)
 	ingressController := manifests.IngressDefaultIngressController()
 	if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
-		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, p.IBMCloudUPI, p.IsPrivate)
+		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, p.IBMCloudUPI, p.IsPrivate, p.AWSNLB)
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
 	}

--- a/support/globalconfig/ingress.go
+++ b/support/globalconfig/ingress.go
@@ -18,9 +18,11 @@ func IngressConfig() *configv1.Ingress {
 }
 
 func ReconcileIngressConfig(cfg *configv1.Ingress, hcp *hyperv1.HostedControlPlane) {
-	cfg.Spec.Domain = IngressDomain(hcp)
 	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.Ingress != nil {
 		cfg.Spec = *hcp.Spec.Configuration.Ingress
+	}
+	if cfg.Spec.Domain == "" {
+		cfg.Spec.Domain = IngressDomain(hcp)
 	}
 }
 
@@ -29,7 +31,9 @@ func IngressDomain(hcp *hyperv1.HostedControlPlane) string {
 		if len(hcp.Spec.Configuration.Ingress.AppsDomain) > 0 {
 			return hcp.Spec.Configuration.Ingress.AppsDomain
 		}
-		return hcp.Spec.Configuration.Ingress.Domain
+		if len(hcp.Spec.Configuration.Ingress.Domain) > 0 {
+			return hcp.Spec.Configuration.Ingress.Domain
+		}
 	}
 	return fmt.Sprintf("apps.%s", BaseDomain(hcp))
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
The ingress.config.openshift.io API allows setting the type of LoadBalancer to use for AWS ingress. This commit honors that setting when creating the initial default IngressController for clusters on AWS.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-14784

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced. 
- [x] This change includes unit tests.