### PR TITLE
HOSTEDCP-1020: Add Create Cluster for KubeVirt for HCP CLI

### DIFF
--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -72,10 +72,10 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 }
 
 func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
-	return core.CreateCluster(ctx, opts, applyPlatformSpecificsValues)
+	return core.CreateCluster(ctx, opts, ApplyPlatformSpecificsValues)
 }
 
-func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
+func ApplyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
 	if opts.KubevirtPlatform.ServicePublishingStrategy != NodePortServicePublishingStrategy && opts.KubevirtPlatform.ServicePublishingStrategy != IngressServicePublishingStrategy {
 		return fmt.Errorf("service publish strategy %s is not supported, supported options: %s, %s", opts.KubevirtPlatform.ServicePublishingStrategy, IngressServicePublishingStrategy, NodePortServicePublishingStrategy)
 	}

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -1,12 +1,13 @@
 package cluster
 
 import (
-	"github.com/openshift/hypershift/api/v1beta1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/cmd/cluster/agent"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/log"
+	"github.com/openshift/hypershift/product-cli/cmd/cluster/kubevirt"
 )
 
 func NewCreateCommands() *cobra.Command {
@@ -38,6 +39,7 @@ func NewCreateCommands() *cobra.Command {
 	}
 
 	cmd.AddCommand(agent.NewCreateCommand(opts))
+	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
 
 	return cmd
 }

--- a/product-cli/cmd/cluster/kubevirt/OWNERS
+++ b/product-cli/cmd/cluster/kubevirt/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - davidvossel
+  - nirarg
+reviewers:
+  - davidvossel
+  - nirarg

--- a/product-cli/cmd/cluster/kubevirt/create.go
+++ b/product-cli/cmd/cluster/kubevirt/create.go
@@ -1,0 +1,63 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
+)
+
+func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "kubevirt",
+		Short:        "Creates basic functional HostedCluster resources for the KubeVirt platform",
+		SilenceUsage: true,
+	}
+
+	opts.KubevirtPlatform = core.KubevirtPlatformCreateOptions{
+		ServicePublishingStrategy: kubevirt.IngressServicePublishingStrategy,
+		APIServerAddress:          "",
+		Memory:                    "8Gi",
+		Cores:                     2,
+		ContainerDiskImage:        "",
+		RootVolumeSize:            32,
+		InfraKubeConfigFile:       "",
+		CacheStrategyType:         "",
+	}
+
+	cmd.Flags().StringVar(&opts.KubevirtPlatform.Memory, "memory", opts.KubevirtPlatform.Memory, "The amount of memory which is visible inside the Guest OS (type BinarySI, e.g. 5Gi, 100Mi)")
+	cmd.Flags().Uint32Var(&opts.KubevirtPlatform.Cores, "cores", opts.KubevirtPlatform.Cores, "The number of cores inside the vmi, Must be a value greater than or equal to 1")
+	cmd.Flags().StringVar(&opts.KubevirtPlatform.RootVolumeStorageClass, "root-volume-storage-class", opts.KubevirtPlatform.RootVolumeStorageClass, "The storage class to use for machines in the NodePool")
+	cmd.Flags().Uint32Var(&opts.KubevirtPlatform.RootVolumeSize, "root-volume-size", opts.KubevirtPlatform.RootVolumeSize, "The size of the root volume for machines in the NodePool in Gi")
+	cmd.Flags().StringVar(&opts.KubevirtPlatform.RootVolumeAccessModes, "root-volume-access-modes", opts.KubevirtPlatform.RootVolumeAccessModes, "The access modes of the root volume to use for machines in the NodePool (comma-delimited list)")
+	cmd.Flags().StringVar(&opts.KubevirtPlatform.ServicePublishingStrategy, "service-publishing-strategy", opts.KubevirtPlatform.ServicePublishingStrategy, fmt.Sprintf("Define how to expose the cluster services. Supported options: %s (Use LoadBalancer and Route to expose services), %s (Select a random node to expose service access through)", kubevirt.IngressServicePublishingStrategy, kubevirt.NodePortServicePublishingStrategy))
+	cmd.Flags().StringVar(&opts.KubevirtPlatform.InfraKubeConfigFile, "infra-kubeconfig-file", opts.KubevirtPlatform.InfraKubeConfigFile, "Path to a kubeconfig file of an external infra cluster to be used to create the guest clusters nodes onto")
+	cmd.Flags().StringVar(&opts.KubevirtPlatform.InfraNamespace, "infra-namespace", opts.KubevirtPlatform.InfraNamespace, "The namespace in the external infra cluster that is used to host the KubeVirt virtual machines. The namespace must exist prior to creating the HostedCluster")
+	cmd.Flags().StringVar(&opts.KubevirtPlatform.CacheStrategyType, "root-volume-cache-strategy", opts.KubevirtPlatform.CacheStrategyType, "Set the boot image caching strategy; Supported values:\n- \"None\": no caching (default).\n- \"PVC\": Cache into a PVC; only for QCOW image; ignored for container images")
+	cmd.Flags().StringArrayVar(&opts.KubevirtPlatform.InfraStorageClassMappings, "infra-storage-class-mapping", opts.KubevirtPlatform.InfraStorageClassMappings, "KubeVirt CSI napping of an infra StorageClass to a guest cluster StorageCluster. Mapping is structured as <infra storage class>/<guest storage class>. Example, mapping the infra storage class ocs-storagecluster-ceph-rbd to a guest storage class called ceph-rdb. --infra-storage-class-mapping=ocs-storagecluster-ceph-rbd/ceph-rdb")
+
+	_ = cmd.MarkPersistentFlagRequired("pull-secret")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if opts.Timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
+		}
+
+		if err := CreateCluster(ctx, opts); err != nil {
+			opts.Log.Error(err, "Failed to create cluster")
+			return err
+		}
+		return nil
+	}
+
+	return cmd
+}
+
+func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
+	return core.CreateCluster(ctx, opts, kubevirt.ApplyPlatformSpecificsValues)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the create cluster command for the KubeVirt platform for the HCP CLI.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1020](https://issues.redhat.com/browse/HOSTEDCP-1020).

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes unit tests.