### PR TITLE
HOSTEDCP-1031: Add Destroy Cluster Cmd for KubeVirt for HCP CLI

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -1,4 +1,4 @@
-package aws
+package destroy
 
 import (
 	"github.com/spf13/cobra"

--- a/product-cli/cmd/cluster/kubevirt/destroy.go
+++ b/product-cli/cmd/cluster/kubevirt/destroy.go
@@ -11,7 +11,7 @@ import (
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "kubevirt",
-		Short:        "Destroys a HostedCluster and its associated infrastructure on Kubevirt platform.",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on KubeVirt platform.",
 		SilenceUsage: true,
 	}
 

--- a/product-cli/cmd/destroy/destroy.go
+++ b/product-cli/cmd/destroy/destroy.go
@@ -1,0 +1,19 @@
+package destroy
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/hypershift/product-cli/cmd/cluster"
+)
+
+func NewCommand() *cobra.Command {
+	destroyCmd := &cobra.Command{
+		Use:          "destroy",
+		Short:        "Commands for destroying HostedClusters",
+		SilenceUsage: true,
+	}
+
+	destroyCmd.AddCommand(cluster.NewDestroyCommands())
+
+	return destroyCmd
+}

--- a/product-cli/main.go
+++ b/product-cli/main.go
@@ -17,13 +17,15 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/hypershift/product-cli/cmd/create"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/openshift/hypershift/pkg/version"
 	"github.com/spf13/cobra"
+
+	"github.com/openshift/hypershift/pkg/version"
+	"github.com/openshift/hypershift/product-cli/cmd/create"
+	"github.com/openshift/hypershift/product-cli/cmd/destroy"
 )
 
 func main() {
@@ -33,7 +35,7 @@ func main() {
 		TraverseChildren: true,
 
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
+			_ = cmd.Help()
 			os.Exit(1)
 		},
 	}
@@ -45,17 +47,18 @@ func main() {
 	defer cancel()
 
 	cmd.AddCommand(create.NewCommand())
+	cmd.AddCommand(destroy.NewCommand())
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT)
 	go func() {
 		<-sigs
-		fmt.Fprintln(os.Stderr, "\nAborted...")
+		_, _ = fmt.Fprintln(os.Stderr, "\nAborted...")
 		cancel()
 	}()
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add destroy cluster command for the KubeVirt platform for the HCP CLI.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1031](https://issues.redhat.com/browse/HOSTEDCP-1031)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes unit tests.