### PR TITLE
[release-4.13] OCPBUGS-14888: Annotate HCP pods with the safe-to-evict-local-volume CA annotation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: client-token,web-identity-token
         hypershift.openshift.io/release-image: quay.io/ocp-dev/test-release-image:latest
       creationTimestamp: null
       labels:

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -1,11 +1,13 @@
 package kubevirt
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	suppconfig "github.com/openshift/hypershift/support/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
@@ -133,6 +135,9 @@ func generateNodeTemplate(memory string, cpu uint32, image string, volumeSize st
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						nodePoolNameLabelKey: "my-pool",
+					},
+					Annotations: map[string]string{
+						suppconfig.PodSafeToEvictLocalVolumesKey: strings.Join(LocalStorageVolumes, ","),
 					},
 				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{

--- a/support/config/deployment_test.go
+++ b/support/config/deployment_test.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -389,6 +391,105 @@ func TestResourceRequestOverrides(t *testing.T) {
 			hcp.Annotations = test.annotations
 			actual := resourceRequestOverrides(hcp)
 			g.Expect(actual).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestApplyTo(t *testing.T) {
+	tests := []struct {
+		name     string
+		volumes  []corev1.Volume
+		expected string
+	}{
+		{
+			name: "if 3 volumes provided and 2 valids for safe annotation, it should only annotate the deployment with these 2 volume names",
+			volumes: []corev1.Volume{
+				corev1.Volume{
+					Name: "test-hostpath",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "test",
+						},
+					},
+				},
+				corev1.Volume{
+					Name: "test-emptydir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMedium("Memory"),
+						},
+					},
+				},
+				corev1.Volume{
+					Name: "test-volume",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "test",
+						},
+					},
+				},
+			},
+			expected: "test-hostpath,test-emptydir",
+		},
+		{
+			name: "no hostpath or emptydir volumes provided, no safe eviction annotation",
+			volumes: []corev1.Volume{
+				corev1.Volume{
+					Name: "test-volume",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "test",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			deployment := &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-deployment",
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-container",
+								},
+							},
+							Volumes: tc.volumes,
+						},
+					},
+				},
+			}
+			dc := &DeploymentConfig{}
+			dc.ApplyTo(deployment)
+
+			localVolumeList := make([]string, 0)
+			for _, volume := range deployment.Spec.Template.Spec.Volumes {
+				// Check the volumes, if they are emptyDir or hostPath, should be annotated
+				if volume.EmptyDir != nil || volume.HostPath != nil {
+					localVolumeList = append(localVolumeList, volume.Name)
+				}
+			}
+
+			// After going through all the volumes in the deployment, validates if
+			// the annotation value makes sense with the expectations.
+			if _, exists := deployment.Spec.Template.ObjectMeta.Annotations[PodSafeToEvictLocalVolumesKey]; exists {
+				g.Expect(deployment.Spec.Template.ObjectMeta.Annotations).To(HaveKeyWithValue(PodSafeToEvictLocalVolumesKey, strings.Join(localVolumeList, ",")))
+			}
 		})
 	}
 }

--- a/support/config/types.go
+++ b/support/config/types.go
@@ -1,0 +1,7 @@
+package config
+
+const (
+	// PodSafeToEvictLocalVolumesKey is an annotation used by the CA operator which makes sure
+	// all the pods annotated with it and the picking the desired local volumes that are safe to evict, could be drained properly.
+	PodSafeToEvictLocalVolumesKey = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
+)


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
- Fixes #[OCPBUGS-11882](https://issues.redhat.com/browse/OCPBUGS-11882)
- Fixes #[OCPBUGS-14888](https://issues.redhat.com/browse/OCPBUGS-14888) (Backport)

Depend on:
- https://github.com/openshift/cluster-network-operator/pull/1836
- https://github.com/openshift/aws-ebs-csi-driver-operator/pull/233

*NOTE: Both approved and tagged*

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes e2e and unit tests.