### PR TITLE
Add ec2:DescribeInstanceTypes to NodePoolManagement role

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1375,7 +1375,8 @@ type AWSRolesRef struct {
 	//        "ec2:DescribeLaunchTemplates",
 	//        "ec2:DescribeLaunchTemplateVersions",
 	//        "ec2:DeleteLaunchTemplate",
-	//        "ec2:DeleteLaunchTemplateVersions"
+	//        "ec2:DeleteLaunchTemplateVersions",
+	//        "ec2:DescribeInstanceTypes"
 	//      ],
 	//      "Resource": [
 	//        "*"

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -219,7 +219,8 @@ const (
         "ec2:DescribeLaunchTemplates",
         "ec2:DescribeLaunchTemplateVersions",
         "ec2:DeleteLaunchTemplate",
-        "ec2:DeleteLaunchTemplateVersions"
+        "ec2:DeleteLaunchTemplateVersions",
+        "ec2:DescribeInstanceTypes"
       ],
       "Resource": [
         "*"

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -6272,12 +6272,12 @@ spec:
                               \"ec2:RunInstances\", \"ec2:TerminateInstances\", \"tag:GetResources\",
                               \"ec2:CreateLaunchTemplate\", \"ec2:CreateLaunchTemplateVersion\",
                               \"ec2:DescribeLaunchTemplates\", \"ec2:DescribeLaunchTemplateVersions\",
-                              \"ec2:DeleteLaunchTemplate\", \"ec2:DeleteLaunchTemplateVersions\"
-                              ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\" },
-                              { \"Condition\": { \"StringLike\": { \"iam:AWSServiceName\":
-                              \"elasticloadbalancing.amazonaws.com\" } }, \"Action\":
-                              [ \"iam:CreateServiceLinkedRole\" ], \"Resource\": [
-                              \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                              \"ec2:DeleteLaunchTemplate\", \"ec2:DeleteLaunchTemplateVersions\",
+                              \"ec2:DescribeInstanceTypes\" ], \"Resource\": [ \"*\"
+                              ], \"Effect\": \"Allow\" }, { \"Condition\": { \"StringLike\":
+                              { \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"
+                              } }, \"Action\": [ \"iam:CreateServiceLinkedRole\" ],
+                              \"Resource\": [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
                               ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                               ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                               ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -6263,12 +6263,12 @@ spec:
                               \"ec2:RunInstances\", \"ec2:TerminateInstances\", \"tag:GetResources\",
                               \"ec2:CreateLaunchTemplate\", \"ec2:CreateLaunchTemplateVersion\",
                               \"ec2:DescribeLaunchTemplates\", \"ec2:DescribeLaunchTemplateVersions\",
-                              \"ec2:DeleteLaunchTemplate\", \"ec2:DeleteLaunchTemplateVersions\"
-                              ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\" },
-                              { \"Condition\": { \"StringLike\": { \"iam:AWSServiceName\":
-                              \"elasticloadbalancing.amazonaws.com\" } }, \"Action\":
-                              [ \"iam:CreateServiceLinkedRole\" ], \"Resource\": [
-                              \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                              \"ec2:DeleteLaunchTemplate\", \"ec2:DeleteLaunchTemplateVersions\",
+                              \"ec2:DescribeInstanceTypes\" ], \"Resource\": [ \"*\"
+                              ], \"Effect\": \"Allow\" }, { \"Condition\": { \"StringLike\":
+                              { \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"
+                              } }, \"Action\": [ \"iam:CreateServiceLinkedRole\" ],
+                              \"Resource\": [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
                               ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                               ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                               ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1855,7 +1855,8 @@ string
 &ldquo;ec2:DescribeLaunchTemplates&rdquo;,
 &ldquo;ec2:DescribeLaunchTemplateVersions&rdquo;,
 &ldquo;ec2:DeleteLaunchTemplate&rdquo;,
-&ldquo;ec2:DeleteLaunchTemplateVersions&rdquo;
+&ldquo;ec2:DeleteLaunchTemplateVersions&rdquo;,
+&ldquo;ec2:DescribeInstanceTypes&rdquo;
 ],
 &ldquo;Resource&rdquo;: [
 &ldquo;<em>&rdquo;

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -33624,11 +33624,12 @@ objects:
                                 \"tag:GetResources\", \"ec2:CreateLaunchTemplate\",
                                 \"ec2:CreateLaunchTemplateVersion\", \"ec2:DescribeLaunchTemplates\",
                                 \"ec2:DescribeLaunchTemplateVersions\", \"ec2:DeleteLaunchTemplate\",
-                                \"ec2:DeleteLaunchTemplateVersions\" ], \"Resource\":
-                                [ \"*\" ], \"Effect\": \"Allow\" }, { \"Condition\":
-                                { \"StringLike\": { \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"
-                                } }, \"Action\": [ \"iam:CreateServiceLinkedRole\"
-                                ], \"Resource\": [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                                \"ec2:DeleteLaunchTemplateVersions\", \"ec2:DescribeInstanceTypes\"
+                                ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\"
+                                }, { \"Condition\": { \"StringLike\": { \"iam:AWSServiceName\":
+                                \"elasticloadbalancing.amazonaws.com\" } }, \"Action\":
+                                [ \"iam:CreateServiceLinkedRole\" ], \"Resource\":
+                                [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
                                 ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                                 ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                                 ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",
@@ -41323,11 +41324,12 @@ objects:
                                 \"tag:GetResources\", \"ec2:CreateLaunchTemplate\",
                                 \"ec2:CreateLaunchTemplateVersion\", \"ec2:DescribeLaunchTemplates\",
                                 \"ec2:DescribeLaunchTemplateVersions\", \"ec2:DeleteLaunchTemplate\",
-                                \"ec2:DeleteLaunchTemplateVersions\" ], \"Resource\":
-                                [ \"*\" ], \"Effect\": \"Allow\" }, { \"Condition\":
-                                { \"StringLike\": { \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"
-                                } }, \"Action\": [ \"iam:CreateServiceLinkedRole\"
-                                ], \"Resource\": [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                                \"ec2:DeleteLaunchTemplateVersions\", \"ec2:DescribeInstanceTypes\"
+                                ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\"
+                                }, { \"Condition\": { \"StringLike\": { \"iam:AWSServiceName\":
+                                \"elasticloadbalancing.amazonaws.com\" } }, \"Action\":
+                                [ \"iam:CreateServiceLinkedRole\" ], \"Resource\":
+                                [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
                                 ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
                                 ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
                                 ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",


### PR DESCRIPTION
**What this PR does / why we need it**:
new permission `ec2:DescribeInstanceTypes` is needed by the `clusters-api-provider-aws`  v.2.0.x 

Rebase https://github.com/openshift/cluster-api-provider-aws/pull/464 currently failing with:
```
E0614 10:58:04.415811       1 controller.go:329] "Reconciler error" err=<
	failed to create AWSMachine instance: UnauthorizedOperation: You are not authorized to perform this operation.
		status code: 403, request id: b99a7e00-bf8a-4b67-8711-04cdabcd032f
 > controller="awsmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSMachine" AWSMachine="e2e-clusters-drzvj-example-9d445/example-9d445-us-east-1b-lhs5m" namespace="e2e-clusters-drzvj-example-9d445" name="example-9d445-us-east-1b-lhs5m" 
```

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.