### PR TITLE
Make NodePool arch input immutable

### DIFF
--- a/api/v1beta1/nodepool_types.go
+++ b/api/v1beta1/nodepool_types.go
@@ -69,6 +69,7 @@ type NodePool struct {
 }
 
 // NodePoolSpec is the desired behavior of a NodePool.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.arch) || has(self.arch)", message="Arch is required once set"
 type NodePoolSpec struct {
 	// ClusterName is the name of the HostedCluster this NodePool belongs to.
 	//
@@ -164,6 +165,7 @@ type NodePoolSpec struct {
 	//
 	// +kubebuilder:default:=amd64
 	// +kubebuilder:validation:Enum=arm64;amd64
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Arch is immutable"
 	// +optional
 	Arch string `json:"arch,omitempty"`
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1007,6 +1007,9 @@ spec:
                 - arm64
                 - amd64
                 type: string
+                x-kubernetes-validations:
+                - message: Arch is immutable
+                  rule: self == oldSelf
               autoScaling:
                 description: Autoscaling specifies auto-scaling behavior for the NodePool.
                 properties:
@@ -1719,6 +1722,9 @@ spec:
             - platform
             - release
             type: object
+            x-kubernetes-validations:
+            - message: Arch is required once set
+              rule: '!has(oldSelf.arch) || has(self.arch)'
           status:
             description: Status is the latest observed status of the NodePool.
             properties:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -43676,6 +43676,9 @@ objects:
                   - arm64
                   - amd64
                   type: string
+                  x-kubernetes-validations:
+                  - message: Arch is immutable
+                    rule: self == oldSelf
                 autoScaling:
                   description: Autoscaling specifies auto-scaling behavior for the
                     NodePool.
@@ -44395,6 +44398,9 @@ objects:
               - platform
               - release
               type: object
+              x-kubernetes-validations:
+              - message: Arch is required once set
+                rule: '!has(oldSelf.arch) || has(self.arch)'
             status:
               description: Status is the latest observed status of the NodePool.
               properties:


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Changing this field in a NodePool is not supported. Enforcing this via CEL to raise the UX bar. This becomes specially important as we plan to GA for self-hosted where consumers interact directly with this API.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.