### PR TITLE
OCPBUGS-14859: Skip AWS resource deletion for 'Unknown' OIDC state

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -4143,12 +4143,8 @@ func hasValidCloudCredentials(hcp *hyperv1.HostedControlPlane) (string, bool) {
 	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform {
 		return "", true
 	}
-	oidcConfigValid := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidOIDCConfiguration))
-	if oidcConfigValid != nil && oidcConfigValid.Status == metav1.ConditionFalse {
-		return "Invalid OIDC configuration", false
-	}
 	validIdentityProvider := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidAWSIdentityProvider))
-	if validIdentityProvider != nil && validIdentityProvider.Status == metav1.ConditionFalse {
+	if validIdentityProvider != nil && validIdentityProvider.Status != metav1.ConditionTrue {
 		return "Invalid AWS identity provider", false
 	}
 	return "", true

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -296,7 +296,7 @@ func ValidCredentials(hc *hyperv1.HostedCluster) bool {
 		return false
 	}
 	validIdentityProvider := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.ValidAWSIdentityProvider))
-	if validIdentityProvider != nil && validIdentityProvider.Status == metav1.ConditionFalse {
+	if validIdentityProvider != nil && validIdentityProvider.Status != metav1.ConditionTrue {
 		return false
 	}
 	return true


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes deletion of aws resources not skipped when OIDC/ValidIdentiityProvider condition is set to `Unknown`

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-14859](https://issues.redhat.com/browse/OCPBUGS-14859)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.