### PR TITLE
Temporarily allow kubevirt to use OpenStack image in order to unblock CI

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -70,11 +70,14 @@ func unsupportedOpenstackDefaultImage(releaseImage *releaseinfo.ReleaseImage) (s
 }
 
 func allowUnsupportedRHCOSVariants(nodePool *hyperv1.NodePool) bool {
-	val, exists := nodePool.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation]
-	if exists && strings.ToLower(val) == "true" {
-		return true
-	}
-	return false
+	// Temporary workaround is to use OpenStack image to unblock CI
+	// Tracking this issue here, https://issues.redhat.com/browse/COS-2271
+	//val, exists := nodePool.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation]
+	//if exists && strings.ToLower(val) == "true" {
+	//	return true
+	//}
+	//return false
+	return true
 }
 
 func GetImage(nodePool *hyperv1.NodePool, releaseImage *releaseinfo.ReleaseImage, hostedNamespace string) (BootImage, error) {


### PR DESCRIPTION


The image digest is empty for 4.14 starting in builds built after june 15th. 

```
            "kubevirt": {
              "release": "414.92.202306141028-0",
              "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
              "digest-ref": ""
            }
```

We're tracking a fix for this here, https://issues.redhat.com/browse/COS-2271. As a work around, this code falls back to using the openstack image instead of the sha digest when `digest-ref` is empty. We will have to revert this change once the digest is fixed in the release image.
