### PR TITLE
properly handle user CA bundle not existing

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3161,7 +3161,7 @@ func (r *HostedControlPlaneReconciler) reconcileMachineConfigServerConfig(ctx co
 	}
 
 	trustedCABundle := manifests.TrustedCABundleConfigMap(hcp.Namespace)
-	if err := r.Get(ctx, client.ObjectKeyFromObject(trustedCABundle), trustedCABundle); err != nil {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(trustedCABundle), trustedCABundle); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get trustedCABundle: %w", err)
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
@@ -40,7 +40,7 @@ func ReconcileMachineConfigServerConfig(cm *corev1.ConfigMap, p *MCSParams) erro
 		return err
 	}
 
-	if p.UserCA != nil {
+	if p.UserCA != nil && len(p.UserCA.Data) > 0 {
 		serializedUserCA, err := serialize(p.UserCA)
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently the code does not gracefully handle the UserCA bundle not existing and errors out on fetching the trusted CA bundle which short circuts any further reconcilation automation. This ensures it is gracefully handled to allow full reconcilation of the control-plane-operator

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.