### PR TITLE
OCPBUGS-14783: Fix NetworkPolicy to work over IPv4 and IPv6

### DIFF
--- a/support/util/util.go
+++ b/support/util/util.go
@@ -245,3 +245,18 @@ func ConvertImageRegistryOverrideStringToMap(envVar string) map[string][]string 
 
 	return imageRegistryOverrides
 }
+
+// IsIPv4 function parse the CIDR and get the IPNet struct if the IPNet.IP cannot be converted to 4bytes format,
+// the function returns nil, if it's an IPv6 it will return nil.
+func IsIPv4(cidr string) (bool, error) {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false, fmt.Errorf("error validating the ClusterNetworkCIDR from HostedCluster: %v", err)
+	}
+
+	if ipnet.IP.To4() != nil {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -244,3 +244,54 @@ func testDecompressFuncErr(t *testing.T, payload []byte) {
 	g.Expect(out.Bytes()).To(BeNil(), "should be a nil byte slice")
 	g.Expect(out.String()).To(BeEmpty(), "should be an empty string")
 }
+
+func TestIsIPv4(t *testing.T) {
+	type args struct {
+		cidrs []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "When an ipv4 CIDR is checked by isIPv4, it should return true",
+			args: args{
+				cidrs: []string{"192.168.1.35/24", "0.0.0.0/0", "127.0.0.1/24"},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "When an ipv6 CIDR is checked by isIPv4, it should return false",
+			args: args{
+				cidrs: []string{"2001::/17", "2001:db8::/62", "::/0", "2000::/3"},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "When a non valid CIDR is checked by isIPv4, it should return an error and false",
+			args: args{
+				cidrs: []string{"192.168.35/68"},
+			},
+			want:    false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, cidr := range tt.args.cidrs {
+				got, err := IsIPv4(cidr)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("isIPv4() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if got != tt.want {
+					t.Errorf("isIPv4() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The implementation added now, validates the ClusterNetwork CIDR used to build the HostedCluster CR. The CIDR added to the NetworkPolicy now matches the ClusterNetwork stack in order to block egress traffic

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-14783](https://issues.redhat.com/browse/OCPBUGS-14783)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.