### PR TITLE
OCPBUGS-14637: Check OwningIngressController also in Labels

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1836,6 +1836,10 @@ func (r *reconciler) ensureServiceLoadBalancersRemoved(ctx context.Context) (boo
 		if _, hasAnnotation := svc.Annotations["ingresscontroller.operator.openshift.io/owning-ingresscontroller"]; hasAnnotation {
 			return false
 		}
+		// The router-default from openshift-ingress namespace it has the same but as a label
+		if _, hasLabel := svc.Labels["ingresscontroller.operator.openshift.io/owning-ingresscontroller"]; hasLabel {
+			return false
+		}
 		return true
 	}, false)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Now the HCCO checks the annotations and labels of the LoadBalancer services in order to decide if we should take care of the deletion or delegate to the ingress-operator

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-14637](https://issues.redhat.com/browse/OCPBUGS-14637)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.