### PR TITLE
HOSTEDCP-1067: Add dependabot dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    vendor: true
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
In order to keep track of dependency updates in an automatic manner, let's add dependabot to the repository.

**What this PR does / why we need it**:

It adds configuration so that the dependabot service manages the go module dependencies in this repository. It will solve the lack of automated dependency detection.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.