### PR TITLE
HOSTEDCP-1000: Add user CA(s) to ocm-trusted-ca-bundle ConfigMap

### DIFF
--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -543,8 +543,25 @@ objects:
           - mountPath: /var/run/secrets/openshift/serviceaccount
             name: token
           - mountPath: /etc/pki/ca-trust/extracted/pem
+            name: trusted-ca-bundle
+            readOnly: true
+        initContainers:
+        - args:
+          - init
+          command:
+          - /usr/bin/hypershift-operator
+          image: ${OPERATOR_IMG}:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          name: init-environment
+          resources: {}
+          securityContext:
+            runAsUser: 1000
+          volumeMounts:
+          - mountPath: /var/run/ca-trust
             name: openshift-config-managed-trusted-ca-bundle
             readOnly: true
+          - mountPath: /trust-bundle
+            name: trusted-ca-bundle
         priorityClassName: hypershift-operator
         serviceAccountName: operator
         volumes:
@@ -568,7 +585,10 @@ objects:
             - key: ca-bundle.crt
               path: tls-ca-bundle.pem
             name: openshift-config-managed-trusted-ca-bundle
+            optional: true
           name: openshift-config-managed-trusted-ca-bundle
+        - emptyDir: {}
+          name: trusted-ca-bundle
   status: {}
 - apiVersion: v1
   kind: Service

--- a/hypershift-operator/init.go
+++ b/hypershift-operator/init.go
@@ -1,0 +1,140 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	configapi "github.com/openshift/api/config/v1"
+	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/support/capabilities"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewInitCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Prepares pre-requisites that are required by the Hypershift Operator",
+		Long:  "Prepares pre-requisites such as merging additional CA trust bundles that are required by the Hypershift Operator",
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+		defer cancel()
+
+		if err := runInit(ctx, ctrl.Log.WithName("init")); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}
+
+func runInit(ctx context.Context, log logr.Logger) error {
+	log.Info("Initializing environment for Hypershift Operator")
+	client, err := util.GetClient()
+	if err != nil {
+		return err
+	}
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return fmt.Errorf("unable to get discovery client: %w", err)
+	}
+	mgmtClusterCaps, err := capabilities.DetectManagementClusterCapabilities(discoveryClient)
+	if err != nil {
+		return fmt.Errorf("unable to detect management cluster capabilities: %w", err)
+	}
+
+	trustedCABundle := new(bytes.Buffer)
+	var ocmTrustedCABundle []byte
+	if _, err := os.Stat("/var/run/ca-trust/tls-ca-bundle.pem"); err == nil {
+		ocmTrustedCABundle, err = os.ReadFile("/var/run/ca-trust/tls-ca-bundle.pem")
+		if err != nil {
+			return fmt.Errorf("unable to read ocm CA trust bundle file: %w", err)
+		}
+	} else if err != nil && errors.Is(err, os.ErrNotExist) {
+		ocmTrustedCABundle, err = os.ReadFile("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+		if err != nil {
+			return fmt.Errorf("unable to read ocm CA trust bundle file: %w", err)
+		}
+	} else {
+		return err
+	}
+
+	if _, err := trustedCABundle.Write(ocmTrustedCABundle); err != nil {
+		return fmt.Errorf("unable to write ocm CA trust bundle to buffer: %w", err)
+	}
+
+	if mgmtClusterCaps.Has(capabilities.CapabilityImage) {
+		// Adds user-specified image registry CA bundle to the full CA trust bundle if it exists
+		imageRegistryCABundle, err := getImageRegistryCABundle(ctx, client)
+		if err != nil {
+			return fmt.Errorf("unable to get CA bundle for image mirror registries: %w", err)
+		}
+		if imageRegistryCABundle != nil {
+			if _, err := trustedCABundle.Write(imageRegistryCABundle.Bytes()); err != nil {
+				return fmt.Errorf("unable to write image registry CA to buffer: %w", err)
+			}
+		}
+	}
+
+	if err := os.WriteFile("/trust-bundle/tls-ca-bundle.pem", trustedCABundle.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	log.Info("Finished initializing environment for Hypershift Operator")
+	return nil
+}
+
+// getImageRegistryCABundle retrieves the image registry CAs listed under image.config.openshift.io
+func getImageRegistryCABundle(ctx context.Context, client crclient.Client) (*bytes.Buffer, error) {
+	img := &configapi.Image{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, img); err != nil {
+		return nil, err
+	}
+	if img == nil || img.Spec.AdditionalTrustedCA.Name == "" {
+		return nil, nil
+	}
+	configmap := &corev1.ConfigMap{}
+	if err := client.Get(ctx, types.NamespacedName{Name: img.Spec.AdditionalTrustedCA.Name, Namespace: "openshift-config"}, configmap); err != nil {
+		return nil, err
+	}
+	if configmap.Data != nil {
+		var buf bytes.Buffer
+		for _, crt := range configmap.Data {
+			buf.WriteString(crt)
+		}
+		if buf.Len() > 0 {
+			return &buf, nil
+		}
+	}
+	return nil, nil
+}

--- a/hypershift-operator/init_test.go
+++ b/hypershift-operator/init_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	configapi "github.com/openshift/api/config/v1"
+	"github.com/openshift/hypershift/api"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetImageRegistryCABundle(t *testing.T) {
+	testCases := []struct {
+		name               string
+		objects            []crclient.Object
+		clusterImageConfig *configapi.Image
+		configmap          *corev1.ConfigMap
+		expectedCert       *bytes.Buffer
+		expectedError      bool
+	}{
+		{
+			name:               "The image.config.openshift.io object doesn't exist",
+			objects:            []crclient.Object{},
+			clusterImageConfig: nil,
+			configmap:          nil,
+			expectedCert:       nil,
+			expectedError:      true,
+		},
+		{
+			name: "The image.config.openshift.io object doesn't specify a trusted CA",
+			objects: []crclient.Object{
+				&configapi.Image{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configapi.ImageSpec{},
+				},
+			},
+			clusterImageConfig: nil,
+			configmap:          nil,
+			expectedCert:       nil,
+			expectedError:      false,
+		},
+		{
+			name: "The trusted CA configmap doesn't exist",
+			objects: []crclient.Object{
+				&configapi.Image{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configapi.ImageSpec{
+						AdditionalTrustedCA: configapi.ConfigMapNameReference{
+							Name: "registry-config",
+						},
+					},
+				},
+			},
+			clusterImageConfig: nil,
+			configmap:          nil,
+			expectedCert:       nil,
+			expectedError:      true,
+		},
+		{
+			name: "The trusted CA configmap has no data",
+			objects: []crclient.Object{
+				&configapi.Image{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configapi.ImageSpec{
+						AdditionalTrustedCA: configapi.ConfigMapNameReference{
+							Name: "registry-config",
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "registry-config",
+						Namespace: "openshift-config",
+					},
+				},
+			},
+			clusterImageConfig: nil,
+			expectedCert:       nil,
+			expectedError:      false,
+		},
+		{
+			name: "The trusted CA configmap has data",
+			objects: []crclient.Object{
+				&configapi.Image{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configapi.ImageSpec{
+						AdditionalTrustedCA: configapi.ConfigMapNameReference{
+							Name: "registry-config",
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "registry-config",
+						Namespace: "openshift-config",
+					},
+					Data: map[string]string{
+						"mirror.registry.com": "test",
+					},
+				},
+			},
+			clusterImageConfig: nil,
+			expectedCert:       bytes.NewBufferString("test"),
+			expectedError:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tc.objects...).Build()
+			ctx := context.Background()
+			cert, err := getImageRegistryCABundle(ctx, client)
+			if tc.expectedError {
+				g.Expect(err).NotTo(BeNil())
+			}
+			g.Expect(cert).To(BeEquivalentTo(tc.expectedCert))
+		})
+	}
+}

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -61,6 +61,10 @@ import (
 )
 
 func main() {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+		o.EncodeTime = zapcore.RFC3339TimeEncoder
+	})))
+
 	cmd := &cobra.Command{
 		Use: "hypershift-operator",
 		Run: func(cmd *cobra.Command, args []string) {
@@ -72,6 +76,7 @@ func main() {
 	cmd.Version = version.String()
 
 	cmd.AddCommand(NewStartCommand())
+	cmd.AddCommand(NewInitCommand())
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -97,10 +102,6 @@ type StartOptions struct {
 }
 
 func NewStartCommand() *cobra.Command {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
-		o.EncodeTime = zapcore.RFC3339TimeEncoder
-	})))
-
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Runs the Hypershift operator",

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -27,6 +27,10 @@ const (
 	// supports security context constraints
 	CapabilitySecurityContextConstraint
 
+	// CapabilityImage indicates if the cluster supports the
+	// image.config.openshift.io api
+	CapabilityImage
+
 	// CapabilityInfrastructure indicates if the cluster supports the
 	// infrastructures.config.openshift.io api
 	CapabilityInfrastructure
@@ -113,6 +117,15 @@ func DetectManagementClusterCapabilities(client discovery.ServerResourcesInterfa
 	}
 	if hasSccCap {
 		discoveredCapabilities[CapabilitySecurityContextConstraint] = struct{}{}
+	}
+
+	// check for image capability
+	hasImageCap, err := isAPIResourceRegistered(client, configv1.GroupVersion, "image")
+	if err != nil {
+		return nil, err
+	}
+	if hasImageCap {
+		discoveredCapabilities[CapabilityImage] = struct{}{}
 	}
 
 	// check for infrastructure capability


### PR DESCRIPTION
[HOSTEDCP-1000](https://issues.redhat.com/browse/HOSTEDCP-1000)
Adds the CA certificates for mirror registries specified by the user to the ocm-trusted-ca-bundle ConfigMap created in
https://github.com/openshift/hypershift/pull/2437 so that these certificates may be used to pull images from these mirror registries.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**: 
Users in disconnected environments will host their own image registry. The certificates from these registries are needed in order to pull from them.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1000](https://issues.redhat.com//browse/HOSTEDCP-1000)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.