### PR TITLE
HOSTEDCP-1027: Add Create kubeconfig for HCP CLI

### DIFF
--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -25,9 +25,9 @@ import (
 const Description string = `
 This command renders kubeconfigs for HostedClusters.
 
-If a single cluster is identified, the kubeconfig is printed to stdout.
+If a single cluster is specified, the kubeconfig is printed to stdout.
 
-If no clusters are identified, this command renders a kubeconfig with a context
+If no clusters are specified, this command renders a kubeconfig with a context
 for every HostedCluster resource. The contexts are named based on the
 HostedCluster following the pattern:
 
@@ -52,17 +52,16 @@ func NewCreateCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	opts := options{}
+	opts := options{
+		namespace: "clusters",
+	}
 
-	cmd.Flags().StringVar(&opts.namespace, "namespace", opts.namespace, "A HostedCluster namespace. Will default to 'clusters' if a --name is supplied")
-	cmd.Flags().StringVar(&opts.name, "name", opts.name, "A HostedCluster name")
+	cmd.Flags().StringVar(&opts.namespace, "namespace", opts.namespace, "A HostedCluster namespace. Defaults to 'clusters'.")
+	cmd.Flags().StringVar(&opts.name, "name", opts.name, "A HostedCluster name.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if opts.name != "" && opts.namespace == "" {
-			opts.namespace = "clusters"
-		}
 		if err := Render(cmd.Context(), opts.namespace, opts.name); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 			return err
 		}
 		return nil

--- a/product-cli/cmd/create/create.go
+++ b/product-cli/cmd/create/create.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hypershift/product-cli/cmd/cluster"
+	"github.com/openshift/hypershift/product-cli/cmd/kubeconfig"
 	"github.com/openshift/hypershift/product-cli/cmd/nodepool"
 )
 
@@ -15,6 +16,7 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(cluster.NewCreateCommands())
+	cmd.AddCommand(kubeconfig.NewCreateCommand())
 	cmd.AddCommand(nodepool.NewCreateCommand())
 
 	return cmd

--- a/product-cli/cmd/kubeconfig/create.go
+++ b/product-cli/cmd/kubeconfig/create.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	hyperShiftKubeConfig "github.com/openshift/hypershift/cmd/kubeconfig"
+	hypershiftkubeconfig "github.com/openshift/hypershift/cmd/kubeconfig"
 )
 
 type options struct {
@@ -20,21 +20,20 @@ func NewCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "kubeconfig",
 		Short:        "Renders kubeconfigs for HostedCluster resources.",
-		Long:         hyperShiftKubeConfig.Description,
+		Long:         hypershiftkubeconfig.Description,
 		SilenceUsage: true,
 	}
 
-	opts := options{}
+	opts := options{
+		namespace: "clusters",
+	}
 
-	cmd.Flags().StringVar(&opts.namespace, "namespace", opts.namespace, "A HostedCluster namespace. Will default to 'clusters' if a --name is supplied")
-	cmd.Flags().StringVar(&opts.name, "name", opts.name, "A HostedCluster name")
+	cmd.Flags().StringVar(&opts.namespace, "namespace", opts.namespace, "A HostedCluster namespace. Defaults to 'clusters'.")
+	cmd.Flags().StringVar(&opts.name, "name", opts.name, "A HostedCluster name.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if opts.name != "" && opts.namespace == "" {
-			opts.namespace = "clusters"
-		}
-		if err := hyperShiftKubeConfig.Render(cmd.Context(), opts.namespace, opts.name); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
+		if err := hypershiftkubeconfig.Render(cmd.Context(), opts.namespace, opts.name); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 			return err
 		}
 		return nil

--- a/product-cli/cmd/kubeconfig/create.go
+++ b/product-cli/cmd/kubeconfig/create.go
@@ -1,0 +1,44 @@
+package kubeconfig
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	hyperShiftKubeConfig "github.com/openshift/hypershift/cmd/kubeconfig"
+)
+
+type options struct {
+	namespace string
+	name      string
+}
+
+// NewCreateCommand returns a command which can render kubeconfigs for HostedCluster
+// resources.
+func NewCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "kubeconfig",
+		Short:        "Renders kubeconfigs for HostedCluster resources.",
+		Long:         hyperShiftKubeConfig.Description,
+		SilenceUsage: true,
+	}
+
+	opts := options{}
+
+	cmd.Flags().StringVar(&opts.namespace, "namespace", opts.namespace, "A HostedCluster namespace. Will default to 'clusters' if a --name is supplied")
+	cmd.Flags().StringVar(&opts.name, "name", opts.name, "A HostedCluster name")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if opts.name != "" && opts.namespace == "" {
+			opts.namespace = "clusters"
+		}
+		if err := hyperShiftKubeConfig.Render(cmd.Context(), opts.namespace, opts.name); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
+			return err
+		}
+		return nil
+	}
+
+	return cmd
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Create kubeconfig for HCP CLI

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1027](https://issues.redhat.com/browse/HOSTEDCP-1027)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.