### PR TITLE
HOSTEDCP-1046: Allow HCP Specification to Support ICSP & IDMS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1087,7 +1087,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 
 	// Reconcile Ignition
 	r.Log.Info("Reconciling core machine configs")
-	if err := r.reconcileCoreIgnitionConfig(ctx, hostedControlPlane, createOrUpdate); err != nil {
+	if err := r.reconcileCoreIgnitionConfig(ctx, hostedControlPlane, releaseImageProvider, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile ignition: %w", err)
 	}
 
@@ -3207,7 +3207,7 @@ func (r *HostedControlPlaneReconciler) reconcileManagedTrustedCABundle(ctx conte
 	return nil
 }
 
-func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.Context, hcp *hyperv1.HostedControlPlane, createOrUpdate upsert.CreateOrUpdateFN) error {
+func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, createOrUpdate upsert.CreateOrUpdateFN) error {
 	sshKey := ""
 	if len(hcp.Spec.SSHKey.Name) > 0 {
 		var sshKeySecret corev1.Secret
@@ -3249,15 +3249,37 @@ func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.C
 		return nil
 	}
 
-	imageDigestMirrorSet := globalconfig.ImageDigestMirrorSet()
-	if err := globalconfig.ReconcileImageDigestMirrors(imageDigestMirrorSet, hcp); err != nil {
-		return fmt.Errorf("failed to reconcile image content policy: %w", err)
+	version, err := semver.Parse(releaseImageProvider.Version())
+	if err != nil {
+		return fmt.Errorf("failed to determine release image version: %w", err)
 	}
 
-	if _, err := createOrUpdate(ctx, r, imageContentPolicyIgnitionConfig, func() error {
-		return ignition.ReconcileImageSourceMirrorsIgnitionConfig(imageContentPolicyIgnitionConfig, p.OwnerRef, imageDigestMirrorSet)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile image content source policy ignition config: %w", err)
+	// ImageDigestMirrorSet is only applicable for release image versions greater than or equal to 4.13
+	// TODO the 'else' branch portion needs to be removed after this ticket is backported to 4.13 - HOSTEDCP-1102
+	if version.Minor >= 13 {
+		r.Log.Info("Reconciling ImageDigestMirrorSet")
+		imageDigestMirrorSet := globalconfig.ImageDigestMirrorSet()
+		if err := globalconfig.ReconcileImageDigestMirrors(imageDigestMirrorSet, hcp); err != nil {
+			return fmt.Errorf("failed to reconcile image content policy: %w", err)
+		}
+
+		if _, err := createOrUpdate(ctx, r, imageContentPolicyIgnitionConfig, func() error {
+			return ignition.ReconcileImageSourceMirrorsIgnitionConfigFromIDMS(imageContentPolicyIgnitionConfig, p.OwnerRef, imageDigestMirrorSet)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile image content source policy ignition config: %w", err)
+		}
+	} else {
+		r.Log.Info("Reconciling ImageContentSourcePolicy")
+		icsp := globalconfig.ImageContentSourcePolicy()
+		if err := globalconfig.ReconcileImageContentSourcePolicy(icsp, hcp); err != nil {
+			return fmt.Errorf("failed to reconcile image content source policy: %w", err)
+		}
+
+		if _, err := createOrUpdate(ctx, r, imageContentPolicyIgnitionConfig, func() error {
+			return ignition.ReconcileImageSourceMirrorsIgnitionConfigFromICSP(imageContentPolicyIgnitionConfig, p.OwnerRef, icsp)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile image content source policy ignition config from ICSP: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow HCP Specification to Support ICSP & IDMS. IDMS is replacing ICSP in OCP 4.13+. hcp.Spec.ImageContentSources was updated in OCPBUGS-11939 to replace ICSP with IDMS; however, HCP needs to support both ICSP & IDMS. Note, OpenShift clusters can only have either ICSP CRs or IDMS CRs; clusters cannot utilize both CR types at the same time.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1046](https://issues.redhat.com/browse/HOSTEDCP-1046)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 