### PR TITLE
Remove --service-publishing-strategy from production cli

### DIFF
--- a/product-cli/cmd/cluster/kubevirt/create.go
+++ b/product-cli/cmd/cluster/kubevirt/create.go
@@ -2,7 +2,7 @@ package kubevirt
 
 import (
 	"context"
-	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
@@ -32,7 +32,6 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.RootVolumeStorageClass, "root-volume-storage-class", opts.KubevirtPlatform.RootVolumeStorageClass, "The storage class to use for machines in the NodePool")
 	cmd.Flags().Uint32Var(&opts.KubevirtPlatform.RootVolumeSize, "root-volume-size", opts.KubevirtPlatform.RootVolumeSize, "The size of the root volume for machines in the NodePool in Gi")
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.RootVolumeAccessModes, "root-volume-access-modes", opts.KubevirtPlatform.RootVolumeAccessModes, "The access modes of the root volume to use for machines in the NodePool (comma-delimited list)")
-	cmd.Flags().StringVar(&opts.KubevirtPlatform.ServicePublishingStrategy, "service-publishing-strategy", opts.KubevirtPlatform.ServicePublishingStrategy, fmt.Sprintf("Define how to expose the cluster services. Supported options: %s (Use LoadBalancer and Route to expose services), %s (Select a random node to expose service access through)", kubevirt.IngressServicePublishingStrategy, kubevirt.NodePortServicePublishingStrategy))
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.InfraKubeConfigFile, "infra-kubeconfig-file", opts.KubevirtPlatform.InfraKubeConfigFile, "Path to a kubeconfig file of an external infra cluster to be used to create the guest clusters nodes onto")
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.InfraNamespace, "infra-namespace", opts.KubevirtPlatform.InfraNamespace, "The namespace in the external infra cluster that is used to host the KubeVirt virtual machines. The namespace must exist prior to creating the HostedCluster")
 	cmd.Flags().StringVar(&opts.KubevirtPlatform.CacheStrategyType, "root-volume-cache-strategy", opts.KubevirtPlatform.CacheStrategyType, "Set the boot image caching strategy; Supported values:\n- \"None\": no caching (default).\n- \"PVC\": Cache into a PVC; only for QCOW image; ignored for container images")


### PR DESCRIPTION
The KubeVirt platform has a cli arg used during cluster create called `service-publishing-strategy`. This arg allowed us to switch between using a NodePort or LoadBalancer for exposing the HCP's api server and other services.

The NodePort option works in dev, but is not resilient enough for production. This is because the NodePort option picks a random mgmt node for the api server passed in the guest cluster's kubeconfig. If that mgmt node ever cycles out, it will result in the guest cluster no longer being accessible. That's fine for development, but we don't want to expose end users to this behavior.