### PR TITLE
Remove context.TODO from non-test files

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
@@ -582,7 +582,7 @@ func (r *Reconciler) nodeToMachineSet(o client.Object) []reconcile.Request {
 			Name:      machineName,
 		},
 	}
-	if err := r.client.Get(context.TODO(), client.ObjectKeyFromObject(machine), machine); err != nil {
+	if err := r.client.Get(context.Background(), client.ObjectKeyFromObject(machine), machine); err != nil {
 		return nil
 	}
 

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -421,7 +421,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		return fmt.Errorf("failed to get ingress controller: %w", err)
 	}
 
-	if err := setupMetrics(mgr); err != nil {
+	if err := setupMetrics(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to setup metrics: %w", err)
 	}
 

--- a/hypershift-operator/metrics.go
+++ b/hypershift-operator/metrics.go
@@ -146,7 +146,7 @@ func (m *hypershiftMetrics) collect(ctx context.Context) error {
 	return nil
 }
 
-func setupMetrics(mgr manager.Manager) error {
+func setupMetrics(ctx context.Context, mgr manager.Manager) error {
 	var hypershiftImage ImageInfo
 
 	// We need to create a new client because the manager one still does not have the cache started
@@ -155,7 +155,7 @@ func setupMetrics(mgr manager.Manager) error {
 		return fmt.Errorf("error creating a temporary client: %w", err)
 	}
 	// Grabbing the Image and ImageID from Operator
-	if hypershiftImage.image, hypershiftImage.imageId, err = getOperatorImage(tmpClient); err != nil {
+	if hypershiftImage.image, hypershiftImage.imageId, err = getOperatorImage(ctx, tmpClient); err != nil {
 		if apierrors.IsNotFound(err) {
 			log := mgr.GetLogger()
 			log.Error(err, "pod not found, reporting empty image")
@@ -359,8 +359,7 @@ func (m *hypershiftMetrics) observeNodePools(ctx context.Context, nodePools *hyp
 	return nil
 }
 
-func getOperatorImage(client crclient.Client) (string, string, error) {
-	ctx := context.TODO()
+func getOperatorImage(ctx context.Context, client crclient.Client) (string, string, error) {
 	var image, imageId string
 	hypershiftNamespace := os.Getenv("MY_NAMESPACE")
 	hypershiftPodName := os.Getenv("MY_NAME")

--- a/hypershift-operator/metrics_test.go
+++ b/hypershift-operator/metrics_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func TestGetOperatorImage(t *testing.T) {
 			t.Setenv("MY_NAME", fakePodName)
 			g := NewWithT(t)
 			client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tc.hypershiftPod).Build()
-			image, imageId, err := getOperatorImage(client)
+			image, imageId, err := getOperatorImage(context.TODO(), client)
 			if tc.expectedError {
 				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			}

--- a/test/e2e/util/pod_exec.go
+++ b/test/e2e/util/pod_exec.go
@@ -84,7 +84,7 @@ func (p *PodExecOptions) Validate() error {
 }
 
 // Run executes a validated remote execution against a pod.
-func (p *PodExecOptions) Run() error {
+func (p *PodExecOptions) Run(ctx context.Context) error {
 	err := p.Validate()
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (p *PodExecOptions) Run() error {
 		return err
 	}
 
-	pod, err := client.Pods(p.Namespace).Get(context.TODO(), p.PodName, metav1.GetOptions{})
+	pod, err := client.Pods(p.Namespace).Get(ctx, p.PodName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -854,7 +854,7 @@ func EnsureSecretEncryptedUsingKMS(t *testing.T, ctx context.Context, hostedClus
 			Config:        restConfig,
 		}
 
-		if err := podExecuter.Run(); err != nil {
+		if err := podExecuter.Run(ctx); err != nil {
 			t.Errorf("failed to execute etcdctl command; %v", err)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed context.TODO from non-test files. According to Jon Bodner's book, _Learning Go: An Idiomatic Approach to Real-World Go Programming_, he states context.TODO is only to be used temporarily for development purposes and should not be included in production code.

**Which issue(s) this PR fixes**:
Fixes N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.