### PR TITLE
HOSTEDCP-1073: enforce blocked rollout of HCP

### DIFF
--- a/support/util/deployment.go
+++ b/support/util/deployment.go
@@ -3,27 +3,37 @@ package util
 import (
 	"context"
 	"fmt"
-	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	"path"
 
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func IsDeploymentReady(ctx context.Context, c crclient.Client, deployment *appsv1.Deployment) (bool, error) {
-	if err := c.Get(ctx, crclient.ObjectKeyFromObject(deployment), deployment); err != nil {
-		return false, fmt.Errorf("failed to fetch %s deployment: %w", deployment.Name, err)
-	}
-
+func IsDeploymentReady(ctx context.Context, deployment *appsv1.Deployment) bool {
 	if *deployment.Spec.Replicas != deployment.Status.AvailableReplicas ||
 		*deployment.Spec.Replicas != deployment.Status.ReadyReplicas ||
 		*deployment.Spec.Replicas != deployment.Status.UpdatedReplicas ||
-		deployment.ObjectMeta.Generation > deployment.Status.ObservedGeneration {
-		return false, nil
+		*deployment.Spec.Replicas != deployment.Status.Replicas ||
+		deployment.Status.UnavailableReplicas != 0 ||
+		deployment.ObjectMeta.Generation != deployment.Status.ObservedGeneration {
+		return false
 	}
 
-	return true, nil
+	return true
+}
+
+func IsStatefulSetReady(ctx context.Context, statefulSet *appsv1.StatefulSet) bool {
+	if *statefulSet.Spec.Replicas != statefulSet.Status.AvailableReplicas ||
+		*statefulSet.Spec.Replicas != statefulSet.Status.ReadyReplicas ||
+		*statefulSet.Spec.Replicas != statefulSet.Status.UpdatedReplicas ||
+		*statefulSet.Spec.Replicas != statefulSet.Status.Replicas ||
+		statefulSet.ObjectMeta.Generation != statefulSet.Status.ObservedGeneration {
+		return false
+	}
+
+	return true
 }
 
 func DeploymentAddKubevirtInfraCredentials(deployment *appsv1.Deployment) {

--- a/support/util/deployment_test.go
+++ b/support/util/deployment_test.go
@@ -7,104 +7,215 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestIsDeploymentReady(t *testing.T) {
-	client := fake.NewClientBuilder().WithRuntimeObjects(
-		// Positive path - all replicas updated, available, ready
-		&appsv1.Deployment{
-			ObjectMeta: v1.ObjectMeta{
-				Name:       "positive-path",
-				Generation: 1,
+	tests := []struct {
+		deployment *appsv1.Deployment
+		ready      bool
+	}{
+		{
+			// Positive path - all replicas updated, available, ready
+			deployment: &appsv1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "positive-path",
+					Generation: 1,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           3,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  3,
+					ReadyReplicas:      3,
+					ObservedGeneration: 1,
+				},
 			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: pointer.Int32(3),
-			},
-			Status: appsv1.DeploymentStatus{
-				UpdatedReplicas:    3,
-				AvailableReplicas:  3,
-				ReadyReplicas:      3,
-				ObservedGeneration: 1,
-			},
+			ready: true,
 		},
-		// Negative path - replicas not yet updated
-		&appsv1.Deployment{
-			ObjectMeta: v1.ObjectMeta{
-				Name:       "negative-path-1",
-				Generation: 1,
+		{
+			// Negative path - replicas not yet updated
+			deployment: &appsv1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "negative-path-1",
+					Generation: 1,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           3,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  3,
+					ReadyReplicas:      3,
+					ObservedGeneration: 1,
+				},
 			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: pointer.Int32(3),
-			},
-			Status: appsv1.DeploymentStatus{
-				UpdatedReplicas:    2,
-				AvailableReplicas:  3,
-				ReadyReplicas:      3,
-				ObservedGeneration: 1,
-			},
+			ready: false,
 		},
-		// Negative path - replicas not yet available
-		&appsv1.Deployment{
-			ObjectMeta: v1.ObjectMeta{
-				Name:       "negative-path-2",
-				Generation: 1,
+		{
+			// Negative path - replicas not yet available
+			deployment: &appsv1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "negative-path-2",
+					Generation: 1,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           3,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  2,
+					ReadyReplicas:      3,
+					ObservedGeneration: 1,
+				},
 			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: pointer.Int32(3),
-			},
-			Status: appsv1.DeploymentStatus{
-				UpdatedReplicas:    3,
-				AvailableReplicas:  2,
-				ReadyReplicas:      3,
-				ObservedGeneration: 1,
-			},
+			ready: false,
 		},
-		// Negative path - generation mismatch
-		&appsv1.Deployment{
-			ObjectMeta: v1.ObjectMeta{
-				Name:       "negative-path-3",
-				Generation: 2,
+		{
+			// Negative path - generation mismatch
+			deployment: &appsv1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "negative-path-3",
+					Generation: 2,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           3,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  3,
+					ReadyReplicas:      3,
+					ObservedGeneration: 1,
+				},
 			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: pointer.Int32(3),
-			},
-			Status: appsv1.DeploymentStatus{
-				UpdatedReplicas:    3,
-				AvailableReplicas:  3,
-				ReadyReplicas:      3,
-				ObservedGeneration: 1,
-			},
+			ready: false,
 		},
-	).Build()
-
-	// Positive path - all replicas updated, available, ready
-	result, err := IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "positive-path"}})
-	if !result || err != nil {
-		t.Errorf("expected result %t, got %t: %v", true, result, err)
+		{
+			// Negative path - surging upgrade
+			deployment: &appsv1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "negative-path-4",
+					Generation: 2,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            3,
+					UpdatedReplicas:     3,
+					AvailableReplicas:   3,
+					ReadyReplicas:       3,
+					ObservedGeneration:  2,
+					UnavailableReplicas: 1,
+				},
+			},
+			ready: false,
+		},
 	}
-
-	// Negative path - replicas not yet updated
-	result, err = IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "negative-path-1"}})
-	if result || err != nil {
-		t.Errorf("expected result %t, got %t: %v", false, result, err)
+	for _, tt := range tests {
+		ready := IsDeploymentReady(context.TODO(), tt.deployment)
+		if ready != tt.ready {
+			t.Errorf("IsDeploymentReady() deployment %s got ready %t, expected %t", tt.deployment.Name, ready, tt.ready)
+			return
+		}
 	}
+}
 
-	// Negative path - replicas not yet available
-	result, err = IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "negative-path-2"}})
-	if result || err != nil {
-		t.Errorf("expected result %t, got %t: %v", false, result, err)
+func TestIsStatefulSetReady(t *testing.T) {
+	tests := []struct {
+		statefulSet *appsv1.StatefulSet
+		ready       bool
+	}{
+		{
+			// Positive path - all replicas updated, available, ready
+			statefulSet: &appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "positive-path",
+					Generation: 1,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas:           3,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  3,
+					ReadyReplicas:      3,
+					ObservedGeneration: 1,
+				},
+			},
+			ready: true,
+		},
+		{
+			// Negative path - replicas not yet updated
+			statefulSet: &appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "negative-path-1",
+					Generation: 1,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas:           3,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  3,
+					ReadyReplicas:      3,
+					ObservedGeneration: 1,
+				},
+			},
+			ready: false,
+		},
+		{
+			// Negative path - replicas not yet available
+			statefulSet: &appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "negative-path-2",
+					Generation: 1,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas:           3,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  2,
+					ReadyReplicas:      3,
+					ObservedGeneration: 1,
+				},
+			},
+			ready: false,
+		},
+		{
+			// Negative path - generation mismatch
+			statefulSet: &appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "negative-path-3",
+					Generation: 2,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas:           3,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  3,
+					ReadyReplicas:      3,
+					ObservedGeneration: 1,
+				},
+			},
+			ready: false,
+		},
 	}
-
-	// Negative path - generation mismatch
-	result, err = IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "negative-path-3"}})
-	if result || err != nil {
-		t.Errorf("expected result %t, got %t: %v", false, result, err)
-	}
-
-	// Negative path - deployment not found
-	result, err = IsDeploymentReady(context.TODO(), client, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "does-not-exist"}})
-	if result || err == nil {
-		t.Errorf("expected result %t, got %t: %v", false, result, err)
+	for _, tt := range tests {
+		ready := IsStatefulSetReady(context.TODO(), tt.statefulSet)
+		if ready != tt.ready {
+			t.Errorf("IsStatefulSetReady() statefulset %s got ready %t, expected %t", tt.statefulSet.Name, ready, tt.ready)
+			return
+		}
 	}
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/HOSTEDCP-1073

After this PR, the HCP reconciliation rolls out in the following runlevels, in line with what the CVO would do, where all components in each runlevel must be fully rolled out before reconciling the next runlevel.
- etcd
- kube-apiserver
- kube-controller-manager, kube-scheduler, openshift-apiserver
- everything else

This fixes both the Jira issue and the issue where previously `IsDeploymentReady` didn't actually work because the `Get` did not get the just create/updated version of the resource.

Timing looks like this:
- 2m30s etcd rollout
- 6m KAS rollout
- 3m30 for KCM, KS, OAS
- 4m for everything else

Total HCP upgrade time is 16m.

Before this change upgrade time was ~10m.  It could be faster if the race in `IsDeploymentReady` is hit, bypassing the KAS and OAS check that already exists.