### PR TITLE
OCPBUGS-12208 ensureExists pullSecret resource reconciliation strategy

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -169,6 +169,11 @@ const (
 	// The format of the annotation value is a commma-separated list of image=ref pairs like:
 	// cluster-network-operator=example.com/cno:latest,ovn-kubernetes=example.com/ovnkube:latest
 	ImageOverridesAnnotation = "hypershift.openshift.io/image-overrides"
+
+	// EnsureExistsPullSecretReconciliation enables a reconciliation behavior on in cluster pull secret
+	// resources that enables user modifications to the resources while ensuring they do exist. This
+	// allows users to execute workflows like disabling insights operator
+	EnsureExistsPullSecretReconciliation = "hypershift.openshift.io/ensureexists-pullsecret-reconcile"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1595,6 +1595,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.ControlPlanePriorityClass,
 		hyperv1.APICriticalPriorityClass,
 		hyperv1.EtcdPriorityClass,
+		hyperv1.EnsureExistsPullSecretReconciliation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]


### PR DESCRIPTION
Currently: there is no path to disable data aggregation from Red Hat insights operator. Clients in sensitive environments operating hypershift under a managed deployment like IBM Cloud Satellite want the ability to disable this flow. This enables a path that will allow the existing documentation for disablement of these resources to work in hypershift environments (https://docs.openshift.com/container-platform/4.12/support/remote_health_monitoring/opting-out-of-remote-health-reporting.html).

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.