### PR TITLE
Revert "HOSTEDCP-1016: Validate publishing strategies"

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3712,10 +3712,6 @@ func (r *HostedClusterReconciler) validateAWSConfig(hc *hyperv1.HostedCluster) e
 		if servicePublishingStrategy != nil && servicePublishingStrategy.Type != hyperv1.Route {
 			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route", serviceType, servicePublishingStrategy.Type))
 		}
-
-		if serviceType != hyperv1.OAuthServer && hc.Spec.Platform.AWS.EndpointAccess != hyperv1.Public && servicePublishingStrategy.Route != nil && servicePublishingStrategy.Route.Hostname != "" {
-			errs = append(errs, fmt.Errorf("setting a hostname for service type %v with publishing strategy %v is not supported in combination with a PublicAndPrivate or Private endpoint access", serviceType, servicePublishingStrategy.Type))
-		}
 	}
 
 	servicePublishingStrategy := hyperutil.ServicePublishingStrategyByTypeByHC(hc, hyperv1.APIServer)
@@ -3727,55 +3723,41 @@ func (r *HostedClusterReconciler) validateAWSConfig(hc *hyperv1.HostedCluster) e
 		if servicePublishingStrategy != nil && servicePublishingStrategy.Type != hyperv1.Route && servicePublishingStrategy.Type != hyperv1.LoadBalancer {
 			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route", hyperv1.APIServer, servicePublishingStrategy.Type))
 		}
+
 	} else {
 		if !hyperutil.UseDedicatedDNSForKASByHC(hc) && servicePublishingStrategy.Type != hyperv1.LoadBalancer {
 			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route or Loadbalancer", hyperv1.APIServer, servicePublishingStrategy.Type))
 		}
 	}
 
-	if hc.Spec.Platform.AWS.EndpointAccess == hyperv1.Public && servicePublishingStrategy.Type != hyperv1.Route {
-		errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported in combination with a Public endpoint access, use Route", hyperv1.APIServer, servicePublishingStrategy.Type))
-	}
-
 	return utilerrors.NewAggregate(errs)
 }
 
-// validatePublishingStrategyMapping validates:
-// 1. Each published serviceType has a unique hostname.
-// 2. APIServer has hostname field set if using Route.
+// validatePublishingStrategyMapping validates that each published serviceType has a unique hostname.
 func (r *HostedClusterReconciler) validatePublishingStrategyMapping(hc *hyperv1.HostedCluster) error {
 	hostnameServiceMap := make(map[string]string, len(hc.Spec.Services))
-	var errs []error
-
 	for _, svc := range hc.Spec.Services {
-		hostname := servicePublishingStrategyHostname(svc)
+		hostname := ""
+		if svc.Type == hyperv1.LoadBalancer && svc.LoadBalancer != nil {
+			hostname = svc.LoadBalancer.Hostname
+		}
+		if svc.Type == hyperv1.Route && svc.Route != nil {
+			hostname = svc.Route.Hostname
+		}
+
 		if hostname == "" {
-			if svc.Service == hyperv1.APIServer && svc.Type == hyperv1.Route {
-				errs = append(errs, fmt.Errorf("hostname field is required for service type %v with publishing strategy %v", svc.Service, svc.Type))
-			}
 			continue
 		}
 
 		serviceType, exists := hostnameServiceMap[hostname]
 		if exists {
-			errs = append(errs, fmt.Errorf("service type %s can't be published with the same hostname %s as service type %s", svc.Service, hostname, serviceType))
-			continue
+			return fmt.Errorf("service type %s can't be published with the same hostname %s as service type %s", svc.Service, hostname, serviceType)
 		}
 
 		hostnameServiceMap[hostname] = string(svc.Service)
 	}
 
-	return utilerrors.NewAggregate(errs)
-}
-
-func servicePublishingStrategyHostname(svc hyperv1.ServicePublishingStrategyMapping) string {
-	if svc.Type == hyperv1.LoadBalancer && svc.LoadBalancer != nil {
-		return svc.LoadBalancer.Hostname
-	}
-	if svc.Type == hyperv1.Route && svc.Route != nil {
-		return svc.Route.Hostname
-	}
-	return ""
+	return nil
 }
 
 func (r *HostedClusterReconciler) validateAzureConfig(ctx context.Context, hc *hyperv1.HostedCluster) error {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -937,10 +937,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 	}
 	for _, cluster := range hostedClusters {
 		cluster.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
-			{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-				Type:  hyperv1.Route,
-				Route: &hyperv1.RoutePublishingStrategy{Hostname: "api.example.com"}},
-			},
+			{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
 			{Service: hyperv1.Konnectivity, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
 			{Service: hyperv1.OAuthServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
 			{Service: hyperv1.Ignition, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
@@ -1118,22 +1115,6 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 				},
 			}},
 			expectedResult:                errors.New(`service type OAuthServer can't be published with the same hostname api.example.com as service type APIServer`),
-			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
-		},
-		{
-			name: "APIServer service with publishing strategy Route doen't have hostname field set, error",
-			hostedCluster: &hyperv1.HostedCluster{Spec: hyperv1.HostedClusterSpec{
-				Services: []hyperv1.ServicePublishingStrategyMapping{
-					{
-						Service: hyperv1.APIServer,
-						ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-							Type:  hyperv1.Route,
-							Route: &hyperv1.RoutePublishingStrategy{},
-						},
-					},
-				},
-			}},
-			expectedResult:                errors.New(`hostname field is required for service type APIServer with publishing strategy Route`),
 			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 		},
 	}


### PR DESCRIPTION
Reverts openshift/hypershift#2651

CI management clusters are failing to create:
```
 - lastTransitionTime: "2023-06-27T14:21:54Z"
    message: service type APIServer with publishing strategy LoadBalancer is not supported
      in combination with a Public endpoint access, use Route
    observedGeneration: 3
    reason: InvalidConfiguration
    status: "False"
    type: ValidConfiguration
```