### PR TITLE
Remove hardcoded AWS CI References

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -42,15 +42,40 @@ Then update the operator ServiceAccount in the hypershift namespace:
 
 ### How to run the e2e tests
 
-1. Install HyperShift.
+1. Complete [Prerequisites](https://hypershift-docs.netlify.app/getting-started/#prerequisites) with a public Route53
+Hosted Zone, for example with the following environment variables:
+
+   ```shell
+   BASE_DOMAIN="my.hypershift.dev"
+   BUCKET_NAME="my-oidc-bucket"
+   AWS_REGION="us-east-2"
+   AWS_CREDS="my/aws-credentials"
+   PULL_SECRET="/my/pull-secret"
+   HYPERSHIFT_IMAGE="quay.io/my/hypershift:latest"
+   ```
+
+2. Install the HyperShift Operator on a cluster, filling in variables such as the S3 bucket name and region based on
+what was done in the prerequisites phase and potentially supplying a custom image.
+
+   ```shell
+   bin/hypershift install \
+   --oidc-storage-provider-s3-bucket-name "${BUCKET_NAME}" \
+   --oidc-storage-provider-s3-credentials "${AWS_CREDS}" \
+   --oidc-storage-provider-s3-region "${AWS_REGION}" \
+   --hypershift-image "${HYPERSHIFT_IMAGE}"
+   ```
+
 2. Run the tests.
 
    ```shell
         $ make e2e
         $ bin/test-e2e -test.v -test.timeout 0 \
-          --e2e.aws-credentials-file /my/aws-credentials \
-          --e2e.pull-secret-file /my/pull-secret \
-          --e2e.base-domain my-basedomain
+          --e2e.aws-credentials-file "${AWS_CREDS}" \
+          --e2e.pull-secret-file "${PULL_SECRET}" \
+          --e2e.aws-region "${AWS_REGION}" \
+          --e2e.availability-zones "${AWS_REGION}a,${AWS_REGION}b,${AWS_REGION}c" \
+          --e2e.aws-oidc-s3-bucket-name "${BUCKET_NAME}" \
+          --e2e.base-domain "${BASE_DOMAIN}"
    ```
 
 ### How to visualize the Go dependency graph

--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -31,6 +31,8 @@ bin/test-e2e \
   -test.parallel=20 \
   --e2e.aws-credentials-file=/etc/hypershift-pool-aws-credentials/credentials \
   --e2e.aws-zones=us-east-1a,us-east-1b,us-east-1c \
+  --e2e.aws-oidc-s3-bucket-name=hypershift-ci-oidc \
+  --e2e.aws-kms-key-alias=alias/hypershift-ci \
   --e2e.pull-secret-file=/etc/ci-pull-credentials/.dockerconfigjson \
   --e2e.base-domain=ci.hypershift.devcluster.openshift.com \
   --e2e.latest-release-image="${OCP_IMAGE_LATEST}" \

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -65,7 +65,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 
 	// find kms key ARN using alias
-	kmsKeyArn, err := e2eutil.GetKMSKeyArn(clusterOpts.AWSPlatform.AWSCredentialsFile, clusterOpts.AWSPlatform.Region)
+	kmsKeyArn, err := e2eutil.GetKMSKeyArn(clusterOpts.AWSPlatform.AWSCredentialsFile, clusterOpts.AWSPlatform.Region, globalOpts.configurableClusterOptions.AWSKmsKeyAlias)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to retrieve kms key arn")
 	g.Expect(kmsKeyArn).NotTo(BeNil(), "failed to retrieve kms key arn")
 

--- a/test/e2e/util/aws.go
+++ b/test/e2e/util/aws.go
@@ -16,24 +16,24 @@ import (
 	"github.com/openshift/hypershift/support/oidc"
 )
 
-const (
-	KMS_KEY_ALIAS = "alias/hypershift-ci"
-)
+func GetKMSKeyArn(awsCreds, awsRegion, alias string) (*string, error) {
+	if alias == "" {
+		return aws.String(""), nil
+	}
 
-func GetKMSKeyArn(awsCreds, awsRegion string) (*string, error) {
 	awsSession := awsutil.NewSession("e2e-kms", awsCreds, "", "", awsRegion)
 	awsConfig := awsutil.NewConfig()
 	kmsClient := kms.New(awsSession, awsConfig)
 
 	input := &kms.DescribeKeyInput{
-		KeyId: aws.String(KMS_KEY_ALIAS),
+		KeyId: aws.String(alias),
 	}
 	out, err := kmsClient.DescribeKey(input)
 	if err != nil {
 		return nil, err
 	}
 	if out.KeyMetadata == nil {
-		return nil, fmt.Errorf("KMS key with alias %v doesn't exist", KMS_KEY_ALIAS)
+		return nil, fmt.Errorf("KMS key with alias %v doesn't exist", alias)
 	}
 
 	return out.KeyMetadata.Arn, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds flags to the e2e binary so that the hardcoded AWS objects can be removed from the e2e codebase:

* --e2e.aws-oidc-s3-bucket-name
* --e2e.aws-kms-key-alias

So that the e2e test can be run accordingly locally after creating the required AWS infrastructure on your own.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.