### PR TITLE
add OWNERS for new ci-tooling area label

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/ci-tooling


### PR DESCRIPTION
**What this PR does / why we need it**:
add OWNERS for new ci-tooling area label

**Which issue(s) this PR fixes**:
N/A