### PR TITLE
Add production cli (hcp) to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN make build
 
 FROM quay.io/openshift/origin-base:4.14
 COPY --from=builder /hypershift/bin/hypershift \
+                    /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \
                     /hypershift/bin/control-plane-operator \
      /usr/bin/


### PR DESCRIPTION
I'm transitioning the KubeVirt platform OpenShift CI lanes to exercise the new production cli (hcp). However, it appears that we aren't building that tool in the hypershift-operator image.


my rehearse runs in this[ ci pr](https://github.com/openshift/release/pull/40716) fail due to no `hcp` cli being present.
```
/bin/bash: line 13: /usr/bin/hcp: No such file or directory
```

I think copying the hcp tool into the hypershift-operator container using the default Dockerfile will resolve this.

