### PR TITLE
[release-4.13] HOSTEDCP-1060: refactor ignition-server reconcilation and add ignition-server proxy

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -46,6 +46,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 		//lint:ignore ST1005 Ignition is proper name
 		return fmt.Errorf("Ignition service strategy not specified")
 	}
+
 	// Reconcile service
 	ignitionServerService := ignitionserver.Service(controlPlaneNamespace)
 	if _, err := createOrUpdate(ctx, c, ignitionServerService, func() error {
@@ -53,6 +54,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition service: %w", err)
 	}
+
 	var ignitionServerAddress string
 	switch serviceStrategy.Type {
 	case hyperv1.Route:
@@ -93,57 +95,24 @@ func ReconcileIgnitionServer(ctx context.Context,
 		return fmt.Errorf("unknown service strategy type for ignition service: %s", serviceStrategy.Type)
 	}
 
-	// Check if PKI needs to be reconciled
 	_, disablePKIReconciliation := hcp.Annotations[hyperv1.DisablePKIReconciliationAnnotation]
-
-	// Reconcile a root CA for ignition serving certificates. We only create this
-	// and don't update it for now.
-	caCertSecret := ignitionserver.IgnitionCACertSecret(controlPlaneNamespace)
 	if !disablePKIReconciliation {
+		// Reconcile a root CA for ignition serving certificates.
+		// We only create this and don't update it for now.
+		caCertSecret := ignitionserver.IgnitionCACertSecret(controlPlaneNamespace)
 		if result, err := createOrUpdate(ctx, c, caCertSecret, func() error {
-			caCertSecret.Type = corev1.SecretTypeTLS
-			return certs.ReconcileSelfSignedCA(caCertSecret, "ignition-root-ca", "openshift", func(o *certs.CAOpts) {
-				o.CASignerCertMapKey = corev1.TLSCertKey
-				o.CASignerKeyMapKey = corev1.TLSPrivateKeyKey
-			})
+			return reconcileCACertSecret(caCertSecret)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile ignition ca cert: %w", err)
 		} else {
 			log.Info("reconciled ignition CA cert secret", "result", result)
 		}
-	}
 
-	// Reconcile a ignition serving certificate issued by the generated root CA. We
-	// only create this and don't update it for now.
-	servingCertSecret := ignitionserver.IgnitionServingCertSecret(controlPlaneNamespace)
-	if !disablePKIReconciliation {
+		// Reconcile an ignition serving certificate issued by the generated root CA.
+		// We only create this and don't update it for now.
+		servingCertSecret := ignitionserver.IgnitionServingCertSecret(controlPlaneNamespace)
 		if result, err := createOrUpdate(ctx, c, servingCertSecret, func() error {
-			servingCertSecret.Type = corev1.SecretTypeTLS
-
-			var dnsNames, ipAddresses []string
-			numericIP := net.ParseIP(ignitionServerAddress)
-			if numericIP == nil {
-				dnsNames = []string{ignitionServerAddress}
-			} else {
-				ipAddresses = []string{ignitionServerAddress}
-			}
-
-			return certs.ReconcileSignedCert(
-				servingCertSecret,
-				caCertSecret,
-				"ignition-server",
-				[]string{"openshift"},
-				nil,
-				corev1.TLSCertKey,
-				corev1.TLSPrivateKeyKey,
-				"",
-				dnsNames,
-				ipAddresses,
-				func(o *certs.CAOpts) {
-					o.CASignerCertMapKey = corev1.TLSCertKey
-					o.CASignerKeyMapKey = corev1.TLSPrivateKeyKey
-				},
-			)
+			return reconcileServingCertSecret(servingCertSecret, caCertSecret, ignitionServerAddress)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile ignition serving cert: %w", err)
 		} else {
@@ -153,30 +122,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 
 	role := ignitionserver.Role(controlPlaneNamespace)
 	if result, err := createOrUpdate(ctx, c, role, func() error {
-		role.Rules = []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{
-					"secrets",
-				},
-				Verbs: []string{"get", "list", "watch", "update", "patch", "delete"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{
-					"configmaps",
-				},
-				Verbs: []string{"get", "list", "watch"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{
-					"events",
-				},
-				Verbs: []string{"*"},
-			},
-		}
-		return nil
+		return reconcileRole(role)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition role: %w", err)
 	} else {
@@ -195,194 +141,41 @@ func ReconcileIgnitionServer(ctx context.Context,
 
 	roleBinding := ignitionserver.RoleBinding(controlPlaneNamespace)
 	if result, err := createOrUpdate(ctx, c, roleBinding, func() error {
-		roleBinding.RoleRef = rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     role.Name,
-		}
-
-		roleBinding.Subjects = []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      sa.Name,
-				Namespace: sa.Namespace,
-			},
-		}
-		return nil
+		return reconcileRoleBinding(roleBinding, role, sa)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition RoleBinding: %w", err)
 	} else {
 		log.Info("Reconciled ignition server rolebinding", "result", result)
 	}
 
-	var probeHandler corev1.ProbeHandler
-	if hasHealthzHandler {
-		probeHandler.HTTPGet = &corev1.HTTPGetAction{
-			Path:   "/healthz",
-			Port:   intstr.FromInt(9090),
-			Scheme: corev1.URISchemeHTTPS,
-		}
-	} else {
-		probeHandler.TCPSocket = &corev1.TCPSocketAction{
-			Port: intstr.FromInt(9090),
-		}
+	ignitionServerLabels := map[string]string{
+		"app":                         ignitionserver.ResourceName,
+		hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
 	}
 
-	// Reconcile deployment
 	ignitionServerDeployment := ignitionserver.Deployment(controlPlaneNamespace)
 	if result, err := createOrUpdate(ctx, c, ignitionServerDeployment, func() error {
-		if ignitionServerDeployment.Annotations == nil {
-			ignitionServerDeployment.Annotations = map[string]string{}
-		}
-		ignitionServerLabels := map[string]string{
-			"app":                         ignitionserver.ResourceName,
-			hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
-		}
-		ignitionServerDeployment.Spec = appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: ignitionServerLabels,
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: ignitionServerLabels,
-				},
-				Spec: corev1.PodSpec{
-					ServiceAccountName:            sa.Name,
-					TerminationGracePeriodSeconds: utilpointer.Int64Ptr(10),
-					Tolerations: []corev1.Toleration{
-						{
-							Key:    "node-role.kubernetes.io/master",
-							Effect: corev1.TaintEffectNoSchedule,
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "serving-cert",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName:  servingCertSecret.Name,
-									DefaultMode: utilpointer.Int32Ptr(0640),
-								},
-							},
-						},
-						{
-							Name: "payloads",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name:            ignitionserver.ResourceName,
-							Image:           utilitiesImage,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Env: []corev1.EnvVar{
-								{
-									Name: "MY_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-							},
-							Command: []string{
-								"/usr/bin/control-plane-operator",
-								"ignition-server",
-								"--cert-file", "/var/run/secrets/ignition/serving-cert/tls.crt",
-								"--key-file", "/var/run/secrets/ignition/serving-cert/tls.key",
-								"--registry-overrides", convertRegistryOverridesToCommandLineFlag(registryOverrides),
-								"--platform", string(hcp.Spec.Platform.Type),
-							},
-							LivenessProbe: &corev1.Probe{
-								ProbeHandler:        probeHandler,
-								InitialDelaySeconds: 120,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       60,
-								FailureThreshold:    6,
-								SuccessThreshold:    1,
-							},
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler:        probeHandler,
-								InitialDelaySeconds: 5,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       60,
-								FailureThreshold:    3,
-								SuccessThreshold:    1,
-							},
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "https",
-									ContainerPort: 9090,
-								},
-								{
-									Name:          "metrics",
-									ContainerPort: 8080,
-								},
-							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("40Mi"),
-									corev1.ResourceCPU:    resource.MustParse("10m"),
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "serving-cert",
-									MountPath: "/var/run/secrets/ignition/serving-cert",
-								},
-								{
-									Name:      "payloads",
-									MountPath: "/payloads",
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		proxy.SetEnvVars(&ignitionServerDeployment.Spec.Template.Spec.Containers[0].Env)
-
-		if hcp.Spec.AdditionalTrustBundle != nil {
-			// Add trusted-ca mount with optional configmap
-			util.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, ignitionServerDeployment)
-		}
-
-		// set security context
-		if !managementClusterHasCapabilitySecurityContextConstraint {
-			ignitionServerDeployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-				RunAsUser: utilpointer.Int64Ptr(config.DefaultSecurityContextUser),
-			}
-		}
-
-		deploymentConfig := config.DeploymentConfig{}
-		deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
-		deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-		deploymentConfig.SetDefaults(hcp, ignitionServerLabels, nil)
-		deploymentConfig.ApplyTo(ignitionServerDeployment)
-
-		return nil
+		return reconcileDeployment(ignitionServerDeployment,
+			utilitiesImage,
+			hcp,
+			defaultIngressDomain,
+			hasHealthzHandler,
+			registryOverrides,
+			managementClusterHasCapabilitySecurityContextConstraint,
+			ignitionServerLabels)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition deployment: %w", err)
 	} else {
 		log.Info("Reconciled ignition server deployment", "result", result)
 	}
 
-	// Reconcile PodMonitor
 	podMonitor := ignitionserver.PodMonitor(controlPlaneNamespace)
-	ownerRef.ApplyTo(podMonitor)
 	if result, err := createOrUpdate(ctx, c, podMonitor, func() error {
-		podMonitor.Spec.Selector = *ignitionServerDeployment.Spec.Selector
-		podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
-			Port: "metrics",
-		}}
-		podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{controlPlaneNamespace}}
-		if podMonitor.Annotations == nil {
-			podMonitor.Annotations = map[string]string{}
-		}
-		util.ApplyClusterIDLabelToPodMonitor(&podMonitor.Spec.PodMetricsEndpoints[0], hcp.Spec.ClusterID)
-		return nil
+		return reconcilePodMonitor(podMonitor,
+			ownerRef,
+			ignitionServerLabels,
+			controlPlaneNamespace,
+			hcp.Spec.ClusterID)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition server pod monitor: %w", err)
 	} else {
@@ -442,4 +235,258 @@ func convertRegistryOverridesToCommandLineFlag(registryOverrides map[string]stri
 	}
 	// this is the equivalent of null on a StringToString command line variable.
 	return "="
+}
+
+func reconcileCACertSecret(caCertSecret *corev1.Secret) error {
+	caCertSecret.Type = corev1.SecretTypeTLS
+	return certs.ReconcileSelfSignedCA(caCertSecret, "ignition-root-ca", "openshift", func(o *certs.CAOpts) {
+		o.CASignerCertMapKey = corev1.TLSCertKey
+		o.CASignerKeyMapKey = corev1.TLSPrivateKeyKey
+	})
+}
+
+func reconcileServingCertSecret(servingCertSecret *corev1.Secret, caCertSecret *corev1.Secret, ignitionServerAddress string) error {
+	servingCertSecret.Type = corev1.SecretTypeTLS
+
+	var dnsNames, ipAddresses []string
+	numericIP := net.ParseIP(ignitionServerAddress)
+	if numericIP == nil {
+		dnsNames = []string{ignitionServerAddress}
+	} else {
+		ipAddresses = []string{ignitionServerAddress}
+	}
+
+	return certs.ReconcileSignedCert(
+		servingCertSecret,
+		caCertSecret,
+		"ignition-server",
+		[]string{"openshift"},
+		nil,
+		corev1.TLSCertKey,
+		corev1.TLSPrivateKeyKey,
+		"",
+		dnsNames,
+		ipAddresses,
+		func(o *certs.CAOpts) {
+			o.CASignerCertMapKey = corev1.TLSCertKey
+			o.CASignerKeyMapKey = corev1.TLSPrivateKeyKey
+		},
+	)
+}
+
+func reconcileRole(role *rbacv1.Role) error {
+	role.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"secrets",
+			},
+			Verbs: []string{"get", "list", "watch", "update", "patch", "delete"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"configmaps",
+			},
+			Verbs: []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"events",
+			},
+			Verbs: []string{"*"},
+		},
+	}
+	return nil
+}
+
+func reconcileRoleBinding(roleBinding *rbacv1.RoleBinding, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
+	roleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     role.Name,
+	}
+
+	roleBinding.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+		},
+	}
+	return nil
+}
+
+func reconcileDeployment(deployment *appsv1.Deployment,
+	utilitiesImage string,
+	hcp *hyperv1.HostedControlPlane,
+	defaultIngressDomain string,
+	hasHealthzHandler bool,
+	registryOverrides map[string]string,
+	managementClusterHasCapabilitySecurityContextConstraint bool,
+	ignitionServerLabels map[string]string,
+) error {
+	var probeHandler corev1.ProbeHandler
+	if hasHealthzHandler {
+		probeHandler.HTTPGet = &corev1.HTTPGetAction{
+			Path:   "/healthz",
+			Port:   intstr.FromInt(9090),
+			Scheme: corev1.URISchemeHTTPS,
+		}
+	} else {
+		probeHandler.TCPSocket = &corev1.TCPSocketAction{
+			Port: intstr.FromInt(9090),
+		}
+	}
+
+	if deployment.Annotations == nil {
+		deployment.Annotations = map[string]string{}
+	}
+
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: ignitionServerLabels,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: ignitionServerLabels,
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName:            ignitionserver.ServiceAccount("").Name,
+				TerminationGracePeriodSeconds: utilpointer.Int64(10),
+				Tolerations: []corev1.Toleration{
+					{
+						Key:    "node-role.kubernetes.io/master",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "serving-cert",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName:  ignitionserver.IgnitionServingCertSecret("").Name,
+								DefaultMode: utilpointer.Int32(0640),
+							},
+						},
+					},
+					{
+						Name: "payloads",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:            ignitionserver.ResourceName,
+						Image:           utilitiesImage,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Env: []corev1.EnvVar{
+							{
+								Name: "MY_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
+							},
+						},
+						Command: []string{
+							"/usr/bin/control-plane-operator",
+							"ignition-server",
+							"--cert-file", "/var/run/secrets/ignition/serving-cert/tls.crt",
+							"--key-file", "/var/run/secrets/ignition/serving-cert/tls.key",
+							"--registry-overrides", convertRegistryOverridesToCommandLineFlag(registryOverrides),
+							"--platform", string(hcp.Spec.Platform.Type),
+						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler:        probeHandler,
+							InitialDelaySeconds: 120,
+							TimeoutSeconds:      5,
+							PeriodSeconds:       60,
+							FailureThreshold:    6,
+							SuccessThreshold:    1,
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler:        probeHandler,
+							InitialDelaySeconds: 5,
+							TimeoutSeconds:      5,
+							PeriodSeconds:       60,
+							FailureThreshold:    3,
+							SuccessThreshold:    1,
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "https",
+								ContainerPort: 9090,
+							},
+							{
+								Name:          "metrics",
+								ContainerPort: 8080,
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("40Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "serving-cert",
+								MountPath: "/var/run/secrets/ignition/serving-cert",
+							},
+							{
+								Name:      "payloads",
+								MountPath: "/payloads",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	proxy.SetEnvVars(&deployment.Spec.Template.Spec.Containers[0].Env)
+
+	if hcp.Spec.AdditionalTrustBundle != nil {
+		// Add trusted-ca mount with optional configmap
+		util.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
+	}
+
+	// set security context
+	if !managementClusterHasCapabilitySecurityContextConstraint {
+		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsUser: utilpointer.Int64(config.DefaultSecurityContextUser),
+		}
+	}
+
+	deploymentConfig := config.DeploymentConfig{}
+	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	deploymentConfig.SetDefaults(hcp, ignitionServerLabels, nil)
+	deploymentConfig.ApplyTo(deployment)
+
+	return nil
+}
+
+func reconcilePodMonitor(podMonitor *prometheusoperatorv1.PodMonitor,
+	ownerRef config.OwnerRef,
+	ignitionServerLabels map[string]string,
+	controlPlaneNamespace string,
+	clusterID string) error {
+	ownerRef.ApplyTo(podMonitor)
+	podMonitor.Spec.Selector = metav1.LabelSelector{
+		MatchLabels: ignitionServerLabels,
+	}
+	podMonitor.Spec.PodMetricsEndpoints = []prometheusoperatorv1.PodMetricsEndpoint{{
+		Port: "metrics",
+	}}
+	podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{controlPlaneNamespace}}
+	if podMonitor.Annotations == nil {
+		podMonitor.Annotations = map[string]string{}
+	}
+	util.ApplyClusterIDLabelToPodMonitor(&podMonitor.Spec.PodMetricsEndpoints[0], clusterID)
+	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -8,6 +8,7 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/certs"
@@ -31,6 +32,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 	c client.Client,
 	createOrUpdate upsert.CreateOrUpdateFN,
 	utilitiesImage string,
+	componentImages map[string]string,
 	hcp *hyperv1.HostedControlPlane,
 	defaultIngressDomain string,
 	hasHealthzHandler bool,
@@ -47,12 +49,28 @@ func ReconcileIgnitionServer(ctx context.Context,
 		return fmt.Errorf("Ignition service strategy not specified")
 	}
 
-	// Reconcile service
+	var routeServiceName string
 	ignitionServerService := ignitionserver.Service(controlPlaneNamespace)
-	if _, err := createOrUpdate(ctx, c, ignitionServerService, func() error {
-		return reconcileIgnitionServerService(ignitionServerService, serviceStrategy)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition service: %w", err)
+	if hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
+		if _, err := createOrUpdate(ctx, c, ignitionServerService, func() error {
+			return reconcileIgnitionServerServiceWithProxy(ignitionServerService, serviceStrategy)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ignition service: %w", err)
+		}
+		ignitionServerProxyService := ignitionserver.ProxyService(controlPlaneNamespace)
+		if _, err := createOrUpdate(ctx, c, ignitionServerProxyService, func() error {
+			return reconcileIgnitionServerProxyService(ignitionServerProxyService, serviceStrategy)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ignition proxy service: %w", err)
+		}
+		routeServiceName = ignitionServerProxyService.Name
+	} else {
+		if _, err := createOrUpdate(ctx, c, ignitionServerService, func() error {
+			return reconcileIgnitionServerService(ignitionServerService, serviceStrategy)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ignition service: %w", err)
+		}
+		routeServiceName = ignitionServerService.Name
 	}
 
 	var ignitionServerAddress string
@@ -62,7 +80,10 @@ func ReconcileIgnitionServer(ctx context.Context,
 		ignitionServerRoute := ignitionserver.Route(controlPlaneNamespace)
 		if util.IsPrivateHCP(hcp) {
 			if _, err := createOrUpdate(ctx, c, ignitionServerRoute, func() error {
-				reconcileInternalRoute(ignitionServerRoute, ownerRef)
+				err := reconcileInternalRoute(ignitionServerRoute, ownerRef, routeServiceName)
+				if err != nil {
+					return fmt.Errorf("failed to reconcile internal route in ignition server: %w", err)
+				}
 				return nil
 			}); err != nil {
 				return fmt.Errorf("failed to reconcile ignition internal route: %w", err)
@@ -73,7 +94,10 @@ func ReconcileIgnitionServer(ctx context.Context,
 				if serviceStrategy.Route != nil {
 					hostname = serviceStrategy.Route.Hostname
 				}
-				reconcileExternalRoute(ignitionServerRoute, ownerRef, hostname, defaultIngressDomain)
+				err := reconcileExternalRoute(ignitionServerRoute, ownerRef, routeServiceName, hostname, defaultIngressDomain)
+				if err != nil {
+					return fmt.Errorf("failed to reconcile external route in ignition server: %w", err)
+				}
 				return nil
 			}); err != nil {
 				return fmt.Errorf("failed to reconcile ignition external route: %w", err)
@@ -124,9 +148,9 @@ func ReconcileIgnitionServer(ctx context.Context,
 	if result, err := createOrUpdate(ctx, c, role, func() error {
 		return reconcileRole(role)
 	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition role: %w", err)
+		return fmt.Errorf("failed to reconcile ignition server role: %w", err)
 	} else {
-		log.Info("Reconciled ignition role", "result", result)
+		log.Info("Reconciled ignition server role", "result", result)
 	}
 
 	sa := ignitionserver.ServiceAccount(controlPlaneNamespace)
@@ -134,7 +158,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 		util.EnsurePullSecret(sa, controlplaneoperator.PullSecret("").Name)
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to reconcile controlplane operator service account: %w", err)
+		return fmt.Errorf("failed to reconcile ignition server service account: %w", err)
 	} else {
 		log.Info("Reconciled ignition server service account", "result", result)
 	}
@@ -143,16 +167,19 @@ func ReconcileIgnitionServer(ctx context.Context,
 	if result, err := createOrUpdate(ctx, c, roleBinding, func() error {
 		return reconcileRoleBinding(roleBinding, role, sa)
 	}); err != nil {
-		return fmt.Errorf("failed to reconcile ignition RoleBinding: %w", err)
+		return fmt.Errorf("failed to reconcile ignition server role binding: %w", err)
 	} else {
-		log.Info("Reconciled ignition server rolebinding", "result", result)
+		log.Info("Reconciled ignition server role binding", "result", result)
 	}
 
 	ignitionServerLabels := map[string]string{
 		"app":                         ignitionserver.ResourceName,
 		hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
 	}
-
+	servingCertSecretName := ignitionserver.IgnitionServingCertSecret("").Name
+	if hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
+		servingCertSecretName = manifests.IgnitionServerCertSecret("").Name
+	}
 	ignitionServerDeployment := ignitionserver.Deployment(controlPlaneNamespace)
 	if result, err := createOrUpdate(ctx, c, ignitionServerDeployment, func() error {
 		return reconcileDeployment(ignitionServerDeployment,
@@ -162,7 +189,8 @@ func ReconcileIgnitionServer(ctx context.Context,
 			hasHealthzHandler,
 			registryOverrides,
 			managementClusterHasCapabilitySecurityContextConstraint,
-			ignitionServerLabels)
+			ignitionServerLabels,
+			servingCertSecretName)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile ignition deployment: %w", err)
 	} else {
@@ -182,12 +210,73 @@ func ReconcileIgnitionServer(ctx context.Context,
 		log.Info("Reconciled ignition server podmonitor", "result", result)
 	}
 
+	if hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
+		role := ignitionserver.ProxyRole(controlPlaneNamespace)
+		if result, err := createOrUpdate(ctx, c, role, func() error {
+			return reconcileProxyRole(role)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ignition proxy role: %w", err)
+		} else {
+			log.Info("Reconciled ignition role", "result", result)
+		}
+
+		sa := ignitionserver.ProxyServiceAccount(controlPlaneNamespace)
+		if result, err := createOrUpdate(ctx, c, sa, func() error {
+			util.EnsurePullSecret(sa, controlplaneoperator.PullSecret("").Name)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ignition proxy service account: %w", err)
+		} else {
+			log.Info("Reconciled ignition proxy service account", "result", result)
+		}
+
+		roleBinding := ignitionserver.ProxyRoleBinding(controlPlaneNamespace)
+		if result, err := createOrUpdate(ctx, c, roleBinding, func() error {
+			return reconcileRoleBinding(roleBinding, role, sa)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ignition proxy role binding: %w", err)
+		} else {
+			log.Info("Reconciled ignition server proxy role binding", "result", result)
+		}
+
+		haproxyImage := componentImages["haproxy-router"]
+		if haproxyImage == "" {
+			return fmt.Errorf("haproxy-router image not found in payload images")
+		}
+		ignitionServerProxyDeployment := ignitionserver.ProxyDeployment(controlPlaneNamespace)
+		if result, err := createOrUpdate(ctx, c, ignitionServerProxyDeployment, func() error {
+			return reconcileProxyDeployment(ignitionServerProxyDeployment,
+				hcp,
+				haproxyImage,
+				managementClusterHasCapabilitySecurityContextConstraint)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ignition proxy deployment: %w", err)
+		} else {
+			log.Info("Reconciled ignition server proxy deployment", "result", result)
+		}
+	}
+
 	return nil
 }
 
 func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy) error {
+	return reconcileIgnitionExternalService(svc, strategy, false)
+}
+
+func reconcileIgnitionServerProxyService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy) error {
+	return reconcileIgnitionExternalService(svc, strategy, true)
+}
+
+func reconcileIgnitionExternalService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy, isProxy bool) error {
+	appLabel := ignitionserver.ResourceName
+	targetPort := intstr.FromInt(9090)
+	if isProxy {
+		appLabel = "ignition-server-proxy"
+		targetPort = intstr.FromInt(443)
+	}
+
 	svc.Spec.Selector = map[string]string{
-		"app": ignitionserver.ResourceName,
+		"app": appLabel,
 	}
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
@@ -198,7 +287,7 @@ func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.Servi
 	portSpec.Port = int32(443)
 	portSpec.Name = "https"
 	portSpec.Protocol = corev1.ProtocolTCP
-	portSpec.TargetPort = intstr.FromInt(9090)
+	portSpec.TargetPort = targetPort
 	switch strategy.Type {
 	case hyperv1.NodePort:
 		svc.Spec.Type = corev1.ServiceTypeNodePort
@@ -214,15 +303,31 @@ func reconcileIgnitionServerService(svc *corev1.Service, strategy *hyperv1.Servi
 	return nil
 }
 
-func reconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
-	ownerRef.ApplyTo(route)
-	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, ignitionserver.Service(route.Namespace).Name)
+func reconcileIgnitionServerServiceWithProxy(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy) error {
+	svc.Spec.Selector = map[string]string{
+		"app": ignitionserver.ResourceName,
+	}
+	svc.Spec.Type = corev1.ServiceTypeClusterIP
+	svc.Spec.Ports = []corev1.ServicePort{
+		{
+			Port:       int32(443),
+			Name:       "https",
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(9090),
+		},
+	}
+	return nil
 }
 
-func reconcileInternalRoute(route *routev1.Route, ownerRef config.OwnerRef) error {
+func reconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, svcName string, hostname string, defaultIngressDomain string) error {
+	ownerRef.ApplyTo(route)
+	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, svcName)
+}
+
+func reconcileInternalRoute(route *routev1.Route, ownerRef config.OwnerRef, svcName string) error {
 	ownerRef.ApplyTo(route)
 	// Assumes ownerRef is the HCP
-	return util.ReconcileInternalRoute(route, ownerRef.Reference.Name, ignitionserver.Service(route.Namespace).Name)
+	return util.ReconcileInternalRoute(route, ownerRef.Reference.Name, svcName)
 }
 
 func convertRegistryOverridesToCommandLineFlag(registryOverrides map[string]string) string {
@@ -301,6 +406,20 @@ func reconcileRole(role *rbacv1.Role) error {
 	return nil
 }
 
+func reconcileProxyRole(role *rbacv1.Role) error {
+	role.Rules = []rbacv1.PolicyRule{
+		{
+			// Copied from https://github.com/openshift/cluster-ingress-operator/blob/649fe5dfe2c6f795651592a045be901b00a1f93a/manifests/00-cluster-role.yaml#L173-L181
+			// Needed to allow PrivilegeEscalation: true
+			APIGroups:     []string{"security.openshift.io"},
+			ResourceNames: []string{"hostnetwork"},
+			Resources:     []string{"securitycontextconstraints"},
+			Verbs:         []string{"use"},
+		},
+	}
+	return nil
+}
+
 func reconcileRoleBinding(roleBinding *rbacv1.RoleBinding, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
 	roleBinding.RoleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
@@ -326,6 +445,7 @@ func reconcileDeployment(deployment *appsv1.Deployment,
 	registryOverrides map[string]string,
 	managementClusterHasCapabilitySecurityContextConstraint bool,
 	ignitionServerLabels map[string]string,
+	servingCertSecretName string,
 ) error {
 	var probeHandler corev1.ProbeHandler
 	if hasHealthzHandler {
@@ -366,7 +486,7 @@ func reconcileDeployment(deployment *appsv1.Deployment,
 						Name: "serving-cert",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName:  ignitionserver.IgnitionServingCertSecret("").Name,
+								SecretName:  servingCertSecretName,
 								DefaultMode: utilpointer.Int32(0640),
 							},
 						},
@@ -450,6 +570,119 @@ func reconcileDeployment(deployment *appsv1.Deployment,
 	}
 	proxy.SetEnvVars(&deployment.Spec.Template.Spec.Containers[0].Env)
 
+	// set security context
+	if !managementClusterHasCapabilitySecurityContextConstraint {
+		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsUser: utilpointer.Int64(config.DefaultSecurityContextUser),
+		}
+	}
+
+	deploymentConfig := config.DeploymentConfig{}
+	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+	deploymentConfig.SetDefaults(hcp, ignitionServerLabels, nil)
+	deploymentConfig.ApplyTo(deployment)
+
+	return nil
+}
+
+func reconcileProxyDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, haproxyImage string, managementClusterHasCapabilitySecurityContextConstraint bool) error {
+	commandScript := `#!/bin/bash
+set -e
+cat /etc/ssl/serving-cert/tls.crt /etc/ssl/serving-cert/tls.key > /tmp/tls.pem
+cat <<EOF > /tmp/haproxy.conf
+defaults
+  mode http
+  timeout connect 5s
+  timeout client 30s
+  timeout server 30s
+
+frontend ignition-server
+  bind *:443 ssl crt /tmp/tls.pem
+  default_backend ignition_servers
+
+backend ignition_servers
+  server ignition-server ignition-server:443 check ssl ca-file /etc/ssl/root-ca/ca.crt
+EOF
+haproxy -f /tmp/haproxy.conf
+`
+
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "ignition-server-proxy",
+			},
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app": "ignition-server-proxy",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:            "haproxy",
+						Image:           haproxyImage,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Command: []string{
+							"/bin/bash",
+						},
+						Args: []string{
+							"-c",
+							commandScript,
+						},
+
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "https",
+								ContainerPort: 443,
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("20Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(true)},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "serving-cert",
+								MountPath: "/etc/ssl/serving-cert",
+							},
+							{
+								Name:      "root-ca",
+								MountPath: "/etc/ssl/root-ca",
+							},
+						},
+					},
+				},
+				ServiceAccountName: ignitionserver.ProxyServiceAccount("").Name,
+				Volumes: []corev1.Volume{
+					{
+						Name: "serving-cert",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName:  ignitionserver.IgnitionServingCertSecret("").Name,
+								DefaultMode: utilpointer.Int32(0640),
+							},
+						},
+					},
+					{
+						Name: "root-ca",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: manifests.RootCAConfigMap("").Name},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	proxy.SetEnvVars(&deployment.Spec.Template.Spec.Containers[0].Env)
+
 	if hcp.Spec.AdditionalTrustBundle != nil {
 		// Add trusted-ca mount with optional configmap
 		util.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
@@ -465,7 +698,7 @@ func reconcileDeployment(deployment *appsv1.Deployment,
 	deploymentConfig := config.DeploymentConfig{}
 	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	deploymentConfig.SetDefaults(hcp, ignitionServerLabels, nil)
+	deploymentConfig.SetDefaults(hcp, nil, utilpointer.Int(1))
 	deploymentConfig.ApplyTo(deployment)
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -246,6 +246,10 @@ func ClusterVersionOperatorServerCertSecret(ns string) *corev1.Secret {
 	return secretFor(ns, "cvo-server")
 }
 
+func IgnitionServerCertSecret(ns string) *corev1.Secret {
+	return secretFor(ns, "ignition-server")
+}
+
 func AWSPodIdentityWebhookServingCert(ns string) *corev1.Secret {
 	return secretFor(ns, "aws-pod-identity-webhook-serving-cert")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ignitionserver.go
@@ -1,0 +1,18 @@
+package pki
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/hypershift/support/config"
+)
+
+func ReconcileIgnitionServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	dnsNames := []string{
+		"ignition-server",
+		fmt.Sprintf("ignition-server.%s.svc", secret.Namespace),
+		fmt.Sprintf("ignition-server.%s.svc.cluster.local", secret.Namespace),
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "ignition-server", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1490,10 +1490,15 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 	// Reconcile the Ignition server
 	if !controlplaneOperatorManagesIgnitionServer {
+		releaseInfo, err := r.ReleaseProvider.Lookup(ctx, hcluster.Spec.Release.Image, pullSecretBytes)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to lookup release image: %w", err)
+		}
 		if err := ignitionserverreconciliation.ReconcileIgnitionServer(ctx,
 			r.Client,
 			createOrUpdate,
 			utilitiesImage,
+			releaseInfo.ComponentImages(),
 			hcp,
 			defaultIngressDomain,
 			ignitionServerHasHealthzHandler,

--- a/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
+++ b/hypershift-operator/controllers/manifests/ignitionserver/manifests.go
@@ -34,6 +34,15 @@ func Service(namespace string) *corev1.Service {
 	}
 }
 
+func ProxyService(namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      ResourceName + "-proxy",
+		},
+	}
+}
+
 func PodMonitor(controlPlaneNamespace string) *prometheusoperatorv1.PodMonitor {
 	return &prometheusoperatorv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -48,6 +57,15 @@ func Deployment(namespace string) *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      ResourceName,
+		},
+	}
+}
+
+func ProxyDeployment(namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      ResourceName + "-proxy",
 		},
 	}
 }
@@ -79,6 +97,15 @@ func ServiceAccount(namespace string) *corev1.ServiceAccount {
 	}
 }
 
+func ProxyServiceAccount(namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      ResourceName + "-proxy",
+		},
+	}
+}
+
 func Role(namespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
@@ -88,11 +115,29 @@ func Role(namespace string) *rbacv1.Role {
 	}
 }
 
+func ProxyRole(namespace string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      ResourceName + "-proxy",
+		},
+	}
+}
+
 func RoleBinding(namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      ResourceName,
+		},
+	}
+}
+
+func ProxyRoleBinding(namespace string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      ResourceName + "-proxy",
 		},
 	}
 }


### PR DESCRIPTION
4.13 backport of https://github.com/openshift/hypershift/pull/2662 and https://github.com/openshift/hypershift/pull/2668 for https://issues.redhat.com/browse/HOSTEDCP-1060

Manual backport required to resolve registry override and featuregate work present in `main`.