### PR TITLE
HOSTEDCP-1019: Add create cluster for Agent for HCP CLI

### DIFF
--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	apifixtures "github.com/openshift/hypershift/api/fixtures"
+	"github.com/openshift/hypershift/api/fixtures"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/util"
 )
@@ -26,10 +26,10 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		AgentNamespace:   "",
 	}
 
-	cmd.Flags().StringVar(&opts.AgentPlatform.APIServerAddress, "api-server-address", opts.AgentPlatform.APIServerAddress, "The API server address that should be used for components outside the control plane")
+	cmd.Flags().StringVar(&opts.AgentPlatform.APIServerAddress, "api-server-address", opts.AgentPlatform.APIServerAddress, "The API server address is the IP address for Kubernetes API communication")
 	cmd.Flags().StringVar(&opts.AgentPlatform.AgentNamespace, "agent-namespace", opts.AgentPlatform.AgentNamespace, "The namespace in which to search for Agents")
-	cmd.MarkFlagRequired("agent-namespace")
-	cmd.MarkPersistentFlagRequired("pull-secret")
+	_ = cmd.MarkFlagRequired("agent-namespace")
+	_ = cmd.MarkPersistentFlagRequired("pull-secret")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -39,7 +39,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 			defer cancel()
 		}
 
-		if err := CreateCluster(ctx, opts); err != nil {
+		if err := createCluster(ctx, opts); err != nil {
 			opts.Log.Error(err, "Failed to create cluster")
 			return err
 		}
@@ -49,11 +49,11 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	return cmd
 }
 
-func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
-	return core.CreateCluster(ctx, opts, applyPlatformSpecificsValues)
+func createCluster(ctx context.Context, opts *core.CreateOptions) error {
+	return core.CreateCluster(ctx, opts, ApplyPlatformSpecificsValues)
 }
 
-func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
+func ApplyPlatformSpecificsValues(ctx context.Context, exampleOptions *fixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
 	if opts.AgentPlatform.APIServerAddress == "" {
 		opts.AgentPlatform.APIServerAddress, err = core.GetAPIServerAddressByNode(ctx, opts.Log)
 		if err != nil {
@@ -68,7 +68,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		exampleOptions.BaseDomain = "example.com"
 	}
 
-	exampleOptions.Agent = &apifixtures.ExampleAgentOptions{
+	exampleOptions.Agent = &fixtures.ExampleAgentOptions{
 		APIServerAddress: opts.AgentPlatform.APIServerAddress,
 		AgentNamespace:   opts.AgentPlatform.AgentNamespace,
 	}

--- a/product-cli/cmd/cluster/agent/create.go
+++ b/product-cli/cmd/cluster/agent/create.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/openshift/hypershift/cmd/cluster/agent"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/spf13/cobra"
+)
+
+func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "agent",
+		Short:        "Creates basic functional HostedCluster resources on Agent",
+		SilenceUsage: true,
+	}
+
+	opts.AgentPlatform = core.AgentPlatformCreateOptions{
+		APIServerAddress: "",
+		AgentNamespace:   "",
+	}
+
+	cmd.Flags().StringVar(&opts.AgentPlatform.APIServerAddress, "api-server-address", opts.AgentPlatform.APIServerAddress, "The API server address is the IP address for Kubernetes API communication")
+	cmd.Flags().StringVar(&opts.AgentPlatform.AgentNamespace, "agent-namespace", opts.AgentPlatform.AgentNamespace, "The namespace in which to search for Agents")
+	_ = cmd.MarkFlagRequired("agent-namespace")
+	_ = cmd.MarkPersistentFlagRequired("pull-secret")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if opts.Timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
+		}
+
+		if err := createCluster(ctx, opts); err != nil {
+			opts.Log.Error(err, "Failed to create cluster")
+			return err
+		}
+		return nil
+	}
+
+	return cmd
+}
+
+func createCluster(ctx context.Context, opts *core.CreateOptions) error {
+	return core.CreateCluster(ctx, opts, agent.ApplyPlatformSpecificsValues)
+}

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -41,6 +41,7 @@ func NewCreateCommands() *cobra.Command {
 		SilenceUsage: true,
 	}
 
+	cmd.AddCommand(agent.NewCreateCommand(opts))
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
 
 	return cmd


### PR DESCRIPTION
**What this PR does / why we need it**:
Add create cluster for Agent for HCP CLI

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1019](https://issues.redhat.com/browse/HOSTEDCP-1019)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.