### PR TITLE
HOSTEDCP-1030: Add destroy cluster for Agent for HCP CLI

### DIFF
--- a/cmd/cluster/agent/destroy.go
+++ b/cmd/cluster/agent/destroy.go
@@ -20,7 +20,7 @@ type DestroyOptions struct {
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "agent",
-		Short:        "Destroys a HostedCluster and its associated infrastructure on Agent.",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on Agent",
 		SilenceUsage: true,
 	}
 

--- a/cmd/kubeconfig/create.go
+++ b/cmd/kubeconfig/create.go
@@ -47,7 +47,7 @@ type options struct {
 func NewCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "kubeconfig",
-		Short:        "Renders kubeconfigs for HostedCluster resources.",
+		Short:        "Renders kubeconfigs for HostedCluster resources",
 		Long:         Description,
 		SilenceUsage: true,
 	}

--- a/product-cli/cmd/cluster/agent/destroy.go
+++ b/product-cli/cmd/cluster/agent/destroy.go
@@ -1,25 +1,26 @@
-package kubevirt
+package agent
 
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hypershift/cmd/cluster/agent"
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/cluster/none"
 	"github.com/openshift/hypershift/cmd/log"
 )
 
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "kubevirt",
-		Short:        "Destroys a HostedCluster and its associated infrastructure on Kubevirt platform",
+		Use:          "agent",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on Agent",
 		SilenceUsage: true,
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := none.DestroyCluster(cmd.Context(), opts); err != nil {
+		if err := agent.DestroyCluster(cmd.Context(), opts); err != nil {
 			log.Log.Error(err, "Failed to destroy cluster")
 			return err
 		}
+
 		return nil
 	}
 

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -6,9 +6,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/cmd/cluster/agent"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/log"
+	"github.com/openshift/hypershift/product-cli/cmd/cluster/agent"
 	"github.com/openshift/hypershift/product-cli/cmd/cluster/kubevirt"
 )
 
@@ -41,7 +41,6 @@ func NewCreateCommands() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.AddCommand(agent.NewCreateCommand(opts))
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
 
 	return cmd
@@ -70,6 +69,7 @@ func NewDestroyCommands() *cobra.Command {
 
 	_ = cmd.MarkPersistentFlagRequired("name")
 
+	cmd.AddCommand(agent.NewDestroyCommand(opts))
 	cmd.AddCommand(kubevirt.NewDestroyCommand(opts))
 
 	return cmd

--- a/product-cli/cmd/cluster/kubevirt/destroy.go
+++ b/product-cli/cmd/cluster/kubevirt/destroy.go
@@ -11,7 +11,7 @@ import (
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "kubevirt",
-		Short:        "Destroys a HostedCluster and its associated infrastructure on KubeVirt platform.",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on KubeVirt platform",
 		SilenceUsage: true,
 	}
 

--- a/product-cli/cmd/kubeconfig/create.go
+++ b/product-cli/cmd/kubeconfig/create.go
@@ -19,7 +19,7 @@ type options struct {
 func NewCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "kubeconfig",
-		Short:        "Renders kubeconfigs for HostedCluster resources.",
+		Short:        "Renders kubeconfigs for HostedCluster resources",
 		Long:         hypershiftkubeconfig.Description,
 		SilenceUsage: true,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add destroy cluster for Agent for HCP CLI

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1030](https://issues.redhat.com/browse/HOSTEDCP-1030)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.