### PR TITLE
Remove DisableStrictZoneCheck from AWS CCM config

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
@@ -16,7 +16,6 @@ const (
 )
 
 const configTemplate = `[Global]
-DisableStrictZoneCheck = true
 Zone = %s
 VPC = %s
 KubernetesClusterID = %s


### PR DESCRIPTION
This option was removed from the CCM and now causes the CCM to crash loop when specified.
Since we were disabling the check anyway, the removal of the check has no effect on the outcome for HyperShift.