### PR TITLE
use combined ca for controller manager arg to appropriately set ca in service accounts pod use

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment_test.go
@@ -9,19 +9,37 @@ import (
 
 func TestKCMArgs(t *testing.T) {
 	testCases := []struct {
-		name     string
-		p        *KubeControllerManagerParams
-		expected []string
+		name          string
+		p             *KubeControllerManagerParams
+		useCombinedCA bool
+		expected      []string
 	}{
 		{
-			name: "Leader elect args get set correctly",
-			p:    &KubeControllerManagerParams{},
+			name:          "Leader elect args get set correctly",
+			p:             &KubeControllerManagerParams{},
+			useCombinedCA: false,
 			expected: []string{
 				"--leader-elect-resource-lock=leases",
 				"--leader-elect=true",
 				// Contrary to everything else, KCM should not have an increased lease duration, see
 				// https://github.com/openshift/cluster-kube-controller-manager-operator/pull/557#issuecomment-904648807
 				"--leader-elect-retry-period=3s",
+			},
+		},
+		{
+			name:          "When combined ca defined: ca arg is set to combined ca",
+			p:             &KubeControllerManagerParams{},
+			useCombinedCA: true,
+			expected: []string{
+				"--root-ca-file=/etc/kubernetes/certs/combined-ca/ca.crt",
+			},
+		},
+		{
+			name:          "When combined ca not utilized: root ca arg is set to root ca bundle",
+			p:             &KubeControllerManagerParams{},
+			useCombinedCA: false,
+			expected: []string{
+				"--root-ca-file=/etc/kubernetes/certs/root-ca/ca.crt",
 			},
 		},
 	}
@@ -32,7 +50,7 @@ func TestKCMArgs(t *testing.T) {
 	)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			args := kcmArgs(tc.p)
+			args := kcmArgs(tc.p, tc.useCombinedCA)
 
 			seen := sets.String{}
 			for _, arg := range args {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -83,6 +83,15 @@ func UserCAConfigMap(ns string) *corev1.ConfigMap {
 	}
 }
 
+func CombinedCAConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "combined-ca",
+			Namespace: ns,
+		},
+	}
+}
+
 func TrustedCABundleConfigMap(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
There was a change on 4.12 and above that removed the combined-ca and instead moved to using the root-ca for the ca bundle of the cloud controller manager arg. This means the ca pods use in their service accounts does not contain the cluster signer ca and therefore has no local trust bundle to be able to validate tls connections if making calls to the kubelet server apis. This fix restores that behavior that existed in 4.11 and below while still maintaining the current path if the combined-ca bundle does not exist

Reference to 4.11 branch: https://github.com/openshift/hypershift/blob/release-4.11/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go#L33

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.