### PR TITLE
OCPBUGS-15655: use client ca bundle for controller manager arg to appropriately set ca in service accounts pod use

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func PullSecret(ns string) *corev1.Secret {
@@ -42,6 +43,7 @@ func VolumeTotalClientCA() *corev1.Volume {
 func BuildVolumeTotalClientCA(v *corev1.Volume) {
 	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
 	v.ConfigMap.Name = manifests.TotalClientCABundle("").Name
+	v.ConfigMap.DefaultMode = utilpointer.Int32(420)
 }
 
 func VolumeAggregatorCA() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2430,7 +2430,12 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 
 	rootCAConfigMap := manifests.RootCAConfigMap(hcp.Namespace)
 	if err := r.Get(ctx, client.ObjectKeyFromObject(rootCAConfigMap), rootCAConfigMap); err != nil {
-		return fmt.Errorf("failed to fetch combined ca configmap: %w", err)
+		return fmt.Errorf("failed to fetch root ca configmap: %w", err)
+	}
+
+	totalClientCAConfigMap := manifests.TotalClientCABundle(hcp.Namespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(totalClientCAConfigMap), totalClientCAConfigMap); err != nil {
+		return fmt.Errorf("failed to fetch total client ca configmap: %w", err)
 	}
 
 	serviceServingCA := manifests.ServiceServingCA(hcp.Namespace)
@@ -2484,7 +2489,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 	}
 
 	if _, err := createOrUpdate(ctx, r, kcmDeployment, func() error {
-		return kcm.ReconcileDeployment(kcmDeployment, kcmConfig, rootCAConfigMap, serviceServingCA, p, util.APIPort(hcp))
+		return kcm.ReconcileDeployment(kcmDeployment, kcmConfig, totalClientCAConfigMap, serviceServingCA, p, util.APIPort(hcp))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile kcm deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -2,6 +2,7 @@ package kcm
 
 import (
 	"fmt"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"path"
 	"strings"
 
@@ -32,15 +33,15 @@ const (
 var (
 	volumeMounts = util.PodVolumeMounts{
 		kcmContainerMain().Name: {
-			kcmVolumeConfig().Name:         "/etc/kubernetes/config",
-			kcmVolumeRootCA().Name:         "/etc/kubernetes/certs/root-ca",
-			kcmVolumeWorkLogs().Name:       "/var/log/kube-controller-manager",
-			kcmVolumeKubeconfig().Name:     "/etc/kubernetes/secrets/svc-kubeconfig",
-			kcmVolumeCertDir().Name:        "/var/run/kubernetes",
-			kcmVolumeClusterSigner().Name:  "/etc/kubernetes/certs/cluster-signer",
-			kcmVolumeServiceSigner().Name:  "/etc/kubernetes/certs/service-signer",
-			kcmVolumeServerCert().Name:     "/etc/kubernetes/certs/server",
-			kcmVolumeRecyclerConfig().Name: "/etc/kubernetes/recycler-config",
+			kcmVolumeConfig().Name:            "/etc/kubernetes/config",
+			common.VolumeTotalClientCA().Name: "/etc/kubernetes/certs/total-client-ca",
+			kcmVolumeWorkLogs().Name:          "/var/log/kube-controller-manager",
+			kcmVolumeKubeconfig().Name:        "/etc/kubernetes/secrets/svc-kubeconfig",
+			kcmVolumeCertDir().Name:           "/var/run/kubernetes",
+			kcmVolumeClusterSigner().Name:     "/etc/kubernetes/certs/cluster-signer",
+			kcmVolumeServiceSigner().Name:     "/etc/kubernetes/certs/service-signer",
+			kcmVolumeServerCert().Name:        "/etc/kubernetes/certs/server",
+			kcmVolumeRecyclerConfig().Name:    "/etc/kubernetes/recycler-config",
 		},
 	}
 	serviceServingCAMount = util.PodVolumeMounts{
@@ -106,7 +107,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceS
 		},
 		Volumes: []corev1.Volume{
 			util.BuildVolume(kcmVolumeConfig(), buildKCMVolumeConfig),
-			util.BuildVolume(kcmVolumeRootCA(), buildKCMVolumeRootCA),
+			util.BuildVolume(common.VolumeTotalClientCA(), common.BuildVolumeTotalClientCA),
 			util.BuildVolume(kcmVolumeWorkLogs(), buildKCMVolumeWorkLogs),
 			util.BuildVolume(kcmVolumeKubeconfig(), buildKCMVolumeKubeconfig),
 			util.BuildVolume(kcmVolumeClusterSigner(), buildKCMVolumeClusterSigner),
@@ -168,18 +169,6 @@ func buildKCMVolumeConfig(v *corev1.Volume) {
 			Name: manifests.KCMConfig("").Name,
 		},
 	}
-}
-
-func kcmVolumeRootCA() *corev1.Volume {
-	return &corev1.Volume{
-		Name: "root-ca",
-	}
-}
-
-func buildKCMVolumeRootCA(v *corev1.Volume) {
-	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
-	v.ConfigMap.Name = manifests.RootCAConfigMap("").Name
-	v.ConfigMap.DefaultMode = pointer.Int32(420)
 }
 
 func kcmVolumeWorkLogs() *corev1.Volume {
@@ -350,7 +339,7 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 		"--leader-elect-resource-lock=leases",
 		"--leader-elect=true",
 		"--leader-elect-retry-period=3s",
-		fmt.Sprintf("--root-ca-file=%s", cpath(kcmVolumeRootCA().Name, certs.CASignerCertMapKey)),
+		fmt.Sprintf("--root-ca-file=%s", cpath(common.VolumeTotalClientCA().Name, certs.CASignerCertMapKey)),
 		fmt.Sprintf("--secure-port=%d", DefaultPort),
 		fmt.Sprintf("--service-account-private-key-file=%s", cpath(kcmVolumeServiceSigner().Name, pki.ServiceSignerPrivateKey)),
 		fmt.Sprintf("--service-cluster-ip-range=%s", p.ServiceCIDR),


### PR DESCRIPTION
There was a change on 4.12 and above that removed the combined-ca and instead moved to using the root-ca for the ca bundle of the cloud controller manager arg. This means the ca pods use in their service accounts does not contain the cluster signer ca and therefore has no local trust bundle to be able to validate tls connections if making calls to the kubelet server apis. This fix restores that behavior that existed in 4.11 and below by using the associated ca bundle that has that info in the later releases

Reference to 4.11 branch: https://github.com/openshift/hypershift/blob/release-4.11/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go#L33

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.