### PR TITLE
[release-4.12] OCPBUGS-15655  use client ca bundle for controller manager arg to appropriately set ca in service accounts pod use

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/common/manifests.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func PullSecret(ns string) *corev1.Secret {
@@ -42,6 +43,7 @@ func VolumeTotalClientCA() *corev1.Volume {
 func BuildVolumeTotalClientCA(v *corev1.Volume) {
 	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
 	v.ConfigMap.Name = manifests.TotalClientCABundle("").Name
+	v.ConfigMap.DefaultMode = utilpointer.Int32(420)
 }
 
 func VolumeAggregatorCA() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2329,7 +2329,12 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 
 	rootCAConfigMap := manifests.RootCAConfigMap(hcp.Namespace)
 	if err := r.Get(ctx, client.ObjectKeyFromObject(rootCAConfigMap), rootCAConfigMap); err != nil {
-		return fmt.Errorf("failed to fetch combined ca configmap: %w", err)
+		return fmt.Errorf("failed to fetch root ca configmap: %w", err)
+	}
+
+	totalClientCAConfigMap := manifests.TotalClientCABundle(hcp.Namespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(totalClientCAConfigMap), totalClientCAConfigMap); err != nil {
+		return fmt.Errorf("failed to fetch total client ca configmap: %w", err)
 	}
 
 	serviceServingCA := manifests.ServiceServingCA(hcp.Namespace)
@@ -2376,7 +2381,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 	}
 
 	if _, err := createOrUpdate(ctx, r, kcmDeployment, func() error {
-		return kcm.ReconcileDeployment(kcmDeployment, kcmConfig, rootCAConfigMap, serviceServingCA, p, util.APIPort(hcp))
+		return kcm.ReconcileDeployment(kcmDeployment, kcmConfig, totalClientCAConfigMap, serviceServingCA, p, util.APIPort(hcp))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile kcm deployment: %w", err)
 	}


### PR DESCRIPTION
There was a change on 4.12 and above that removed the combined-ca and instead moved to using the root-ca for the ca bundle of the cloud controller manager arg. This means the ca pods use in their service accounts does not contain the cluster signer ca and therefore has no local trust bundle to be able to validate tls connections if making calls to the kubelet server apis. This fix restores that behavior that existed in 4.11 and below by using the associated ca bundle that has that info in the later releases

Reference to 4.11 branch: https://github.com/openshift/hypershift/blob/release-4.11/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go#L33

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.