### PR TITLE
OCPBUGS-15723: Let getMachinesForNodePool return machines ordered by creation Timestamp

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2506,7 +2506,7 @@ func (r *NodePoolReconciler) ensureMachineDeletion(nodePool *hyperv1.NodePool) e
 
 // getMachinesForNodePool get all Machines listed with the nodePoolAnnotation
 // within the control plane Namespace for that NodePool.
-func (r *NodePoolReconciler) getMachinesForNodePool(nodePool *hyperv1.NodePool) ([]capiv1.Machine, error) {
+func (r *NodePoolReconciler) getMachinesForNodePool(nodePool *hyperv1.NodePool) ([]*capiv1.Machine, error) {
 	machines := capiv1.MachineList{}
 	controlPlaneNamespace := fmt.Sprintf("%s-%s", nodePool.Namespace, strings.ReplaceAll(nodePool.Spec.ClusterName, ".", "-"))
 
@@ -2515,14 +2515,14 @@ func (r *NodePoolReconciler) getMachinesForNodePool(nodePool *hyperv1.NodePool) 
 	}
 
 	// Filter out only machines belonging to deleted NodePool
-	var machinesForNodePool []capiv1.Machine
+	var machinesForNodePool []*capiv1.Machine
 	for i, machine := range machines.Items {
 		if machine.Annotations[nodePoolAnnotation] == client.ObjectKeyFromObject(nodePool).String() {
-			machinesForNodePool = append(machinesForNodePool, machines.Items[i])
+			machinesForNodePool = append(machinesForNodePool, &machines.Items[i])
 		}
 	}
 
-	return machinesForNodePool, nil
+	return sortedByCreationTimestamp(machinesForNodePool), nil
 }
 
 // getPullSecretBytes retrieves the pull secret bytes from the hosted cluster
@@ -2547,4 +2547,22 @@ func (r *NodePoolReconciler) getPullSecretName(ctx context.Context, hostedCluste
 		return "", fmt.Errorf("pull secret %s/%s missing %q key when retrieving pull secret name", pullSecret.Namespace, pullSecret.Name, corev1.DockerConfigJsonKey)
 	}
 	return pullSecret.Name, nil
+}
+
+// machinesByCreationTimestamp sorts a list of Machine by creation timestamp, using their names as a tie breaker.
+type machinesByCreationTimestamp []*capiv1.Machine
+
+func (o machinesByCreationTimestamp) Len() int      { return len(o) }
+func (o machinesByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o machinesByCreationTimestamp) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(&o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+}
+
+// SortedByCreationTimestamp returns the machines sorted by creation timestamp.
+func sortedByCreationTimestamp(machines []*capiv1.Machine) []*capiv1.Machine {
+	sort.Sort(machinesByCreationTimestamp(machines))
+	return machines
 }


### PR DESCRIPTION

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This prevent the NodePool controller from producing a different condition message to convey the same state of the world


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.