### PR TITLE
OCPBUGS-15769: Set --balance-similar-node-groups for autoscaler

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -37,6 +37,7 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 		fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),
 		fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
 		fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
+		"--balance-similar-node-groups=true",
 		"--v=4",
 	}
 


### PR DESCRIPTION
This indicates the autoscaler to detect similar node groups and balance the number of nodes between them https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md. For a HA setup is recommended to create similar pools across Zones and let the Autoscaler balance them

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.