### PR TITLE
kubevirt: Annotate VMs to be live migratable

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -155,6 +155,11 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 		Spec: kubevirtv1.VirtualMachineSpec{
 			RunStrategy: &runAlways,
 			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubevirt.io/allow-pod-bridge-network-live-migration": "",
+					},
+				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
 					Domain: kubevirtv1.DomainSpec{
 						CPU:    &kubevirtv1.CPU{Cores: cores},

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -312,7 +312,8 @@ func generateNodeTemplate(memory string, cpu uint32, volumeSize string) *capikub
 						hyperv1.InfraIDLabel:      "1234",
 					},
 					Annotations: map[string]string{
-						suppconfig.PodSafeToEvictLocalVolumesKey: strings.Join(LocalStorageVolumes, ","),
+						suppconfig.PodSafeToEvictLocalVolumesKey:              strings.Join(LocalStorageVolumes, ","),
+						"kubevirt.io/allow-pod-bridge-network-live-migration": "",
 					},
 				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
By default KubeVirt virtual machines using bridge binding are not migratable, this change annotate them to allow KubeVirt and ovn-kubernetes to migrate them.


**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.