### PR TITLE
HOSTEDCP-1063: Disallow webhooks URLs targeting control plane services

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -193,6 +193,10 @@ const (
 	// DedicatedRequestServingComponentsTopology indicates that control plane request serving
 	// components should be scheduled on dedicated nodes in the management cluster.
 	DedicatedRequestServingComponentsTopology = "dedicated-request-serving-components"
+
+	// AllowGuestWebhooksServiceLabel marks a service deployed in the control plane as a valid target
+	// for validating/mutating webhooks running in the guest cluster.
+	AllowGuestWebhooksServiceLabel = "hypershift.openshift.io/allow-guest-webhooks"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -199,6 +199,7 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 		&apiregistrationv1.APIService{},
 		&operatorv1.Network{},
 		&admissionregistrationv1.MutatingWebhookConfiguration{},
+		&admissionregistrationv1.ValidatingWebhookConfiguration{},
 		&prometheusoperatorv1.PrometheusRule{},
 		&operatorv1.IngressController{},
 		&imageregistryv1.Config{},
@@ -512,6 +513,8 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 
 	log.Info("reconciling observed configuration")
 	errs = append(errs, r.reconcileObservedConfiguration(ctx, hcp)...)
+
+	errs = append(errs, r.ensureGuestAdmissionWebhooksAreValid(ctx))
 
 	// Delete the DNS operator deployment in the hosted cluster, if it is
 	// present there.  A separate DNS operator deployment runs as part of
@@ -1653,6 +1656,71 @@ func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyp
 	}
 
 	return remaining, errors.NewAggregate(errs)
+}
+
+func (r *reconciler) ensureGuestAdmissionWebhooksAreValid(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	cpServices := &corev1.ServiceList{}
+	if err := r.cpClient.List(ctx, cpServices, client.InNamespace(r.hcpNamespace)); err != nil {
+		return fmt.Errorf("failed to list control plane services: %w", err)
+	}
+
+	// disallow all urls tageting services in the hcp namespace by default unless 'hypershift.openshift.io/allow-guest-webhooks' label is present.
+	disallowedUrls := make([]string, 0)
+	for _, svc := range cpServices.Items {
+		if _, exist := svc.Labels[hyperv1.AllowGuestWebhooksServiceLabel]; exist {
+			continue
+		}
+
+		disallowedUrls = append(disallowedUrls, fmt.Sprintf("https://%s:", svc.Name))
+		disallowedUrls = append(disallowedUrls, fmt.Sprintf("https://%s.%s.svc", svc.Name, svc.Namespace))
+		disallowedUrls = append(disallowedUrls, fmt.Sprintf("https://%s.%s.svc.cluster.local", svc.Name, svc.Namespace))
+	}
+
+	validatingWebhookConfigurations := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
+	if err := r.client.List(ctx, validatingWebhookConfigurations); err != nil {
+		return fmt.Errorf("failed to list validatingWebhookConfigurations: %w", err)
+	}
+
+	errs := make([]error, 0)
+	for _, configuration := range validatingWebhookConfigurations.Items {
+		for _, webhook := range configuration.Webhooks {
+			if webhook.ClientConfig.URL != nil && !isAllowedWebhookUrl(disallowedUrls, *webhook.ClientConfig.URL) {
+				log.Info("deleting validating webhook configuration with a disallowed url", "webhook_name", configuration.Name, "disallowed_url", *webhook.ClientConfig.URL)
+				errs = append(errs, r.client.Delete(ctx, &configuration))
+				break
+			}
+		}
+	}
+
+	mutatingWebhookConfigurations := &admissionregistrationv1.MutatingWebhookConfigurationList{}
+	if err := r.client.List(ctx, mutatingWebhookConfigurations); err != nil {
+		errs = append(errs, fmt.Errorf("failed to list mutatingWebhookConfigurations: %w", err))
+		return errors.NewAggregate(errs)
+	}
+
+	for _, configuration := range mutatingWebhookConfigurations.Items {
+		for _, webhook := range configuration.Webhooks {
+			if webhook.ClientConfig.URL != nil && !isAllowedWebhookUrl(disallowedUrls, *webhook.ClientConfig.URL) {
+				log.Info("deleting mutating webhook configuration with a disallowed url", "webhook_name", configuration.Name, "disallowed_url", *webhook.ClientConfig.URL)
+				errs = append(errs, r.client.Delete(ctx, &configuration))
+				break
+			}
+		}
+	}
+
+	return errors.NewAggregate(errs)
+}
+
+func isAllowedWebhookUrl(disallowedUrls []string, url string) bool {
+	for i := range disallowedUrls {
+		if strings.Contains(url, disallowedUrls[i]) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (r *reconciler) ensureResourceCreationIsBlocked(ctx context.Context) error {

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -27,6 +27,8 @@ import (
 	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
 
 const (
@@ -118,6 +120,8 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 				&configv1.FeatureGate{}:     allSelector,
 				&configv1.ClusterOperator{}: allSelector,
 				&configv1.OperatorHub{}:     allSelector,
+				&admissionregistrationv1.ValidatingWebhookConfiguration{}: allSelector,
+				&admissionregistrationv1.MutatingWebhookConfiguration{}:   allSelector,
 
 				// Needed for inplace upgrader.
 				&corev1.Node{}: allSelector,

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -218,6 +218,7 @@ func validatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 	e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
 	e2eutil.EnsurePSANotPrivileged(t, ctx, guestClient)
+	e2eutil.EnsureGuestWebhooksValidated(t, ctx, guestClient)
 }
 
 func validatePrivateCluster(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Disallow mutating/validating webhooks using URLs targeting any service in the hcp namespace, unless 'hypershift.io/allow-guest-webhooks' flag is present.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1063](https://issues.redhat.com/browse/HOSTEDCP-1063)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.