### PR TITLE
OCPBUGS-15331,OCPBUGS-16049: Enable AdvertiseAddress dual stack and IPv6 support and added the changes to be included in the certificates

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -613,7 +613,8 @@ type CIDRBlock string
 type APIServerNetworking struct {
 	// AdvertiseAddress is the address that nodes will use to talk to the API
 	// server. This is an address associated with the loopback adapter of each
-	// node. If not specified, 172.20.0.1 is used.
+	// node. If not specified, the controller will take default values.
+	// The default values will be set as 172.20.0.1 or fd00::1.
 	AdvertiseAddress *string `json:"advertiseAddress,omitempty"`
 
 	// Port is the port at which the APIServer is exposed inside a node. Other

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5914,7 +5914,8 @@ spec:
                         description: AdvertiseAddress is the address that nodes will
                           use to talk to the API server. This is an address associated
                           with the loopback adapter of each node. If not specified,
-                          172.20.0.1 is used.
+                          the controller will take default values. The default values
+                          will be set as 172.20.0.1 or fd00::1.
                         type: string
                       allowedCIDRBlocks:
                         description: AllowedCIDRBlocks is an allow list of CIDR blocks

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -5904,7 +5904,8 @@ spec:
                         description: AdvertiseAddress is the address that nodes will
                           use to talk to the API server. This is an address associated
                           with the loopback adapter of each node. If not specified,
-                          172.20.0.1 is used.
+                          the controller will take default values. The default values
+                          will be set as 172.20.0.1 or fd00::1.
                         type: string
                       allowedCIDRBlocks:
                         description: AllowedCIDRBlocks is an allow list of CIDR blocks

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/blang/semver"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
@@ -129,7 +130,7 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 		ImagePolicyConfig:            imagePolicyConfig(p.InternalRegistryHostName, p.ExternalRegistryHostNames),
 		ProjectConfig:                projectConfig(p.DefaultNodeSelector),
 		ServiceAccountPublicKeyFiles: []string{cpath(kasVolumeServiceAccountKey().Name, pki.ServiceSignerPublicKey)},
-		ServicesSubnet:               p.ServiceNetwork[0],
+		ServicesSubnet:               strings.Join(p.ServiceNetwork, ","),
 	}
 	args := kubeAPIServerArgs{}
 	args.Set("advertise-address", p.AdvertiseAddress)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -103,7 +103,9 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		params.Image = hcp.Spec.Configuration.Image
 		params.Scheduler = hcp.Spec.Configuration.Scheduler
 	}
-	params.AdvertiseAddress = util.AdvertiseAddressWithDefault(hcp, config.DefaultAdvertiseAddress)
+
+	params.AdvertiseAddress = util.GetAdvertiseAddress(hcp, config.DefaultAdvertiseIPv4Address, config.DefaultAdvertiseIPv6Address)
+
 	params.APIServerPort = util.BindAPIPortWithDefault(hcp, config.DefaultAPIServerPort)
 	if _, ok := hcp.Annotations[hyperv1.PortierisImageAnnotation]; ok {
 		params.Images.Portieris = hcp.Annotations[hyperv1.PortierisImageAnnotation]

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
@@ -13,11 +13,11 @@ import (
 type PKIParams struct {
 	// ServiceCIDR
 	// Subnet for cluster services
-	ServiceCIDR string `json:"serviceCIDR"`
+	ServiceCIDR []string `json:"serviceCIDR"`
 
 	// ClusterCIDR
 	// Subnet for pods
-	ClusterCIDR string `json:"clusterCIDR"`
+	ClusterCIDR []string `json:"clusterCIDR"`
 
 	// ExternalAPIAddress
 	// An externally accessible DNS name or IP for the API server. Currently obtained from the load balancer DNS name.
@@ -32,7 +32,7 @@ type PKIParams struct {
 	ExternalKconnectivityAddress string `json:"externalKconnectivityAddress"`
 
 	// NodeInternalAPIServerIP
-	// A fixed IP that pods on worker nodes will use to communicate with the API server - 172.20.0.1
+	// A fixed IP that pods on worker nodes will use to communicate with the API server - 172.20.0.1 for IPv4 and fd00::1 in IPv6 case
 	NodeInternalAPIServerIP string `json:"nodeInternalAPIServerIP"`
 
 	// ExternalOauthAddress
@@ -54,9 +54,22 @@ func NewPKIParams(hcp *hyperv1.HostedControlPlane,
 	apiExternalAddress,
 	oauthExternalAddress,
 	konnectivityExternalAddress string) *PKIParams {
+	svcCIDRs := make([]string, 0)
+	clusterCIDRs := make([]string, 0)
+
+	// Go over all service networks in order to include them in the PKI certificates
+	for _, svcCIDR := range hcp.Spec.Networking.ServiceNetwork {
+		svcCIDRs = append(svcCIDRs, svcCIDR.CIDR.String())
+	}
+
+	// Go over all cluster networks in order to include them in the PKI certificates
+	for _, clusterCIDR := range hcp.Spec.Networking.ClusterNetwork {
+		clusterCIDRs = append(clusterCIDRs, clusterCIDR.CIDR.String())
+	}
+
 	p := &PKIParams{
-		ServiceCIDR:                  util.FirstServiceCIDR(hcp.Spec.Networking.ServiceNetwork),
-		ClusterCIDR:                  util.FirstClusterCIDR(hcp.Spec.Networking.ClusterNetwork),
+		ServiceCIDR:                  svcCIDRs,
+		ClusterCIDR:                  clusterCIDRs,
 		Namespace:                    hcp.Namespace,
 		ExternalAPIAddress:           apiExternalAddress,
 		InternalAPIAddress:           fmt.Sprintf("api.%s.hypershift.local", hcp.Name),
@@ -65,6 +78,18 @@ func NewPKIParams(hcp *hyperv1.HostedControlPlane,
 		IngressSubdomain:             globalconfig.IngressDomain(hcp),
 		OwnerRef:                     config.OwnerRefFrom(hcp),
 	}
-	p.NodeInternalAPIServerIP = util.AdvertiseAddressWithDefault(hcp, config.DefaultAdvertiseAddress)
+
+	// If the first serviceCIDR is an IPv4 we need to set the config.DefaultAdvertiseIPv4Address
+	// as fake IP in the node to access the haproxy exposed as kube-api-server-proxy
+	// Even with that, we cannot set more than one AdvertiseAddress so both
+	// are not supported at the same time.
+	// Check this for more info: https://github.com/kubernetes/enhancements/issues/2438
+	ipv4, err := util.IsIPv4(p.ServiceCIDR[0])
+	if err != nil || ipv4 {
+		p.NodeInternalAPIServerIP = util.AdvertiseAddressWithDefault(hcp, config.DefaultAdvertiseIPv4Address)
+	} else {
+		p.NodeInternalAPIServerIP = util.AdvertiseAddressWithDefault(hcp, config.DefaultAdvertiseIPv6Address)
+	}
+
 	return p
 }

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -831,7 +831,8 @@ string
 <td>
 <p>AdvertiseAddress is the address that nodes will use to talk to the API
 server. This is an address associated with the loopback adapter of each
-node. If not specified, 172.20.0.1 is used.</p>
+node. If not specified, the controller will take default values.
+The default values will be set as 172.20.0.1 or fd00::1.</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -33257,7 +33257,8 @@ objects:
                           description: AdvertiseAddress is the address that nodes
                             will use to talk to the API server. This is an address
                             associated with the loopback adapter of each node. If
-                            not specified, 172.20.0.1 is used.
+                            not specified, the controller will take default values.
+                            The default values will be set as 172.20.0.1 or fd00::1.
                           type: string
                         allowedCIDRBlocks:
                           description: AllowedCIDRBlocks is an allow list of CIDR
@@ -40955,7 +40956,8 @@ objects:
                           description: AdvertiseAddress is the address that nodes
                             will use to talk to the API server. This is an address
                             associated with the loopback adapter of each node. If
-                            not specified, 172.20.0.1 is used.
+                            not specified, the controller will take default values.
+                            The default values will be set as 172.20.0.1 or fd00::1.
                           type: string
                         allowedCIDRBlocks:
                           description: AllowedCIDRBlocks is an allow list of CIDR

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -62,6 +62,8 @@ func (r *NodePoolReconciler) isHAProxyIgnitionConfigManaged(ctx context.Context,
 func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context, componentImages map[string]string, hcluster *hyperv1.HostedCluster, controlPlaneOperatorImage string) (cfg string, missing bool, err error) {
 	var apiServerExternalAddress string
 	var apiServerExternalPort int32
+	var apiServerInternalAddress string
+
 	if util.IsPrivateHC(hcluster) {
 		apiServerExternalAddress = fmt.Sprintf("api.%s.hypershift.local", hcluster.Name)
 		apiServerExternalPort = util.InternalAPIPortFromHostedClusterWithDefault(hcluster, config.DefaultAPIServerPort)
@@ -97,7 +99,19 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 		return "", true, fmt.Errorf("release image doesn't have a %s image", haProxyRouterImageName)
 	}
 
-	apiServerInternalAddress := config.DefaultAdvertiseAddress
+	// This provides support for HTTP Proxy on IPv6 scenarios
+	ipv4, err := util.IsIPv4(hcluster.Spec.Networking.ServiceNetwork[0].CIDR.String())
+	if err != nil {
+		return "", true, fmt.Errorf("error checking the stack in the first ServiceNetworkCIDR %s: %w", hcluster.Spec.Networking.ServiceNetwork[0].CIDR.String(), err)
+	}
+
+	// Set the default
+	if ipv4 {
+		apiServerInternalAddress = config.DefaultAdvertiseIPv4Address
+	} else {
+		apiServerInternalAddress = config.DefaultAdvertiseIPv6Address
+	}
+
 	//TODO: in order to prevent periodic kube-apiserver network blimps in the LoadBalancer
 	//publish strategy this should change.
 	//However: will need API changes for service publishing strategy. Best function to call:

--- a/hypershift-operator/controllers/nodepool/haproxy_test.go
+++ b/hypershift-operator/controllers/nodepool/haproxy_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/openshift/hypershift/api/util/ipnet"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/support/testutil"
 	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -81,6 +82,7 @@ kind: Config`
 			name: "private cluster uses .local address",
 			hc: hc(func(hc *hyperv1.HostedCluster) {
 				hc.Spec.Platform.AWS.EndpointAccess = hyperv1.Private
+				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
 			}),
 
 			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:6443"},
@@ -90,6 +92,7 @@ kind: Config`
 			hc: hc(func(hc *hyperv1.HostedCluster) {
 				hc.Spec.Platform.AWS.EndpointAccess = hyperv1.Private
 				hc.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{Port: utilpointer.Int32(443)}
+				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
 			}),
 
 			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:443"},
@@ -98,6 +101,7 @@ kind: Config`
 			name: "public and private cluster uses .local address",
 			hc: hc(func(hc *hyperv1.HostedCluster) {
 				hc.Spec.Platform.AWS.EndpointAccess = hyperv1.PublicAndPrivate
+				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
 			}),
 
 			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:6443"},
@@ -107,6 +111,7 @@ kind: Config`
 			hc: hc(func(hc *hyperv1.HostedCluster) {
 				hc.Spec.Platform.AWS.EndpointAccess = hyperv1.PublicAndPrivate
 				hc.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{Port: utilpointer.Int32(443)}
+				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
 			}),
 
 			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:443"},
@@ -116,6 +121,7 @@ kind: Config`
 			hc: hc(func(hc *hyperv1.HostedCluster) {
 				hc.Spec.Platform.AWS.EndpointAccess = hyperv1.Public
 				hc.Status.KubeConfig = &corev1.LocalObjectReference{Name: "kk"}
+				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
 			}),
 			other: []crclient.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "kk", Namespace: hc().Namespace},
@@ -132,6 +138,7 @@ kind: Config`
 				hc.Spec.Platform.AWS.EndpointAccess = hyperv1.Public
 				hc.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{Port: utilpointer.Int32(443)}
 				hc.Status.KubeConfig = &corev1.LocalObjectReference{Name: "kk"}
+				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
 			}),
 			other: []crclient.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "kk", Namespace: hc().Namespace},

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1768,7 +1768,7 @@ func (r *NodePoolReconciler) getConfig(ctx context.Context,
 
 		haproxyIgnitionConfig, missing, err := r.reconcileHAProxyIgnitionConfig(ctx, releaseImage.ComponentImages(), hcluster, cpoImage)
 		if err != nil {
-			return "", false, fmt.Errorf("failed to generate haporoxy ignition config: %w", err)
+			return "", false, fmt.Errorf("failed to generate haproxy ignition config: %w", err)
 		}
 		if missing {
 			missingConfigs = true

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	api "github.com/openshift/hypershift/api"
+	"github.com/openshift/hypershift/api/util/ipnet"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -792,6 +793,11 @@ kind: Config`)},
 			hc := &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"hypershift.openshift.io/control-plane-operator-image": "cpo-image"}},
 				Status:     hyperv1.HostedClusterStatus{KubeConfig: &corev1.LocalObjectReference{Name: "kubeconfig"}},
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						ServiceNetwork: []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+					},
+				},
 			}
 			releaseImage := &releaseinfo.ReleaseImage{ImageStream: &imagev1.ImageStream{Spec: imagev1.ImageStreamSpec{Tags: []imagev1.TagReference{{
 				Name: "haproxy-router",

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -19,7 +19,8 @@ const (
 
 	DefaultServiceAccountIssuer  = "https://kubernetes.default.svc"
 	DefaultImageRegistryHostname = "image-registry.openshift-image-registry.svc:5000"
-	DefaultAdvertiseAddress      = "172.20.0.1"
+	DefaultAdvertiseIPv4Address  = "172.20.0.1"
+	DefaultAdvertiseIPv6Address  = "fd00::1"
 	DefaultEtcdURL               = "https://etcd-client:2379"
 	DefaultAPIServerPort         = 6443
 	DefaultServiceNodePortRange  = "30000-32767"

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -121,3 +121,20 @@ func AllowedCIDRBlocks(hcp *hyperv1.HostedControlPlane) []hyperv1.CIDRBlock {
 	}
 	return nil
 }
+
+func GetAdvertiseAddress(hcp *hyperv1.HostedControlPlane, ipv4DefaultAddress, ipv6DefaultAddress string) string {
+	var advertiseAddress string
+
+	ipv4, err := IsIPv4(hcp.Spec.Networking.ServiceNetwork[0].CIDR.String())
+	if err != nil || ipv4 {
+		if address := AdvertiseAddressWithDefault(hcp, ipv4DefaultAddress); len(address) > 0 {
+			advertiseAddress = address
+		}
+	} else {
+		if address := AdvertiseAddressWithDefault(hcp, ipv6DefaultAddress); len(address) > 0 {
+			advertiseAddress = address
+		}
+	}
+
+	return advertiseAddress
+}

--- a/support/util/networking_test.go
+++ b/support/util/networking_test.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/hypershift/api/util/ipnet"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	DefaultAdvertiseIPv4Address = "172.20.0.1"
+	DefaultAdvertiseIPv6Address = "fd00::1"
+)
+
+func TestGetAdvertiseAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		hcp  *hyperv1.HostedControlPlane
+		want string
+	}{
+		{
+			name: "given an AdvertiseAddress in the HCP, it should return it",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Networking: hyperv1.ClusterNetworking{
+						APIServer: &hyperv1.APIServerNetworking{
+							AdvertiseAddress: pointer.String("192.168.1.1"),
+						},
+						ServiceNetwork: []hyperv1.ServiceNetworkEntry{{
+							CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64"),
+						}},
+					},
+				},
+			},
+			want: "192.168.1.1",
+		},
+		{
+			name: "given no AdvertiseAddress/es in the HCP, it should return IPv4 based default address",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Networking: hyperv1.ClusterNetworking{
+						ServiceNetwork: []hyperv1.ServiceNetworkEntry{{
+							CIDR: *ipnet.MustParseCIDR("192.168.1.0/24"),
+						}},
+					},
+				},
+			},
+			want: DefaultAdvertiseIPv4Address,
+		},
+		{
+			name: "given no AdvertiseAddress/es in the HCP, it should return IPv6 based default address",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Networking: hyperv1.ClusterNetworking{
+						ServiceNetwork: []hyperv1.ServiceNetworkEntry{{
+							CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64"),
+						}},
+					},
+				},
+			},
+			want: DefaultAdvertiseIPv6Address,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetAdvertiseAddress(tt.hcp, DefaultAdvertiseIPv4Address, DefaultAdvertiseIPv6Address); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAdvertiseAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -260,3 +260,14 @@ func IsIPv4(cidr string) (bool, error) {
 		return false, nil
 	}
 }
+
+// FirstUsableIP returns the first usable IP in both, IPv4 and IPv6 stacks.
+func FirstUsableIP(cidr string) (string, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("error validating the incoming CIDR %s: %w", cidr, err)
+	}
+	ip := ipNet.IP
+	ip[len(ipNet.IP)-1]++
+	return ip.String(), nil
+}

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -295,3 +295,49 @@ func TestIsIPv4(t *testing.T) {
 		})
 	}
 }
+
+func TestFirstUsableIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		cidr    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Given IPv4 CIDR, it should return the first ip of the network range",
+			cidr:    "192.168.1.0/24",
+			want:    "192.168.1.1",
+			wantErr: false,
+		},
+		{
+			name:    "Given IPv6 CIDR, it should return the first ip of the network range",
+			cidr:    "2000::/3",
+			want:    "2000::1",
+			wantErr: false,
+		},
+		{
+			name:    "Given a malformed IPv4 CIDR, it should return empty string and err",
+			cidr:    "192.168.1.35.53/24",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Given a malformed IPv6 CIDR, it should return empty string and err",
+			cidr:    "2001::44444444444444/17",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FirstUsableIP(tt.cidr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FirstUsableIP() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("FirstUsableIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes:

- Now IPv6 and Dual Stack scenarios are covered in self-hosted environments.
- KAS PKI modified to include IPv4/6 addresses into the certificate
- Proxy still support only single stack scenarios, using the first ServiceCIDR as a AdvertiseAddress or InternalAPIAddress, but IPv4 and IPv6 could be used in any case (this is temporary meanwhile the Issue mentioned down bellow is open).

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-15331](https://issues.redhat.com/browse/OCPBUGS-15331)
Fixes #[OCPBUGS-16049](https://issues.redhat.com/browse/OCPBUGS-16049)

## Caveats:

- https://github.com/kubernetes/enhancements/issues/2438 - This issue prevents the KAS to support dual stack and the `AdvertiseAddress` even being an slice, it only supports only one element (if more provided it will take the last one as the AdvertiseAddress).

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.