### PR TITLE
HOSTEDCP-413: Add HyperShift operator upgrade e2e test

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -201,18 +201,18 @@ func NewCommand() *cobra.Command {
 			return err
 		}
 
-		objects, err := hyperShiftOperatorManifests(opts)
+		objects, err := HyperShiftOperatorManifests(opts)
 		if err != nil {
 			return err
 		}
 
-		err = apply(cmd.Context(), objects)
+		err = Apply(cmd.Context(), objects)
 		if err != nil {
 			return err
 		}
 
 		if opts.WaitUntilAvailable {
-			if err := waitUntilAvailable(cmd.Context(), opts); err != nil {
+			if err := WaitUntilAvailable(cmd.Context(), opts); err != nil {
 				return err
 			}
 		}
@@ -225,7 +225,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func apply(ctx context.Context, objects []crclient.Object) error {
+func Apply(ctx context.Context, objects []crclient.Object) error {
 	client, err := util.GetClient()
 	if err != nil {
 		return err
@@ -260,7 +260,7 @@ func apply(ctx context.Context, objects []crclient.Object) error {
 	return errors.NewAggregate(errs)
 }
 
-func waitUntilAvailable(ctx context.Context, opts Options) error {
+func WaitUntilAvailable(ctx context.Context, opts Options) error {
 	client, err := util.GetClient()
 	if err != nil {
 		return err
@@ -367,7 +367,7 @@ func fetchImageRefs(file string) (map[string]string, error) {
 	return result, nil
 }
 
-func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
+func HyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	var objects []crclient.Object
 
 	var images map[string]string

--- a/cmd/install/install_render.go
+++ b/cmd/install/install_render.go
@@ -59,7 +59,7 @@ func NewRenderCommand(opts *Options) *cobra.Command {
 			}
 			objects = []crclient.Object{templateObject}
 		} else {
-			objects, err = hyperShiftOperatorManifests(*opts)
+			objects, err = HyperShiftOperatorManifests(*opts)
 			if err != nil {
 				return err
 			}
@@ -154,7 +154,7 @@ func hyperShiftOperatorTemplateManifest(opts *Options) (crclient.Object, error) 
 	}
 
 	// create manifests
-	objects, err := hyperShiftOperatorManifests(*opts)
+	objects, err := HyperShiftOperatorManifests(*opts)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -9,7 +9,7 @@ set -o monitor
 set -x
 
 CI_TESTS_RUN=${1:-}
-if [ -z  ${CI_TESTS_RUN} ]
+if [ -z  "${CI_TESTS_RUN}" ]
 then
       echo "Running all tests"
 else
@@ -27,7 +27,7 @@ trap generate_junit EXIT
 bin/test-e2e \
   -test.v \
   -test.timeout=2h10m \
-  -test.run=${CI_TESTS_RUN} \
+  -test.run="${CI_TESTS_RUN}" \
   -test.parallel=20 \
   --e2e.aws-credentials-file=/etc/hypershift-pool-aws-credentials/credentials \
   --e2e.aws-zones=us-east-1a,us-east-1b,us-east-1c \
@@ -37,6 +37,7 @@ bin/test-e2e \
   --e2e.base-domain=ci.hypershift.devcluster.openshift.com \
   --e2e.latest-release-image="${OCP_IMAGE_LATEST}" \
   --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" \
+  --e2e.ci-hypershift-operator="${CI_HYPERSHIFT_OPERATOR}" \
   --e2e.additional-tags="expirationDate=$(date -d '4 hours' --iso=minutes --utc)" \
   --e2e.aws-endpoint-access=PublicAndPrivate \
   --e2e.external-dns-domain=service.ci.hypershift.devcluster.openshift.com | tee /tmp/test_out

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -99,6 +99,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSProcessors, "e2e.powervs-processors", "0.5", "Number of processors allocated. Default is 0.5")
 	flag.IntVar(&globalOpts.configurableClusterOptions.PowerVSMemory, "e2e.powervs-memory", 32, "Amount of memory allocated (in GB). Default is 32")
 	flag.BoolVar(&globalOpts.SkipAPIBudgetVerification, "e2e.skip-api-budget", false, "Bool to avoid send metrics to E2E Server on local test execution.")
+	flag.StringVar(&globalOpts.configurableClusterOptions.CI_HyperShiftOperator, "e2e.ci-hypershift-operator", "", "The CI built HyperShift operator based on the contents of the PR")
 	flag.StringVar(&globalOpts.configurableClusterOptions.EtcdStorageClass, "e2e.etcd-storage-class", "", "The persistent volume storage class for etcd data volumes")
 	flag.BoolVar(&globalOpts.RequestServingIsolation, "e2e.test-request-serving-isolation", false, "If set, TestCreate creates a cluster with request serving isolation topology")
 
@@ -363,6 +364,7 @@ type configurableClusterOptions struct {
 	AWSCredentialsFile          string
 	AzureCredentialsFile        string
 	AzureLocation               string
+	CI_HyperShiftOperator       string
 	Region                      string
 	Zone                        stringSliceVar
 	PullSecretFile              string

--- a/test/e2e/operator_upgrade_test.go
+++ b/test/e2e/operator_upgrade_test.go
@@ -1,0 +1,149 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/cmd/install"
+	"github.com/openshift/hypershift/cmd/version"
+	"github.com/openshift/hypershift/support/metrics"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+)
+
+const (
+	awsCredentialsSecretKey = "credentials"
+	awsRegion               = "us-east-1"
+)
+
+// TestOperatorUpgrade implements a test that installs the latest HyperShift operator, upgrades the HyperShift operator
+// based on the PR it's tested against, and ensures there were no restarted/crashed pods in the guest cluster during the upgrade.
+func TestOperatorUpgrade(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	client, err := e2eutil.GetClient()
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get k8s client")
+
+	// Create HC with a PublicAndPrivate endpoint access config
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts.AWSPlatform.EndpointAccess = string(hyperv1.PublicAndPrivate)
+	clusterOpts.AWSPlatform.InstanceType = "m5.xlarge"
+
+	zones := strings.Split(globalOpts.configurableClusterOptions.Zone.String(), ",")
+	if len(zones) >= 3 {
+		// CreateCluster also tests multi-zone workers work properly if a sufficient number of zones are configured
+		t.Logf("Sufficient zones available for InfrastructureAvailabilityPolicy HighlyAvailable")
+		clusterOpts.AWSPlatform.Zones = zones
+		clusterOpts.InfrastructureAvailabilityPolicy = string(hyperv1.HighlyAvailable)
+		clusterOpts.NodePoolReplicas = 1
+	}
+
+	// Create a guest cluster
+	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
+
+	// Sanity check the cluster by waiting for the nodes to report ready
+	t.Logf("Waiting for guest client to become available")
+	guestClient := e2eutil.WaitForGuestClient(t, testContext, client, hostedCluster)
+
+	// Wait for Nodes to be Ready
+	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
+	e2eutil.WaitForNReadyNodes(t, testContext, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
+
+	// Wait for the rollout to be complete
+	t.Logf("Waiting for cluster rollout. Image: %s", globalOpts.LatestReleaseImage)
+	e2eutil.WaitForImageRollout(t, testContext, client, hostedCluster, globalOpts.LatestReleaseImage)
+	err = client.Get(testContext, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get hosted cluster")
+
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, testContext, client, guestClient, hostedCluster.Namespace)
+	e2eutil.EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+	e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
+
+	// Set installation options
+	opts := install.Options{
+		HyperShiftImage:                           version.HyperShiftImage,
+		Namespace:                                 "hypershift",
+		PrivatePlatform:                           string(hyperv1.AWSPlatform),
+		OIDCStorageProviderS3BucketName:           "operator-upgrade-hosted-" + clusterOpts.AWSPlatform.Region,
+		OIDCStorageProviderS3Credentials:          globalOpts.configurableClusterOptions.AWSCredentialsFile,
+		OIDCStorageProviderS3Region:               awsRegion,
+		OIDCStorageProviderS3CredentialsSecret:    "",
+		OIDCStorageProviderS3CredentialsSecretKey: awsCredentialsSecretKey,
+		EnableConversionWebhook:                   true,
+		AWSPrivateCreds:                           globalOpts.configurableClusterOptions.AWSCredentialsFile,
+		AWSPrivateRegion:                          awsRegion,
+		AWSPrivateCredentialsSecret:               "",
+		AWSPrivateCredentialsSecretKey:            awsCredentialsSecretKey,
+		EnableValidatingWebhook:                   false,
+	}
+
+	// Ensure S3 bucket is available
+	s3Details := make(map[string]string)
+	s3Details["s3Creds"] = opts.OIDCStorageProviderS3Credentials
+	s3Details["seedName"] = e2eutil.SimpleNameGenerator.GenerateName("")
+	s3Details["s3Region"] = opts.OIDCStorageProviderS3Region
+
+	if opts.OIDCStorageProviderS3BucketName == "" {
+		bucket, err := e2eutil.CreateS3Bucket(ctx, s3Details)
+		g.Expect(err).NotTo(HaveOccurred(), "error creating S3 bucket")
+		opts.OIDCStorageProviderS3BucketName = bucket
+		defer func() {
+			awsConfig := &aws.Config{
+				Region:      aws.String(s3Details["s3Region"]),
+				Credentials: credentials.NewSharedCredentials(s3Details["s3Creds"], "default"),
+			}
+			if err := e2eutil.DeleteS3Bucket(ctx, *awsConfig, bucket); err != nil {
+				t.Errorf("error deleting S3 bucket: %s", bucket)
+			}
+		}()
+	}
+
+	g.Expect(opts.OIDCStorageProviderS3BucketName).NotTo(BeEmpty(), "S3 bucket name parameter it's empty")
+	s3Details["bucketName"] = opts.OIDCStorageProviderS3BucketName
+
+	opts.ApplyDefaults()
+
+	if os.Getenv("CI") == "true" {
+		opts.PlatformMonitoring = metrics.PlatformMonitoringAll
+		opts.EnableCIDebugOutput = true
+	}
+
+	// Deploy latest HyperShift operator on guest cluster
+	t.Log("Deploying Latest Hypershift Version: " + version.HyperShiftImage)
+	objects, err := install.HyperShiftOperatorManifests(opts)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to object conversion from installation options:", err)
+
+	err = install.Apply(ctx, objects)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to apply hypershift installation manifests:", err)
+
+	err = install.WaitUntilAvailable(ctx, opts)
+	g.Expect(err).NotTo(HaveOccurred(), "failed waiting hypershift installation:", err)
+
+	// Deploy CI HyperShift operator on guest cluster
+	t.Log("Deploying CI Hypershift Version: " + globalOpts.configurableClusterOptions.CI_HyperShiftOperator)
+	opts.HyperShiftImage = globalOpts.configurableClusterOptions.CI_HyperShiftOperator
+	objects, err = install.HyperShiftOperatorManifests(opts)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to object conversion from installation options:", err)
+
+	err = install.Apply(ctx, objects)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to apply CI hypershift installation manifests:", err)
+
+	err = install.WaitUntilAvailable(ctx, opts)
+	g.Expect(err).NotTo(HaveOccurred(), "failed waiting CI hypershift installation:", err)
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -4,6 +4,17 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
@@ -36,14 +47,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
-	"strings"
-	"testing"
-	"time"
 )
 
 func UpdateObject[T crclient.Object](t *testing.T, ctx context.Context, client crclient.Client, original T, mutate func(obj T)) error {
@@ -522,6 +528,62 @@ func EnsureAllContainersHavePullPolicyIfNotPresent(t *testing.T, ctx context.Con
 			}
 		}
 	})
+}
+
+func CreateS3Bucket(ctx context.Context, s3Details map[string]string) (string, error) {
+	bucket := fmt.Sprintf("%s-%s", s3Details["s3Region"], "test-migration")
+
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String(s3Details["s3Region"]),
+		Credentials: credentials.NewSharedCredentials(s3Details["s3Creds"], "default"),
+	})
+	if err != nil {
+		return "", fmt.Errorf("error creating s3 session: %v", err)
+	}
+
+	svc := s3.New(sess)
+
+	if _, err := svc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+		ACL:    aws.String("public-read"),
+	}); err != nil {
+		return "", fmt.Errorf("Unable to create bucket %q, %v", bucket, err)
+	}
+
+	if err = svc.WaitUntilBucketExists(&s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	}); err != nil {
+		return "", fmt.Errorf("Error occurred while waiting for bucket to be created, %v", bucket)
+	}
+
+	fmt.Printf("Bucket %q successfully created\n", bucket)
+
+	return bucket, nil
+}
+
+func DeleteS3Bucket(ctx context.Context, awsConfig aws.Config, bucket string) error {
+	sess, err := session.NewSession(&awsConfig)
+	if err != nil {
+		return fmt.Errorf("error creating s3 session: %v", err)
+	}
+
+	svc := s3.New(sess)
+
+	if _, err := svc.DeleteBucket(&s3.DeleteBucketInput{
+		Bucket: aws.String(bucket),
+	}); err != nil {
+		return fmt.Errorf("Unable to delete bucket %q, %v", bucket, err)
+	}
+
+	if err = svc.WaitUntilBucketNotExists(&s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	}); err != nil {
+		return fmt.Errorf("Error occurred while waiting for bucket to be deleted, %v", bucket)
+	}
+
+	fmt.Printf("Bucket %q successfully deleted\n", bucket)
+
+	return nil
 }
 
 func EnsureNodeCountMatchesNodePoolReplicas(t *testing.T, ctx context.Context, hostClient, guestClient crclient.Client, nodePoolNamespace string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a HyperShift operator upgrade e2e test which installs the latest HyperShift operator version then installs the CI built HyperShift operator from the pull request, and re-verifies health following the HyperShift operator upgrade.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-413](https://issues.redhat.com/browse/HOSTEDCP-413)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.