### PR TITLE
OCPBUGS-14862 Improve clarity around hypershift operator permissions

### DIFF
--- a/docs/content/how-to/aws/deploy-aws-private-clusters.md
+++ b/docs/content/how-to/aws/deploy-aws-private-clusters.md
@@ -35,6 +35,7 @@ following steps will reference elements of the steps you already performed.
                 "ec2:DeleteVpcEndpointServiceConfigurations",
                 "ec2:DescribeVpcEndpointServicePermissions",
                 "ec2:ModifyVpcEndpointServicePermissions",
+                "ec2:RejectVpcEndpointConnections",
                 "ec2:CreateTags",
                 "elasticloadbalancing:DescribeLoadBalancers"
               ],
@@ -59,6 +60,7 @@ following steps will reference elements of the steps you already performed.
                 "ec2:DeleteVpcEndpointServiceConfigurations",
                 "ec2:DescribeVpcEndpointServicePermissions",
                 "ec2:ModifyVpcEndpointServicePermissions",
+                "ec2:RejectVpcEndpointConnections",
                 "ec2:CreateTags",
                 "elasticloadbalancing:DescribeLoadBalancers"
               ],


### PR DESCRIPTION
* The operator now expects to be able to perform ec2:RejectVpcEndpointConnections
* The message of AWS errors is logged, which can help identify which AWS operation is running into errors.

**What this PR does / why we need it**:
In response to feedback during QA, we should document required permissions and return AWS error messages to improve the troubleshooting experience when AWS permissions are missing.

**Which issue(s) this PR fixes**:
OCPBUGS-14862

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.