### PR TITLE
OCPBUGS-15769: Include hypershift specific labels to be ignored by similar autoscaler groups

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -326,6 +326,8 @@ const (
 
 func GetIgnoreLabels() []string {
 	return []string{
+		// Hypershift
+		"hypershift.openshift.io/nodePool",
 		// AWS
 		AwsIgnoredLabelEbsCsiZone,
 		// Azure


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up for https://github.com/openshift/hypershift/pull/2769

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.