### PR TITLE
HOSTEDCP-1093: Add default flags to HCP create cluster CLI cmd

### DIFF
--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -14,25 +14,23 @@ import (
 
 func NewCreateCommands() *cobra.Command {
 	opts := &core.CreateOptions{
-		Namespace:                      "clusters",
-		Name:                           "example",
-		ReleaseImage:                   "",
-		PullSecretFile:                 "",
-		ControlPlaneAvailabilityPolicy: "HighlyAvailable",
-		Render:                         false,
-		InfraID:                        "",
-		ServiceCIDR:                    "172.31.0.0/16",
-		ClusterCIDR:                    "10.132.0.0/14",
-		Wait:                           false,
-		Timeout:                        0,
-		ExternalDNSDomain:              "",
 		AdditionalTrustBundle:          "",
+		ClusterCIDR:                    "10.132.0.0/14",
+		ControlPlaneAvailabilityPolicy: "HighlyAvailable",
 		ImageContentSources:            "",
-		NodeSelector:                   nil,
+		InfraID:                        "",
 		Log:                            log.Log,
+		Name:                           "example",
+		Namespace:                      "clusters",
 		NodeDrainTimeout:               0,
+		NodeSelector:                   nil,
 		NodeUpgradeType:                v1beta1.UpgradeTypeReplace,
-		Arch:                           "amd64",
+		PullSecretFile:                 "",
+		ReleaseImage:                   "",
+		Render:                         false,
+		ServiceCIDR:                    "172.31.0.0/16",
+		Timeout:                        0,
+		Wait:                           false,
 	}
 
 	cmd := &cobra.Command{
@@ -41,10 +39,34 @@ func NewCreateCommands() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If 0 or greater, creates a nodepool with that many replicas; else if less than 0, does not create a nodepool.")
-	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "File path to a pull secret.")
-	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the cluster.")
+	cmd.PersistentFlags().StringVar(&opts.AdditionalTrustBundle, "additional-trust-bundle", opts.AdditionalTrustBundle, "Filepath to a file with a user CA bundle.")
+	cmd.PersistentFlags().StringArrayVar(&opts.Annotations, "annotations", opts.Annotations, "Annotations to apply to the HostedCluster (format: key=value). Annotations can be specified multiple times.")
+	cmd.PersistentFlags().BoolVar(&opts.AutoRepair, "auto-repair", opts.AutoRepair, "Enables machine auto-repair with machine health checks.")
+	cmd.PersistentFlags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "Ingress base domain for the cluster.")
+	cmd.PersistentFlags().StringVar(&opts.ClusterCIDR, "cluster-cidr", opts.ClusterCIDR, "CIDR of the cluster network.")
+	cmd.PersistentFlags().StringVar(&opts.ControlPlaneAvailabilityPolicy, "control-plane-availability-policy", opts.ControlPlaneAvailabilityPolicy, "Availability policy for HostedCluster components. Supported options: SingleReplica, HighlyAvailable.")
+	cmd.PersistentFlags().StringVar(&opts.EtcdStorageClass, "etcd-storage-class", opts.EtcdStorageClass, "Persistent volume storage class for etcd data volumes")
+	cmd.PersistentFlags().BoolVar(&opts.FIPS, "fips", opts.FIPS, "Enables FIPS mode for nodes in the cluster.")
+	cmd.PersistentFlags().BoolVar(&opts.GenerateSSH, "generate-ssh", opts.GenerateSSH, "If true, generates an SSH key that can be used to access the nodes in a NodePool.")
+	cmd.PersistentFlags().StringVar(&opts.ImageContentSources, "image-content-sources", opts.ImageContentSources, "Filepath to a file with image content sources.")
+	cmd.PersistentFlags().StringVar(&opts.InfrastructureAvailabilityPolicy, "infra-availability-policy", opts.InfrastructureAvailabilityPolicy, "Availability policy for infrastructure services in guest cluster. Supported options: SingleReplica, HighlyAvailable.")
+	cmd.PersistentFlags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Infrastructure ID of the HostedCluster. Inferred from the HostedCluster by default.")
+	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The HostedCluster's name.")
+	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The HostedCluster's namespace name.")
+	cmd.PersistentFlags().DurationVar(&opts.NodeDrainTimeout, "node-drain-timeout", opts.NodeDrainTimeout, "The NodeDrainTimeout for any created NodePools.")
+	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If set to 0 or greater, NodePools will be created with that many replicas. If set to less than 0, no NodePools will be created.")
+	cmd.PersistentFlags().StringToStringVar(&opts.NodeSelector, "node-selector", opts.NodeSelector, "A comma separated list of key=value pairs to use as the node selector for the Hosted Control Plane pods to stick to. (e.g. role=cp,disk=fast)")
+	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
+	cmd.PersistentFlags().StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other.")
+	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Filepath to a pull secret.")
+	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the HostedCluster.")
+	cmd.PersistentFlags().BoolVar(&opts.Render, "render", opts.Render, "Renders the HostedCluster manifest output as YAML to stdout instead of automatically applying the manifests to the management cluster.")
+	cmd.PersistentFlags().StringVar(&opts.ServiceCIDR, "service-cidr", opts.ServiceCIDR, "The CIDR of the service network.")
+	cmd.PersistentFlags().StringVar(&opts.SSHKeyFile, "ssh-key", opts.SSHKeyFile, "Filepath to an SSH key file.")
+	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the duration of the wait (Examples: 30s, 1h30m45s, etc.) 0 means no timeout.")
+	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If true, the create command will block until the HostedCluster is up. Requires at least one NodePool with at least one node.")
 
+	_ = cmd.MarkPersistentFlagRequired("name")
 	_ = cmd.MarkPersistentFlagRequired("pull-secret")
 
 	cmd.AddCommand(agent.NewCreateCommand(opts))
@@ -56,11 +78,11 @@ func NewCreateCommands() *cobra.Command {
 func NewDestroyCommands() *cobra.Command {
 
 	opts := &core.DestroyOptions{
-		Namespace:             "clusters",
-		Name:                  "",
 		ClusterGracePeriod:    10 * time.Minute,
-		Log:                   log.Log,
 		DestroyCloudResources: true,
+		Log:                   log.Log,
+		Name:                  "",
+		Namespace:             "clusters",
 	}
 
 	cmd := &cobra.Command{
@@ -68,11 +90,12 @@ func NewDestroyCommands() *cobra.Command {
 		Short:        "Destroys a HostedCluster and its associated infrastructure.",
 		SilenceUsage: true,
 	}
-	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A cluster namespace")
-	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "A cluster name (required)")
-	cmd.PersistentFlags().DurationVar(&opts.ClusterGracePeriod, "cluster-grace-period", opts.ClusterGracePeriod, "How long to wait for the cluster to be deleted before forcibly destroying its infra")
-	cmd.PersistentFlags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Infrastructure ID inferred from the hosted cluster by default")
-	cmd.PersistentFlags().BoolVar(&opts.DestroyCloudResources, "destroy-cloud-resources", opts.DestroyCloudResources, "If true, cloud resources such as load balancers and persistent storage disks created by the cluster during its lifetime are removed")
+
+	cmd.PersistentFlags().DurationVar(&opts.ClusterGracePeriod, "cluster-grace-period", opts.ClusterGracePeriod, "Period of time to wait for the HostedCluster to be deleted before forcibly destroying its infrastructure.")
+	cmd.PersistentFlags().BoolVar(&opts.DestroyCloudResources, "destroy-cloud-resources", opts.DestroyCloudResources, "If true, cloud resources, such as load balancers and persistent storage disks, created by the HostedCluster during its lifetime are removed.")
+	cmd.PersistentFlags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "The HostedCluster's infrastructure ID. This is inferred from the HostedCluster by default.")
+	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The HostedCluster's name.")
+	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The HostedCluster's namespace name.")
 
 	_ = cmd.MarkPersistentFlagRequired("name")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds cloud platform-agnostic default flags to the HCP create cluster CLI command.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1093](https://issues.redhat.com/browse/HOSTEDCP-1093)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.