### PR TITLE
[release 4.12] OCPBUGS-11555: OAuth OpenShift deployment requires ConfigMap mount patch2

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/config.go
@@ -58,7 +58,7 @@ func generateOAuthConfig(ctx context.Context, client crclient.Client, namespace 
 	}
 
 	cpath := func(volume, file string) string {
-		dir := volumeMounts.Path(oauthContainerMain().Name, volume)
+		dir := volumeMountsCABundle.Path(oauthContainerMain().Name, volume)
 		return path.Join(dir, file)
 	}
 


### PR DESCRIPTION
This is an additional fix for 11555, making it so the container also does not try to mount the CA bundle mount.

This patch only applies to 4.12 as it is a z stream updgrade issue.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.