### PR TITLE
OTA-855: Enable CVO to evaluate conditional updates on self-managed HyperShift deployed on OpenShift

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -23,7 +23,7 @@ type CVOParams struct {
 	PlatformType            hyperv1.PlatformType
 }
 
-func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *CVOParams {
+func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext, enableCVOManagementClusterMetricsAccess bool) *CVOParams {
 	p := &CVOParams{
 		CLIImage:                releaseImageProvider.GetImage("cli"),
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
@@ -32,6 +32,11 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imagepr
 		OwnerRef:                config.OwnerRefFrom(hcp),
 		ClusterID:               hcp.Spec.ClusterID,
 		PlatformType:            hcp.Spec.Platform.Type,
+	}
+	if enableCVOManagementClusterMetricsAccess {
+		p.DeploymentConfig.AdditionalLabels = map[string]string{
+			config.NeedMetricsServerAccessLabel: "true",
+		}
 	}
 	p.DeploymentConfig.Resources = config.ResourcesSpec{
 		cvoContainerPrepPayload().Name: {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/cvo.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/cvo.go
@@ -4,13 +4,43 @@ import (
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const clusterVersionOperator = "cluster-version-operator"
 
 func ClusterVersionOperatorDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cluster-version-operator",
+			Name:      clusterVersionOperator,
+			Namespace: ns,
+		},
+	}
+}
+
+func ClusterVersionOperatorRole(ns string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterVersionOperator,
+			Namespace: ns,
+		},
+	}
+}
+
+func ClusterVersionOperatorRoleBinding(ns string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterVersionOperator,
+			Namespace: ns,
+		},
+	}
+}
+
+func ClusterVersionOperatorServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterVersionOperator,
 			Namespace: ns,
 		},
 	}
@@ -19,7 +49,7 @@ func ClusterVersionOperatorDeployment(ns string) *appsv1.Deployment {
 func ClusterVersionOperatorServiceMonitor(ns string) *prometheusoperatorv1.ServiceMonitor {
 	return &prometheusoperatorv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cluster-version-operator",
+			Name:      clusterVersionOperator,
 			Namespace: ns,
 		},
 	}
@@ -28,7 +58,7 @@ func ClusterVersionOperatorServiceMonitor(ns string) *prometheusoperatorv1.Servi
 func ClusterVersionOperatorService(controlPlaneNamespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cluster-version-operator",
+			Name:      clusterVersionOperator,
 			Namespace: controlPlaneNamespace,
 		},
 	}

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -395,15 +395,18 @@ func NewStartCommand() *cobra.Command {
 		}
 		setupLog.Info("Using metrics set", "set", metricsSet.String())
 
+		enableCVOManagementClusterMetricsAccess := (os.Getenv(config.EnableCVOManagementClusterMetricsAccessEnvVar) == "1")
+
 		if err := (&hostedcontrolplane.HostedControlPlaneReconciler{
-			Client:                        mgr.GetClient(),
-			ManagementClusterCapabilities: mgmtClusterCaps,
-			ReleaseProvider:               releaseProvider,
-			EnableCIDebugOutput:           enableCIDebugOutput,
-			OperateOnReleaseImage:         os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
-			DefaultIngressDomain:          defaultIngressDomain,
-			MetricsSet:                    metricsSet,
-			CertRotationScale:             certRotationScale,
+			Client:                                  mgr.GetClient(),
+			ManagementClusterCapabilities:           mgmtClusterCaps,
+			ReleaseProvider:                         releaseProvider,
+			EnableCIDebugOutput:                     enableCIDebugOutput,
+			OperateOnReleaseImage:                   os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
+			DefaultIngressDomain:                    defaultIngressDomain,
+			MetricsSet:                              metricsSet,
+			CertRotationScale:                       certRotationScale,
+			EnableCVOManagementClusterMetricsAccess: enableCVOManagementClusterMetricsAccess,
 		}).SetupWithManager(mgr, upsert.New(enableCIDebugOutput).CreateOrUpdate); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")
 			os.Exit(1)

--- a/hypershift-operator/controllers/manifests/networkpolicy/manifests.go
+++ b/hypershift-operator/controllers/manifests/networkpolicy/manifests.go
@@ -41,6 +41,15 @@ func ManagementKASNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
 	}
 }
 
+func MetricsServerNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "metrics-server",
+		},
+	}
+}
+
 func OpenshiftMonitoringNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	pkiconfig "github.com/openshift/hypershift/control-plane-pki-operator/config"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -307,6 +308,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	}
 
 	monitoringDashboards := (os.Getenv("MONITORING_DASHBOARDS") == "1")
+	enableCVOManagementClusterMetricsAccess := (os.Getenv(config.EnableCVOManagementClusterMetricsAccessEnvVar) == "1")
 
 	certRotationScale, err := pkiconfig.GetCertRotationScale()
 	if err != nil {
@@ -314,19 +316,20 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	}
 
 	hostedClusterReconciler := &hostedcluster.HostedClusterReconciler{
-		Client:                        mgr.GetClient(),
-		ManagementClusterCapabilities: mgmtClusterCaps,
-		HypershiftOperatorImage:       operatorImage,
-		ReleaseProvider:               releaseProviderWithOpenShiftImageRegistryOverrides,
-		EnableOCPClusterMonitoring:    opts.EnableOCPClusterMonitoring,
-		EnableCIDebugOutput:           opts.EnableCIDebugOutput,
-		ImageMetadataProvider:         imageMetaDataProvider,
-		MetricsSet:                    metricsSet,
-		OperatorNamespace:             opts.Namespace,
-		SREConfigHash:                 sreConfigHash,
-		KubevirtInfraClients:          kvinfra.NewKubevirtInfraClientMap(),
-		MonitoringDashboards:          monitoringDashboards,
-		CertRotationScale:             certRotationScale,
+		Client:                                  mgr.GetClient(),
+		ManagementClusterCapabilities:           mgmtClusterCaps,
+		HypershiftOperatorImage:                 operatorImage,
+		ReleaseProvider:                         releaseProviderWithOpenShiftImageRegistryOverrides,
+		EnableOCPClusterMonitoring:              opts.EnableOCPClusterMonitoring,
+		EnableCIDebugOutput:                     opts.EnableCIDebugOutput,
+		ImageMetadataProvider:                   imageMetaDataProvider,
+		MetricsSet:                              metricsSet,
+		OperatorNamespace:                       opts.Namespace,
+		SREConfigHash:                           sreConfigHash,
+		KubevirtInfraClients:                    kvinfra.NewKubevirtInfraClientMap(),
+		MonitoringDashboards:                    monitoringDashboards,
+		CertRotationScale:                       certRotationScale,
+		EnableCVOManagementClusterMetricsAccess: enableCVOManagementClusterMetricsAccess,
 	}
 	if opts.OIDCStorageProviderS3BucketName != "" {
 		awsSession := awsutil.NewSession("hypershift-operator-oidc-bucket", opts.OIDCStorageProviderS3Credentials, "", "", opts.OIDCStorageProviderS3Region)

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -5,6 +5,10 @@ const (
 	// to prevent any pod which doesn't contain the label from accessing the management cluster KAS.
 	NeedManagementKASAccessLabel = "hypershift.openshift.io/need-management-kas-access"
 
+	// NeedMetricsServerAccessLabel is used by network policies
+	// to allow egress communication to the metrics server on the management cluster.
+	NeedMetricsServerAccessLabel = "hypershift.openshift.io/need-metrics-server-access"
+
 	// EtcdPriorityClass is for etcd pods.
 	EtcdPriorityClass = "hypershift-etcd"
 
@@ -36,5 +40,6 @@ const (
 	KCMRecommendedRenewDeadline = "12s"
 	KCMRecommendedRetryPeriod   = "3s"
 
-	DefaultIngressDomainEnvVar = "DEFAULT_INGRESS_DOMAIN"
+	DefaultIngressDomainEnvVar                    = "DEFAULT_INGRESS_DOMAIN"
+	EnableCVOManagementClusterMetricsAccessEnvVar = "ENABLE_CVO_MANAGEMENT_CLUSTER_METRICS_ACCESS"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request will enable the hosted Cluster Version Operator (CVO) to evaluate conditional updates on self-managed HyperShift deployed on an OpenShift management cluster.

**Which issue(s) this PR fixes**:
Implements #[OTA-855](https://issues.redhat.com/browse/OTA-855)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.