### PR TITLE
HOSTEDCP-1061: [release-4.13] Implement dedicated request serving nodes for HostedClusters

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -149,6 +149,25 @@ const (
 	// RouteVisibilityPrivate is a value for RouteVisibilityLabel that will result
 	// in the labeled route being ignored by external-dns
 	RouteVisibilityPrivate = "private"
+
+	// HostedClusterLabel is used as a label on nodes that are dedicated to a specific hosted cluster
+	HostedClusterLabel = "hypershift.openshift.io/cluster"
+
+	// RequestServingComponentLabel is used as a label on pods and nodes for dedicated serving components.
+	RequestServingComponentLabel = "hypershift.openshift.io/request-serving-component"
+
+	// TopologyAnnotation indicates the type of topology that should take effect for the
+	// hosted cluster's control plane workloads. Currently the only value supported is "dedicated-request-serving-components".
+	// We implicitly support shared and dedicated.
+	TopologyAnnotation = "hypershift.openshift.io/topology"
+
+	// HostedClusterScheduledAnnotation indicates that a hosted cluster with dedicated request serving components
+	// has been assigned dedicated nodes. If not present, the hosted cluster needs scheduling.
+	HostedClusterScheduledAnnotation = "hypershift.openshift.io/cluster-scheduled"
+
+	// DedicatedRequestServingComponentsTopology indicates that control plane request serving
+	// components should be scheduled on dedicated nodes in the management cluster.
+	DedicatedRequestServingComponentsTopology = "dedicated-request-serving-components"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -298,7 +298,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	params.OwnerRef = config.OwnerRefFrom(hcp)
 
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	params.DeploymentConfig.SetDefaults(hcp, kasLabels(), nil)
+	params.DeploymentConfig.SetRequestServingDefaults(hcp, kasLabels(), nil)
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return params

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -75,7 +75,8 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 		},
 	}
 	p.ServerDeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
-	p.ServerDeploymentConfig.SetDefaults(hcp, nil, pointer.Int(1))
+
+	p.ServerDeploymentConfig.SetRequestServingDefaults(hcp, nil, pointer.Int(1))
 	p.ServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	p.AgentDeploymentConfig.Resources = config.ResourcesSpec{

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -134,7 +134,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, images map[string]str
 			SuccessThreshold:    1,
 		},
 	}
-	p.DeploymentConfig.SetDefaults(hcp, oauthServerLabels, nil)
+	p.DeploymentConfig.SetRequestServingDefaults(hcp, oauthServerLabels, nil)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	p.OauthConfigOverrides = map[string]*ConfigOverride{}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1573,6 +1573,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.DisableProfilingAnnotation,
 		hyperv1.PrivateIngressControllerAnnotation,
 		hyperv1.CleanupCloudResourcesAnnotation,
+		hyperv1.TopologyAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -1,0 +1,216 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/support/upsert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	ControlPlaneTaint                              = "hypershift.openshift.io/control-plane"
+	ControlPlaneServingComponentTaint              = "hypershift.openshift.io/control-plane-serving-component"
+	HostedClusterTaint                             = "hypershift.openshift.io/cluster"
+	ControlPlaneServingComponentAvailableNodeTaint = "hypershift.openshift.io/control-plane-serving-component-available"
+
+	ControlPlaneServingComponentLabel = "hypershift.openshift.io/control-plane-serving-component"
+
+	HostedClusterNameLabel      = "hypershift.openshift.io/cluster-name"
+	HostedClusterNamespaceLabel = "hypershift.openshift.io/cluster-namespace"
+)
+
+type DedicatedServingComponentNodeReaper struct {
+	client.Client
+}
+
+func (r *DedicatedServingComponentNodeReaper) SetupWithManager(mgr ctrl.Manager) error {
+	servingComponentPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: map[string]string{hyperv1.RequestServingComponentLabel: "true"}})
+	if err != nil {
+		return err
+	}
+	builder := ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).WithEventFilter(servingComponentPredicate).Named("DedicatedServingComponentNodeReaper")
+	return builder.Complete(r)
+}
+
+func (r *DedicatedServingComponentNodeReaper) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx, "node", req.Name)
+	node := &corev1.Node{}
+	if err := r.Get(ctx, req.NamespacedName, node); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("node not found, aborting reconcile", "name", req.NamespacedName.String())
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get node %q: %w", req.NamespacedName.String(), err)
+	}
+	log.Info("Reconciling node")
+
+	if _, hasServingComponentLabel := node.Labels[hyperv1.RequestServingComponentLabel]; !hasServingComponentLabel {
+		log.Info("Skipping node because it doesn't have the control plane serving component label")
+		return ctrl.Result{}, nil
+	}
+
+	if _, hasHostedClusterLabel := node.Labels[hyperv1.HostedClusterLabel]; !hasHostedClusterLabel {
+		log.Info("Skipping node because it has not been allocated to a hosted cluster")
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Node has been allocated to a hosted cluster, checking whether hosted cluster still exists.")
+	name := node.Labels[HostedClusterNameLabel]
+	namespace := node.Labels[HostedClusterNamespaceLabel]
+	hc := &hyperv1.HostedCluster{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, hc); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to get hosted cluster %s/%s: %w", namespace, name, err)
+		}
+		log.Info("The hosted cluster is not found. Deleting node.")
+		if err := r.Delete(ctx, node); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete node: %w", err)
+		}
+		log.Info("Node deleted")
+	} else {
+		log.Info("The hosted cluster exists, will check again later.")
+		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+type DedicatedServingComponentScheduler struct {
+	client.Client
+	createOrUpdate upsert.CreateOrUpdateFN
+}
+
+func (r *DedicatedServingComponentScheduler) SetupWithManager(mgr ctrl.Manager, createOrUpdateProvider upsert.CreateOrUpdateProvider) error {
+
+	r.createOrUpdate = createOrUpdateProvider.CreateOrUpdate
+	builder := ctrl.NewControllerManagedBy(mgr).
+		For(&hyperv1.HostedCluster{}).
+		WithOptions(controller.Options{
+			RateLimiter:             workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 10*time.Second),
+			MaxConcurrentReconciles: 10,
+		}).Named("DedicatedServingComponentScheduler")
+	return builder.Complete(r)
+}
+
+func (r *DedicatedServingComponentScheduler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	hcluster := &hyperv1.HostedCluster{}
+	log := ctrl.LoggerFrom(ctx, "hostedcluster", req.NamespacedName.String())
+	err := r.Get(ctx, req.NamespacedName, hcluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("hostedcluster not found, aborting reconcile", "name", req.NamespacedName)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get cluster %q: %w", req.NamespacedName, err)
+	}
+	if !hcluster.DeletionTimestamp.IsZero() {
+		log.Info("hostedcluster is deleted, nothing to do")
+		return ctrl.Result{}, nil
+	}
+	if hcTopology := hcluster.Annotations[hyperv1.TopologyAnnotation]; hcTopology != hyperv1.DedicatedRequestServingComponentsTopology {
+		log.Info("hostedcluster does not use isolated request serving components, nothing to do")
+		return ctrl.Result{}, nil
+	}
+	if scheduled := hcluster.Annotations[hyperv1.HostedClusterScheduledAnnotation]; scheduled == "true" {
+		log.Info("hostedcluster is already scheduled, nothing to do")
+		return ctrl.Result{}, nil
+	}
+	nodeList := &corev1.NodeList{}
+	if err := r.List(ctx, nodeList, client.HasLabels{hyperv1.RequestServingComponentLabel}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	nodesToUse := map[string]*corev1.Node{}
+	// first, find any existing nodes already labeled for this hostedcluster
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		zone, hasZoneLabel := node.Labels["topology.kubernetes.io/zone"]
+		if !hasZoneLabel {
+			continue
+		}
+		hcLabel, hasHCLabel := node.Labels[hyperv1.HostedClusterLabel]
+		if !hasHCLabel {
+			continue
+		}
+		if hcLabel == fmt.Sprintf("%s-%s", hcluster.Namespace, hcluster.Name) {
+			nodesToUse[zone] = node
+			log.Info("Found existing node for hosted cluster", "node", node.Name, "zone", zone)
+		}
+	}
+
+	if len(nodesToUse) < 2 {
+		for i := range nodeList.Items {
+			node := &nodeList.Items[i]
+			zone, hasZoneLabel := node.Labels["topology.kubernetes.io/zone"]
+			if !hasZoneLabel {
+				// No zone has been set on the node, we cannot use it
+				continue
+			}
+			_, hasHCLabel := node.Labels[hyperv1.HostedClusterLabel]
+			if hasHCLabel {
+				// The node has been allocated to a different hosted cluster, skip it
+				continue
+			}
+			if nodesToUse[zone] == nil {
+				log.Info("Found node to allocate for hosted cluster", "node", node.Name, "zone", zone)
+				nodesToUse[zone] = node
+			}
+			if len(nodesToUse) == 2 {
+				break
+			}
+		}
+	}
+	if len(nodesToUse) < 2 {
+		return ctrl.Result{}, fmt.Errorf("failed to find enough available nodes for cluster, found %d", len(nodesToUse))
+	}
+	for _, node := range nodesToUse {
+		originalNode := node.DeepCopy()
+
+		// Add taint and labels for specific hosted cluster
+		hasTaint := false
+		hcNameValue := fmt.Sprintf("%s-%s", hcluster.Namespace, hcluster.Name)
+		for i := range node.Spec.Taints {
+			if node.Spec.Taints[i].Key == HostedClusterTaint {
+				node.Spec.Taints[i].Value = hcNameValue
+				node.Spec.Taints[i].Effect = corev1.TaintEffectNoSchedule
+				hasTaint = true
+				break
+			}
+		}
+		if !hasTaint {
+			node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+				Key:    HostedClusterTaint,
+				Value:  hcNameValue,
+				Effect: corev1.TaintEffectNoSchedule,
+			})
+		}
+		node.Labels[hyperv1.HostedClusterLabel] = hcNameValue
+		node.Labels[HostedClusterNameLabel] = hcluster.Name
+		node.Labels[HostedClusterNamespaceLabel] = hcluster.Namespace
+
+		if err := r.Patch(ctx, node, client.MergeFrom(originalNode)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update labels and taints on node %s: %w", node.Name, err)
+		}
+		log.Info("Node tainted and labeled for hosted cluster", "node", node.Name)
+	}
+
+	// finally update HostedCluster with new annotation
+	log.Info("Setting scheduled annotation on hosted cluster")
+	originalHcluster := hcluster.DeepCopy()
+	hcluster.Annotations[hyperv1.HostedClusterScheduledAnnotation] = "true"
+	if err := r.Patch(ctx, hcluster, client.MergeFrom(originalHcluster)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update hostedcluster annotation: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes_test.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes_test.go
@@ -1,0 +1,240 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperapi "github.com/openshift/hypershift/api"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestNodeReaper(t *testing.T) {
+	const clusterNamespace = "clusters"
+	const nodeName = "n1"
+	node := func(mods ...func(*corev1.Node)) *corev1.Node {
+		n := &corev1.Node{}
+		n.Name = nodeName
+		n.Labels = map[string]string{hyperv1.RequestServingComponentLabel: "true"}
+		for _, m := range mods {
+			m(n)
+		}
+		return n
+	}
+	withCluster := func(name string) func(*corev1.Node) {
+		return func(n *corev1.Node) {
+			n.Labels[hyperv1.HostedClusterLabel] = fmt.Sprintf("%s-%s", clusterNamespace, name)
+			n.Labels[HostedClusterNamespaceLabel] = clusterNamespace
+			n.Labels[HostedClusterNameLabel] = name
+		}
+	}
+	cluster := func(name string) *hyperv1.HostedCluster {
+		c := &hyperv1.HostedCluster{}
+		c.Namespace = clusterNamespace
+		c.Name = name
+		return c
+	}
+
+	tests := []struct {
+		name         string
+		existing     []client.Object
+		expectDelete bool
+	}{
+		{
+			name: "no associated cluster",
+			existing: []client.Object{
+				node(),
+			},
+		},
+		{
+			name: "associated existing cluster",
+			existing: []client.Object{
+				node(withCluster("c1")),
+				cluster("c1"),
+			},
+		},
+		{
+			name: "associated with non-existent cluster",
+			existing: []client.Object{
+				node(withCluster("c1")),
+			},
+			expectDelete: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := &DedicatedServingComponentNodeReaper{
+				Client: fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(test.existing...).Build(),
+			}
+			req := reconcile.Request{}
+			req.Name = nodeName
+			_, err := r.Reconcile(context.Background(), req)
+			g := NewGomegaWithT(t)
+			g.Expect(err).ToNot(HaveOccurred())
+			if test.expectDelete {
+				n := &corev1.Node{}
+				err := r.Get(context.Background(), client.ObjectKeyFromObject(node()), n)
+				g.Expect(err).ToNot(BeNil())
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}
+		})
+	}
+}
+
+func TestHostedClusterScheduler(t *testing.T) {
+	hostedcluster := func(mods ...func(*hyperv1.HostedCluster)) *hyperv1.HostedCluster {
+		hc := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test",
+				Annotations: map[string]string{
+					hyperv1.TopologyAnnotation: hyperv1.DedicatedRequestServingComponentsTopology,
+				},
+			},
+		}
+		for _, m := range mods {
+			m(hc)
+		}
+		return hc
+	}
+	deletedHC := func(hc *hyperv1.HostedCluster) {
+		now := metav1.Now()
+		hc.DeletionTimestamp = &now
+	}
+	scheduledHC := func(hc *hyperv1.HostedCluster) {
+		hc.Annotations[hyperv1.HostedClusterScheduledAnnotation] = "true"
+	}
+	hcName := func(name string) func(*hyperv1.HostedCluster) {
+		return func(hc *hyperv1.HostedCluster) {
+			hc.Name = name
+		}
+	}
+	_ = hcName
+
+	node := func(name, zone string, mods ...func(*corev1.Node)) *corev1.Node {
+		n := &corev1.Node{}
+		n.Name = name
+		n.Labels = map[string]string{
+			hyperv1.RequestServingComponentLabel: "true",
+			"topology.kubernetes.io/zone":        zone,
+		}
+		for _, m := range mods {
+			m(n)
+		}
+		return n
+	}
+
+	withCluster := func(hc *hyperv1.HostedCluster) func(*corev1.Node) {
+		return func(n *corev1.Node) {
+			n.Labels[HostedClusterNameLabel] = hc.Name
+			n.Labels[HostedClusterNamespaceLabel] = hc.Namespace
+			n.Labels[hyperv1.HostedClusterLabel] = fmt.Sprintf("%s-%s", hc.Namespace, hc.Name)
+		}
+	}
+
+	nodeZone := func(n *corev1.Node) string {
+		return n.Labels["topology.kubernetes.io/zone"]
+	}
+
+	nodes := func(n ...*corev1.Node) []client.Object {
+		result := make([]client.Object, 0, len(n))
+		for _, node := range n {
+			result = append(result, node)
+		}
+		return result
+	}
+
+	tests := []struct {
+		name                  string
+		hc                    *hyperv1.HostedCluster
+		nodes                 []client.Object
+		checkScheduledNodes   bool
+		checkScheduledCluster bool
+		expectError           bool
+	}{
+		{
+			name: "deleted hosted cluster",
+			hc:   hostedcluster(deletedHC),
+		},
+		{
+			name: "scheduled hosted cluster",
+			hc:   hostedcluster(scheduledHC),
+		},
+		{
+			name:                  "available nodes",
+			hc:                    hostedcluster(),
+			nodes:                 nodes(node("n1", "zone-a"), node("n2", "zone-a"), node("n3", "zone-b"), node("n4", "zone-c")),
+			checkScheduledNodes:   true,
+			checkScheduledCluster: true,
+		},
+		{
+			name:                  "available node, existing assigned node",
+			hc:                    hostedcluster(),
+			nodes:                 nodes(node("n1", "zone-a", withCluster(hostedcluster())), node("n2", "zone-b")),
+			checkScheduledNodes:   true,
+			checkScheduledCluster: true,
+		},
+		{
+			name:        "no available nodes",
+			hc:          hostedcluster(),
+			nodes:       nodes(node("n1", "zone-a", withCluster(hostedcluster(hcName("other")))), node("n2", "zone-b", withCluster(hostedcluster(hcName("other"))))),
+			expectError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			c := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(test.hc).WithObjects(test.nodes...).Build()
+			r := &DedicatedServingComponentScheduler{
+				Client:         c,
+				createOrUpdate: controllerutil.CreateOrUpdate,
+			}
+			req := reconcile.Request{}
+			req.Name = hostedcluster().Name
+			req.Namespace = hostedcluster().Namespace
+			_, err := r.Reconcile(context.Background(), req)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			if test.checkScheduledCluster {
+				actual := hostedcluster()
+				err := c.Get(context.Background(), client.ObjectKeyFromObject(actual), actual)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(actual.Annotations).To(HaveKey(hyperv1.HostedClusterScheduledAnnotation))
+			}
+			if test.checkScheduledNodes {
+				hc := hostedcluster()
+				nodeList := &corev1.NodeList{}
+				err := c.List(context.Background(), nodeList)
+				g.Expect(err).ToNot(HaveOccurred())
+				scheduledNodeIndices := []int{}
+				for i, node := range nodeList.Items {
+					if _, hasLabel := node.Labels[hyperv1.HostedClusterLabel]; hasLabel {
+						scheduledNodeIndices = append(scheduledNodeIndices, i)
+						g.Expect(node.Labels[hyperv1.HostedClusterLabel]).To(Equal(fmt.Sprintf("%s-%s", hc.Namespace, hc.Name)))
+						g.Expect(node.Labels[HostedClusterNameLabel]).To(Equal(hc.Name))
+						g.Expect(node.Labels[HostedClusterNamespaceLabel]).To(Equal(hc.Namespace))
+						g.Expect(node.Spec.Taints).To(ContainElement(corev1.Taint{
+							Key:    HostedClusterTaint,
+							Value:  fmt.Sprintf("%s-%s", hc.Namespace, hc.Name),
+							Effect: corev1.TaintEffectNoSchedule,
+						}))
+					}
+				}
+				g.Expect(scheduledNodeIndices).To(HaveLen(2))
+				g.Expect(nodeZone(&nodeList.Items[scheduledNodeIndices[0]])).ToNot(Equal(nodeZone(&nodeList.Items[scheduledNodeIndices[1]])))
+			}
+		})
+	}
+}

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -21,7 +21,6 @@ const (
 
 	// There are used by NodeAffinity to prefer/tolerate Nodes.
 	controlPlaneLabelTolerationKey = "hypershift.openshift.io/control-plane"
-	clusterLabelTolerationKey      = "hypershift.openshift.io/cluster"
 
 	// colocationLabelKey is used by PodAffinity to prefer colocating pods that belong to the same hosted cluster.
 	colocationLabelKey = "hypershift.openshift.io/hosted-control-plane"
@@ -34,17 +33,18 @@ const (
 )
 
 type DeploymentConfig struct {
-	Replicas                  int                   `json:"replicas"`
-	Scheduling                Scheduling            `json:"scheduling"`
-	AdditionalLabels          AdditionalLabels      `json:"additionalLabels"`
-	AdditionalAnnotations     AdditionalAnnotations `json:"additionalAnnotations"`
-	SecurityContexts          SecurityContextSpec   `json:"securityContexts"`
-	SetDefaultSecurityContext bool                  `json:"setDefaultSecurityContext"`
-	LivenessProbes            LivenessProbes        `json:"livenessProbes"`
-	ReadinessProbes           ReadinessProbes       `json:"readinessProbes"`
-	Resources                 ResourcesSpec         `json:"resources"`
-	DebugDeployments          sets.String           `json:"debugDeployments"`
-	ResourceRequestOverrides  ResourceOverrides     `json:"resourceRequestOverrides"`
+	Replicas                  int
+	Scheduling                Scheduling
+	AdditionalLabels          AdditionalLabels
+	AdditionalAnnotations     AdditionalAnnotations
+	SecurityContexts          SecurityContextSpec
+	SetDefaultSecurityContext bool
+	LivenessProbes            LivenessProbes
+	ReadinessProbes           ReadinessProbes
+	Resources                 ResourcesSpec
+	DebugDeployments          sets.String
+	ResourceRequestOverrides  ResourceOverrides
+	IsolateAsRequestServing   bool
 }
 
 func (c *DeploymentConfig) SetContainerResourcesIfPresent(container *corev1.Container) {
@@ -209,11 +209,19 @@ func (c *DeploymentConfig) setControlPlaneIsolation(hcp *hyperv1.HostedControlPl
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 		{
-			Key:      clusterLabelTolerationKey,
+			Key:      hyperv1.HostedClusterLabel,
 			Operator: corev1.TolerationOpEqual,
 			Value:    clusterKey(hcp),
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
+	}
+	if c.IsolateAsRequestServing {
+		c.Scheduling.Tolerations = append(c.Scheduling.Tolerations, corev1.Toleration{
+			Key:      hyperv1.RequestServingComponentLabel,
+			Operator: corev1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
 	}
 
 	if c.Scheduling.Affinity == nil {
@@ -240,7 +248,7 @@ func (c *DeploymentConfig) setControlPlaneIsolation(hcp *hyperv1.HostedControlPl
 			Preference: corev1.NodeSelectorTerm{
 				MatchExpressions: []corev1.NodeSelectorRequirement{
 					{
-						Key:      clusterLabelTolerationKey,
+						Key:      hyperv1.HostedClusterLabel,
 						Operator: corev1.NodeSelectorOpIn,
 						Values:   []string{clusterKey(hcp)},
 					},
@@ -248,6 +256,28 @@ func (c *DeploymentConfig) setControlPlaneIsolation(hcp *hyperv1.HostedControlPl
 			},
 		},
 	}
+
+	if c.IsolateAsRequestServing {
+		c.Scheduling.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      hyperv1.RequestServingComponentLabel,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+						{
+							Key:      hyperv1.HostedClusterLabel,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{clusterKey(hcp)},
+						},
+					},
+				},
+			},
+		}
+	}
+
 }
 
 // setNodeSelector sets a nodeSelector passed through the API.
@@ -272,10 +302,28 @@ func (c *DeploymentConfig) setLocation(hcp *hyperv1.HostedControlPlane, multiZon
 func (c *DeploymentConfig) setReplicas(availability hyperv1.AvailabilityPolicy) {
 	switch availability {
 	case hyperv1.HighlyAvailable:
-		c.Replicas = 3
+		if c.IsolateAsRequestServing {
+			c.Replicas = 2
+		} else {
+			c.Replicas = 3
+		}
 	default:
 		c.Replicas = 1
 	}
+}
+
+// SetRequestServingDefaults wraps the call to SetDefaults. It is meant to be invoked by request serving components so that their sheduling
+// attributes can be modified accordingly.
+func (c *DeploymentConfig) SetRequestServingDefaults(hcp *hyperv1.HostedControlPlane, multiZoneSpreadLabels map[string]string, replicas *int) {
+	if hcp.Annotations[hyperv1.TopologyAnnotation] == hyperv1.DedicatedRequestServingComponentsTopology {
+		c.IsolateAsRequestServing = true
+	}
+	c.SetDefaults(hcp, multiZoneSpreadLabels, replicas)
+	if c.AdditionalLabels == nil {
+		c.AdditionalLabels = map[string]string{}
+	}
+	c.AdditionalLabels[hyperv1.RequestServingComponentLabel] = "true"
+
 }
 
 // SetDefaults populates opinionated default DeploymentConfig for any Deployment.

--- a/support/config/deployment_test.go
+++ b/support/config/deployment_test.go
@@ -209,7 +209,7 @@ func TestSetLocation(t *testing.T) {
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 		{
-			Key:      clusterLabelTolerationKey,
+			Key:      hyperv1.HostedClusterLabel,
 			Operator: corev1.TolerationOpEqual,
 			Value:    hcp.Namespace,
 			Effect:   corev1.TaintEffectNoSchedule,
@@ -237,7 +237,7 @@ func TestSetLocation(t *testing.T) {
 					Preference: corev1.NodeSelectorTerm{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
-								Key:      clusterLabelTolerationKey,
+								Key:      hyperv1.HostedClusterLabel,
 								Operator: corev1.NodeSelectorOpIn,
 								Values:   []string{hcp.Namespace},
 							},

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -39,6 +40,11 @@ func TestCreateCluster(t *testing.T) {
 		clusterOpts.NodePoolReplicas = 1
 	}
 
+	if globalOpts.RequestServingIsolation {
+		clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
+		clusterOpts.Annotations = append(clusterOpts.Annotations, fmt.Sprintf("%s=%s", hyperv1.TopologyAnnotation, hyperv1.DedicatedRequestServingComponentsTopology))
+	}
+
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	validatePublicCluster(t, ctx, client, hostedCluster, &clusterOpts)
@@ -65,6 +71,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 	g.Expect(kmsKeyArn).NotTo(BeNil(), "failed to retrieve kms key arn")
 
 	clusterOpts.AWSPlatform.EtcdKMSKeyARN = *kmsKeyArn
+
 	hostedCluster := e2eutil.CreateCluster(t, ctx, client, &clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 
 	g.Expect(hostedCluster.Spec.SecretEncryption.KMS.AWS.ActiveKey.ARN).To(Equal(*kmsKeyArn))

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -96,6 +96,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSProcessors, "e2e.powervs-processors", "0.5", "Number of processors allocated. Default is 0.5")
 	flag.IntVar(&globalOpts.configurableClusterOptions.PowerVSMemory, "e2e.powervs-memory", 32, "Amount of memory allocated (in GB). Default is 32")
 	flag.BoolVar(&globalOpts.SkipAPIBudgetVerification, "e2e.skip-api-budget", false, "Bool to avoid send metrics to E2E Server on local test execution.")
+	flag.BoolVar(&globalOpts.RequestServingIsolation, "e2e.test-request-serving-isolation", false, "If set, TestCreate creates a cluster with request serving isolation topology")
 
 	flag.Parse()
 
@@ -318,6 +319,10 @@ type options struct {
 	// SkipAPIBudgetVerification implies that you are executing the e2e tests
 	// from local to verify that them works fine before push
 	SkipAPIBudgetVerification bool
+
+	// If set, the CreateCluster test will create a cluster with request serving
+	// isolation topology.
+	RequestServingIsolation bool
 }
 
 type configurableClusterOptions struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables an isolation mode of only request serving pods in which those pods are allocated to dedicated nodes of the management cluster. The rest of the control plane pods can coexist with the pods of other hosted clusters in common nodes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1061](https://issues.redhat.com//browse/HOSTEDCP-1061)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.