### PR TITLE
OCPBUGS-16135: fix deletion bug when hostedzone is already deleted

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -743,6 +743,13 @@ func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointSe
 		if fqdn != "" && zoneID != "" {
 			record, err := findRecord(ctx, route53Client, zoneID, fqdn)
 			if err != nil {
+				if awsErr, ok := err.(awserr.Error); ok {
+					if awsErr.Code() == route53.ErrCodeNoSuchHostedZone {
+						log.Info("Hosted Zone not found", "hostedzone", zoneID)
+						return true, nil
+					}
+				}
+
 				return false, err
 			}
 			if record != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a case where the deletion of an awsendpointservice can hang when the control plane operator is unable to perform route53:ListResourceRecordSets due to the Route53 Hosted Zone not existing anymore. In this case, we should just exit early as the record no longer exists.

**Which issue(s) this PR fixes**:
Fixes OCPBUGS-16135

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.