### PR TITLE
HOSTEDCP-710: Make ImageContentSource immutable

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -196,6 +196,7 @@ const (
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.imageContentSources) || has(self.imageContentSources)", message="ImageContentSources is required once set"
 type HostedClusterSpec struct {
 	// Release specifies the desired OCP release payload for the hosted cluster.
 	//
@@ -347,6 +348,8 @@ type HostedClusterSpec struct {
 	//
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ImageContentSources is immutable"
 	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
 
 	// AdditionalTrustBundle is a reference to a ConfigMap containing a

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5883,6 +5883,9 @@ spec:
                   - source
                   type: object
                 type: array
+                x-kubernetes-validations:
+                - message: ImageContentSources is immutable
+                  rule: self == oldSelf
               infraID:
                 description: InfraID is a globally unique identifier for the cluster.
                   This identifier will be used to associate various cloud resources
@@ -7031,6 +7034,9 @@ spec:
             - services
             - sshKey
             type: object
+            x-kubernetes-validations:
+            - message: ImageContentSources is required once set
+              rule: '!has(oldSelf.imageContentSources) || has(self.imageContentSources)'
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -33225,6 +33225,9 @@ objects:
                     - source
                     type: object
                   type: array
+                  x-kubernetes-validations:
+                  - message: ImageContentSources is immutable
+                    rule: self == oldSelf
                 infraID:
                   description: InfraID is a globally unique identifier for the cluster.
                     This identifier will be used to associate various cloud resources
@@ -34390,6 +34393,9 @@ objects:
               - services
               - sshKey
               type: object
+              x-kubernetes-validations:
+              - message: ImageContentSources is required once set
+                rule: '!has(oldSelf.imageContentSources) || has(self.imageContentSources)'
             status:
               description: Status is the latest observed status of the HostedCluster.
               properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes ImageContentSource immutable

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-710](https://issues.redhat.com/browse/HOSTEDCP-710)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.