### PR TITLE
HOSTEDCP-1001: Image registryOverride included in the image metadata extraction flow

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -16,6 +17,7 @@ import (
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/proxy"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -188,6 +190,52 @@ func ReconcileIgnitionServer(ctx context.Context,
 	if hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
 		servingCertSecretName = manifests.IgnitionServerCertSecret("").Name
 	}
+
+	if len(openShiftRegistryOverrides) > 0 {
+		// Ignition server cannot handle ImageContentSourcePolicies or ImageDigestMachineSet, so we need to
+		// fill the registryOverrides in the case of disconnected environments
+		mirrorImage := lookupDisconnectedRegistry(ctx, openShiftRegistryOverrides)
+		if len(mirrorImage) < 1 {
+			// In a weird case where the entry is not in the openShiftRegistryOverrides, we need to figure it out
+			log.Info("failed to find the release entry in the openShiftRegistryOverrides, figuring out the disconnected registry")
+			sourceRef, err := reference.Parse(hcp.Spec.ReleaseImage)
+			if err != nil {
+				return fmt.Errorf("failed to parse hosted control plane image reference %q: %w", hcp.Spec.ReleaseImage, err)
+			}
+			privateRegistry := sourceRef.Registry
+			if strings.Contains(privateRegistry, "quay.io") || strings.Contains(privateRegistry, "registry.redhat.io") {
+				return fmt.Errorf("failed to reconcile ignition server, the ReleaseImage set should point to a disconnected registry, now is pointing to: %s", privateRegistry)
+			}
+			mirrorImage = fmt.Sprintf("%s/openshift/release", privateRegistry)
+		}
+
+		sourceRef, err := reference.Parse(mirrorImage)
+		if err != nil {
+			return fmt.Errorf("failed to parse private registry hosted control plane image reference %q: %w", mirrorImage, err)
+		}
+		privateRegistry := sourceRef.Registry
+
+		if !strings.HasPrefix(componentImages["machine-config-operator"], privateRegistry) {
+			ocpReleaseMcoImage := componentImages["machine-config-operator"]
+			mcoSha, err := reference.Parse(ocpReleaseMcoImage)
+			if err != nil {
+				return fmt.Errorf("failed to parse machine-config-operator image reference %q: %w", ocpReleaseMcoImage, err)
+			}
+			registryOverrides[ocpReleaseMcoImage] = fmt.Sprintf("%s@%s", mirrorImage, mcoSha.ID)
+		}
+
+		if !strings.HasPrefix(componentImages["cluster-config-operator"], privateRegistry) {
+			ocpReleaseCCOImage := componentImages["cluster-config-operator"]
+			ccoSha, err := reference.Parse(ocpReleaseCCOImage)
+			if err != nil {
+				return fmt.Errorf("failed to parse cluster-config-operator image reference %s: %w", ocpReleaseCCOImage, err)
+			}
+			registryOverrides[ocpReleaseCCOImage] = fmt.Sprintf("%s@%s", mirrorImage, ccoSha.ID)
+		}
+
+		delete(registryOverrides, "")
+	}
+
 	ignitionServerDeployment := ignitionserver.Deployment(controlPlaneNamespace)
 	if result, err := createOrUpdate(ctx, c, ignitionServerDeployment, func() error {
 		return reconcileDeployment(ignitionServerDeployment,
@@ -842,4 +890,20 @@ EOF
 cp /tmp/manifests/99_feature-gate.yaml %[1]s/99_feature-gate.yaml
 `
 	return fmt.Sprintf(script, workDir, featureGateYAML)
+}
+
+func lookupDisconnectedRegistry(ctx context.Context, strOcpOverrides string) string {
+	ocpOverrides := strings.Split(strOcpOverrides, ",")
+	for _, entry := range ocpOverrides {
+		sourceImage := strings.Split(entry, "=")[0]
+		mirrorImage := strings.Split(entry, "=")[1]
+
+		if strings.Contains(sourceImage, "openshift-release-dev") || strings.Contains(sourceImage, "ocp/release") {
+			// Production releases: 'openshift-release-dev'
+			// Nightly releases: 'ocp/release'
+			return mirrorImage
+		}
+	}
+
+	return ""
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver_test.go
@@ -1,6 +1,8 @@
 package ignitionserver
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -137,6 +139,42 @@ func TestReconcileIgnitionServerServiceRoute(t *testing.T) {
 			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Port).To(Equal(int32(443)))
 			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Name).To(Equal("https"))
 			g.Expect(test.inputIgnitionServerService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+		})
+	}
+}
+
+func TestLookupDisconnectedRegistry(t *testing.T) {
+	type args struct {
+		ctx          context.Context
+		ocpOverrides string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "given an wellformed openshiftRegistryOverrides string, it should return the mirrorImage pointing to the private registry",
+			args: args{
+				ctx:          context.TODO(),
+				ocpOverrides: "quay.io/jparrill=registry.hypershiftbm.lab:5000/jparrill,quay.io/karmab=registry.hypershiftbm.lab:5000/karmab,quay.io/mavazque=registry.hypershiftbm.lab:5000/mavazque,quay.io/ocp-release=registry.hypershiftbm.lab:5000/openshift/release-images,quay.io/openshift-release-dev/ocp-v4.0-art-dev=registry.hypershiftbm.lab:5000/openshift/release,registry.access.redhat.com/openshift4/ose-oauth-proxy=registry.hypershiftbm.lab:5000/openshift4/ose-oauth-proxy,registry.redhat.io/lvms4=registry.hypershiftbm.lab:5000/lvms4,registry.redhat.io/multicluster-engine=registry.hypershiftbm.lab:5000/acm-d,registry.redhat.io/openshift4=registry.hypershiftbm.lab:5000/openshift4,registry.redhat.io/openshift4=registry.hypershiftbm.lab:5000/openshift4,registry.redhat.io/rhacm2=registry.hypershiftbm.lab:5000/acm-d,registry.redhat.io/rhel8=registry.hypershiftbm.lab:5000/rhel8",
+			},
+			want: "registry.hypershiftbm.lab:5000/openshift/release",
+		},
+		{
+			name: "given an wellformed openshiftRegistryOverrides string without ocpRelease entry, it should return an empty slice",
+			args: args{
+				ctx:          context.TODO(),
+				ocpOverrides: "quay.io/jparrill=registry.hypershiftbm.lab:5000/jparrill,quay.io/karmab=registry.hypershiftbm.lab:5000/karmab,quay.io/mavazque=registry.hypershiftbm.lab:5000/mavazque,registry.access.redhat.com/openshift4/ose-oauth-proxy=registry.hypershiftbm.lab:5000/openshift4/ose-oauth-proxy,registry.redhat.io/lvms4=registry.hypershiftbm.lab:5000/lvms4,registry.redhat.io/multicluster-engine=registry.hypershiftbm.lab:5000/acm-d,registry.redhat.io/openshift4=registry.hypershiftbm.lab:5000/openshift4,registry.redhat.io/openshift4=registry.hypershiftbm.lab:5000/openshift4,registry.redhat.io/rhacm2=registry.hypershiftbm.lab:5000/acm-d,registry.redhat.io/rhel8=registry.hypershiftbm.lab:5000/rhel8",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lookupDisconnectedRegistry(tt.args.ctx, tt.args.ocpOverrides); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("lookupDisconnectedRegistry() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -970,7 +970,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get controlPlaneOperatorImage: %w", err)
 	}
-	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes)
+	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes, hcluster.Spec.ImageContentSources)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to look up image metadata for %s: %w", controlPlaneOperatorImage, err)
 	}

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -50,7 +50,7 @@ func (r *NodePoolReconciler) isHAProxyIgnitionConfigManaged(ctx context.Context,
 		return false, "", fmt.Errorf("failed to get controlPlaneOperatorImage: %w", err)
 	}
 
-	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes)
+	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes, hcluster.Spec.ImageContentSources)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to look up image metadata for %s: %w", controlPlaneOperatorImage, err)
 	}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2480,7 +2480,7 @@ func (r *NodePoolReconciler) detectCPOCapabilities(ctx context.Context, hostedCl
 		return nil, fmt.Errorf("failed to get controlPlaneOperatorImage: %w", err)
 	}
 
-	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes)
+	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes, hostedCluster.Spec.ImageContentSources)
 	if err != nil {
 		return nil, fmt.Errorf("failed to look up image metadata for %s: %w", controlPlaneOperatorImage, err)
 	}

--- a/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
+++ b/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
@@ -3,6 +3,7 @@ package fakeimagemetadataprovider
 import (
 	"context"
 
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 )
 
@@ -10,6 +11,6 @@ type FakeImageMetadataProvider struct {
 	Result *dockerv1client.DockerImageConfig
 }
 
-func (f *FakeImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
+func (f *FakeImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte, imageContentSources []hyperv1.ImageContentSource) (*dockerv1client.DockerImageConfig, error) {
 	return f.Result, nil
 }


### PR DESCRIPTION
This PR has been tested and validated in a bare metal environment based on IPv6/Disconnected

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-1001](https://issues.redhat.com/browse/HOSTEDCP-1001)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.