### PR TITLE
OCPBUGS-16232: skip z-stream version check when upgrade is forced

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1736,12 +1736,7 @@ func TestIsUpgradeable(t *testing.T) {
 					},
 				},
 				Status: hyperv1.HostedClusterStatus{
-					Version: &hyperv1.ClusterVersionStatus{
-						Desired: configv1.Release{
-							Image:   releaseImageFrom,
-							Version: "4.12.0",
-						},
-					},
+					Version: &hyperv1.ClusterVersionStatus{},
 					Conditions: []metav1.Condition{
 						{
 							Type:   string(hyperv1.ClusterVersionUpgradeable),


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-16232