### PR TITLE
Kubevirt: allow to specify network in nodepool spec

### DIFF
--- a/api/v1beta1/nodepool_types.go
+++ b/api/v1beta1/nodepool_types.go
@@ -551,6 +551,12 @@ type KubevirtCompute struct {
 	// +optional
 	// +kubebuilder:default=2
 	Cores *uint32 `json:"cores"`
+
+	// Network represents network where to attach guest VM
+	//
+	// +optional
+	// +kubebuilder:default=default
+	Network string `json:"network,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=ReadWriteOnce;ReadWriteMany;ReadOnly;ReadWriteOncePod


### PR DESCRIPTION
**What this PR does / why we need it**:
allow to provide network in kubevirt nodepool spec, so that guest workers belong to a multus (or SRIOV) network

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.