### PR TITLE
HOSTEDCP-1094: e2e autoscaler balancing similar node groups

### DIFF
--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -104,10 +104,10 @@ func TestAutoscaling(t *testing.T) {
 		bytes, ok := memCapacity.AsInt64()
 		g.Expect(ok).Should(BeTrue())
 
-		// 55% - enough that the existing and new nodes will
+		// 50% - enough that the existing and new nodes will
 		// be used, not enough to have more than 1 pod per
 		// node.
-		workloadMemRequest := resource.MustParse(fmt.Sprintf("%v", 0.55*float32(bytes)))
+		workloadMemRequest := resource.MustParse(fmt.Sprintf("%v", 0.50*float32(bytes)))
 
 		// force the cluster to double its size. the cluster autoscaler should
 		// place 1 more node in each of the the nodepools created.

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -33,6 +33,7 @@ func TestAutoscaling(t *testing.T) {
 	// create one nodePool with 1 replica in each AZ
 	zones := strings.Split(globalOpts.configurableClusterOptions.Zone.String(), ",")
 	clusterOpts.AWSPlatform.Zones = zones
+	clusterOpts.InfrastructureAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.NodePoolReplicas = 1
 
 	numNodePools := len(zones)

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -104,10 +104,10 @@ func TestAutoscaling(t *testing.T) {
 		bytes, ok := memCapacity.AsInt64()
 		g.Expect(ok).Should(BeTrue())
 
-		// 60% - enough that the existing and new nodes will
+		// 55% - enough that the existing and new nodes will
 		// be used, not enough to have more than 1 pod per
 		// node.
-		workloadMemRequest := resource.MustParse(fmt.Sprintf("%v", 0.6*float32(bytes)))
+		workloadMemRequest := resource.MustParse(fmt.Sprintf("%v", 0.55*float32(bytes)))
 
 		// force the cluster to double its size. the cluster autoscaler should
 		// place 1 more node in each of the the nodepools created.

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -211,27 +211,27 @@ func executeNodePoolTest(t *testing.T, ctx context.Context, mgmtClient crclient.
 func validateNodePoolConditions(t *testing.T, ctx context.Context, client crclient.Client, nodePool *hyperv1.NodePool) {
 	expectedConditions := conditions.ExpectedNodePoolConditions()
 
-	if nodePool.Spec.AutoScaling != nil {
-		expectedConditions[hyperv1.NodePoolAutoscalingEnabledConditionType] = corev1.ConditionTrue
-	} else {
-		expectedConditions[hyperv1.NodePoolAutoscalingEnabledConditionType] = corev1.ConditionFalse
-	}
-
-	if nodePool.Spec.Management.AutoRepair {
-		expectedConditions[hyperv1.NodePoolAutorepairEnabledConditionType] = corev1.ConditionTrue
-	} else {
-		expectedConditions[hyperv1.NodePoolAutorepairEnabledConditionType] = corev1.ConditionFalse
-	}
-
-	if nodePool.Spec.Arch != "" && nodePool.Spec.Platform.Type != hyperv1.AWSPlatform {
-		expectedConditions[hyperv1.NodePoolValidArchPlatform] = corev1.ConditionFalse
-	}
-
 	start := time.Now()
 	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 10*time.Minute, func(ctx context.Context) (bool, error) {
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(nodePool), nodePool); err != nil {
 			t.Logf("Failed to get nodepool: %v", err)
 			return false, nil
+		}
+
+		if nodePool.Spec.AutoScaling != nil {
+			expectedConditions[hyperv1.NodePoolAutoscalingEnabledConditionType] = corev1.ConditionTrue
+		} else {
+			expectedConditions[hyperv1.NodePoolAutoscalingEnabledConditionType] = corev1.ConditionFalse
+		}
+
+		if nodePool.Spec.Management.AutoRepair {
+			expectedConditions[hyperv1.NodePoolAutorepairEnabledConditionType] = corev1.ConditionTrue
+		} else {
+			expectedConditions[hyperv1.NodePoolAutorepairEnabledConditionType] = corev1.ConditionFalse
+		}
+
+		if nodePool.Spec.Arch != "" && nodePool.Spec.Platform.Type != hyperv1.AWSPlatform {
+			expectedConditions[hyperv1.NodePoolValidArchPlatform] = corev1.ConditionFalse
 		}
 
 		for _, condition := range nodePool.Status.Conditions {

--- a/test/e2e/util/scheme.go
+++ b/test/e2e/util/scheme.go
@@ -5,6 +5,7 @@ import (
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 var (
@@ -19,4 +20,5 @@ func init() {
 	operatorsv1.AddToScheme(scheme)
 	operatorsv1alpha1.AddToScheme(scheme)
 	capikubevirt.AddToScheme(scheme)
+	capiv1.AddToScheme(scheme)
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -273,6 +273,21 @@ func WaitForNReadyNodesByNodePool(t *testing.T, ctx context.Context, client crcl
 	return nodesFromNodePool
 }
 
+func MachineDeploymentByNodepool(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, nodepoolName string) (*capiv1.MachineDeployment, error) {
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+	md := &capiv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodepoolName,
+			Namespace: hcpNamespace,
+		},
+	}
+
+	if err := client.Get(ctx, crclient.ObjectKeyFromObject(md), md); err != nil {
+		return nil, err
+	}
+	return md, nil
+}
+
 func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, image string) {
 	start := time.Now()
 	g := NewWithT(t)


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates autoscaler e2e to validate `--balance-similar-node-groups` feature of the autoscaler

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.