### PR TITLE
Revert "HOSTEDCP-710: Make ImageContentSource immutable"

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -196,7 +196,6 @@ const (
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.imageContentSources) || has(self.imageContentSources)", message="ImageContentSources is required once set"
 type HostedClusterSpec struct {
 	// Release specifies the desired OCP release payload for the hosted cluster.
 	//
@@ -348,8 +347,6 @@ type HostedClusterSpec struct {
 	//
 	// +optional
 	// +immutable
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ImageContentSources is immutable"
 	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
 
 	// AdditionalTrustBundle is a reference to a ConfigMap containing a

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5883,9 +5883,6 @@ spec:
                   - source
                   type: object
                 type: array
-                x-kubernetes-validations:
-                - message: ImageContentSources is immutable
-                  rule: self == oldSelf
               infraID:
                 description: InfraID is a globally unique identifier for the cluster.
                   This identifier will be used to associate various cloud resources
@@ -7034,9 +7031,6 @@ spec:
             - services
             - sshKey
             type: object
-            x-kubernetes-validations:
-            - message: ImageContentSources is required once set
-              rule: '!has(oldSelf.imageContentSources) || has(self.imageContentSources)'
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -33225,9 +33225,6 @@ objects:
                     - source
                     type: object
                   type: array
-                  x-kubernetes-validations:
-                  - message: ImageContentSources is immutable
-                    rule: self == oldSelf
                 infraID:
                   description: InfraID is a globally unique identifier for the cluster.
                     This identifier will be used to associate various cloud resources
@@ -34393,9 +34390,6 @@ objects:
               - services
               - sshKey
               type: object
-              x-kubernetes-validations:
-              - message: ImageContentSources is required once set
-                rule: '!has(oldSelf.imageContentSources) || has(self.imageContentSources)'
             status:
               description: Status is the latest observed status of the HostedCluster.
               properties:


### PR DESCRIPTION
Reverts openshift/hypershift#2815

This is necessary for the ability to convert from public endpoints (public registries) to private endpoints (private registries) in IBM Cloud