### PR TITLE
[HOSTEDCP-1041] Accurately default latest release image using hypershift-operator supported versions

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -1522,7 +1522,10 @@ type AzurePlatformSpec struct {
 type Release struct {
 	// Image is the image pullspec of an OCP release payload image.
 	//
-	// +kubebuilder:validation:Pattern=^(\w+\S+)$
+	// If no image is explicilty defined, this will default to the latest
+	// OCP release supported by the hypershift operator.
+	//
+	// +optional
 	Image string `json:"image"`
 }
 

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1543,7 +1543,10 @@ type AzurePlatformSpec struct {
 type Release struct {
 	// Image is the image pullspec of an OCP release payload image.
 	//
-	// +kubebuilder:validation:Pattern=^(\w+\S+)$
+	// If no image is explicilty defined, this will default to the latest
+	// OCP release supported by the hypershift operator.
+	//
+	// +optional
 	Image string `json:"image"`
 }
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -26,7 +26,6 @@ import (
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/cmd/util"
-	"github.com/openshift/hypershift/cmd/version"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/releaseinfo"
 )
@@ -156,13 +155,6 @@ type AzurePlatformOptions struct {
 }
 
 func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures.ExampleOptions, error) {
-	if len(opts.ReleaseImage) == 0 {
-		defaultVersion, err := version.LookupDefaultOCPVersion(opts.ReleaseStream)
-		if err != nil {
-			return nil, fmt.Errorf("release image is required when unable to lookup default OCP version: %w", err)
-		}
-		opts.ReleaseImage = defaultVersion.PullSpec
-	}
 	if err := defaultNetworkType(ctx, opts, &releaseinfo.RegistryClientProvider{}, os.ReadFile); err != nil {
 		return nil, fmt.Errorf("failed to default network: %w", err)
 	}
@@ -438,6 +430,9 @@ func CreateCluster(ctx context.Context, opts *CreateOptions, platformSpecificApp
 
 func defaultNetworkType(ctx context.Context, opts *CreateOptions, releaseProvider releaseinfo.Provider, readFile func(string) ([]byte, error)) error {
 	if opts.NetworkType != "" {
+		return nil
+	} else if opts.ReleaseImage == "" {
+		opts.NetworkType = string(hyperv1.OVNKubernetes)
 		return nil
 	}
 	version, err := getReleaseSemanticVersion(ctx, opts, releaseProvider, readFile)

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -2989,12 +2989,10 @@ spec:
                   by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy."
                 properties:
                   image:
-                    description: Image is the image pullspec of an OCP release payload
-                      image.
-                    pattern: ^(\w+\S+)$
+                    description: "Image is the image pullspec of an OCP release payload
+                      image. \n If no image is explicilty defined, this will default
+                      to the latest OCP release supported by the hypershift operator."
                     type: string
-                required:
-                - image
                 type: object
               secretEncryption:
                 description: SecretEncryption specifies a Kubernetes secret encryption
@@ -6711,12 +6709,10 @@ spec:
                   by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy."
                 properties:
                   image:
-                    description: Image is the image pullspec of an OCP release payload
-                      image.
-                    pattern: ^(\w+\S+)$
+                    description: "Image is the image pullspec of an OCP release payload
+                      image. \n If no image is explicilty defined, this will default
+                      to the latest OCP release supported by the hypershift operator."
                     type: string
-                required:
-                - image
                 type: object
               secretEncryption:
                 description: SecretEncryption specifies a Kubernetes secret encryption

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -764,12 +764,10 @@ spec:
                   platform).
                 properties:
                   image:
-                    description: Image is the image pullspec of an OCP release payload
-                      image.
-                    pattern: ^(\w+\S+)$
+                    description: "Image is the image pullspec of an OCP release payload
+                      image. \n If no image is explicilty defined, this will default
+                      to the latest OCP release supported by the hypershift operator."
                     type: string
-                required:
-                - image
                 type: object
               replicas:
                 description: Replicas is the desired number of nodes the pool should
@@ -1685,12 +1683,10 @@ spec:
                   platform).
                 properties:
                   image:
-                    description: Image is the image pullspec of an OCP release payload
-                      image.
-                    pattern: ^(\w+\S+)$
+                    description: "Image is the image pullspec of an OCP release payload
+                      image. \n If no image is explicilty defined, this will default
+                      to the latest OCP release supported by the hypershift operator."
                     type: string
-                required:
-                - image
                 type: object
               replicas:
                 description: Replicas is the desired number of nodes the pool should

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -7195,7 +7195,10 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Image is the image pullspec of an OCP release payload image.</p>
+<p>If no image is explicilty defined, this will default to the latest
+OCP release supported by the hypershift operator.</p>
 </td>
 </tr>
 </tbody>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -30276,12 +30276,11 @@ objects:
                     be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy."
                   properties:
                     image:
-                      description: Image is the image pullspec of an OCP release payload
-                        image.
-                      pattern: ^(\w+\S+)$
+                      description: "Image is the image pullspec of an OCP release
+                        payload image. \n If no image is explicilty defined, this
+                        will default to the latest OCP release supported by the hypershift
+                        operator."
                       type: string
-                  required:
-                  - image
                   type: object
                 secretEncryption:
                   description: SecretEncryption specifies a Kubernetes secret encryption
@@ -34068,12 +34067,11 @@ objects:
                     be driven by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy."
                   properties:
                     image:
-                      description: Image is the image pullspec of an OCP release payload
-                        image.
-                      pattern: ^(\w+\S+)$
+                      description: "Image is the image pullspec of an OCP release
+                        payload image. \n If no image is explicilty defined, this
+                        will default to the latest OCP release supported by the hypershift
+                        operator."
                       type: string
-                  required:
-                  - image
                   type: object
                 secretEncryption:
                   description: SecretEncryption specifies a Kubernetes secret encryption
@@ -43435,12 +43433,11 @@ objects:
                     the AWS platform).
                   properties:
                     image:
-                      description: Image is the image pullspec of an OCP release payload
-                        image.
-                      pattern: ^(\w+\S+)$
+                      description: "Image is the image pullspec of an OCP release
+                        payload image. \n If no image is explicilty defined, this
+                        will default to the latest OCP release supported by the hypershift
+                        operator."
                       type: string
-                  required:
-                  - image
                   type: object
                 replicas:
                   description: Replicas is the desired number of nodes the pool should
@@ -44367,12 +44364,11 @@ objects:
                     the AWS platform).
                   properties:
                     image:
-                      description: Image is the image pullspec of an OCP release payload
-                        image.
-                      pattern: ^(\w+\S+)$
+                      description: "Image is the image pullspec of an OCP release
+                        payload image. \n If no image is explicilty defined, this
+                        will default to the latest OCP release supported by the hypershift
+                        operator."
                       type: string
-                  required:
-                  - image
                   type: object
                 replicas:
                   description: Replicas is the desired number of nodes the pool should


### PR DESCRIPTION
Previously, the hostedCluster.Spec.Release.Image was required and the `hcp` or `hypershift` cli defaulted that value client side. This posed several issues though.
1. The defaulting did not take into consideration what the max and min version the deployed hypershift operator supports, which will eventually lead to the client defaulting unsupported versions.
2. This logic was all client side, which meant that it couldn't be used in a gitops flow or reused by the console web UI.

The new logic performs defaulting  the release image on the backend. It takes into account the latest/min supported versions and picks the most recent version that falls within those constraints.