### PR TITLE
HOSTEDCP-1020: Remove name as a persistent flag required field

### DIFF
--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -66,7 +66,6 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the duration of the wait (Examples: 30s, 1h30m45s, etc.) 0 means no timeout.")
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If true, the create command will block until the HostedCluster is up. Requires at least one NodePool with at least one node.")
 
-	_ = cmd.MarkPersistentFlagRequired("name")
 	_ = cmd.MarkPersistentFlagRequired("pull-secret")
 
 	cmd.AddCommand(agent.NewCreateCommand(opts))


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes name as a persistent flag required field since this is already initialized. Marking the field as required forces a user to include the flag in the cli command.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1020](https://issues.redhat.com/browse/HOSTEDCP-1020)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.