### PR TITLE
HOSTEDCP-1110: [backport-4.13] Allow HCP Specification to Support ICSP & IDMS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -991,7 +991,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 
 	// Reconcile Ignition
 	r.Log.Info("Reconciling core machine configs")
-	if err := r.reconcileCoreIgnitionConfig(ctx, hostedControlPlane, createOrUpdate); err != nil {
+	if err := r.reconcileCoreIgnitionConfig(ctx, hostedControlPlane, releaseImage, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile ignition: %w", err)
 	}
 
@@ -3128,7 +3128,7 @@ func (r *HostedControlPlaneReconciler) reconcileManagedTrustedCABundle(ctx conte
 	return nil
 }
 
-func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.Context, hcp *hyperv1.HostedControlPlane, createOrUpdate upsert.CreateOrUpdateFN) error {
+func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage, createOrUpdate upsert.CreateOrUpdateFN) error {
 	sshKey := ""
 	if len(hcp.Spec.SSHKey.Name) > 0 {
 		var sshKeySecret corev1.Secret
@@ -3159,31 +3159,47 @@ func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.C
 		return fmt.Errorf("failed to reconcile ssh key ignition config: %w", err)
 	}
 
-	imageContentSourceIgnitionConfig := manifests.ImageContentSourcePolicyIgnitionConfig(hcp.GetNamespace())
-	if !p.HasImageContentSourcePolicy {
-		// ensure the icsp configmap has been removed if no longer needed
-		err := r.Get(ctx, client.ObjectKeyFromObject(imageContentSourceIgnitionConfig), imageContentSourceIgnitionConfig)
+	// Ensure the imageDigestMirrorSet configmap has been removed if no longer needed
+	imageContentPolicyIgnitionConfig := manifests.ImageContentPolicyIgnitionConfig(hcp.GetNamespace())
+	if !p.HasImageMirrorPolicies {
+		_, err := util.DeleteIfNeeded(ctx, r.Client, imageContentPolicyIgnitionConfig)
 		if err != nil {
-			if !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to check whether image content source policy configuration configmap exists: %w", err)
-			}
-		} else {
-			if err := r.Delete(ctx, imageContentSourceIgnitionConfig); err != nil {
-				return fmt.Errorf("failed to delete image content source policy configuration configmap: %w", err)
-			}
+			return fmt.Errorf("failed to delete image content source policy configuration configmap: %w", err)
 		}
 		return nil
 	}
 
-	icsp := globalconfig.ImageContentSourcePolicy()
-	if err := globalconfig.ReconcileImageContentSourcePolicy(icsp, hcp); err != nil {
-		return fmt.Errorf("failed to reconcile image content source policy: %w", err)
+	version, err := semver.Parse(releaseImage.ImageStream.Name)
+	if err != nil {
+		return fmt.Errorf("failed to determine release image version: %w", err)
 	}
 
-	if _, err := createOrUpdate(ctx, r, imageContentSourceIgnitionConfig, func() error {
-		return ignition.ReconcileImageContentSourcePolicyIgnitionConfig(imageContentSourceIgnitionConfig, p.OwnerRef, icsp)
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile image content source policy ignition config: %w", err)
+	// ImageDigestMirrorSet is only applicable for release image versions greater than or equal to 4.13
+	// TODO the 'else' branch portion needs to be removed after this ticket is backported to 4.13 - HOSTEDCP-1102
+	if version.Minor >= 13 {
+		r.Log.Info("Reconciling ImageDigestMirrorSet")
+		imageDigestMirrorSet := globalconfig.ImageDigestMirrorSet()
+		if err := globalconfig.ReconcileImageDigestMirrors(imageDigestMirrorSet, hcp); err != nil {
+			return fmt.Errorf("failed to reconcile image content policy: %w", err)
+		}
+
+		if _, err := createOrUpdate(ctx, r, imageContentPolicyIgnitionConfig, func() error {
+			return ignition.ReconcileImageSourceMirrorsIgnitionConfigFromIDMS(imageContentPolicyIgnitionConfig, p.OwnerRef, imageDigestMirrorSet)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile image content source policy ignition config: %w", err)
+		}
+	} else {
+		r.Log.Info("Reconciling ImageContentSourcePolicy")
+		icsp := globalconfig.ImageContentSourcePolicy()
+		if err := globalconfig.ReconcileImageContentSourcePolicy(icsp, hcp); err != nil {
+			return fmt.Errorf("failed to reconcile image content source policy: %w", err)
+		}
+
+		if _, err := createOrUpdate(ctx, r, imageContentPolicyIgnitionConfig, func() error {
+			return ignition.ReconcileImageSourceMirrorsIgnitionConfigFromICSP(imageContentPolicyIgnitionConfig, p.OwnerRef, icsp)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile image content source policy ignition config from ICSP: %w", err)
+		}
 	}
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/ignition/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignition/params.go
@@ -6,18 +6,18 @@ import (
 )
 
 type IgnitionConfigParams struct {
-	OwnerRef                    config.OwnerRef
-	FIPSEnabled                 bool
-	SSHKey                      string
-	HasImageContentSourcePolicy bool
+	OwnerRef               config.OwnerRef
+	FIPSEnabled            bool
+	SSHKey                 string
+	HasImageMirrorPolicies bool
 }
 
 func NewIgnitionConfigParams(hcp *hyperv1.HostedControlPlane, sshKey string) *IgnitionConfigParams {
 	params := &IgnitionConfigParams{
-		OwnerRef:                    config.OwnerRefFrom(hcp),
-		FIPSEnabled:                 hcp.Spec.FIPS,
-		SSHKey:                      sshKey,
-		HasImageContentSourcePolicy: len(hcp.Spec.ImageContentSources) > 0,
+		OwnerRef:               config.OwnerRefFrom(hcp),
+		FIPSEnabled:            hcp.Spec.FIPS,
+		SSHKey:                 sshKey,
+		HasImageMirrorPolicies: len(hcp.Spec.ImageContentSources) > 0,
 	}
 
 	return params

--- a/control-plane-operator/controllers/hostedcontrolplane/ignition/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignition/reconcile.go
@@ -3,14 +3,17 @@ package ignition
 import (
 	"bytes"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/clarketm/json"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
-	"github.com/openshift/api/operator/v1alpha1"
+
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
@@ -50,8 +53,12 @@ func ReconcileWorkerSSHIgnitionConfig(cm *corev1.ConfigMap, ownerRef config.Owne
 	return reconcileMachineConfigIgnitionConfigMap(cm, machineConfig, ownerRef)
 }
 
-func ReconcileImageContentSourcePolicyIgnitionConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef, imageContentSourcePolicy *v1alpha1.ImageContentSourcePolicy) error {
-	return reconcileICSPIgnitionConfigMap(cm, imageContentSourcePolicy, ownerRef)
+func ReconcileImageSourceMirrorsIgnitionConfigFromICSP(cm *corev1.ConfigMap, ownerRef config.OwnerRef, imageContentSourcePolicy *operatorv1alpha1.ImageContentSourcePolicy) error {
+	return reconcileImageContentTypeIgnitionConfigMap(cm, imageContentSourcePolicy, ownerRef)
+}
+
+func ReconcileImageSourceMirrorsIgnitionConfigFromIDMS(cm *corev1.ConfigMap, ownerRef config.OwnerRef, imageDigestMirrorSet *configv1.ImageDigestMirrorSet) error {
+	return reconcileImageContentTypeIgnitionConfigMap(cm, imageDigestMirrorSet, ownerRef)
 }
 
 func workerSSHConfig(sshKey string) ([]byte, error) {
@@ -89,17 +96,24 @@ func SetMachineConfigLabels(mc *mcfgv1.MachineConfig) {
 	}
 }
 
-func reconcileICSPIgnitionConfigMap(cm *corev1.ConfigMap, icsp *v1alpha1.ImageContentSourcePolicy, ownerRef config.OwnerRef) error {
+func reconcileImageContentTypeIgnitionConfigMap(cm *corev1.ConfigMap, imageContentType client.Object, ownerRef config.OwnerRef) error {
 	scheme := runtime.NewScheme()
-	v1alpha1.Install(scheme)
+	err := operatorv1alpha1.Install(scheme)
+	if err != nil {
+		return err
+	}
+	err = configv1.Install(scheme)
+	if err != nil {
+		return err
+	}
 	yamlSerializer := jsonserializer.NewSerializerWithOptions(
 		jsonserializer.DefaultMetaFactory, scheme, scheme,
 		jsonserializer.SerializerOptions{Yaml: true, Pretty: true, Strict: true})
-	imageContentSourceBytesBuffer := bytes.NewBuffer([]byte{})
-	if err := yamlSerializer.Encode(icsp, imageContentSourceBytesBuffer); err != nil {
-		return fmt.Errorf("failed to serialize image content source policy: %w", err)
+	imageContentTypeBytesBuffer := bytes.NewBuffer([]byte{})
+	if err := yamlSerializer.Encode(imageContentType, imageContentTypeBytesBuffer); err != nil {
+		return fmt.Errorf("failed to serialize image content type policy: %w", err)
 	}
-	return ReconcileIgnitionConfigMap(cm, imageContentSourceBytesBuffer.String(), ownerRef)
+	return ReconcileIgnitionConfigMap(cm, imageContentTypeBytesBuffer.String(), ownerRef)
 }
 
 func reconcileMachineConfigIgnitionConfigMap(cm *corev1.ConfigMap, mc *mcfgv1.MachineConfig, ownerRef config.OwnerRef) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/ignition.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/ignition.go
@@ -41,7 +41,7 @@ func IgnitionFIPSConfig(ns string) *corev1.ConfigMap {
 	}
 }
 
-func ImageContentSourcePolicyIgnitionConfig(ns string) *corev1.ConfigMap {
+func ImageContentPolicyIgnitionConfig(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ignition-config-40-image-content-source",

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,11 +31,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/blang/semver"
 	"github.com/go-logr/logr"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
 	configv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	kubevirtcsi "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt"
@@ -63,7 +67,6 @@ import (
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
 const (
@@ -276,7 +279,7 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 	}
 
 	log.Info("reconciling guest cluster global configuration")
-	if err := r.reconcileConfig(ctx, hcp); err != nil {
+	if err := r.reconcileConfig(ctx, hcp, releaseImage); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile global configuration: %w", err))
 	}
 
@@ -554,7 +557,7 @@ func (r *reconciler) reconcileCRDs(ctx context.Context) error {
 	return errors.NewAggregate(errs)
 }
 
-func (r *reconciler) reconcileConfig(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+func (r *reconciler) reconcileConfig(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage) error {
 	var errs []error
 
 	apiServerAddress := hcp.Status.ControlPlaneEndpoint.Host
@@ -619,11 +622,9 @@ func (r *reconciler) reconcileConfig(ctx context.Context, hcp *hyperv1.HostedCon
 		errs = append(errs, fmt.Errorf("failed to reconcile proxy config: %w", err))
 	}
 
-	icsp := globalconfig.ImageContentSourcePolicy()
-	if _, err := r.CreateOrUpdate(ctx, r.client, icsp, func() error {
-		return globalconfig.ReconcileImageContentSourcePolicy(icsp, hcp)
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile image content source policy: %w", err))
+	err := r.reconcileImageContentPolicyType(ctx, hcp, releaseImage)
+	if err != nil {
+		errs = append(errs, err)
 	}
 
 	installConfigCM := manifests.InstallConfigConfigMap()
@@ -1927,4 +1928,39 @@ func (r *reconciler) reconcileStorage(ctx context.Context, hcp *hyperv1.HostedCo
 		}
 	}
 	return errs
+}
+
+// reconcileImageContentPolicyType reconciles the image content policy based on the release image version.
+// ImageDigestMirrorSets are used for versions >= 4.13 and ImageContentSourcePolicy for all other versions.
+// TODO the 'else' branch portion needs to be removed after this ticket is backported to 4.13 - HOSTEDCP-1102
+func (r *reconciler) reconcileImageContentPolicyType(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImage *releaseinfo.ReleaseImage) error {
+	icsp := globalconfig.ImageContentSourcePolicy()
+	version, err := semver.Parse(releaseImage.Version())
+	if err != nil {
+		return fmt.Errorf("failed to determine release image version: %w", err)
+	}
+
+	// ImageDigestMirrorSet is only applicable for release image versions greater than or equal to 4.13
+	if version.Minor >= 13 {
+		// First, delete any current ImageContentSourcePolicy
+		_, err = util.DeleteIfNeeded(ctx, r.client, icsp)
+		if err != nil {
+			return fmt.Errorf("failed to delete image content source policy configuration configmap: %w", err)
+		}
+
+		// Next, reconcile the ImageDigestMirrorSet
+		idms := globalconfig.ImageDigestMirrorSet()
+		if _, err = r.CreateOrUpdate(ctx, r.client, idms, func() error {
+			return globalconfig.ReconcileImageDigestMirrors(idms, hcp)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile image digest mirror set: %w", err)
+		}
+	} else {
+		if _, err = r.CreateOrUpdate(ctx, r.client, icsp, func() error {
+			return globalconfig.ReconcileImageContentSourcePolicy(icsp, hcp)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile image content source policy: %w", err)
+		}
+	}
+	return nil
 }

--- a/support/globalconfig/imagecontentsource.go
+++ b/support/globalconfig/imagecontentsource.go
@@ -1,10 +1,12 @@
 package globalconfig
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ImageContentSourcePolicy() *operatorv1alpha1.ImageContentSourcePolicy {
@@ -19,6 +21,38 @@ func ImageContentSourcePolicy() *operatorv1alpha1.ImageContentSourcePolicy {
 	}
 }
 
+// ImageContentSourcePolicyList returns an initialized ImageContentSourcePolicyList pointer
+func ImageContentSourcePolicyList() *operatorv1alpha1.ImageContentSourcePolicyList {
+	return &operatorv1alpha1.ImageContentSourcePolicyList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ImageContentSourcePolicyList",
+			APIVersion: configv1.GroupVersion.String(),
+		},
+	}
+}
+
+func ImageDigestMirrorSet() *configv1.ImageDigestMirrorSet {
+	return &configv1.ImageDigestMirrorSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ImageDigestMirrorSet",
+			APIVersion: configv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	}
+}
+
+func ImageDigestMirrorSetList() *configv1.ImageDigestMirrorSetList {
+	return &configv1.ImageDigestMirrorSetList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ImageDigestMirrorSetList",
+			APIVersion: configv1.GroupVersion.String(),
+		},
+	}
+}
+
+// ReconcileImageContentSourcePolicy reconciles the ImageContentSources from the HCP spec into an ImageContentSourcePolicy
 func ReconcileImageContentSourcePolicy(icsp *operatorv1alpha1.ImageContentSourcePolicy, hcp *hyperv1.HostedControlPlane) error {
 	if icsp.Labels == nil {
 		icsp.Labels = map[string]string{}
@@ -29,6 +63,29 @@ func ReconcileImageContentSourcePolicy(icsp *operatorv1alpha1.ImageContentSource
 		icsp.Spec.RepositoryDigestMirrors = append(icsp.Spec.RepositoryDigestMirrors, operatorv1alpha1.RepositoryDigestMirrors{
 			Source:  imageContentSourceEntry.Source,
 			Mirrors: imageContentSourceEntry.Mirrors,
+		})
+	}
+	return nil
+}
+
+// ReconcileImageDigestMirrors reconciles the ImageContentSources from the HCP spec into an ImageDigestMirrorSet
+func ReconcileImageDigestMirrors(idms *configv1.ImageDigestMirrorSet, hcp *hyperv1.HostedControlPlane) error {
+	if idms.Labels == nil {
+		idms.Labels = map[string]string{}
+	}
+
+	idms.Labels["machineconfiguration.openshift.io/role"] = "worker"
+	idms.Spec.ImageDigestMirrors = []configv1.ImageDigestMirrors{}
+	for _, source := range hcp.Spec.ImageContentSources {
+		var mirrors []configv1.ImageMirror
+
+		for _, mirror := range source.Mirrors {
+			mirrors = append(mirrors, configv1.ImageMirror(mirror))
+		}
+
+		idms.Spec.ImageDigestMirrors = append(idms.Spec.ImageDigestMirrors, configv1.ImageDigestMirrors{
+			Source:  source.Source,
+			Mirrors: mirrors,
 		})
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow HCP Specification to Support ICSP & IDMS. IDMS is replacing ICSP
in OCP 4.13+. hcp.Spec.ImageContentSources was updated in OCPBUGS-11939
to replace ICSP with IDMS; however, HCP needs to support both ICSP &
IDMS. Note, OpenShift clusters can only have either ICSP CRs or IDMS
CRs; clusters cannot utilize both CR types at the same time.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1110](https://issues.redhat.com/browse/HOSTEDCP-1110)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.