### PR TITLE
[CNV-31227] Add workload management annotation to kubevirt-csi daemonset

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -309,6 +309,11 @@ func reconcileTenantNodeClusterRoleBinding(crb *rbacv1.ClusterRoleBinding, saNam
 func reconcileTenantDaemonset(ds *appsv1.DaemonSet, componentImages map[string]string) error {
 	ds.Spec = *daemonset.Spec.DeepCopy()
 
+	if ds.Spec.Template.ObjectMeta.Annotations == nil {
+		ds.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+	}
+
+	ds.Spec.Template.ObjectMeta.Annotations["target.workload.openshift.io/management"] = `{"effect": "PreferredDuringScheduling"}`
 	csiDriverImage, exists := componentImages["kubevirt-csi-driver"]
 	if !exists {
 		return fmt.Errorf("unable to detect kubevirt-csi-driver image from release payload")


### PR DESCRIPTION
The KubeVirt platform is currently failing a conformance test [1] due to a missing annotation on the kubevirt-csi daemonset. This PR resolves that failure.


1. [sig-node][apigroup:config.openshift.io] CPU Partitioning cluster platform workloads should be annotated correctly for DaemonSets [Suite:openshift/conformance/parallel]
