### PR TITLE
HOSTEDCP-1046, HOSTEDCP-1102: Follow-on Items

### DIFF
--- a/docs/content/how-to/disconnected/automatically-initialize-registry-overrides.md
+++ b/docs/content/how-to/disconnected/automatically-initialize-registry-overrides.md
@@ -4,8 +4,8 @@ The HyperShift Operator (HO) will automatically initialize the control plane ope
 
 !!! note
 
-    OpenShift management clusters do not allow both ICSP and IDMS CR instances. 
-    IDMS CRs should be used with OpenShift release image versions 4.13 or higher. 
+    OpenShift management clusters do not allow both ICSP and IDMS CR instances.
+    IDMS CRs should be used with OpenShift release image versions 4.13 or higher.
     ICSPs will be deprecated in future OpenShift release versions.
 
 ## Technical Implementation Details
@@ -17,7 +17,7 @@ The `Lookup` function for `ProviderWithOpenShiftImageRegistryOverrides` will use
 The `ProviderWithOpenShiftImageRegistryOverrides` is also provided to the `HostedClusterReconciler` as its `ReleaseProvider`. When the `HostedClusterReconciler` is reconciling, it will pass any image registry overrides to the ignition server reconciler and the CPO deployment specification.
 
 ### Ignition Server
-The ignition server reconciler forwards this information on to the `ignition-server` container as an environment variable called `OPENSHIFT_IMG_OVERRIDES`. `hypershift/ignition-server/cmd/start.go` retrieves this information for the `ReleaseProvider` for the `TokenSecretReconciler`.
+The ignition server reconciler forwards this information on to the `ignition-server` container as an environment variable called `OPENSHIFT_IMG_OVERRIDES`. `hypershift/ignition-server/cmd/start.go` retrieves this information for the `ReleaseProvider` for the `TokenSecretReconciler`. An important caveat for the ignition server, it cannot follow the ImageContentSourcePolicy or ImageDigestMirrorSet rules because there is not a runtime running inside the pod to do the transformations. So, it's necessary to do the image URL live translation to the custom registry address.
 
 ### Control Plane Operator
 The `HostedClusterReconciler` passes on the image registry override information as an environment variable in the CPO called `OPENSHIFT_IMG_OVERRIDES`. The CPO will check for the existence of this environment variable when it runs. If the variable exists, it's used to build the HostedControlPlaneReconciler's `releaseProvider`.

--- a/docs/content/how-to/disconnected/automatically-initialize-registry-overrides.md
+++ b/docs/content/how-to/disconnected/automatically-initialize-registry-overrides.md
@@ -1,0 +1,23 @@
+# Automatically Initialize RegistryOverrides with Image Content Type Policies
+## General
+The HyperShift Operator (HO) will automatically initialize the control plane operator (CPO) with any image registry override information from any ImageContentSourcePolicy (ICSP) or any ImageDigestMirrorSet (IDMS) instances from an OpenShift management cluster.
+
+!!! note
+
+    OpenShift management clusters do not allow both ICSP and IDMS CR instances. 
+    IDMS CRs should be used with OpenShift release image versions 4.13 or higher. 
+    ICSPs will be deprecated in future OpenShift release versions.
+
+## Technical Implementation Details
+### General
+In `hypershift-operator/main.go`, the HO will look to see if its management cluster has either ICSP or IDMS capabilities. If so, it will retrieve the image registry information from the appropriate ICSP or IDMS instances and store them in a variable called `imageRegistryOverrides`. This variable is then provided to a custom release image provider called `ProviderWithOpenShiftImageRegistryOverrides`.
+
+### ProviderWithOpenShiftImageRegistryOverrides
+The `Lookup` function for `ProviderWithOpenShiftImageRegistryOverrides` will use the source and mirror information in `imageRegistryOverrides` when attempting to look up release images.
+The `ProviderWithOpenShiftImageRegistryOverrides` is also provided to the `HostedClusterReconciler` as its `ReleaseProvider`. When the `HostedClusterReconciler` is reconciling, it will pass any image registry overrides to the ignition server reconciler and the CPO deployment specification.
+
+### Ignition Server
+The ignition server reconciler forwards this information on to the `ignition-server` container as an environment variable called `OPENSHIFT_IMG_OVERRIDES`. `hypershift/ignition-server/cmd/start.go` retrieves this information for the `ReleaseProvider` for the `TokenSecretReconciler`.
+
+### Control Plane Operator
+The `HostedClusterReconciler` passes on the image registry override information as an environment variable in the CPO called `OPENSHIFT_IMG_OVERRIDES`. The CPO will check for the existence of this environment variable when it runs. If the variable exists, it's used to build the HostedControlPlaneReconciler's `releaseProvider`.

--- a/docs/content/how-to/disconnected/disconnected-workarounds.md
+++ b/docs/content/how-to/disconnected/disconnected-workarounds.md
@@ -1,0 +1,78 @@
+# Disconnected workarounds
+
+## Make ImageContentSourcePolicies work using image tags
+The ImageContentSourcePolicies (ICSP) have not exposed the API to handle the parameter `mirror-by-digest-only`, so in order to do that, we need to manually create a MachineConfig change to be applied in all the HostedCluster workers. This change will perform a similar action in the workers like an ICSP.
+
+!!! note
+
+    You don't need to do this with future versions of Openshift because `config.openshift.io/v1` has an exposed API to do this, called `ImageTagMirrorSet`.
+
+!!! note
+
+    This workaround could also be applied in the management cluster first, prior to deploying a HostedCluster from the management cluster.
+
+This is our MachineConfig template:
+
+- `mc-icsp-template.yaml`
+```yaml
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-worker-mirror-by-digest-registries
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,$B64_RAWICSP
+        filesystem: root
+        mode: 420
+        path: /etc/containers/registries.conf.d/99-mirror-by-digest-registries.conf
+```
+
+Basically, we create a file inside of `/etc/containers/registries.conf.d/` called `99-mirror-by-digest-registries.conf` which tells the runtime to use the custom registry instead of the external one.
+
+Also, here we have our final file content:
+
+- `icsp-raw-mc.yaml`
+```ini
+[[registry]]
+  prefix = ""
+  location = "registry.redhat.io/openshift4/ose-kube-rbac-proxy"
+  mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "registry.ocp-edge-cluster-0.qe.lab.redhat.com:5000/openshift4/ose-kube-rbac-proxy"
+
+[[registry]]
+  prefix = ""
+  location = "quay.io/acm-d"
+  mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "registry.ocp-edge-cluster-0.qe.lab.redhat.com:5000/acm-d"
+
+[[registry]]
+  prefix = ""
+  location = "quay.io/open-cluster-management/addon-manager"
+  mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "registry.ocp-edge-cluster-0.qe.lab.redhat.com:5000/open-cluster-management/addon-manager"
+```
+
+Now we just need to mix the things up and apply them into our HostedCluster
+
+```bash
+export B64_RAWICSP=$(cat icsp-raw-mc.yaml | base64)
+envsubst < mc-icsp-template.yaml | oc apply -f -
+```
+
+These two commands will create the MachineConfig change in the Openshift cluster, so eventually the worker nodes will get rebooted.
+
+After applying this change, the worker nodes will be able to consume the mirror when only the tags are involved.

--- a/docs/content/how-to/disconnected/image-content-sources.md
+++ b/docs/content/how-to/disconnected/image-content-sources.md
@@ -1,0 +1,27 @@
+# Setting up Alternative Image Registries Through ImageContentSources
+## What is ImageContentSources and why do we need it?
+Users can set up alternative image registry information for their guest clusters to use through a field called `ImageContentSources` in a hosted control plane's specification. Alternatively, this field can also be set through the HyperShift CLI by specifying a filepath to a file containing the source and mirrors for the alternative registry information, `--image-content-sources=/path/to/file/with/sources_and_mirrors.yml`.
+
+Here is an example of the expected format for this field, `ImageContentSources`:
+```
+- mirrors:
+    - brew.registry.redhat.io
+  source: registry.redhat.io
+- mirrors:
+    - brew.registry.redhat.io
+  source: registry.xyz.redhat.io
+- mirrors:
+    - brew.registry.redhat.io
+  source: registry-proxy.engineering.redhat.com
+```
+!!! note
+
+    This is also the expected format for the file if you choose to use the HyperShift CLI flag.
+
+## How ImageContentSources are used in the nodes within a NodePool
+`ImageContentSources` are reconciled, through the HostedClusterConfigOperator (HCCO), to either an ImageContentSourcePolicy (ICSP) custom resources (CR) or an ImageDigestMirrorSet (IDMS) CR. The CR is then included in the configuration for the Nodes in a NodePool through the NodePool controller's functions, `reconcile > getConfig > defaultAndValidateConfigManifest`.
+
+!!! important
+
+    ICSPs will be deprecated in future OpenShift releases, likely starting with v4.17. IDMSs are the replacement CR for ICSPs but are only available in OpenShift starting in v4.13.
+    The HCCO will automatically delete any ICSPs previously used in the node configuration setup through the Control Plane Operator (CPO) starting in OpenShift v4.13.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,6 +74,9 @@ nav:
     - how-to/azure/create-azure-cluster.md
   - 'Agent':
     - how-to/agent/create-agent-cluster.md
+  - 'Disconnected':
+    - how-to/disconnected/automatically-initialize-registry-overrides.md
+    - how-to/disconnected/image-content-sources.md
   - 'Kubevirt':
     - how-to/kubevirt/create-kubevirt-cluster.md
     - how-to/kubevirt/ingress-and-dns.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
   - 'Disconnected':
     - how-to/disconnected/automatically-initialize-registry-overrides.md
     - how-to/disconnected/image-content-sources.md
+    - how-to/disconnected/disconnected-workarounds.md
   - 'Kubevirt':
     - how-to/kubevirt/create-kubevirt-cluster.md
     - how-to/kubevirt/ingress-and-dns.md


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow on for [HOSTEDCP-1046](https://issues.redhat.com//browse/HOSTEDCP-1046) that:
* Removes the version check on reconciling the image content type policy since that is not needed in release image versions greater than 4.13 (for [HOSTEDCP-1102](https://issues.redhat.com//browse/HOSTEDCP-1102)).
* Adds documentation on the ImageContentSources field.
* Adds documentation on how RegistryOverrides are automatically initialized by the HyperShift Operator from ICSPs or IDMSs within the management cluster.
* Adds documentation on disconnected environment workaround with respect to ICSP and image tags.

**Which issue(s) this PR fixes**:
Fixes 
* [HOSTEDCP-1046](https://issues.redhat.com/browse/HOSTEDCP-1046)
* [HOSTEDCP-1102](https://issues.redhat.com/browse/HOSTEDCP-1102)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.