### PR TITLE
kubevirt: Reconcile EgressFirewall only for ovn-k

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -109,11 +109,13 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 		if err != nil {
 			return err
 		}
-		egressFirewall := egressfirewall.VirtLauncherEgressFirewall(kvInfraCluster.Namespace)
-		if _, err := createOrUpdate(ctx, kvInfraCluster.Client, egressFirewall, func() error {
-			return reconcileVirtLauncherEgressFirewall(egressFirewall)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile firewall to deny metadata server egress: %w", err)
+		if hcluster.Spec.Networking.NetworkType == hyperv1.OVNKubernetes {
+			egressFirewall := egressfirewall.VirtLauncherEgressFirewall(kvInfraCluster.Namespace)
+			if _, err := createOrUpdate(ctx, kvInfraCluster.Client, egressFirewall, func() error {
+				return reconcileVirtLauncherEgressFirewall(egressFirewall)
+			}); err != nil {
+				return fmt.Errorf("failed to reconcile firewall to deny metadata server egress: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
At some lab experimental scenarios users are using different CNIs. This change remove the ovn-k API dependency to remove problems with other CNIs.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.