### PR TITLE
OCPBUGS-16809: Configured IgnitionProxy to support IPv4 and IPv6

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -692,7 +692,7 @@ defaults
   timeout server 30s
 
 frontend ignition-server
-  bind *:8443 ssl crt /tmp/tls.pem
+  bind :::8443 v4v6 ssl crt /tmp/tls.pem
   default_backend ignition_servers
 
 backend ignition_servers

--- a/hypershift-operator/controllers/hostedcluster/ignitionserver/ignitionserver.go
+++ b/hypershift-operator/controllers/hostedcluster/ignitionserver/ignitionserver.go
@@ -657,7 +657,7 @@ defaults
   timeout server 30s
 
 frontend ignition-server
-  bind *:443 ssl crt /tmp/tls.pem
+  bind :::443 v4v6 ssl crt /tmp/tls.pem
   default_backend ignition_servers
 
 backend ignition_servers


### PR DESCRIPTION
Modified the Ignition proxy server to support IPv4 and IPv6

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-16809](https://issues.redhat.com/browse/OCPBUGS-16809)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.