### PR TITLE
HOSTEDCP-1025: Add HCP CLI Command to Create a NodePool on AWS

### DIFF
--- a/product-cli/cmd/nodepool/aws/create.go
+++ b/product-cli/cmd/nodepool/aws/create.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"github.com/spf13/cobra"
+
+	hypershiftaws "github.com/openshift/hypershift/cmd/nodepool/aws"
+	"github.com/openshift/hypershift/cmd/nodepool/core"
+)
+
+func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
+	platformOpts := &hypershiftaws.AWSPlatformCreateOptions{
+		InstanceType:   "",
+		RootVolumeIOPS: 0,
+		RootVolumeSize: 120,
+		RootVolumeType: "gp3",
+	}
+	cmd := &cobra.Command{
+		Use:          "aws",
+		Short:        "Creates basic functional NodePool resources for AWS platform",
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVar(&platformOpts.InstanceType, "instance-type", platformOpts.InstanceType, "The AWS instance type of the NodePool.")
+	cmd.Flags().StringVar(&platformOpts.SubnetID, "subnet-id", platformOpts.SubnetID, "The AWS subnet ID in which to create the NodePool.")
+	cmd.Flags().StringVar(&platformOpts.SecurityGroupID, "securitygroup-id", platformOpts.SecurityGroupID, "The AWS security group in which to create the NodePool.")
+	cmd.Flags().StringVar(&platformOpts.InstanceProfile, "instance-profile", platformOpts.InstanceProfile, "The AWS instance profile for the NodePool.")
+	cmd.Flags().StringVar(&platformOpts.RootVolumeType, "root-volume-type", platformOpts.RootVolumeType, "The type of the root volume for the NodePool machines.")
+	cmd.Flags().Int64Var(&platformOpts.RootVolumeIOPS, "root-volume-iops", platformOpts.RootVolumeIOPS, "The IOPS of the root volume for the NodePool machines.")
+	cmd.Flags().Int64Var(&platformOpts.RootVolumeSize, "root-volume-size", platformOpts.RootVolumeSize, "The size of the root volume for the NodePool machines.")
+	cmd.Flags().StringVar(&platformOpts.RootVolumeEncryptionKey, "root-volume-kms-key", platformOpts.RootVolumeEncryptionKey, "The KMS key ID or ARN to use for root volume encryption for the NodePool machines.")
+
+	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
+
+	return cmd
+}

--- a/product-cli/cmd/nodepool/create.go
+++ b/product-cli/cmd/nodepool/create.go
@@ -5,13 +5,10 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
-	hyperShiftKubeVirt "github.com/openshift/hypershift/cmd/nodepool/kubevirt"
 	"github.com/openshift/hypershift/product-cli/cmd/nodepool/agent"
+	"github.com/openshift/hypershift/product-cli/cmd/nodepool/aws"
 	"github.com/openshift/hypershift/product-cli/cmd/nodepool/kubevirt"
 )
-
-// The following lines are needed in order to validate that any platform implementing PlatformOptions satisfy the interface
-var _ core.PlatformOptions = &hyperShiftKubeVirt.KubevirtPlatformCreateOptions{}
 
 func NewCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -21,26 +18,25 @@ func NewCreateCommand() *cobra.Command {
 	}
 
 	opts := &core.CreateNodePoolOptions{
-		Namespace:       "clusters",
 		ClusterName:     "example",
+		Namespace:       "clusters",
 		NodeCount:       2,
-		ReleaseImage:    "",
 		NodeUpgradeType: hyperv1.UpgradeTypeReplace,
-		Arch:            "amd64",
+		ReleaseImage:    "",
 	}
 
-	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The name of the NodePool")
-	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace in which to create the NodePool")
-	cmd.PersistentFlags().Int32Var(&opts.NodeCount, "node-count", opts.NodeCount, "The number of nodes to create in the NodePool")
-	cmd.PersistentFlags().StringVar(&opts.ClusterName, "cluster-name", opts.ClusterName, "The name of the HostedCluster nodes in this pool will join")
-	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes. If empty, defaults to the same release image as the HostedCluster.")
+	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The name of the NodePool.")
+	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace in which to create the NodePool.")
+	cmd.PersistentFlags().Int32Var(&opts.NodeCount, "node-count", opts.NodeCount, "The number of nodes to create in the NodePool.")
+	cmd.PersistentFlags().StringVar(&opts.ClusterName, "cluster-name", opts.ClusterName, "The name of the HostedCluster nodes in this pool will join.")
+	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes; if this is empty, defaults to the same release image as the HostedCluster.")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
-	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The processor architecture for the NodePool (e.g. arm64, amd64)")
-	cmd.PersistentFlags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying")
+	cmd.PersistentFlags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying.")
 
 	_ = cmd.MarkPersistentFlagRequired("name")
 
 	cmd.AddCommand(agent.NewCreateCommand(opts))
+	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
 
 	return cmd


### PR DESCRIPTION
**What this PR does / why we need it**:
Add HCP CLI Command to Create a NodePool on AWS

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1025](https://issues.redhat.com/browse/HOSTEDCP-1025)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.