### PR TITLE
HOSTEDCP-1029: Add HCP CLI Command to Destroy a Cluster on AWS

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -57,10 +57,10 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		}
 
 		if len(opts.CredentialSecretName) == 0 {
-			if err := isRequiredOption("aws-creds", opts.AWSPlatform.AWSCredentialsFile); err != nil {
+			if err := IsRequiredOption("aws-creds", opts.AWSPlatform.AWSCredentialsFile); err != nil {
 				return err
 			}
-			if err := isRequiredOption("pull-secret", opts.PullSecretFile); err != nil {
+			if err := IsRequiredOption("pull-secret", opts.PullSecretFile); err != nil {
 				return err
 			}
 		} else {
@@ -249,7 +249,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 }
 
 // IsRequiredOption returns a cobra style error message when the flag value is empty
-func isRequiredOption(flag string, value string) error {
+func IsRequiredOption(flag string, value string) error {
 	if len(value) == 0 {
 		return fmt.Errorf("required flag(s) \"%s\" not set", flag)
 	}

--- a/cmd/cluster/aws/destroy_test.go
+++ b/cmd/cluster/aws/destroy_test.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_ValidateCredentialInfo(t *testing.T) {
+	tests := map[string]struct {
+		inputOptions *core.DestroyOptions
+		expectError  bool
+	}{
+		"when CredentialSecretName is blank and aws-creds is also blank": {
+			inputOptions: &core.DestroyOptions{
+				CredentialSecretName: "",
+				AWSPlatform: core.AWSPlatformDestroyOptions{
+					AWSCredentialsFile: "",
+				},
+			},
+			expectError: true,
+		},
+		"when CredentialSecretName is blank and aws-creds is not blank": {
+			inputOptions: &core.DestroyOptions{
+				CredentialSecretName: "",
+				AWSPlatform: core.AWSPlatformDestroyOptions{
+					AWSCredentialsFile: "asdf",
+				},
+			},
+			expectError: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			err := ValidateCredentialInfo(test.inputOptions)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}

--- a/product-cli/cmd/cluster/aws/destroy.go
+++ b/product-cli/cmd/cluster/aws/destroy.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"github.com/spf13/cobra"
+
+	hypershiftaws "github.com/openshift/hypershift/cmd/cluster/aws"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/log"
+)
+
+func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "aws",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on AWS.",
+		SilenceUsage: true,
+	}
+
+	opts.AWSPlatform = core.AWSPlatformDestroyOptions{
+		AWSCredentialsFile: "",
+		PreserveIAM:        false,
+		Region:             "us-east-1",
+	}
+
+	cmd.Flags().StringVar(&opts.AWSPlatform.AWSCredentialsFile, "aws-creds", opts.AWSPlatform.AWSCredentialsFile, "Filepath to an AWS credentials file.")
+	cmd.Flags().BoolVar(&opts.AWSPlatform.PreserveIAM, "preserve-iam", opts.AWSPlatform.PreserveIAM, "If set to true, skip deleting IAM. Otherwise, destroy any default generated IAM along with other infrastructure.")
+	cmd.Flags().StringVar(&opts.AWSPlatform.Region, "region", opts.AWSPlatform.Region, "A HostedCluster's region.")
+	cmd.Flags().StringVar(&opts.AWSPlatform.BaseDomain, "base-domain", opts.AWSPlatform.BaseDomain, "A HostedCluster's base domain.")
+	cmd.Flags().StringVar(&opts.AWSPlatform.BaseDomainPrefix, "base-domain-prefix", opts.AWSPlatform.BaseDomainPrefix, "A HostedCluster's base domain prefix.")
+	cmd.Flags().StringVar(&opts.CredentialSecretName, "secret-creds", opts.CredentialSecretName, "A Kubernetes secret with a platform credentials: pull-secret and base-domain. The secret must exist in the supplied \"--namespace\".")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		err := hypershiftaws.ValidateCredentialInfo(opts)
+		if err != nil {
+			return err
+		}
+
+		if err = hypershiftaws.DestroyCluster(cmd.Context(), opts); err != nil {
+			log.Log.Error(err, "Failed to destroy cluster")
+			return err
+		}
+
+		return nil
+	}
+
+	return cmd
+}

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/product-cli/cmd/cluster/agent"
+	"github.com/openshift/hypershift/product-cli/cmd/cluster/aws"
 	"github.com/openshift/hypershift/product-cli/cmd/cluster/kubevirt"
 )
 
@@ -99,6 +100,7 @@ func NewDestroyCommands() *cobra.Command {
 	_ = cmd.MarkPersistentFlagRequired("name")
 
 	cmd.AddCommand(agent.NewDestroyCommand(opts))
+	cmd.AddCommand(aws.NewDestroyCommand(opts))
 	cmd.AddCommand(kubevirt.NewDestroyCommand(opts))
 
 	return cmd


### PR DESCRIPTION
**What this PR does / why we need it**:
Add HCP CLI Command to Destroy a Cluster on AWS

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1029](https://issues.redhat.com/browse/HOSTEDCP-1029)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced. 
- [x] This change includes unit tests.