### PR TITLE
Revert "OCPBUGS-16809: Configured IgnitionProxy to support IPv4 and IPv6"

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -692,7 +692,7 @@ defaults
   timeout server 30s
 
 frontend ignition-server
-  bind :::8443 v4v6 ssl crt /tmp/tls.pem
+  bind *:8443 ssl crt /tmp/tls.pem
   default_backend ignition_servers
 
 backend ignition_servers

--- a/hypershift-operator/controllers/hostedcluster/ignitionserver/ignitionserver.go
+++ b/hypershift-operator/controllers/hostedcluster/ignitionserver/ignitionserver.go
@@ -657,7 +657,7 @@ defaults
   timeout server 30s
 
 frontend ignition-server
-  bind :::443 v4v6 ssl crt /tmp/tls.pem
+  bind *:443 ssl crt /tmp/tls.pem
   default_backend ignition_servers
 
 backend ignition_servers


### PR DESCRIPTION
Reverts openshift/hypershift#2850, tracked by [TRT-1168](https://issues.redhat.com//browse/TRT-1168)

TRT suspects this PR as being a possible cause of a recent payload regression. We are floating this revert to perform additional testing.  It seems unlikely this is the cause, but we don't have any other candidates at the moment. Workers are failing to provision on the nightly jobs (se jira above for details)

Holding pending confirmation:
/hold
