### PR TITLE
[HOSTEDCP-1041] Defaulting webhook for self managed HCP

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1659,7 +1659,7 @@ type ManagedEtcdStorageSpec struct {
 	//
 	// +optional
 	// +immutable
-	RestoreSnapshotURL []string `json:"restoreSnapshotURL"`
+	RestoreSnapshotURL []string `json:"restoreSnapshotURL,omitempty"`
 }
 
 // PersistentVolumeEtcdStorageSpec is the configuration for PersistentVolume

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -16,26 +16,35 @@ func TestDefaultNetworkType(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "Already configured, no change",
-			opts:     &CreateOptions{NetworkType: "foo"},
+			name: "Already configured, no change",
+			opts: &CreateOptions{
+				NetworkType:  "foo",
+				ReleaseImage: "4.11.0",
+			},
 			expected: "foo",
 		},
 		{
-			name:     "4.10, SDN",
-			opts:     &CreateOptions{},
+			name: "4.10, SDN",
+			opts: &CreateOptions{
+				ReleaseImage: "4.10.0",
+			},
 			provider: &fake.FakeReleaseProvider{Version: "4.10.0"},
 			expected: "OpenShiftSDN",
 		},
 		{
-			name:     "4.11, ovn-k",
-			opts:     &CreateOptions{},
+			name: "4.11, ovn-k",
+			opts: &CreateOptions{
+				ReleaseImage: "4.11.0",
+			},
 			provider: &fake.FakeReleaseProvider{Version: "4.11.0"},
 			expected: "OVNKubernetes",
 		},
 		{
-			name:     "4.12, ovn-k",
-			opts:     &CreateOptions{},
-			provider: &fake.FakeReleaseProvider{Version: "4.11.0"},
+			name: "4.12, ovn-k",
+			opts: &CreateOptions{
+				ReleaseImage: "4.12.0",
+			},
+			provider: &fake.FakeReleaseProvider{Version: "4.12.0"},
 			expected: "OVNKubernetes",
 		},
 	}

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/util"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -1433,4 +1434,84 @@ func (o HyperShiftReaderClusterRoleBinding) Build() *rbacv1.ClusterRoleBinding {
 		},
 	}
 	return binding
+}
+
+type HyperShiftMutatingWebhookConfiguration struct {
+	Namespace *corev1.Namespace
+}
+
+func (o HyperShiftMutatingWebhookConfiguration) Build() *admissionregistrationv1.MutatingWebhookConfiguration {
+	scope := admissionregistrationv1.NamespacedScope
+	hcPath := "/mutate-hypershift-openshift-io-v1beta1-hostedcluster"
+	npPath := "/mutate-hypershift-openshift-io-v1beta1-nodepool"
+	sideEffects := admissionregistrationv1.SideEffectClassNone
+	timeout := int32(15)
+	mutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MutatingWebhookConfiguration",
+			APIVersion: admissionregistrationv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace.Name,
+			Name:      hyperv1.GroupVersion.Group,
+			Annotations: map[string]string{
+				"service.beta.openshift.io/inject-cabundle": "true",
+			},
+		},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
+			{
+				Name: "hostedclusters.hypershift.openshift.io",
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Create,
+						},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{"hypershift.openshift.io"},
+							APIVersions: []string{"v1beta1"},
+							Resources:   []string{"hostedclusters"},
+							Scope:       &scope,
+						},
+					},
+				},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: "hypershift",
+						Name:      "operator",
+						Path:      &hcPath,
+					},
+				},
+				SideEffects:             &sideEffects,
+				AdmissionReviewVersions: []string{"v1"},
+				TimeoutSeconds:          &timeout,
+			},
+			{
+				Name: "nodepools.hypershift.openshift.io",
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Create,
+						},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{"hypershift.openshift.io"},
+							APIVersions: []string{"v1beta1"},
+							Resources:   []string{"nodepools"},
+							Scope:       &scope,
+						},
+					},
+				},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: "hypershift",
+						Name:      "operator",
+						Path:      &npPath,
+					},
+				},
+				SideEffects:             &sideEffects,
+				AdmissionReviewVersions: []string{"v1"},
+				TimeoutSeconds:          &timeout,
+			},
+		},
+	}
+	return mutatingWebhookConfiguration
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -1,22 +1,85 @@
 package hostedcluster
 
 import (
+	"context"
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/support/supportedversion"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// SetupWebhookWithManager sets up webhooks.
+type hostedClusterDefaulter struct {
+}
+
+type nodePoolDefaulter struct {
+	client client.Client
+}
+
+func (defaulter *hostedClusterDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	hcluster, ok := obj.(*hyperv1.HostedCluster)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a HostedCluster but got a %T", obj))
+	}
+
+	if hcluster.Spec.Release.Image != "" {
+		return nil
+	}
+
+	pullSpec, err := supportedversion.LookupLatestSupportedRelease(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to find default release image: %w", err)
+	}
+	hcluster.Spec.Release.Image = pullSpec
+
+	return nil
+}
+
+func (defaulter *nodePoolDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	np, ok := obj.(*hyperv1.NodePool)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a NodePool but got a %T", obj))
+	}
+
+	if np.Spec.Release.Image != "" {
+		return nil
+	} else if np.Spec.ClusterName == "" {
+		return fmt.Errorf("nodePool.Spec.ClusterName is a required field")
+	}
+
+	hc := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      np.Spec.ClusterName,
+			Namespace: np.Namespace,
+		},
+	}
+
+	err := defaulter.client.Get(ctx, client.ObjectKeyFromObject(hc), hc)
+	if err != nil {
+		return fmt.Errorf("error retrieving HostedCluster named [%s], %v", np.Spec.ClusterName, err)
+	}
+	np.Spec.Release.Image = hc.Spec.Release.Image
+
+	return nil
+}
+
+// SetupWebhookWithManager sets up HostedCluster webhooks.
 func SetupWebhookWithManager(mgr ctrl.Manager) error {
+
 	err := ctrl.NewWebhookManagedBy(mgr).
 		For(&hyperv1.HostedCluster{}).
+		WithDefaulter(&hostedClusterDefaulter{}).
 		Complete()
 	if err != nil {
 		return fmt.Errorf("unable to register hostedcluster webhook: %w", err)
 	}
 	err = ctrl.NewWebhookManagedBy(mgr).
 		For(&hyperv1.NodePool{}).
+		WithDefaulter(&nodePoolDefaulter{client: mgr.GetClient()}).
 		Complete()
 	if err != nil {
 		return fmt.Errorf("unable to register nodepool webhook: %w", err)
@@ -28,4 +91,5 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("unable to register hostedcontrolplane webhook: %w", err)
 	}
 	return nil
+
 }

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -1,7 +1,11 @@
 package supportedversion
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
 	"github.com/blang/semver"
@@ -75,4 +79,44 @@ func IsValidReleaseVersion(version, currentVersion, latestVersionSupported, minS
 	}
 
 	return nil
+}
+
+type ocpVersion struct {
+	Name        string `json:"name"`
+	PullSpec    string `json:"pullSpec"`
+	DownloadURL string `json:"downloadURL"`
+}
+
+// LookupLatestSupportedRelease picks the latest multi-arch image supported by this Hypershift Operator
+func LookupLatestSupportedRelease(ctx context.Context) (string, error) {
+	prefix := "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-multi/latest"
+	filter := fmt.Sprintf("in=>4.%d.%d+<+4.%d.0",
+		MinSupportedVersion.Minor, MinSupportedVersion.Patch, LatestSupportedVersion.Minor+1)
+
+	releaseURL := fmt.Sprintf("%s?%s", prefix, filter)
+
+	var version ocpVersion
+
+	req, err := http.NewRequestWithContext(ctx, "GET", releaseURL, nil)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	err = json.Unmarshal(body, &version)
+	if err != nil {
+		return "", err
+	}
+	return version.PullSpec, nil
 }


### PR DESCRIPTION
Previously, the hostedCluster.Spec.Release.Image was required and the hcp or hypershift cli defaulted that value client side. This posed several issues though.

1. The defaulting did not take into consideration what the max and min version the deployed hypershift operator supports, which will eventually lead to the client defaulting unsupported versions.
2. This logic was all client side, which meant that it couldn't be used in a gitops flow or reused by the console web UI.

The new logic performs defaulting the release image on the backend using an **optional** mutating webhook. The logic takes into account the latest/min supported versions and picks the most recent version that falls within those constraints.

A webhook was chosen over performing defaults in the controller's reconcile loop due to the following reasons. 
* The Webhook requires no api changes (such as making the release image optional)
* Error discovery occurs immediately at creation time (http Post response) rather than after admission via condition
