### PR TITLE
HOSTEDCP-1121: Ensure SG reconciliation for aws endpoint

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -365,7 +365,7 @@ func hasAWSConfig(platform *hyperv1.PlatformSpec) bool {
 		platform.AWS.CloudProviderConfig.Subnet != nil && platform.AWS.CloudProviderConfig.Subnet.ID != nil
 }
 
-func diffSubnetIDs(desired []string, existing []*string) (added, removed []*string) {
+func diffIDs(desired []string, existing []*string) (added, removed []*string) {
 	var found bool
 	for i, desiredID := range desired {
 		found = false
@@ -446,14 +446,24 @@ func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointService(ctx context.C
 		log.Info("endpoint exists", "endpointID", endpointID)
 		endpointDNSEntries = output.VpcEndpoints[0].DnsEntries
 
-		// ensure endpoint has the right subnets
-		added, removed := diffSubnetIDs(awsEndpointService.Spec.SubnetIDs, output.VpcEndpoints[0].SubnetIds)
-		if added != nil || removed != nil {
-			log.Info("endpoint subnets have changed")
+		// Ensure endpoint has the right subnets.
+		addedSubnet, removedSubnet := diffIDs(awsEndpointService.Spec.SubnetIDs, output.VpcEndpoints[0].SubnetIds)
+
+		// Ensure endpoint has the right SG.
+		exitingSG := make([]*string, 0)
+		for _, group := range output.VpcEndpoints[0].Groups {
+			exitingSG = append(exitingSG, group.GroupId)
+		}
+		addedSG, removedSG := diffIDs([]string{hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID}, exitingSG)
+
+		if addedSubnet != nil || removedSubnet != nil || addedSG != nil || removedSG != nil {
+			log.Info("endpoint subnets or security groups have changed")
 			_, err := ec2Client.ModifyVpcEndpointWithContext(ctx, &ec2.ModifyVpcEndpointInput{
-				VpcEndpointId:   aws.String(endpointID),
-				AddSubnetIds:    added,
-				RemoveSubnetIds: removed,
+				VpcEndpointId:          aws.String(endpointID),
+				AddSubnetIds:           addedSubnet,
+				RemoveSubnetIds:        removedSubnet,
+				AddSecurityGroupIds:    addedSG,
+				RemoveSecurityGroupIds: removedSG,
 			})
 			if err != nil {
 				msg := err.Error()

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_diffSubnetIDs(t *testing.T) {
+func Test_diffIDs(t *testing.T) {
 	subnet1 := "1"
 	subnet2 := "2"
 	subnet3 := "3"
@@ -71,7 +71,7 @@ func Test_diffSubnetIDs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotAdded, gotRemoved := diffSubnetIDs(tt.args.desired, tt.args.existing)
+			gotAdded, gotRemoved := diffIDs(tt.args.desired, tt.args.existing)
 			if !reflect.DeepEqual(gotAdded, tt.wantAdded) {
 				t.Errorf("diffSubnetIDs() gotAdded = %v, want %v", gotAdded, tt.wantAdded)
 			}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This ensures that clusters running before we enforced the hypershift security group on the endpoint creation get that SG as well. 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.