### PR TITLE
WRKLDS-730: use default /healthz path for readiness probe in OCM and RCM

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -75,7 +75,7 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, observ
 		ocmContainerMain().Name: {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/healthz/ready",
+					Path:   "/healthz",
 					Port:   intstr.FromInt(int(servingPort)),
 					Scheme: corev1.URISchemeHTTPS,
 				},

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
@@ -69,7 +69,7 @@ func NewOpenShiftRouteControllerManagerParams(hcp *hyperv1.HostedControlPlane, o
 		routeOCMContainerMain().Name: {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/healthz/ready",
+					Path:   "/healthz",
 					Port:   intstr.FromInt(int(servingPort)),
 					Scheme: corev1.URISchemeHTTPS,
 				},


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

openshift-controller-manager deployment uses `/healthz` endpoint https://github.com/openshift/cluster-openshift-controller-manager-operator/blob/master/bindata/v3.11.0/openshift-controller-manager/deploy.yaml even though `/healhtz/ready` is available, there does not seem to be good reason for using it: https://github.com/openshift/openshift-controller-manager/blob/80c4923e0b2014ec8b8a6845c21078e6cc036f91/pkg/cmd/controller/standalone_apiserver.go#L75

With a switch to library-go in https://github.com/openshift/route-controller-manager/pull/28 (and k8s.io/apiserver) `/healthz/ready` endpoint is no longer available: https://github.com/kubernetes/apiserver/blob/d2172f30e1af3782a7124e21b8cb4676fc789acc/pkg/server/config.go#L412, so we need to update endpoints here accordingly

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/WRKLDS-730 and followup to https://github.com/openshift/hypershift/pull/2674

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.