### PR TITLE
skip olm-collect-profiles in EnsureComponentsHaveNeedManagementKASAccessLabel

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -856,6 +856,10 @@ func checkPodsHaveLabel(ctx context.Context, c crclient.Client, components []str
 			continue
 		}
 
+		if strings.HasPrefix(pod.Labels["name"], "olm-collect-profiles") {
+			continue
+		}
+
 		if pod.Labels["name"] != "" {
 			got = append(got, pod.Labels["name"])
 			continue


### PR DESCRIPTION
Follow on to https://github.com/openshift/hypershift/pull/2854

This causes e2e to fail ~5% of the time depending on what random `spec.schedule` is selected for the `olm-collect-profiles` CronJob

Example failure:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hypershift/2834/pull-ci-openshift-hypershift-main-e2e-aws/1686695356840022016