### PR TITLE
Kubevirt how-to docs updates

### DIFF
--- a/docs/content/how-to/kubevirt/configuring-storage.md
+++ b/docs/content/how-to/kubevirt/configuring-storage.md
@@ -9,7 +9,7 @@ etcd volumes.
 KubeVirt CSI permits any infra storage class with the `ReadWriteMany` access
 mode to be exposed to the guest cluster. This mapping of infra cluster storage
 class to guest cluster storage class can be configured during cluster creation
-using the `hypershift` cli tool and the `--infra-storage-class-mapping` cli
+using the `hcp` cli tool and the `--infra-storage-class-mapping` cli
 argument.
 
 Below is an example of how to map two infra storage classes called `infra-sc1`
@@ -24,7 +24,7 @@ export MEM="6Gi"
 export CPU="2"
 export WORKER_COUNT="2"
 
-hypershift create cluster kubevirt \
+hcp create cluster kubevirt \
 --name $CLUSTER_NAME \
 --node-pool-replicas $WORKER_COUNT \
 --pull-secret $PULL_SECRET \
@@ -48,7 +48,7 @@ mapping that was configured during cluster creation.
 ## KubeVirt VM Root Volume Configuration
 
 The storage class used to host the KubeVirt Virtual Machine root volumes can be
-configured at cluster creation time using the `hypershift` cli tool and the
+configured at cluster creation time using the `hcp` cli tool and the
 `--root-volume-storage-class` argument. Likewise, the size of the volume can be
 configured using the `--root-volume-size` cli argument.
 
@@ -63,7 +63,7 @@ export MEM="6Gi"
 export CPU="2"
 export WORKER_COUNT="2"
 
-hypershift create cluster kubevirt \
+hcp create cluster kubevirt \
 --name $CLUSTER_NAME \
 --node-pool-replicas $WORKER_COUNT \
 --pull-secret $PULL_SECRET \
@@ -86,7 +86,7 @@ KubeVirt VM added as a worker node to the cluster. This reduces VM startup time
 by only requiring a single image import, and can further reduce overall cluster
 storage usage when the storage class supports copy on write cloning.
 
-Image caching can be enabled during cluster creation using the `hypershift` cli
+Image caching can be enabled during cluster creation using the `hcp` cli
 tool with the `--root-volume-cache-strategy=PVC` argument. Below is an example.
 
 
@@ -97,7 +97,7 @@ export MEM="6Gi"
 export CPU="2"
 export WORKER_COUNT="2"
 
-hypershift create cluster kubevirt \
+hcp create cluster kubevirt \
 --name $CLUSTER_NAME \
 --node-pool-replicas $WORKER_COUNT \
 --pull-secret $PULL_SECRET \
@@ -109,7 +109,7 @@ hypershift create cluster kubevirt \
 ## ETCD Storage Configuration
 
 The storage class used to host the etcd data can be customized at cluster
-creation time using the `hypershift` cli and the `--etcd-storage-class` cli
+creation time using the `hcp` cli and the `--etcd-storage-class` cli
 argument. When no `--etcd-storage-class` argument is provided, the default
 storage class will be used.
 
@@ -122,7 +122,7 @@ export MEM="6Gi"
 export CPU="2"
 export WORKER_COUNT="2"
 
-hypershift create cluster kubevirt \
+hcp create cluster kubevirt \
 --name $CLUSTER_NAME \
 --node-pool-replicas $WORKER_COUNT \
 --pull-secret $PULL_SECRET \

--- a/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
+++ b/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
@@ -13,15 +13,21 @@ Install an OCP cluster running on VMs within a management OCP cluster
 * The OpenShift CLI (`oc`) or Kubernetes CLI (`kubectl`).
 * A valid [pull secret](https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned) file for the `quay.io/openshift-release-dev` repository.
 
-## Installing HyperShift Operator and hypershift cli tool
+## Installing HyperShift Operator and cli tooling
 
-Before creating a guest cluster, the Hypershift operator and hypershift cli tool
-must be installed.
+Before creating a guest cluster, the hcp cli, hypershift cli, and HyperShift
+Operator must be installed.
 
-### Build the HyperShift CLI
+The `hypershift` cli tool is a development tool that is used to install
+developer builds of the HyperShift Operator.
 
-The command below builds latest hypershift cli tool from source and places the
-cli tool within the /usr/local/bin directory.
+The `hcp` cli tool is used to manage the creation and destruction of guest
+clusters.
+
+### Build the HyperShift and HCP CLI
+
+The command below builds latest hypershift and hcp cli tools from source and
+places the cli tool within the /usr/local/bin directory.
 
 !!! note
 
@@ -29,13 +35,17 @@ cli tool within the /usr/local/bin directory.
   
 ```shell
 podman run --rm --privileged -it -v \
-$PWD:/output docker.io/library/golang:1.18 /bin/bash -c \
+$PWD:/output docker.io/library/golang:1.20 /bin/bash -c \
 'git clone https://github.com/openshift/hypershift.git && \
 cd hypershift/ && \
-make hypershift && \
-mv bin/hypershift /output/hypershift
+make hypershift product-cli && \
+mv bin/hypershift /output/hypershift && \
+mv bin/hcp /output/hcp'
+
 sudo install -m 0755 -o root -g root $PWD/hypershift /usr/local/bin/hypershift
+sudo install -m 0755 -o root -g root $PWD/hcp /usr/local/bin/hcp
 rm $PWD/hypershift
+rm $PWD/hcp
 ```
 
 ## Deploy the HyperShift Operator
@@ -63,7 +73,7 @@ Once all the [prerequisites](#prerequisites) are met, and the HyperShift
 operator is installed, it is now possible to create a guest cluster.
 
 Below is an example of how to create a guest cluster using environment
-variables and the `hypershift` cli tool.
+variables and the `hcp` cli tool.
 
 !!! note
 
@@ -77,7 +87,7 @@ export MEM="6Gi"
 export CPU="2"
 export WORKER_COUNT="2"
 
-hypershift create cluster kubevirt \
+hcp create cluster kubevirt \
 --name $CLUSTER_NAME \
 --node-pool-replicas $WORKER_COUNT \
 --pull-secret $PULL_SECRET \
@@ -123,10 +133,10 @@ example         4.12.7    example-admin-kubeconfig         Completed  True      
 
 CLI access to the guest cluster is gained by retrieving the guest cluster's
 kubeconfig. Below is an example of how to retrieve the guest cluster's
-kubeconfig using the hypershift cli.
+kubeconfig using the hcp cli.
 
 ```shell
-hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
+hcp create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
 ```
 
 If we access the cluster, we will see we have two nodes.
@@ -186,7 +196,7 @@ export MEM="6Gi"
 export CPU="4"
 export DISK="16"
 
-hypershift create nodepool kubevirt \
+hcp create nodepool kubevirt \
   --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
   --node-count $WORKER_COUNT \
@@ -236,6 +246,6 @@ example-extra-cpu         example         2               2               False 
 To delete a HostedCluster:
 
 ```shell
-hypershift destroy cluster kubevirt --name $CLUSTER_NAME
+hcp destroy cluster kubevirt --name $CLUSTER_NAME
 ```
 

--- a/docs/content/how-to/kubevirt/external-infrastructure.md
+++ b/docs/content/how-to/kubevirt/external-infrastructure.md
@@ -24,7 +24,7 @@ management and infrastructure clusters are distinctly different.
  * Creation of a namespace on the external infrastructure cluster for the KubeVirt worker nodes to be hosted in.
  * A kubeconfig for the external infrastructure cluster
 
-Once the prerequisites are met, the `hypershift` cli tool can be used to create
+Once the prerequisites are met, the `hcp` cli tool can be used to create
 the guest cluster. In order to place the KubeVirt worker VMs on the
 infrastructure cluster, use the `--infra-kubeconfig-file` and `--infra-namespace`
 arguments.
@@ -38,7 +38,7 @@ export MEM="6Gi"
 export CPU="2"
 export WORKER_COUNT="2"
 
-hypershift create cluster kubevirt \
+hcp create cluster kubevirt \
 --name $CLUSTER_NAME \
 --node-pool-replicas $WORKER_COUNT \
 --pull-secret $PULL_SECRET \

--- a/docs/content/how-to/kubevirt/ingress-and-dns.md
+++ b/docs/content/how-to/kubevirt/ingress-and-dns.md
@@ -48,7 +48,7 @@ export CPU="2"
 export WORKER_COUNT="2"
 export BASE_DOMAIN=hypershift.lab
 
-hypershift create cluster kubevirt \
+hcp create cluster kubevirt \
 --name $CLUSTER_NAME \
 --node-pool-replicas $WORKER_COUNT \
 --pull-secret $PULL_SECRET \
@@ -71,7 +71,7 @@ example                   example-admin-kubeconfig         Partial    True      
 If we access the HostedCluster this is what we will see:
 
 ```shell
-hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
+hcp create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
 ```
 
 ```shell

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -76,6 +76,9 @@ nav:
     - how-to/agent/create-agent-cluster.md
   - 'Kubevirt':
     - how-to/kubevirt/create-kubevirt-cluster.md
+    - how-to/kubevirt/ingress-and-dns.md
+    - how-to/kubevirt/configuring-storage.md
+    - how-to/kubevirt/external-infrastructure.md
   - 'None':
     - how-to/none/create-none-cluster.md
   - 'PowerVS':


### PR DESCRIPTION
This addresses two issues with the kubevirt platform docs.

1. Some new sections where not added to the documentation's index yaml, which caused these sections to not appear in the left hand navigation bar.
2. This transitions the documentation to reference the new `hcp` cli tool over the `hypershift` cli tool during cluster creation/destruction. The `hypershift` cli tool is still referenced as a method of installing a development version of the HyperShift Operator.