### PR TITLE
SDN-4042: Increase upgrade rollout timers

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -226,7 +226,10 @@ func WaitForNReadyNodesByNodePool(t *testing.T, ctx context.Context, client crcl
 	start := time.Now()
 
 	// waitTimeout for nodes to become Ready
-	waitTimeout := 30 * time.Minute
+	// NOTE: The upgrade times are originally 30 minutes each for all platforms except (KubevirtPlatform && PowerVSPlatform).
+	// Due to well-known reasons (https://issues.redhat.com/browse/SDN-4042), these numbers are increased to
+	// 45 minutes only for the 4.13->4.14 upgrades - for all platforms. This will be brought down in 4.15 release.
+	waitTimeout := 45 * time.Minute
 	switch platform {
 	case hyperv1.KubevirtPlatform:
 		waitTimeout = 45 * time.Minute


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

For interconnect upgrades (https://issues.redhat.com/browse/SDN-4042) - i.e when moving from OCP 4.13 to OCP 4.14 where IC is enabled, we do a 2 phase rollout of ovnkube-master and ovnkube-node pods in the openshift-ovn-kubernetes namespace. This is to ensure we have minimum disruption since major architectural components are being brought from control-plane down to the data-plane.
Since its a two phase roll out with each phase taking taking approximately 10mins, we effectively double the time it takes for OVNK component to upgrade thereby increasing the timeout thresholds for upgrades rollout. Thus opening this PR to push up the timers.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes SDN-4042

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.