### PR TITLE
OCPBUGS-17446: Set advertise-address in HCP etcd to resolvable name

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -192,7 +192,7 @@ func buildEtcdContainer(p *EtcdParams, namespace string) func(c *corev1.Containe
 --initial-advertise-peer-urls=https://${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc:2380 \
 --listen-peer-urls=https://%s:2380 \
 --listen-client-urls=https://%s:2379,https://localhost:2379 \
---advertise-client-urls=https://${HOSTNAME}.etcd-client.${NAMESPACE}.svc:2379 \
+--advertise-client-urls=https://${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc:2379 \
 --listen-metrics-urls=https://%s:2382 \
 --initial-cluster-token=etcd-cluster \
 --initial-cluster=${INITIAL_CLUSTER} \

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile_test.go
@@ -19,7 +19,7 @@ const (
 --initial-advertise-peer-urls=https://${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc:2380 \
 --listen-peer-urls=https://%s:2380 \
 --listen-client-urls=https://%s:2379,https://localhost:2379 \
---advertise-client-urls=https://${HOSTNAME}.etcd-client.${NAMESPACE}.svc:2379 \
+--advertise-client-urls=https://${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc:2379 \
 --listen-metrics-urls=https://%s:2382 \
 --initial-cluster-token=etcd-cluster \
 --initial-cluster=${INITIAL_CLUSTER} \

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
@@ -32,8 +32,8 @@ func ReconcileEtcdServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerR
 	dnsNames := []string{
 		fmt.Sprintf("etcd-client.%s.svc", secret.Namespace),
 		fmt.Sprintf("etcd-client.%s.svc.cluster.local", secret.Namespace),
-		fmt.Sprintf("*.etcd-client.%s.svc", secret.Namespace),
-		fmt.Sprintf("*.etcd-client.%s.svc.cluster.local", secret.Namespace),
+		fmt.Sprintf("*.etcd-discovery.%s.svc", secret.Namespace),
+		fmt.Sprintf("*.etcd-discovery.%s.svc.cluster.local", secret.Namespace),
 		"etcd-client",
 		"localhost",
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the host name used for an etcd member's advertise address and ensures that the etcd server certificate considers that address a valid address.

This allows referencing etcd members by their advertise address directly. The name that was used previously did not resolve.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-17446

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.