### PR TITLE
Allow overriding pod security admission label

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -197,6 +197,11 @@ const (
 	// AllowGuestWebhooksServiceLabel marks a service deployed in the control plane as a valid target
 	// for validating/mutating webhooks running in the guest cluster.
 	AllowGuestWebhooksServiceLabel = "hypershift.openshift.io/allow-guest-webhooks"
+
+	// PodSecurityAdmissionLabelOverrideAnnotation allows overriding the pod security admission label on
+	// hosted control plane namespacces. The default is 'Restricted'. Valid values are 'Restricted', 'Baseline', or 'Privileged'
+	// See https://github.com/openshift/enhancements/blob/master/enhancements/authentication/pod-security-admission.md
+	PodSecurityAdmissionLabelOverrideAnnotation = "hypershift.openshift.io/pod-security-admission-label-override"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -997,7 +997,12 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		controlPlaneNamespace.Labels["hypershift.openshift.io/hosted-control-plane"] = "true"
 
 		// Set pod security labels on HCP namespace
-		if useRestrictedPSA {
+		psaOverride := hcluster.Annotations[hyperv1.PodSecurityAdmissionLabelOverrideAnnotation]
+		if psaOverride != "" {
+			controlPlaneNamespace.Labels["pod-security.kubernetes.io/enforce"] = psaOverride
+			controlPlaneNamespace.Labels["pod-security.kubernetes.io/audit"] = psaOverride
+			controlPlaneNamespace.Labels["pod-security.kubernetes.io/warn"] = psaOverride
+		} else if useRestrictedPSA {
 			controlPlaneNamespace.Labels["pod-security.kubernetes.io/enforce"] = "restricted"
 			controlPlaneNamespace.Labels["pod-security.kubernetes.io/audit"] = "restricted"
 			controlPlaneNamespace.Labels["pod-security.kubernetes.io/warn"] = "restricted"


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces an annotation to override the pod security admission label for hosted control plane namespaces.

This is a follow up to https://github.com/openshift/hypershift/pull/2778 where the default PSA is now changed to 'Restricted'. For some consumers like IBM, this label may be too restrictive for other workloads they may want to run in the control plane namespace.


**Checklist**
- [x] Subject and description added to both, commit and PR.