### PR TITLE
Revert "[HOSTEDCP-1041] Defaulting webhook for self managed HCP"

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -1672,7 +1672,7 @@ type ManagedEtcdStorageSpec struct {
 	//
 	// +optional
 	// +immutable
-	RestoreSnapshotURL []string `json:"restoreSnapshotURL,omitempty"`
+	RestoreSnapshotURL []string `json:"restoreSnapshotURL"`
 }
 
 // PersistentVolumeEtcdStorageSpec is the configuration for PersistentVolume

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -26,6 +26,7 @@ import (
 	apifixtures "github.com/openshift/hypershift/api/fixtures"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/cmd/version"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/releaseinfo"
 )
@@ -156,6 +157,13 @@ type AzurePlatformOptions struct {
 }
 
 func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures.ExampleOptions, error) {
+	if len(opts.ReleaseImage) == 0 {
+		defaultVersion, err := version.LookupDefaultOCPVersion(opts.ReleaseStream)
+		if err != nil {
+			return nil, fmt.Errorf("release image is required when unable to lookup default OCP version: %w", err)
+		}
+		opts.ReleaseImage = defaultVersion.PullSpec
+	}
 	if err := defaultNetworkType(ctx, opts, &releaseinfo.RegistryClientProvider{}, os.ReadFile); err != nil {
 		return nil, fmt.Errorf("failed to default network: %w", err)
 	}
@@ -432,11 +440,7 @@ func CreateCluster(ctx context.Context, opts *CreateOptions, platformSpecificApp
 func defaultNetworkType(ctx context.Context, opts *CreateOptions, releaseProvider releaseinfo.Provider, readFile func(string) ([]byte, error)) error {
 	if opts.NetworkType != "" {
 		return nil
-	} else if opts.ReleaseImage == "" {
-		opts.NetworkType = string(hyperv1.OVNKubernetes)
-		return nil
 	}
-
 	version, err := getReleaseSemanticVersion(ctx, opts, releaseProvider, readFile)
 	if err != nil {
 		return fmt.Errorf("failed to get version for release image %s: %w", opts.ReleaseImage, err)

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -16,35 +16,26 @@ func TestDefaultNetworkType(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "Already configured, no change",
-			opts: &CreateOptions{
-				NetworkType:  "foo",
-				ReleaseImage: "4.11.0",
-			},
+			name:     "Already configured, no change",
+			opts:     &CreateOptions{NetworkType: "foo"},
 			expected: "foo",
 		},
 		{
-			name: "4.10, SDN",
-			opts: &CreateOptions{
-				ReleaseImage: "4.10.0",
-			},
+			name:     "4.10, SDN",
+			opts:     &CreateOptions{},
 			provider: &fake.FakeReleaseProvider{Version: "4.10.0"},
 			expected: "OpenShiftSDN",
 		},
 		{
-			name: "4.11, ovn-k",
-			opts: &CreateOptions{
-				ReleaseImage: "4.11.0",
-			},
+			name:     "4.11, ovn-k",
+			opts:     &CreateOptions{},
 			provider: &fake.FakeReleaseProvider{Version: "4.11.0"},
 			expected: "OVNKubernetes",
 		},
 		{
-			name: "4.12, ovn-k",
-			opts: &CreateOptions{
-				ReleaseImage: "4.12.0",
-			},
-			provider: &fake.FakeReleaseProvider{Version: "4.12.0"},
+			name:     "4.12, ovn-k",
+			opts:     &CreateOptions{},
+			provider: &fake.FakeReleaseProvider{Version: "4.11.0"},
 			expected: "OVNKubernetes",
 		},
 	}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -60,7 +60,6 @@ type Options struct {
 	ImageRefsFile                             string
 	HyperShiftOperatorReplicas                int32
 	Development                               bool
-	EnableDefaultingWebhook                   bool
 	EnableValidatingWebhook                   bool
 	EnableConversionWebhook                   bool
 	Template                                  bool
@@ -141,7 +140,7 @@ func (o *Options) ApplyDefaults() {
 	switch {
 	case o.Development:
 		o.HyperShiftOperatorReplicas = 0
-	case o.EnableDefaultingWebhook || o.EnableConversionWebhook:
+	case o.EnableConversionWebhook:
 		o.HyperShiftOperatorReplicas = 2
 	default:
 		o.HyperShiftOperatorReplicas = 1
@@ -164,7 +163,6 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", "hypershift", "The namespace in which to install HyperShift")
 	cmd.PersistentFlags().StringVar(&opts.HyperShiftImage, "hypershift-image", version.HyperShiftImage, "The HyperShift image to deploy")
 	cmd.PersistentFlags().BoolVar(&opts.Development, "development", false, "Enable tweaks to facilitate local development")
-	cmd.PersistentFlags().BoolVar(&opts.EnableDefaultingWebhook, "enable-defaulting-webhook", false, "Enable webhook for defaulting hypershift API types")
 	cmd.PersistentFlags().BoolVar(&opts.EnableValidatingWebhook, "enable-validating-webhook", false, "Enable webhook for validating hypershift API types")
 	cmd.PersistentFlags().MarkDeprecated("enable-validating-webhook", "This field is deprecated and has no effect")
 	cmd.PersistentFlags().BoolVar(&opts.EnableConversionWebhook, "enable-conversion-webhook", true, "Enable webhook for converting hypershift API types")
@@ -417,13 +415,6 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 	}.Build()
 	objects = append(objects, operatorRoleBinding)
 
-	if opts.EnableDefaultingWebhook {
-		mutatingWebhookConfiguration := assets.HyperShiftMutatingWebhookConfiguration{
-			Namespace: operatorNamespace,
-		}.Build()
-		objects = append(objects, mutatingWebhookConfiguration)
-	}
-
 	var oidcSecret *corev1.Secret
 	if opts.OIDCStorageProviderS3Credentials != "" {
 		oidcCreds, err := os.ReadFile(opts.OIDCStorageProviderS3Credentials)
@@ -557,7 +548,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 		Replicas:                       opts.HyperShiftOperatorReplicas,
 		EnableOCPClusterMonitoring:     opts.PlatformMonitoring == metrics.PlatformMonitoringAll,
 		EnableCIDebugOutput:            opts.EnableCIDebugOutput,
-		EnableWebhook:                  opts.EnableDefaultingWebhook || opts.EnableConversionWebhook,
+		EnableWebhook:                  opts.EnableConversionWebhook,
 		PrivatePlatform:                opts.PrivatePlatform,
 		AWSPrivateRegion:               opts.AWSPrivateRegion,
 		AWSPrivateSecret:               operatorCredentialsSecret,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -1,85 +1,22 @@
 package hostedcluster
 
 import (
-	"context"
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/support/supportedversion"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type hostedClusterDefaulter struct {
-}
-
-type nodePoolDefaulter struct {
-	client client.Client
-}
-
-func (defaulter *hostedClusterDefaulter) Default(ctx context.Context, obj runtime.Object) error {
-	hcluster, ok := obj.(*hyperv1.HostedCluster)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("expected a HostedCluster but got a %T", obj))
-	}
-
-	if hcluster.Spec.Release.Image != "" {
-		return nil
-	}
-
-	pullSpec, err := supportedversion.LookupLatestSupportedRelease(ctx)
-	if err != nil {
-		return fmt.Errorf("unable to find default release image: %w", err)
-	}
-	hcluster.Spec.Release.Image = pullSpec
-
-	return nil
-}
-
-func (defaulter *nodePoolDefaulter) Default(ctx context.Context, obj runtime.Object) error {
-	np, ok := obj.(*hyperv1.NodePool)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("expected a NodePool but got a %T", obj))
-	}
-
-	if np.Spec.Release.Image != "" {
-		return nil
-	} else if np.Spec.ClusterName == "" {
-		return fmt.Errorf("nodePool.Spec.ClusterName is a required field")
-	}
-
-	hc := &hyperv1.HostedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      np.Spec.ClusterName,
-			Namespace: np.Namespace,
-		},
-	}
-
-	err := defaulter.client.Get(ctx, client.ObjectKeyFromObject(hc), hc)
-	if err != nil {
-		return fmt.Errorf("error retrieving HostedCluster named [%s], %v", np.Spec.ClusterName, err)
-	}
-	np.Spec.Release.Image = hc.Spec.Release.Image
-
-	return nil
-}
-
-// SetupWebhookWithManager sets up HostedCluster webhooks.
+// SetupWebhookWithManager sets up webhooks.
 func SetupWebhookWithManager(mgr ctrl.Manager) error {
-
 	err := ctrl.NewWebhookManagedBy(mgr).
 		For(&hyperv1.HostedCluster{}).
-		WithDefaulter(&hostedClusterDefaulter{}).
 		Complete()
 	if err != nil {
 		return fmt.Errorf("unable to register hostedcluster webhook: %w", err)
 	}
 	err = ctrl.NewWebhookManagedBy(mgr).
 		For(&hyperv1.NodePool{}).
-		WithDefaulter(&nodePoolDefaulter{client: mgr.GetClient()}).
 		Complete()
 	if err != nil {
 		return fmt.Errorf("unable to register nodepool webhook: %w", err)
@@ -91,5 +28,4 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("unable to register hostedcontrolplane webhook: %w", err)
 	}
 	return nil
-
 }

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -1,11 +1,7 @@
 package supportedversion
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
 
 	"github.com/blang/semver"
@@ -79,44 +75,4 @@ func IsValidReleaseVersion(version, currentVersion, latestVersionSupported, minS
 	}
 
 	return nil
-}
-
-type ocpVersion struct {
-	Name        string `json:"name"`
-	PullSpec    string `json:"pullSpec"`
-	DownloadURL string `json:"downloadURL"`
-}
-
-// LookupLatestSupportedRelease picks the latest multi-arch image supported by this Hypershift Operator
-func LookupLatestSupportedRelease(ctx context.Context) (string, error) {
-	prefix := "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-multi/latest"
-	filter := fmt.Sprintf("in=>4.%d.%d+<+4.%d.0",
-		MinSupportedVersion.Minor, MinSupportedVersion.Patch, LatestSupportedVersion.Minor+1)
-
-	releaseURL := fmt.Sprintf("%s?%s", prefix, filter)
-
-	var version ocpVersion
-
-	req, err := http.NewRequestWithContext(ctx, "GET", releaseURL, nil)
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Unexpected status code: %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	err = json.Unmarshal(body, &version)
-	if err != nil {
-		return "", err
-	}
-	return version.PullSpec, nil
 }


### PR DESCRIPTION
Reverts openshift/hypershift#2864

Took out CI, must restore

`
2023-08-09T12:11:42Z	ERROR	Failed to create cluster	{"error": "failed to apply object \"clusters/c67a39c9c1920084cf95-mgmt\": HostedCluster.hypershift.openshift.io \"c67a39c9c1920084cf95-mgmt\" is invalid: spec.release.image: Invalid value: \"\": spec.release.image in body should match '^(\\w+\\S+)$'"}
github.com/openshift/hypershift/cmd/cluster/aws.NewCreateCommand.func1
`

Removal of the client-side release image defaulting in combination with the disabling (by default) the webhook caused this.

Example job
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn/1689157066083536896

cc @davidvossel 
