### PR TITLE
fix-CNV-30260: KubeVirt: fix failed conformance test

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/daemonset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/daemonset.yaml
@@ -12,7 +12,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 0
-      maxUnavailable: 1
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
## What this PR does / why we need it
The "[sig-arch] Managed cluster should only include cluster daemonsets that have maxUnavailable or maxSurge update of 10 percent or maxUnavailable of 33 percent [Suite:openshift/conformance/parallel]" conformance test is failing.

The kubevirt-csi-node DaemonSet in the KubeVirt gueest cluster is with wrong configurations: spec.updateStrategy.rollingUpdate.maxUnavailable must not be > 10%, but was 1.

This PR set it to  %10.

Fixes [CNV-30260](https://issues.redhat.com/browse/CNV-30260)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.