### PR TITLE
OCPBUGS-14611: Ignored cloud dangling objects after timeout on HC teardown

### DIFF
--- a/api/v1beta1/hostedcluster_conditions.go
+++ b/api/v1beta1/hostedcluster_conditions.go
@@ -39,10 +39,8 @@ const (
 	// A failure here may require external user intervention to resolve. E.g. cloud provider perms were corrupted. E.g. the guest cluster was broken
 	// and kube resource deletion that affects cloud infra like service type load balancer can't succeed.
 	CloudResourcesDestroyed ConditionType = "CloudResourcesDestroyed"
-	// HostedClusterDestroyed indicates that a hosted cluster is destroying. This condition really means that it has finished destroying,
-	// but the resource is waiting for the grace period so it can go away.
-	// This grace period was introduced in order to notify when cloud dangling objects are not deleted that the user created.
-	// This condition will be grabbed by OCM personnel to report any dangling objects to the user.
+	// HostedClusterDestroyed indicates that a hosted has finished destroying and that it is waiting for a destroy grace period to go away.
+	// The grace period is determined by the hypershift.openshift.io/destroy-grace-period annotation in the HostedCluster if present.
 	HostedClusterDestroyed ConditionType = "HostedClusterDestroyed"
 	// ExternalDNSReachable bubbles up the same condition from HCP. It signals if the configured external DNS is reachable.
 	// A failure here requires external user intervention to resolve. E.g. changing the external DNS domain or making sure the domain is created

--- a/api/v1beta1/hostedcluster_conditions.go
+++ b/api/v1beta1/hostedcluster_conditions.go
@@ -39,6 +39,11 @@ const (
 	// A failure here may require external user intervention to resolve. E.g. cloud provider perms were corrupted. E.g. the guest cluster was broken
 	// and kube resource deletion that affects cloud infra like service type load balancer can't succeed.
 	CloudResourcesDestroyed ConditionType = "CloudResourcesDestroyed"
+	// HostedClusterDestroyed indicates that a hosted cluster is destroying. This condition really means that it has finished destroying,
+	// but the resource is waiting for the grace period so it can go away.
+	// This grace period was introduced in order to notify when cloud dangling objects are not deleted that the user created.
+	// This condition will be grabbed by OCM personnel to report any dangling objects to the user.
+	HostedClusterDestroyed ConditionType = "HostedClusterDestroyed"
 	// ExternalDNSReachable bubbles up the same condition from HCP. It signals if the configured external DNS is reachable.
 	// A failure here requires external user intervention to resolve. E.g. changing the external DNS domain or making sure the domain is created
 	// and registered correctly.
@@ -150,11 +155,12 @@ const (
 
 // Reasons.
 const (
-	StatusUnknownReason       = "StatusUnknown"
-	AsExpectedReason          = "AsExpected"
-	NotFoundReason            = "NotFound"
-	WaitingForAvailableReason = "waitingForAvailable"
-	SecretNotFoundReason      = "SecretNotFound"
+	StatusUnknownReason         = "StatusUnknown"
+	AsExpectedReason            = "AsExpected"
+	NotFoundReason              = "NotFound"
+	WaitingForAvailableReason   = "WaitingForAvailable"
+	SecretNotFoundReason        = "SecretNotFound"
+	WaitingForGracePeriodReason = "WaitingForGracePeriod"
 
 	InfraStatusFailureReason           = "InfraStatusFailure"
 	WaitingOnInfrastructureReadyReason = "WaitingOnInfrastructureReady"

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -21,6 +21,9 @@ const (
 	SkipReleaseImageValidation                = "hypershift.openshift.io/skip-release-image-validation"
 	IdentityProviderOverridesAnnotationPrefix = "idpoverrides.hypershift.openshift.io/"
 	OauthLoginURLOverrideAnnotation           = "oauth.hypershift.openshift.io/login-url-override"
+	// HCDestroyGracePeriodAnnotation it's an annotation which will delay the HostedCluster destroy an amount of time in order to let OCM personnel to grab the CloudDanglingObjects and report them to the final user. It's an string which will be parsed
+	// sample: hypershift.openshift.io/destroy-grace-period: "600s"
+	HCDestroyGracePeriodAnnotation = "hypershift.openshift.io/destroy-grace-period"
 	// ControlPlanePriorityClass is for pods in the HyperShift Control Plane that are not API critical but still need elevated priority. E.g Cluster Version Operator.
 	ControlPlanePriorityClass = "hypershift.openshift.io/control-plane-priority-class"
 	// APICriticalPriorityClass is for pods that are required for API calls and resource admission to succeed. This includes pods like kube-apiserver, aggregated API servers, and webhooks.

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -21,7 +21,8 @@ const (
 	SkipReleaseImageValidation                = "hypershift.openshift.io/skip-release-image-validation"
 	IdentityProviderOverridesAnnotationPrefix = "idpoverrides.hypershift.openshift.io/"
 	OauthLoginURLOverrideAnnotation           = "oauth.hypershift.openshift.io/login-url-override"
-	// HCDestroyGracePeriodAnnotation it's an annotation which will delay the HostedCluster destroy an amount of time in order to let OCM personnel to grab the CloudDanglingObjects and report them to the final user. It's an string which will be parsed
+	// HCDestroyGracePeriodAnnotation is an annotation which will delay the removal of the HostedCluster finalizer to allow consumers to read the status of the HostedCluster
+	// before the resource goes away. The format of the annotation is a go duration string with a numeric component and unit.
 	// sample: hypershift.openshift.io/destroy-grace-period: "600s"
 	HCDestroyGracePeriodAnnotation = "hypershift.openshift.io/destroy-grace-period"
 	// ControlPlanePriorityClass is for pods in the HyperShift Control Plane that are not API critical but still need elevated priority. E.g Cluster Version Operator.

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -103,7 +103,7 @@ const (
 	ImageStreamAutoscalerImage             = "cluster-autoscaler"
 	ImageStreamClusterMachineApproverImage = "cluster-machine-approver"
 
-	resourceDeletionTimeout = 2 * time.Minute
+	resourceDeletionTimeout = 10 * time.Minute
 
 	hcpReadyRequeueInterval    = 1 * time.Minute
 	hcpNotReadyRequeueInterval = 15 * time.Second
@@ -3746,7 +3746,7 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 		}
 
 		if timeElapsed > resourceDeletionTimeout {
-			log.Info("Giving up on resource deletion since there has not been an update before timeout", "timeElapsed", duration.ShortHumanDuration(timeElapsed))
+			log.Info("Giving up on resource deletion after timeout", "timeElapsed", duration.ShortHumanDuration(timeElapsed))
 			return true, nil
 		}
 		return false, nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -69,8 +68,9 @@ import (
 )
 
 const (
-	ControllerName       = "resources"
-	SecretHashAnnotation = "hypershift.openshift.io/kubeadmin-secret-hash"
+	ControllerName                   = "resources"
+	SecretHashAnnotation             = "hypershift.openshift.io/kubeadmin-secret-hash"
+	RegistryConfigDeletionAnnotation = "hypershift.openshift.io/registry-config-deletion-timestamp"
 )
 
 var (
@@ -79,6 +79,10 @@ var (
 	// only once.
 	deleteDNSOperatorDeploymentOnce sync.Once
 	deleteCVORemovedResourcesOnce   sync.Once
+
+	// deletionSecondsTimeout is set to 600s or 10m and it's a confortable amount
+	// of time that needs the controller to give up on cloud resource deletion.
+	deletionSecondsTimeout = 600 * time.Second
 )
 
 type reconciler struct {
@@ -1547,22 +1551,42 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 
 	var status metav1.ConditionStatus
 	var reason, message string
+	var ltt metav1.Time
+	var ignoredTotal int
+	requeue := false
 
 	if err != nil {
 		reason = "ErrorOccurred"
 		status = metav1.ConditionFalse
 		message = fmt.Sprintf("Error: %v", err)
 	} else {
-		if remaining.Len() == 0 {
+		if len(remaining) == 0 {
 			reason = "CloudResourcesDestroyed"
 			status = metav1.ConditionTrue
 			message = "All guest resources destroyed"
+			ltt = metav1.Now()
 		} else {
+			// check remaining
+			remainingSlice := make([]string, 0)
+			for object, ignored := range remaining {
+				remainingSlice = append(remainingSlice, object)
+				if ignored {
+					ignoredTotal += 1
+				}
+			}
+
 			reason = "RemainingCloudResources"
 			status = metav1.ConditionFalse
-			message = fmt.Sprintf("Remaining resources: %s", strings.Join(remaining.List(), ","))
+			message = fmt.Sprintf("Remaining resources: %s", strings.Join(remainingSlice, ","))
+			// Only update the LastTransitionTime when the controller is still waiting for remaining objects
+			// or ltt is not set.
+			if len(remaining) > ignoredTotal {
+				ltt = metav1.Now()
+				requeue = true
+			}
 		}
 	}
+
 	resourcesDestroyedCond := &metav1.Condition{
 		Type:    string(hyperv1.CloudResourcesDestroyed),
 		Status:  status,
@@ -1571,7 +1595,7 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 		// Here LastTransitionTime is used to indicate the last time the condition was updated by this
 		// controller. This is used by the CPO as a heartbeat to determine whether resource deletion is
 		// still in progress.
-		LastTransitionTime: metav1.Now(),
+		LastTransitionTime: ltt,
 	}
 	// Ensure the LastTransitionTime is updated because the hostedcontrolplane controller relies on that
 	// timestamp to use as a heartbeat.
@@ -1580,7 +1604,7 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 		return ctrl.Result{}, fmt.Errorf("failed to set resources destroyed condition: %w", err)
 	}
 
-	if remaining.Len() > 0 {
+	if requeue {
 		// If we are still waiting for resources to go away, ensure we are requeued in at most 30 secs,
 		// so we can at least update the timestamp on the condition.
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -1615,56 +1639,68 @@ func setStatusConditionWithTransitionUpdate(conditions *[]metav1.Condition, newC
 	existingCondition.ObservedGeneration = newCondition.ObservedGeneration
 }
 
-func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyperv1.HostedControlPlane) (sets.String, error) {
+func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyperv1.HostedControlPlane) (map[string]bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	remaining := sets.NewString()
+	remainingIgnoredResources := make(map[string]bool)
 	log.Info("Ensuring resource creation is blocked in cluster")
 	if err := r.ensureResourceCreationIsBlocked(ctx); err != nil {
-		return remaining, err
+		return remainingIgnoredResources, err
 	}
+
 	var errs []error
 	log.Info("Ensuring image registry storage is removed")
-	removed, err := r.ensureImageRegistryStorageRemoved(ctx)
+	removed, ignored, err := r.ensureImageRegistryStorageRemoved(ctx)
 	if err != nil {
 		errs = append(errs, err)
 	}
-	if !removed {
-		remaining.Insert("image-registry")
+	if !removed && !ignored {
+		remainingIgnoredResources["image-registry"] = false
+	} else if ignored {
+		remainingIgnoredResources["image-registry"] = true
 	} else {
 		log.Info("Image registry is removed")
 	}
+
 	log.Info("Ensuring ingress controllers are removed")
-	removed, err = r.ensureIngressControllersRemoved(ctx, hcp)
+	removed, ignored, err = r.ensureIngressControllersRemoved(ctx, hcp)
 	if err != nil {
 		errs = append(errs, err)
 	}
-	if !removed {
-		remaining.Insert("ingress-controllers")
+	if !removed && !ignored {
+		remainingIgnoredResources["ingress-controllers"] = false
+	} else if ignored {
+		remainingIgnoredResources["ingress-controllers"] = true
 	} else {
 		log.Info("Ingress controllers are removed")
 	}
+
 	log.Info("Ensuring load balancers are removed")
-	removed, err = r.ensureServiceLoadBalancersRemoved(ctx)
+	removed, ignored, err = r.ensureServiceLoadBalancersRemoved(ctx)
 	if err != nil {
 		errs = append(errs, err)
 	}
-	if !removed {
-		remaining.Insert("loadbalancers")
+	if !removed && !ignored {
+		remainingIgnoredResources["loadbalancers"] = false
+	} else if ignored {
+		remainingIgnoredResources["loadbalancers"] = true
 	} else {
 		log.Info("Load balancers are removed")
 	}
+
 	log.Info("Ensuring persistent volumes are removed")
-	removed, err = r.ensurePersistentVolumesRemoved(ctx)
+	removed, ignored, err = r.ensurePersistentVolumesRemoved(ctx)
 	if err != nil {
 		errs = append(errs, err)
 	}
-	if !removed {
-		remaining.Insert("persistent-volumes")
+	if !removed && !ignored {
+		remainingIgnoredResources["persistent-volumes"] = false
+	} else if ignored {
+		remainingIgnoredResources["persistent-volumes"] = true
 	} else {
 		log.Info("Persistent volumes are removed")
 	}
 
-	return remaining, errors.NewAggregate(errs)
+	return remainingIgnoredResources, errors.NewAggregate(errs)
 }
 
 func (r *reconciler) ensureGuestAdmissionWebhooksAreValid(ctx context.Context) error {
@@ -1801,16 +1837,37 @@ func reconcileCreationBlockerWebhook(wh *admissionregistrationv1.ValidatingWebho
 	}
 }
 
-func (r *reconciler) ensureIngressControllersRemoved(ctx context.Context, hcp *hyperv1.HostedControlPlane) (bool, error) {
+// ensureIngressControllersRemoved returns firstly a boolean, indicating if the resource involved (IngressimageController)
+// has been deleted or not. Also it returns another boolean which indicates if that resources is being ignored because of the
+// resource deletion timeout and an error if one occurred.
+func (r *reconciler) ensureIngressControllersRemoved(ctx context.Context, hcp *hyperv1.HostedControlPlane) (bool, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
+
 	ingressControllers := &operatorv1.IngressControllerList{}
 	if err := r.client.List(ctx, ingressControllers); err != nil {
-		return false, fmt.Errorf("failed to list ingress controllers: %w", err)
+		return false, false, fmt.Errorf("failed to list ingress controllers: %w", err)
 	}
 	if len(ingressControllers.Items) == 0 {
 		log.Info("There are no ingresscontrollers, nothing to do")
-		return true, nil
+		return true, false, nil
 	}
+
+	// If the DeletionTimestamp reaches the gracePeriod, the controller
+	// should ignore the object and continue with the deletion
+	counter := 0
+	for i := range ingressControllers.Items {
+		ic := &ingressControllers.Items[i]
+		if ic.DeletionTimestamp != nil {
+			if time.Since(ic.ObjectMeta.DeletionTimestamp.Time) > deletionSecondsTimeout {
+				counter += 1
+			}
+		}
+	}
+	if counter == len(ingressControllers.Items) {
+		log.Info("ingressControllers deletion timeout reached, ignoring object and continuing with the deprovision")
+		return false, true, nil
+	}
+
 	var errs []error
 	for i := range ingressControllers.Items {
 		ic := &ingressControllers.Items[i]
@@ -1822,14 +1879,14 @@ func (r *reconciler) ensureIngressControllersRemoved(ctx context.Context, hcp *h
 		}
 	}
 	if len(errs) > 0 {
-		return false, fmt.Errorf("failed to delete ingress controllers: %w", errors.NewAggregate(errs))
+		return false, false, fmt.Errorf("failed to delete ingress controllers: %w", errors.NewAggregate(errs))
 	}
 
 	// Force deleting pods under openshift-ingress to unblock ingress-controller deletion.
 	// Ingress-operator is dependent on these pods deletion on removing the finalizers of ingress-controller.
 	routerPods := &corev1.PodList{}
 	if err := r.uncachedClient.List(ctx, routerPods, &client.ListOptions{Namespace: "openshift-ingress"}); err != nil {
-		return false, fmt.Errorf("failed to list pods under openshift-ingress namespace: %w", err)
+		return false, false, fmt.Errorf("failed to list pods under openshift-ingress namespace: %w", err)
 	}
 
 	for i := range routerPods.Items {
@@ -1841,7 +1898,7 @@ func (r *reconciler) ensureIngressControllersRemoved(ctx context.Context, hcp *h
 	}
 
 	if len(errs) > 0 {
-		return false, fmt.Errorf("failed to force delete pods under openshift-ingress namespace: %w", errors.NewAggregate(errs))
+		return false, false, fmt.Errorf("failed to force delete pods under openshift-ingress namespace: %w", errors.NewAggregate(errs))
 	}
 
 	// Remove ingress service and route that were created by HCCO in case of basedomain passthrough feature is enabled
@@ -1879,40 +1936,71 @@ func (r *reconciler) ensureIngressControllersRemoved(ctx context.Context, hcp *h
 	}
 
 	if len(errs) > 0 {
-		return false, fmt.Errorf("failed to delete ingress resources on infra cluster: %w", errors.NewAggregate(errs))
+		return false, false, fmt.Errorf("failed to delete ingress resources on infra cluster: %w", errors.NewAggregate(errs))
 	}
 
-	return false, nil
+	return false, false, nil
 }
 
-func (r *reconciler) ensureImageRegistryStorageRemoved(ctx context.Context) (bool, error) {
+// ensureImageRegistryStorageRemoved returns firstly a boolean, indicating if the resource involved (imageRegistry)
+// has been deleted or not. Also it returns another boolean which indicates if that resources is being ignored because of the
+// resource deletion timeout and an error if one occurred.
+func (r *reconciler) ensureImageRegistryStorageRemoved(ctx context.Context) (bool, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	registryConfig := manifests.Registry()
 	if err := r.client.Get(ctx, client.ObjectKeyFromObject(registryConfig), registryConfig); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("registry operator config does not exist, nothing to do")
-			return true, nil
+			return true, false, nil
 		}
-		return false, fmt.Errorf("failed to get registry operator configuration: %w", err)
+		return false, false, fmt.Errorf("failed to get registry operator configuration: %w", err)
 	}
+
+	// If the registryConfig has a RegistryConfigDeletionAnnotation annotation will parse the timestamp included
+	// and check if the timestamp exceeds the timeout.
+	if registryConfig.Annotations[RegistryConfigDeletionAnnotation] != "" {
+		annotationTimestamp, err := time.Parse(time.RFC3339, registryConfig.Annotations[RegistryConfigDeletionAnnotation])
+		if err != nil {
+			if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
+				registryConfig.Annotations[RegistryConfigDeletionAnnotation] = ""
+				return nil
+			}); err != nil {
+				return false, false, fmt.Errorf("failed to update image registry annotation: %w", err)
+			}
+		}
+		if time.Since(annotationTimestamp) > deletionSecondsTimeout {
+			log.Info("registry config deletion timeout reached, ignoring object and continuing with the deprovision")
+			return false, true, nil
+		}
+	}
+
 	// If storage has already been removed, nothing to do
 	// When the registry operator has been removed, management state in status is currently cleared.
 	if registryConfig.Status.Storage.ManagementState == "" || registryConfig.Status.Storage.ManagementState == "Removed" {
 		log.Info("Registry operator management state is blank or removed, done cleaning up")
-		return true, nil
+		return true, false, nil
 	}
+
 	log.Info("Setting management state for registry operator to removed")
 	if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
 		registryConfig.Spec.ManagementState = operatorv1.Removed
+		if registryConfig.Annotations == nil {
+			registryConfig.Annotations = make(map[string]string)
+		}
+
+		if registryConfig.Annotations[RegistryConfigDeletionAnnotation] == "" {
+			registryConfig.Annotations[RegistryConfigDeletionAnnotation] = time.Now().Format(time.RFC3339)
+		}
 		return nil
 	}); err != nil {
-		return false, fmt.Errorf("failed to update image registry management state: %w", err)
+		return false, false, fmt.Errorf("failed to update image registry management state: %w", err)
 	}
-	return false, nil
+	return false, false, nil
 }
 
-func (r *reconciler) ensureServiceLoadBalancersRemoved(ctx context.Context) (bool, error) {
-	_, err := cleanupResources(ctx, r.client, &corev1.ServiceList{}, func(obj client.Object) bool {
+func (r *reconciler) ensureServiceLoadBalancersRemoved(ctx context.Context) (bool, bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	_, _, err := cleanupResources(ctx, r.client, &corev1.ServiceList{}, func(obj client.Object) bool {
 		svc := obj.(*corev1.Service)
 		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 			return false
@@ -1927,37 +2015,62 @@ func (r *reconciler) ensureServiceLoadBalancersRemoved(ctx context.Context) (boo
 		return true
 	}, false)
 	if err != nil {
-		return false, fmt.Errorf("failed to remove load balancer services: %w", err)
+		return false, false, fmt.Errorf("failed to remove load balancer services: %w", err)
 	}
 
-	removed, err := allLoadBalancersRemoved(ctx, r.client)
+	removed, ignored, err := allLoadBalancersRemoved(ctx, r.client)
 	if err != nil {
-		return false, fmt.Errorf("error checking load balancer services: %w", err)
+		return false, false, fmt.Errorf("error checking load balancer services: %w", err)
 	}
 
-	return removed, nil
+	if ignored {
+		log.Info("giving up in load balancer deletion")
+		return true, ignored, nil
+	}
+
+	return removed, ignored, nil
 }
 
-func (r *reconciler) ensurePersistentVolumesRemoved(ctx context.Context) (bool, error) {
+func (r *reconciler) ensurePersistentVolumesRemoved(ctx context.Context) (bool, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	pvs := &corev1.PersistentVolumeList{}
 	if err := r.client.List(ctx, pvs); err != nil {
-		return false, fmt.Errorf("cannot list persistent volumes: %w", err)
+		return false, false, fmt.Errorf("cannot list persistent volumes: %w", err)
 	}
+
+	pvcsRemain, ignored, err := cleanupResources(ctx, r.client, &corev1.PersistentVolumeClaimList{}, nil, false)
+	if err != nil {
+		return false, false, fmt.Errorf("failed to remove persistent volume claims: %w", err)
+	}
+
+	if ignored {
+		log.Info("giving up in persistent volume claim deletion")
+		return true, ignored, nil
+	}
+
 	if len(pvs.Items) == 0 {
 		log.Info("There are no more persistent volumes. Nothing to cleanup.")
-		return true, nil
+		return true, false, nil
 	}
-	if _, err := cleanupResources(ctx, r.client, &corev1.PersistentVolumeClaimList{}, nil, false); err != nil {
-		return false, fmt.Errorf("failed to remove persistent volume claims: %w", err)
-	}
-	if _, err := cleanupResources(ctx, r.uncachedClient, &corev1.PodList{}, func(obj client.Object) bool {
+
+	if _, _, err := cleanupResources(ctx, r.uncachedClient, &corev1.PodList{}, func(obj client.Object) bool {
 		pod := obj.(*corev1.Pod)
 		return hasAttachedPVC(pod)
 	}, true); err != nil {
-		return false, fmt.Errorf("failed to remove pods: %w", err)
+		return false, false, fmt.Errorf("failed to remove pods: %w", err)
 	}
-	return false, nil
+
+	if !pvcsRemain {
+		_, ignored, err := cleanupResources(ctx, r.client, &corev1.PersistentVolumeList{}, nil, false)
+		if err != nil {
+			return false, false, fmt.Errorf("failed to remove pending persistent volumes: %w", err)
+		}
+		if ignored {
+			log.Info("giving up in persistent volume deletion")
+			return true, ignored, nil
+		}
+	}
+	return false, false, nil
 }
 
 func (r *reconciler) reconcileInstallConfigMap(ctx context.Context, releaseImage *releaseinfo.ReleaseImage) error {
@@ -1999,35 +2112,58 @@ func shouldCleanupCloudResources(hcp *hyperv1.HostedControlPlane) bool {
 
 // cleanupResources generically deletes resources of a given type using an optional filter
 // function. The result is a boolean indicating whether resources were found that match
-// the filter and an error if one occurred.
-func cleanupResources(ctx context.Context, c client.Client, list client.ObjectList, filter func(client.Object) bool, force bool) (bool, error) {
+// the filter, another boolean which indicate if resource is being ignored because of the
+// resource deletion timeout and an error if one occurred.
+func cleanupResources(ctx context.Context, c client.Client, list client.ObjectList, filter func(client.Object) bool, force bool) (bool, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if err := c.List(ctx, list); err != nil {
-		return false, fmt.Errorf("cannot list %T: %w", list, err)
+		return false, false, fmt.Errorf("cannot list %T: %w", list, err)
 	}
 
 	var errs []error
 	foundResource := false
 	a := listAccessor(list)
+	ignoredObjects := make(map[string]bool)
+
 	for i := 0; i < a.len(); i++ {
 		obj := a.item(i)
 		if filter == nil || filter(obj) {
 			foundResource = true
+			var deleteErr error
 			if obj.GetDeletionTimestamp().IsZero() {
+				ignoredObjects[fmt.Sprintf("%s-%s-%s", obj.GetNamespace(), obj.GetName(), obj.GetObjectKind().GroupVersionKind().Kind)] = false
 				log.Info("Deleting resource", "type", fmt.Sprintf("%T", obj), "name", client.ObjectKeyFromObject(obj).String())
-				var deleteErr error
 				if force {
 					deleteErr = c.Delete(ctx, obj, &client.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)})
 				} else {
 					deleteErr = c.Delete(ctx, obj)
 				}
-				if deleteErr != nil {
-					errs = append(errs, deleteErr)
+			}
+			// If the cloudResource is still there after the timeout, it's marked as removed
+			if ts := obj.GetDeletionTimestamp(); ts != nil {
+				if time.Since(ts.Time) > deletionSecondsTimeout {
+					log.Info(fmt.Sprintf("deletion timeout reached for: %s-%s-%s", obj.GetNamespace(), obj.GetName(), obj.GetObjectKind().GroupVersionKind().Kind))
+					ignoredObjects[fmt.Sprintf("%s-%s-%s", obj.GetNamespace(), obj.GetName(), obj.GetObjectKind().GroupVersionKind().Kind)] = true
 				}
+			}
+			if deleteErr != nil {
+				errs = append(errs, deleteErr)
 			}
 		}
 	}
-	return foundResource, errors.NewAggregate(errs)
+
+	timedOut := 0
+	for obj := range ignoredObjects {
+		if ignoredObjects[obj] {
+			timedOut += 1
+		}
+		if len(ignoredObjects) == timedOut {
+			log.Info("deletion timeout reached in all the objects, ignoring them and continuing with the deprovision", "IgnoredObjects", ignoredObjects)
+			return foundResource, true, nil
+		}
+
+	}
+	return foundResource, false, errors.NewAggregate(errs)
 }
 
 type genericListAccessor struct {
@@ -2118,19 +2254,24 @@ func (r *reconciler) reconcileImageContentPolicyType(ctx context.Context, hcp *h
 
 // allLoadBalancersRemoved checks any service of type corev1.ServiceTypeLoadBalancer exists.
 // If any one service of type corev1.ServiceTypeLoadBalancer exists, will return false or else will return true.
-func allLoadBalancersRemoved(ctx context.Context, c client.Client) (bool, error) {
+func allLoadBalancersRemoved(ctx context.Context, c client.Client) (bool, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	list := &corev1.ServiceList{}
 	if err := c.List(ctx, list); err != nil {
-		return false, fmt.Errorf("cannot list %T: %w", list, err)
+		return false, false, fmt.Errorf("cannot list %T: %w", list, err)
 	}
 
 	for _, svc := range list.Items {
 		if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
 			log.Info("Waiting on service of type LoadBalancer to be deleted", "name", svc.Name, "namespace", svc.Namespace)
-			return false, nil
+			if svc.DeletionTimestamp != nil && time.Since(svc.DeletionTimestamp.Time) > deletionSecondsTimeout {
+				log.Info("load balancer deletion timeout reached, ignoring object and continuing with the deprovision")
+				return false, true, nil
+			}
+
+			return false, false, nil
 		}
 	}
 
-	return true, nil
+	return true, false, nil
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -486,7 +486,6 @@ func TestDestroyCloudResources(t *testing.T) {
 		ingressControllers := &operatorv1.IngressControllerList{}
 		err := c.List(context.Background(), ingressControllers)
 		g.Expect(err).ToNot(HaveOccurred())
-		fmt.Println(len(ingressControllers.Items))
 		g.Expect(len(ingressControllers.Items)).To(Equal(0))
 	}
 
@@ -615,7 +614,6 @@ func TestDestroyCloudResources(t *testing.T) {
 		cond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
 		g.Expect(cond).ToNot(BeNil())
 		g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-		g.Expect(cond.LastTransitionTime.Time.After(originalConditionTime)).To(BeTrue())
 	}
 
 	tests := []struct {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -486,6 +486,7 @@ func TestDestroyCloudResources(t *testing.T) {
 		ingressControllers := &operatorv1.IngressControllerList{}
 		err := c.List(context.Background(), ingressControllers)
 		g.Expect(err).ToNot(HaveOccurred())
+		fmt.Println(len(ingressControllers.Items))
 		g.Expect(len(ingressControllers.Items)).To(Equal(0))
 	}
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2867,10 +2867,8 @@ When this is false for too long and there&rsquo;s no clear indication in the &ld
 an error that may require user intervention to resolve.</p>
 </td>
 </tr><tr><td><p>&#34;HostedClusterDestroyed&#34;</p></td>
-<td><p>HostedClusterDestroyed indicates that a hosted cluster is destroying. This condition really means that it has finished destroying,
-but the resource is waiting for the grace period so it can go away.
-This grace period was introduced in order to notify when cloud dangling objects are not deleted that the user created.
-This condition will be grabbed by OCM personnel to report any dangling objects to the user.</p>
+<td><p>HostedClusterDestroyed indicates that a hosted has finished destroying and that it is waiting for a destroy grace period to go away.
+The grace period is determined by the hypershift.openshift.io/destroy-grace-period annotation in the HostedCluster if present.</p>
 </td>
 </tr><tr><td><p>&#34;Progressing&#34;</p></td>
 <td><p>HostedClusterProgressing indicates whether the HostedCluster is attempting

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2866,6 +2866,12 @@ When this is false for too long and there&rsquo;s no clear indication in the &ld
 <td><p>HostedClusterDegraded indicates whether the HostedCluster is encountering
 an error that may require user intervention to resolve.</p>
 </td>
+</tr><tr><td><p>&#34;HostedClusterDestroyed&#34;</p></td>
+<td><p>HostedClusterDestroyed indicates that a hosted cluster is destroying. This condition really means that it has finished destroying,
+but the resource is waiting for the grace period so it can go away.
+This grace period was introduced in order to notify when cloud dangling objects are not deleted that the user created.
+This condition will be grabbed by OCM personnel to report any dangling objects to the user.</p>
+</td>
 </tr><tr><td><p>&#34;Progressing&#34;</p></td>
 <td><p>HostedClusterProgressing indicates whether the HostedCluster is attempting
 an initial deployment or upgrade.

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -99,6 +99,7 @@ type StartOptions struct {
 	OIDCStorageProviderS3Region      string
 	OIDCStorageProviderS3Credentials string
 	EnableUWMTelemetryRemoteWrite    bool
+	HCDestroyGracePeriod             time.Duration
 }
 
 func NewStartCommand() *cobra.Command {

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -99,7 +99,6 @@ type StartOptions struct {
 	OIDCStorageProviderS3Region      string
 	OIDCStorageProviderS3Credentials string
 	EnableUWMTelemetryRemoteWrite    bool
-	HCDestroyGracePeriod             time.Duration
 }
 
 func NewStartCommand() *cobra.Command {


### PR DESCRIPTION
This patch basically adds a HostedCluster destroy grace period when there are cloud dangling objects that Hypershift cannot delete. It includes a default timeout, initially set to 0 seconds, and it should be increased depending of the deployment needs.
    
If the Time.Now() reaches the DeletionTimestamp + timeout (of that concrete object), the controller mark that object as ignored and it will continue with deprovisioning.
Cloud objects involved:
    
    - ImageRegistryStorage
    - IngressControllers
    - LoadBalancers
    - PersistentVolumes
    
When the cluster is marked as deleted but not finalized, a new condition is created "HostedClusterDestroyed". That condition will give extra time for OCM to grab the non deleted cloud dangling objects and send a notification to the final user. After that the finalizer is deleted and the HostedCluster fully destroyed
   
**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-14611](https://issues.redhat.com/browse/OCPBUGS-14611)
Fixes #[OCPBUGS-16233](https://issues.redhat.com/browse/OCPBUGS-16233)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.