### PR TITLE
OCPBUGS-18072: Set emptyDir storage for the image registry only on initial time for None and Kubevirt platform

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/registry.go
@@ -25,9 +25,10 @@ func ReconcileRegistryConfig(cfg *imageregistryv1.Config, platform hyperv1.Platf
 	if cfg.Spec.HTTPSecret == "" {
 		cfg.Spec.HTTPSecret = generateImageRegistrySecret()
 	}
-	if (platform == hyperv1.KubevirtPlatform || platform == hyperv1.NonePlatform) &&
-		cfg.Spec.Storage.EmptyDir == nil {
 
+	// Initially assign storage as emptyDir for KubevirtPlatform and NonePlatform
+	// Allow user to change storage afterwards
+	if cfg.ResourceVersion == "" && (platform == hyperv1.KubevirtPlatform || platform == hyperv1.NonePlatform) {
 		cfg.Spec.Storage = imageregistryv1.ImageRegistryConfigStorage{EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{}}
 	}
 	// IBM Cloud platform allows to initialize the registry config and then afterwards the client is in full control of the updates


### PR DESCRIPTION
This allows the user to override with custom storage for image registry

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.