### PR TITLE
HOSTEDCP-1022: Set Arch to amd64

### DIFF
--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -16,6 +16,7 @@ import (
 func NewCreateCommands() *cobra.Command {
 	opts := &core.CreateOptions{
 		AdditionalTrustBundle:          "",
+		Arch:                           "amd64",
 		ClusterCIDR:                    "10.132.0.0/14",
 		ControlPlaneAvailabilityPolicy: "HighlyAvailable",
 		ImageContentSources:            "",


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets Arch to amd64 so the InstanceType is chosen through the HCP CLI. This is consistent with how the hypershift CLI sets Arch as well.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [HOSTEDCP-1022](https://issues.redhat.com/browse/HOSTEDCP-1022)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.