### PR TITLE
HOSTEDCP-1081: Perform etcd recovery when etcd member data is lost

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile_test.go
@@ -13,6 +13,11 @@ import (
 
 const (
 	etcdScriptTemplate = `
+CLUSTER_STATE="new"
+if [[ -f /etc/etcd/clusterstate/existing ]]; then
+  CLUSTER_STATE="existing"
+fi
+
 /usr/bin/etcd \
 --data-dir=/var/lib/data \
 --name=${HOSTNAME} \
@@ -23,7 +28,7 @@ const (
 --listen-metrics-urls=https://%s:2382 \
 --initial-cluster-token=etcd-cluster \
 --initial-cluster=${INITIAL_CLUSTER} \
---initial-cluster-state=new \
+--initial-cluster-state=${CLUSTER_STATE} \
 --quota-backend-bytes=${QUOTA_BACKEND_BYTES} \
 --snapshot-count=10000 \
 --peer-client-cert-auth=true \


### PR DESCRIPTION
**What this PR does / why we need it**:
When an etcd member's data has been lost, the only recourse we currently have is to do a hacky manual recovery. With this change, it is as simple as deleting the bad member's pvc and pod to restore a member.

Automates the steps described in https://issues.redhat.com/browse/HOSTEDCP-1081

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1081](https://issues.redhat.com//browse/HOSTEDCP-1081)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.