### PR TITLE
HOSTEDCP-1085: Create a monitoring dashboard per HostedCluster

### DIFF
--- a/cmd/install/assets/dashboard-template/monitoring-dashboard-template.json
+++ b/cmd/install/assets/dashboard-template/monitoring-dashboard-template.json
@@ -1,0 +1,301 @@
+{
+    "annotations": {
+        "list": [
+
+        ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "links": [
+
+    ],
+    "refresh": "10s",
+    "rows": [
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                    "aliasColors": {
+
+                    },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 10,
+                    "id": 7,
+                    "interval": "1m",
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "rightSide": true,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 0,
+                    "links": [
+
+                    ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+
+                    ],
+                    "spaceLength": 10,
+                    "span": 12,
+                    "stack": true,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"__CONTROL_PLANE_NAMESPACE__\"}) by (pod)",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{pod}}",
+                            "legendLink": null
+                        }
+                    ],
+                    "thresholds": [
+
+                    ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "CPU Usage",
+                    "tooltip": {
+                        "shared": false,
+                        "sort": 2,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [
+
+                        ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "CPU",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                    "aliasColors": {
+
+                    },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 10,
+                    "id": 9,
+                    "interval": "1m",
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "rightSide": true,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 0,
+                    "links": [
+
+                    ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+
+                    ],
+                    "spaceLength": 10,
+                    "span": 12,
+                    "stack": true,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\", namespace=\"__CONTROL_PLANE_NAMESPACE__\"}) by (pod)",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{pod}}",
+                            "legendLink": null
+                        }
+                    ],
+                    "thresholds": [
+
+                    ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Memory Usage (w/o cache)",
+                    "tooltip": {
+                        "shared": false,
+                        "sort": 2,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [
+
+                        ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "bytes",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Memory",
+            "titleSize": "h6"
+        }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+        "hosted-control-planes"
+    ],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "text": "default",
+                    "value": "default"
+                },
+                "hide": 0,
+                "label": "Data Source",
+                "name": "datasource",
+                "options": [
+
+                ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "text": "",
+                    "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [
+
+                ],
+                "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [
+
+                ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "UTC",
+    "title": "Hosted Control Planes / __NAMESPACE__ / __NAME__",
+    "version": 0
+}

--- a/docs/content/how-to/per-hostedcluster-dashboard.md
+++ b/docs/content/how-to/per-hostedcluster-dashboard.md
@@ -1,0 +1,26 @@
+# Create Monitoring Dashboard per Hosted Cluster
+
+The HyperShift operator can create/destroy a separate monitoring dashboard in the console of the management cluster for each HostedCluster that it manages. This functionality can be optionally enabled on installation of the HyperShift operator.
+
+### Enable Monitoring Dashboards
+
+To enable monitoring dashboards, use the `--monitoring-dashboards` flag when running `hypershift install`. Alternatively, to enable monitoring dashboards in an existing installation, set the `MONITORING_DASHBOARDS` environment variable to `1` on the hypershift operator deployment:
+
+```
+oc set env deployment/operator -n hypershift MONITORING_DASHBOARDS=1
+```
+
+### Dashboards
+
+When monitoring dashboards are enabled, the HyperShift operator creates a configmap named `cp-[NAMESPACE]-[NAME]` in the `openshift-config-managed` namespace (where NAMESPACE is the namespace of the HostedCluster and NAME is the name of the HostedCluster) for each HostedCluster that the operator manages. This results in a new dashboard getting added under Observe -> Dashboards in the administrative console of the management cluster. When a HostedCluster is deleted, its corresponding dashboard is also deleted.
+
+### Customize Monitoring Dashboards
+
+To generate per-cluster dashboards, the HyperShift operator uses a template stored in a ConfigMap named `monitoring-dashboard-template` in the operator namespace (`hypershift`). This template contains a set of grafana panels that contain the various metrics that should go on the dashboard. Edit the content of this ConfigMap to customize the dashboards. When a particular HostedCluster's dashboard is generated, the following strings will be replaced with values that correspond to the specific HostedCluster:
+
+| Name                          | Description                                                                      |
+|-------------------------------|----------------------------------------------------------------------------------|
+| `__NAME__`                    | The name of the HostedCluster                                                    |
+| `__NAMESPACE__`               | The namespace of the HostedCluster                                               |
+| `__CONTROL_PLANE_NAMESPACE__` | The namespace where the control plane pods of the HostedCluster are placed       |
+| `__CLUSTER_ID__`              | The UUID of the HostedCluster (matches the `_id` label of HostedCluster metrics) |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - how-to/upgrades.md
   - how-to/restart-control-plane-components.md
   - how-to/pause-reconciliation.md
+  - how-to/per-hostedcluster-dashboard.md
   - how-to/debug-nodes.md
   - how-to/metrics-sets.md
   - how-to/troubleshooting.md

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -167,6 +167,8 @@ type HostedClusterReconciler struct {
 	overwriteReconcile   func(ctx context.Context, req ctrl.Request, log logr.Logger, hcluster *hyperv1.HostedCluster) (ctrl.Result, error)
 	now                  func() metav1.Time
 	KubevirtInfraClients kvinfra.KubevirtInfraClientMap
+
+	MonitoringDashboards bool
 }
 
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters,verbs=get;list;watch;create;update;patch;delete
@@ -1378,6 +1380,13 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		})
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile capi cluster: %w", err)
+		}
+	}
+
+	// Reconcile the monitoring dashboard if configured
+	if r.MonitoringDashboards {
+		if err := r.reconcileMonitoringDashboard(ctx, createOrUpdate, hcluster); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile monitoring dashboard: %w", err)
 		}
 	}
 
@@ -3301,6 +3310,22 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		}
 	}
 
+	if r.MonitoringDashboards {
+		// Delete the monitoring dashboard cm
+		monitoringDashboard := manifests.MonitoringDashboard(hc.Namespace, hc.Name)
+		if err := r.Get(ctx, client.ObjectKeyFromObject(monitoringDashboard), monitoringDashboard); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return false, fmt.Errorf("failed to get monitoring dashboard: %w", err)
+			}
+		} else {
+			if err := r.Delete(ctx, monitoringDashboard); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return false, fmt.Errorf("failed to delete monitoring dashboard: %w", err)
+				}
+			}
+		}
+	}
+
 	// Cleanup Platform specifics.
 
 	if err = p.DeleteCredentials(ctx, r.Client, hc,
@@ -4401,6 +4426,52 @@ func (r *HostedClusterReconciler) dereferenceAWSRoles(ctx context.Context, roles
 		rolesRef.KubeCloudControllerARN = arn
 	}
 
+	return nil
+}
+
+type DashboardTemplateData struct {
+	Name                  string
+	Namespace             string
+	ID                    string
+	ControlPlaneNamespace string
+}
+
+func (r *HostedClusterReconciler) reconcileMonitoringDashboard(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hc *hyperv1.HostedCluster) error {
+	log := ctrl.LoggerFrom(ctx)
+	dashboardTemplate := manifests.MonitoringDashboardTemplate(r.OperatorNamespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dashboardTemplate), dashboardTemplate); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("WARNING: monitoring dashboard template is not found. No dashboard will be generated")
+			return nil
+		}
+		return fmt.Errorf("failed to read monitoring dashboard template: %w", err)
+	}
+	dashboard := dashboardTemplate.Data["template"]
+	varsToReplace := map[string]string{
+		"__NAME__":                    hc.Name,
+		"__NAMESPACE__":               hc.Namespace,
+		"__CONTROL_PLANE_NAMESPACE__": manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name).Name,
+		"__CLUSTER_ID__":              hc.Spec.ClusterID,
+	}
+	for k, v := range varsToReplace {
+		dashboard = strings.ReplaceAll(dashboard, k, v)
+	}
+
+	dashboardCM := manifests.MonitoringDashboard(hc.Namespace, hc.Name)
+	if _, err := createOrUpdate(ctx, r.Client, dashboardCM, func() error {
+		if dashboardCM.Labels == nil {
+			dashboardCM.Labels = map[string]string{}
+		}
+		dashboardCM.Labels["console.openshift.io/dashboard"] = "true"
+
+		if dashboardCM.Data == nil {
+			dashboardCM.Data = map[string]string{}
+		}
+		dashboardCM.Data["hostedcluster-dashboard.json"] = dashboard
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile monitoring dashboard: %w", err)
+	}
 	return nil
 }
 

--- a/hypershift-operator/controllers/manifests/manifests.go
+++ b/hypershift-operator/controllers/manifests/manifests.go
@@ -2,9 +2,10 @@ package manifests
 
 import (
 	"fmt"
+	"strings"
+
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strings"
 
 	mcfgv1 "github.com/openshift/hypershift/thirdparty/machineconfigoperator/pkg/apis/machineconfiguration.openshift.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -76,4 +77,22 @@ func ReconcileKubevirtInfraTempRoute(route *routev1.Route) error {
 		},
 	}
 	return nil
+}
+
+func MonitoringDashboardTemplate(namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "monitoring-dashboard-template",
+			Namespace: namespace,
+		},
+	}
+}
+
+func MonitoringDashboard(clusterNamespace, clusterName string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("hc-%s-%s", clusterNamespace, clusterName),
+			Namespace: "openshift-config-managed",
+		},
+	}
 }

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -286,6 +286,8 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		OpenShiftImageRegistryOverrides: imageRegistryOverrides,
 	}
 
+	monitoringDashboards := (os.Getenv("MONITORING_DASHBOARDS") == "1")
+
 	hostedClusterReconciler := &hostedcluster.HostedClusterReconciler{
 		Client:                        mgr.GetClient(),
 		ManagementClusterCapabilities: mgmtClusterCaps,
@@ -298,6 +300,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		OperatorNamespace:             opts.Namespace,
 		SREConfigHash:                 sreConfigHash,
 		KubevirtInfraClients:          kvinfra.NewKubevirtInfraClientMap(),
+		MonitoringDashboards:          monitoringDashboards,
 	}
 	if opts.OIDCStorageProviderS3BucketName != "" {
 		awsSession := awsutil.NewSession("hypershift-operator-oidc-bucket", opts.OIDCStorageProviderS3Credentials, "", "", opts.OIDCStorageProviderS3Region)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an install option to enable monitoring dashboards for HostedClusters created by the HyperShift operator. Each dashboard consists of a ConfigMap that is placed in the openshift-config-managed namespace of the management cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1085](https://issues.redhat.com//browse/HOSTEDCP-1085)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.