### PR TITLE
OCPBUGS-17680: Remove immutable note from PullSecret

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -303,8 +303,6 @@ type HostedClusterSpec struct {
 	// PullSecret references a pull secret to be injected into the container
 	// runtime of all cluster nodes. The secret must have a key named
 	// ".dockerconfigjson" whose value is the pull secret JSON.
-	//
-	// +immutable
 	PullSecret corev1.LocalObjectReference `json:"pullSecret"`
 
 	// SSHKey references an SSH key to be injected into all cluster node sshd


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the immutable note from the HostedCluster.Spec.PullSecret. This field is mutable since 4.12.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-17680](https://issues.redhat.com/browse/OCPBUGS-17680)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.