### PR TITLE
OCPBUGS-17680: Add pull secret to mutable fields in webhook val

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -165,6 +165,7 @@ func filterMutableHostedClusterSpecFields(spec *hyperv1.HostedClusterSpec) {
 	spec.AdditionalTrustBundle = nil
 	spec.SecretEncryption = nil
 	spec.PausedUntil = nil
+	spec.PullSecret.Name = ""
 	for i, svc := range spec.Services {
 		if svc.Type == hyperv1.NodePort && svc.NodePort != nil {
 			spec.Services[i].NodePort.Address = ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Add PullSecret.Name to mutable fields in the HostedCluster webhook validation.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [OCPBUGS-17680](https://issues.redhat.com/browse/OCPBUGS-17680)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.