### PR TITLE
OCPBUGS-17669: Validate HostedCluster name against RFC1123

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -117,6 +117,8 @@ hypershift create cluster aws \
     The cluster name (`--name`) _must be unique within the base domain_ to
     avoid unexpected and conflicting cluster management behavior.
 
+    The cluster name must also adhere to the [RFC1123 standard](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names).
+
 !!! note
 
     A default NodePool will be created for the cluster with 3 replicas per the

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -3524,6 +3525,10 @@ func (r *HostedClusterReconciler) validateConfigAndClusterCapabilities(ctx conte
 		errs = append(errs, err)
 	}
 
+	if err := r.validateHostedClusterName(hc); err != nil {
+		errs = append(errs, err)
+	}
+
 	// TODO(IBM): Revisit after fleets no longer use conflicting network CIDRs
 	if hc.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
 		if err := r.validateNetworks(hc); err != nil {
@@ -3723,6 +3728,16 @@ func (r *HostedClusterReconciler) validatePublishingStrategyMapping(hc *hyperv1.
 		hostnameServiceMap[hostname] = string(svc.Service)
 	}
 
+	return nil
+}
+
+// validateHostedClusterName validates a HostedCluster name confirms to RFC1123 convention
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+func (r *HostedClusterReconciler) validateHostedClusterName(hc *hyperv1.HostedCluster) error {
+	errs := validation.IsDNS1123Label(hc.Name)
+	if len(errs) > 0 {
+		return fmt.Errorf("hostedcluster name failed RFC1123 validation: %s", strings.Join(errs[:], " "))
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Validates the HostedCluster name meets RFC1123 in the HostedCluster controller.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-17669](https://issues.redhat.com/browse/OCPBUGS-17669)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.