### PR TITLE
STOR-1443: Sync `05_operator_role-hypershift.yaml` manifest from cluster-csi-snapsht-controller-operator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/05_operator_role-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/05_operator_role-hypershift.yaml
@@ -68,6 +68,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - hypershift.openshift.io
   resources:
   - hostedcontrolplanes


### PR DESCRIPTION
**What this PR does / why we need it**:

The [PR](https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/157) implements restarting `csi-snapshot-webhook` if the secret `csi-snapshot-webhook-secret` is updated. To do it, the operator needs to monitor for secret updates. This requires new perms in `05_operator_role-hypershift.yaml`. This PR simply syncs those changes to hypershift repo manifest.

/cc @openshift/storage 

**Checklist**
- [*] Subject and description added to both, commit and PR.
- [*] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.