### PR TITLE
OCPBUGS-17812: Update Etcd health check to mirror standalone etcd

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -19,8 +19,9 @@ const (
 )
 
 type EtcdParams struct {
-	EtcdImage string
-	CPOImage  string
+	EtcdImage         string
+	EtcdOperatorImage string
+	CPOImage          string
 
 	OwnerRef         config.OwnerRef `json:"ownerRef"`
 	DeploymentConfig config.DeploymentConfig
@@ -45,11 +46,12 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imagep
 	}
 
 	p := &EtcdParams{
-		EtcdImage:    releaseImageProvider.GetImage("etcd"),
-		CPOImage:     releaseImageProvider.GetImage("controlplane-operator"),
-		OwnerRef:     config.OwnerRefFrom(hcp),
-		Availability: hcp.Spec.ControllerAvailabilityPolicy,
-		IPv6:         !ipv4,
+		EtcdImage:         releaseImageProvider.GetImage("etcd"),
+		EtcdOperatorImage: releaseImageProvider.GetImage("cluster-etcd-operator"),
+		CPOImage:          releaseImageProvider.GetImage("controlplane-operator"),
+		OwnerRef:          config.OwnerRefFrom(hcp),
+		Availability:      hcp.Spec.ControllerAvailabilityPolicy,
+		IPv6:              !ipv4,
 	}
 	p.DeploymentConfig.Resources = config.ResourcesSpec{
 		etcdContainer().Name: {


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous etcd health check uses an exec probe. Because we don't set a timeout, the timeout defafults to 1. This commit modifies the etcd statefulset to use a sidecar container with the cluster etcd operator image that implements an http get type of probe. It also modifies the timeouts to mirror those set in the standalone case.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-17812](https://issues.redhat.com/browse/OCPBUGS-17812)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.