### PR TITLE
HOSTEDCP-1156: Add defaulting webhook to installation and notes

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -88,8 +88,13 @@ AWS_CREDS="$HOME/.aws/credentials"
 hypershift install \
   --oidc-storage-provider-s3-bucket-name $BUCKET_NAME \
   --oidc-storage-provider-s3-credentials $AWS_CREDS \
-  --oidc-storage-provider-s3-region $REGION
+  --oidc-storage-provider-s3-region $REGION \
+  --enable-defaulting-webhook true
 ```
+
+!!! note 
+
+    `enable-defaulting-webhook` is only for OCP version 4.14 and higher.
 
 ## Create a Hosted Cluster
 Create a new hosted cluster, specifying the domain of the public zone provided in the
@@ -118,6 +123,10 @@ hypershift create cluster aws \
     avoid unexpected and conflicting cluster management behavior.
 
     The cluster name must also adhere to the [RFC1123 standard](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names).
+
+!!! important
+
+    You must include either flag, `release-image` or `release-stream`, when the `enable-defaulting-webhook` is not enabled on the installation of the HyperShift operator.
 
 !!! note
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the enable-defaulting-webhook flag to the hypershift install and a note about the flag only being available for OCP versions greater than or equal to 4.14. 

Adds note to create cluster command that either the release-image or release-stream flag is needed when the enable-defaulting-webhook is not available.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1156](https://issues.redhat.com/browse/HOSTEDCP-1156)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.