### PR TITLE
OCPBUGS-17827: remove NeedManagementKASAccessLabel from router deployments

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -35,9 +35,6 @@ func hcpRouterLabels() map[string]string {
 
 func HCPRouterConfig(hcp *hyperv1.HostedControlPlane, setDefaultSecurityContext bool) config.DeploymentConfig {
 	cfg := config.DeploymentConfig{
-		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
-		},
 		Resources: config.ResourcesSpec{
 			hcpRouterContainerMain().Name: {
 				Requests: corev1.ResourceList{

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -796,9 +796,6 @@ func EnsureNetworkPolicies(t *testing.T, ctx context.Context, c crclient.Client,
 				"hosted-cluster-config-operator",
 				"cloud-controller-manager",
 			}
-			if hostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform {
-				want = append(want, "private-router")
-			}
 
 			g := NewWithT(t)
 			err := checkPodsHaveLabel(ctx, c, want, hcpNamespace, client.MatchingLabels{suppconfig.NeedManagementKASAccessLabel: "true"})


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-17827

This fix is complicated by the fact that, once merged, the new e2e binary is used immediately against potentially older CPOs in CI release tests.