### PR TITLE
OCPBUGS-16770: e2e: fix pod filter for olm-collect-profiles

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -862,7 +862,7 @@ func checkPodsHaveLabel(ctx context.Context, c crclient.Client, components []str
 			continue
 		}
 
-		if strings.HasPrefix(pod.Labels["name"], "olm-collect-profiles") {
+		if strings.HasPrefix(pod.Labels["job-name"], "olm-collect-profiles") {
 			continue
 		}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-16770

Flake is still occurring:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn/1693407514986549248

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn/1693407514986549248/artifacts/e2e-aws-ovn/run-e2e/artifacts/TestUpgradeControlPlane/namespaces/e2e-clusters-nhsbw-example-hxqmx/core/pods/olm-collect-profiles-28209612-96sjp.yaml

`olm-collect-profiles` do not have a `name` label, but they do have a `job-name` label.  Use that.