### PR TITLE
TRT-1202: add annotation to skip release image validation

### DIFF
--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -19,6 +19,7 @@ const (
 	// AuditWebhookKubeconfigKey is the key name in the AuditWebhook secret that stores audit webhook kubeconfig
 	AuditWebhookKubeconfigKey                 = "webhook-kubeconfig"
 	DisablePKIReconciliationAnnotation        = "hypershift.openshift.io/disable-pki-reconciliation"
+	SkipReleaseImageValidation                = "hypershift.openshift.io/skip-release-image-validation"
 	IdentityProviderOverridesAnnotationPrefix = "idpoverrides.hypershift.openshift.io/"
 	OauthLoginURLOverrideAnnotation           = "oauth.hypershift.openshift.io/login-url-override"
 	// KonnectivityServerImageAnnotation is a temporary annotation that allows the specification of the konnectivity server image.

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -18,6 +18,7 @@ const (
 	// AuditWebhookKubeconfigKey is the key name in the AuditWebhook secret that stores audit webhook kubeconfig
 	AuditWebhookKubeconfigKey                 = "webhook-kubeconfig"
 	DisablePKIReconciliationAnnotation        = "hypershift.openshift.io/disable-pki-reconciliation"
+	SkipReleaseImageValidation                = "hypershift.openshift.io/skip-release-image-validation"
 	IdentityProviderOverridesAnnotationPrefix = "idpoverrides.hypershift.openshift.io/"
 	OauthLoginURLOverrideAnnotation           = "oauth.hypershift.openshift.io/login-url-override"
 	// ControlPlanePriorityClass is for pods in the HyperShift Control Plane that are not API critical but still need elevated priority. E.g Cluster Version Operator.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3599,6 +3599,9 @@ func (r *HostedClusterReconciler) validateUserCAConfigMaps(ctx context.Context, 
 }
 
 func (r *HostedClusterReconciler) validateReleaseImage(ctx context.Context, hc *hyperv1.HostedCluster) error {
+	if _, exists := hc.Annotations[hyperv1.SkipReleaseImageValidation]; exists {
+		return nil
+	}
 	var pullSecret corev1.Secret
 	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hc.Spec.PullSecret.Name}, &pullSecret); err != nil {
 		return fmt.Errorf("failed to get pull secret: %w", err)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1483,6 +1483,36 @@ func TestValidateReleaseImage(t *testing.T) {
 			},
 			expectedResult: nil,
 		},
+		{
+			name: "skip release image validation with annotation, success",
+			other: []crclient.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"},
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: nil,
+					},
+				},
+			},
+			hostedCluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						hyperv1.SkipReleaseImageValidation: "true",
+					},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						NetworkType: hyperv1.OVNKubernetes,
+					},
+					PullSecret: corev1.LocalObjectReference{
+						Name: "pull-secret",
+					},
+					Release: hyperv1.Release{
+						Image: "image-4.11.0",
+					},
+				},
+			},
+			expectedResult: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -191,6 +191,9 @@ func (h *hypershiftTest) createHostedCluster(opts *core.CreateOptions, platform 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace.Name,
 			Name:      SimpleNameGenerator.GenerateName("example-"),
+			Annotations: map[string]string{
+				hyperv1.SkipReleaseImageValidation: "true",
+			},
 		},
 		Spec: hyperv1.HostedClusterSpec{
 			Platform: hyperv1.PlatformSpec{


### PR DESCRIPTION
Whenever, the branch occurs and new release streams are created, we have to create a PR like[ this one](https://github.com/openshift/hypershift/pull/2927) to bump the supported version in the HO.

However, we can't merge such a PR until automatic fast-forward to the `release-4.14` branch stops, which means that we are blocking 4.15 release payload during this period of time.

The PR adds annotation to skip release image validation to use for our e2e flows.