### PR TITLE
Add e2e test for etcd member recovery

### DIFF
--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"math/rand"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -38,8 +39,10 @@ func TestHAEtcdChaos(t *testing.T) {
 	clusterOpts.NodePoolReplicas = 0
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+		t.Run("SingleMemberRecovery", testSingleMemberRecovery(ctx, mgtClient, hostedCluster))
 		t.Run("KillRandomMembers", testKillRandomMembers(ctx, mgtClient, hostedCluster))
 		t.Run("KillAllMembers", testKillAllMembers(ctx, mgtClient, hostedCluster))
+
 	}).Execute(&clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 }
 
@@ -202,6 +205,23 @@ func testKillAllMembers(parentCtx context.Context, client crclient.Client, clust
 		}
 		wg.Wait()
 
+		// Ensure that all etcd pods are replaced
+		err = wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+			for _, pod := range etcdPods.Items {
+				actual := &corev1.Pod{}
+				if err := client.Get(ctx, crclient.ObjectKeyFromObject(&pod), actual); err != nil {
+					t.Logf("failed to get pod %s: %v", pod.Name, err)
+					return false, nil
+				}
+				if pod.UID == actual.UID {
+					t.Logf("pod %s not replaced yet", pod.Name)
+					return false, nil
+				}
+			}
+			return true, nil
+		}, ctx.Done())
+		g.Expect(err).NotTo(HaveOccurred(), "failed to wait for etcd pods to be replaced")
+
 		// The etcd cluster should eventually roll out completely
 		err = wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 			err := client.Get(ctx, crclient.ObjectKeyFromObject(etcdSts), etcdSts)
@@ -227,6 +247,87 @@ func testKillAllMembers(parentCtx context.Context, client crclient.Client, clust
 			return true, nil
 		}, ctx.Done())
 		g.Expect(err).NotTo(HaveOccurred(), "failed to verify data following disruption")
+	}
+}
+
+// testSingleMemberRecovery ensures that the etcd cluster can recover from a single member losing its data
+func testSingleMemberRecovery(parentCtx context.Context, client crclient.Client, cluster *hyperv1.HostedCluster) func(t *testing.T) {
+	return func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(parentCtx)
+		defer cancel()
+
+		guestNamespace := manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name
+		t.Logf("Hosted control plane namespace is %s", guestNamespace)
+
+		// Wait for a guest client to become available
+		t.Logf("Waiting for guest client to become available")
+		_ = e2eutil.WaitForGuestClient(t, ctx, client, cluster)
+
+		// Find etcd pods in the control plane namespace
+		etcdSts := cpomanifests.EtcdStatefulSet(guestNamespace)
+		err := client.Get(ctx, crclient.ObjectKeyFromObject(etcdSts), etcdSts)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get etcd statefulset")
+
+		etcdPods := &corev1.PodList{}
+		err = client.List(ctx, etcdPods, &crclient.ListOptions{
+			Namespace:     manifests.HostedControlPlaneNamespace(cluster.Namespace, cluster.Name).Name,
+			LabelSelector: labels.Set(etcdSts.Spec.Selector.MatchLabels).AsSelector(),
+		})
+
+		// Delete a single etcd pod along with its pvc
+		randomPod := randomPods(etcdPods.Items, 1)[0]
+		originalPodID := randomPod.UID
+		pvcName := "data-etcd" + strings.TrimPrefix(randomPod.Name, "etcd")
+		pvc := &corev1.PersistentVolumeClaim{}
+		pvc.Name = pvcName
+		pvc.Namespace = randomPod.Namespace
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func(pod *corev1.Pod) {
+			defer wg.Done()
+			err := client.Delete(ctx, pod)
+			g.Expect(err).ToNot(HaveOccurred(), "failed to delete etcd pod")
+			t.Logf("Deleted etcd pod %s", pod.Name)
+		}(&randomPod)
+		go func(pvc *corev1.PersistentVolumeClaim) {
+			defer wg.Done()
+			err := client.Delete(ctx, pvc)
+			g.Expect(err).ToNot(HaveOccurred(), "failed to delete etcd pvc")
+			t.Logf("Deleted etcd pvc %s", pvc.Name)
+		}(pvc)
+		wg.Wait()
+
+		// Wait for etcd pod to be replaced
+		t.Log("Waiting for deleted pod to be replaced")
+		err = wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+			err := client.Get(ctx, crclient.ObjectKeyFromObject(&randomPod), &randomPod)
+			if err != nil {
+				t.Logf("failed to get pod %s/%s: %v", randomPod.Namespace, randomPod.Name, err)
+				return false, nil
+			}
+			if randomPod.UID == originalPodID {
+				t.Log("original pod has not been replaced")
+				return false, nil
+			}
+			t.Log("original pod is now replaced")
+			return true, nil
+		}, ctx.Done())
+
+		// The etcd cluster should eventually roll out completely
+		t.Log("Waiting for etcd statefulset to recover")
+		err = wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+			err := client.Get(ctx, crclient.ObjectKeyFromObject(etcdSts), etcdSts)
+			if err != nil {
+				t.Logf("failed to get statefulset %s/%s: %s", etcdSts.Namespace, etcdSts.Name, err)
+				return false, nil
+			}
+			return *etcdSts.Spec.Replicas == etcdSts.Status.ReadyReplicas, nil
+		}, ctx.Done())
+		g.Expect(err).NotTo(HaveOccurred(), "etcd statefulset available replicas never converged")
+		t.Logf("etcd statefulset recovered successfully")
+
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a test under the etcd chaos test to verify that we can recover from the destruction of a single member along with its data.
