### PR TITLE
Draft: OCPBUGS-15565 changing contolplane ns pod security to baseline

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1010,7 +1010,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			controlPlaneNamespace.Labels["pod-security.kubernetes.io/audit"] = "restricted"
 			controlPlaneNamespace.Labels["pod-security.kubernetes.io/warn"] = "restricted"
 		} else {
-			controlPlaneNamespace.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
+			controlPlaneNamespace.Labels["pod-security.kubernetes.io/enforce"] = "baseline"
 			controlPlaneNamespace.Labels["pod-security.kubernetes.io/audit"] = "privileged"
 			controlPlaneNamespace.Labels["pod-security.kubernetes.io/warn"] = "privileged"
 		}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
sets the pod security admission level of control plane namespaces as `baseline`.

**Which issue(s) this PR fixes** :
Fixes # [OCPBUGS-15565](https://issues.redhat.com/browse/OCPBUGS-15565)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.