### PR TITLE
OCPBUGS-16813: do not hardcode ignition-server-proxy replicas

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -849,7 +849,7 @@ haproxy -f /tmp/haproxy.conf
 		deploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}
 	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-	deploymentConfig.SetRequestServingDefaults(hcp, nil, utilpointer.Int(1))
+	deploymentConfig.SetRequestServingDefaults(hcp, nil, nil)
 	deploymentConfig.ApplyTo(deployment)
 
 	return nil


### PR DESCRIPTION
Fixes the ignition-server-proxy part of https://issues.redhat.com/browse/OCPBUGS-16813

Allow `replicas` for the `ignition-server-proxy` Deployment to be controlled by the HC `ControllerAvailabilityPolicy`