### PR TITLE
OCPBUGS-17827: remove NeedManagementKASAccessLabel from router pods

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -35,9 +35,6 @@ func hcpRouterLabels() map[string]string {
 
 func HCPRouterConfig(hcp *hyperv1.HostedControlPlane, setDefaultSecurityContext bool) config.DeploymentConfig {
 	cfg := config.DeploymentConfig{
-		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
-		},
 		Resources: config.ResourcesSpec{
 			hcpRouterContainerMain().Name: {
 				Requests: corev1.ResourceList{


### PR DESCRIPTION
Part 2/3 for https://issues.redhat.com/browse/OCPBUGS-17827 follow on to https://github.com/openshift/hypershift/pull/2928

