### PR TITLE
OCPBUGS-17985: Handle empty mirrorImage result for ignition disconnected registry

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -192,7 +192,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 	}
 
 	var (
-		ICSFound    bool
+		icsFound    bool
 		sourceRef   reference.DockerImageReference
 		mirrorImage string
 	)
@@ -202,17 +202,16 @@ func ReconcileIgnitionServer(ctx context.Context,
 		// Ignition server cannot handle ImageContentSourcePolicies or ImageDigestMachineSet, so we need to
 		// fill the registryOverrides in the case of disconnected environments
 		mirrorImage = lookupDisconnectedRegistry(ctx, openShiftRegistryOverrides)
-		sourceRef, err = reference.Parse(mirrorImage)
-		if err != nil {
-			return fmt.Errorf("failed to parse private registry hosted control plane image reference %q: %w", mirrorImage, err)
-		}
-
-		if len(sourceRef.String()) > 0 {
-			ICSFound = true
+		if len(mirrorImage) > 0 {
+			sourceRef, err = reference.Parse(mirrorImage)
+			if err != nil {
+				return fmt.Errorf("failed to parse private registry hosted control plane image reference %q: %w", mirrorImage, err)
+			}
+			icsFound = true
 		}
 	}
 
-	if ICSFound {
+	if icsFound {
 		privateRegistry := sourceRef.Registry
 
 		if !strings.HasPrefix(componentImages["machine-config-operator"], privateRegistry) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The lookupDisconnectedRegistry function can return an empty string if the registry doesn't match a release repo. However, we don't handle that result in the calling code in ReconcileIgnitionServer. This commit adds handling for an empty string.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-17985

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.