### PR TITLE
STOR-1445: Sync `10_deployment-hypershift.yaml` from `cluster-storage-operator` repo

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
@@ -19,6 +19,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         command:
         - cluster-storage-operator


### PR DESCRIPTION
**What this PR does / why we need it**:

The [PR](https://github.com/openshift/cluster-storage-operator/pull/394) has a commit:

> [STOR-1445](https://issues.redhat.com//browse/STOR-1445): Add commnad-line option --terminate-on-files to operators dependent on `metrics-serving-cert`

which restarts CSO if the secret `cluster-storage-operator-serving-cert` is updated. This PR simply syncs those changes to hypershift repo asset yaml.

/cc @openshift/storage 

**Checklist**
- [*] Subject and description added to both, commit and PR.
- [*] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.