### PR TITLE
OCPBUGS-17827: e2e: remove private-router from NeedManagementKASAccessLabel allowlist

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -796,9 +796,6 @@ func EnsureNetworkPolicies(t *testing.T, ctx context.Context, c crclient.Client,
 				"cloud-controller-manager",
 				"olm-collect-profiles",
 			}
-			if hostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform {
-				want = append(want, "private-router")
-			}
 
 			g := NewWithT(t)
 			err := checkPodsHaveLabel(ctx, c, want, hcpNamespace, client.MatchingLabels{suppconfig.NeedManagementKASAccessLabel: "true"})


### PR DESCRIPTION
Part 3/3 for https://issues.redhat.com/browse/OCPBUGS-17827