### PR TITLE
[OCPBUGS-17517] Add a default value (32Gi) for nodepool in `create nodepool kubevirt` command

### DIFF
--- a/cmd/cluster/aws/destroy.go
+++ b/cmd/cluster/aws/destroy.go
@@ -16,7 +16,7 @@ import (
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "aws",
-		Short:        "Destroys a HostedCluster and its associated infrastructure on AWS.",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on AWS",
 		SilenceUsage: true,
 	}
 
@@ -59,7 +59,7 @@ func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error
 	baseDomainPrefix := o.AWSPlatform.BaseDomainPrefix
 	region := o.AWSPlatform.Region
 
-	//Override the credentialSecret with credentialFile
+	// Override the credentialSecret with credentialFile
 	var awsKeyID, awsSecretKey string
 	var err error
 	if len(o.AWSPlatform.AWSCredentialsFile) == 0 && len(o.CredentialSecretName) > 0 {
@@ -145,7 +145,7 @@ func ValidateCredentialInfo(opts *core.DestroyOptions) error {
 			return err
 		}
 	} else {
-		//Check the secret exists now, otherwise stop
+		// Check the secret exists now, otherwise stop
 		opts.Log.Info("Retrieving credentials secret", "namespace", opts.Namespace, "name", opts.CredentialSecretName)
 		if _, err := util.GetSecret(opts.CredentialSecretName, opts.Namespace); err != nil {
 			return err

--- a/cmd/cluster/azure/destroy.go
+++ b/cmd/cluster/azure/destroy.go
@@ -17,7 +17,7 @@ import (
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "azure",
-		Short:        "Destroys a hHostedCluster and its resources on Azure",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on Azure",
 		SilenceUsage: true,
 	}
 

--- a/cmd/cluster/kubevirt/create.go
+++ b/cmd/cluster/kubevirt/create.go
@@ -24,7 +24,7 @@ const (
 func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "kubevirt",
-		Short:        "Creates basic functional HostedCluster resources for KubeVirt platform",
+		Short:        "Creates basic functional HostedCluster resources on KubeVirt platform",
 		SilenceUsage: true,
 	}
 

--- a/cmd/cluster/none/destroy.go
+++ b/cmd/cluster/none/destroy.go
@@ -14,7 +14,7 @@ import (
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "none",
-		Short:        "Destroys a HostedCluster and its associated infrastructure on None.",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on None",
 		SilenceUsage: true,
 	}
 

--- a/cmd/nodepool/kubevirt/create.go
+++ b/cmd/nodepool/kubevirt/create.go
@@ -29,6 +29,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 		Memory:                     "4Gi",
 		Cores:                      2,
 		ContainerDiskImage:         "",
+		RootVolumeSize:             32,
 		CacheStrategyType:          "",
 		NetworkInterfaceMultiQueue: "",
 	}

--- a/product-cli/cmd/cluster/aws/destroy.go
+++ b/product-cli/cmd/cluster/aws/destroy.go
@@ -11,7 +11,7 @@ import (
 func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "aws",
-		Short:        "Destroys a HostedCluster and its associated infrastructure on AWS.",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on AWS",
 		SilenceUsage: true,
 	}
 

--- a/product-cli/cmd/cluster/kubevirt/create.go
+++ b/product-cli/cmd/cluster/kubevirt/create.go
@@ -12,7 +12,7 @@ import (
 func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "kubevirt",
-		Short:        "Creates basic functional HostedCluster resources for the KubeVirt platform",
+		Short:        "Creates basic functional HostedCluster resources on KubeVirt platform",
 		SilenceUsage: true,
 	}
 

--- a/product-cli/cmd/nodepool/kubevirt/create.go
+++ b/product-cli/cmd/nodepool/kubevirt/create.go
@@ -12,6 +12,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 		Memory:             "8Gi",
 		Cores:              2,
 		ContainerDiskImage: "",
+		RootVolumeSize:     32,
 		CacheStrategyType:  "",
 	}
 	cmd := &cobra.Command{


### PR DESCRIPTION
Without this default, when issuing the `hypershift create nodepool kubevirt` command without specifying the `--root-volume-size` arg, the VMs' storage request is created with 0, which is not valid, and VMIs are not being created.
The default of 32Gi is taken from the hostedcluster default for the same:
https://github.com/openshift/hypershift/blob/7575b03733f056027cc1eed4565b7a8a5deaf7d9/cmd/cluster/kubevirt/create.go#L37

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-17517](https://issues.redhat.com/browse/OCPBUGS-17517)
**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.