### PR TITLE
OCPBUGS-18024: Set Arch to amd64 for HCP NodePool Create

### DIFF
--- a/product-cli/cmd/nodepool/create.go
+++ b/product-cli/cmd/nodepool/create.go
@@ -18,6 +18,7 @@ func NewCreateCommand() *cobra.Command {
 	}
 
 	opts := &core.CreateNodePoolOptions{
+		Arch:            "amd64",
 		ClusterName:     "example",
 		Namespace:       "clusters",
 		NodeCount:       2,


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets Arch to amd64 for HCP NodePool Create so the InstanceType is chosen through the HCP CLI.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-18024](https://issues.redhat.com/browse/OCPBUGS-18024)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.