### PR TITLE
TRT-1202: set SkipReleaseImageValidation annotation properly on e2e clusters

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -447,6 +447,7 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		Log:         util.NewLogr(t),
 		Annotations: []string{
 			fmt.Sprintf("%s=true", hyperv1.CleanupCloudResourcesAnnotation),
+			fmt.Sprintf("%s=true", hyperv1.SkipReleaseImageValidation),
 		},
 		SkipAPIBudgetVerification: o.SkipAPIBudgetVerification,
 		EtcdStorageClass:          o.configurableClusterOptions.EtcdStorageClass,

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -191,9 +191,6 @@ func (h *hypershiftTest) createHostedCluster(opts *core.CreateOptions, platform 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace.Name,
 			Name:      SimpleNameGenerator.GenerateName("example-"),
-			Annotations: map[string]string{
-				hyperv1.SkipReleaseImageValidation: "true",
-			},
 		},
 		Spec: hyperv1.HostedClusterSpec{
 			Platform: hyperv1.PlatformSpec{


### PR DESCRIPTION
Fix it for real this time