### PR TITLE
MGMT-15368: Document scaling down NodePools

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -197,6 +197,10 @@ oc scale nodepool/$NODEPOOL_NAME \
   --replicas=$NODEPOOL_REPLICAS
 ```
 
+!!! note
+
+    See the [Scale Down](./how-to/automated-machine-management/nodepool-lifecycle.md#scale-down) section of the [NodePool lifecycle page](./how-to/automated-machine-management/nodepool-lifecycle.md) for more details when scaling down NodePools.
+
 ## Delete a Hosted Cluster
 To delete a Hosted Cluster:
 

--- a/docs/content/how-to/automated-machine-management/nodepool-lifecycle.md
+++ b/docs/content/how-to/automated-machine-management/nodepool-lifecycle.md
@@ -83,3 +83,25 @@ spec:
   config:
     - name: ${CONFIGMAP_NAME}
 ```
+
+## Scale Down
+
+Scaling a NodePool down will remove Nodes from the hosted cluster.
+
+### Scaling To Zero
+
+Node(s) can become stuck when removing all Nodes from a cluster (scaling NodePool(s) down to zero) because the Node(s) cannot be drained successfully from the cluster.
+
+Several conditions can prevent Node(s) from being drained successfully:
+
+- The hosted cluster contains `PodDisruptionBudgets` that require at least 
+- The hosted cluster contains pods that use `PersistentVolumes``
+
+#### Prevention
+
+To prevent Nodes from becoming stuck when scaling down, set the `.spec.nodeDrainTimeout` in the NodePool CR to a value greater than `0s`. 
+
+This forces Nodes to be removed once the timeout specified in the field has been reached even if the Node cannot be drained successfully.
+
+!!! note
+    See the [Hypershift API reference page](../../reference/api.md) for more details.


### PR DESCRIPTION



<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Nodes can become stuck if scaling down all NodePools for a cluster to zero if there are nodes that can't be drained successfully.

Adds documentation so users are aware of this issue and how to prevent it.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [MGMT-15368](https://issues.redhat.com/browse/MGMT-15368)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.