### PR TITLE
HOSTEDCP-591: Amend OLM catalog IS according to OpenShiftImageRegistryOverrides

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -68,6 +68,14 @@ const (
 	// NOTE: We'll expose this in the API if the use case gets generalised.
 	PrivateIngressControllerAnnotation = "hypershift.openshift.io/private-ingress-controller"
 
+	// CertifiedOperatorsCatalogImageAnnotation, CommunityOperatorsCatalogImageAnnotation, RedHatMarketplaceCatalogImageAnnotation and RedHatOperatorsCatalogImageAnnotation
+	// are annotations that can be used to override the address of the images used for the OLM catalogs if in the `management` OLMCatalogPlacement mode.
+	// If used, all of them should be set at the same time referring images only by digest (`...@sha256:<id>`)
+	CertifiedOperatorsCatalogImageAnnotation = "hypershift.openshift.io/certified-operators-catalog-image"
+	CommunityOperatorsCatalogImageAnnotation = "hypershift.openshift.io/community-operators-catalog-image"
+	RedHatMarketplaceCatalogImageAnnotation  = "hypershift.openshift.io/redhat-marketplace-catalog-image"
+	RedHatOperatorsCatalogImageAnnotation    = "hypershift.openshift.io/redhat-operators-catalog-image"
+
 	// ClusterAPIProviderAWSImage overrides the CAPI AWS provider image to use for
 	// a HostedControlPlane.
 	ClusterAPIProviderAWSImage = "hypershift.openshift.io/capi-provider-aws-image"

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
@@ -14,15 +14,19 @@ var packageServerLabels = map[string]string{
 }
 
 type OperatorLifecycleManagerParams struct {
-	CLIImage                string
-	OLMImage                string
-	ProxyImage              string
-	OperatorRegistryImage   string
-	ReleaseVersion          string
-	DeploymentConfig        config.DeploymentConfig
-	PackageServerConfig     config.DeploymentConfig
-	AvailabilityProberImage string
-	NoProxy                 []string
+	CLIImage                               string
+	OLMImage                               string
+	ProxyImage                             string
+	OperatorRegistryImage                  string
+	CertifiedOperatorsCatalogImageOverride string
+	CommunityOperatorsCatalogImageOverride string
+	RedHatMarketplaceCatalogImageOverride  string
+	RedHatOperatorsCatalogImageOverride    string
+	ReleaseVersion                         string
+	DeploymentConfig                       config.DeploymentConfig
+	PackageServerConfig                    config.DeploymentConfig
+	AvailabilityProberImage                string
+	NoProxy                                []string
 	config.OwnerRef
 }
 
@@ -64,6 +68,11 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, releaseI
 	if hcp.Spec.OLMCatalogPlacement == "management" {
 		params.NoProxy = append(params.NoProxy, "certified-operators", "community-operators", "redhat-operators", "redhat-marketplace")
 	}
+
+	params.CertifiedOperatorsCatalogImageOverride = hcp.Annotations[hyperv1.CertifiedOperatorsCatalogImageAnnotation]
+	params.CommunityOperatorsCatalogImageOverride = hcp.Annotations[hyperv1.CommunityOperatorsCatalogImageAnnotation]
+	params.RedHatMarketplaceCatalogImageOverride = hcp.Annotations[hyperv1.RedHatMarketplaceCatalogImageAnnotation]
+	params.RedHatOperatorsCatalogImageOverride = hcp.Annotations[hyperv1.RedHatOperatorsCatalogImageAnnotation]
 
 	return params
 }

--- a/docs/content/how-to/disconnected/automatically-initialize-registry-overrides.md
+++ b/docs/content/how-to/disconnected/automatically-initialize-registry-overrides.md
@@ -21,3 +21,8 @@ The ignition server reconciler forwards this information on to the `ignition-ser
 
 ### Control Plane Operator
 The `HostedClusterReconciler` passes on the image registry override information as an environment variable in the CPO called `OPENSHIFT_IMG_OVERRIDES`. The CPO will check for the existence of this environment variable when it runs. If the variable exists, it's used to build the HostedControlPlaneReconciler's `releaseProvider`.
+When using the `management` (default) OLMCatalogPlacement mode, the same information will be used also to amend the address used for the imageStreams used for the OLM catalog images: this implicitly assumes that the images used for
+the 4 default OLM catalogs got mirrored to the internal registry using the original name and tag.
+The cluster admin will be able to bypass OpenShiftImageRegistryOverrides for OLM catalogs using 4 annotations (`hypershift.openshift.io/certified-operators-catalog-image`, `hypershift.openshift.io/community-operators-catalog-image`, `hypershift.openshift.io/redhat-marketplace-catalog-image`, `hypershift.openshift.io/redhat-operators-catalog-image`) on the HostedCluster CR to directly specify the address (only by digest) of the 4 images to be used for OLM operator catalogs.
+In this case the imageStream are not going to be created, and it will be up to the guest cluster owner updating the value of the annotations when the internal mirror will get refreshed to pull in operator updates.
+Please notice that if this override mechanism is required, all the 4 values for the 4 default catalog sources are needed.


### PR DESCRIPTION
**What this PR does / why we need it**:
Amend the image address used for the imageStreams
used for the OLM catalog source according to the value
of OpenShiftImageRegistryOverrides as genetically used
in the control plane operator in order to handle the disconnected use case.
This will implicitly assume that the images used for
the 4 default OLM catalogs got mirrored to the internal registry
using the original name and tag.

An annotation based escape mechanism is also defined:
the owner of the hostedcluster will be able to inject custom
addresses (only by digest) for the catalog images.
In that case the imageStream mechanism is completely skipped
and the catalog deployments are directly with the values
in the annotations.
It will be completely up to the user to manually refresh
them when the internal mirror will get refreshed.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/HOSTEDCP-591

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.