### PR TITLE
[CNV-31919] Validate KubeVirt platform required versioning

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -3593,6 +3594,10 @@ func (r *HostedClusterReconciler) validateConfigAndClusterCapabilities(ctx conte
 		errs = append(errs, err)
 	}
 
+	if err := r.validateKubevirtConfig(ctx, hc); err != nil {
+		errs = append(errs, err)
+	}
+
 	if err := r.validateAzureConfig(ctx, hc); err != nil {
 		errs = append(errs, err)
 	}
@@ -3686,11 +3691,7 @@ func (r *HostedClusterReconciler) validateReleaseImage(ctx context.Context, hc *
 		}
 		currentVersion = &version
 	}
-	minSupportedVersion := supportedversion.MinSupportedVersion
-	if hc.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-		// IBM Cloud is allowed to manage 4.9 clusters
-		minSupportedVersion = semver.MustParse("4.9.0")
-	}
+	minSupportedVersion := supportedversion.GetMinSupportedVersion(hc)
 
 	return supportedversion.IsValidReleaseVersion(&version, currentVersion, &supportedversion.LatestSupportedVersion, &minSupportedVersion, hc.Spec.Networking.NetworkType, hc.Spec.Platform.Type)
 }
@@ -3785,6 +3786,67 @@ func (r *HostedClusterReconciler) validateAWSConfig(hc *hyperv1.HostedCluster) e
 	} else {
 		if !hyperutil.UseDedicatedDNSForKASByHC(hc) && servicePublishingStrategy.Type != hyperv1.LoadBalancer {
 			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route or Loadbalancer", hyperv1.APIServer, servicePublishingStrategy.Type))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func (r *HostedClusterReconciler) validateKubevirtConfig(ctx context.Context, hc *hyperv1.HostedCluster) error {
+	if hc.Spec.Platform.Type != hyperv1.KubevirtPlatform {
+		return nil
+	}
+
+	val, exists := hc.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation]
+	if exists {
+		if isTrue, _ := strconv.ParseBool(val); isTrue {
+			// This is an unsupported escape hatch annotation for internal use
+			// Some HCP users are using the kubevirt platform in unconventional ways
+			// and we need to maintain the ability to use unsupported versions
+			return nil
+		}
+
+	}
+
+	var creds *hyperv1.KubevirtPlatformCredentials
+
+	if hc.Spec.Platform.Kubevirt != nil && hc.Spec.Platform.Kubevirt.Credentials != nil {
+		creds = hc.Spec.Platform.Kubevirt.Credentials
+	}
+
+	kvInfraClient, err := r.KubevirtInfraClients.DiscoverKubevirtClusterClient(ctx,
+		r.Client,
+		hc.Spec.InfraID,
+		creds,
+		hc.Namespace,
+		hc.Namespace)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+
+	if cnvVersion, err := kvInfraClient.GetInfraKubevirtVersion(); err != nil {
+		errs = append(errs, err)
+	} else {
+		// ignore "Pre" so this check works accurately with pre-release CNV versions.
+		cnvVersion.Pre = []semver.PRVersion{}
+		minCNVVersion := semver.MustParse("1.0.0")
+
+		if cnvVersion.LT(minCNVVersion) {
+			errs = append(errs, fmt.Errorf("infrastructure kubevirt version is [%s], hypershift kubevirt platform requires kubevirt version [%s] or greater", cnvVersion.String(), minCNVVersion.String()))
+		}
+	}
+
+	if k8sVersion, err := kvInfraClient.GetInfraK8sVersion(); err != nil {
+		errs = append(errs, err)
+	} else {
+		// ignore "Pre" so this check works accurately with pre-release K8s versions.
+		k8sVersion.Pre = []semver.PRVersion{}
+		minK8sVersion := semver.MustParse("1.27.0")
+
+		if k8sVersion.LT(minK8sVersion) {
+			errs = append(errs, fmt.Errorf("infrastructure Kubernetes version is [%s], hypershift kubevirt platform requires Kubernetes version [%s] or greater", k8sVersion.String(), minK8sVersion.String()))
 		}
 	}
 
@@ -4383,15 +4445,15 @@ func (r *HostedClusterReconciler) reconcileKubevirtPlatformDefaultSettings(ctx c
 	// auto generate the basedomain by retrieving the default ingress *.apps dns.
 	if hc.Spec.Platform.Kubevirt.BaseDomainPassthrough != nil && *hc.Spec.Platform.Kubevirt.BaseDomainPassthrough {
 		if hc.Spec.DNS.BaseDomain == "" {
-			kvInfraCluster, err := r.KubevirtInfraClients.DiscoverKubevirtClusterClient(ctx, r.Client, hc.Spec.InfraID, hc.Spec.Platform.Kubevirt.Credentials, hc.Namespace, hc.Namespace)
+			kvInfraClient, err := r.KubevirtInfraClients.DiscoverKubevirtClusterClient(ctx, r.Client, hc.Spec.InfraID, hc.Spec.Platform.Kubevirt.Credentials, hc.Namespace, hc.Namespace)
 			if err != nil {
 				return err
 			}
 			// kubevirtInfraTempRoute is used to resolve the base domain of the infra cluster without accessing IngressController
-			kubevirtInfraTempRoute := manifests.KubevirtInfraTempRoute(kvInfraCluster.Namespace)
+			kubevirtInfraTempRoute := manifests.KubevirtInfraTempRoute(kvInfraClient.GetInfraNamespace())
 
 			createOrUpdateProvider := upsert.New(r.EnableCIDebugOutput)
-			_, err = createOrUpdateProvider.CreateOrUpdate(ctx, kvInfraCluster.Client, kubevirtInfraTempRoute, func() error {
+			_, err = createOrUpdateProvider.CreateOrUpdate(ctx, kvInfraClient.GetInfraClient(), kubevirtInfraTempRoute, func() error {
 				return manifests.ReconcileKubevirtInfraTempRoute(kubevirtInfraTempRoute)
 			})
 			if err != nil {
@@ -4421,7 +4483,7 @@ func (r *HostedClusterReconciler) reconcileKubevirtPlatformDefaultSettings(ctx c
 				// This is possible using OCP wildcard routes
 				hc.Spec.DNS.BaseDomain = baseDomain
 
-				if err := kvInfraCluster.Delete(ctx, kubevirtInfraTempRoute); err != nil {
+				if err := kvInfraClient.GetInfraClient().Delete(ctx, kubevirtInfraTempRoute); err != nil {
 					return err
 				}
 			} else {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -888,7 +888,12 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "kubevirt"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kubevirt",
+				Annotations: map[string]string{
+					hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation: "true",
+				},
+			},
 			Spec: hyperv1.HostedClusterSpec{
 				Platform: hyperv1.PlatformSpec{
 					Type: hyperv1.KubevirtPlatform,
@@ -964,7 +969,9 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 		now:                   metav1.Now,
 	}
 
-	r.KubevirtInfraClients = newKVInfraMapMock(objects)
+	r.KubevirtInfraClients = kvinfra.NewMockKubevirtInfraClientMap(&createTypeTrackingClient{Client: fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build()},
+		"v1.0.0",
+		"1.27.0")
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
@@ -1019,6 +1026,8 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 		other                         []crclient.Object
 		managementClusterCapabilities capabilities.CapabiltyChecker
 		expectedResult                error
+		infraKubeVirtVersion          string
+		infraK8sVersion               string
 	}{
 		{
 			name: "Cluster uses route but not supported, error",
@@ -1155,6 +1164,38 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 			expectedResult:                errors.New(`service type OAuthServer can't be published with the same hostname api.example.com as service type APIServer`),
 			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 		},
+		{
+			name: "KubeVirt cluster meeting min infra cluster versions should succeed",
+			hostedCluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.KubevirtPlatform,
+				}}},
+			other: []crclient.Object{
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "creds"}},
+			},
+			infraKubeVirtVersion: "v1.0.0",
+			infraK8sVersion:      "v1.27.0",
+		},
+		{
+			name: "KubeVirt cluster not meeting min infra cluster versions should fail",
+			hostedCluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.KubevirtPlatform,
+				}}},
+			other: []crclient.Object{
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "creds"}},
+			},
+			infraKubeVirtVersion: "v0.99.0",
+			infraK8sVersion:      "v1.26.99",
+
+			expectedResult: errors.New(`[infrastructure kubevirt version is [0.99.0], hypershift kubevirt platform requires kubevirt version [1.0.0] or greater, infrastructure Kubernetes version is [1.26.99], hypershift kubevirt platform requires Kubernetes version [1.27.0] or greater]`),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1163,6 +1204,8 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 				Client:                        fake.NewClientBuilder().WithObjects(tc.other...).Build(),
 				ManagementClusterCapabilities: tc.managementClusterCapabilities,
 			}
+
+			r.KubevirtInfraClients = kvinfra.NewMockKubevirtInfraClientMap(r.Client, tc.infraKubeVirtVersion, tc.infraK8sVersion)
 
 			ctx := context.Background()
 			actual := r.validateConfigAndClusterCapabilities(ctx, tc.hostedCluster)
@@ -1512,6 +1555,65 @@ func TestValidateReleaseImage(t *testing.T) {
 				},
 			},
 			expectedResult: nil,
+		},
+		{
+			name: "KubeVirt platform unsupported release, error",
+			other: []crclient.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"},
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: nil,
+					},
+				},
+			},
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						NetworkType: hyperv1.OVNKubernetes,
+					},
+					PullSecret: corev1.LocalObjectReference{
+						Name: "pull-secret",
+					},
+					Release: hyperv1.Release{
+						Image: "image-4.13.0",
+					},
+
+					Platform: hyperv1.PlatformSpec{
+						Type:     hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{},
+					},
+				},
+			},
+			expectedResult: errors.New(`the minimum version supported for platform KubeVirt is: "4.14.0". Attempting to use: "4.13.0"`),
+		},
+		{
+			name: "KubeVirt platform supported release, success",
+			other: []crclient.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"},
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: nil,
+					},
+				},
+			},
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						NetworkType: hyperv1.OVNKubernetes,
+					},
+					PullSecret: corev1.LocalObjectReference{
+						Name: "pull-secret",
+					},
+					Release: hyperv1.Release{
+						Image: "image-4.14.0",
+					},
+
+					Platform: hyperv1.PlatformSpec{
+						Type:     hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{},
+					},
+				},
+			},
 		},
 	}
 
@@ -3100,29 +3202,4 @@ func TestReportHostedClusterDeletionDuration(t *testing.T) {
 			}
 		})
 	}
-}
-
-type kubevirtInfraClientMapMock struct {
-	cluster *kvinfra.KubevirtInfraClient
-}
-
-func newKVInfraMapMock(objects []crclient.Object) kvinfra.KubevirtInfraClientMap {
-	return &kubevirtInfraClientMapMock{
-		cluster: &kvinfra.KubevirtInfraClient{
-			Client:    &createTypeTrackingClient{Client: fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build()},
-			Namespace: "kubevirt-kubevirt",
-		},
-	}
-}
-
-func (k *kubevirtInfraClientMapMock) DiscoverKubevirtClusterClient(_ context.Context, _ crclient.Client, _ string, _ *hyperv1.KubevirtPlatformCredentials, _ string, _ string) (*kvinfra.KubevirtInfraClient, error) {
-	return k.cluster, nil
-}
-
-func (k *kubevirtInfraClientMapMock) GetClient(_ string) *kvinfra.KubevirtInfraClient {
-	return k.cluster
-}
-
-func (*kubevirtInfraClientMapMock) Delete(_ string) {
-	// interface's empty implementation
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -30,7 +30,7 @@ func (defaulter *hostedClusterDefaulter) Default(ctx context.Context, obj runtim
 		return nil
 	}
 
-	pullSpec, err := supportedversion.LookupLatestSupportedRelease(ctx)
+	pullSpec, err := supportedversion.LookupLatestSupportedRelease(ctx, hcluster)
 	if err != nil {
 		return fmt.Errorf("unable to find default release image: %w", err)
 	}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -2187,27 +2187,9 @@ func TestDefaultNodePoolAMI(t *testing.T) {
 	}
 }
 
-type kubevirtInfraClientMapMock struct {
-	cluster *kvinfra.KubevirtInfraClient
-}
-
 func newKVInfraMapMock(objects []client.Object) kvinfra.KubevirtInfraClientMap {
-	return &kubevirtInfraClientMapMock{
-		cluster: &kvinfra.KubevirtInfraClient{
-			Client:    fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build(),
-			Namespace: "kubevirt-kubevirt",
-		},
-	}
-}
-
-func (k *kubevirtInfraClientMapMock) DiscoverKubevirtClusterClient(_ context.Context, _ client.Client, _ string, _ *hyperv1.KubevirtPlatformCredentials, _ string, _ string) (*kvinfra.KubevirtInfraClient, error) {
-	return k.cluster, nil
-}
-
-func (k *kubevirtInfraClientMapMock) GetClient(_ string) *kvinfra.KubevirtInfraClient {
-	return k.cluster
-}
-
-func (*kubevirtInfraClientMapMock) Delete(_ string) {
-	// interface's empty implementation
+	return kvinfra.NewMockKubevirtInfraClientMap(
+		fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build(),
+		"",
+		"")
 }

--- a/test/e2e/nodepool_kv_cache_image_test.go
+++ b/test/e2e/nodepool_kv_cache_image_test.go
@@ -72,7 +72,7 @@ func (k KubeVirtCacheTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []
 
 	dv := &v1beta1.DataVolume{}
 	g.Expect(
-		infraClient.Get(k.ctx, crclient.ObjectKey{Namespace: guestNamespace, Name: np.Status.Platform.KubeVirt.CacheName}, dv),
+		infraClient.GetInfraClient().Get(k.ctx, crclient.ObjectKey{Namespace: guestNamespace, Name: np.Status.Platform.KubeVirt.CacheName}, dv),
 	).To(Succeed())
 
 	g.Expect(dv.Status.Phase).Should(Equal(v1beta1.Succeeded))


### PR DESCRIPTION
This PR only impacts the hypershift-operator. We are doing some validation checks to ensure that we only allow creation of HCPs with supported guest, mgmt, and infra versions.

The minimum requirements are
* HCP payload >= v4.14.0
* KubeVirt >= v1.0.0 [CNV 4.14]
* Kubernetes >= v1.27.0 [OCP 4.14]
