### PR TITLE
fix(ignition): Add HCP label to ignition-server by default

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -175,6 +175,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 	ignitionServerLabels := map[string]string{
 		"app":                         ignitionserver.ResourceName,
 		hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
+		"hypershift.openshift.io/hosted-control-plane": hcp.Namespace, // Intentionally adding hcp label to avoid upgrade restriction
 	}
 	servingCertSecretName := ignitionserver.IgnitionServingCertSecret("").Name
 	if hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform {


### PR DESCRIPTION
**What this PR does / why we need it**: Add hcp label to ignition-server `MatchLabels` by default to avoid upgrade restriction from `4.12.27+` to `4.13.7+`
https://redhat-internal.slack.com/archives/C01C8502FMM/p1692808565816429

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.