### PR TITLE
OCPBUGS-11939, OCPBUGS-18128, OCPBUGS-18460 , OCPBUGS-18602, OCPBUGS-18879: Support Disconnected HCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -229,7 +229,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, deploymentConfig *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, additionalTrustBundle *corev1.LocalObjectReference, hcp *hyperv1.HostedControlPlane) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, deploymentConfig *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, additionalTrustBundle *corev1.LocalObjectReference, hcp *hyperv1.HostedControlPlane, openShiftTrustedCABundleConfigMapForCPOExists bool) error {
 	// Before this change we did
 	// 		Selector: &metav1.LabelSelector{
 	//			MatchLabels: hccLabels,
@@ -277,6 +277,9 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 	}
 	if additionalTrustBundle != nil {
 		util.DeploymentAddTrustBundleVolume(additionalTrustBundle, deployment)
+	}
+	if openShiftTrustedCABundleConfigMapForCPOExists {
+		util.DeploymentAddOpenShiftTrustedCABundleConfigMap(deployment)
 	}
 	if isExternalInfraKv(hcp) {
 		// injects the kubevirt credentials secret volume, volume mount path, and appends cli arg.

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -229,7 +229,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, deploymentConfig *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, additionalTrustBundle *corev1.LocalObjectReference, hcp *hyperv1.HostedControlPlane, openShiftTrustedCABundleConfigMapForCPOExists bool) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, deploymentConfig *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, additionalTrustBundle *corev1.LocalObjectReference, hcp *hyperv1.HostedControlPlane, openShiftTrustedCABundleConfigMapForCPOExists bool, registryOverrides map[string]string, openShiftImageRegistryOverrides map[string][]string) error {
 	// Before this change we did
 	// 		Selector: &metav1.LabelSelector{
 	//			MatchLabels: hccLabels,
@@ -264,7 +264,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
-					util.BuildContainer(hccContainerMain(), buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion, enableCIDebugOutput, platformType, konnectivityAddress, konnectivityPort, oauthAddress, oauthPort, releaseImage)),
+					util.BuildContainer(hccContainerMain(), buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion, enableCIDebugOutput, platformType, konnectivityAddress, konnectivityPort, oauthAddress, oauthPort, releaseImage, registryOverrides, openShiftImageRegistryOverrides)),
 				},
 				Volumes: []corev1.Volume{
 					util.BuildVolume(hccVolumeKubeconfig(), buildHCCVolumeKubeconfig),
@@ -322,7 +322,7 @@ func hccVolumeClusterSignerCA() *corev1.Volume {
 	}
 }
 
-func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string) func(c *corev1.Container) {
+func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, registryOverrides map[string]string, openShiftImageRegistryOverrides map[string][]string) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.ImagePullPolicy = corev1.PullIfNotPresent
@@ -340,6 +340,7 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 			fmt.Sprintf("--konnectivity-port=%d", konnectivityPort),
 			fmt.Sprintf("--oauth-address=%s", oauthAddress),
 			fmt.Sprintf("--oauth-port=%d", oauthPort),
+			"--registry-overrides", util.ConvertRegistryOverridesToCommandLineFlag(registryOverrides),
 		}
 		if platformType == hyperv1.IBMCloudPlatform {
 			c.Command = append(c.Command, "--controllers=controller-manager-ca,resources,inplaceupgrader,drainer,hcpstatus")
@@ -365,6 +366,10 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 			{
 				Name:  "OPERATE_ON_RELEASE_IMAGE",
 				Value: releaseImage,
+			},
+			{
+				Name:  "OPENSHIFT_IMG_OVERRIDES",
+				Value: util.ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(openShiftImageRegistryOverrides),
 			},
 		}
 		proxy.SetEnvVars(&c.Env)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3477,7 +3477,7 @@ func (r *HostedControlPlaneReconciler) reconcileHostedClusterConfigOperator(ctx 
 
 	deployment := manifests.ConfigOperatorDeployment(hcp.Namespace)
 	if _, err = createOrUpdate(ctx, r.Client, deployment, func() error {
-		return configoperator.ReconcileDeployment(deployment, p.Image, hcp.Name, p.OpenShiftVersion, p.KubernetesVersion, p.OwnerRef, &p.DeploymentConfig, p.AvailabilityProberImage, r.EnableCIDebugOutput, hcp.Spec.Platform.Type, util.APIPort(hcp), infraStatus.KonnectivityHost, infraStatus.KonnectivityPort, infraStatus.OAuthHost, infraStatus.OAuthPort, hcp.Spec.ReleaseImage, hcp.Spec.AdditionalTrustBundle, hcp, openShiftTrustedCABundleConfigMapForCPOExists)
+		return configoperator.ReconcileDeployment(deployment, p.Image, hcp.Name, p.OpenShiftVersion, p.KubernetesVersion, p.OwnerRef, &p.DeploymentConfig, p.AvailabilityProberImage, r.EnableCIDebugOutput, hcp.Spec.Platform.Type, util.APIPort(hcp), infraStatus.KonnectivityHost, infraStatus.KonnectivityPort, infraStatus.OAuthHost, infraStatus.OAuthPort, hcp.Spec.ReleaseImage, hcp.Spec.AdditionalTrustBundle, hcp, openShiftTrustedCABundleConfigMapForCPOExists, r.ReleaseProvider.GetRegistryOverrides(), r.ReleaseProvider.GetOpenShiftImageRegistryOverrides())
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile config operator deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1008,6 +1008,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 		r.ManagementClusterCapabilities.Has(capabilities.CapabilitySecurityContextConstraint),
 		config.OwnerRefFrom(hostedControlPlane),
 		openShiftTrustedCABundleConfigMapForCPOExists,
+		r.ReleaseProvider.GetMirroredReleaseImage(),
 	); err != nil {
 		return fmt.Errorf("failed to reconcile ignition server: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/cpo.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/cpo.go
@@ -1,0 +1,15 @@
+package manifests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func OpenShiftTrustedCABundleFromCPO(namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "openshift-config-managed-trusted-ca-bundle",
+		},
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1595,8 +1595,13 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile SRE metrics config: %w", err)
 	}
 
+	openShiftTrustedCABundleConfigMapExists, err := r.reconcileOpenShiftTrustedCAs(ctx, hcp)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile OpenShift trusted CAs: %w", err)
+	}
+
 	// Reconcile the control plane operator
-	err = r.reconcileControlPlaneOperator(ctx, createOrUpdate, hcluster, hcp, controlPlaneOperatorImage, utilitiesImage, defaultIngressDomain, cpoHasUtilities)
+	err = r.reconcileControlPlaneOperator(ctx, createOrUpdate, hcluster, hcp, controlPlaneOperatorImage, utilitiesImage, defaultIngressDomain, cpoHasUtilities, openShiftTrustedCABundleConfigMapExists)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile control plane operator: %w", err)
 	}
@@ -2016,7 +2021,7 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(ctx context.Context, cre
 
 // reconcileControlPlaneOperator orchestrates reconciliation of the control plane
 // operator components.
-func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane, controlPlaneOperatorImage, utilitiesImage, defaultIngressDomain string, cpoHasUtilities bool) error {
+func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hostedControlPlane *hyperv1.HostedControlPlane, controlPlaneOperatorImage, utilitiesImage, defaultIngressDomain string, cpoHasUtilities bool, openShiftTrustedCABundleConfigMapExists bool) error {
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 	err := r.Client.Get(ctx, client.ObjectKeyFromObject(controlPlaneNamespace), controlPlaneNamespace)
 	if err != nil {
@@ -2092,6 +2097,7 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	_, err = createOrUpdate(ctx, r.Client, controlPlaneOperatorDeployment, func() error {
 		return reconcileControlPlaneOperatorDeployment(
 			controlPlaneOperatorDeployment,
+			openShiftTrustedCABundleConfigMapExists,
 			hcluster,
 			hostedControlPlane,
 			controlPlaneOperatorImage,
@@ -2135,6 +2141,41 @@ func (r *HostedClusterReconciler) reconcileControlPlaneOperator(ctx context.Cont
 	}
 
 	return nil
+}
+
+// reconcileOpenShiftTrustedCAs checks for the existence of /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem, if it exists,
+// creates a new ConfigMap to be mounted in the CPO deployment utilizing the file
+func (r *HostedClusterReconciler) reconcileOpenShiftTrustedCAs(ctx context.Context, hostedControlPlane *hyperv1.HostedControlPlane) (bool, error) {
+	trustedCABundle := new(bytes.Buffer)
+	var trustCABundleFile []byte
+
+	_, err := os.Stat("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+	if err == nil {
+		trustCABundleFile, err = os.ReadFile("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+		if err != nil {
+			return false, fmt.Errorf("unable to read trust bundle file: %w", err)
+		}
+	}
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	if _, err = trustedCABundle.Write(trustCABundleFile); err != nil {
+		return false, fmt.Errorf("unable to write trust bundle to buffer: %w", err)
+	}
+
+	// Next, save the contents to a new ConfigMap in the hosted control plane's namespace
+	openShiftTrustedCABundleConfigMapForCPO := manifests.OpenShiftTrustedCABundleForNamespace(hostedControlPlane.Namespace)
+	openShiftTrustedCABundleConfigMapForCPO.Data["ca-bundle.crt"] = trustedCABundle.String()
+	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, openShiftTrustedCABundleConfigMapForCPO, NoopReconcile); err != nil {
+		return false, fmt.Errorf("failed to create openshift-config-managed-trusted-ca-bundle for CPO deployment %T: %w", trustedCABundle.String(), err)
+	}
+
+	return true, nil
 }
 
 func servicePublishingStrategyByType(hcp *hyperv1.HostedCluster, svcType hyperv1.ServiceType) *hyperv1.ServicePublishingStrategy {
@@ -2200,6 +2241,7 @@ func GetControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 
 func reconcileControlPlaneOperatorDeployment(
 	deployment *appsv1.Deployment,
+	openShiftTrustedCABundleConfigMapExists bool,
 	hc *hyperv1.HostedCluster,
 	hcp *hyperv1.HostedControlPlane,
 	cpoImage,
@@ -2337,6 +2379,10 @@ func reconcileControlPlaneOperatorDeployment(
 				},
 			},
 		},
+	}
+
+	if openShiftTrustedCABundleConfigMapExists {
+		hyperutil.DeploymentAddOpenShiftTrustedCABundleConfigMap(deployment)
 	}
 
 	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1042,7 +1042,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get controlPlaneOperatorImage: %w", err)
 	}
-	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes, hcluster.Spec.ImageContentSources)
+	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to look up image metadata for %s: %w", controlPlaneOperatorImage, err)
 	}

--- a/hypershift-operator/controllers/manifests/manifests.go
+++ b/hypershift-operator/controllers/manifests/manifests.go
@@ -96,3 +96,15 @@ func MonitoringDashboard(clusterNamespace, clusterName string) *corev1.ConfigMap
 		},
 	}
 }
+
+func OpenShiftTrustedCABundleForNamespace(namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "openshift-config-managed-trusted-ca-bundle",
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": "",
+		},
+	}
+}

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -50,7 +50,7 @@ func (r *NodePoolReconciler) isHAProxyIgnitionConfigManaged(ctx context.Context,
 		return false, "", fmt.Errorf("failed to get controlPlaneOperatorImage: %w", err)
 	}
 
-	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes, hcluster.Spec.ImageContentSources)
+	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to look up image metadata for %s: %w", controlPlaneOperatorImage, err)
 	}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2599,7 +2599,7 @@ func (r *NodePoolReconciler) detectCPOCapabilities(ctx context.Context, hostedCl
 		return nil, fmt.Errorf("failed to get controlPlaneOperatorImage: %w", err)
 	}
 
-	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes, hostedCluster.Spec.ImageContentSources)
+	controlPlaneOperatorImageMetadata, err := r.ImageMetadataProvider.ImageMetadata(ctx, controlPlaneOperatorImage, pullSecretBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to look up image metadata for %s: %w", controlPlaneOperatorImage, err)
 	}

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -290,6 +290,10 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		OpenShiftImageRegistryOverrides: imageRegistryOverrides,
 	}
 
+	imageMetaDataProvider := &hyperutil.RegistryClientImageMetadataProvider{
+		OpenShiftImageRegistryOverrides: imageRegistryOverrides,
+	}
+
 	monitoringDashboards := (os.Getenv("MONITORING_DASHBOARDS") == "1")
 
 	hostedClusterReconciler := &hostedcluster.HostedClusterReconciler{
@@ -299,7 +303,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		ReleaseProvider:               releaseProviderWithOpenShiftImageRegistryOverrides,
 		EnableOCPClusterMonitoring:    opts.EnableOCPClusterMonitoring,
 		EnableCIDebugOutput:           opts.EnableCIDebugOutput,
-		ImageMetadataProvider:         &hyperutil.RegistryClientImageMetadataProvider{},
+		ImageMetadataProvider:         imageMetaDataProvider,
 		MetricsSet:                    metricsSet,
 		OperatorNamespace:             opts.Namespace,
 		SREConfigHash:                 sreConfigHash,

--- a/support/releaseinfo/fake/fake.go
+++ b/support/releaseinfo/fake/fake.go
@@ -109,6 +109,10 @@ func (*FakeReleaseProvider) GetOpenShiftImageRegistryOverrides() map[string][]st
 	return nil
 }
 
+func (*FakeReleaseProvider) GetMirroredReleaseImage() string {
+	return ""
+}
+
 func GetReleaseImage(ctx context.Context, hc *hyperv1.HostedCluster, client crclient.WithWatch, releaseProvider *FakeReleaseProvider) *releaseinfo.ReleaseImage {
 	var pullSecret corev1.Secret
 	if err := client.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hc.Spec.PullSecret.Name}, &pullSecret); err != nil {

--- a/support/releaseinfo/registry_image_content_policies.go
+++ b/support/releaseinfo/registry_image_content_policies.go
@@ -12,6 +12,7 @@ var _ ProviderWithOpenShiftImageRegistryOverrides = (*ProviderWithOpenShiftImage
 type ProviderWithOpenShiftImageRegistryOverridesDecorator struct {
 	Delegate                        ProviderWithRegistryOverrides
 	OpenShiftImageRegistryOverrides map[string][]string
+	mirroredReleaseImage            string
 
 	lock sync.Mutex
 }
@@ -30,6 +31,7 @@ func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) Lookup(ctx contex
 				// Attempt to lookup image with mirror registry destination
 				releaseImage, err := p.Delegate.Lookup(ctx, image, pullSecret)
 				if releaseImage != nil {
+					p.mirroredReleaseImage = image
 					return releaseImage, nil
 				}
 
@@ -47,4 +49,8 @@ func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) GetRegistryOverri
 
 func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) GetOpenShiftImageRegistryOverrides() map[string][]string {
 	return p.OpenShiftImageRegistryOverrides
+}
+
+func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) GetMirroredReleaseImage() string {
+	return p.mirroredReleaseImage
 }

--- a/support/releaseinfo/releaseinfo.go
+++ b/support/releaseinfo/releaseinfo.go
@@ -28,6 +28,7 @@ type ProviderWithRegistryOverrides interface {
 type ProviderWithOpenShiftImageRegistryOverrides interface {
 	ProviderWithRegistryOverrides
 	GetOpenShiftImageRegistryOverrides() map[string][]string
+	GetMirroredReleaseImage() string
 }
 
 // ReleaseImage wraps an ImageStream with some utilities that help the user

--- a/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
+++ b/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
@@ -3,7 +3,6 @@ package fakeimagemetadataprovider
 import (
 	"context"
 
-	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 )
 
@@ -11,6 +10,6 @@ type FakeImageMetadataProvider struct {
 	Result *dockerv1client.DockerImageConfig
 }
 
-func (f *FakeImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte, imageContentSources []hyperv1.ImageContentSource) (*dockerv1client.DockerImageConfig, error) {
+func (f *FakeImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
 	return f.Result, nil
 }

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
+)
+
+func TestGetRegistryOverrides(t *testing.T) {
+	ctx := context.TODO()
+	testsCases := []struct {
+		name           string
+		ref            reference.DockerImageReference
+		source         string
+		mirror         string
+		expectedImgRef *reference.DockerImageReference
+		expectAnErr    bool
+	}{
+		{
+			name: "if failed to parse source image",
+			ref: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.14.0-rc.0-multi",
+			},
+			source:         "",
+			mirror:         "",
+			expectedImgRef: nil,
+			expectAnErr:    true,
+		},
+		{
+			name: "if registry override coincidence not found",
+			ref: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.14.0-rc.0-multi",
+			},
+			source: "quay.io/openshift-release-dev/ocp-release:4.14.0-rc.0-multi",
+			mirror: "my_registry/openshift-release-dev/ocp-release:4.14.0-rc.0-multi",
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.14.0-rc.0-multi",
+			},
+			expectAnErr: false,
+		},
+		{
+			name: "if registry override coincidence is found",
+			ref: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.14.0-rc.0-multi",
+			},
+			source: "quay.io/openshift-release-dev/ocp-release:4.14.0-rc.0-multi",
+			mirror: "my_registry/openshift-release-dev/ocp-release:4.14.0-rc.0-multi",
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "",
+				Name:      "openshift-release-dev/ocp-release",
+				Namespace: "my_registry",
+				Tag:       "4.14.0-rc.0-multi",
+			},
+			expectAnErr: false,
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			imgRef, err := GetRegistryOverrides(ctx, tc.ref, tc.source, tc.mirror)
+			g.Expect(imgRef).To(Equal(tc.expectedImgRef))
+			g.Expect(err != nil).To(Equal(tc.expectAnErr))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains the work needed to support HCP in a disconnected environment. The majority of the work in this PR is to determine image metadata in a disconnected environment, include user-ca bundles in appropriate HCP pods, and fixing the ignition server to support extracting image files in disconnected environments.

[OCPBUGS-11939](https://github.com/openshift/hypershift/pull/2950/commits/160d7a9055cdfc291e699872520b79b6ea8a1a48) - Get the image metadata from any ICSP/IDMS in a management cluster allowing a hosted cluster to be created in a disconnected environment with image mirror registry data from the ICSP/IDMS.

[OCPBUGS-18128](https://github.com/openshift/hypershift/pull/2950/commits/41cdd9fbc06e87b212fcf6c63c602526656936a2)  - Automatically include the user created CA ConfigMap in the CPO deployment. This is accomplished in the HCC by combining the image registry CAs, listed in an Image (image.config.openshift.io) resource named 'clusters' in the 'openshift-config' namespace, to the CAs in the openshift-config-managed-trusted-ca-bundle ConfigMap from the
'hypershift' namespace and saving this to a new ConfigMap in the hostedcluster namespace. This new ConfigMap is then mounted as a volume in the CPO deployment.

[OCPBUGS-18460](https://github.com/openshift/hypershift/pull/2950/commits/3877ce239065eaa8564453b0a1bbe4d9b5598f5f) - Includes the user created CA ConfigMap in the ignition server deployment. This is accomplished by checking for the existence of a ConfigMap containing the needed CA data and mounting it to the ignition server deployment if the ConfigMap exists.

[OCPBUGS-18602](https://github.com/openshift/hypershift/pull/2950/commits/5fd9537ecca92ed547867bfe405e31acb153b497) - Includes the OpenShiftTrustedCABundle ConfigMap in the HCCO deployment.

[OCPBUGS-18602](https://github.com/openshift/hypershift/pull/2950/commits/80d5f214251359a73eb5689a28892e11c5ceb0e6) - Updates the HCCO release provider to include registry overrides and OpenShift image registry overrides.

[OCPBUGS-18879](https://github.com/openshift/hypershift/pull/2950/commits/6e43ed0e1b3ad19839e5deee87b548d8edd5398d) - Adds functionality to support extracting image files into release-manifests/image-reference config directory when working in a disconnected environment in the ignition server. Also, now catches the error when extracting image references to the config directory.

**Which issue(s) this PR fixes**:
- Fixes [OCPBUGS-11939](https://issues.redhat.com/browse/OCPBUGS-11939)
- Fixes [OCPBUGS-18128](https://issues.redhat.com/browse/OCPBUGS-18128)
- Fixes [OCPBUGS-18460](https://issues.redhat.com/browse/OCPBUGS-18460)
- Fixes [OCPBUGS-18602](https://issues.redhat.com/browse/OCPBUGS-18602)
- Fixes [OCPBUGS-18879](https://issues.redhat.com/browse/OCPBUGS-18879)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.