### PR TITLE
HOSTEDCP-1161: Add ability for CI to share infra for HCs created in an e2e run

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -87,6 +87,7 @@ type ExampleOptions struct {
 	ControlPlaneAvailabilityPolicy   hyperv1.AvailabilityPolicy
 	InfrastructureAvailabilityPolicy hyperv1.AvailabilityPolicy
 	UpgradeType                      hyperv1.UpgradeType
+	ServiceAccountSigningKey         string
 }
 
 func (o ExampleOptions) Resources() *ExampleResources {
@@ -443,6 +444,9 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			SecretEncryption: secretEncryption,
 			Networking: hyperv1.ClusterNetworking{
 				NetworkType: o.NetworkType,
+			},
+			ServiceAccountSigningKey: &corev1.LocalObjectReference{
+				Name: o.ServiceAccountSigningKey,
 			},
 			Services:   services,
 			InfraID:    o.InfraID,

--- a/cmd/cluster/aws/destroy.go
+++ b/cmd/cluster/aws/destroy.go
@@ -68,20 +68,23 @@ func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error
 			return err
 		}
 	}
-	o.Log.Info("Destroying infrastructure", "infraID", infraID)
-	destroyInfraOpts := awsinfra.DestroyInfraOptions{
-		Region:             region,
-		InfraID:            infraID,
-		AWSCredentialsFile: o.AWSPlatform.AWSCredentialsFile,
-		AWSKey:             awsKeyID,
-		AWSSecretKey:       awsSecretKey,
-		Name:               o.Name,
-		BaseDomain:         baseDomain,
-		BaseDomainPrefix:   baseDomainPrefix,
-		Log:                o.Log,
-	}
-	if err := destroyInfraOpts.Run(ctx); err != nil {
-		return fmt.Errorf("failed to destroy infrastructure: %w", err)
+
+	if !o.AWSPlatform.PreserveInfra {
+		o.Log.Info("Destroying infrastructure", "infraID", infraID)
+		destroyInfraOpts := awsinfra.DestroyInfraOptions{
+			Region:             region,
+			InfraID:            infraID,
+			AWSCredentialsFile: o.AWSPlatform.AWSCredentialsFile,
+			AWSKey:             awsKeyID,
+			AWSSecretKey:       awsSecretKey,
+			Name:               o.Name,
+			BaseDomain:         baseDomain,
+			BaseDomainPrefix:   baseDomainPrefix,
+			Log:                o.Log,
+		}
+		if err := destroyInfraOpts.Run(ctx); err != nil {
+			return fmt.Errorf("failed to destroy infrastructure: %w", err)
+		}
 	}
 
 	if !o.AWSPlatform.PreserveIAM {

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -78,6 +78,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
+	cmd.PersistentFlags().StringVar(&opts.ServiceAccountSigningKey, "service-account-signing-key", opts.ServiceAccountSigningKey, "The service account signing key to use for the HC")
 	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The default processor architecture for the NodePool (e.g. arm64, amd64)")
 	cmd.PersistentFlags().StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -77,6 +77,7 @@ type CreateOptions struct {
 	SkipAPIBudgetVerification        bool
 	CredentialSecretName             string
 	NodeUpgradeType                  hyperv1.UpgradeType
+	ServiceAccountSigningKey         string
 	PausedUntil                      string
 
 	// BeforeApply is called immediately before resources are applied to the
@@ -291,6 +292,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		Arch:                             opts.Arch,
 		NodeSelector:                     opts.NodeSelector,
 		UpgradeType:                      opts.NodeUpgradeType,
+		ServiceAccountSigningKey:         opts.ServiceAccountSigningKey,
 		PausedUntil:                      opts.PausedUntil,
 	}, nil
 }

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -43,6 +43,7 @@ type AWSPlatformDestroyOptions struct {
 	AWSCredentialsFile string
 	BaseDomain         string
 	BaseDomainPrefix   string
+	PreserveInfra      bool
 	PreserveIAM        bool
 	Region             string
 	PostDeleteAction   func()

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2639,7 +2639,6 @@ func (r *HostedControlPlaneReconciler) reconcileOpenShiftOAuthAPIServer(ctx cont
 
 func (r *HostedControlPlaneReconciler) reconcileOAuthServer(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, oauthHost string, oauthPort int32, createOrUpdate upsert.CreateOrUpdateFN) error {
 	p := oauth.NewOAuthServerParams(hcp, releaseImageProvider, oauthHost, oauthPort, r.SetDefaultSecurityContext)
-
 	sessionSecret := manifests.OAuthServerServiceSessionSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, sessionSecret, func() error {
 		return oauth.ReconcileSessionSecret(sessionSecret, p.OwnerRef)

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -197,11 +197,15 @@ func (h *hypershiftTest) createHostedCluster(opts *core.CreateOptions, platform 
 		}
 	}
 
+	hcName := opts.Name
+	if opts.Name == "" {
+		hcName = SimpleNameGenerator.GenerateName("example-")
+	}
 	// Build the skeletal HostedCluster based on the provided platform.
 	hc := &hyperv1.HostedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace.Name,
-			Name:      SimpleNameGenerator.GenerateName("example-"),
+			Name:      hcName,
 		},
 		Spec: hyperv1.HostedClusterSpec{
 			Platform: hyperv1.PlatformSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Explore ability for CI to share infra for HCs created in an e2e run

This is to evaluate savings from reusing infra (hours) + moving from nat gateways to ec2 nat instances (data transfer)

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
/hold

Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.