### PR TITLE
OCPBUGS-18127: Trigger a rolling upgrade on NodePool .spec.platfrom changes

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -908,6 +908,10 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		}
 	}
 
+	if err := r.cleanupMachineTemplates(ctx, log, nodePool, controlPlaneNamespace); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Reconcile (Platform)MachineTemplate.
 	template, mutateTemplate, machineTemplateSpecJSON, err := machineTemplateBuilders(hcluster, nodePool, infraID, ami, powervsBootImage, kubevirtBootImage, cpoCapabilities.CreateDefaultAWSSecurityGroup)
 	if err != nil {
@@ -1007,6 +1011,66 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		})
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *NodePoolReconciler) cleanupMachineTemplates(ctx context.Context, log logr.Logger, nodePool *hyperv1.NodePool, controlPlaneNamespace string) error {
+	// list machineSets
+	machineSets := &capiv1.MachineSetList{}
+	if err := r.Client.List(ctx, machineSets, client.InNamespace(controlPlaneNamespace)); err != nil {
+		return fmt.Errorf("failed to list machineSets: %w", err)
+	}
+
+	// filter machineSets owned by this nodePool.
+	nodePoolKey := client.ObjectKeyFromObject(nodePool).String()
+	filtered := make([]*capiv1.MachineSet, 0, len(machineSets.Items))
+	for idx := range machineSets.Items {
+		ms := &machineSets.Items[idx]
+		// skip if machineSet doesn't belong to the nodePool
+		if ms.Annotations[nodePoolAnnotation] != nodePoolKey {
+			continue
+		}
+
+		filtered = append(filtered, ms)
+	}
+
+	if len(filtered) == 0 {
+		// initial machineSet has not been created.
+		log.Info("initial machineSet has not been created.")
+		return nil
+	}
+
+	ref := filtered[0].Spec.Template.Spec.InfrastructureRef
+	machineTemplates := new(unstructured.UnstructuredList)
+	machineTemplates.SetAPIVersion(ref.APIVersion)
+	machineTemplates.SetKind(ref.Kind)
+	if err := r.Client.List(ctx, machineTemplates, client.InNamespace(ref.Namespace)); err != nil {
+		return fmt.Errorf("failed to list MachineTemplates: %w", err)
+	}
+
+	// delete old machine templates not currently referenced by any machineSet.
+	for _, mt := range machineTemplates.Items {
+		// skip if MachineTempalte doesn't belong to the nodePool.
+		if mt.GetAnnotations()[nodePoolAnnotation] != nodePoolKey {
+			continue
+		}
+
+		shouldDelete := true
+		for _, ms := range filtered {
+			if mt.GetName() == ms.Spec.Template.Spec.InfrastructureRef.Name {
+				shouldDelete = false
+				break
+			}
+		}
+
+		if shouldDelete {
+			log.Info("deleting machineTemplate", "name", mt.GetName())
+			if err := r.Client.Delete(ctx, &mt); err != nil {
+				return fmt.Errorf("failed to delete MachineTemplate %s: %w", mt.GetName(), err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r *NodePoolReconciler) addKubeVirtCacheNameToStatus(kubevirtBootImage kubevirt.BootImage, nodePool *hyperv1.NodePool) {
@@ -2443,12 +2507,14 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 		return nil, nil, "", fmt.Errorf("unsupported platform type: %s", nodePool.Spec.Platform.Type)
 	}
 	template.SetNamespace(manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name).Name)
-	template.SetName(nodePool.GetName())
 
 	machineTemplateSpecJSON, err := json.Marshal(machineTemplateSpec)
 	if err != nil {
 		return nil, nil, "", err
 	}
+
+	// ensures a rolling upgrade is triggered, by creating a new template with a differnt name if any field changes.
+	template.SetName(fmt.Sprintf("%s-%s", nodePool.GetName(), supportutil.HashStruct(machineTemplateSpecJSON)))
 
 	return template, mutateTemplate, string(machineTemplateSpecJSON), nil
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3,6 +3,7 @@ package nodepool
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/api/image/docker10"
 	imagev1 "github.com/openshift/api/image/v1"
+	supportutil "github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1497,6 +1499,8 @@ func RunTestMachineTemplateBuilders(t *testing.T, preCreateMachineTemplate bool)
 	}
 	expectedMachineTemplateSpecJSON, err := json.Marshal(expectedMachineTemplate.Spec)
 	g.Expect(err).ToNot(HaveOccurred())
+
+	expectedMachineTemplate.SetName(fmt.Sprintf("%s-%s", nodePool.GetName(), supportutil.HashStruct(expectedMachineTemplateSpecJSON)))
 
 	template, mutateTemplate, machineTemplateSpecJSON, err := machineTemplateBuilders(hcluster, nodePool, infraID, ami, "", nil, true)
 	g.Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/nodepool_rolling_upgrade_test.go
+++ b/test/e2e/nodepool_rolling_upgrade_test.go
@@ -1,0 +1,115 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	npcontroller "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type RollingUpgradeTest struct {
+	ctx        context.Context
+	mgmtClient crclient.Client
+
+	hostedCluster *hyperv1.HostedCluster
+}
+
+func NewRollingUpgradeTest(ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) *RollingUpgradeTest {
+	return &RollingUpgradeTest{
+		ctx:           ctx,
+		mgmtClient:    mgmtClient,
+		hostedCluster: hostedCluster,
+	}
+}
+
+func (k *RollingUpgradeTest) Setup(t *testing.T) {
+	if globalOpts.Platform != hyperv1.AWSPlatform {
+		t.Skip("test only supported on platform AWS")
+	}
+}
+
+func (k *RollingUpgradeTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k.hostedCluster.Name + "-" + "test-rolling-upgrade",
+			Namespace: k.hostedCluster.Namespace,
+		},
+	}
+	defaultNodepool.Spec.DeepCopyInto(&nodePool.Spec)
+
+	nodePool.Spec.Replicas = &twoReplicas
+	nodePool.Spec.Platform.AWS.InstanceType = "m5.large"
+	nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
+
+	return nodePool, nil
+}
+
+func (k *RollingUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
+	g := NewWithT(t)
+
+	instanceType := "m5.xlarge"
+	// change instance type to trigger a rolling upgrade
+	err := e2eutil.UpdateObject(t, k.ctx, k.mgmtClient, &nodePool, func(obj *hyperv1.NodePool) {
+		obj.Spec.Platform.AWS.InstanceType = instanceType
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// wait until the machine deployment starts the rolling upgrade.
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name).Name
+	md := &capiv1.MachineDeployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      nodePool.Name,
+			Namespace: controlPlaneNamespace,
+		},
+	}
+	err = wait.PollImmediateWithContext(k.ctx, 5*time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
+		if err := k.mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(md), md); err != nil {
+			return false, err
+		}
+
+		phase := md.Status.GetTypedPhase()
+		if phase == capiv1.MachineDeploymentPhaseScalingDown || phase == capiv1.MachineDeploymentPhaseScalingUp ||
+			md.Status.Replicas > *md.Spec.Replicas {
+			return true, nil
+		}
+		return false, nil
+	})
+	g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed waiting for machine deployment to start the rolling upgrade, phase=%s", md.Status.Phase))
+
+	// wait until the rolling upgrade is completed
+	err = wait.PollImmediateWithContext(k.ctx, 30*time.Second, 30*time.Minute, func(ctx context.Context) (done bool, err error) {
+		if err := k.mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(md), md); err != nil {
+			return false, err
+		}
+
+		if npcontroller.MachineDeploymentComplete(md) {
+			return true, nil
+		}
+		return false, nil
+	})
+	g.Expect(err).ToNot(HaveOccurred(), "failed waiting for the rolling upgrade to complete")
+
+	// check all aws machines have the new instance type
+	awsMachines := &capiaws.AWSMachineList{}
+	err = k.mgmtClient.List(k.ctx, awsMachines, crclient.InNamespace(controlPlaneNamespace), crclient.MatchingLabels{capiv1.MachineDeploymentLabelName: md.Name})
+	g.Expect(err).ToNot(HaveOccurred(), "failed to list aws machines")
+
+	for _, machine := range awsMachines.Items {
+		g.Expect(machine.Spec.InstanceType).To(Equal(instanceType))
+	}
+}

--- a/test/e2e/nodepool_rolling_upgrade_test.go
+++ b/test/e2e/nodepool_rolling_upgrade_test.go
@@ -69,7 +69,6 @@ func (k *RollingUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes 
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
-	// wait until the machine deployment starts the rolling upgrade.
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name).Name
 	md := &capiv1.MachineDeployment{
 		ObjectMeta: v1.ObjectMeta{
@@ -77,7 +76,8 @@ func (k *RollingUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes 
 			Namespace: controlPlaneNamespace,
 		},
 	}
-	err = wait.PollImmediateWithContext(k.ctx, 5*time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
+	// wait until the machine deployment starts the rolling upgrade.
+	err = wait.PollImmediateWithContext(k.ctx, 5*time.Second, 2*time.Minute, func(ctx context.Context) (done bool, err error) {
 		if err := k.mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(md), md); err != nil {
 			return false, err
 		}

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -99,6 +99,10 @@ func TestNodePool(t *testing.T) {
 				name: "KubeVirtCacheTest",
 				test: NewKubeVirtCacheTest(ctx, mgtClient, hostedCluster),
 			},
+			{
+				name: "TestRollingUpgrade",
+				test: NewRollingUpgradeTest(ctx, mgtClient, hostedCluster),
+			},
 		}
 
 		for _, testCase := range nodePoolTests {


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures a rolling upgrade is triggered, by creating a new machine template with a different name if any field under .spec.platfrom changes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-18127](https://issues.redhat.com/browse/OCPBUGS-18127)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.