### PR TITLE
HOSTEDCP-1178 fix limited support label key

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -134,7 +134,7 @@ const (
 	// LimitedSupportLabel is a label that can be used by consumers to indicate
 	// a cluster is somehow out of regular support policy.
 	// https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-limited-support_rosa-service-definition.
-	LimitedSupportLabel = "hypershift.openshift.io/limited-support"
+	LimitedSupportLabel = "api.openshift.com/limited-support"
 
 	// SilenceClusterAlertsLabel  is a label that can be used by consumers to indicate
 	// alerts from a cluster can be silenced or ignored


### PR DESCRIPTION
**What this PR does / why we need it**:
The existing label key that was used in ROSA was `api.openshift.com/limited-support`

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1178](https://issues.redhat.com//browse/HOSTEDCP-1178)