### PR TITLE
OCPBUGS-18266: fix Progressing condition when ControlPlaneRelease is set

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3656,7 +3656,7 @@ func isProgressing(hc *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseI
 		}
 	}
 
-	if hc.Status.Version == nil || hyperutil.HCControlPlaneReleaseImage(hc) != hc.Status.Version.Desired.Image {
+	if hc.Status.Version == nil || hc.Spec.Release.Image != hc.Status.Version.Desired.Image {
 		// cluster is doing initial rollout or upgrading
 		return true, nil
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-18266

HC status will always reflect the `Release`, not the `ControlPlaneRelease`.  Thus we should always compare `Status.Version.Desired.Image` against `Spec.Release.Image`.