### PR TITLE
HOSTEDCP-979: Re-enable nodepool in-place upgrade tests

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -75,26 +75,24 @@ func TestNodePool(t *testing.T) {
 				name: "TestNTOMachineConfigGetsRolledOut",
 				test: NewNTOMachineConfigRolloutTest(ctx, mgtClient, hostedCluster, hostedClusterClient),
 			},
-			/*
-				// TODO: (csrwng) Re-enable when https://issues.redhat.com/browse/OCPBUGS-10218 is fixed
-				{
-					name:            "TestNTOMachineConfigAppliedInPlace",
-					test:            NewNTOMachineConfigRolloutTest(ctx, mgmtClient, hostedCluster, hostedClusterClient),
-					manifestBuilder: NewNTOMachineConfigInPlaceRolloutTestManifest(hostedCluster),
-				},
-			*/
+
+			{
+				name:            "TestNTOMachineConfigAppliedInPlace",
+				test:            NewNTOMachineConfigRolloutTest(ctx, mgtClient, hostedCluster, hostedClusterClient),
+				manifestBuilder: NewNTOMachineConfigInPlaceRolloutTestManifest(hostedCluster),
+			},
+
 			{
 				name: "TestNodePoolReplaceUpgrade",
 				test: NewNodePoolUpgradeTest(ctx, mgtClient, hostedCluster, hostedClusterClient, clusterOpts, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
 			},
-			// TODO: (jparrill) Re-enable when https://issues.redhat.com/browse/OCPBUGS-10218 is fixed
-			/*
-				{
-					name:            "TestNodePoolInPlaceUpgrade",
-					test:            NewNodePoolUpgradeTest(ctx, mgmtClient, hostedCluster, hostedClusterClient, clusterOpts, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
-					manifestBuilder: NewNodePoolInPlaceUpgradeTestManifest(hostedCluster, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
-				},
-			*/
+
+			{
+				name:            "TestNodePoolInPlaceUpgrade",
+				test:            NewNodePoolUpgradeTest(ctx, mgtClient, hostedCluster, hostedClusterClient, clusterOpts, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
+				manifestBuilder: NewNodePoolInPlaceUpgradeTestManifest(hostedCluster, globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage),
+			},
+
 			{
 				name: "KubeVirtCacheTest",
 				test: NewKubeVirtCacheTest(ctx, mgtClient, hostedCluster),


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-979](https://issues.redhat.com/browse/HOSTEDCP-979)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.