### PR TITLE
OCPBUGS-3873 adding rbac for UserOAuthAccessToken

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -168,3 +168,19 @@ func ImageTriggerControllerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		},
 	}
 }
+
+func UserOAuthClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:openshift:useroauthaccesstoken-manager",
+		},
+	}
+}
+
+func UserOAuthClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:openshift:useroauthaccesstoken-manager",
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -549,3 +549,38 @@ func ReconcileDeployerClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
 	}
 	return nil
 }
+
+func ReconcileUserOAuthClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:openshift:useroauthaccesstoken-manager",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			Kind:     "Group",
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Name:     "system:authenticated:oauth",
+		},
+	}
+	return nil
+}
+
+func ReconcileUserOAuthClusterRole(r *rbacv1.ClusterRole) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"oauth.openshift.io"},
+			Resources: []string{"useroauthaccesstokens"},
+			Verbs:     []string{"get", "list", "watch", "delete"},
+		},
+	}
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -806,6 +806,9 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 
 		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.DeployerClusterRole, reconcile: rbac.ReconcileDeployerClusterRole},
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.DeployerClusterRoleBinding, reconcile: rbac.ReconcileDeployerClusterRoleBinding},
+
+		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.UserOAuthClusterRole, reconcile: rbac.ReconcileUserOAuthClusterRole},
+		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.UserOAuthClusterRoleBinding, reconcile: rbac.ReconcileUserOAuthClusterRoleBinding},
 	}
 	var errs []error
 	for _, m := range rbac {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds rbac to hosted clusters to allow users created through OAuth to retrieve the `UserOAuthAccessToken` 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

[OCPBUGS-3873](https://issues.redhat.com/browse/OCPBUGS-3873)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.