### PR TITLE
OCPBUGS-7840: Untangle kas port

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -635,8 +635,10 @@ type APIServerNetworking struct {
 	AdvertiseAddress *string `json:"advertiseAddress,omitempty"`
 
 	// Port is the port at which the APIServer is exposed inside a node. Other
-	// pods using host networking cannot listen on this port. If not specified,
-	// 6443 is used.
+	// pods using host networking cannot listen on this port.
+	// It's defaulted in the backend to 443.
+	// This is only useful by IBM to bypass a limitation that prevents them from using some ports.
+	// However, its semantic was accidentally coupled with the SVC port.
 	Port *int32 `json:"port,omitempty"`
 
 	// AllowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -636,9 +636,10 @@ type APIServerNetworking struct {
 
 	// Port is the port at which the APIServer is exposed inside a node. Other
 	// pods using host networking cannot listen on this port.
-	// It's defaulted in the backend to 443.
-	// This is only useful by IBM to bypass a limitation that prevents them from using some ports.
-	// However, its semantic was accidentally coupled with the SVC port.
+	// If unset 6443 is used.
+	// This is useful to choose a port other than the default one which might interfere with customer environments e.g. https://github.com/openshift/hypershift/pull/356.
+	// Setting this to 443 is possible only for backward compatibility reasons and it's discouraged.
+	// Doing so, it would result in the controller overriding the KAS endpoint in the guest cluster having a discrepancy with the KAS Pod and potentially causing temporarily network failures.
 	Port *int32 `json:"port,omitempty"`
 
 	// AllowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5961,7 +5961,14 @@ spec:
                       port:
                         description: Port is the port at which the APIServer is exposed
                           inside a node. Other pods using host networking cannot listen
-                          on this port. If not specified, 6443 is used.
+                          on this port. If unset 6443 is used. This is useful to choose
+                          a port other than the default one which might interfere
+                          with customer environments e.g. https://github.com/openshift/hypershift/pull/356.
+                          Setting this to 443 is possible only for backward compatibility
+                          reasons and it's discouraged. Doing so, it would result
+                          in the controller overriding the KAS endpoint in the guest
+                          cluster having a discrepancy with the KAS Pod and potentially
+                          causing temporarily network failures.
                         format: int32
                         type: integer
                     type: object

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -5929,7 +5929,14 @@ spec:
                       port:
                         description: Port is the port at which the APIServer is exposed
                           inside a node. Other pods using host networking cannot listen
-                          on this port. If not specified, 6443 is used.
+                          on this port. If unset 6443 is used. This is useful to choose
+                          a port other than the default one which might interfere
+                          with customer environments e.g. https://github.com/openshift/hypershift/pull/356.
+                          Setting this to 443 is possible only for backward compatibility
+                          reasons and it's discouraged. Doing so, it would result
+                          in the controller overriding the KAS endpoint in the guest
+                          cluster having a discrepancy with the KAS Pod and potentially
+                          causing temporarily network failures.
                         format: int32
                         type: integer
                     type: object

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -180,7 +180,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 					{
 						Protocol:   corev1.ProtocolTCP,
 						Port:       apiPort,
-						TargetPort: intstr.FromInt(6443),
+						TargetPort: intstr.FromInt(int(apiPort)),
 					},
 				},
 				LoadBalancerSourceRanges: allowCIDRString,

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -249,6 +249,8 @@ func ReconcileRouterService(svc *corev1.Service, kasPort int32, internal, crossZ
 	foundHTTPS := false
 	foundKAS := false
 
+	// TODO (alberto): why this criteria?
+	// Introduced here https://github.com/openshift/hypershift/pull/1614/files#diff-62c16653415b8d89921cb26796abc479c31da1654095f7c46b551b470533d66dR368-R372.
 	if kasPort == 443 {
 		foundKAS = true
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -40,18 +40,23 @@ type KubeAPIServerParams struct {
 	CloudProviderConfig *corev1.LocalObjectReference `json:"cloudProviderConfig"`
 	CloudProviderCreds  *corev1.LocalObjectReference `json:"cloudProviderCreds"`
 
-	ServiceAccountIssuer string                       `json:"serviceAccountIssuer"`
-	ServiceCIDRs         []string                     `json:"serviceCIDRs"`
-	ClusterCIDRs         []string                     `json:"clusterCIDRs"`
-	AdvertiseAddress     string                       `json:"advertiseAddress"`
-	ExternalAddress      string                       `json:"externalAddress"`
-	ExternalPort         int32                        `json:"externalPort"`
-	InternalAddress      string                       `json:"internalAddress"`
-	InternalPort         int32                        `json:"internalPort"`
+	ServiceAccountIssuer string   `json:"serviceAccountIssuer"`
+	ServiceCIDRs         []string `json:"serviceCIDRs"`
+	ClusterCIDRs         []string `json:"clusterCIDRs"`
+	AdvertiseAddress     string   `json:"advertiseAddress"`
+	ExternalAddress      string   `json:"externalAddress"`
+	// ExternalPort is the port coming from the status of the SVC which is exposing the KAS, e.g. common router LB, dedicated private/public/ LB...
+	// This is used to build kas urls for generated internal kubeconfigs for example.
+	ExternalPort    int32  `json:"externalPort"`
+	InternalAddress string `json:"internalAddress"`
+	// InternalPort is the port that was used to expose the KAS SVC.
+	// This is used to build kas urls for generated external kubeconfigs for example.
+	InternalPort int32 `json:"internalPort"`
+	// APIServerPort is port to expose the KAS Pod.
+	APIServerPort        int32                        `json:"apiServerPort"`
 	ExternalOAuthAddress string                       `json:"externalOAuthAddress"`
 	ExternalOAuthPort    int32                        `json:"externalOAuthPort"`
 	EtcdURL              string                       `json:"etcdAddress"`
-	APIServerPort        int32                        `json:"apiServerPort"`
 	KubeConfigRef        *hyperv1.KubeconfigSecretRef `json:"kubeConfigRef"`
 	AuditWebhookRef      *corev1.LocalObjectReference `json:"auditWebhookRef"`
 	ConsolePublicURL     string                       `json:"consolePublicURL"`
@@ -65,7 +70,9 @@ type KubeAPIServerParams struct {
 }
 
 type KubeAPIServerServiceParams struct {
-	APIServerPort       int
+	// APIServerPort is the port used for the SVC.
+	APIServerPort int
+	// APIServerListenPort is the port used for the TargetPort.
 	APIServerListenPort int
 	AllowedCIDRBlocks   []string
 	OwnerReference      *metav1.OwnerReference

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
@@ -43,7 +43,7 @@ func TestNewAPIServerParamsAPIAdvertiseAddressAndPort(t *testing.T) {
 			port:               pointer.Int32(6789),
 			serviceNetworkCIDR: "10.0.0.0/24",
 			expectedAddress:    config.DefaultAdvertiseIPv4Address,
-			expectedPort:       config.DefaultAPIServerPort,
+			expectedPort:       6789,
 		},
 		{
 			name: "port set for NodePort service Publishing Strategy",

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -864,8 +864,11 @@ int32
 </td>
 <td>
 <p>Port is the port at which the APIServer is exposed inside a node. Other
-pods using host networking cannot listen on this port. If not specified,
-6443 is used.</p>
+pods using host networking cannot listen on this port.
+If unset 6443 is used.
+This is useful to choose a port other than the default one which might interfere with customer environments e.g. <a href="https://github.com/openshift/hypershift/pull/356">https://github.com/openshift/hypershift/pull/356</a>.
+Setting this to 443 is possible only for backward compatibility reasons and it&rsquo;s discouraged.
+Doing so, it would result in the controller overriding the KAS endpoint in the guest cluster having a discrepancy with the KAS Pod and potentially causing temporarily network failures.</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -35495,8 +35495,15 @@ objects:
                         port:
                           description: Port is the port at which the APIServer is
                             exposed inside a node. Other pods using host networking
-                            cannot listen on this port. If not specified, 6443 is
-                            used.
+                            cannot listen on this port. If unset 6443 is used. This
+                            is useful to choose a port other than the default one
+                            which might interfere with customer environments e.g.
+                            https://github.com/openshift/hypershift/pull/356. Setting
+                            this to 443 is possible only for backward compatibility
+                            reasons and it's discouraged. Doing so, it would result
+                            in the controller overriding the KAS endpoint in the guest
+                            cluster having a discrepancy with the KAS Pod and potentially
+                            causing temporarily network failures.
                           format: int32
                           type: integer
                       type: object
@@ -43204,8 +43211,15 @@ objects:
                         port:
                           description: Port is the port at which the APIServer is
                             exposed inside a node. Other pods using host networking
-                            cannot listen on this port. If not specified, 6443 is
-                            used.
+                            cannot listen on this port. If unset 6443 is used. This
+                            is useful to choose a port other than the default one
+                            which might interfere with customer environments e.g.
+                            https://github.com/openshift/hypershift/pull/356. Setting
+                            this to 443 is possible only for backward compatibility
+                            reasons and it's discouraged. Doing so, it would result
+                            in the controller overriding the KAS endpoint in the guest
+                            cluster having a discrepancy with the KAS Pod and potentially
+                            causing temporarily network failures.
                           format: int32
                           type: integer
                       type: object

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -4174,22 +4174,6 @@ func (r *HostedClusterReconciler) defaultAPIPortIfNeeded(ctx context.Context, hc
 	if hcluster.Spec.Networking.APIServer != nil && hcluster.Spec.Networking.APIServer.Port != nil {
 		return nil
 	}
-	for _, publishingStrategy := range hcluster.Spec.Services {
-		if publishingStrategy.Service != hyperv1.APIServer {
-			continue
-		}
-		if publishingStrategy.Type == hyperv1.Route {
-			if hcluster.Spec.Networking.APIServer == nil {
-				hcluster.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{}
-			}
-
-			hcluster.Spec.Networking.APIServer.Port = k8sutilspointer.Int32(443)
-			if err := r.Update(ctx, hcluster); err != nil {
-				return fmt.Errorf("failed to update hostedcluster after defaulting the apiserver port: %w", err)
-			}
-		}
-		break
-	}
 
 	if !r.ManagementClusterCapabilities.Has(capabilities.CapabilityInfrastructure) {
 		return nil

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -112,10 +112,8 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 		apiServerInternalAddress = config.DefaultAdvertiseIPv6Address
 	}
 
-	//TODO: in order to prevent periodic kube-apiserver network blimps in the LoadBalancer
-	//publish strategy this should change.
-	//However: will need API changes for service publishing strategy. Best function to call:
-	//apiServerInternalPort := util.BindAPIPortWithDefaultFromHostedCluster(hcluster, config.DefaultAPIServerPort)
+	// TODO (alberto): Technically this should call util.BindAPIPortWithDefaultFromHostedCluster and let 443 be an invalid value.
+	// How ever we allow it here to keep backward compatibility with existing clusters which defaulted .port to 443.
 	apiServerInternalPort := haproxyFrontendListenAddress(hcluster, config.DefaultAPIServerPort)
 	if hcluster.Spec.Networking.APIServer != nil {
 		if hcluster.Spec.Networking.APIServer.AdvertiseAddress != nil {

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -86,6 +86,8 @@ func BindAPIPortWithDefaultFromHostedCluster(hc *hyperv1.HostedCluster, defaultV
 // InternalAPIPortWithDefault will retrieve the port to use to contact the APIServer over the Kubernetes service domain
 // kube-apiserver.NAMESPACE.svc.cluster.local:INTERNAL_API_PORT
 func InternalAPIPortWithDefault(hcp *hyperv1.HostedControlPlane, defaultValue int32) int32 {
+	// TODO (alberto): Why is the exposed port for the SVC coming from .Spec.Networking.APIServer.Port?
+	// The API input is meant to be just the KAS Pod Port (and so the nodes haproxy).
 	if port := APIPort(hcp); port != nil {
 		return *port
 	}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
With this change, existing HCs defaulting Networking.APIServer.Port to 443 will preserve current behaviour of overriding the kas endpoint in the guest cluster.
This is to avoid data plane rollouts that would result from changing the haproxy config.

New HCs wont default to 443 and they won't override the kas endpoint. Setting Networking.APIServer.Port to 443 by a consumer is still techincally possible but unrecommended.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.