### PR TITLE
ACM-6435: add pausedUntil create cluster option in CLI

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -76,6 +76,7 @@ type ExampleOptions struct {
 	EtcdStorageClass                 string
 	ExternalDNSDomain                string
 	Arch                             string
+	PausedUntil                      string
 	AWS                              *ExampleAWSOptions
 	None                             *ExampleNoneOptions
 	Agent                            *ExampleAgentOptions
@@ -460,6 +461,10 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		},
 	}
 
+	if len(o.PausedUntil) > 0 {
+		cluster.Spec.PausedUntil = &o.PausedUntil
+	}
+
 	if o.BaseDomainPrefix == "none" {
 		// set empty prefix explicitly
 		cluster.Spec.DNS.BaseDomainPrefix = pointer.String("")
@@ -619,6 +624,12 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		nodePools = append(nodePools, nodePool)
 	default:
 		panic("Unsupported platform")
+	}
+
+	if len(o.PausedUntil) > 0 {
+		for _, nodePool := range nodePools {
+			nodePool.Spec.PausedUntil = &o.PausedUntil
+		}
 	}
 
 	return &ExampleResources{

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -79,6 +79,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
 	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The default processor architecture for the NodePool (e.g. arm64, amd64)")
+	cmd.PersistentFlags().StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(none.NewCreateCommand(opts))

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -263,7 +263,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		if opts.PausedUntil != "true" {
 			_, err := time.Parse(time.RFC3339, opts.PausedUntil)
 			if err != nil {
-				return nil, fmt.Errorf("invalid pausedUntil value, should be \"true\" or RFC3339 format date: %w", err)
+				return nil, fmt.Errorf("invalid pausedUntil value, should be \"true\" or a valid RFC3339 date format: %w", err)
 			}
 		}
 	}

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -259,12 +259,10 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 
 	// validate pausedUntil value
 	// valid values are either "true" or RFC3339 format date
-	if len(opts.PausedUntil) > 0 {
-		if opts.PausedUntil != "true" {
-			_, err := time.Parse(time.RFC3339, opts.PausedUntil)
-			if err != nil {
-				return nil, fmt.Errorf("invalid pausedUntil value, should be \"true\" or a valid RFC3339 date format: %w", err)
-			}
+	if len(opts.PausedUntil) > 0 && opts.PausedUntil != "true" {
+		_, err := time.Parse(time.RFC3339, opts.PausedUntil)
+		if err != nil {
+			return nil, fmt.Errorf("invalid pausedUntil value, should be \"true\" or a valid RFC3339 date format: %w", err)
 		}
 	}
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -77,6 +77,7 @@ type CreateOptions struct {
 	SkipAPIBudgetVerification        bool
 	CredentialSecretName             string
 	NodeUpgradeType                  hyperv1.UpgradeType
+	PausedUntil                      string
 
 	// BeforeApply is called immediately before resources are applied to the
 	// server, giving the user an opportunity to inspect or mutate the resources.
@@ -256,6 +257,17 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 
 	}
 
+	// validate pausedUntil value
+	// valid values are either "true" or RFC3339 format date
+	if len(opts.PausedUntil) > 0 {
+		if opts.PausedUntil != "true" {
+			_, err := time.Parse(time.RFC3339, opts.PausedUntil)
+			if err != nil {
+				return nil, fmt.Errorf("invalid pausedUntil value, should be \"true\" or RFC3339 format date: %w", err)
+			}
+		}
+	}
+
 	return &apifixtures.ExampleOptions{
 		AdditionalTrustBundle:            string(userCABundle),
 		ImageContentSources:              imageContentSources,
@@ -280,6 +292,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		Arch:                             opts.Arch,
 		NodeSelector:                     opts.NodeSelector,
 		UpgradeType:                      opts.NodeUpgradeType,
+		PausedUntil:                      opts.PausedUntil,
 	}, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -249,7 +249,7 @@ func serviceFirstNodePortAvailable(svc *corev1.Service) bool {
 // If it doesn't exist: it returns as there's no need to add it
 func pauseHostedControlPlane(ctx context.Context, c client.Client, hcp *hyperv1.HostedControlPlane, pauseValue *string) error {
 	// At the initial hosted cluster creation time, there is no HCP.
-	if hcp != nil {
+	if hcp == nil {
 		return nil
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -248,20 +248,23 @@ func serviceFirstNodePortAvailable(svc *corev1.Service) bool {
 // pauseHostedControlPlane will handle adding the pausedUntil field to the hostedControlPlane object if it exists.
 // If it doesn't exist: it returns as there's no need to add it
 func pauseHostedControlPlane(ctx context.Context, c client.Client, hcp *hyperv1.HostedControlPlane, pauseValue *string) error {
+	// At the initial hosted cluster creation time, there is no HCP.
 	if hcp != nil {
-		err := c.Get(ctx, client.ObjectKeyFromObject(hcp), hcp)
-		if err != nil {
-			if !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to get hostedcontrolplane: %w", err)
-			}
-			return nil
-		}
+		return nil
+	}
 
-		if hcp.Spec.PausedUntil != pauseValue {
-			hcp.Spec.PausedUntil = pauseValue
-			if err := c.Update(ctx, hcp); err != nil {
-				return fmt.Errorf("failed to pause hostedcontrolplane: %w", err)
-			}
+	err := c.Get(ctx, client.ObjectKeyFromObject(hcp), hcp)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get hostedcontrolplane: %w", err)
+		}
+		return nil
+	}
+
+	if hcp.Spec.PausedUntil != pauseValue {
+		hcp.Spec.PausedUntil = pauseValue
+		if err := c.Update(ctx, hcp); err != nil {
+			return fmt.Errorf("failed to pause hostedcontrolplane: %w", err)
 		}
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -248,19 +248,21 @@ func serviceFirstNodePortAvailable(svc *corev1.Service) bool {
 // pauseHostedControlPlane will handle adding the pausedUntil field to the hostedControlPlane object if it exists.
 // If it doesn't exist: it returns as there's no need to add it
 func pauseHostedControlPlane(ctx context.Context, c client.Client, hcp *hyperv1.HostedControlPlane, pauseValue *string) error {
-	err := c.Get(ctx, client.ObjectKeyFromObject(hcp), hcp)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		} else {
-			return fmt.Errorf("failed to get hostedcontrolplane: %w", err)
+	if hcp != nil {
+		err := c.Get(ctx, client.ObjectKeyFromObject(hcp), hcp)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			} else {
+				return fmt.Errorf("failed to get hostedcontrolplane: %w", err)
+			}
 		}
-	}
 
-	if hcp.Spec.PausedUntil != pauseValue {
-		hcp.Spec.PausedUntil = pauseValue
-		if err := c.Update(ctx, hcp); err != nil {
-			return fmt.Errorf("failed to pause hostedcontrolplane: %w", err)
+		if hcp.Spec.PausedUntil != pauseValue {
+			hcp.Spec.PausedUntil = pauseValue
+			if err := c.Update(ctx, hcp); err != nil {
+				return fmt.Errorf("failed to pause hostedcontrolplane: %w", err)
+			}
 		}
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -251,11 +251,10 @@ func pauseHostedControlPlane(ctx context.Context, c client.Client, hcp *hyperv1.
 	if hcp != nil {
 		err := c.Get(ctx, client.ObjectKeyFromObject(hcp), hcp)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
-			} else {
+			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("failed to get hostedcontrolplane: %w", err)
 			}
+			return nil
 		}
 
 		if hcp.Spec.PausedUntil != pauseValue {

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -33,6 +33,7 @@ func NewCreateCommands() *cobra.Command {
 		ServiceCIDR:                    "172.31.0.0/16",
 		Timeout:                        0,
 		Wait:                           false,
+		PausedUntil:                    "",
 	}
 
 	cmd := &cobra.Command{
@@ -67,6 +68,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.SSHKeyFile, "ssh-key", opts.SSHKeyFile, "Filepath to an SSH key file.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the duration of the wait (Examples: 30s, 1h30m45s, etc.) 0 means no timeout.")
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If true, the create command will block until the HostedCluster is up. Requires at least one NodePool with at least one node.")
+	cmd.PersistentFlags().StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 
 	_ = cmd.MarkPersistentFlagRequired("pull-secret")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is to add `pausedUntil` create cluster option in `hcp` CLI to support MCE's cluster create/update Ansible automation template. https://issues.redhat.com/browse/ACM-1368 

MCE is integrated with Red Hat Ansible Automation Platform so that you can create prehook and posthook Ansible job instances that occur before or after creating or upgrading hive clusters. MCE should provide users same experience with hosted clusters. This requires an ability to pause cluster provisioning so that prehook job can be executed before cluster creation. MCE's cluster curator controller orchestrates this and clears the `spec.pausedUntil` from the HostedCluster and NodePools when the conditions are met.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.