### PR TITLE
OCPBUGS-18308: Do not use mgmt cluster ICSP to mutate CCO image in KAS pod

### DIFF
--- a/support/releaseinfo/registry_mirror_provider.go
+++ b/support/releaseinfo/registry_mirror_provider.go
@@ -40,5 +40,9 @@ func (p *RegistryMirrorProviderDecorator) Lookup(ctx context.Context, image stri
 }
 
 func (p *RegistryMirrorProviderDecorator) GetRegistryOverrides() map[string]string {
-	return p.RegistryOverrides
+	result := map[string]string{}
+	for k, v := range p.RegistryOverrides {
+		result[k] = v
+	}
+	return result
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this PR, if an ICSP was present in the mgmt cluster, we would end up using it to modify the cluster config operator image for the kube apiserver. This should not happen, since we should rely on the mgmt cluster's container runtime to do the substitution.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-18308](https://issues.redhat.com/browse/OCPBUGS-18308)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.