### PR TITLE
HOSTEDCP-1051 addition of grace period for aws infra destruction

### DIFF
--- a/cmd/cluster/aws/destroy.go
+++ b/cmd/cluster/aws/destroy.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"fmt"
-
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/errors"
 
@@ -32,6 +31,7 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AWSPlatform.BaseDomain, "base-domain", opts.AWSPlatform.BaseDomain, "Cluster's base domain; inferred from the hosted cluster by default")
 	cmd.Flags().StringVar(&opts.AWSPlatform.BaseDomainPrefix, "base-domain-prefix", opts.AWSPlatform.BaseDomainPrefix, "Cluster's base domain prefix; inferred from the hosted cluster by default")
 	cmd.Flags().StringVar(&opts.CredentialSecretName, "secret-creds", opts.CredentialSecretName, "A Kubernetes secret with a platform credential, pull-secret and base-domain. The secret must exist in the supplied \"--namespace\"")
+	cmd.Flags().DurationVar(&opts.AWSPlatform.AwsInfraGracePeriod, "aws-infra-grace-period", opts.AWSPlatform.AwsInfraGracePeriod, "Timeout for destroying infrastructure in minutes")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		err := ValidateCredentialInfo(opts)
@@ -70,15 +70,16 @@ func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error
 	}
 	o.Log.Info("Destroying infrastructure", "infraID", infraID)
 	destroyInfraOpts := awsinfra.DestroyInfraOptions{
-		Region:             region,
-		InfraID:            infraID,
-		AWSCredentialsFile: o.AWSPlatform.AWSCredentialsFile,
-		AWSKey:             awsKeyID,
-		AWSSecretKey:       awsSecretKey,
-		Name:               o.Name,
-		BaseDomain:         baseDomain,
-		BaseDomainPrefix:   baseDomainPrefix,
-		Log:                o.Log,
+		Region:              region,
+		InfraID:             infraID,
+		AWSCredentialsFile:  o.AWSPlatform.AWSCredentialsFile,
+		AWSKey:              awsKeyID,
+		AWSSecretKey:        awsSecretKey,
+		Name:                o.Name,
+		BaseDomain:          baseDomain,
+		BaseDomainPrefix:    baseDomainPrefix,
+		AwsInfraGracePeriod: o.AWSPlatform.AwsInfraGracePeriod,
+		Log:                 o.Log,
 	}
 	if err := destroyInfraOpts.Run(ctx); err != nil {
 		return fmt.Errorf("failed to destroy infrastructure: %w", err)

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -40,12 +40,13 @@ type DestroyOptions struct {
 }
 
 type AWSPlatformDestroyOptions struct {
-	AWSCredentialsFile string
-	BaseDomain         string
-	BaseDomainPrefix   string
-	PreserveIAM        bool
-	Region             string
-	PostDeleteAction   func()
+	AWSCredentialsFile  string
+	BaseDomain          string
+	BaseDomainPrefix    string
+	PreserveIAM         bool
+	Region              string
+	PostDeleteAction    func()
+	AwsInfraGracePeriod time.Duration
 }
 
 type AzurePlatformDestroyOptions struct {

--- a/product-cli/cmd/cluster/aws/destroy.go
+++ b/product-cli/cmd/cluster/aws/destroy.go
@@ -27,6 +27,7 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AWSPlatform.BaseDomain, "base-domain", opts.AWSPlatform.BaseDomain, "A HostedCluster's base domain.")
 	cmd.Flags().StringVar(&opts.AWSPlatform.BaseDomainPrefix, "base-domain-prefix", opts.AWSPlatform.BaseDomainPrefix, "A HostedCluster's base domain prefix.")
 	cmd.Flags().StringVar(&opts.CredentialSecretName, "secret-creds", opts.CredentialSecretName, "A Kubernetes secret with a platform credentials: pull-secret and base-domain. The secret must exist in the supplied \"--namespace\".")
+	cmd.Flags().DurationVar(&opts.AWSPlatform.AwsInfraGracePeriod, "aws-infra-grace-period", opts.AWSPlatform.AwsInfraGracePeriod, "Timeout for destroying infrastructure in minutes")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		err := hypershiftaws.ValidateCredentialInfo(opts)


### PR DESCRIPTION

**What this PR does / why we need it**:

Adds InfraGracePeriod timeout flag for deleting AWS infrastructure resources so that if something goes wrong with deleting the infrastructure resources, the deletion process is not stuck.

**Which issue(s) this PR fixes** 
Fixes #

[HOSTEDCP-1051](https://issues.redhat.com/browse/HOSTEDCP-1051)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.