### PR TITLE
[kubevirt platform] Detect Suboptimal MTU and raise HostedCluster Condition accordingly

### DIFF
--- a/api/v1beta1/hostedcluster_conditions.go
+++ b/api/v1beta1/hostedcluster_conditions.go
@@ -106,6 +106,11 @@ const (
 	// A failure here is unlikely to resolve without the changing user input.
 	ValidReleaseImage ConditionType = "ValidReleaseImage"
 
+	// ValidKubeVirtInfraNetworkMTU indicates if the MTU configured on an infra cluster
+	// hosting a guest cluster utilizing kubevirt platform is a sufficient value that will avoid
+	// performance degradation due to fragmentation of the double encapsulation in ovn-kubernetes
+	ValidKubeVirtInfraNetworkMTU ConditionType = "ValidKubeVirtInfraNetworkMTU"
+
 	// ValidAWSIdentityProvider indicates if the Identity Provider referenced
 	// in the cloud credentials is healthy. E.g. for AWS the idp ARN is referenced in the iam roles.
 	// 		"Version": "2012-10-17",
@@ -191,6 +196,8 @@ const (
 
 	ReconciliationPausedConditionReason             = "ReconciliationPaused"
 	ReconciliationInvalidPausedUntilConditionReason = "InvalidPausedUntilValue"
+
+	KubeVirtSuboptimalMTUReason = "KubeVirtSuboptimalMTUDetected"
 )
 
 // Messages.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -403,6 +403,10 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile network operator: %w", err))
 	}
+	// Detect suboptimal MTU size on kubevirt hosted cluster with ovn-k and raise a condition in such a case
+	if err := networkoperator.DetectSuboptimalMTU(ctx, r.cpClient, networkOperator, hcp); err != nil {
+		errs = append(errs, err)
+	}
 	// this allows users to disable data collection in sensitive environments
 	// solves https://issues.redhat.com/browse/OCPBUGS-12208
 	ensureExistsReconcilationStrategy := false

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2960,6 +2960,11 @@ A failure here is unlikely to resolve without the changing user input.</p>
 supported by the underlying management cluster.
 A failure here is unlikely to resolve without the changing user input.</p>
 </td>
+</tr><tr><td><p>&#34;ValidKubeVirtInfraNetworkMTU&#34;</p></td>
+<td><p>ValidKubeVirtInfraNetworkMTU indicates if the MTU configured on an infra cluster
+hosting a guest cluster utilizing kubevirt platform is a sufficient value that will avoid
+performance degradation due to fragmentation of the double encapsulation in ovn-kubernetes</p>
+</td>
 </tr><tr><td><p>&#34;ValidOIDCConfiguration&#34;</p></td>
 <td><p>ValidOIDCConfiguration indicates if an AWS cluster&rsquo;s OIDC condition is
 detected as invalid.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -624,6 +624,17 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		meta.SetStatusCondition(&hcluster.Status.Conditions, *condition)
 	}
 
+	// Copy the ValidKubeVirtInfraNetworkMTU condition from the HostedControlPlane
+	if hcluster.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+		if hcp != nil {
+			validMtuCondCreated := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidKubeVirtInfraNetworkMTU))
+			if validMtuCondCreated != nil {
+				validMtuCondCreated.ObservedGeneration = hcluster.Generation
+				meta.SetStatusCondition(&hcluster.Status.Conditions, *validMtuCondCreated)
+			}
+		}
+	}
+
 	// Copy conditions from hostedcontrolplane
 	{
 		hcpConditions := []hyperv1.ConditionType{

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -35,11 +35,11 @@ func ExpectedHCConditions() map[hyperv1.ConditionType]metav1.ConditionStatus {
 		hyperv1.ClusterVersionFailing:     metav1.ConditionFalse,
 		hyperv1.ClusterVersionProgressing: metav1.ConditionFalse,
 
-		// conditions with no strong gurantees
+		// conditions with no strong guarantees
 		//
 		// UnmanagedEtcdAvailable is only set if hcluster.Spec.Etcd.ManagementType == hyperv1.Unmanaged.
 		hyperv1.UnmanagedEtcdAvailable: metav1.ConditionTrue,
-		// ClusterVersionUpgradeable is not always guranteed to be true.
+		// ClusterVersionUpgradeable is not always guaranteed to be true.
 		hyperv1.ClusterVersionUpgradeable: metav1.ConditionTrue,
 		// ExternalDNSReachable could be set to ConditionUnknown if external DNS is not configured or HC is private.
 		hyperv1.ExternalDNSReachable: metav1.ConditionTrue,

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1499,11 +1499,15 @@ func validateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 	} else {
 		expectedConditions[hyperv1.ExternalDNSReachable] = metav1.ConditionTrue
 	}
-
 	if !hasWorkerNodes {
 		expectedConditions[hyperv1.ClusterVersionAvailable] = metav1.ConditionFalse
 		expectedConditions[hyperv1.ClusterVersionSucceeding] = metav1.ConditionFalse
 		expectedConditions[hyperv1.ClusterVersionProgressing] = metav1.ConditionTrue
+	}
+
+	if hostedCluster.Spec.Platform.Type == hyperv1.KubevirtPlatform &&
+		hostedCluster.Spec.Networking.NetworkType == hyperv1.OVNKubernetes {
+		expectedConditions[hyperv1.ValidKubeVirtInfraNetworkMTU] = metav1.ConditionTrue
 	}
 
 	start := time.Now()


### PR DESCRIPTION
When using an hosted cluster based on a kubevirt provider, we recommend having a management cluster with MTU of 9000 bytes or grater in order for the hosted cluster to function properly. If a smaller sized MTU is used, a performance degragation is expected. We should bring visibility when this occurs, in terms of a new condition on the HostedCluster resource, e.g.:

```
    - lastTransitionTime: "2023-09-08T12:18:14Z"
      message: A suboptimal MTU size of 8900 has been detected. Due to performance,
        we recommend setting an MTU of 9000 bytes or greater for the infra cluster
        that hosts the KubeVirt VirtualMachines. When smaller MTUs are used, the cluster
        will still operate, but network performance will be degraded due to fragmentation
        of the double encapsulated ovn-k.
      observedGeneration: 1
      reason: KubeVirtSuboptimalMTUDetected
      status: "True"
      type: SubOptimalMTUDetected
```

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
https://issues.redhat.com/browse/CNV-30446
**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.