### PR TITLE
OCPBUGS-18399: Preserve mirror order when serializing ICSP to env

### DIFF
--- a/support/util/util.go
+++ b/support/util/util.go
@@ -215,13 +215,20 @@ func ConvertRegistryOverridesToCommandLineFlag(registryOverrides map[string]stri
 // ConvertOpenShiftImageRegistryOverridesToCommandLineFlag converts a map of image registry sources and their mirrors into a string
 func ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(registryOverrides map[string][]string) string {
 	var commandLineFlagArray []string
-	for registrySource, registryReplacements := range registryOverrides {
+	var sortedRegistrySources []string
+
+	for k := range registryOverrides {
+		sortedRegistrySources = append(sortedRegistrySources, k)
+	}
+	sort.Strings(sortedRegistrySources)
+
+	for _, registrySource := range sortedRegistrySources {
+		registryReplacements := registryOverrides[registrySource]
 		for _, registryReplacement := range registryReplacements {
 			commandLineFlagArray = append(commandLineFlagArray, fmt.Sprintf("%s=%s", registrySource, registryReplacement))
 		}
 	}
 	if len(commandLineFlagArray) > 0 {
-		sort.Strings(commandLineFlagArray)
 		return strings.Join(commandLineFlagArray, ",")
 	}
 	// this is the equivalent of null on a StringToString command line variable.


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, when serializing management cluster ICSP to environment variables, the order in which mirrors are listed in the original ICSP is lost because we sort all entries alphabetically. This change switches sorting to only the registry keys and preserves the ordering of the mirrors within that key.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-18399](https://issues.redhat.com/browse/OCPBUGS-18399)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.