### PR TITLE
Disable nto inplace test for kubevirt

### DIFF
--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -55,19 +55,26 @@ type NTOMachineConfigRolloutTest struct {
 
 	hostedCluster       *hyperv1.HostedCluster
 	hostedClusterClient crclient.Client
+
+	inplace bool
 }
 
-func NewNTOMachineConfigRolloutTest(ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hcClient crclient.Client) *NTOMachineConfigRolloutTest {
+func NewNTOMachineConfigRolloutTest(ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hcClient crclient.Client, inplace bool) *NTOMachineConfigRolloutTest {
 	return &NTOMachineConfigRolloutTest{
 		ctx:                 ctx,
 		hostedCluster:       hostedCluster,
 		hostedClusterClient: hcClient,
 		mgmtClient:          mgmtClient,
+		inplace:             inplace,
 	}
 }
 
 func (mc *NTOMachineConfigRolloutTest) Setup(t *testing.T) {
 	t.Log("Starting test NTOMachineConfigRolloutTest")
+
+	if mc.inplace && globalOpts.Platform == hyperv1.KubevirtPlatform {
+		t.Skip("test can't run for the platform kubevirt")
+	}
 }
 
 func (mc *NTOMachineConfigRolloutTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -73,12 +73,12 @@ func TestNodePool(t *testing.T) {
 			},
 			{
 				name: "TestNTOMachineConfigGetsRolledOut",
-				test: NewNTOMachineConfigRolloutTest(ctx, mgtClient, hostedCluster, hostedClusterClient),
+				test: NewNTOMachineConfigRolloutTest(ctx, mgtClient, hostedCluster, hostedClusterClient, false),
 			},
 
 			{
 				name:            "TestNTOMachineConfigAppliedInPlace",
-				test:            NewNTOMachineConfigRolloutTest(ctx, mgtClient, hostedCluster, hostedClusterClient),
+				test:            NewNTOMachineConfigRolloutTest(ctx, mgtClient, hostedCluster, hostedClusterClient, true),
 				manifestBuilder: NewNTOMachineConfigInPlaceRolloutTestManifest(hostedCluster),
 			},
 

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -38,8 +38,6 @@ func createClusterOpts(ctx context.Context, client crclient.Client, hc *hyperv1.
 	switch hc.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		opts.InfraID = hc.Name
-	case hyperv1.KubevirtPlatform:
-		opts.KubevirtPlatform.RootVolumeSize = 16
 	case hyperv1.PowerVSPlatform:
 		opts.InfraID = fmt.Sprintf("%s-infra", hc.Name)
 	}


### PR DESCRIPTION
In order to restore the ability for devs to merge into the hypershift repo, I am disabling this test until https://issues.redhat.com/browse/OCPBUGS-18566 is resolved. 