### PR TITLE
HOSTEDCP-1185: Add flag to create a single NAT gateway

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -47,6 +47,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.AWSPlatform.EnableProxy, "enable-proxy", opts.AWSPlatform.EnableProxy, "If a proxy should be set up, rather than allowing direct internet access from the nodes")
 	cmd.Flags().StringVar(&opts.CredentialSecretName, "secret-creds", opts.CredentialSecretName, "A Kubernetes secret with a platform credential (--aws-creds), --pull-secret and --base-domain value. The secret must exist in the supplied \"--namespace\"")
 	cmd.Flags().StringVar(&opts.AWSPlatform.IssuerURL, "oidc-issuer-url", "", "The OIDC provider issuer URL")
+	cmd.Flags().BoolVar(&opts.AWSPlatform.SingleNATGateway, "single-nat-gateway", opts.AWSPlatform.SingleNATGateway, "If enabled, only a single NAT gateway is created, even if multiple zones are specified")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -139,6 +140,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			Zones:              opts.AWSPlatform.Zones,
 			EnableProxy:        opts.AWSPlatform.EnableProxy,
 			SSHKeyFile:         opts.SSHKeyFile,
+			SingleNATGateway:   opts.AWSPlatform.SingleNATGateway,
 		}
 		infra, err = opt.CreateInfra(ctx, opts.Log)
 		if err != nil {

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -147,6 +147,7 @@ type AWSPlatformOptions struct {
 	Zones                   []string
 	EtcdKMSKeyARN           string
 	EnableProxy             bool
+	SingleNATGateway        bool
 }
 
 type AzurePlatformOptions struct {


### PR DESCRIPTION

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
When creating multi-zone hosted clusters, the --single-nat-gateway flag allows creating a single nat gateway instead of 3 and configures all cluster traffic to flow through that gateway. This is meant to be used in development and testing so that we can avoid spending on a nat gateway for every zone of a hosted cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1185](https://issues.redhat.com/browse/HOSTEDCP-1185)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.