### PR TITLE
e2e: skip CNO pod restart check

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -420,6 +420,11 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 			t.Fatalf("failed to list pods in namespace %s: %v", namespace, err)
 		}
 		for _, pod := range podList.Items {
+			// TODO: Remove this when https://issues.redhat.com/browse/OCPBUGS-18569 is resolved
+			if strings.HasPrefix(pod.Name, "cluster-network-operator-") {
+				continue
+			}
+
 			// TODO: Remove this when https://issues.redhat.com/browse/OCPBUGS-6953 is resolved
 			if strings.HasPrefix(pod.Name, "ovnkube-master-") {
 				continue


### PR DESCRIPTION
We are getting flakes with the CNO pod restarting due to https://github.com/openshift/cluster-network-operator/pull/1986

Because the fix is in the CNO and this is not an urgent bugfix, lets skip on our side until they can merge the fix.

cc @csrwng @enxebre 