### PR TITLE
feat: add _id label to all hypershift operator metrics

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3267,7 +3267,7 @@ func deleteAWSEndpointServices(ctx context.Context, c client.Client, hc *hyperv1
 					return false, fmt.Errorf("failed to remove finalizer from awsendpointservice: %w", err)
 				}
 			}
-			hcmetrics.SkippedCloudResourcesDeletion.WithLabelValues(hc.Namespace, hc.Name).Set(float64(1))
+			hcmetrics.SkippedCloudResourcesDeletion.WithLabelValues(hc.Namespace, hc.Name, hc.Spec.ClusterID).Set(float64(1))
 			log.Info("Removed finalizer for awsendpointservice because the HC has no valid aws credentials", "name", ep.Name)
 			continue
 		}
@@ -4619,7 +4619,7 @@ func reportAvailableTime(hcluster *hyperv1.HostedCluster) {
 	// SLI: Hosted Cluster available duration.
 	availableTime := clusterAvailableTime(hcluster)
 	if availableTime != nil {
-		hcmetrics.HostedClusterAvailableDuration.WithLabelValues(hcluster.Namespace, hcluster.Name).Set(*availableTime)
+		hcmetrics.HostedClusterAvailableDuration.WithLabelValues(hcluster.Namespace, hcluster.Name, hcluster.Spec.ClusterID).Set(*availableTime)
 		if hcluster.Annotations == nil {
 			hcluster.Annotations = make(map[string]string)
 		}
@@ -4631,7 +4631,7 @@ func reportClusterVersionRolloutTime(hcluster *hyperv1.HostedCluster) {
 	// SLI: Hosted Cluster roll out duration.
 	versionRolloutTime := clusterVersionRolloutTime(hcluster)
 	if versionRolloutTime != nil {
-		hcmetrics.HostedClusterInitialRolloutDuration.WithLabelValues(hcluster.Namespace, hcluster.Name).Set(*versionRolloutTime)
+		hcmetrics.HostedClusterInitialRolloutDuration.WithLabelValues(hcluster.Namespace, hcluster.Name, hcluster.Spec.ClusterID).Set(*versionRolloutTime)
 	}
 }
 
@@ -4666,9 +4666,9 @@ func reportProxyConfig(hcluster *hyperv1.HostedCluster) {
 		if hcluster.Spec.Configuration.Proxy.TrustedCA.Name != "" {
 			proxyTrustedCA = "1"
 		}
-		hcmetrics.ProxyConfig.WithLabelValues(hcluster.Namespace, hcluster.Name, proxyHTTP, proxyHTTPS, proxyTrustedCA).Set(1)
+		hcmetrics.ProxyConfig.WithLabelValues(hcluster.Namespace, hcluster.Name, hcluster.Spec.ClusterID, proxyHTTP, proxyHTTPS, proxyTrustedCA).Set(1)
 	} else {
-		hcmetrics.ProxyConfig.WithLabelValues(hcluster.Namespace, hcluster.Name, proxyHTTP, proxyHTTPS, proxyTrustedCA).Set(0)
+		hcmetrics.ProxyConfig.WithLabelValues(hcluster.Namespace, hcluster.Name, hcluster.Spec.ClusterID, proxyHTTP, proxyHTTPS, proxyTrustedCA).Set(0)
 	}
 }
 
@@ -4677,12 +4677,12 @@ func reportHostedClusterGuestCloudResourcesDeletionDuration(hcluster *hyperv1.Ho
 	condition := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
 	if condition != nil && condition.Status == metav1.ConditionTrue {
 		guestClusterResourceDeletionDuration := condition.LastTransitionTime.Sub(hcluster.DeletionTimestamp.Time).Seconds()
-		hcmetrics.HostedClusterGuestCloudResourcesDeletionDuration.WithLabelValues(hcluster.Namespace, hcluster.Name).Set(guestClusterResourceDeletionDuration)
+		hcmetrics.HostedClusterGuestCloudResourcesDeletionDuration.WithLabelValues(hcluster.Namespace, hcluster.Name, hcluster.Spec.ClusterID).Set(guestClusterResourceDeletionDuration)
 	}
 }
 
 func reportHostedClusterDeletionDuration(hcluster *hyperv1.HostedCluster, funcClock clock.WithTickerAndDelayedExecution) {
 	// SLI: HostedCluster deletion duration.
 	deletionDuration := funcClock.Since(hcluster.DeletionTimestamp.Time).Seconds()
-	hcmetrics.HostedClusterDeletionDuration.WithLabelValues(hcluster.Namespace, hcluster.Name).Set(deletionDuration)
+	hcmetrics.HostedClusterDeletionDuration.WithLabelValues(hcluster.Namespace, hcluster.Name, hcluster.Spec.ClusterID).Set(deletionDuration)
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -2391,6 +2391,9 @@ func TestSkipCloudResourceDeletionMetric(t *testing.T) {
 				Metric: []*dto.Metric{{
 					Label: []*dto.LabelPair{
 						{
+							Name: pointer.String("_id"), Value: pointer.String("id"),
+						},
+						{
 							Name: pointer.String("name"), Value: pointer.String("hcluster"),
 						},
 						{
@@ -2422,7 +2425,8 @@ func TestSkipCloudResourceDeletionMetric(t *testing.T) {
 					DeletionTimestamp: &metav1.Time{Time: time.Now().Round(time.Second)},
 				},
 				Spec: hyperv1.HostedClusterSpec{
-					InfraID: "fakeInfraID",
+					ClusterID: "id",
+					InfraID:   "fakeInfraID",
 					Platform: hyperv1.PlatformSpec{
 						Type: hyperv1.PlatformType(hyperv1.AWSPlatform),
 						AWS: &hyperv1.AWSPlatformSpec{
@@ -2525,6 +2529,9 @@ func TestReportAvailableTime(t *testing.T) {
 				Metric: []*dto.Metric{{
 					Label: []*dto.LabelPair{
 						{
+							Name: pointer.String("_id"), Value: pointer.String("id"),
+						},
+						{
 							Name: pointer.String("name"), Value: pointer.String("hc"),
 						},
 						{
@@ -2547,6 +2554,9 @@ func TestReportAvailableTime(t *testing.T) {
 				},
 				Status: hyperv1.HostedClusterStatus{
 					Conditions: tc.conditions,
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
 				},
 			}
 
@@ -2589,6 +2599,9 @@ func TestReportClusterVersionRolloutTime(t *testing.T) {
 				Metric: []*dto.Metric{{
 					Label: []*dto.LabelPair{
 						{
+							Name: pointer.String("_id"), Value: pointer.String("id"),
+						},
+						{
 							Name: pointer.String("name"), Value: pointer.String("hc"),
 						},
 						{
@@ -2620,6 +2633,9 @@ func TestReportClusterVersionRolloutTime(t *testing.T) {
 				Metric: []*dto.Metric{{
 					Label: []*dto.LabelPair{
 						{
+							Name: pointer.String("_id"), Value: pointer.String("id"),
+						},
+						{
 							Name: pointer.String("name"), Value: pointer.String("hc"),
 						},
 						{
@@ -2644,6 +2660,9 @@ func TestReportClusterVersionRolloutTime(t *testing.T) {
 					Version: &hyperv1.ClusterVersionStatus{
 						History: tc.updateHistory,
 					},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
 				},
 			}
 
@@ -2880,6 +2899,9 @@ func TestReportProxyConfig(t *testing.T) {
 				Metric: []*dto.Metric{{
 					Label: []*dto.LabelPair{
 						{
+							Name: pointer.String("_id"), Value: pointer.String("id"),
+						},
+						{
 							Name: pointer.String("name"), Value: pointer.String("hc"),
 						},
 						{
@@ -2907,6 +2929,9 @@ func TestReportProxyConfig(t *testing.T) {
 				Type: func() *dto.MetricType { v := dto.MetricType(1); return &v }(),
 				Metric: []*dto.Metric{{
 					Label: []*dto.LabelPair{
+						{
+							Name: pointer.String("_id"), Value: pointer.String("id"),
+						},
 						{
 							Name: pointer.String("name"), Value: pointer.String("hc"),
 						},
@@ -2938,6 +2963,7 @@ func TestReportProxyConfig(t *testing.T) {
 					CreationTimestamp: metav1.Time{Time: time.Time{}.Add(time.Hour)},
 				},
 				Spec: hyperv1.HostedClusterSpec{
+					ClusterID:     "id",
 					Configuration: &tc.clusterConf,
 				},
 			}
@@ -2989,6 +3015,9 @@ func TestReportHostedClusterGuestCloudResourcesDeletionDuration(t *testing.T) {
 				Metric: []*dto.Metric{{
 					Label: []*dto.LabelPair{
 						{
+							Name: pointer.String("_id"), Value: pointer.String("id"),
+						},
+						{
 							Name: pointer.String("name"), Value: pointer.String("hc"),
 						},
 						{
@@ -3016,6 +3045,9 @@ func TestReportHostedClusterGuestCloudResourcesDeletionDuration(t *testing.T) {
 				},
 				Status: hyperv1.HostedClusterStatus{
 					Conditions: tc.conditions,
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
 				},
 			}
 
@@ -3054,6 +3086,9 @@ func TestReportHostedClusterDeletionDuration(t *testing.T) {
 				Metric: []*dto.Metric{{
 					Label: []*dto.LabelPair{
 						{
+							Name: pointer.String("_id"), Value: pointer.String("id"),
+						},
+						{
 							Name: pointer.String("name"), Value: pointer.String("hc"),
 						},
 						{
@@ -3077,6 +3112,9 @@ func TestReportHostedClusterDeletionDuration(t *testing.T) {
 					Name:              "hc",
 					Namespace:         "any",
 					DeletionTimestamp: &deletionTime,
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
 				},
 			}
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -320,7 +320,7 @@ func (AWS) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hype
 				errs = append(errs, fmt.Errorf("failed to delete machine %s/%s: %w", awsMachine.Namespace, awsMachine.Name, err))
 				continue
 			}
-			hcmetrics.SkippedCloudResourcesDeletion.WithLabelValues(hc.Namespace, hc.Name).Set(float64(1))
+			hcmetrics.SkippedCloudResourcesDeletion.WithLabelValues(hc.Namespace, hc.Name, hc.Spec.ClusterID).Set(float64(1))
 			logger.Info("skipping cleanup of awsmachine because of invalid AWS identity provider", "machine", client.ObjectKeyFromObject(awsMachine))
 		}
 	}

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -11,31 +11,31 @@ var (
 	HostedClusterDeletionDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Help: "Time in seconds it took from HostedCluster having a deletion timestamp to all hypershift finalizers being removed",
 		Name: DeletionDurationMetricName,
-	}, []string{"namespace", "name"})
+	}, []string{"namespace", "name", "_id"})
 
 	GuestCloudResourcesDeletionDurationMetricName    = "hypershift_cluster_guest_cloud_resources_deletion_duration_seconds"
 	HostedClusterGuestCloudResourcesDeletionDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Help: "Time in seconds it took from HostedCluster having a deletion timestamp to the CloudResourcesDestroyed being true",
 		Name: GuestCloudResourcesDeletionDurationMetricName,
-	}, []string{"namespace", "name"})
+	}, []string{"namespace", "name", "_id"})
 
 	AvailableDurationName          = "hypershift_cluster_available_duration_seconds"
 	HostedClusterAvailableDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Help: "Time in seconds it took from initial cluster creation to HostedClusterAvailable condition becoming true",
 		Name: AvailableDurationName,
-	}, []string{"namespace", "name"})
+	}, []string{"namespace", "name", "_id"})
 
 	InitialRolloutDurationName          = "hypershift_cluster_initial_rollout_duration_seconds"
 	HostedClusterInitialRolloutDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Help: "Time in seconds it took from initial cluster creation and rollout of initial version",
 		Name: InitialRolloutDurationName,
-	}, []string{"namespace", "name"})
+	}, []string{"namespace", "name", "_id"})
 
 	ClusterUpgradeDurationMetricName = "hypershift_cluster_upgrade_duration_seconds"
 	ClusterUpgradeDuration           = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Help: "Time in seconds it took a cluster to upgrade and rollout a given version",
 		Name: ClusterUpgradeDurationMetricName,
-	}, []string{"namespace", "name", "previous_version", "new_version"})
+	}, []string{"namespace", "name", "_id", "previous_version", "new_version"})
 
 	LimitedSupportEnabledName = "hypershift_cluster_limited_support_enabled"
 	LimitedSupportEnabled     = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -53,13 +53,13 @@ var (
 	ProxyConfig = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Help: "Indicates cluster proxy state for each cluster",
 		Name: ProxyName,
-	}, []string{"namespace", "name", "proxy_http", "proxy_https", "proxy_trusted_ca"})
+	}, []string{"namespace", "name", "_id", "proxy_http", "proxy_https", "proxy_trusted_ca"})
 
 	SkippedCloudResourcesDeletionName = "hypershift_cluster_skipped_cloud_resources_deletion"
 	SkippedCloudResourcesDeletion     = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Help: "Indicates the operator will skip the aws resources deletion",
 		Name: SkippedCloudResourcesDeletionName,
-	}, []string{"namespace", "name"})
+	}, []string{"namespace", "name", "_id"})
 )
 
 func init() {
@@ -91,6 +91,7 @@ func ReportClusterUpgradeDuration(hc *hyperv1.HostedCluster) {
 			ClusterUpgradeDuration.With(prometheus.Labels{
 				"namespace":        hc.Namespace,
 				"name":             hc.Name,
+				"_id":              hc.Spec.ClusterID,
 				"previous_version": prevVersion.Version,
 				"new_version":      newVersion.Version,
 			}).Set(upgradeDuration)


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

This PR adds the `_id` label to all the hypershift operator metrics that didn't have it yet. 
For ROSA, this significantly facilitates promql queries on metrics coming from the hypershift operator and hosted clusters, as the hosted cluster metrics also contain the same `_id` label.
Currently, to combine metrics from HC and the hypershift operator in a query, we need to aggregate another metric containing both `_id` and `exported_namespace`. With this change, we can directly aggregate through `_id`.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #HOSTEDCP-1183 (note the ticket isn't groomed yet)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.