### PR TITLE
[release-4.12] MULTIARCH-3709: PowerVS - Add reuse resource flags to e2e test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -95,6 +95,9 @@ func TestMain(m *testing.M) {
 	flag.Var(&globalOpts.configurableClusterOptions.PowerVSProcType, "e2e.powervs-proc-type", "Processor type (dedicated, shared, capped). Default is shared")
 	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSProcessors, "e2e.powervs-processors", "0.5", "Number of processors allocated. Default is 0.5")
 	flag.IntVar(&globalOpts.configurableClusterOptions.PowerVSMemory, "e2e.powervs-memory", 32, "Amount of memory allocated (in GB). Default is 32")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSCloudInstanceID, "e2e-powervs-cloud-instance-id", "", "IBM Cloud PowerVS Service Instance ID. Use this flag to reuse an existing PowerVS Service Instance resource for cluster's infra")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSCloudConnection, "e2e-powervs-cloud-connection", "", "Cloud Connection in given zone. Use this flag to reuse an existing Cloud Connection resource for cluster's infra")
+	flag.StringVar(&globalOpts.configurableClusterOptions.PowerVSVPC, "e2e-powervs-vpc", "", "IBM Cloud VPC Name. Use this flag to reuse an existing VPC resource for cluster's infra")
 	flag.BoolVar(&globalOpts.SkipAPIBudgetVerification, "e2e.skip-api-budget", false, "Bool to avoid send metrics to E2E Server on local test execution.")
 
 	flag.Parse()
@@ -344,6 +347,9 @@ type configurableClusterOptions struct {
 	PowerVSProcType            hyperv1.PowerVSNodePoolProcType
 	PowerVSProcessors          string
 	PowerVSMemory              int
+	PowerVSCloudInstanceID     string
+	PowerVSCloudConnection     string
+	PowerVSVPC                 string
 }
 
 var nextAWSZoneIndex = 0
@@ -380,14 +386,17 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 			DiskSizeGB:      120,
 		},
 		PowerVSPlatform: core.PowerVSPlatformOptions{
-			ResourceGroup: o.configurableClusterOptions.PowerVSResourceGroup,
-			Region:        o.configurableClusterOptions.PowerVSRegion,
-			Zone:          o.configurableClusterOptions.PowerVSZone,
-			VPCRegion:     o.configurableClusterOptions.PowerVSVpcRegion,
-			SysType:       o.configurableClusterOptions.PowerVSSysType,
-			ProcType:      o.configurableClusterOptions.PowerVSProcType,
-			Processors:    o.configurableClusterOptions.PowerVSProcessors,
-			Memory:        int32(o.configurableClusterOptions.PowerVSMemory),
+			ResourceGroup:   o.configurableClusterOptions.PowerVSResourceGroup,
+			Region:          o.configurableClusterOptions.PowerVSRegion,
+			Zone:            o.configurableClusterOptions.PowerVSZone,
+			VPCRegion:       o.configurableClusterOptions.PowerVSVpcRegion,
+			SysType:         o.configurableClusterOptions.PowerVSSysType,
+			ProcType:        o.configurableClusterOptions.PowerVSProcType,
+			Processors:      o.configurableClusterOptions.PowerVSProcessors,
+			Memory:          int32(o.configurableClusterOptions.PowerVSMemory),
+			CloudInstanceID: o.configurableClusterOptions.PowerVSCloudInstanceID,
+			CloudConnection: o.configurableClusterOptions.PowerVSCloudConnection,
+			VPC:             o.configurableClusterOptions.PowerVSVPC,
 		},
 		ServiceCIDR: "172.31.0.0/16",
 		ClusterCIDR: "10.132.0.0/14",

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -284,11 +284,14 @@ func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster
 		return azure.DestroyCluster(ctx, opts)
 	case hyperv1.PowerVSPlatform:
 		opts.PowerVSPlatform = core.PowerVSPlatformDestroyOptions{
-			BaseDomain:    createOpts.BaseDomain,
-			ResourceGroup: createOpts.PowerVSPlatform.ResourceGroup,
-			Region:        createOpts.PowerVSPlatform.Region,
-			Zone:          createOpts.PowerVSPlatform.Zone,
-			VPCRegion:     createOpts.PowerVSPlatform.VPCRegion,
+			BaseDomain:      createOpts.BaseDomain,
+			ResourceGroup:   createOpts.PowerVSPlatform.ResourceGroup,
+			Region:          createOpts.PowerVSPlatform.Region,
+			Zone:            createOpts.PowerVSPlatform.Zone,
+			VPCRegion:       createOpts.PowerVSPlatform.VPCRegion,
+			CloudInstanceID: createOpts.PowerVSPlatform.CloudInstanceID,
+			CloudConnection: createOpts.PowerVSPlatform.CloudConnection,
+			VPC:             createOpts.PowerVSPlatform.VPC,
 		}
 		return powervs.DestroyCluster(ctx, opts)
 


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Manual cherry-pick of #2902

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.