### PR TITLE
Bump hypershift version to 4.15

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1349,13 +1349,13 @@ func TestValidateReleaseImage(t *testing.T) {
 						Name: "pull-secret",
 					},
 					Release: hyperv1.Release{
-						Image: "image-4.12.0",
+						Image: "image-4.13.0",
 					},
 				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{
-							Image: "image-4.11.0",
+							Image: "image-4.12.0",
 						},
 					},
 				},
@@ -1381,7 +1381,7 @@ func TestValidateReleaseImage(t *testing.T) {
 						Name: "pull-secret",
 					},
 					Release: hyperv1.Release{
-						Image: "image-4.12.0",
+						Image: "image-4.13.0",
 					},
 				},
 			},
@@ -1406,13 +1406,13 @@ func TestValidateReleaseImage(t *testing.T) {
 						Name: "pull-secret",
 					},
 					Release: hyperv1.Release{
-						Image: "image-4.12.0",
+						Image: "image-4.13.0",
 					},
 				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{
-							Image: "image-4.12.0",
+							Image: "image-4.13.0",
 						},
 					},
 				},
@@ -1438,13 +1438,13 @@ func TestValidateReleaseImage(t *testing.T) {
 						Name: "pull-secret",
 					},
 					Release: hyperv1.Release{
-						Image: "image-4.12.0",
+						Image: "image-4.13.0",
 					},
 				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{
-							Image: "image-4.11.1",
+							Image: "image-4.12.1",
 						},
 					},
 				},
@@ -1470,13 +1470,13 @@ func TestValidateReleaseImage(t *testing.T) {
 						Name: "pull-secret",
 					},
 					Release: hyperv1.Release{
-						Image: "image-4.12.0",
+						Image: "image-4.13.0",
 					},
 				},
 				Status: hyperv1.HostedClusterStatus{
 					Version: &hyperv1.ClusterVersionStatus{
 						Desired: configv1.Release{
-							Image: "image-4.12.0",
+							Image: "image-4.13.0",
 						},
 					},
 				},
@@ -1525,9 +1525,10 @@ func TestValidateReleaseImage(t *testing.T) {
 						"image-4.9.0":  "4.9.0",
 						"image-4.10.0": "4.10.0",
 						"image-4.11.0": "4.11.0",
-						"image-4.11.1": "4.11.1",
 						"image-4.12.0": "4.12.0",
+						"image-4.12.1": "4.12.1",
 						"image-4.13.0": "4.13.0",
+						"image-4.14.0": "4.14.0",
 					},
 				},
 			}

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -16,7 +16,7 @@ import (
 // HyperShift operator.
 // NOTE: The .0 (z release) should be ignored. It's only here to support
 // semver parsing.
-var LatestSupportedVersion = semver.MustParse("4.14.0")
+var LatestSupportedVersion = semver.MustParse("4.15.0")
 var MinSupportedVersion = semver.MustParse(subtractMinor(&LatestSupportedVersion, uint64(SupportedPreviousMinorVersions)).String())
 
 // SupportedPreviousMinorVersions is the number of minor versions prior to current

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSupportedVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
-	g.Expect(Supported()).To(Equal([]string{"4.14", "4.13", "4.12"}))
+	g.Expect(Supported()).To(Equal([]string{"4.15", "4.14", "4.13"}))
 }
 
 func TestIsValidReleaseVersion(t *testing.T) {


### PR DESCRIPTION
The current setting, 4.14, breaks the CI when trying to create cluster from command line.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.