### PR TITLE
enable CGO_ENABLED for building FIPS compliant images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ PROMTOOL=GO111MODULE=on GOFLAGS=-mod=vendor go run github.com/prometheus/prometh
 
 GO_GCFLAGS ?= -gcflags=all='-N -l'
 GO=GO111MODULE=on GOFLAGS=-mod=vendor go
-GO_BUILD_RECIPE=CGO_ENABLED=0 $(GO) build $(GO_GCFLAGS)
-GO_E2E_RECIPE=CGO_ENABLED=0 $(GO) test $(GO_GCFLAGS) -tags e2e -c
+GO_BUILD_RECIPE=CGO_ENABLED=1 $(GO) build $(GO_GCFLAGS)
+GO_E2E_RECIPE=CGO_ENABLED=1 $(GO) test $(GO_GCFLAGS) -tags e2e -c
 
 CI_TESTS_RUN ?= ""
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is for backporting https://github.com/openshift/hypershift/pull/2997 into 4.14 branch.

The current hypershift operator cannot be run in FIPS enabled cluster because the binary is not FIPS compliant. In order to build FIPS compliant images, CGO_ENABLED needs to be set to 1. 

CGO_ENABLED=1 is necessary so that the Golang program can be compiled to use C libraries such as FIPS compliant crypto libraries on a build machine where those libraries are available.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

https://issues.redhat.com/browse/HYPBLD-99

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.