### PR TITLE
OCPBUGS-18907: add KAS endpoints to Except in router egress rule

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -227,6 +227,7 @@ func (r *HostedClusterReconciler) managedResources() []client.Object {
 		&corev1.Namespace{},
 		&corev1.ServiceAccount{},
 		&corev1.Service{},
+		&corev1.Endpoints{},
 		&agentv1.AgentCluster{},
 		&capiibmv1.IBMVPCCluster{},
 		&capikubevirt.KubevirtCluster{},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -979,7 +979,13 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 	}
 	watchedResources := sets.String{}
 	for _, resource := range r.managedResources() {
-		watchedResources.Insert(fmt.Sprintf("%T", resource))
+		resourceType := fmt.Sprintf("%T", resource)
+		// We watch Endpoints for changes to the kubernetes Endpoint in the default namespace
+		// but never create an Endpoints resource
+		if resourceType == "*v1.Endpoints" {
+			continue
+		}
+		watchedResources.Insert(resourceType)
 	}
 	if diff := cmp.Diff(client.createdTypes.List(), watchedResources.List()); diff != "" {
 		t.Errorf("the set of resources that are being created differs from the one that is being watched: %s", diff)


### PR DESCRIPTION
Even though the `router` does not have the KAS mgmt label, it can still access the KAS because the `private-router` NetworkPolicy allows it.