### PR TITLE
OCPBUGS-17906: reconcile Authentication global config

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -659,6 +659,13 @@ func (r *reconciler) reconcileConfig(ctx context.Context, hcp *hyperv1.HostedCon
 		errs = append(errs, fmt.Errorf("failed to reconcile cloud credentials config: %w", err))
 	}
 
+	authenticationConfig := globalconfig.AuthenticationConfiguration()
+	if _, err := r.CreateOrUpdate(ctx, r.client, authenticationConfig, func() error {
+		return globalconfig.ReconcileAuthenticationConfiguration(authenticationConfig, hcp.Spec.Configuration, hcp.Spec.IssuerURL)
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile authentication config: %w", err))
+	}
+
 	return errors.NewAggregate(errs)
 }
 

--- a/support/globalconfig/authentication.go
+++ b/support/globalconfig/authentication.go
@@ -1,0 +1,24 @@
+package globalconfig
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+)
+
+func AuthenticationConfiguration() *configv1.Authentication {
+	return &configv1.Authentication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	}
+}
+
+func ReconcileAuthenticationConfiguration(authentication *configv1.Authentication, config *hyperv1.ClusterConfiguration, issuerURL string) error {
+	if config != nil && config.Authentication != nil {
+		authentication.Spec = *config.Authentication
+	}
+	authentication.Spec.ServiceAccountIssuer = issuerURL
+	return nil
+}

--- a/support/globalconfig/cloudcreds.go
+++ b/support/globalconfig/cloudcreds.go
@@ -14,8 +14,7 @@ func CloudCredentialsConfiguration() *operatorv1.CloudCredential {
 }
 
 func ReconcileCloudCredentialsConfiguration(cfg *operatorv1.CloudCredential) error {
-	// Always use default mode for cloud credentials
-	cfg.Spec.CredentialsMode = operatorv1.CloudCredentialsModeDefault
+	cfg.Spec.CredentialsMode = operatorv1.CloudCredentialsModeManual
 
 	// Because we don't run the CCO, setting the management state to unmanaged.
 	// This should change if/when we run the CCO on the control plane side.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-17906

We currently take the `AuthenticationSpec` in `spec.Configuration` in the HC.  The HO even copies ref'ed secrets/configmaps into the HCP namespace.  However, the HCCO does not reconcile the Authentication global config into the guest cluster.

This PR adds that reconcilation.