### PR TITLE
OCPBUGS-19332: Use impersonated client for fetching the localhost-kubeconfig from ma…

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -134,7 +134,15 @@ func NewDumpCommand() *cobra.Command {
 
 func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 	start := time.Now()
-	c, err := util.GetClient()
+	var c client.Client
+	var err error
+
+	if len(opts.ImpersonateAs) > 0 {
+		c, err = util.GetImpersonatedClient(opts.ImpersonateAs)
+	} else {
+		c, err = util.GetClient()
+	}
+
 	if err != nil {
 		return err
 	}
@@ -175,6 +183,13 @@ func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to get a config for management cluster: %w", err)
 	}
+
+	if len(opts.ImpersonateAs) > 0 {
+		restConfig.Impersonate = restclient.ImpersonationConfig{
+			UserName: opts.ImpersonateAs,
+		}
+	}
+
 	kubeClient, err := kubeclient.NewForConfig(restConfig)
 	if err != nil {
 		return fmt.Errorf("failed to get a kubernetes client: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
When attempting to dump guest cluster while impersonating as a user, the impersonation is missing for fetching the `localhost-kubeconfig` from management cluster. This PR adds the Impersonated Client.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
We found this issue while trying to dump a guest cluster.
[OCPBUGS-19332](https://issues.redhat.com/browse/OCPBUGS-19332)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.