### PR TITLE
OCPBUGS-13829: set accesstoken-inactivity-timeout flag to openshift-oauth-apiserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -166,8 +166,11 @@ func buildOAuthContainerMain(p *OAuthDeploymentParams) func(c *corev1.Container)
 			fmt.Sprintf("--client-ca-file=%s", cpath(common.VolumeTotalClientCA().Name, certs.CASignerCertMapKey)),
 		}
 		if p.AuditWebhookRef != nil {
-			c.Args = append(c.Args, fmt.Sprintf("audit-webhook-config-file=%s", oauthAuditWebhookConfigFile()))
-			c.Args = append(c.Args, "audit-webhook-mode=batch")
+			c.Args = append(c.Args, fmt.Sprintf("--audit-webhook-config-file=%s", oauthAuditWebhookConfigFile()))
+			c.Args = append(c.Args, "--audit-webhook-mode=batch")
+		}
+		if p.AccessTokenInactivityTimeout != nil {
+			c.Args = append(c.Args, fmt.Sprintf("--accesstoken-inactivity-timeout=%s", p.AccessTokenInactivityTimeout.Duration.String()))
 		}
 		c.VolumeMounts = oauthVolumeMounts.ContainerMounts(c.Name)
 		c.WorkingDir = oauthVolumeMounts.Path(oauthContainerMain().Name, oauthVolumeWorkLogs().Name)

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -3,6 +3,7 @@ package oapi
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -34,16 +35,17 @@ type OpenShiftAPIServerParams struct {
 }
 
 type OAuthDeploymentParams struct {
-	Image                   string
-	EtcdURL                 string
-	MinTLSVersion           string
-	CipherSuites            []string
-	ServiceAccountIssuerURL string
-	DeploymentConfig        config.DeploymentConfig
-	AvailabilityProberImage string
-	Availability            hyperv1.AvailabilityPolicy
-	OwnerRef                config.OwnerRef
-	AuditWebhookRef         *corev1.LocalObjectReference
+	Image                        string
+	EtcdURL                      string
+	MinTLSVersion                string
+	CipherSuites                 []string
+	ServiceAccountIssuerURL      string
+	DeploymentConfig             config.DeploymentConfig
+	AvailabilityProberImage      string
+	Availability                 hyperv1.AvailabilityPolicy
+	OwnerRef                     config.OwnerRef
+	AuditWebhookRef              *corev1.LocalObjectReference
+	AccessTokenInactivityTimeout *metav1.Duration
 }
 
 func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *OpenShiftAPIServerParams {
@@ -226,6 +228,10 @@ func (p *OpenShiftAPIServerParams) OAuthAPIServerDeploymentParams(hcp *hyperv1.H
 
 	if hcp.Spec.AuditWebhook != nil && len(hcp.Spec.AuditWebhook.Name) > 0 {
 		params.AuditWebhookRef = hcp.Spec.AuditWebhook
+	}
+
+	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.OAuth != nil && hcp.Spec.Configuration.OAuth.TokenConfig.AccessTokenInactivityTimeout != nil {
+		params.AccessTokenInactivityTimeout = hcp.Spec.Configuration.OAuth.TokenConfig.AccessTokenInactivityTimeout
 	}
 
 	return params


### PR DESCRIPTION
Standalone `cluster-authentication-operator` sets the `accesstoken-inactivity-timeout` flag on the `openshift-oauth-apiserver` when `tokenConfig.accessTokenInactivityTimeout` is set in the global OAuth config.

We pass this to `oauth-openshift` via the config file but not to `openshift-oauth-apiserver` via its flag.  This results in OAuth tokens not expiring when expected.