### PR TITLE
[release-4.14] CNV-31919: Validate KubeVirt platform required versioning

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -888,7 +888,12 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "kubevirt"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kubevirt",
+				Annotations: map[string]string{
+					hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation: "true",
+				},
+			},
 			Spec: hyperv1.HostedClusterSpec{
 				Platform: hyperv1.PlatformSpec{
 					Type: hyperv1.KubevirtPlatform,
@@ -964,7 +969,9 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 		now:                   metav1.Now,
 	}
 
-	r.KubevirtInfraClients = newKVInfraMapMock(objects)
+	r.KubevirtInfraClients = kvinfra.NewMockKubevirtInfraClientMap(&createTypeTrackingClient{Client: fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build()},
+		"v1.0.0",
+		"1.27.0")
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
@@ -1019,6 +1026,8 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 		other                         []crclient.Object
 		managementClusterCapabilities capabilities.CapabiltyChecker
 		expectedResult                error
+		infraKubeVirtVersion          string
+		infraK8sVersion               string
 	}{
 		{
 			name: "Cluster uses route but not supported, error",
@@ -1155,6 +1164,38 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 			expectedResult:                errors.New(`service type OAuthServer can't be published with the same hostname api.example.com as service type APIServer`),
 			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 		},
+		{
+			name: "KubeVirt cluster meeting min infra cluster versions should succeed",
+			hostedCluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.KubevirtPlatform,
+				}}},
+			other: []crclient.Object{
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "creds"}},
+			},
+			infraKubeVirtVersion: "v1.0.0",
+			infraK8sVersion:      "v1.27.0",
+		},
+		{
+			name: "KubeVirt cluster not meeting min infra cluster versions should fail",
+			hostedCluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.KubevirtPlatform,
+				}}},
+			other: []crclient.Object{
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "creds"}},
+			},
+			infraKubeVirtVersion: "v0.99.0",
+			infraK8sVersion:      "v1.26.99",
+
+			expectedResult: errors.New(`[infrastructure kubevirt version is [0.99.0], hypershift kubevirt platform requires kubevirt version [1.0.0] or greater, infrastructure Kubernetes version is [1.26.99], hypershift kubevirt platform requires Kubernetes version [1.27.0] or greater]`),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1163,6 +1204,8 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 				Client:                        fake.NewClientBuilder().WithObjects(tc.other...).Build(),
 				ManagementClusterCapabilities: tc.managementClusterCapabilities,
 			}
+
+			r.KubevirtInfraClients = kvinfra.NewMockKubevirtInfraClientMap(r.Client, tc.infraKubeVirtVersion, tc.infraK8sVersion)
 
 			ctx := context.Background()
 			actual := r.validateConfigAndClusterCapabilities(ctx, tc.hostedCluster)
@@ -1513,6 +1556,65 @@ func TestValidateReleaseImage(t *testing.T) {
 			},
 			expectedResult: nil,
 		},
+		{
+			name: "KubeVirt platform unsupported release, error",
+			other: []crclient.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"},
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: nil,
+					},
+				},
+			},
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						NetworkType: hyperv1.OVNKubernetes,
+					},
+					PullSecret: corev1.LocalObjectReference{
+						Name: "pull-secret",
+					},
+					Release: hyperv1.Release{
+						Image: "image-4.13.0",
+					},
+
+					Platform: hyperv1.PlatformSpec{
+						Type:     hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{},
+					},
+				},
+			},
+			expectedResult: errors.New(`the minimum version supported for platform KubeVirt is: "4.14.0". Attempting to use: "4.13.0"`),
+		},
+		{
+			name: "KubeVirt platform supported release, success",
+			other: []crclient.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"},
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: nil,
+					},
+				},
+			},
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						NetworkType: hyperv1.OVNKubernetes,
+					},
+					PullSecret: corev1.LocalObjectReference{
+						Name: "pull-secret",
+					},
+					Release: hyperv1.Release{
+						Image: "image-4.14.0",
+					},
+
+					Platform: hyperv1.PlatformSpec{
+						Type:     hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1528,6 +1630,7 @@ func TestValidateReleaseImage(t *testing.T) {
 						"image-4.11.1": "4.11.1",
 						"image-4.12.0": "4.12.0",
 						"image-4.13.0": "4.13.0",
+						"image-4.14.0": "4.14.0",
 					},
 				},
 			}
@@ -3099,29 +3202,4 @@ func TestReportHostedClusterDeletionDuration(t *testing.T) {
 			}
 		})
 	}
-}
-
-type kubevirtInfraClientMapMock struct {
-	cluster *kvinfra.KubevirtInfraClient
-}
-
-func newKVInfraMapMock(objects []crclient.Object) kvinfra.KubevirtInfraClientMap {
-	return &kubevirtInfraClientMapMock{
-		cluster: &kvinfra.KubevirtInfraClient{
-			Client:    &createTypeTrackingClient{Client: fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build()},
-			Namespace: "kubevirt-kubevirt",
-		},
-	}
-}
-
-func (k *kubevirtInfraClientMapMock) DiscoverKubevirtClusterClient(_ context.Context, _ crclient.Client, _ string, _ *hyperv1.KubevirtPlatformCredentials, _ string, _ string) (*kvinfra.KubevirtInfraClient, error) {
-	return k.cluster, nil
-}
-
-func (k *kubevirtInfraClientMapMock) GetClient(_ string) *kvinfra.KubevirtInfraClient {
-	return k.cluster
-}
-
-func (*kubevirtInfraClientMapMock) Delete(_ string) {
-	// interface's empty implementation
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -30,7 +30,7 @@ func (defaulter *hostedClusterDefaulter) Default(ctx context.Context, obj runtim
 		return nil
 	}
 
-	pullSpec, err := supportedversion.LookupLatestSupportedRelease(ctx)
+	pullSpec, err := supportedversion.LookupLatestSupportedRelease(ctx, hcluster)
 	if err != nil {
 		return fmt.Errorf("unable to find default release image: %w", err)
 	}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -2187,27 +2187,9 @@ func TestDefaultNodePoolAMI(t *testing.T) {
 	}
 }
 
-type kubevirtInfraClientMapMock struct {
-	cluster *kvinfra.KubevirtInfraClient
-}
-
 func newKVInfraMapMock(objects []client.Object) kvinfra.KubevirtInfraClientMap {
-	return &kubevirtInfraClientMapMock{
-		cluster: &kvinfra.KubevirtInfraClient{
-			Client:    fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build(),
-			Namespace: "kubevirt-kubevirt",
-		},
-	}
-}
-
-func (k *kubevirtInfraClientMapMock) DiscoverKubevirtClusterClient(_ context.Context, _ client.Client, _ string, _ *hyperv1.KubevirtPlatformCredentials, _ string, _ string) (*kvinfra.KubevirtInfraClient, error) {
-	return k.cluster, nil
-}
-
-func (k *kubevirtInfraClientMapMock) GetClient(_ string) *kvinfra.KubevirtInfraClient {
-	return k.cluster
-}
-
-func (*kubevirtInfraClientMapMock) Delete(_ string) {
-	// interface's empty implementation
+	return kvinfra.NewMockKubevirtInfraClientMap(
+		fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build(),
+		"",
+		"")
 }

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/blang/semver"
@@ -18,6 +19,26 @@ import (
 // semver parsing.
 var LatestSupportedVersion = semver.MustParse("4.14.0")
 var MinSupportedVersion = semver.MustParse(subtractMinor(&LatestSupportedVersion, uint64(SupportedPreviousMinorVersions)).String())
+
+func GetMinSupportedVersion(hc *hyperv1.HostedCluster) semver.Version {
+	defaultMinVersion := semver.MustParse(subtractMinor(&LatestSupportedVersion, uint64(SupportedPreviousMinorVersions)).String())
+
+	switch hc.Spec.Platform.Type {
+	case hyperv1.KubevirtPlatform:
+		val, exists := hc.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation]
+		if exists {
+			if isTrue, _ := strconv.ParseBool(val); isTrue {
+				// This is an unsupported escape hatch annotation for internal use
+				return defaultMinVersion
+			}
+		}
+		return semver.MustParse("4.14.0")
+	case hyperv1.IBMCloudPlatform:
+		return semver.MustParse("4.9.0")
+	default:
+		return defaultMinVersion
+	}
+}
 
 // SupportedPreviousMinorVersions is the number of minor versions prior to current
 // version that are supported.
@@ -75,7 +96,7 @@ func IsValidReleaseVersion(version, currentVersion, latestVersionSupported, minS
 	}
 
 	if (version.Major == minSupportedVersion.Major && version.Minor < minSupportedVersion.Minor) || version.Major < minSupportedVersion.Major {
-		return fmt.Errorf("the minimum version supported is: %q. Attempting to use: %q", MinSupportedVersion, version)
+		return fmt.Errorf("the minimum version supported for platform %s is: %q. Attempting to use: %q", string(platformType), minSupportedVersion, version)
 	}
 
 	return nil
@@ -88,10 +109,13 @@ type ocpVersion struct {
 }
 
 // LookupLatestSupportedRelease picks the latest multi-arch image supported by this Hypershift Operator
-func LookupLatestSupportedRelease(ctx context.Context) (string, error) {
+func LookupLatestSupportedRelease(ctx context.Context, hc *hyperv1.HostedCluster) (string, error) {
+
+	minSupportedVersion := GetMinSupportedVersion(hc)
+
 	prefix := "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-multi/latest"
 	filter := fmt.Sprintf("in=>4.%d.%d+<+4.%d.0",
-		MinSupportedVersion.Minor, MinSupportedVersion.Patch, LatestSupportedVersion.Minor+1)
+		minSupportedVersion.Minor, minSupportedVersion.Patch, LatestSupportedVersion.Minor+1)
 
 	releaseURL := fmt.Sprintf("%s?%s", prefix, filter)
 

--- a/test/e2e/nodepool_kv_cache_image_test.go
+++ b/test/e2e/nodepool_kv_cache_image_test.go
@@ -72,7 +72,7 @@ func (k KubeVirtCacheTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []
 
 	dv := &v1beta1.DataVolume{}
 	g.Expect(
-		infraClient.Get(k.ctx, crclient.ObjectKey{Namespace: guestNamespace, Name: np.Status.Platform.KubeVirt.CacheName}, dv),
+		infraClient.GetInfraClient().Get(k.ctx, crclient.ObjectKey{Namespace: guestNamespace, Name: np.Status.Platform.KubeVirt.CacheName}, dv),
 	).To(Succeed())
 
 	g.Expect(dv.Status.Phase).Should(Equal(v1beta1.Succeeded))


### PR DESCRIPTION
This PR only impacts the hypershift-operator. We are doing some validation checks to ensure that we only allow creation of HCPs with supported guest, mgmt, and infra versions.

The minimum requirements are

HCP payload >= v4.14.0
KubeVirt >= v1.0.0 [CNV 4.14]
Kubernetes >= v1.27.0 [OCP 4.14]