### PR TITLE
OCPBUGS-17669: Remove cluster name validation from HCC

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -3620,10 +3619,6 @@ func (r *HostedClusterReconciler) validateConfigAndClusterCapabilities(ctx conte
 		errs = append(errs, err)
 	}
 
-	if err := r.validateHostedClusterName(hc); err != nil {
-		errs = append(errs, err)
-	}
-
 	// TODO(IBM): Revisit after fleets no longer use conflicting network CIDRs
 	if hc.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
 		if err := r.validateNetworks(hc); err != nil {
@@ -3883,16 +3878,6 @@ func (r *HostedClusterReconciler) validatePublishingStrategyMapping(hc *hyperv1.
 		hostnameServiceMap[hostname] = string(svc.Service)
 	}
 
-	return nil
-}
-
-// validateHostedClusterName validates a HostedCluster name confirms to RFC1123 convention
-// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-func (r *HostedClusterReconciler) validateHostedClusterName(hc *hyperv1.HostedCluster) error {
-	errs := validation.IsDNS1123Label(hc.Name)
-	if len(errs) > 0 {
-		return fmt.Errorf("hostedcluster name failed RFC1123 validation: %s", strings.Join(errs[:], " "))
-	}
 	return nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1119,16 +1119,6 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 			expectedResult: errors.New(`cannot parse cluster ID "foobar": invalid UUID length: 6`),
 		},
 		{
-			name: "invalid cluster name",
-			hostedCluster: &hyperv1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster-4.14",
-				},
-				Spec: hyperv1.HostedClusterSpec{},
-			},
-			expectedResult: errors.New(`hostedcluster name failed RFC1123 validation: a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')`),
-		},
-		{
 			name: "Setting network CIDRs overlapped, not allowed",
 			hostedCluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR mostly reverts https://github.com/openshift/hypershift/pull/2914. The note added to the docs in that PR should remain. This PR removes the cluster name validation from the HostedCluster Controller (HCC). This is not needed in the HCC since the KAS will reject a HostedCluster CR with an invalid name automatically.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-17669](https://issues.redhat.com/browse/OCPBUGS-17669)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.