### PR TITLE
OCPBUGS-19674: Report correct port when API exposed via route

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -110,7 +110,7 @@ func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublis
 			return host, port, message, err
 		}
 		host = strategy.Route.Hostname
-		port = int32(apiServerPort)
+		port = 443
 	}
 	return
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -829,6 +829,12 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	{
 		if hcp != nil {
 			hcluster.Status.ControlPlaneEndpoint = hcp.Status.ControlPlaneEndpoint
+
+			// TODO: (cewong) Remove this hack when we no longer need to support HostedControlPlanes that report
+			// the wrong port for the route strategy.
+			if isAPIServerRoute(hcluster) {
+				hcluster.Status.ControlPlaneEndpoint.Port = 443
+			}
 			hcluster.Status.OAuthCallbackURLTemplate = hcp.Status.OAuthCallbackURLTemplate
 		}
 	}
@@ -4743,4 +4749,13 @@ func reportHostedClusterDeletionDuration(hcluster *hyperv1.HostedCluster, funcCl
 	// SLI: HostedCluster deletion duration.
 	deletionDuration := funcClock.Since(hcluster.DeletionTimestamp.Time).Seconds()
 	hcmetrics.HostedClusterDeletionDuration.WithLabelValues(hcluster.Namespace, hcluster.Name, hcluster.Spec.ClusterID).Set(deletionDuration)
+}
+
+func isAPIServerRoute(hcluster *hyperv1.HostedCluster) bool {
+	for _, svc := range hcluster.Spec.Services {
+		if svc.Service == hyperv1.APIServer {
+			return svc.Type == hyperv1.Route
+		}
+	}
+	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When using a route to expose the API server, the external port should be
443. This commit makes the change in the HyperShift operator, as well as the real fix in the control plane operator so that we can account for existing hosted control planes that report the wrong port.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-19674](https://issues.redhat.com/browse/OCPBUGS-19674)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.