### PR TITLE
HOSTEDCP-1212: Bump Golang to v1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.20 as builder
 
 WORKDIR /hypershift
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN make build
 
-FROM quay.io/openshift/origin-base:4.14
+FROM quay.io/openshift/origin-base:4.15
 COPY --from=builder /hypershift/bin/hypershift \
                     /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -122,7 +122,7 @@ func NewDumpCommand() *cobra.Command {
 	cmd.MarkFlagRequired("artifact-dir")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		if err := DumpCluster(cmd.Context(), opts); err != nil {
 			opts.Log.Error(err, "Error")
 			return err

--- a/fast.Dockerfile
+++ b/fast.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-base:4.14
+FROM quay.io/openshift/origin-base:4.15
 
 LABEL io.openshift.hypershift.control-plane-operator-skips-haproxy=true
 LABEL io.openshift.hypershift.control-plane-operator-subcommands=true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Azure/azure-sdk-for-go v63.4.0+incompatible

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-hive/hypershift/hack/tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Golang to v1.20

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [HOSTEDCP-1212](https://issues.redhat.com/browse/HOSTEDCP-1212)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.