### PR TITLE
HOSTEDCP-1209: set ubi Containerfile labels

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -30,6 +30,15 @@ RUN cd /usr/bin && \
 
 ENTRYPOINT ["/usr/bin/hypershift"]
 
+LABEL name="multicluster-engine/hypershift-operator"
+LABEL description="HyperShift Operator is an operator to manage the lifecycle of Hosted Clusters"
+LABEL summary="HyperShift Operator"
+LABEL url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-rhel8-operator/"
+LABEL version=4.15
+LABEL com.redhat.component="multicluster-engine-hypershift-operator"
+LABEL io.k8s.description="HyperShift Operator"
+LABEL io.k8s.display-name="hypershift-operator"
+LABEL io.openshift.tags="data,images"
 LABEL io.openshift.hypershift.control-plane-operator-subcommands=true
 LABEL io.openshift.hypershift.control-plane-operator-skips-haproxy=true
 LABEL io.openshift.hypershift.ignition-server-healthz-handler=true


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent the ubi8 image labels from being inherited, we must set our own.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [HOSTEDCP-1209](https://issues.redhat.com//browse/HOSTEDCP-1209)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.