### PR TITLE
OCPBUGS-15215: OAuth template config in HostedCluter.configuration.ouath is not honored in HyperShift

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2691,7 +2691,7 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServer(ctx context.Context,
 
 	deployment := manifests.OAuthServerDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return oauth.ReconcileDeployment(ctx, r, deployment, p.OwnerRef, oauthConfig, p.OAuthServerImage, p.DeploymentConfig, p.IdentityProviders(), p.OauthConfigOverrides, p.AvailabilityProberImage, util.APIPort(hcp), p.NamedCertificates(), p.Socks5ProxyImage, p.NoProxy)
+		return oauth.ReconcileDeployment(ctx, r, deployment, p.OwnerRef, oauthConfig, p.OAuthServerImage, p.DeploymentConfig, p.IdentityProviders(), p.OauthConfigOverrides, p.AvailabilityProberImage, util.APIPort(hcp), p.NamedCertificates(), p.Socks5ProxyImage, p.NoProxy, p.ConfigParams(oauthServingCert))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile oauth deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -65,6 +65,7 @@ type OAuthConfigParams struct {
 	// when the login a provider uses doesn't conform to the standard login url in hypershift. The only supported use case
 	// for this is IBMCloud Red Hat Openshift
 	LoginURLOverride string
+	OAuthTemplates   configv1.OAuthTemplates
 }
 
 // ConfigOverride defines the oauth parameters that can be overridden in special use cases. The only supported
@@ -177,6 +178,17 @@ func (p *OAuthServerParams) NamedCertificates() []configv1.APIServerNamedServing
 	}
 }
 
+func (p *OAuthServerParams) OauthTemplates() configv1.OAuthTemplates {
+	emptyTemplates := configv1.OAuthTemplates{}
+
+	if p.OAuth != nil {
+		if p.OAuth.Templates != emptyTemplates {
+			return p.OAuth.Templates
+		}
+	}
+	return emptyTemplates
+}
+
 func (p *OAuthServerParams) IdentityProviders() []configv1.IdentityProvider {
 	if p.OAuth != nil {
 		return p.OAuth.IdentityProviders
@@ -227,6 +239,7 @@ func (p *OAuthServerParams) ConfigParams(servingCert *corev1.Secret) *OAuthConfi
 		OauthConfigOverrides:         p.OauthConfigOverrides,
 		LoginURLOverride:             p.LoginURLOverride,
 		NamedCertificates:            p.NamedCertificates(),
+		OAuthTemplates:               p.OauthTemplates(),
 	}
 }
 


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Fixes OAuth template config in HostedCluter.configuration.ouath is not honored in HyperShift bug.


**Which issue(s) this PR fixes** :
Fixes #

https://issues.redhat.com/browse/OCPBUGS-15215

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.