### PR TITLE
Update kubevirt csi driver deployment with proper timeouts

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/controller.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/controller.yaml
@@ -26,7 +26,7 @@ spec:
             - "--infra-cluster-labels=$(INFRACLUSTER_LABELS)"
             - "--run-node-service=false"
             - "--run-controller-service=true"
-            - --v=5
+            - "--v=5"
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -61,10 +61,12 @@ spec:
         - name: csi-provisioner
           image: quay.io/openshift/origin-csi-external-provisioner:latest
           args:
-            - --csi-address=$(ADDRESS)
-            - --default-fstype=ext4
-            - --v=5
+            - "--csi-address=$(ADDRESS)"
+            - "--default-fstype=ext4"
+            - "--v=5"
             - "--kubeconfig=/var/run/secrets/tenantcluster/kubeconfig"
+            - "--timeout=3m"
+            - "--retry-interval-max=1m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -76,9 +78,11 @@ spec:
         - name: csi-attacher
           image: quay.io/openshift/origin-csi-external-attacher:latest
           args:
-            - --csi-address=$(ADDRESS)
-            - --v=5
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
             - "--kubeconfig=/var/run/secrets/tenantcluster/kubeconfig"
+            - "--timeout=3m"
+            - "--retry-interval-max=1m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -94,9 +98,9 @@ spec:
         - name: csi-liveness-probe
           image: quay.io/openshift/origin-csi-livenessprobe:latest
           args:
-            - --csi-address=/csi/csi.sock
-            - --probe-timeout=3s
-            - --health-port=10301
+            - "--csi-address=/csi/csi.sock"
+            - "--probe-timeout=3s"
+            - "--health-port=10301"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/daemonset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
             - "--node-name=$(KUBE_NODE_NAME)"
             - "--run-node-service=true"
             - "--run-controller-service=false"
-            - --v=5
+            - "--v=5"
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -80,9 +80,9 @@ spec:
             privileged: true
           image: quay.io/openshift/origin-csi-node-driver-registrar:latest
           args:
-            - --csi-address=$(ADDRESS)
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v=5
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            - "--v=5"
           lifecycle:
             preStop:
               exec:
@@ -106,9 +106,9 @@ spec:
         - name: csi-liveness-probe
           image: quay.io/openshift/origin-csi-livenessprobe:latest
           args:
-            - --csi-address=/csi/csi.sock
-            - --probe-timeout=3s
-            - --health-port=10300
+            - "--csi-address=/csi/csi.sock"
+            - "--probe-timeout=3s"
+            - "--health-port=10300"
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubevirt/csi-driver/pull/93 updated the timeouts of the csi-provisioner and csi-attacher to be 3 minutes instead of 15 seconds to avoid the timeout happening while waiting for disk to hotplug.

This PR modifies the controller deployment and daemonset to match that PR
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.