### PR TITLE
OCPBUGS-19746, OCPBUGS-16189: Added network validations

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"reflect"
 	"sort"
@@ -3972,9 +3973,95 @@ func (r *HostedClusterReconciler) validateHostedClusterSupport(hc *hyperv1.Hoste
 }
 
 func (r *HostedClusterReconciler) validateNetworks(hc *hyperv1.HostedCluster) error {
-	errs := validateSliceNetworkCIDRs(hc)
+	var errs field.ErrorList
+	errs = append(errs, validateSliceNetworkCIDRs(hc)...)
+	errs = append(errs, checkAdvertiseAddressOverlapping(hc)...)
 
 	return errs.ToAggregate()
+}
+
+// findAdvertiseAddress function returns a string and an error indicating the AdvertiseAddress for the hostedcluster.
+// if the advertise address is properly set, it will return that value and nil, otherwise will return an error.
+// if the advertise address is not set, it will return the default one based on the network primary stack.
+func findAdvertiseAddress(hc *hyperv1.HostedCluster) (net.IP, *field.Error) {
+	var advertiseAddress net.IP
+	if hc.Spec.Networking.APIServer != nil && hc.Spec.Networking.APIServer.AdvertiseAddress != nil {
+		ipaddr := net.ParseIP(*hc.Spec.Networking.APIServer.AdvertiseAddress)
+		if ipaddr == nil {
+			return ipaddr, field.Invalid(field.NewPath("hc.Spec.Networking.APIServer.AdvertiseAddress"),
+				k8sutilspointer.String(ipaddr.String()),
+				fmt.Sprintf("advertise address set in HostedCluster %s is not parseable", *hc.Spec.Networking.APIServer.AdvertiseAddress),
+			)
+		}
+
+		return ipaddr, nil
+	}
+
+	ipaddr := net.ParseIP(hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String())
+	if ipaddr == nil {
+		return ipaddr, field.Invalid(field.NewPath("hc.Spec.Networking.ClusterNetwork[0].CIDR.IP"),
+			k8sutilspointer.String(ipaddr.String()),
+			fmt.Sprintf("Cluster Network ip address %s is not parseable", hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String()),
+		)
+	}
+
+	if strings.Contains(hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String(), ".") {
+		advertiseAddress = net.ParseIP(config.DefaultAdvertiseIPv4Address)
+	}
+
+	if strings.Contains(hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String(), ":") {
+		advertiseAddress = net.ParseIP(config.DefaultAdvertiseIPv6Address)
+	}
+
+	return advertiseAddress, nil
+}
+
+// checkAdvertiseAddressOverlapping validates that the AdvertiseAddress defined does not overlap with
+// the ClusterNetwork, ServiceNetwork and MachineNetwork
+func checkAdvertiseAddressOverlapping(hc *hyperv1.HostedCluster) field.ErrorList {
+	var errs field.ErrorList
+	var advAddress netip.Addr
+
+	networks := make(map[string]string, 0)
+
+	if len(hc.Spec.Networking.ClusterNetwork) > 0 {
+		networks["spec.networking.ClusterNetwork"] = hc.Spec.Networking.ClusterNetwork[0].CIDR.String()
+	}
+
+	if len(hc.Spec.Networking.ServiceNetwork) > 0 {
+		networks["spec.networking.ServiceNetwork"] = hc.Spec.Networking.ServiceNetwork[0].CIDR.String()
+	}
+
+	if len(hc.Spec.Networking.MachineNetwork) > 0 {
+		networks["spec.networking.MachineNetwork"] = hc.Spec.Networking.MachineNetwork[0].CIDR.String()
+	}
+
+	advAddr, fieldErr := findAdvertiseAddress(hc)
+	if fieldErr != nil {
+		errs = append(errs, fieldErr)
+		return errs
+	}
+
+	advAddress = netip.MustParseAddr(advAddr.String())
+
+	for fieldPath, cidr := range networks {
+		network, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			errs = append(errs, field.Invalid(field.NewPath(fieldPath),
+				k8sutilspointer.String(cidr),
+				fmt.Sprintf("error parsing field %s prefix: %v", fieldPath, err),
+			))
+		}
+
+		if network.Contains(advAddress) {
+			errs = append(errs, field.Invalid(field.NewPath(fieldPath),
+				k8sutilspointer.String(cidr),
+				fmt.Sprintf("the field %s with content %s overlaps with the defined AdvertiseAddress %s prefix: %v", fieldPath, cidr, advAddress.String(), err),
+			))
+		}
+	}
+
+	return errs
 }
 
 func validateSliceNetworkCIDRs(hc *hyperv1.HostedCluster) field.ErrorList {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3974,6 +3974,7 @@ func (r *HostedClusterReconciler) validateHostedClusterSupport(hc *hyperv1.Hoste
 
 func (r *HostedClusterReconciler) validateNetworks(hc *hyperv1.HostedCluster) error {
 	var errs field.ErrorList
+	errs = append(errs, validateNetworkStackAddresses(hc)...)
 	errs = append(errs, validateSliceNetworkCIDRs(hc)...)
 	errs = append(errs, checkAdvertiseAddressOverlapping(hc)...)
 
@@ -4014,6 +4015,65 @@ func findAdvertiseAddress(hc *hyperv1.HostedCluster) (net.IP, *field.Error) {
 	}
 
 	return advertiseAddress, nil
+}
+
+// validateNetworkStackAddresses validates that Networks defined in the HostedCluster are in the same network stack
+// between each other against the primary IP using ClusterNetwork as a base.
+func validateNetworkStackAddresses(hc *hyperv1.HostedCluster) field.ErrorList {
+	var errs field.ErrorList
+	ipv4 := make([]string, 0)
+	ipv6 := make([]string, 0)
+
+	networks := make(map[string]string, 0)
+
+	if len(hc.Spec.Networking.ClusterNetwork) > 0 {
+		networks["spec.networking.ClusterNetwork"] = hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String()
+	}
+
+	if len(hc.Spec.Networking.ServiceNetwork) > 0 {
+		networks["spec.networking.ServiceNetwork"] = hc.Spec.Networking.ServiceNetwork[0].CIDR.IP.String()
+	}
+
+	if len(hc.Spec.Networking.MachineNetwork) > 0 {
+		networks["spec.networking.MachineNetwork"] = hc.Spec.Networking.MachineNetwork[0].CIDR.IP.String()
+	}
+
+	advAddr, err := findAdvertiseAddress(hc)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	networks["spec.networking.APIServerNetworking.AdvertiseAddress"] = advAddr.String()
+
+	for fieldpath, ipaddr := range networks {
+		checkIP := net.ParseIP(ipaddr)
+
+		if checkIP != nil && strings.Contains(ipaddr, ".") {
+			ipv4 = append(ipv4, ipaddr)
+		}
+
+		if checkIP != nil && strings.Contains(ipaddr, ":") {
+			ipv6 = append(ipv6, ipaddr)
+		}
+
+		// This check ensures that the IPv6 and IPv4 is a valid ip
+		if checkIP == nil {
+			errs = append(errs, field.Invalid(field.NewPath(fieldpath),
+				k8sutilspointer.String(ipaddr),
+				fmt.Sprintf("error checking network stack of %s with ip %s", fieldpath, ipaddr),
+			))
+		}
+	}
+
+	if len(ipv4) > 0 && len(ipv6) > 0 {
+		// Invalid result, means that there are mixed stacks in the primary position of the stack
+		errs = append(errs, field.Forbidden(field.NewPath("spec.networking"),
+			fmt.Sprintf("declare multiple network stacks as primary network in the cluster definition is not allowed, ipv4: %v, ipv6: %v", ipv4, ipv6),
+		))
+	}
+
+	return errs
+
 }
 
 // checkAdvertiseAddressOverlapping validates that the AdvertiseAddress defined does not overlap with

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -23,6 +23,7 @@ import (
 	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
 	"github.com/openshift/hypershift/support/capabilities"
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
+	"github.com/openshift/hypershift/support/config"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/upsert"
@@ -951,6 +952,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 		}
 		cluster.Spec.PullSecret = corev1.LocalObjectReference{Name: "secret"}
 		cluster.Spec.InfraID = "infra-id"
+		cluster.Spec.Networking.ClusterNetwork = []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}}
 		objects = append(objects, cluster)
 	}
 
@@ -1015,8 +1017,11 @@ func (c *createTypeTrackingClient) Create(ctx context.Context, obj crclient.Obje
 func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 
 	// For network test below.
+	clusterNet := make([]hyperv1.ClusterNetworkEntry, 2)
+	cidr, _ := ipnet.ParseCIDR("192.168.1.0/24")
+	clusterNet[0].CIDR = *cidr
 	machineNet := make([]hyperv1.MachineNetworkEntry, 2)
-	cidr, _ := ipnet.ParseCIDR("172.16.0.0/24")
+	cidr, _ = ipnet.ParseCIDR("172.16.0.0/24")
 	machineNet[0].CIDR = *cidr
 	cidr, _ = ipnet.ParseCIDR("172.16.1.0/24")
 	machineNet[1].CIDR = *cidr
@@ -1047,6 +1052,9 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 							Type: hyperv1.Route,
 						}},
 					},
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: clusterNet,
+					},
 				}},
 			managementClusterCapabilities: &fakecapabilities.FakeSupportNoCapabilities{},
 			expectedResult:                errors.New(`cluster does not support Routes, but service "" is exposed via a Route`),
@@ -1063,6 +1071,9 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 							Type: hyperv1.Route,
 						}},
 					},
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: clusterNet,
+					},
 				}},
 			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 		},
@@ -1072,12 +1083,17 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{
-					Type: hyperv1.AzurePlatform,
-					Azure: &hyperv1.AzurePlatformSpec{
-						Credentials: corev1.LocalObjectReference{Name: "creds"},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							Credentials: corev1.LocalObjectReference{Name: "creds"},
+						},
 					},
-				}}},
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: clusterNet,
+					},
+				}},
 			other: []crclient.Object{
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "creds"}},
 			},
@@ -1089,12 +1105,17 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{
-					Type: hyperv1.AzurePlatform,
-					Azure: &hyperv1.AzurePlatformSpec{
-						Credentials: corev1.LocalObjectReference{Name: "creds"},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							Credentials: corev1.LocalObjectReference{Name: "creds"},
+						},
 					},
-				}}},
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: clusterNet,
+					},
+				}},
 			other: []crclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: "creds"},
@@ -1115,6 +1136,9 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 				},
 				Spec: hyperv1.HostedClusterSpec{
 					ClusterID: "foobar",
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: clusterNet,
+					},
 				}},
 			expectedResult: errors.New(`cannot parse cluster ID "foobar": invalid UUID length: 6`),
 		},
@@ -1128,6 +1152,7 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 					Networking: hyperv1.ClusterNetworking{
 						ServiceNetwork: serviceNet,
 						MachineNetwork: machineNet,
+						ClusterNetwork: clusterNet,
 					},
 				},
 			},
@@ -1156,6 +1181,9 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 							},
 						},
 					},
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: clusterNet,
+					},
 				}},
 			expectedResult:                errors.New(`service type OAuthServer can't be published with the same hostname api.example.com as service type APIServer`),
 			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
@@ -1166,9 +1194,14 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{
-					Type: hyperv1.KubevirtPlatform,
-				}}},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: clusterNet,
+					},
+				}},
 			other: []crclient.Object{
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "creds"}},
 			},
@@ -1181,9 +1214,14 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: hyperv1.HostedClusterSpec{Platform: hyperv1.PlatformSpec{
-					Type: hyperv1.KubevirtPlatform,
-				}}},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: clusterNet,
+					},
+				}},
 			other: []crclient.Object{
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "creds"}},
 			},
@@ -3233,6 +3271,208 @@ func TestReportHostedClusterDeletionDuration(t *testing.T) {
 
 			if diff := cmp.Diff(result, tc.expected); diff != "" {
 				t.Errorf("result differs from actual: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateSliceNetworkCIDRs(t *testing.T) {
+	tests := []struct {
+		name    string
+		mn      []hyperv1.MachineNetworkEntry
+		cn      []hyperv1.ClusterNetworkEntry
+		sn      []hyperv1.ServiceNetworkEntry
+		wantErr bool
+	}{
+		{
+			name:    "given a conflicting IPv6 clusterNetwork overlapped with machineNetwork, it should fail",
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/48")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/64")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64")}},
+			wantErr: true,
+		},
+		{
+			name:    "given different IPv6 network CIDRs, it should success",
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/48")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd01::/64")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64")}},
+			wantErr: false,
+		},
+		{
+			name:    "given a conflicting IPv4 clusterNetwork overlapped with serviceNetwork, it should fail",
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/16")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			wantErr: true,
+		},
+		{
+			name:    "given different IPv4 network CIDRs, it should success",
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hc",
+					Namespace: "any",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						MachineNetwork: tt.mn,
+						ClusterNetwork: tt.cn,
+						ServiceNetwork: tt.sn,
+					},
+				},
+			}
+			err := validateSliceNetworkCIDRs(hc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSliceNetworkCIDRs() wantErr %v, err %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestCheckAdvertiseAddressOverlapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		mn      []hyperv1.MachineNetworkEntry
+		cn      []hyperv1.ClusterNetworkEntry
+		sn      []hyperv1.ServiceNetworkEntry
+		aa      *hyperv1.APIServerNetworking
+		wantErr bool
+	}{
+		{
+			name:    "given an IPv6 defined AdvertiseAddress overlapped with ClusterNetwork, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("fd03::1")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/48")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd03::/64")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64")}},
+			wantErr: true,
+		},
+		{
+			name:    "given not overlapped IPv6 networks CIDRs and not defined AdvertiseAddress, it should success",
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/48")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd01::/64")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64")}},
+			wantErr: false,
+		},
+		{
+			name:    "given an IPv4 defined AdvertiseAddress overlapped with MachineNetwork, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("192.168.1.1")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/16")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			wantErr: true,
+		},
+		{
+			name:    "given not overlapped IPv4 networks CIDRs and not defined AdvertiseAddress, it should success",
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			wantErr: false,
+		},
+		{
+			name:    "given a not valid AdvertiseAddress, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("192.168.2.1.2")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hc",
+					Namespace: "any",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						MachineNetwork: tt.mn,
+						ClusterNetwork: tt.cn,
+						ServiceNetwork: tt.sn,
+						APIServer:      tt.aa,
+					},
+				},
+			}
+			g := NewGomegaWithT(t)
+			err := checkAdvertiseAddressOverlapping(hc)
+			g.Expect((err != nil)).To(Equal(tt.wantErr))
+		})
+	}
+}
+
+func TestFindAdvertiseAddress(t *testing.T) {
+	tests := []struct {
+		name             string
+		aa               *hyperv1.APIServerNetworking
+		cn               []hyperv1.ClusterNetworkEntry
+		resultAdvAddress string
+		wantErr          bool
+	}{
+		{
+			name:             "given a defined AdvertiseAddress, should be the result and IPv4",
+			aa:               &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("192.168.1.1")},
+			cn:               []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			resultAdvAddress: "192.168.1.1",
+		},
+		{
+			name:             "given a hc without AdvertiseAddress, it should return the default IPv4 address",
+			cn:               []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			resultAdvAddress: config.DefaultAdvertiseIPv4Address,
+		},
+		{
+			name:             "given an IPv6 hc with defined AdvertiseAddress, it should return that address",
+			aa:               &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("fd03::1")},
+			cn:               []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd01::/64")}},
+			resultAdvAddress: "fd03::1",
+		},
+		{
+			name:             "given an IPv6 hc wihtout AdvertiseAddress, it return IPv6 default address",
+			cn:               []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd01::/64")}},
+			resultAdvAddress: config.DefaultAdvertiseIPv6Address,
+		},
+		{
+			name:    "given an invalid IPv4 AdvertiseAddress, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("192.168.1.1222")},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			wantErr: true,
+		},
+		{
+			name:    "given an invalid IPv6 AdvertiseAddress, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("fd03::4444444")},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd01::/64")}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hc",
+					Namespace: "any",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: tt.cn,
+						APIServer:      tt.aa,
+					},
+				},
+			}
+			g := NewGomegaWithT(t)
+			avdAddress, err := findAdvertiseAddress(hc)
+			if tt.wantErr {
+				g.Expect(err).To(Not(BeNil()))
+				g.Expect(avdAddress).To(BeEmpty())
+			} else {
+				g.Expect(avdAddress.String()).To(Equal(tt.resultAdvAddress))
 			}
 		})
 	}


### PR DESCRIPTION
[OCPBUGS-19746](https://github.com/openshift/hypershift/pull/3047/commits/773aa1b71af559a16b7f3bc4fa80dac40ff4f4d2) - Added network validations for AdvertiseAddress

- Implemented a validation mechanism for the AdvertiseAddress, which verifies its absence of overlap with the presently defined networks.

  When the AdvertiseAddress is explicitly specified by the user, it will be utilised for the validation. In cases where it is not explicitly defined, the controller will automatically employ the default definitions, contingent upon the primary network stack.

  Furthermore, this commit encompasses the inclusion of unit tests for the 'validateSliceNetworkCIDRs' function.

[OCPBUGS-16189](https://github.com/openshift/hypershift/pull/3047/commits/c5427639656a844c0d219a95b7dc6f5d6ce62ca6) - Implemented primary IP Network stack validations

- Implemented a network validation mechanism to ensure proper correlation among the ClusterNetwork, ServiceNetwork, and MachineNetwork by utilising the same network stack.

Which issue(s) this PR fixes:

- Fixes [OCPBUGS-19746](https://issues.redhat.com/browse/OCPBUGS-19746)
- Fixes [OCPBUGS-16189](https://issues.redhat.com/browse/OCPBUGS-16189)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.