### PR TITLE
OCPBUGS-16079: No error for overlapping service network and API IP

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3983,6 +3983,7 @@ func (r *HostedClusterReconciler) validateNetworks(hc *hyperv1.HostedCluster) er
 	errs = append(errs, validateNetworkStackAddresses(hc)...)
 	errs = append(errs, validateSliceNetworkCIDRs(hc)...)
 	errs = append(errs, checkAdvertiseAddressOverlapping(hc)...)
+	errs = append(errs, validateNodePortVsServiceNetwork(hc)...)
 
 	return errs.ToAggregate()
 }
@@ -4126,7 +4127,23 @@ func checkAdvertiseAddressOverlapping(hc *hyperv1.HostedCluster) field.ErrorList
 			))
 		}
 	}
+	return errs
+}
 
+// Validate that the nodeport IP is not within the ServiceNetwork CIDR.
+func validateNodePortVsServiceNetwork(hc *hyperv1.HostedCluster) field.ErrorList {
+	var errs field.ErrorList
+
+	ip := getNodePortIP(hc)
+	if ip != nil {
+		// Validate that the nodeport IP is not within the ServiceNetwork CIDR.
+		for _, cidr := range hc.Spec.Networking.ServiceNetwork {
+			netCIDR := (net.IPNet)(cidr.CIDR)
+			if netCIDR.Contains(ip) {
+				errs = append(errs, field.Invalid(field.NewPath("spec.networking.ServiceNetwork"), cidr.CIDR.String(), fmt.Sprintf("Nodeport IP is within the service network range: %s is within %s", ip, cidr.CIDR.String())))
+			}
+		}
+	}
 	return errs
 }
 
@@ -4877,6 +4894,15 @@ func reportHostedClusterDeletionDuration(hcluster *hyperv1.HostedCluster, funcCl
 	// SLI: HostedCluster deletion duration.
 	deletionDuration := funcClock.Since(hcluster.DeletionTimestamp.Time).Seconds()
 	hcmetrics.HostedClusterDeletionDuration.WithLabelValues(hcluster.Namespace, hcluster.Name, hcluster.Spec.ClusterID).Set(deletionDuration)
+}
+
+func getNodePortIP(hcluster *hyperv1.HostedCluster) net.IP {
+	for _, svc := range hcluster.Spec.Services {
+		if svc.Service == hyperv1.APIServer && svc.Type == hyperv1.NodePort {
+			return net.ParseIP(svc.NodePort.Address)
+		}
+	}
+	return nil
 }
 
 func isAPIServerRoute(hcluster *hyperv1.HostedCluster) bool {


### PR DESCRIPTION
Fixes: OCPBUGS-16079

Ensure that the nodeport IP for the API Server does not conflict with the Service Network CIDR.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.