### PR TITLE
HOSTEDCP-1113: Improve NodePool CPU arch & platform check

### DIFF
--- a/api/v1beta1/nodepool_conditions.go
+++ b/api/v1beta1/nodepool_conditions.go
@@ -74,4 +74,5 @@ const (
 	IgnitionNotReached                    = "ignitionNotReached"
 	DefaultAWSSecurityGroupNotReadyReason = "DefaultSGNotReady"
 	NodePoolValidArchPlatform             = "ValidArchPlatform"
+	NodePoolInvalidArchPlatform           = "InvalidArchPlatform"
 )

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -454,13 +454,13 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		ObservedGeneration: nodePool.Generation,
 	})
 
-	// Validate arch platform support
-	if (nodePool.Spec.Arch != "") && (nodePool.Spec.Platform.Type != hyperv1.AWSPlatform) {
+	// Validate modifying CPU arch support for platform
+	if (nodePool.Spec.Arch != "amd64") && (nodePool.Spec.Platform.Type != hyperv1.AWSPlatform) {
 		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolValidArchPlatform,
 			Status:             corev1.ConditionFalse,
-			Reason:             hyperv1.NodePoolValidationFailedReason,
-			Message:            fmt.Sprintf("Arch flag is not supported for platform: %s", nodePool.Spec.Platform.Type),
+			Reason:             hyperv1.NodePoolInvalidArchPlatform,
+			Message:            fmt.Sprintf("CPU arch %s is not supported for platform: %s, use 'amd64' instead", nodePool.Spec.Arch, nodePool.Spec.Platform.Type),
 			ObservedGeneration: nodePool.Generation,
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves the UX around notifying a user the CPU arch cannot be changed from the default amd64 unless changing the NodePool CPU arch is supported for the platform.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1113](https://issues.redhat.com/browse/HOSTEDCP-1113)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.