### PR TITLE
Add aws-ebs-csi-driver-operator to allowed NeedManagementKASAccessLab…

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -800,6 +800,7 @@ func EnsureNetworkPolicies(t *testing.T, ctx context.Context, c crclient.Client,
 				"hosted-cluster-config-operator",
 				"cloud-controller-manager",
 				"olm-collect-profiles",
+				"aws-ebs-csi-driver-operator",
 			}
 
 			g := NewWithT(t)
@@ -884,7 +885,7 @@ func getComponentName(pod *corev1.Pod) string {
 	return ""
 }
 
-func checkPodsHaveLabel(ctx context.Context, c crclient.Client, components []string, namespace string, labels map[string]string) error {
+func checkPodsHaveLabel(ctx context.Context, c crclient.Client, allowedComponents []string, namespace string, labels map[string]string) error {
 	// Get all Pods with wanted label.
 	podList := &corev1.PodList{}
 	err := c.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels(labels))
@@ -902,7 +903,7 @@ func checkPodsHaveLabel(ctx context.Context, c crclient.Client, components []str
 			return fmt.Errorf("unable to determine component name for pod that has NeedManagementKASAccessLabel: %s", pod.Name)
 		}
 		allowed := false
-		for _, component := range components {
+		for _, component := range allowedComponents {
 			if component == componentName {
 				allowed = true
 				break


### PR DESCRIPTION
…el in test

This is needed now so https://github.com/openshift/cluster-storage-operator/pull/403 can pass

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.