### PR TITLE
OCPBUGS-20249: Set KAS config pod security Enforce to privileged

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -92,7 +92,7 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 									Kind:       "PodSecurityConfiguration",
 								},
 								Defaults: podsecurityadmissionv1beta1.PodSecurityDefaults{
-									Enforce:        "restricted",
+									Enforce:        "privileged",
 									EnforceVersion: "latest",
 									Audit:          "restricted",
 									AuditVersion:   "latest",


### PR DESCRIPTION
**What this PR does / why we need it**:
Set hosted cluster KAS config pod security enforcement to privileged.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-20249](https://issues.redhat.com/browse/OCPBUGS-20249)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.