### PR TITLE
HOSTEDCP-1229: Move azure cloud provider to out of tree

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/manifests.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/manifests.go
@@ -1,0 +1,43 @@
+package azure
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CCMServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func CCMDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-cloud-controller-manager",
+			Namespace: ns,
+		},
+	}
+}
+
+func ccmContainer() *corev1.Container {
+	return &corev1.Container{
+		Name: "cloud-controller-manager",
+	}
+}
+
+func ccmVolumeKubeconfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "kubeconfig",
+	}
+}
+
+func ccmCloudConfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cloud-config",
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/params.go
@@ -1,0 +1,47 @@
+package azure
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+type AzureParams struct {
+	ClusterID        string                  `json:"clusterID"`
+	ClusterNetwork   string                  `json:"clusterNetwork"`
+	OwnerRef         *metav1.OwnerReference  `json:"ownerRef"`
+	DeploymentConfig config.DeploymentConfig `json:"deploymentConfig"`
+}
+
+func NewAzureParams(hcp *hyperv1.HostedControlPlane) *AzureParams {
+	if hcp.Spec.Platform.Azure == nil {
+		return nil
+	}
+	p := &AzureParams{
+		ClusterID:      hcp.Spec.InfraID,
+		ClusterNetwork: hcp.Spec.Networking.ClusterNetwork[0].CIDR.String(),
+	}
+	p.OwnerRef = config.ControllerOwnerRef(hcp)
+
+	p.DeploymentConfig.SetDefaults(hcp, ccmLabels(), pointer.Int(1))
+	p.DeploymentConfig.Resources = config.ResourcesSpec{
+		ccmContainer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+				corev1.ResourceCPU:    resource.MustParse("75m"),
+			},
+		},
+	}
+	p.DeploymentConfig.AdditionalLabels = additionalLabels()
+	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
+		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
+	}
+	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+
+	return p
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -13,7 +13,7 @@ const (
 	Provider       = "azure"
 )
 
-// ReconcileCloudConfigWithCredentials reconciles as expected by Nodes Kubelet.
+// ReconcileCloudConfig reconciles as expected by Nodes Kubelet.
 func ReconcileCloudConfig(cm *corev1.ConfigMap, hcp *hyperv1.HostedControlPlane, credentialsSecret *corev1.Secret) error {
 	cfg := azureConfigWithoutCredentials(hcp, credentialsSecret)
 	serializedConfig, err := json.MarshalIndent(cfg, "", "  ")
@@ -65,9 +65,11 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 	}
 }
 
-// AzureConfig is a copy of the relevant subset of the upstream type
+// AzureConfig was originally a copy of the relevant subset of the upstream type
 // at https://github.com/kubernetes/kubernetes/blob/30a21e9abdbbeb78d2b7ce59a79e46299ced2742/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go#L123
 // in order to not pick up the huge amount of transient dependencies that type pulls in.
+// Now the source is https://github.com/kubernetes-sigs/cloud-provider-azure/blob/e5d670328a51e31787fc949ddf41a3efcd90d651/examples/out-of-tree/cloud-controller-manager.yaml#L232
+// https://github.com/kubernetes-sigs/cloud-provider-azure/tree/e5d670328a51e31787fc949ddf41a3efcd90d651/pkg/provider/config
 type AzureConfig struct {
 	Cloud                        string `json:"cloud"`
 	TenantID                     string `json:"tenantId"`

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
@@ -1,0 +1,121 @@
+package azure
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/util"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ReconcileCCMServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(sa)
+	util.EnsurePullSecret(sa, controlplaneoperator.PullSecret("").Name)
+	return nil
+}
+
+func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, p *AzureParams, serviceAccountName string, releaseImageProvider *imageprovider.ReleaseImageProvider) error {
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: ccmLabels(),
+		},
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: ccmLabels(),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					util.BuildContainer(ccmContainer(), buildCCMContainer(p, releaseImageProvider.GetImage("azure-cloud-controller-manager"), hcp.Namespace)),
+				},
+				Volumes:            []corev1.Volume{},
+				ServiceAccountName: serviceAccountName,
+			},
+		},
+	}
+
+	addVolumes(deployment)
+
+	config.OwnerRefFrom(hcp).ApplyTo(deployment)
+	p.DeploymentConfig.ApplyTo(deployment)
+	return nil
+}
+
+func addVolumes(deployment *appsv1.Deployment) {
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmVolumeKubeconfig(), buildCCMVolumeKubeconfig),
+	)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		util.BuildVolume(ccmCloudConfig(), buildCCMCloudConfig),
+	)
+}
+
+func podVolumeMounts() util.PodVolumeMounts {
+	return util.PodVolumeMounts{
+		ccmContainer().Name: util.ContainerVolumeMounts{
+			ccmVolumeKubeconfig().Name: "/etc/kubernetes/kubeconfig",
+			ccmCloudConfig().Name:      "/etc/cloud",
+		},
+	}
+}
+
+// TODO (Alberto): move all signature input into params?
+func buildCCMContainer(p *AzureParams, controllerManagerImage, namespace string) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = controllerManagerImage
+		c.ImagePullPolicy = corev1.PullIfNotPresent
+		c.Command = []string{"/bin/azure-cloud-controller-manager"}
+		c.Args = []string{
+			"--cloud-config=/etc/cloud/" + CloudConfigKey,
+			"--cloud-provider=azure",
+			"--controllers=*,-cloud-node",
+			"--configure-cloud-routes=false",
+			"--bind-address=127.0.0.1",
+			"--cluster-name=" + p.ClusterID,
+			"--leader-elect=true",
+			"--route-reconciliation-period=10s",
+			"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+			fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),
+			fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
+			fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
+			"--leader-elect-resource-namespace=openshift-cloud-controller-manager",
+			"--v=4",
+		}
+		c.VolumeMounts = podVolumeMounts().ContainerMounts(c.Name)
+	}
+}
+
+func buildCCMVolumeKubeconfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.KASServiceKubeconfigSecret("").Name,
+	}
+}
+
+func buildCCMCloudConfig(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName: manifests.AzureProviderConfigWithCredentials("").Name,
+	}
+}
+
+func ccmLabels() map[string]string {
+	return map[string]string{
+		"app": "cloud-controller-manager",
+	}
+}
+
+func additionalLabels() map[string]string {
+	return map[string]string{
+		hyperv1.ControlPlaneComponent: "cloud-controller-manager",
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2092,6 +2092,7 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure cloud config: %w", err)
 		}
+
 		withSecrets := manifests.AzureProviderConfigWithCredentials(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, withSecrets, func() error {
 			return azure.ReconcileCloudConfigWithCredentials(withSecrets, hcp, credentialsSecret)
@@ -3686,6 +3687,22 @@ func (r *HostedControlPlaneReconciler) reconcileCloudControllerManager(ctx conte
 		deployment := aws.CCMDeployment(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, deployment, func() error {
 			return aws.ReconcileDeployment(deployment, hcp, p.DeploymentConfig, sa.Name, releaseImageProvider)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile %s cloud controller manager deployment: %w", hcp.Spec.Platform.Type, err)
+		}
+	case hyperv1.AzurePlatform:
+		ownerRef := config.OwnerRefFrom(hcp)
+		sa := azure.CCMServiceAccount(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, sa, func() error {
+			return azure.ReconcileCCMServiceAccount(sa, ownerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile %s cloud provider service account: %w", hcp.Spec.Platform.Type, err)
+		}
+
+		p := azure.NewAzureParams(hcp)
+		deployment := azure.CCMDeployment(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, deployment, func() error {
+			return azure.ReconcileDeployment(deployment, hcp, p, sa.Name, releaseImageProvider)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile %s cloud controller manager deployment: %w", hcp.Spec.Platform.Type, err)
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -9,7 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
@@ -104,12 +103,6 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	}
 	params.DeploymentConfig.SetDefaults(hcp, kcmLabels(), nil)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
-
-	switch hcp.Spec.Platform.Type {
-	case hyperv1.AzurePlatform:
-		params.CloudProvider = azure.Provider
-		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}
-	}
 
 	params.SetDefaultSecurityContext = setDefaultSecurityContext
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
@@ -5,6 +5,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// AzureProviderConfig is a configMap for azure config.
+// TODO (alberto): can we drop this completely?
+// It has some consumers atm: it's reconciled into guest cluster, ignition local provider. Review them and drop it.
 func AzureProviderConfig(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/cloudcontrollermanager/azure/cloud_node_manager.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/cloudcontrollermanager/azure/cloud_node_manager.go
@@ -1,0 +1,52 @@
+package azure
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const CloudNodeManagerName = "azure-cloud-node-manager"
+
+var labels = map[string]string{
+	"k8s-app": CloudNodeManagerName,
+}
+
+func CloudNodeManagerClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   CloudNodeManagerName,
+			Labels: labels,
+		},
+	}
+}
+
+func CloudNodeManagerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   CloudNodeManagerName,
+			Labels: labels,
+		},
+	}
+}
+
+func CloudNodeManagerServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CloudNodeManagerName,
+			Namespace: "kube-system",
+			Labels:    labels,
+		},
+	}
+}
+
+func CloudNodeManagerDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CloudNodeManagerName,
+			Namespace: "kube-system",
+			Labels:    labels,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the cloud manager to reconcile Azure

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1229](https://issues.redhat.com/browse/HOSTEDCP-1229)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.