### PR TITLE
HOSTEDCP-1232: Add clusterName label to CAPI kubeconfig secret

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2250,7 +2250,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 	if _, err := createOrUpdate(ctx, r, capiKubeconfigSecret, func() error {
 		// TODO(alberto): This secret is currently using the cluster-admin kubeconfig for the guest cluster.
 		// We should create a separate kubeconfig with a tight set of permissions for it to use.
-		return kas.ReconcileServiceCAPIKubeconfigSecret(capiKubeconfigSecret, clientCertSecret, rootCA, p.OwnerRef, p.InternalPort)
+		return kas.ReconcileServiceCAPIKubeconfigSecret(capiKubeconfigSecret, clientCertSecret, rootCA, p.OwnerRef, p.InternalPort, hcp.Spec.InfraID)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile CAPI service admin kubeconfig secret: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Starting from v1.5, CAPI uses a cached client to retrieve the kubeconfig secret. However, only secrets with the clusterName label `cluster.x-k8s.io/cluster-name` are cached, see:
https://github.com/kubernetes-sigs/cluster-api/pull/8940/files#diff-8bdee7925f4d1adc50383754391472636156a2a857a7c76290f6073c8d83f5cdR216

This PR ensures we can consume CAPI v1.5+,  by adding the required label to the kubeconfig secret generated for CAPI.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1232](https://issues.redhat.com/browse/HOSTEDCP-1232)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.