### PR TITLE
OCPBUGS-23015: Configure HSTS for kube-apiserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -206,6 +206,7 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 	args.Set("shutdown-send-retry-after", "true")
 	args.Set("storage-backend", "etcd3")
 	args.Set("storage-media-type", "application/vnd.kubernetes.protobuf")
+	args.Set("strict-transport-security-directives", p.APIServerSTSDirectives)
 	args.Set("tls-cert-file", cpath(kasVolumeServerCert().Name, corev1.TLSCertKey))
 	args.Set("tls-private-key-file", cpath(kasVolumeServerCert().Name, corev1.TLSPrivateKeyKey))
 	config.APIServerArguments = args

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -67,7 +67,8 @@ type KubeAPIServerParams struct {
 
 	Images KubeAPIServerImages `json:"images"`
 
-	Availability hyperv1.AvailabilityPolicy
+	Availability           hyperv1.AvailabilityPolicy
+	APIServerSTSDirectives string
 }
 
 type KubeAPIServerServiceParams struct {
@@ -337,6 +338,13 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		params.CloudProvider = azure.Provider
 		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}
 	}
+
+	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+		params.APIServerSTSDirectives = "max-age=31536000"
+	} else {
+		params.APIServerSTSDirectives = "max-age=31536000,includeSubDomains,preload"
+	}
+
 	if hcp.Spec.AuditWebhook != nil && len(hcp.Spec.AuditWebhook.Name) > 0 {
 		params.AuditWebhookRef = hcp.Spec.AuditWebhook
 	}
@@ -431,6 +439,7 @@ func (p *KubeAPIServerParams) ConfigParams() KubeAPIServerConfigParams {
 		AuditWebhookEnabled:          p.AuditWebhookRef != nil,
 		ConsolePublicURL:             p.ConsolePublicURL,
 		DisableProfiling:             p.DisableProfiling,
+		APIServerSTSDirectives:       p.APIServerSTSDirectives,
 	}
 }
 
@@ -455,6 +464,7 @@ type KubeAPIServerConfigParams struct {
 	AuditWebhookEnabled          bool
 	ConsolePublicURL             string
 	DisableProfiling             bool
+	APIServerSTSDirectives       string
 }
 
 func (p *KubeAPIServerParams) TLSSecurityProfile() *configv1.TLSSecurityProfile {


### PR DESCRIPTION
Add "--strict-transport-security-directives" for kube-apiserver.

OCP has enabled HSTS in kube-apiserver since OCP 4.12: https://github.com/openshift/cluster-kube-apiserver-operator/blob/release-4.12/bindata/assets/config/defaultconfig.yaml

IBM Cloud uses only "max-age=31536000".

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.