### PR TITLE
SDN-4062: Revert "SDN-4042: Increase upgrade rollout timers"

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -228,10 +228,7 @@ func WaitForNReadyNodesByNodePool(t *testing.T, ctx context.Context, client crcl
 	start := time.Now()
 
 	// waitTimeout for nodes to become Ready
-	// NOTE: The upgrade times are originally 30 minutes each for all platforms except (KubevirtPlatform && PowerVSPlatform).
-	// Due to well-known reasons (https://issues.redhat.com/browse/SDN-4042), these numbers are increased to
-	// 45 minutes only for the 4.13->4.14 upgrades - for all platforms. This will be brought down in 4.15 release.
-	waitTimeout := 45 * time.Minute
+	waitTimeout := 30 * time.Minute
 	switch platform {
 	case hyperv1.KubevirtPlatform:
 		waitTimeout = 45 * time.Minute


### PR DESCRIPTION
Reverts openshift/hypershift#2881
IC upgrades were a one time thing, reverting this back to original values in 4.15/main branch.
