### PR TITLE
OCPBUGS-18341: change required pod anti-affinity rule to preferred rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMG ?= hypershift:latest
 CRD_OPTIONS ?= "crd"
 
 # Runtime CLI to use for building and pushing images
-RUNTIME ?= "docker"
+RUNTIME ?= $(shell sh hack/utils.sh get_container_engine)
 
 TOOLS_DIR=./hack/tools
 BIN_DIR=bin

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMG ?= hypershift:latest
 CRD_OPTIONS ?= "crd"
 
 # Runtime CLI to use for building and pushing images
-RUNTIME ?= $(shell sh hack/utils.sh get_container_engine)
+RUNTIME ?= "docker"
 
 TOOLS_DIR=./hack/tools
 BIN_DIR=bin

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -508,18 +508,21 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "name",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{HypershiftOperatorName},
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "name",
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{HypershiftOperatorName},
+												},
 											},
 										},
+										TopologyKey: "kubernetes.io/hostname",
 									},
-									TopologyKey: "kubernetes.io/hostname",
+									Weight: 10,
 								},
 							},
 						},

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -445,14 +445,16 @@ objects:
       spec:
         affinity:
           podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                - key: name
-                  operator: In
-                  values:
-                  - operator
-              topologyKey: kubernetes.io/hostname
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                    - operator
+                topologyKey: kubernetes.io/hostname
+              weight: 10
         containers:
         - args:
           - run


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the hypershift operator pod anti-affinity rule from `required` to `preferred` while keeping the default replica at 2 so that the hypershift operator can be installed on SNO and can be upgraded (rolling update) on 2-node OCP cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

https://issues.redhat.com/browse/OCPBUGS-18341

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.