### PR TITLE
[release-4.14] OCPBUGS-20547,OCPBUGS-20180: Added network validations

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"reflect"
 	"sort"
@@ -4050,9 +4051,95 @@ func (r *HostedClusterReconciler) validateHostedClusterSupport(hc *hyperv1.Hoste
 }
 
 func (r *HostedClusterReconciler) validateNetworks(hc *hyperv1.HostedCluster) error {
-	errs := validateSliceNetworkCIDRs(hc)
+	var errs field.ErrorList
+	errs = append(errs, validateSliceNetworkCIDRs(hc)...)
+	errs = append(errs, checkAdvertiseAddressOverlapping(hc)...)
 
 	return errs.ToAggregate()
+}
+
+// findAdvertiseAddress function returns a string and an error indicating the AdvertiseAddress for the hostedcluster.
+// if the advertise address is properly set, it will return that value and nil, otherwise will return an error.
+// if the advertise address is not set, it will return the default one based on the network primary stack.
+func findAdvertiseAddress(hc *hyperv1.HostedCluster) (net.IP, *field.Error) {
+	var advertiseAddress net.IP
+	if hc.Spec.Networking.APIServer != nil && hc.Spec.Networking.APIServer.AdvertiseAddress != nil {
+		ipaddr := net.ParseIP(*hc.Spec.Networking.APIServer.AdvertiseAddress)
+		if ipaddr == nil {
+			return ipaddr, field.Invalid(field.NewPath("hc.Spec.Networking.APIServer.AdvertiseAddress"),
+				k8sutilspointer.String(ipaddr.String()),
+				fmt.Sprintf("advertise address set in HostedCluster %s is not parseable", *hc.Spec.Networking.APIServer.AdvertiseAddress),
+			)
+		}
+
+		return ipaddr, nil
+	}
+
+	ipaddr := net.ParseIP(hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String())
+	if ipaddr == nil {
+		return ipaddr, field.Invalid(field.NewPath("hc.Spec.Networking.ClusterNetwork[0].CIDR.IP"),
+			k8sutilspointer.String(ipaddr.String()),
+			fmt.Sprintf("Cluster Network ip address %s is not parseable", hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String()),
+		)
+	}
+
+	if strings.Contains(hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String(), ".") {
+		advertiseAddress = net.ParseIP(config.DefaultAdvertiseIPv4Address)
+	}
+
+	if strings.Contains(hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String(), ":") {
+		advertiseAddress = net.ParseIP(config.DefaultAdvertiseIPv6Address)
+	}
+
+	return advertiseAddress, nil
+}
+
+// checkAdvertiseAddressOverlapping validates that the AdvertiseAddress defined does not overlap with
+// the ClusterNetwork, ServiceNetwork and MachineNetwork
+func checkAdvertiseAddressOverlapping(hc *hyperv1.HostedCluster) field.ErrorList {
+	var errs field.ErrorList
+	var advAddress netip.Addr
+
+	networks := make(map[string]string, 0)
+
+	if len(hc.Spec.Networking.ClusterNetwork) > 0 {
+		networks["spec.networking.ClusterNetwork"] = hc.Spec.Networking.ClusterNetwork[0].CIDR.String()
+	}
+
+	if len(hc.Spec.Networking.ServiceNetwork) > 0 {
+		networks["spec.networking.ServiceNetwork"] = hc.Spec.Networking.ServiceNetwork[0].CIDR.String()
+	}
+
+	if len(hc.Spec.Networking.MachineNetwork) > 0 {
+		networks["spec.networking.MachineNetwork"] = hc.Spec.Networking.MachineNetwork[0].CIDR.String()
+	}
+
+	advAddr, fieldErr := findAdvertiseAddress(hc)
+	if fieldErr != nil {
+		errs = append(errs, fieldErr)
+		return errs
+	}
+
+	advAddress = netip.MustParseAddr(advAddr.String())
+
+	for fieldPath, cidr := range networks {
+		network, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			errs = append(errs, field.Invalid(field.NewPath(fieldPath),
+				k8sutilspointer.String(cidr),
+				fmt.Sprintf("error parsing field %s prefix: %v", fieldPath, err),
+			))
+		}
+
+		if network.Contains(advAddress) {
+			errs = append(errs, field.Invalid(field.NewPath(fieldPath),
+				k8sutilspointer.String(cidr),
+				fmt.Sprintf("the field %s with content %s overlaps with the defined AdvertiseAddress %s prefix: %v", fieldPath, cidr, advAddress.String(), err),
+			))
+		}
+	}
+
+	return errs
 }
 
 func validateSliceNetworkCIDRs(hc *hyperv1.HostedCluster) field.ErrorList {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -956,6 +956,8 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 		cluster.Spec.PullSecret = corev1.LocalObjectReference{Name: "secret"}
 		cluster.Spec.InfraID = "infra-id"
 		cluster.Spec.Networking.ClusterNetwork = []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}}
+		cluster.Spec.Networking.MachineNetwork = []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
+		cluster.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}}
 		objects = append(objects, cluster)
 	}
 
@@ -3632,6 +3634,118 @@ func TestFindAdvertiseAddress(t *testing.T) {
 				g.Expect(avdAddress).To(BeEmpty())
 			} else {
 				g.Expect(avdAddress.String()).To(Equal(tt.resultAdvAddress))
+			}
+		})
+	}
+}
+
+func TestValidateNetworkStackAddresses(t *testing.T) {
+	tests := []struct {
+		name    string
+		cn      []hyperv1.ClusterNetworkEntry
+		mn      []hyperv1.MachineNetworkEntry
+		sn      []hyperv1.ServiceNetworkEntry
+		aa      *hyperv1.APIServerNetworking
+		wantErr bool
+	}{
+		{
+			name:    "given an IPv6 clusterNetwork and an IPv4 ServiceNetwork, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("fd03::1")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/48")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd03::/64")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			wantErr: true,
+		},
+		{
+			name:    "on IPv6 and IPv4 Advertise Address, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("192.168.1.1")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/48")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd01::/64")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64")}},
+			wantErr: true,
+		},
+		{
+			name:    "on IPv6 and defining Advertise Address, it should success",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("fd03::1")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/48")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd01::/64")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64")}},
+			wantErr: false,
+		},
+		{
+			name:    "given an IPv4 clusterNetwork and an IPv6 ServiceNetwork, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("192.168.1.1")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/16")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64")}},
+			wantErr: true,
+		},
+		{
+			name:    "on IPv4 and defining IPv6 Advertise Address, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("fd03::1")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			wantErr: true,
+		},
+		{
+			name:    "on IPv4 and defining Advertise Address, it should success",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("192.168.1.1")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.0.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			wantErr: false,
+		},
+		{
+			name:    "on IPv4, it should success",
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			wantErr: false,
+		},
+		{
+			name:    "on IPv6, it should success",
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/48")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd01::/64")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64")}},
+			wantErr: false,
+		},
+		{
+			name:    "given an IPv4 invalid advertise address, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("192.168.1.1.2")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.0.0/24")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
+			wantErr: true,
+		},
+		{
+			name:    "given an IPv6 invalid advertise address, it should fail",
+			aa:      &hyperv1.APIServerNetworking{AdvertiseAddress: pointer.String("fd03::1::32")},
+			mn:      []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd02::/48")}},
+			cn:      []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd03::/64")}},
+			sn:      []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("2620:52:0:1306::1/64")}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hc",
+					Namespace: "any",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: tt.cn,
+						ServiceNetwork: tt.sn,
+						MachineNetwork: tt.mn,
+						APIServer:      tt.aa,
+					},
+				},
+			}
+			err := validateNetworkStackAddresses(hc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateNetworkStackAddresses() wantErr %v, err %v", tt.wantErr, err)
 			}
 		})
 	}


### PR DESCRIPTION
Backport for:
- [OCPBUGS-16189](https://issues.redhat.com/browse/OCPBUGS-16189)
- [OCPBUGS-19746](https://issues.redhat.com/browse/OCPBUGS-19746)

Manual cherry-pick from #3047 

Reason: There was a unit testing failure which I've fixed here. Original automatic PR: https://github.com/openshift/hypershift/pull/3080