### PR TITLE
Remove unused ability to override KonnectivityImage

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -32,14 +32,7 @@ const (
 	APICriticalPriorityClass = "hypershift.openshift.io/api-critical-priority-class"
 	// EtcdPriorityClass is for etcd pods.
 	EtcdPriorityClass = "hypershift.openshift.io/etcd-priority-class"
-	// KonnectivityServerImageAnnotation is a temporary annotation that allows the specification of the konnectivity server image.
-	// This will be removed when Konnectivity is added to the Openshift release payload
-	KonnectivityServerImageAnnotation = "hypershift.openshift.io/konnectivity-server-image"
-	// KonnectivityAgentImageAnnotation is a temporary annotation that allows the specification of the konnectivity agent image.
-	// This will be removed when Konnectivity is added to the Openshift release payload
-	KonnectivityAgentImageAnnotation = "hypershift.openshift.io/konnectivity-agent-image"
-	// ControlPlaneOperatorImageAnnotation is a annotation that allows the specification of the control plane operator image.
-	// This is used for development and e2e workflows
+	// ControlPlaneOperatorImageAnnotation is used for development and e2e workflows.
 	ControlPlaneOperatorImageAnnotation = "hypershift.openshift.io/control-plane-operator-image"
 	// RestartDateAnnotation is a annotation that can be used to trigger a rolling restart of all components managed by hypershift.
 	// it is important in some situations like CA rotation where components need to be fully restarted to pick up new CAs. It's also

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -346,9 +346,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	if _, ok := hcp.Annotations[hyperv1.IBMCloudKMSProviderImage]; ok {
 		params.Images.IBMCloudKMS = hcp.Annotations[hyperv1.IBMCloudKMSProviderImage]
 	}
-	if _, ok := hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]; ok {
-		params.Images.KonnectivityServer = hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]
-	}
 
 	params.KubeConfigRef = hcp.Spec.KubeConfig
 	params.OwnerRef = config.OwnerRefFrom(hcp)

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -95,10 +95,6 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider
 		p.KonnectivityAgentImage = image
 	}
 
-	if _, ok := hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]; ok {
-		p.KonnectivityAgentImage = hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]
-	}
-
 	return p
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/params.go
@@ -60,9 +60,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 	if _, ok := images["apiserver-network-proxy"]; ok {
 		p.Image = images["apiserver-network-proxy"]
 	}
-	if _, ok := hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]; ok {
-		p.Image = hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]
-	}
+
 	p.DeploymentConfig.SetReleaseImageAnnotation(hcp.Spec.ReleaseImage)
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	return p

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -134,9 +134,6 @@ func defaultCommand() *cobra.Command {
 }
 
 const (
-	// TODO: Include konnectivity image in release payload
-	defaultKonnectivityImage = "registry.ci.openshift.org/hypershift/apiserver-network-proxy:latest"
-
 	// Default AWS KMS provider image. Can be overriden with annotation on HostedCluster
 	defaultAWSKMSProviderImage = "registry.ci.openshift.org/hypershift/aws-encryption-provider:latest"
 )
@@ -326,13 +323,6 @@ func NewStartCommand() *cobra.Command {
 		}
 		setupLog.Info("Using CPO image", "image", cpoImage)
 
-		konnectivityServerImage := defaultKonnectivityImage
-		konnectivityAgentImage := defaultKonnectivityImage
-		if envImage := os.Getenv(images.KonnectivityEnvVar); len(envImage) > 0 {
-			konnectivityServerImage = envImage
-			konnectivityAgentImage = envImage
-		}
-
 		awsKMSProviderImage := defaultAWSKMSProviderImage
 		if envImage := os.Getenv(images.AWSEncryptionProviderEnvVar); len(envImage) > 0 {
 			awsKMSProviderImage = envImage
@@ -341,8 +331,6 @@ func NewStartCommand() *cobra.Command {
 		componentImages := map[string]string{
 			util.AvailabilityProberImageName: availabilityProberImage,
 			"hosted-cluster-config-operator": hostedClusterConfigOperatorImage,
-			"konnectivity-server":            konnectivityServerImage,
-			"konnectivity-agent":             konnectivityAgentImage,
 			"socks5-proxy":                   socks5ProxyImage,
 			"token-minter":                   tokenMinterImage,
 			"aws-kms-provider":               awsKMSProviderImage,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1678,8 +1678,6 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	mirroredAnnotations := []string{
 		hyperv1.DisablePKIReconciliationAnnotation,
 		hyperv1.OauthLoginURLOverrideAnnotation,
-		hyperv1.KonnectivityAgentImageAnnotation,
-		hyperv1.KonnectivityServerImageAnnotation,
 		hyperv1.RestartDateAnnotation,
 		hyperv1.IBMCloudKMSProviderImage,
 		hyperv1.AWSKMSProviderImage,


### PR DESCRIPTION
Initially we allow overrding defaultKonnectivityImage so we could pin an image while let product builders inject their own. Konnectiviy image comes from payload now.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.