### PR TITLE
HOSTEDCP-1050: Add e2e to check we dont regress affinity opinions

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3148,7 +3148,7 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 
 	collectProfilesCronJob := manifests.CollectProfilesCronJob(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, collectProfilesCronJob, func() error {
-		olm.ReconcileCollectProfilesCronJob(collectProfilesCronJob, p.OwnerRef, p.OLMImage, hcp.Namespace)
+		olm.ReconcileCollectProfilesCronJob(collectProfilesCronJob, p.OwnerRef, p.OLMImage, hcp)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile collect profiles cronjob: %w", err)

--- a/docs/content/contribute/run-tests.md
+++ b/docs/content/contribute/run-tests.md
@@ -11,7 +11,10 @@ title: Run tests
         bin/test-e2e -test.v -test.timeout 0 \
         --e2e.aws-credentials-file /my/aws-credentials \
         --e2e.pull-secret-file /my/pull-secret \
-        --e2e.base-domain my-basedomain
+        --e2e.base-domain my-basedomain \
+        --e2e.aws-oidc-s3-bucket-name my-bucket-name
+
+*Note* if the s3 bucket is not in the `us-east-1` region then you need to add the `--e2e.aws-region` flag.
 
 # How to run e2e tests for the "None" platform
 

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -108,7 +108,9 @@ func (h *hypershiftTest) after(hostedCluster *hyperv1.HostedCluster, opts *core.
 		NoticePreemptionOrFailedScheduling(t, context.Background(), h.client, hostedCluster)
 		EnsureAllRoutesUseHCPRouter(t, context.Background(), h.client, hostedCluster)
 		EnsureNetworkPolicies(t, context.Background(), h.client, hostedCluster)
-		CheckAffinityOpinions(t, context.Background(), h.client, hostedCluster)
+		if platform == hyperv1.AWSPlatform {
+			EnsureHCPPodsAffinitiesAndTolerations(t, context.Background(), h.client, hostedCluster)
+		}
 	})
 }
 

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -108,6 +108,7 @@ func (h *hypershiftTest) after(hostedCluster *hyperv1.HostedCluster, opts *core.
 		NoticePreemptionOrFailedScheduling(t, context.Background(), h.client, hostedCluster)
 		EnsureAllRoutesUseHCPRouter(t, context.Background(), h.client, hostedCluster)
 		EnsureNetworkPolicies(t, context.Background(), h.client, hostedCluster)
+		CheckAffinityOpinions(t, context.Background(), h.client, hostedCluster)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds e2e to check that we don't regress our affinity opinions

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1050](https://issues.redhat.com/browse/HOSTEDCP-1050)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.