### PR TITLE
OCPBUGS-21869: Remove EnsurePSANotPrivileged

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -38,7 +38,6 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	kapierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -570,42 +569,6 @@ func EnsureMachineDeploymentGeneration(t *testing.T, ctx context.Context, hostCl
 			if machineDeployment.Generation != expectedGeneration {
 				t.Errorf("machineDeployment %s does not have expected generation %d but %d", crclient.ObjectKeyFromObject(&machineDeployment), expectedGeneration, machineDeployment.Generation)
 			}
-		}
-	})
-}
-
-func EnsurePSANotPrivileged(t *testing.T, ctx context.Context, guestClient crclient.Client) {
-	t.Run("EnsurePSANotPrivileged", func(t *testing.T) {
-		testNamespaceName := "e2e-psa-check"
-		namespace := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: testNamespaceName,
-			},
-		}
-		if err := guestClient.Create(ctx, namespace); err != nil {
-			t.Fatalf("failed to create namespace: %v", err)
-		}
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: testNamespaceName,
-			},
-			Spec: corev1.PodSpec{
-				NodeSelector: map[string]string{
-					"e2e.openshift.io/unschedulable": "should-not-run",
-				},
-				Containers: []corev1.Container{
-					{Name: "first", Image: "something-innocuous"},
-				},
-				HostPID: true, // enforcement of restricted or baseline policy should reject this
-			},
-		}
-		err := guestClient.Create(ctx, pod)
-		if err == nil {
-			t.Errorf("pod admitted when rejection was expected")
-		}
-		if !kapierror.IsForbidden(err) {
-			t.Errorf("forbidden error expected, got %s", err)
 		}
 	})
 }
@@ -1444,7 +1407,6 @@ func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 
 	EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
 	EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-	EnsurePSANotPrivileged(t, ctx, guestClient)
 	EnsureGuestWebhooksValidated(t, ctx, guestClient)
 
 	if numNodes > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes EnsurePSANotPrivileged test since enforce was reverted back to privilege through https://github.com/openshift/hypershift/pull/3083.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [OCPBUGS-21869](https://issues.redhat.com/browse/OCPBUGS-21869)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.