### PR TITLE
OCPBUGS-21626: Validate accessTokenInactivityTimeout >= 300s

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -2100,6 +2100,7 @@ type ClusterConfiguration struct {
 	// It is used to configure the integrated OAuth server.
 	// This configuration is only honored when the top level Authentication config has type set to IntegratedOAuth.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="!has(self.tokenConfig.accessTokenInactivityTimeout) || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds() >= 300", message="spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout minimum acceptable token timeout value is 300 seconds"
 	OAuth *configv1.OAuthSpec `json:"oauth,omitempty"`
 
 	// Scheduler holds cluster-wide config information to run the Kubernetes Scheduler

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5614,6 +5614,12 @@ spec:
                             type: integer
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
+                        minimum acceptable token timeout value is 300 seconds
+                      rule: '!has(self.tokenConfig.accessTokenInactivityTimeout) ||
+                        duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                        >= 300'
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -5594,6 +5594,12 @@ spec:
                             type: integer
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
+                        minimum acceptable token timeout value is 300 seconds
+                      rule: '!has(self.tokenConfig.accessTokenInactivityTimeout) ||
+                        duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                        >= 300'
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -35589,6 +35589,12 @@ objects:
                               type: integer
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
+                          minimum acceptable token timeout value is 300 seconds
+                        rule: '!has(self.tokenConfig.accessTokenInactivityTimeout)
+                          || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                          >= 300'
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.
@@ -43318,6 +43324,12 @@ objects:
                               type: integer
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
+                          minimum acceptable token timeout value is 300 seconds
+                        rule: '!has(self.tokenConfig.accessTokenInactivityTimeout)
+                          || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                          >= 300'
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Validates that accessTokenInactivityTimeout >= 300s, similar to Standalone https://github.com/openshift/kubernetes/blob/c0449761f4ad0c3a585990c26aea90a1dadb82cb/openshift-kube-apiserver/admission/customresourcevalidation/oauth/validate_idp.go#L75C1-L81

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-21626](https://issues.redhat.com/browse/OCPBUGS-21626)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.