### PR TITLE
OCPBUGS-20526: Align PSA labels on guest cluster namespaces with standalone OCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"path"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,5 +68,24 @@ func reconcileConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, minTLS
 			CipherSuites:  cipherSuites,
 		},
 	}
+
+	// disables automatically setting the `pod-security.kubernetes.io/enforce` label on namespaces by the pod-security-admission-label-synchronization-controller
+	// see https://github.com/openshift/cluster-policy-controller/blob/50c2a8337f08856bbae4cd419bb8ffcbdf92567c/pkg/cmd/controller/psalabelsyncer.go#L19
+	index := -1
+	for i := range cfg.FeatureGates {
+		fg := cfg.FeatureGates[i]
+		if strings.HasPrefix(fg, "OpenShiftPodSecurityAdmission") {
+			index = i
+			break
+		}
+	}
+
+	if index != -1 {
+		// overwrite
+		cfg.FeatureGates[index] = "OpenShiftPodSecurityAdmission=false"
+	} else {
+		cfg.FeatureGates = append(cfg.FeatureGates, "OpenShiftPodSecurityAdmission=false")
+	}
+
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `OpenShiftPodSecurityAdmission=false` featureGate to ClusterPolicyController, to disable setting `pod-security.kubernetes.io/enforce` label on namespace in the guest cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-20526](https://issues.redhat.com/browse/OCPBUGS-20526)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.