### PR TITLE
OCPBUGS-21776: Cluster-policy-controller: add missing RBAC for privileged namespaces PSA syncer controller

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -87,6 +87,22 @@ func PodSecurityAdmissionLabelSyncerControllerRoleBinding() *rbacv1.ClusterRoleB
 	}
 }
 
+func PriviligedNamespacesPSALabelSyncerClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:openshift:controller:privileged-namespaces-psa-label-syncer",
+		},
+	}
+}
+
+func PriviligedNamespacesPSALabelSyncerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:openshift:controller:privileged-namespaces-psa-label-syncer",
+		},
+	}
+}
+
 func NodeBootstrapperClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -391,6 +391,73 @@ func ReconcilePodSecurityAdmissionLabelSyncerControllerClusterRole(r *rbacv1.Clu
 	return nil
 }
 
+func ReconcilePodSecurityAdmissionLabelSyncerControllerRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:openshift:controller:podsecurity-admission-label-syncer-controller",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "podsecurity-admission-label-syncer-controller",
+			Namespace: "openshift-infra",
+		},
+	}
+	return nil
+}
+
+func ReconcilePriviligedNamespacesPSALabelSyncerClusterRole(r *rbacv1.ClusterRole) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups:     []string{""},
+			Resources:     []string{"namespaces"},
+			ResourceNames: []string{"default", "kube-system", "kube-public"},
+			Verbs: []string{
+				"patch",
+			},
+		},
+	}
+	return nil
+}
+
+func ReconcilePriviligedNamespacesPSALabelSyncerClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:openshift:controller:privileged-namespaces-psa-label-syncer",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "privileged-namespaces-psa-label-syncer",
+			Namespace: "openshift-infra",
+		},
+	}
+	return nil
+}
+
 func ReconcileImageTriggerControllerClusterRole(r *rbacv1.ClusterRole) error {
 	r.Rules = []rbacv1.PolicyRule{
 		{
@@ -446,26 +513,6 @@ func ReconcileImageTriggerControllerClusterRole(r *rbacv1.ClusterRole) error {
 				"watch",
 				"update",
 			},
-		},
-	}
-	return nil
-}
-
-func ReconcilePodSecurityAdmissionLabelSyncerControllerRoleBinding(r *rbacv1.ClusterRoleBinding) error {
-	if r.Annotations == nil {
-		r.Annotations = map[string]string{}
-	}
-	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
-	r.RoleRef = rbacv1.RoleRef{
-		APIGroup: rbacv1.SchemeGroupVersion.Group,
-		Kind:     "ClusterRole",
-		Name:     "system:openshift:controller:podsecurity-admission-label-syncer-controller",
-	}
-	r.Subjects = []rbacv1.Subject{
-		{
-			Kind:      "ServiceAccount",
-			Name:      "podsecurity-admission-label-syncer-controller",
-			Namespace: "openshift-infra",
 		},
 	}
 	return nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -806,6 +806,9 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.PodSecurityAdmissionLabelSyncerControllerClusterRole, reconcile: rbac.ReconcilePodSecurityAdmissionLabelSyncerControllerClusterRole},
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.PodSecurityAdmissionLabelSyncerControllerRoleBinding, reconcile: rbac.ReconcilePodSecurityAdmissionLabelSyncerControllerRoleBinding},
 
+		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.PriviligedNamespacesPSALabelSyncerClusterRole, reconcile: rbac.ReconcilePriviligedNamespacesPSALabelSyncerClusterRole},
+		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.PriviligedNamespacesPSALabelSyncerClusterRoleBinding, reconcile: rbac.ReconcilePriviligedNamespacesPSALabelSyncerClusterRoleBinding},
+
 		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.DeployerClusterRole, reconcile: rbac.ReconcileDeployerClusterRole},
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.DeployerClusterRoleBinding, reconcile: rbac.ReconcileDeployerClusterRoleBinding},
 


### PR DESCRIPTION
PriviligedNamespacesPSALabelSyncer RBAC added in https://github.com/openshift/cluster-kube-controller-manager-operator/pull/743

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-21776](https://issues.redhat.com/browse/OCPBUGS-21776)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.