### PR TITLE
CNV-35774: Improve CRD defaulting for HostedCluster and NodePool

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -189,7 +189,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				},
 			}
 		}
-		services = getIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
+		services = GetIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
 		if o.ExternalDNSDomain != "" {
 			for i, svc := range services {
 				switch svc.Service {
@@ -233,7 +233,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		if o.None.APIServerAddress != "" {
 			services = getServicePublishingStrategyMappingByAPIServerAddress(o.None.APIServerAddress, o.NetworkType)
 		} else {
-			services = getIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
+			services = GetIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
 		}
 	case o.Agent != nil:
 		platformSpec = hyperv1.PlatformSpec{
@@ -272,7 +272,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		case "NodePort":
 			services = getServicePublishingStrategyMappingByAPIServerAddress(o.Kubevirt.APIServerAddress, o.NetworkType)
 		case "Ingress":
-			services = getIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
+			services = GetIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
 		default:
 			panic(fmt.Sprintf("service publishing type %s is not supported", o.Kubevirt.ServicePublishingStrategy))
 		}
@@ -380,7 +380,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			}
 		}
 
-		services = getIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
+		services = GetIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
 		if o.ExternalDNSDomain != "" {
 			for i, svc := range services {
 				switch svc.Service {
@@ -438,7 +438,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				ImageRegistryOperatorCloudCreds: corev1.LocalObjectReference{Name: o.PowerVS.Resources.ImageRegistryOperatorCloudCreds.Name},
 			},
 		}
-		services = getIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
+		services = GetIngressServicePublishingStrategyMapping(o.NetworkType, o.ExternalDNSDomain != "")
 	default:
 		panic("no platform specified")
 	}
@@ -700,7 +700,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 	}
 }
 
-func getIngressServicePublishingStrategyMapping(netType hyperv1.NetworkType, usesExternalDNS bool) []hyperv1.ServicePublishingStrategyMapping {
+func GetIngressServicePublishingStrategyMapping(netType hyperv1.NetworkType, usesExternalDNS bool) []hyperv1.ServicePublishingStrategyMapping {
 	// TODO (Alberto): Default KAS to Route if endpointAccess is Private.
 	apiServiceStrategy := hyperv1.LoadBalancer
 	if usesExternalDNS {

--- a/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -205,6 +205,7 @@ type HostedClusterSpec struct {
 	// Networking specifies network configuration for the cluster.
 	//
 	// +immutable
+	// +kubebuilder:default={networkType: "OVNKubernetes", clusterNetwork: {{cidr: "10.132.0.0/14"}}, serviceNetwork: {{cidr: "172.31.0.0/16"}}}
 	Networking ClusterNetworking `json:"networking"`
 
 	// Autoscaling specifies auto-scaling behavior that applies to all NodePools
@@ -529,6 +530,7 @@ type ClusterNetworking struct {
 	//
 	// +immutable
 	// +optional
+	// +kubebuilder:default:={{cidr: "10.132.0.0/14"}}
 	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork,omitempty"`
 
 	// ServiceNetwork is the list of IP address pools for services.
@@ -537,6 +539,7 @@ type ClusterNetworking struct {
 	//
 	// +immutable
 	// +optional
+	// +kubebuilder:default:={{cidr: "172.31.0.0/16"}}
 	ServiceNetwork []ServiceNetworkEntry `json:"serviceNetwork,omitempty"`
 
 	// NetworkType specifies the SDN provider used for cluster networking.

--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -364,6 +364,7 @@ type NodePoolManagement struct {
 	// in the NodePool. The default is false.
 	//
 	// +optional
+	// +kubebuilder:default=false
 	AutoRepair bool `json:"autoRepair"`
 }
 
@@ -697,12 +698,13 @@ const (
 // on KubeVirt platform.
 type KubevirtNodePoolPlatform struct {
 	// RootVolume represents values associated with the VM volume that will host rhcos
+	// +kubebuilder:default={persistent: {size: "32Gi"}, type: "Persistent"}
 	RootVolume *KubevirtRootVolume `json:"rootVolume"`
 
 	// Compute contains values representing the virtual hardware requested for the VM
 	//
 	// +optional
-	// +kubebuilder:default={memory: "4Gi", cores: 2}
+	// +kubebuilder:default={memory: "8Gi", cores: 2}
 	Compute *KubevirtCompute `json:"compute"`
 
 	// NetworkInterfaceMultiQueue If set to "Enable", virtual network interfaces configured with a virtio bus will also

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -311,6 +311,7 @@ type HostedClusterSpec struct {
 	// Networking specifies network configuration for the cluster.
 	//
 	// +immutable
+	// +kubebuilder:default={networkType: "OVNKubernetes", clusterNetwork: {{cidr: "10.132.0.0/14"}}, serviceNetwork: {{cidr: "172.31.0.0/16"}}}
 	Networking ClusterNetworking `json:"networking"`
 
 	// Autoscaling specifies auto-scaling behavior that applies to all NodePools
@@ -626,12 +627,14 @@ type ClusterNetworking struct {
 	// ClusterNetwork is the list of IP address pools for pods.
 	//
 	// +immutable
+	// +kubebuilder:default:={{cidr: "10.132.0.0/14"}}
 	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork"`
 
 	// ServiceNetwork is the list of IP address pools for services.
 	// NOTE: currently only one entry is supported.
 	//
 	// +optional
+	// +kubebuilder:default:={{cidr: "172.31.0.0/16"}}
 	ServiceNetwork []ServiceNetworkEntry `json:"serviceNetwork"`
 
 	// NetworkType specifies the SDN provider used for cluster networking.

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -358,6 +358,7 @@ type NodePoolManagement struct {
 	// in the NodePool. The default is false.
 	//
 	// +optional
+	// +kubebuilder:default=false
 	AutoRepair bool `json:"autoRepair"`
 }
 
@@ -691,12 +692,13 @@ const (
 // on KubeVirt platform.
 type KubevirtNodePoolPlatform struct {
 	// RootVolume represents values associated with the VM volume that will host rhcos
+	// +kubebuilder:default={persistent: {size: "32Gi"}, type: "Persistent"}
 	RootVolume *KubevirtRootVolume `json:"rootVolume"`
 
 	// Compute contains values representing the virtual hardware requested for the VM
 	//
 	// +optional
-	// +kubebuilder:default={memory: "4Gi", cores: 2}
+	// +kubebuilder:default={memory: "8Gi", cores: 2}
 	Compute *KubevirtCompute `json:"compute"`
 
 	// NetworkInterfaceMultiQueue If set to "Enable", virtual network interfaces configured with a virtio bus will also

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -2312,6 +2312,12 @@ spec:
                 format: uri
                 type: string
               networking:
+                default:
+                  clusterNetwork:
+                  - cidr: 10.132.0.0/14
+                  networkType: OVNKubernetes
+                  serviceNetwork:
+                  - cidr: 172.31.0.0/16
                 description: Networking specifies network configuration for the cluster.
                 properties:
                   apiServer:
@@ -2342,6 +2348,8 @@ spec:
                         type: integer
                     type: object
                   clusterNetwork:
+                    default:
+                    - cidr: 10.132.0.0/14
                     description: 'ClusterNetwork is the list of IP address pools for
                       pods. TODO: make this required in the next version of the API'
                     items:
@@ -2404,6 +2412,8 @@ spec:
                     format: cidr
                     type: string
                   serviceNetwork:
+                    default:
+                    - cidr: 172.31.0.0/16
                     description: 'ServiceNetwork is the list of IP address pools for
                       services. NOTE: currently only one entry is supported. TODO:
                       make this required in the next version of the API'
@@ -6325,6 +6335,12 @@ spec:
                 format: uri
                 type: string
               networking:
+                default:
+                  clusterNetwork:
+                  - cidr: 10.132.0.0/14
+                  networkType: OVNKubernetes
+                  serviceNetwork:
+                  - cidr: 172.31.0.0/16
                 description: Networking specifies network configuration for the cluster.
                 properties:
                   apiServer:
@@ -6363,6 +6379,8 @@ spec:
                         type: integer
                     type: object
                   clusterNetwork:
+                    default:
+                    - cidr: 10.132.0.0/14
                     description: ClusterNetwork is the list of IP address pools for
                       pods.
                     items:
@@ -6409,6 +6427,8 @@ spec:
                     - Other
                     type: string
                   serviceNetwork:
+                    default:
+                    - cidr: 172.31.0.0/16
                     description: 'ServiceNetwork is the list of IP address pools for
                       services. NOTE: currently only one entry is supported.'
                     items:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -2328,6 +2328,8 @@ spec:
                         type: integer
                     type: object
                   clusterNetwork:
+                    default:
+                    - cidr: 10.132.0.0/14
                     description: 'ClusterNetwork is the list of IP address pools for
                       pods. TODO: make this required in the next version of the API'
                     items:
@@ -2390,6 +2392,8 @@ spec:
                     format: cidr
                     type: string
                   serviceNetwork:
+                    default:
+                    - cidr: 172.31.0.0/16
                     description: 'ServiceNetwork is the list of IP address pools for
                       services. NOTE: currently only one entry is supported. TODO:
                       make this required in the next version of the API'
@@ -6331,6 +6335,8 @@ spec:
                         type: integer
                     type: object
                   clusterNetwork:
+                    default:
+                    - cidr: 10.132.0.0/14
                     description: ClusterNetwork is the list of IP address pools for
                       pods.
                     items:
@@ -6377,6 +6383,8 @@ spec:
                     - Other
                     type: string
                   serviceNetwork:
+                    default:
+                    - cidr: 172.31.0.0/16
                     description: 'ServiceNetwork is the list of IP address pools for
                       services. NOTE: currently only one entry is supported.'
                     items:

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -139,6 +139,7 @@ spec:
                   pool, such as upgrade strategies and auto-repair behaviors.
                 properties:
                   autoRepair:
+                    default: false
                     description: AutoRepair specifies whether health checks should
                       be enabled for machines in the NodePool. The default is false.
                     type: boolean
@@ -548,7 +549,7 @@ spec:
                       compute:
                         default:
                           cores: 2
-                          memory: 4Gi
+                          memory: 8Gi
                         description: Compute contains values representing the virtual
                           hardware requested for the VM
                         properties:
@@ -591,6 +592,10 @@ spec:
                         - Disable
                         type: string
                       rootVolume:
+                        default:
+                          persistent:
+                            size: 32Gi
+                          type: Persistent
                         description: RootVolume represents values associated with
                           the VM volume that will host rhcos
                         properties:
@@ -1113,6 +1118,7 @@ spec:
                   pool, such as upgrade strategies and auto-repair behaviors.
                 properties:
                   autoRepair:
+                    default: false
                     description: AutoRepair specifies whether health checks should
                       be enabled for machines in the NodePool. The default is false.
                     type: boolean
@@ -1514,7 +1520,7 @@ spec:
                       compute:
                         default:
                           cores: 2
-                          memory: 4Gi
+                          memory: 8Gi
                         description: Compute contains values representing the virtual
                           hardware requested for the VM
                         properties:
@@ -1557,6 +1563,10 @@ spec:
                         - Disable
                         type: string
                       rootVolume:
+                        default:
+                          persistent:
+                            size: 32Gi
+                          type: Persistent
                         description: RootVolume represents values associated with
                           the VM volume that will host rhcos
                         properties:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -36573,6 +36573,12 @@ objects:
                   format: uri
                   type: string
                 networking:
+                  default:
+                    clusterNetwork:
+                    - cidr: 10.132.0.0/14
+                    networkType: OVNKubernetes
+                    serviceNetwork:
+                    - cidr: 172.31.0.0/16
                   description: Networking specifies network configuration for the
                     cluster.
                   properties:
@@ -36605,6 +36611,8 @@ objects:
                           type: integer
                       type: object
                     clusterNetwork:
+                      default:
+                      - cidr: 10.132.0.0/14
                       description: 'ClusterNetwork is the list of IP address pools
                         for pods. TODO: make this required in the next version of
                         the API'
@@ -36668,6 +36676,8 @@ objects:
                       format: cidr
                       type: string
                     serviceNetwork:
+                      default:
+                      - cidr: 172.31.0.0/16
                       description: 'ServiceNetwork is the list of IP address pools
                         for services. NOTE: currently only one entry is supported.
                         TODO: make this required in the next version of the API'
@@ -40664,6 +40674,12 @@ objects:
                   format: uri
                   type: string
                 networking:
+                  default:
+                    clusterNetwork:
+                    - cidr: 10.132.0.0/14
+                    networkType: OVNKubernetes
+                    serviceNetwork:
+                    - cidr: 172.31.0.0/16
                   description: Networking specifies network configuration for the
                     cluster.
                   properties:
@@ -40704,6 +40720,8 @@ objects:
                           type: integer
                       type: object
                     clusterNetwork:
+                      default:
+                      - cidr: 10.132.0.0/14
                       description: ClusterNetwork is the list of IP address pools
                         for pods.
                       items:
@@ -40750,6 +40768,8 @@ objects:
                       - Other
                       type: string
                     serviceNetwork:
+                      default:
+                      - cidr: 172.31.0.0/16
                       description: 'ServiceNetwork is the list of IP address pools
                         for services. NOTE: currently only one entry is supported.'
                       items:
@@ -44777,6 +44797,8 @@ objects:
                           type: integer
                       type: object
                     clusterNetwork:
+                      default:
+                      - cidr: 10.132.0.0/14
                       description: 'ClusterNetwork is the list of IP address pools
                         for pods. TODO: make this required in the next version of
                         the API'
@@ -44840,6 +44862,8 @@ objects:
                       format: cidr
                       type: string
                     serviceNetwork:
+                      default:
+                      - cidr: 172.31.0.0/16
                       description: 'ServiceNetwork is the list of IP address pools
                         for services. NOTE: currently only one entry is supported.
                         TODO: make this required in the next version of the API'
@@ -48859,6 +48883,8 @@ objects:
                           type: integer
                       type: object
                     clusterNetwork:
+                      default:
+                      - cidr: 10.132.0.0/14
                       description: ClusterNetwork is the list of IP address pools
                         for pods.
                       items:
@@ -48905,6 +48931,8 @@ objects:
                       - Other
                       type: string
                     serviceNetwork:
+                      default:
+                      - cidr: 172.31.0.0/16
                       description: 'ServiceNetwork is the list of IP address pools
                         for services. NOTE: currently only one entry is supported.'
                       items:
@@ -50716,6 +50744,7 @@ objects:
                     the pool, such as upgrade strategies and auto-repair behaviors.
                   properties:
                     autoRepair:
+                      default: false
                       description: AutoRepair specifies whether health checks should
                         be enabled for machines in the NodePool. The default is false.
                       type: boolean
@@ -51130,7 +51159,7 @@ objects:
                         compute:
                           default:
                             cores: 2
-                            memory: 4Gi
+                            memory: 8Gi
                           description: Compute contains values representing the virtual
                             hardware requested for the VM
                           properties:
@@ -51173,6 +51202,10 @@ objects:
                           - Disable
                           type: string
                         rootVolume:
+                          default:
+                            persistent:
+                              size: 32Gi
+                            type: Persistent
                           description: RootVolume represents values associated with
                             the VM volume that will host rhcos
                           properties:
@@ -51701,6 +51734,7 @@ objects:
                     the pool, such as upgrade strategies and auto-repair behaviors.
                   properties:
                     autoRepair:
+                      default: false
                       description: AutoRepair specifies whether health checks should
                         be enabled for machines in the NodePool. The default is false.
                       type: boolean
@@ -52107,7 +52141,7 @@ objects:
                         compute:
                           default:
                             cores: 2
-                            memory: 4Gi
+                            memory: 8Gi
                           description: Compute contains values representing the virtual
                             hardware requested for the VM
                           properties:
@@ -52150,6 +52184,10 @@ objects:
                           - Disable
                           type: string
                         rootVolume:
+                          default:
+                            persistent:
+                              size: 32Gi
+                            type: Persistent
                           description: RootVolume represents values associated with
                             the VM volume that will host rhcos
                           properties:


### PR DESCRIPTION
This PR is part of an effort to improve the overall API defaulting for the HostedCluster and NodePool objects. The goal to begin transitioning defaulting logic that currently lives within the client tooling (hypershift/hcp) and make these same defaults function when someone is using the API directly.

This PR contains the following generic changes
- HostedCluster Network CRD defaults
- NodePool  NodePoolManagement, UpgradeType, and AutoRepair CRD defaults

and the following kubevirt platform specific changes
- NodePool KubeVirt platform CRD defaults
- NodePool mutating webhook initializes kubevirt platform spec when Kubevirt platform is in use in order for CRD defaults to be applied
- HostedCluster mutating webhook initializes some dynamic kubevirt values related to the baseDomainPassthrough features and the generateID (which is used for external infra)

