### PR TITLE
HOSTEDCP-1438: Preserve container resources for more hosted control plane components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -297,6 +297,20 @@ func ReconcileServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef
 func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
 	params.OwnerRef.ApplyTo(dep)
 
+	cnoResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+		},
+	}
+	// preserve existing resource requirements
+	mainContainer := util.FindContainer(operatorName, dep.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		if len(mainContainer.Resources.Requests) > 0 || len(mainContainer.Resources.Limits) > 0 {
+			cnoResources = mainContainer.Resources
+		}
+	}
+
 	dep.Spec.Replicas = utilpointer.Int32(1)
 	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": operatorName}}
 	dep.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
@@ -538,12 +552,7 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 				Name:  "KUBECONFIG",
 				Value: "/etc/kubernetes/kubeconfig",
 			}},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("10Mi"),
-				},
-			},
+			Resources: cnoResources,
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: "hosted-etc-kube", MountPath: "/etc/kubernetes"},
 				{Name: "konnectivity-proxy-cert", MountPath: "/etc/konnectivity/proxy-client"},

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -23,6 +23,10 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+const (
+	hostedClusterConfigOperatorName = "hosted-cluster-config-operator"
+)
+
 func ReconcileServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef) error {
 	ownerRef.ApplyTo(sa)
 	util.EnsurePullSecret(sa, common.PullSecret("").Name)
@@ -254,8 +258,8 @@ var (
 		},
 	}
 	hccLabels = map[string]string{
-		"app":                         "hosted-cluster-config-operator",
-		hyperv1.ControlPlaneComponent: "hosted-cluster-config-operator",
+		"app":                         hostedClusterConfigOperatorName,
+		hyperv1.ControlPlaneComponent: hostedClusterConfigOperatorName,
 	}
 )
 
@@ -277,6 +281,13 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 	}
 
 	ownerRef.ApplyTo(deployment)
+
+	// preserve existing resource requirements for main scheduler container
+	mainContainer := util.FindContainer(hostedClusterConfigOperatorName, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: selectorLabels,
@@ -343,7 +354,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 
 func hccContainerMain() *corev1.Container {
 	return &corev1.Container{
-		Name: "hosted-cluster-config-operator",
+		Name: hostedClusterConfigOperatorName,
 	}
 }
 
@@ -371,7 +382,7 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 		c.ImagePullPolicy = corev1.PullIfNotPresent
 		c.Command = []string{
 			"/usr/bin/control-plane-operator",
-			"hosted-cluster-config-operator",
+			hostedClusterConfigOperatorName,
 			fmt.Sprintf("--initial-ca-file=%s", path.Join(volumeMounts.Path(c.Name, hccVolumeRootCA().Name), certs.CASignerCertMapKey)),
 			fmt.Sprintf("--cluster-signer-ca-file=%s", path.Join(volumeMounts.Path(c.Name, hccVolumeClusterSignerCA().Name), certs.CASignerCertMapKey)),
 			fmt.Sprintf("--target-kubeconfig=%s", path.Join(volumeMounts.Path(c.Name, hccVolumeKubeconfig().Name), kas.KubeconfigKey)),

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -988,7 +988,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 	r.Log.Info("Reconciling Kube Scheduler")
 	schedulerDeployment := manifests.SchedulerDeployment(hostedControlPlane.Namespace)
 	if err := r.reconcileKubeScheduler(ctx, hostedControlPlane, releaseImageProvider, createOrUpdate, schedulerDeployment); err != nil {
-		return fmt.Errorf("failed to reconcile kube controller manager: %w", err)
+		return fmt.Errorf("failed to reconcile kube scheduler: %w", err)
 	}
 
 	r.Log.Info("Looking up observed configuration")

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -97,6 +97,19 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 }
 
 func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
+	ingressOpResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("80Mi"),
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+		},
+	}
+	// preserve existing resource requirements
+	mainContainer := util.FindContainer(ingressOperatorContainerName, dep.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		if len(mainContainer.Resources.Requests) > 0 || len(mainContainer.Resources.Limits) > 0 {
+			ingressOpResources = mainContainer.Resources
+		}
+	}
 	dep.Spec.Replicas = utilpointer.Int32(1)
 	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": operatorName}}
 	dep.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
@@ -147,13 +160,10 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
 				Value: manifests.KubeAPIServerService("").Name,
 			},
 		},
-		Name:            ingressOperatorContainerName,
-		Image:           params.IngressOperatorImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("80Mi"),
-		}},
+		Name:                     ingressOperatorContainerName,
+		Image:                    params.IngressOperatorImage,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		Resources:                ingressOpResources,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "ingress-operator-kubeconfig", MountPath: "/etc/kubernetes"},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -140,10 +140,16 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	auditConfigHash := util.ComputeHash(auditConfigBytes)
 
 	// preserve existing resource requirements for main KAS container
-	mainContainer := util.FindContainer(kasContainerMain().Name, deployment.Spec.Template.Spec.Containers)
-	if mainContainer != nil {
-		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
+	kasContainer := util.FindContainer(kasContainerMain().Name, deployment.Spec.Template.Spec.Containers)
+	if kasContainer != nil {
+		deploymentConfig.SetContainerResourcesIfPresent(kasContainer)
 	}
+	// preserve existing resource requirements for the konnectivy-server container
+	konnectivityContainer := util.FindContainer(konnectivityServerContainer().Name, deployment.Spec.Template.Spec.Containers)
+	if konnectivityContainer != nil {
+		deploymentConfig.SetContainerResourcesIfPresent(konnectivityContainer)
+	}
+
 	if deployment.Spec.Selector == nil {
 		deployment.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: kasLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
@@ -14,16 +14,27 @@ import (
 	"github.com/openshift/hypershift/support/util"
 )
 
+const (
+	packageServerName = "packageserver"
+)
+
 var (
 	packageServerDeployment = assets.MustDeployment(content.ReadFile, "assets/packageserver-deployment.yaml")
 )
 
 func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string) error {
 	ownerRef.ApplyTo(deployment)
+
+	// preserve existing resource requirements
+	mainContainer := util.FindContainer(packageServerName, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		dc.SetContainerResourcesIfPresent(mainContainer)
+	}
+
 	deployment.Spec = packageServerDeployment.DeepCopy().Spec
 	for i, container := range deployment.Spec.Template.Spec.Containers {
 		switch container.Name {
-		case "packageserver":
+		case packageServerName:
 			deployment.Spec.Template.Spec.Containers[i].Image = olmImage
 		case "socks5-proxy":
 			deployment.Spec.Template.Spec.Containers[i].Image = socks5ProxyImage


### PR DESCRIPTION
**What this PR does / why we need it**:
The changes here simply extends what was already started back in https://github.com/openshift/hypershift/pull/1082 to more components.  Specifically, adding container resource preservation for the following control-plane components:
```
hosted-cluster-config-operator
cluster-network-operator
konnectivity-server
konnectivity-agent
machine-approver-controller
cluster-autoscaler
olm-operator
packageserver
cluster-node-tuning-operator
ingress-operator
ignition-server
catalog-operator
```