### PR TITLE
HOSTEDCP-1200: remove CNO pod exception from EnsureNoCrashingPods

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -417,11 +417,6 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 			t.Fatalf("failed to list pods in namespace %s: %v", namespace, err)
 		}
 		for _, pod := range podList.Items {
-			// TODO: Remove this when https://issues.redhat.com/browse/OCPBUGS-18569 is resolved
-			if strings.HasPrefix(pod.Name, "cluster-network-operator-") {
-				continue
-			}
-
 			// TODO: Remove this when https://issues.redhat.com/browse/OCPBUGS-6953 is resolved
 			if strings.HasPrefix(pod.Name, "ovnkube-master-") {
 				continue


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes CNO pod exception from EnsureNoCrashingPods 
- resolved by https://issues.redhat.com/browse/OCPBUGS-18569 , https://github.com/openshift/cluster-network-operator/pull/1986

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1200](https://issues.redhat.com/browse/HOSTEDCP-1200)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.