### PR TITLE
HOSTEDCP-1200: remove ovnkube-master exception from EnsureNoCrashingPods

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -422,11 +422,6 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 				continue
 			}
 
-			// TODO: Remove this when https://issues.redhat.com/browse/OCPBUGS-6953 is resolved
-			if strings.HasPrefix(pod.Name, "ovnkube-master-") {
-				continue
-			}
-
 			// TODO: Figure out why Route kind does not exist when ingress-operator first starts
 			if strings.HasPrefix(pod.Name, "ingress-operator-") {
 				continue


### PR DESCRIPTION
**What this PR does / why we need it**:  
removes ovnkube-master exception from EnsureNoCrashingPods
- solved by https://issues.redhat.com/browse/OCPBUGS-6953 ,https://github.com/openshift/ovn-kubernetes/pull/1509

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1200](https://issues.redhat.com/browse/HOSTEDCP-1200)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.