### PR TITLE
HOSTEDCP-1200: remove cluster-node-tuning-operator exception from EnsureNoCrashin…

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -450,11 +450,6 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 				continue
 			}
 
-			// TODO: Drop this when this discussion https://redhat-internal.slack.com/archives/C01C8502FMM/p1677761198989759 is resolved.
-			if strings.HasPrefix(pod.Name, "cluster-node-tuning-operator") {
-				continue
-			}
-
 			// TODO: 4.11 and later, FBC based catalogs can in excess of 150s to start
 			// https://github.com/openshift/hypershift/pull/1746
 			// https://github.com/operator-framework/operator-lifecycle-manager/pull/2791


### PR DESCRIPTION
**What this PR does / why we need it**:
removes cluster-node-tuning-operator exception from EnsureNoCrashingPods
- solved by https://github.com/openshift/cluster-node-tuning-operator/pull/578

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1200](https://issues.redhat.com/browse/HOSTEDCP-1200)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.