### PR TITLE
HOSTEDCP-1200: remove ingress-operator exception from EnsureNoCrashingPods

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -427,11 +427,6 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 				continue
 			}
 
-			// TODO: Figure out why Route kind does not exist when ingress-operator first starts
-			if strings.HasPrefix(pod.Name, "ingress-operator-") {
-				continue
-			}
-
 			// TODO: Figure out why default-http backend health check is failing and triggering liveness probe to restart
 			if strings.HasPrefix(pod.Name, "router-") {
 				continue


### PR DESCRIPTION
**What this PR does / why we need it**:
 remove ingress-operator exception from EnsureNoCrashingPods
- unable to reproduce issue so removing exception for now

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1200](https://issues.redhat.com/browse/HOSTEDCP-1200)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.