### PR TITLE
HOSTEDCP-1200: remove cluster-autoscaler exception from EnsureNoCrash…

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -437,12 +437,6 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 				continue
 			}
 
-			// TODO: Autoscaler is restarting because it times out accessing the kube apiserver for leader election.
-			// Investigate a fix.
-			if strings.HasPrefix(pod.Name, "cluster-autoscaler") {
-				continue
-			}
-
 			// TODO: Machine approver started restarting in the UpgradeControlPlane test with the following error:
 			// F1122 15:17:01.880727       1 main.go:144] Can't create clients: failed to create client: Unauthorized
 			// Investigate a fix.


### PR DESCRIPTION
**What this PR does / why we need it**:
 remove the cluster-autoscaler exception from EnsureNoCrashingPods
- unable to reproduce the issue so removing the exception for now

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1200](https://issues.redhat.com/browse/HOSTEDCP-1200)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.