### PR TITLE
HOSTEDCP-1200: remove catalog exception from EnsureNoCrashingPods

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -455,14 +455,6 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 				continue
 			}
 
-			// TODO: 4.11 and later, FBC based catalogs can in excess of 150s to start
-			// https://github.com/openshift/hypershift/pull/1746
-			// https://github.com/operator-framework/operator-lifecycle-manager/pull/2791
-			// Investigate a fix.
-			if strings.Contains(pod.Name, "-catalog") {
-				continue
-			}
-
 			for _, containerStatus := range pod.Status.ContainerStatuses {
 				if containerStatus.RestartCount > 0 {
 					t.Errorf("Container %s in pod %s has a restartCount > 0 (%d)", containerStatus.Name, pod.Name, containerStatus.RestartCount)


### PR DESCRIPTION
**What this PR does / why we need it**:
 remove the catalog exception from EnsureNoCrashingPods
- unable to reproduce the issue so removing the exception for now

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1200](https://issues.redhat.com/browse/HOSTEDCP-1200)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.