### PR TITLE
CNV-34094: Add validating webhook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.14.0
 	golang.org/x/net v0.17.0
+	golang.org/x/sync v0.4.0
 	golang.org/x/time v0.3.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/square/go-jose.v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -1238,6 +1238,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
@@ -1,0 +1,112 @@
+package hostedcluster
+
+import (
+	"context"
+	"github.com/openshift/hypershift/kubevirtexternalinfra"
+	"testing"
+
+	"github.com/openshift/hypershift/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift/hypershift/support/api"
+)
+
+func TestValidateKubevirtCluster(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		hc          *v1beta1.HostedCluster
+		cnvVersion  string
+		k8sVersion  string
+		expectError bool
+	}{
+		{
+			name: "happy case - versions are valid",
+			hc: &v1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-under-test",
+					Namespace: "myns",
+				},
+				Spec: v1beta1.HostedClusterSpec{
+					Platform: v1beta1.PlatformSpec{
+						Type:     v1beta1.KubevirtPlatform,
+						Kubevirt: &v1beta1.KubevirtPlatformSpec{},
+					},
+				},
+			},
+			cnvVersion:  "1.0.0",
+			k8sVersion:  "1.27.0",
+			expectError: false,
+		},
+		{
+			name: "cnv version not supported",
+			hc: &v1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-under-test",
+					Namespace: "myns",
+				},
+				Spec: v1beta1.HostedClusterSpec{
+					Platform: v1beta1.PlatformSpec{
+						Type:     v1beta1.KubevirtPlatform,
+						Kubevirt: &v1beta1.KubevirtPlatformSpec{},
+					},
+				},
+			},
+			cnvVersion:  "0.111.0",
+			k8sVersion:  "1.27.0",
+			expectError: true,
+		},
+		{
+			name: "k8s version not supported",
+			hc: &v1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-under-test",
+					Namespace: "myns",
+				},
+				Spec: v1beta1.HostedClusterSpec{
+					Platform: v1beta1.PlatformSpec{
+						Type:     v1beta1.KubevirtPlatform,
+						Kubevirt: &v1beta1.KubevirtPlatformSpec{},
+					},
+				},
+			},
+			cnvVersion:  "1.0.0",
+			k8sVersion:  "1.26.99",
+			expectError: true,
+		},
+		{
+			name: "no kubevirt field",
+			hc: &v1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-under-test",
+					Namespace: "myns",
+				},
+				Spec: v1beta1.HostedClusterSpec{
+					Platform: v1beta1.PlatformSpec{
+						Type: v1beta1.KubevirtPlatform,
+					},
+				},
+			},
+			cnvVersion:  "1.0.0",
+			k8sVersion:  "1.27.0",
+			expectError: true,
+		},
+	} {
+		t.Run(testCase.name, func(tt *testing.T) {
+			cl := fake.NewClientBuilder().WithScheme(api.Scheme).Build()
+			clientMap := kubevirtexternalinfra.NewMockKubevirtInfraClientMap(cl, testCase.cnvVersion, testCase.k8sVersion)
+
+			v := kubevirtClusterValidator{
+				clientMap: clientMap,
+			}
+
+			err := v.validate(context.Background(), cl, testCase.hc)
+
+			if testCase.expectError && err == nil {
+				t.Error("should return error but didn't")
+			} else if !testCase.expectError && err != nil {
+				t.Errorf("should not return error but returned %q", err.Error())
+			}
+		})
+	}
+}

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,132 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type token struct{}
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
+type Group struct {
+	cancel func(error)
+
+	wg sync.WaitGroup
+
+	sem chan token
+
+	errOnce sync.Once
+	err     error
+}
+
+func (g *Group) done() {
+	if g.sem != nil {
+		<-g.sem
+	}
+	g.wg.Done()
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := withCancelCause(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel(g.err)
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
+// active goroutines in the group exceeding the configured limit.
+//
+// The first call to return a non-nil error cancels the group's context, if the
+// group was created by calling WithContext. The error will be returned by Wait.
+func (g *Group) Go(f func() error) {
+	if g.sem != nil {
+		g.sem <- token{}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel(g.err)
+				}
+			})
+		}
+	}()
+}
+
+// TryGo calls the given function in a new goroutine only if the number of
+// active goroutines in the group is currently below the configured limit.
+//
+// The return value reports whether the goroutine was started.
+func (g *Group) TryGo(f func() error) bool {
+	if g.sem != nil {
+		select {
+		case g.sem <- token{}:
+			// Note: this allows barging iff channels in general allow barging.
+		default:
+			return false
+		}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel(g.err)
+				}
+			})
+		}
+	}()
+	return true
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
+//
+// Any subsequent call to the Go method will block until it can add an active
+// goroutine without exceeding the configured limit.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (g *Group) SetLimit(n int) {
+	if n < 0 {
+		g.sem = nil
+		return
+	}
+	if len(g.sem) != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	}
+	g.sem = make(chan token, n)
+}

--- a/vendor/golang.org/x/sync/errgroup/go120.go
+++ b/vendor/golang.org/x/sync/errgroup/go120.go
@@ -1,0 +1,14 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.20
+// +build go1.20
+
+package errgroup
+
+import "context"
+
+func withCancelCause(parent context.Context) (context.Context, func(error)) {
+	return context.WithCancelCause(parent)
+}

--- a/vendor/golang.org/x/sync/errgroup/pre_go120.go
+++ b/vendor/golang.org/x/sync/errgroup/pre_go120.go
@@ -1,0 +1,15 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.20
+// +build !go1.20
+
+package errgroup
+
+import "context"
+
+func withCancelCause(parent context.Context) (context.Context, func(error)) {
+	ctx, cancel := context.WithCancel(parent)
+	return ctx, func(error) { cancel() }
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -732,6 +732,9 @@ golang.org/x/oauth2/google/internal/externalaccount
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
+# golang.org/x/sync v0.4.0
+## explicit; go 1.17
+golang.org/x/sync/errgroup
 # golang.org/x/sys v0.13.0
 ## explicit; go 1.17
 golang.org/x/sys/cpu


### PR DESCRIPTION
**What this PR does / why we need it**:
Add validating webhook for HostedClusters and NodePools, to check if kubevirt external infra cluster is with sufficient CNV and K8s versions.

This is already checked on the operator, but adding this logic to the webhook will prevent the creating of resources in insufficient environment, in advance. Fixing this error is not an easy task and require upgrading the infra cluster, or the CNV installation, and we prefer to fail fast in this case.

**Which issue(s) this PR fixes**
Fixes #[CNV-34094](https://issues.redhat.com//browse/CNV-34094)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.