### PR TITLE
run EnsurePSANotPrivileged for TestCreateCluster only

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -39,8 +39,10 @@ func TestCreateCluster(t *testing.T) {
 		clusterOpts.Annotations = append(clusterOpts.Annotations, fmt.Sprintf("%s=%s", hyperv1.TopologyAnnotation, hyperv1.DedicatedRequestServingComponentsTopology))
 	}
 
-	e2eutil.NewHypershiftTest(t, ctx, nil).
-		Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
+	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+		guestClient := e2eutil.WaitForGuestClient(t, testContext, mgtClient, hostedCluster)
+		e2eutil.EnsurePSANotPrivileged(t, ctx, guestClient)
+	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 }
 
 func TestCreateClusterCustomConfig(t *testing.T) {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1442,7 +1442,6 @@ func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 
 	EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
 	EnsureNoCrashingPods(t, ctx, client, hostedCluster)
-	EnsurePSANotPrivileged(t, ctx, guestClient)
 	EnsureGuestWebhooksValidated(t, ctx, guestClient)
 
 	if numNodes > 0 {


### PR DESCRIPTION
presub e2e on `main` is blocked on this because the upgrade test does a y-stream upgrade and deploys 4.14 where this check is currently run, and fails, before the upgrade.

xref https://github.com/openshift/hypershift/pull/3107