### PR TITLE
OCPBUGS-20161: Remove unncessary kas port exposure on service

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -125,7 +125,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	if util.IsPrivateHCP(hcp) {
 		p.APIServerAddress = fmt.Sprintf("api.%s.hypershift.local", hcp.Name)
-		p.APIServerPort = util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort)
+		p.APIServerPort = 443
 	} else {
 		p.APIServerAddress = hcp.Status.ControlPlaneEndpoint.Host
 		p.APIServerPort = hcp.Status.ControlPlaneEndpoint.Port

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1401,7 +1401,7 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	if util.IsPrivateHCP(hcp) {
 		svc := manifests.PrivateRouterService(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r.Client, svc, func() error {
-			return ingress.ReconcileRouterService(svc, util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort), true, true)
+			return ingress.ReconcileRouterService(svc, true, true)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile private router service: %w", err)
 		}
@@ -1423,7 +1423,7 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	// When Public access endpoint we need to create a Service type LB external for the KAS.
 	if util.IsPublicHCP(hcp) && exposeKASThroughRouter {
 		if _, err := createOrUpdate(ctx, r.Client, pubSvc, func() error {
-			return ingress.ReconcileRouterService(pubSvc, util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort), false, util.IsPrivateHCP(hcp))
+			return ingress.ReconcileRouterService(pubSvc, false, util.IsPrivateHCP(hcp))
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile router service: %w", err)
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1361,7 +1361,6 @@ func TestReconcileHCPRouterServices(t *testing.T) {
 				Selector: map[string]string{"app": "private-router"},
 				Ports: []corev1.ServicePort{
 					{Name: "https", Port: 443, TargetPort: intstr.FromString("https"), Protocol: corev1.ProtocolTCP},
-					{Name: "kube-apiserver", Port: 6443, TargetPort: intstr.FromString("https"), Protocol: corev1.ProtocolTCP},
 				},
 			},
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -382,8 +382,9 @@ func (p *KubeAPIServerParams) ExternalURL() string {
 	return fmt.Sprintf("https://%s:%d", p.ExternalAddress, p.ExternalPort)
 }
 
+// InternalURL is used by ReconcileBootstrapKubeconfigSecret.
 func (p *KubeAPIServerParams) InternalURL() string {
-	return fmt.Sprintf("https://%s:%d", p.InternalAddress, p.InternalPort)
+	return fmt.Sprintf("https://%s:%d", p.InternalAddress, 443)
 }
 
 func (p *KubeAPIServerParams) ExternalKubeconfigKey() string {

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -66,7 +66,7 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 
 	if util.IsPrivateHC(hcluster) {
 		apiServerExternalAddress = fmt.Sprintf("api.%s.hypershift.local", hcluster.Name)
-		apiServerExternalPort = util.InternalAPIPortFromHostedClusterWithDefault(hcluster, config.DefaultAPIServerPort)
+		apiServerExternalPort = 443
 	} else {
 		if hcluster.Status.KubeConfig == nil {
 			return "", true, nil

--- a/hypershift-operator/controllers/nodepool/haproxy_test.go
+++ b/hypershift-operator/controllers/nodepool/haproxy_test.go
@@ -85,7 +85,7 @@ kind: Config`
 				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
 			}),
 
-			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:6443"},
+			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:443"},
 		},
 		{
 			name: "private cluster uses .local address and custom apiserver port",
@@ -104,7 +104,7 @@ kind: Config`
 				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
 			}),
 
-			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:6443"},
+			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:443"},
 		},
 		{
 			name: "public and private cluster uses .local address and custom apiserver port",
@@ -126,11 +126,11 @@ kind: Config`
 			other: []crclient.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "kk", Namespace: hc().Namespace},
 				Data: map[string][]byte{
-					"kubeconfig": []byte(kubeconfig(6443)),
+					"kubeconfig": []byte(kubeconfig(443)),
 				},
 			}},
 
-			expectedHAProxyConfigContent: []string{"kubeconfig-host:6443"},
+			expectedHAProxyConfigContent: []string{"kubeconfig-host:443"},
 		},
 		{
 			name: "public cluster uses address from kubeconfig and custom port",

--- a/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_private_cluster_uses_.local_address.yaml
+++ b/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_private_cluster_uses_.local_address.yaml
@@ -26,4 +26,4 @@ backend remote_apiserver
   option httpchk GET /version
   option log-health-checks
   default-server inter 10s fall 3 rise 3
-  server controlplane api.hc.hypershift.local:6443
+  server controlplane api.hc.hypershift.local:443

--- a/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_public_and_private_cluster_uses_.local_address.yaml
+++ b/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_public_and_private_cluster_uses_.local_address.yaml
@@ -26,4 +26,4 @@ backend remote_apiserver
   option httpchk GET /version
   option log-health-checks
   default-server inter 10s fall 3 rise 3
-  server controlplane api.hc.hypershift.local:6443
+  server controlplane api.hc.hypershift.local:443

--- a/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_public_cluster_uses_address_from_kubeconfig.yaml
+++ b/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_public_cluster_uses_address_from_kubeconfig.yaml
@@ -26,4 +26,4 @@ backend remote_apiserver
   option httpchk GET /version
   option log-health-checks
   default-server inter 10s fall 3 rise 3
-  server controlplane kubeconfig-host:6443
+  server controlplane kubeconfig-host:443

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -96,15 +96,6 @@ func InternalAPIPortWithDefault(hcp *hyperv1.HostedControlPlane, defaultValue in
 	return defaultValue
 }
 
-// InternalAPIPortFromHostedClusterWithDefault will retrieve the port to use to contact the APIServer over the Kubernetes service domain
-// kube-apiserver.NAMESPACE.svc.cluster.local:INTERNAL_API_PORT
-func InternalAPIPortFromHostedClusterWithDefault(hc *hyperv1.HostedCluster, defaultValue int32) int32 {
-	if hc.Spec.Networking.APIServer != nil && hc.Spec.Networking.APIServer.Port != nil {
-		return *hc.Spec.Networking.APIServer.Port
-	}
-	return defaultValue
-}
-
 func AdvertiseAddress(hcp *hyperv1.HostedControlPlane) *string {
 	if hcp != nil && hcp.Spec.Networking.APIServer != nil {
 		return hcp.Spec.Networking.APIServer.AdvertiseAddress


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This was first introduced here https://github.com/openshift/hypershift/pull/1614/files#diff-62c16653415b8d89921cb26796abc479c31da1654095f7c46b551b470533d66dR368-R372 not sure with which purpose.

With the changes in https://github.com/openshift/hypershift/pull/2964/files#diff-39a001edaf01802e79e43b99b8ce38585ea7079c7253be01fe33a4902a9ca184 we stopped defaulting the kas container port to 443 resulting in this "if" to evaluate as true and exposing a new port https://github.com/openshift/hypershift/pull/2964/files#diff-62c16653415b8d89921cb26796abc479c31da1654095f7c46b551b470533d66dL277

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.