### PR TITLE
OCPBUGS-10423: Update regex validation for nodepool.spec.taints.value

### DIFF
--- a/api/v1beta1/nodepool_types.go
+++ b/api/v1beta1/nodepool_types.go
@@ -914,7 +914,7 @@ type Taint struct {
 	Key string `json:"key"`
 	// The taint value corresponding to the taint key.
 	// +optional
-	// +kubebuilder:validation:Pattern:=`(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?`
+	// +kubebuilder:validation:Pattern:=`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`
 	Value string `json:"value,omitempty"`
 	// Required. The effect of the taint on pods
 	// that do not tolerate the taint.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1752,7 +1752,7 @@ spec:
                       type: string
                     value:
                       description: The taint value corresponding to the taint key.
-                      pattern: (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
                       type: string
                   required:
                   - effect

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -47863,7 +47863,7 @@ objects:
                         type: string
                       value:
                         description: The taint value corresponding to the taint key.
-                        pattern: (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
                         type: string
                     required:
                     - effect


### PR DESCRIPTION
**What this PR does / why we need it**:
Update regex validation for nodepool.spec.taints.value. Previous validation wasnt actually validating the following case
 -  `must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345'`

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-10423](https://issues.redhat.com/browse/OCPBUGS-10423)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.