### PR TITLE
HOSTEDCP-1206: Req serving isolation e2e enxebre

### DIFF
--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -33,11 +33,12 @@ trap generate_junit EXIT
 
 REQUEST_SERVING_COMPONENT_TEST="${REQUEST_SERVING_COMPONENT_TEST:-}"
 REQUEST_SERVING_COMPONENT_PARAMS=""
+
 if [[ -n "${REQUEST_SERVING_COMPONENT_TEST}" ]]; then
    REQUEST_SERVING_COMPONENT_PARAMS="--e2e.test-request-serving-isolation \
   --e2e.management-parent-kubeconfig=${MGMT_PARENT_KUBECONFIG} \
-  --e2e.management-cluster-namespace=$(cat $MGMT_HC_NAMESPACE) \
-  --e2e.management-cluster-name=$(cat $MGMT_HC_NAME)"
+  --e2e.management-cluster-namespace=$(cat "${SHARED_DIR}/management_cluster_namespace") \
+  --e2e.management-cluster-name=$(cat "${SHARED_DIR}/management_cluster_name")"
 fi
 
 bin/test-e2e \

--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -31,6 +31,14 @@ generate_junit() {
 }
 trap generate_junit EXIT
 
+REQUEST_SERVING_COMPONENT_PARAMS=""
+if [[ -n "${REQUEST_SERVING_COMPONENT_TEST}" ]]; then
+   REQUEST_SERVING_COMPONENT_PARAMS="--e2e.test-request-serving-isolation \
+  --e2e.management-parent-kubeconfig=${MGMT_PARENT_KUBECONFIG} \
+  --e2e.management-cluster-namespace=$(cat $MGMT_HC_NAMESPACE) \
+  --e2e.management-cluster-name=$(cat $MGMT_HC_NAME)"
+fi
+
 bin/test-e2e \
   -test.v \
   -test.timeout=2h10m \
@@ -46,6 +54,7 @@ bin/test-e2e \
   --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" \
   --e2e.additional-tags="expirationDate=$(date -d '4 hours' --iso=minutes --utc)" \
   --e2e.aws-endpoint-access=PublicAndPrivate \
-  --e2e.external-dns-domain=service.ci.hypershift.devcluster.openshift.com | tee /tmp/test_out &
+  --e2e.external-dns-domain=service.ci.hypershift.devcluster.openshift.com \
+  ${REQUEST_SERVING_COMPONENT_PARAMS} | tee /tmp/test_out &
 
 wait $!

--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -31,6 +31,7 @@ generate_junit() {
 }
 trap generate_junit EXIT
 
+REQUEST_SERVING_COMPONENT_TEST="${REQUEST_SERVING_COMPONENT_TEST:-}"
 REQUEST_SERVING_COMPONENT_PARAMS=""
 if [[ -n "${REQUEST_SERVING_COMPONENT_TEST}" ]]; then
    REQUEST_SERVING_COMPONENT_PARAMS="--e2e.test-request-serving-isolation \

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -43,7 +43,7 @@ func TestCreateClusterRequestServingIsolation(t *testing.T) {
 		t.Skip("Skipping request serving isolation test")
 	}
 	if globalOpts.Platform != hyperv1.AWSPlatform {
-		t.Skip("Request serving isolation test requirest the AWS platform")
+		t.Skip("Request serving isolation test requires the AWS platform")
 	}
 	t.Parallel()
 
@@ -69,6 +69,8 @@ func TestCreateClusterRequestServingIsolation(t *testing.T) {
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		guestClient := e2eutil.WaitForGuestClient(t, testContext, mgtClient, hostedCluster)
 		e2eutil.EnsurePSANotPrivileged(t, ctx, guestClient)
+		e2eutil.EnsureAllReqServingPodsLandOnReqServingNodes(t, ctx, guestClient)
+		e2eutil.EnsureOnlyRequestServingPodsOnRequestServingNodes(t, ctx, guestClient)
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 }
 

--- a/test/e2e/util/requestserving.go
+++ b/test/e2e/util/requestserving.go
@@ -1,0 +1,114 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	hyperapi "github.com/openshift/hypershift/support/api"
+	supportutil "github.com/openshift/hypershift/support/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func SetupRequestServingNodePools(ctx context.Context, t *testing.T, kubeconfigPath, mgmtHCNamespace, mgmtHCName string) []*hyperv1.NodePool {
+	g := NewWithT(t)
+	mgmtParentClient := kubeClient(t, kubeconfigPath)
+	nodePoolList := &hyperv1.NodePoolList{}
+	err := mgmtParentClient.List(ctx, nodePoolList, client.InNamespace(mgmtHCNamespace))
+	g.Expect(err).ToNot(HaveOccurred(), "cannot list nodepools in management parent cluster namespace "+mgmtHCNamespace)
+
+	// filter  management cluster nodepools
+	var mgmtNodePools []hyperv1.NodePool
+	for _, nodePool := range nodePoolList.Items {
+		if nodePool.Spec.ClusterName == mgmtHCName && nodePool.Spec.Platform.AWS != nil {
+			mgmtNodePools = append(mgmtNodePools, nodePool)
+		}
+	}
+	g.Expect(len(mgmtNodePools) >= 2).To(BeTrue(), "we need at least 2 AWS management cluster nodepools in different zones")
+
+	var nodePoolA, nodePoolB *hyperv1.NodePool
+	nodePoolA = &mgmtNodePools[0]
+	for i := range mgmtNodePools[1:] {
+		nodePool := &mgmtNodePools[1+i]
+		if nodePool.Spec.Platform.AWS.Subnet.ID != nodePoolA.Spec.Platform.AWS.Subnet.ID {
+			nodePoolB = nodePool
+			break
+		}
+	}
+	g.Expect(nodePoolB).ToNot(BeNil(), "did not find 2 nodepools with different subnets in parent")
+
+	// Prepare and create nodepools for request serving components
+	reqServingNodePoolA := nodePoolA.DeepCopy()
+	reqServingNodePoolB := nodePoolB.DeepCopy()
+
+	prepareNodePool := func(np *hyperv1.NodePool) {
+		np.ObjectMeta = metav1.ObjectMeta{
+			Name:      SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-reqserving-", mgmtHCName)),
+			Namespace: mgmtHCNamespace,
+		}
+		np.Status = hyperv1.NodePoolStatus{}
+		np.Spec.Replicas = pointer.Int32(1)
+		np.Spec.AutoScaling = nil
+		np.Spec.NodeLabels = map[string]string{
+			hyperv1.RequestServingComponentLabel: "true",
+		}
+		np.Spec.Taints = []hyperv1.Taint{
+			{
+				Key:    hyperv1.RequestServingComponentLabel,
+				Value:  "true",
+				Effect: corev1.TaintEffectNoSchedule,
+			},
+		}
+	}
+
+	var result []*hyperv1.NodePool
+	for _, np := range []*hyperv1.NodePool{reqServingNodePoolA, reqServingNodePoolB} {
+		prepareNodePool(np)
+		err := mgmtParentClient.Create(ctx, np)
+		g.Expect(err).ToNot(HaveOccurred(), "failed to create request management nodepool")
+		t.Logf("Created request serving nodepool %s/%s", np.Namespace, np.Name)
+		result = append(result, np)
+	}
+
+	// Wait for nodes to become available for each nodepool
+	mgmtClient, err := GetClient()
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get management cluster client")
+	_ = WaitForNReadyNodesByNodePool(t, ctx, mgmtClient, 1, hyperv1.AWSPlatform, reqServingNodePoolA.Name)
+	_ = WaitForNReadyNodesByNodePool(t, ctx, mgmtClient, 1, hyperv1.AWSPlatform, reqServingNodePoolB.Name)
+
+	return result
+}
+
+func TearDownRequestServingNodePools(ctx context.Context, t *testing.T, kubeconfigPath string, nodePools []*hyperv1.NodePool) {
+	g := NewWithT(t)
+	mgmtParentClient := kubeClient(t, kubeconfigPath)
+	var errs []error
+	for _, np := range nodePools {
+		t.Logf("Tearing down request serving nodepool %s/%s", np.Namespace, np.Name)
+		_, err := supportutil.DeleteIfNeeded(ctx, mgmtParentClient, np)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	g.Expect(errors.NewAggregate(errs)).ToNot(HaveOccurred())
+}
+
+func kubeClient(t *testing.T, kubeconfigPath string) client.Client {
+	g := NewWithT(t)
+	kubeconfigBytes, err := os.ReadFile(kubeconfigPath)
+	g.Expect(err).ToNot(HaveOccurred(), "cannot read kubeconfig: "+kubeconfigPath)
+	mgmtParentRESTConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
+	g.Expect(err).ToNot(HaveOccurred(), "cannot create REST config from kubeconfig")
+
+	kubeClient, err := client.New(mgmtParentRESTConfig, client.Options{Scheme: hyperapi.Scheme})
+	g.Expect(err).ToNot(HaveOccurred(), "cannot get client")
+	return kubeClient
+}

--- a/test/e2e/util/requestserving.go
+++ b/test/e2e/util/requestserving.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/scheduler"
 	"os"
 	"testing"
 
@@ -58,7 +59,8 @@ func SetupRequestServingNodePools(ctx context.Context, t *testing.T, kubeconfigP
 		np.Spec.Replicas = pointer.Int32(1)
 		np.Spec.AutoScaling = nil
 		np.Spec.NodeLabels = map[string]string{
-			hyperv1.RequestServingComponentLabel: "true",
+			hyperv1.RequestServingComponentLabel:      "true",
+			scheduler.OSDFleetManagerPairedNodesLabel: "true",
 		}
 		np.Spec.Taints = []hyperv1.Taint{
 			{


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**: 
supersedes [github.com/openshift/hypershift/pull/3104](https://github.com/openshift/hypershift/pull/3104)

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1206](https://issues.redhat.com/browse/HOSTEDCP-1206)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.