### PR TITLE
HOSTEDCP-1254: disable deployment of integrated oauth when authentication type is OIDC and set KAS flags

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -69,6 +69,12 @@ var (
 		},
 	}
 
+	oidcCAVolumeMount = util.PodVolumeMounts{
+		kasContainerMain().Name: {
+			kasVolumeOIDCCA().Name: "/etc/kubernetes/certs/oidc-ca",
+		},
+	}
+
 	cloudProviderConfigVolumeMount = util.PodVolumeMounts{
 		kasContainerMain().Name: {
 			kasVolumeCloudConfig().Name: "/etc/kubernetes/cloud",
@@ -112,6 +118,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	port int32,
 	payloadVersion string,
 	featureGateSpec *configv1.FeatureGateSpec,
+	oidcCA *corev1.LocalObjectReference,
 ) error {
 
 	secretEncryptionData := hcp.Spec.SecretEncryption
@@ -249,6 +256,9 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	applyNamedCertificateMounts(namedCertificates, &deployment.Spec.Template.Spec)
 	applyCloudConfigVolumeMount(cloudProviderConfigRef, &deployment.Spec.Template.Spec, cloudProviderName)
 	util.ApplyCloudProviderCreds(&deployment.Spec.Template.Spec, cloudProviderName, cloudProviderCreds, images.TokenMinterImage, kasContainerMain().Name)
+	if oidcCA != nil {
+		applyOIDCCAVolumeMount(oidcCA, &deployment.Spec.Template.Spec)
+	}
 
 	if cloudProviderName == aws.Provider {
 		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, corev1.Container{
@@ -521,6 +531,12 @@ func buildKASVolumeKonnectivityCA(v *corev1.Volume) {
 	v.ConfigMap.Name = manifests.KonnectivityCAConfigMap("").Name
 }
 
+func kasVolumeOIDCCA() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "oidc-ca",
+	}
+}
+
 func kasVolumeServerCert() *corev1.Volume {
 	return &corev1.Volume{
 		Name: "server-crt",
@@ -700,6 +716,31 @@ func applyCloudConfigVolumeMount(configRef *corev1.LocalObjectReference, podSpec
 		container.VolumeMounts = append(container.VolumeMounts,
 			cloudProviderConfigVolumeMount.ContainerMounts(kasContainerMain().Name)...)
 	}
+}
+
+func buildKASVolumeOIDCCA(configMapName string) func(v *corev1.Volume) {
+	return func(v *corev1.Volume) {
+		v.ConfigMap = &corev1.ConfigMapVolumeSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+			DefaultMode:          pointer.Int32(0640),
+		}
+	}
+}
+
+func applyOIDCCAVolumeMount(oidcCA *corev1.LocalObjectReference, podSpec *corev1.PodSpec) {
+	podSpec.Volumes = append(podSpec.Volumes, util.BuildVolume(kasVolumeOIDCCA(), buildKASVolumeOIDCCA(oidcCA.Name)))
+	var container *corev1.Container
+	for i, c := range podSpec.Containers {
+		if c.Name == kasContainerMain().Name {
+			container = &podSpec.Containers[i]
+			break
+		}
+	}
+	if container == nil {
+		panic("main kube apiserver container not found in spec")
+	}
+	container.VolumeMounts = append(container.VolumeMounts,
+		oidcCAVolumeMount.ContainerMounts(kasContainerMain().Name)...)
 }
 
 func invokeBootstrapRenderScript(workDir, payloadVersion, featureGateYaml string) string {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -33,6 +33,7 @@ type KubeAPIServerImages struct {
 
 type KubeAPIServerParams struct {
 	APIServer           *configv1.APIServerSpec      `json:"apiServer"`
+	Authentication      *configv1.AuthenticationSpec `json:"authentication"`
 	FeatureGate         *configv1.FeatureGateSpec    `json:"featureGate"`
 	Network             *configv1.NetworkSpec        `json:"network"`
 	Image               *configv1.ImageSpec          `json:"image"`
@@ -57,6 +58,7 @@ type KubeAPIServerParams struct {
 	APIServerPort        int32                        `json:"apiServerPort"`
 	ExternalOAuthAddress string                       `json:"externalOAuthAddress"`
 	ExternalOAuthPort    int32                        `json:"externalOAuthPort"`
+	OIDCCAConfigMap      *corev1.LocalObjectReference `json:"oidcCAConfigMap"`
 	EtcdURL              string                       `json:"etcdAddress"`
 	KubeConfigRef        *hyperv1.KubeconfigSecretRef `json:"kubeConfigRef"`
 	AuditWebhookRef      *corev1.LocalObjectReference `json:"auditWebhookRef"`
@@ -113,6 +115,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 	if hcp.Spec.Configuration != nil {
 		params.APIServer = hcp.Spec.Configuration.APIServer
+		params.Authentication = hcp.Spec.Configuration.Authentication
 		params.FeatureGate = hcp.Spec.Configuration.FeatureGate
 		params.Network = hcp.Spec.Configuration.Network
 		params.Image = hcp.Spec.Configuration.Image
@@ -439,6 +442,7 @@ func (p *KubeAPIServerParams) ConfigParams() KubeAPIServerConfigParams {
 		ConsolePublicURL:             p.ConsolePublicURL,
 		DisableProfiling:             p.DisableProfiling,
 		APIServerSTSDirectives:       p.APIServerSTSDirectives,
+		Authentication:               p.Authentication,
 	}
 }
 
@@ -464,6 +468,7 @@ type KubeAPIServerConfigParams struct {
 	ConsolePublicURL             string
 	DisableProfiling             bool
 	APIServerSTSDirectives       string
+	Authentication               *configv1.AuthenticationSpec
 }
 
 func (p *KubeAPIServerParams) TLSSecurityProfile() *configv1.TLSSecurityProfile {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -101,6 +101,15 @@ func KonnectivityCAConfigMap(ns string) *corev1.ConfigMap {
 	}
 }
 
+func OIDCCAConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oidc-ca",
+			Namespace: ns,
+		},
+	}
+}
+
 func OpenShiftOAuthMasterCABundle(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -364,23 +364,30 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		errs = append(errs, fmt.Errorf("failed to reconcile openshift apiserver endpoints: %w", err))
 	}
 
-	log.Info("reconciling openshift oauth apiserver apiservices")
-	if err := r.reconcileOpenshiftOAuthAPIServerAPIServices(ctx, hcp); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile openshift apiserver service: %w", err))
-	}
+	if util.HCPOAuthEnabled(hcp) {
+		log.Info("reconciling openshift oauth apiserver apiservices")
+		if err := r.reconcileOpenshiftOAuthAPIServerAPIServices(ctx, hcp); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile openshift apiserver service: %w", err))
+		}
 
-	log.Info("reconciling openshift oauth apiserver service")
-	openshiftOAuthAPIServerService := manifests.OpenShiftOAuthAPIServerClusterService()
-	if _, err := r.CreateOrUpdate(ctx, r.client, openshiftOAuthAPIServerService, func() error {
-		oapi.ReconcileClusterService(openshiftOAuthAPIServerService)
-		return nil
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile openshift oauth apiserver service: %w", err))
-	}
+		log.Info("reconciling openshift oauth apiserver service")
+		openshiftOAuthAPIServerService := manifests.OpenShiftOAuthAPIServerClusterService()
+		if _, err := r.CreateOrUpdate(ctx, r.client, openshiftOAuthAPIServerService, func() error {
+			oapi.ReconcileClusterService(openshiftOAuthAPIServerService)
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile openshift oauth apiserver service: %w", err))
+		}
 
-	log.Info("reconciling openshift oauth apiserver endpoints")
-	if err := r.reconcileOpenshiftOAuthAPIServerEndpoints(ctx, hcp); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile openshift apiserver endpoints: %w", err))
+		log.Info("reconciling openshift oauth apiserver endpoints")
+		if err := r.reconcileOpenshiftOAuthAPIServerEndpoints(ctx, hcp); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile openshift apiserver endpoints: %w", err))
+		}
+
+		log.Info("reconciling kubeadmin password hash secret")
+		if err := r.reconcileKubeadminPasswordHashSecret(ctx, hcp); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile kubeadmin password hash secret: %w", err))
+		}
 	}
 
 	log.Info("reconciling kube apiserver service monitor")
@@ -389,11 +396,6 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		return monitoring.ReconcileKubeAPIServerServiceMonitor(kasServiceMonitor)
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile the kube apiserver service monitor: %w", err))
-	}
-
-	log.Info("reconciling kubeadmin password hash secret")
-	if err := r.reconcileKubeadminPasswordHashSecret(ctx, hcp); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile kubeadmin password hash secret: %w", err))
 	}
 
 	log.Info("reconciling network operator")
@@ -428,45 +430,47 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		}
 	}
 
-	log.Info("reconciling oauth serving cert ca bundle")
-	if err := r.reconcileOAuthServingCertCABundle(ctx, hcp); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile oauth serving cert CA bundle: %w", err))
-	}
-
 	log.Info("reconciling user cert CA bundle")
 	if err := r.reconcileUserCertCABundle(ctx, hcp); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile user cert CA bundle: %w", err))
 	}
 
-	log.Info("reconciling oauth browser client")
-	oauthBrowserClient := manifests.OAuthServerBrowserClient()
-	if _, err := r.CreateOrUpdate(ctx, r.client, oauthBrowserClient, func() error {
-		return oauth.ReconcileBrowserClient(oauthBrowserClient, r.oauthAddress, r.oauthPort)
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile oauth browser client: %w", err))
-	}
+	if util.HCPOAuthEnabled(hcp) {
+		log.Info("reconciling oauth serving cert ca bundle")
+		if err := r.reconcileOAuthServingCertCABundle(ctx, hcp); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile oauth serving cert CA bundle: %w", err))
+		}
 
-	log.Info("reconciling oauth challenging client")
-	oauthChallengingClient := manifests.OAuthServerChallengingClient()
-	if _, err := r.CreateOrUpdate(ctx, r.client, oauthChallengingClient, func() error {
-		return oauth.ReconcileChallengingClient(oauthChallengingClient, r.oauthAddress, r.oauthPort)
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile oauth challenging client: %w", err))
-	}
+		log.Info("reconciling oauth browser client")
+		oauthBrowserClient := manifests.OAuthServerBrowserClient()
+		if _, err := r.CreateOrUpdate(ctx, r.client, oauthBrowserClient, func() error {
+			return oauth.ReconcileBrowserClient(oauthBrowserClient, r.oauthAddress, r.oauthPort)
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile oauth browser client: %w", err))
+		}
 
-	log.Info("reconciling oauth serving cert rbac")
-	oauthServingCertRole := manifests.OAuthServingCertRole()
-	if _, err := r.CreateOrUpdate(ctx, r.client, oauthServingCertRole, func() error {
-		return oauth.ReconcileOauthServingCertRole(oauthServingCertRole)
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile oauth serving cert role: %w", err))
-	}
+		log.Info("reconciling oauth challenging client")
+		oauthChallengingClient := manifests.OAuthServerChallengingClient()
+		if _, err := r.CreateOrUpdate(ctx, r.client, oauthChallengingClient, func() error {
+			return oauth.ReconcileChallengingClient(oauthChallengingClient, r.oauthAddress, r.oauthPort)
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile oauth challenging client: %w", err))
+		}
 
-	oauthServingCertRoleBinding := manifests.OAuthServingCertRoleBinding()
-	if _, err := r.CreateOrUpdate(ctx, r.client, oauthServingCertRoleBinding, func() error {
-		return oauth.ReconcileOauthServingCertRoleBinding(oauthServingCertRoleBinding)
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile oauth serving cert rolebinding: %w", err))
+		log.Info("reconciling oauth serving cert rbac")
+		oauthServingCertRole := manifests.OAuthServingCertRole()
+		if _, err := r.CreateOrUpdate(ctx, r.client, oauthServingCertRole, func() error {
+			return oauth.ReconcileOauthServingCertRole(oauthServingCertRole)
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile oauth serving cert role: %w", err))
+		}
+
+		oauthServingCertRoleBinding := manifests.OAuthServingCertRoleBinding()
+		if _, err := r.CreateOrUpdate(ctx, r.client, oauthServingCertRoleBinding, func() error {
+			return oauth.ReconcileOauthServingCertRoleBinding(oauthServingCertRoleBinding)
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile oauth serving cert rolebinding: %w", err))
+		}
 	}
 
 	log.Info("reconciling cloud credential secrets")
@@ -819,6 +823,7 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.DeployerClusterRoleBinding, reconcile: rbac.ReconcileDeployerClusterRoleBinding},
 
 		// ClusterRole and ClusterRoleBinding for useroauthaccesstokens referenced from https://github.com/openshift/cluster-authentication-operator/tree/bebf0fd3932be12594227b415fecd5d664611bc0/bindata/oauth-apiserver/RBAC
+		// Let this go by for now
 		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.UserOAuthClusterRole, reconcile: rbac.ReconcileUserOAuthClusterRole},
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.UserOAuthClusterRoleBinding, reconcile: rbac.ReconcileUserOAuthClusterRoleBinding},
 	}

--- a/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
+++ b/hypershift-operator/controllers/manifests/controlplaneoperator/manifests.go
@@ -149,3 +149,12 @@ func ServiceAccountSigningKeySecret(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func OIDCCAConfigMap(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oidc-ca",
+			Namespace: ns,
+		},
+	}
+}

--- a/support/util/oauth.go
+++ b/support/util/oauth.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func HCPOAuthEnabled(hcp *hyperv1.HostedControlPlane) bool {
+	return oauthEnabled(hcp.Spec.Configuration)
+}
+
+func HCOAuthEnabled(hc *hyperv1.HostedCluster) bool {
+	return oauthEnabled(hc.Spec.Configuration)
+}
+
+func ConfigOAuthEnabled(authentication *configv1.AuthenticationSpec) bool {
+	if authentication != nil &&
+		authentication.Type == configv1.AuthenticationTypeOIDC {
+		return false
+	}
+	return true
+}
+
+func oauthEnabled(config *hyperv1.ClusterConfiguration) bool {
+	if config != nil {
+		return ConfigOAuthEnabled(config.Authentication)
+	}
+	return true
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/HOSTEDCP-1254

WIP:
:heavy_check_mark: Needs to be able to handle Authentication type `OIDC` but no `OIDCProviders`