### PR TITLE
OCPBUGS-22868: Fixed accessTokenInactivityTimeout validation

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -2102,7 +2102,7 @@ type ClusterConfiguration struct {
 	// It is used to configure the integrated OAuth server.
 	// This configuration is only honored when the top level Authentication config has type set to IntegratedOAuth.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="!has(self.tokenConfig.accessTokenInactivityTimeout) || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds() >= 300", message="spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout minimum acceptable token timeout value is 300 seconds"
+	// +kubebuilder:validation:XValidation:rule="!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout) || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds() >= 300", message="spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout minimum acceptable token timeout value is 300 seconds"
 	OAuth *configv1.OAuthSpec `json:"oauth,omitempty"`
 
 	// Scheduler holds cluster-wide config information to run the Kubernetes Scheduler

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5964,8 +5964,8 @@ spec:
                     x-kubernetes-validations:
                     - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
                         minimum acceptable token timeout value is 300 seconds
-                      rule: '!has(self.tokenConfig.accessTokenInactivityTimeout) ||
-                        duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                      rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
+                        || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                         >= 300'
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -5944,8 +5944,8 @@ spec:
                     x-kubernetes-validations:
                     - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
                         minimum acceptable token timeout value is 300 seconds
-                      rule: '!has(self.tokenConfig.accessTokenInactivityTimeout) ||
-                        duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                      rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
+                        || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                         >= 300'
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -35951,7 +35951,7 @@ objects:
                       x-kubernetes-validations:
                       - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
                           minimum acceptable token timeout value is 300 seconds
-                        rule: '!has(self.tokenConfig.accessTokenInactivityTimeout)
+                        rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                           || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                           >= 300'
                     proxy:
@@ -44051,7 +44051,7 @@ objects:
                       x-kubernetes-validations:
                       - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
                           minimum acceptable token timeout value is 300 seconds
-                        rule: '!has(self.tokenConfig.accessTokenInactivityTimeout)
+                        rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                           || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                           >= 300'
                     proxy:


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/openshift/hypershift/pull/3110 made `accessTokenInactivityTimeout` field required accidentally, this fixes that.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-21626](https://issues.redhat.com/browse/OCPBUGS-21626)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.