### PR TITLE
HOSTEDCP-1278: Adjustment cluster-cidr,service-cidr to support dualstack

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -63,8 +63,8 @@ type ExampleOptions struct {
 	ImageContentSources              []hyperv1.ImageContentSource
 	InfraID                          string
 	MachineCIDR                      string
-	ServiceCIDR                      string
-	ClusterCIDR                      string
+	ServiceCIDR                      []string
+	ClusterCIDR                      []string
 	NodeSelector                     map[string]string
 	BaseDomain                       string
 	BaseDomainPrefix                 string
@@ -472,12 +472,18 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		cluster.Spec.DNS.BaseDomainPrefix = pointer.String(o.BaseDomainPrefix)
 	}
 
-	if o.ClusterCIDR != "" {
-		cluster.Spec.Networking.ClusterNetwork = []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR(o.ClusterCIDR)}}
+	var clusterNetworkEntries []hyperv1.ClusterNetworkEntry
+	for _, cidr := range o.ClusterCIDR {
+		clusterNetworkEntries = append(clusterNetworkEntries, hyperv1.ClusterNetworkEntry{CIDR: *ipnet.MustParseCIDR(cidr)})
 	}
-	if o.ServiceCIDR != "" {
-		cluster.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR(o.ServiceCIDR)}}
+	cluster.Spec.Networking.ClusterNetwork = clusterNetworkEntries
+
+	var serviceNetworkEntries []hyperv1.ServiceNetworkEntry
+	for _, cidr := range o.ServiceCIDR {
+		serviceNetworkEntries = append(serviceNetworkEntries, hyperv1.ServiceNetworkEntry{CIDR: *ipnet.MustParseCIDR(cidr)})
 	}
+	cluster.Spec.Networking.ServiceNetwork = serviceNetworkEntries
+
 	if o.MachineCIDR != "" {
 		cluster.Spec.Networking.MachineNetwork = []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR(o.MachineCIDR)}}
 	}

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -28,8 +28,8 @@ func NewCreateCommands() *cobra.Command {
 		Render:                         false,
 		InfrastructureJSON:             "",
 		InfraID:                        "",
-		ServiceCIDR:                    "172.31.0.0/16",
-		ClusterCIDR:                    "10.132.0.0/14",
+		ServiceCIDR:                    []string{"172.31.0.0/16"},
+		ClusterCIDR:                    []string{"10.132.0.0/14"},
 		Wait:                           false,
 		Timeout:                        0,
 		ExternalDNSDomain:              "",
@@ -72,8 +72,8 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.EtcdStorageClass, "etcd-storage-class", opts.EtcdStorageClass, "The persistent volume storage class for etcd data volumes")
 	cmd.PersistentFlags().StringVar(&opts.InfrastructureJSON, "infra-json", opts.InfrastructureJSON, "Path to file containing infrastructure information for the cluster. If not specified, infrastructure will be created")
 	cmd.PersistentFlags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Infrastructure ID to use for hosted cluster resources.")
-	cmd.PersistentFlags().StringVar(&opts.ServiceCIDR, "service-cidr", opts.ServiceCIDR, "The CIDR of the service network")
-	cmd.PersistentFlags().StringVar(&opts.ClusterCIDR, "cluster-cidr", opts.ClusterCIDR, "The CIDR of the cluster network")
+	cmd.PersistentFlags().StringArrayVar(&opts.ServiceCIDR, "service-cidr", opts.ServiceCIDR, "The CIDR of the service network. Can be specified multiple times.")
+	cmd.PersistentFlags().StringArrayVar(&opts.ClusterCIDR, "cluster-cidr", opts.ClusterCIDR, "The CIDR of the cluster network. Can be specified multiple times.")
 	cmd.PersistentFlags().StringToStringVar(&opts.NodeSelector, "node-selector", opts.NodeSelector, "A comma separated list of key=value to use as node selector for the Hosted Control Plane pods to stick to. E.g. role=cp,disk=fast")
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -60,8 +60,8 @@ type CreateOptions struct {
 	ReleaseStream                    string
 	Render                           bool
 	SSHKeyFile                       string
-	ServiceCIDR                      string
-	ClusterCIDR                      string
+	ServiceCIDR                      []string
+	ClusterCIDR                      []string
 	ExternalDNSDomain                string
 	Arch                             string
 	NodeSelector                     map[string]string

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -17,7 +17,7 @@ func NewCreateCommands() *cobra.Command {
 	opts := &core.CreateOptions{
 		AdditionalTrustBundle:          "",
 		Arch:                           "amd64",
-		ClusterCIDR:                    "10.132.0.0/14",
+		ClusterCIDR:                    []string{"10.132.0.0/14"},
 		ControlPlaneAvailabilityPolicy: "HighlyAvailable",
 		ImageContentSources:            "",
 		InfraID:                        "",
@@ -30,7 +30,7 @@ func NewCreateCommands() *cobra.Command {
 		PullSecretFile:                 "",
 		ReleaseImage:                   "",
 		Render:                         false,
-		ServiceCIDR:                    "172.31.0.0/16",
+		ServiceCIDR:                    []string{"172.31.0.0/16"},
 		Timeout:                        0,
 		Wait:                           false,
 		PausedUntil:                    "",
@@ -46,7 +46,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVar(&opts.Annotations, "annotations", opts.Annotations, "Annotations to apply to the HostedCluster (format: key=value). Annotations can be specified multiple times.")
 	cmd.PersistentFlags().BoolVar(&opts.AutoRepair, "auto-repair", opts.AutoRepair, "Enables machine auto-repair with machine health checks.")
 	cmd.PersistentFlags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "Ingress base domain for the cluster.")
-	cmd.PersistentFlags().StringVar(&opts.ClusterCIDR, "cluster-cidr", opts.ClusterCIDR, "CIDR of the cluster network.")
+	cmd.PersistentFlags().StringArrayVar(&opts.ClusterCIDR, "cluster-cidr", opts.ClusterCIDR, "CIDR of the cluster network. Can be specified multiple times.")
 	cmd.PersistentFlags().StringVar(&opts.ControlPlaneAvailabilityPolicy, "control-plane-availability-policy", opts.ControlPlaneAvailabilityPolicy, "Availability policy for HostedCluster components. Supported options: SingleReplica, HighlyAvailable.")
 	cmd.PersistentFlags().StringVar(&opts.EtcdStorageClass, "etcd-storage-class", opts.EtcdStorageClass, "Persistent volume storage class for etcd data volumes")
 	cmd.PersistentFlags().BoolVar(&opts.FIPS, "fips", opts.FIPS, "Enables FIPS mode for nodes in the cluster.")
@@ -64,7 +64,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Filepath to a pull secret.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the HostedCluster.")
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", opts.Render, "Renders the HostedCluster manifest output as YAML to stdout instead of automatically applying the manifests to the management cluster.")
-	cmd.PersistentFlags().StringVar(&opts.ServiceCIDR, "service-cidr", opts.ServiceCIDR, "The CIDR of the service network.")
+	cmd.PersistentFlags().StringArrayVar(&opts.ServiceCIDR, "service-cidr", opts.ServiceCIDR, "The CIDR of the service network. Can be specified multiple times.")
 	cmd.PersistentFlags().StringVar(&opts.SSHKeyFile, "ssh-key", opts.SSHKeyFile, "Filepath to an SSH key file.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the duration of the wait (Examples: 30s, 1h30m45s, etc.) 0 means no timeout.")
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If true, the create command will block until the HostedCluster is up. Requires at least one NodePool with at least one node.")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -450,8 +450,8 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 			CloudConnection: o.configurableClusterOptions.PowerVSCloudConnection,
 			VPC:             o.configurableClusterOptions.PowerVSVPC,
 		},
-		ServiceCIDR: "172.31.0.0/16",
-		ClusterCIDR: "10.132.0.0/14",
+		ServiceCIDR: []string{"172.31.0.0/16"},
+		ClusterCIDR: []string{"10.132.0.0/14"},
 		BeforeApply: o.BeforeApply,
 		Log:         util.NewLogr(t),
 		Annotations: []string{


### PR DESCRIPTION
**What this PR does / why we need it**:
Adjustment cluster-cidr,service-cidr to support dual-stack

**Which issue(s) this PR fixes** 
[HOSTEDCP-1278](https://issues.redhat.com/browse/HOSTEDCP-1278)

**test** 
```
➜  hcp create cluster aws --base-domain qe.devcluster.openshift.com --aws-creds config/awscredentials  --pull-secret config/.dockerconfigjson
➜  oc get hostedcluster -n clusters example -ojsonpath='{.spec.networking}'     
{"clusterNetwork":[{"cidr":"10.132.0.0/14"}],"machineNetwork":[{"cidr":"10.0.0.0/16"}],"networkType":"OVNKubernetes","serviceNetwork":[{"cidr":"172.31.0.0/16"}]} 

➜  hcp create cluster aws --base-domain qe.devcluster.openshift.com --aws-creds config/awscredentials  \
  --pull-secret config/.dockerconfigjson --name testv6 \
  --cluster-cidr fd03::/48 --service-cidr fd04::/112
➜  oc get hostedcluster -n clusters testv6 -ojsonpath='{.spec.networking}'                                                                 
{"clusterNetwork":[{"cidr":"fd03::/48"}],"machineNetwork":[{"cidr":"10.0.0.0/16"}],"networkType":"OVNKubernetes","serviceNetwork":[{"cidr":"fd04::/112"}]}

➜  hcp create cluster aws --base-domain qe.devcluster.openshift.com --aws-creds config/awscredentials  \
  --pull-secret config/.dockerconfigjson --name testv4v6 \
  --cluster-cidr fd03::/48 --cluster-cidr 10.132.0.0/14 \
  --service-cidr fd04::/112 --service-cidr 172.31.0.0/16
➜  oc get hostedcluster -n clusters testv4v6 -ojsonpath='{.spec.networking}'     
{"clusterNetwork":[{"cidr":"fd03::/48"},{"cidr":"10.132.0.0/14"}],"machineNetwork":[{"cidr":"10.0.0.0/16"}],"networkType":"OVNKubernetes","serviceNetwork":[{"cidr":"fd04::/112"},{"cidr":"172.31.0.0/16"}]}    
```

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.]