### PR TITLE
NO-JIRA: Add --auto-repair flag to `hcp create nodepool`

### DIFF
--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -24,6 +24,7 @@ type CreateNodePoolOptions struct {
 	Render          bool
 	NodeUpgradeType hyperv1.UpgradeType
 	Arch            string
+	AutoRepair      bool
 }
 
 type PlatformOptions interface {
@@ -84,6 +85,7 @@ func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts
 		Spec: hyperv1.NodePoolSpec{
 			Management: hyperv1.NodePoolManagement{
 				UpgradeType: o.NodeUpgradeType,
+				AutoRepair:  o.AutoRepair,
 			},
 			ClusterName: o.ClusterName,
 			Replicas:    &o.NodeCount,

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -43,6 +43,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The processor architecture for the NodePool (e.g. arm64, amd64)")
 
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying")
+	cmd.PersistentFlags().BoolVar(&opts.AutoRepair, "auto-repair", opts.AutoRepair, "Enables machine auto-repair with machine health checks.")
 
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
 	cmd.AddCommand(aws.NewCreateCommand(opts))

--- a/product-cli/cmd/nodepool/create.go
+++ b/product-cli/cmd/nodepool/create.go
@@ -33,6 +33,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes; if this is empty, defaults to the same release image as the HostedCluster.")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying.")
+	cmd.PersistentFlags().BoolVar(&opts.AutoRepair, "auto-repair", opts.AutoRepair, "Enables machine auto-repair with machine health checks.")
 
 	_ = cmd.MarkPersistentFlagRequired("name")
 


### PR DESCRIPTION
The `--auto-repair` flag is already present during `hcp create cluster...` however this value is not present when creating a new nodepool for an existing cluster. This PR addresses that by bringing parity to the cli nodepool creation.