### PR TITLE
HOSTEDCP-1281: Fix a bug in the validating webhook

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -34,7 +34,6 @@ func (o *ExampleResources) AsObjects() []crclient.Object {
 	objects := []crclient.Object{
 		o.Namespace,
 		o.PullSecret,
-		o.Cluster,
 	}
 	objects = append(objects, o.Resources...)
 	if o.SSHKey != nil {
@@ -43,6 +42,9 @@ func (o *ExampleResources) AsObjects() []crclient.Object {
 	if o.AdditionalTrustBundle != nil {
 		objects = append(objects, o.AdditionalTrustBundle)
 	}
+
+	objects = append(objects, o.Cluster)
+
 	for _, nodePool := range o.NodePools {
 		objects = append(objects, nodePool)
 	}


### PR DESCRIPTION
## What this PR does / why we need it
When creating a HostedCluster from command line, the HostedCluster CR is one of the first resources that been created. Some resources are created later but are actually needed.

The new validating webhook need the secret that holds the kubeconfig of the infra-cluster (when creating a a cluster with an external KubeVirt infra cluster). The webhook is called for HostedCluster cration, while the secret is not created yet, and so the creation of the HostedCluster fails.

This PR changes the order of the resources when creatig a new cluster, so all the dependencies are created before the HostedCluster CR.

### Which issue(s) this PR fixes
Fixes #[HOSTEDCP-1281](https://issues.redhat.com//browse/HOSTEDCP-1281)

### Checklist
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.