### PR TITLE
HOSTEDCP-1283: Fixed Azure nodes not joining

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -323,8 +323,8 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 
 	// TODO: Extract this from the release image or require a parameter
 	// Extraction is done like this:
-	// docker run --rm -it --entrypoint cat quay.io/openshift-release-dev/ocp-release:4.10.0-rc.0-x86_64 release-manifests/0000_50_installer_coreos-bootimages.yaml |yaml2json |jq .data.stream -r|jq '.architectures.x86_64["rhel-coreos-extensions"]["azure-disk"].url'
-	sourceURL := "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202110081407-0-azure.x86_64.vhd"
+	// podman run --rm -it --entrypoint cat quay.io/openshift-release-dev/ocp-release:4.14.1-x86_64 release-manifests/0000_50_installer_coreos-bootimages.yaml |yq .data.stream -r|yq '.architectures.x86_64["rhel-coreos-extensions"]["azure-disk"].url'
+	sourceURL := "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202310170514-0-azure.x86_64.vhd"
 	blobName := "rhcos.x86_64.vhd"
 
 	// Explicitly check this, Azure API makes inferring the problem from the error message extremely hard

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -33,7 +33,9 @@ func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1
 				StorageAccountType: nodePool.Spec.Platform.Azure.DiskStorageAccountType,
 			},
 		},
-		SubnetName:             hcluster.Spec.Platform.Azure.SubnetName,
+		NetworkInterfaces: []capiazure.NetworkInterface{{
+			SubnetName: hcluster.Spec.Platform.Azure.SubnetName,
+		}},
 		Identity:               capiazure.VMIdentityUserAssigned,
 		UserAssignedIdentities: []capiazure.UserAssignedIdentity{{ProviderID: hcluster.Spec.Platform.Azure.MachineIdentityID}},
 		SSHPublicKey:           sshKey,


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates RHOCS image used for the nodes, and fix AzureMachine template `SubnetName` not being propagated correctly.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1283](https://issues.redhat.com/browse/HOSTEDCP-1283)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.