### PR TITLE
[release-4.14] OCPBUGS-22360: Validate accessTokenInactivityTimeout >= 300s

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -2097,6 +2097,7 @@ type ClusterConfiguration struct {
 	// It is used to configure the integrated OAuth server.
 	// This configuration is only honored when the top level Authentication config has type set to IntegratedOAuth.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="!has(self.tokenConfig.accessTokenInactivityTimeout) || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds() >= 300", message="spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout minimum acceptable token timeout value is 300 seconds"
 	OAuth *configv1.OAuthSpec `json:"oauth,omitempty"`
 
 	// Scheduler holds cluster-wide config information to run the Kubernetes Scheduler

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -2097,7 +2097,7 @@ type ClusterConfiguration struct {
 	// It is used to configure the integrated OAuth server.
 	// This configuration is only honored when the top level Authentication config has type set to IntegratedOAuth.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="!has(self.tokenConfig.accessTokenInactivityTimeout) || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds() >= 300", message="spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout minimum acceptable token timeout value is 300 seconds"
+	// +kubebuilder:validation:XValidation:rule="!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout) || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds() >= 300", message="spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout minimum acceptable token timeout value is 300 seconds"
 	OAuth *configv1.OAuthSpec `json:"oauth,omitempty"`
 
 	// Scheduler holds cluster-wide config information to run the Kubernetes Scheduler

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5620,8 +5620,8 @@ spec:
                     x-kubernetes-validations:
                     - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
                         minimum acceptable token timeout value is 300 seconds
-                      rule: '!has(self.tokenConfig.accessTokenInactivityTimeout) ||
-                        duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                      rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
+                        || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                         >= 300'
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -5617,6 +5617,12 @@ spec:
                             type: integer
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
+                        minimum acceptable token timeout value is 300 seconds
+                      rule: '!has(self.tokenConfig.accessTokenInactivityTimeout) ||
+                        duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                        >= 300'
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -5597,6 +5597,12 @@ spec:
                             type: integer
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
+                        minimum acceptable token timeout value is 300 seconds
+                      rule: '!has(self.tokenConfig.accessTokenInactivityTimeout) ||
+                        duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                        >= 300'
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -5600,8 +5600,8 @@ spec:
                     x-kubernetes-validations:
                     - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
                         minimum acceptable token timeout value is 300 seconds
-                      rule: '!has(self.tokenConfig.accessTokenInactivityTimeout) ||
-                        duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                      rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
+                        || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                         >= 300'
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -35595,7 +35595,7 @@ objects:
                       x-kubernetes-validations:
                       - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
                           minimum acceptable token timeout value is 300 seconds
-                        rule: '!has(self.tokenConfig.accessTokenInactivityTimeout)
+                        rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                           || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                           >= 300'
                     proxy:
@@ -43336,7 +43336,7 @@ objects:
                       x-kubernetes-validations:
                       - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
                           minimum acceptable token timeout value is 300 seconds
-                        rule: '!has(self.tokenConfig.accessTokenInactivityTimeout)
+                        rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                           || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                           >= 300'
                     proxy:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -35592,6 +35592,12 @@ objects:
                               type: integer
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
+                          minimum acceptable token timeout value is 300 seconds
+                        rule: '!has(self.tokenConfig.accessTokenInactivityTimeout)
+                          || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                          >= 300'
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.
@@ -43327,6 +43333,12 @@ objects:
                               type: integer
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
+                          minimum acceptable token timeout value is 300 seconds
+                        rule: '!has(self.tokenConfig.accessTokenInactivityTimeout)
+                          || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                          >= 300'
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/hypershift/pull/3110 and https://github.com/openshift/hypershift/pull/3157