### PR TITLE
OCPBUGS-20157: add e2e to ensure pods dont land in default pool

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -50,9 +50,7 @@ func TestCreateClusterRequestServingIsolation(t *testing.T) {
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 
-	nodePools := e2eutil.SetupRequestServingNodePools(ctx, t, globalOpts.ManagementParentKubeconfig, globalOpts.ManagementClusterNamespace, globalOpts.ManagementClusterName)
-	nonReqServingNodePool := e2eutil.SetupNonRequestServingNodePool(ctx, t, globalOpts.ManagementParentKubeconfig, globalOpts.ManagementClusterNamespace, globalOpts.ManagementClusterName)
-	nodePools = append(nodePools, nonReqServingNodePool)
+	nodePools := e2eutil.SetupReqServingClusterNodePools(ctx, t, globalOpts.ManagementParentKubeconfig, globalOpts.ManagementClusterNamespace, globalOpts.ManagementClusterName)
 	defer e2eutil.TearDownNodePools(ctx, t, globalOpts.ManagementParentKubeconfig, nodePools)
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -46,7 +46,7 @@ func TestNodePool(t *testing.T) {
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		hostedClusterClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
 
-		// Get the newly created defautlt NodePool
+		// Get the newly created default NodePool
 		nodepools := &hyperv1.NodePoolList{}
 		if err := mgtClient.List(ctx, nodepools, crclient.InNamespace(hostedCluster.Namespace)); err != nil {
 			t.Fatalf("failed to list nodepools in namespace %s: %v", hostedCluster.Namespace, err)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1680,7 +1680,7 @@ func EnsureAllReqServingPodsLandOnReqServingNodes(t *testing.T, ctx context.Cont
 func EnsureNoHCPPodsLandOnDefaultNode(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	g := NewWithT(t)
 
-	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 	var podList corev1.PodList
 	if err := client.List(ctx, &podList, crclient.InNamespace(namespace)); err != nil {
 		t.Fatalf("failed to list pods in namespace %s: %v", namespace, err)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1676,3 +1676,28 @@ func EnsureAllReqServingPodsLandOnReqServingNodes(t *testing.T, ctx context.Cont
 		g.Expect(node.Labels).To(HaveKeyWithValue(hyperv1.RequestServingComponentLabel, "true"))
 	}
 }
+
+func EnsureNoHCPPodsLandOnDefaultNode(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+
+	namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
+	var podList corev1.PodList
+	if err := client.List(ctx, &podList, crclient.InNamespace(namespace)); err != nil {
+		t.Fatalf("failed to list pods in namespace %s: %v", namespace, err)
+	}
+
+	var HCPNodes corev1.NodeList
+	if err := client.List(ctx, &HCPNodes, crclient.MatchingLabels{"hypershift.openshift.io/control-plane": "true"}); err != nil {
+		t.Fatalf("failed to list nodes with \"hypershift.openshift.io/control-plane\": \"true\" label: %v", err)
+	}
+
+	var hcpNodeNames []string
+	for _, node := range HCPNodes.Items {
+		hcpNodeNames = append(hcpNodeNames, node.Name)
+	}
+
+	for _, pod := range podList.Items {
+		g.Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue("hypershift.openshift.io/control-plane", "true"))
+		g.Expect(hcpNodeNames).To(ContainElement(pod.Spec.NodeName))
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Adds e2e to ensure pods dont land in default nodepool

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Supports # [OCPBUGS-20157](https://issues.redhat.com/browse/OCPBUGS-20157)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.