### PR TITLE
HOSTEDCP-1237: Retrieve RHCOS VHD image from release image

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -43,6 +43,7 @@ type CreateInfraOptions struct {
 	CredentialsFile string
 	Credentials     *apifixtures.AzureCreds
 	OutputFile      string
+	RHCOSImage      string
 }
 
 func NewCreateCommand() *cobra.Command {
@@ -321,10 +322,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 	}
 	l.Info("Successflly created blobcontainer", "name", *imageContainer.Name)
 
-	// TODO: Extract this from the release image or require a parameter
-	// Extraction is done like this:
-	// podman run --rm -it --entrypoint cat quay.io/openshift-release-dev/ocp-release:4.14.1-x86_64 release-manifests/0000_50_installer_coreos-bootimages.yaml |yq .data.stream -r|yq '.architectures.x86_64["rhel-coreos-extensions"]["azure-disk"].url'
-	sourceURL := "https://rhcos.blob.core.windows.net/imagebucket/rhcos-414.92.202310170514-0-azure.x86_64.vhd"
+	sourceURL := o.RHCOSImage
 	blobName := "rhcos.x86_64.vhd"
 
 	// Explicitly check this, Azure API makes inferring the problem from the error message extremely hard

--- a/support/releaseinfo/deserialize_test.go
+++ b/support/releaseinfo/deserialize_test.go
@@ -16,8 +16,19 @@ func TestDeserializeImageStream(t *testing.T) {
 
 func TestDeserializeImageMetadata(t *testing.T) {
 	for _, imageMetadata := range [][]byte{fixtures.CoreOSBootImagesYAML_4_8, fixtures.CoreOSBootImagesYAML_4_10} {
-		if _, err := DeserializeImageMetadata(imageMetadata); err != nil {
+		var coreOSMetadata *CoreOSStreamMetadata
+		coreOSMetadata, err := DeserializeImageMetadata(imageMetadata)
+		if err != nil {
 			t.Fatal(err)
 		}
+
+		if _, ok := coreOSMetadata.Architectures["x86_64"]; !ok {
+			t.Fatal(err)
+		}
+
+		if coreOSMetadata.Architectures["x86_64"].RHCOS.AzureDisk.URL == "" {
+			t.Fatal(err)
+		}
+
 	}
 }

--- a/support/releaseinfo/releaseinfo.go
+++ b/support/releaseinfo/releaseinfo.go
@@ -47,6 +47,7 @@ type CoreOSArchitecture struct {
 	// Artifacts is a map of platform name to Artifacts
 	Artifacts map[string]CoreOSArtifact `json:"artifacts"`
 	Images    CoreOSImages              `json:"images"`
+	RHCOS     CoreRHCOSImage            `json:"rhel-coreos-extensions"`
 }
 
 type CoreOSArtifact struct {
@@ -65,6 +66,15 @@ type CoreOSImages struct {
 	AWS      CoreOSAWSImages      `json:"aws"`
 	PowerVS  CoreOSPowerVSImages  `json:"powervs"`
 	Kubevirt CoreOSKubevirtImages `json:"kubevirt"`
+}
+
+type CoreRHCOSImage struct {
+	AzureDisk CoreAzureDisk `json:"azure-disk"`
+}
+
+type CoreAzureDisk struct {
+	Release string `json:"release"`
+	URL     string `json:"url"`
 }
 
 type CoreOSAWSImages struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Retrieves the RHCOS VHD image from release image rather than hardcoding it

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1237](https://issues.redhat.com/browse/HOSTEDCP-1237)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.