### PR TITLE
OCPBUGS-23177: Set goaway-chance on kube-apiserver to 0.001

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -181,7 +181,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 	featureGates := append([]string{}, p.FeatureGates...)
 	featureGates = append(featureGates, "StructuredAuthenticationConfiguration=true")
 	args.Set("feature-gates", featureGates...)
-	args.Set("goaway-chance", "0")
+	args.Set("goaway-chance", "0.001")
 	args.Set("http2-max-streams-per-connection", "2000")
 	args.Set("kubelet-certificate-authority", cpath(kasVolumeKubeletClientCA().Name, certs.CASignerCertMapKey))
 	args.Set("kubelet-client-certificate", cpath(kasVolumeKubeletClientCert().Name, corev1.TLSCertKey))


### PR DESCRIPTION
This helps to mitigate potential HTTP/2 DOS attacks on the kubernetes apiserver as described in https://cloud.google.com/anthos/clusters/docs/security-bulletins#gcp-2023-030.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-23177

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.