### PR TITLE
HOSTEDCP-1285: Kas port svc cleanup

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -45,7 +45,6 @@ import (
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
-	"github.com/openshift/hypershift/support/config"
 	supportutil "github.com/openshift/hypershift/support/util"
 )
 
@@ -203,7 +202,7 @@ func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 		Out:       forwarderOutput,
 		ErrOut:    forwarderOutput,
 	}
-	podPort := supportutil.BindAPIPortWithDefaultFromHostedCluster(hostedCluster, config.DefaultAPIServerPort)
+	podPort := supportutil.KASPodPortFromHostedCluster(hostedCluster)
 	forwarderStop := make(chan struct{})
 	if err := forwarder.ForwardPorts([]string{fmt.Sprintf("%d:%d", localPort, podPort)}, forwarderStop); err != nil {
 		return fmt.Errorf("cannot forward kube apiserver port: %w, output: %s", err, forwarderOutput.String())

--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -178,7 +178,7 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 		},
 	}
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, util.APIPort(hcp)), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
 
 	deploymentConfig := config.DeploymentConfig{
 		AdditionalLabels: map[string]string{

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
@@ -32,7 +32,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, image string, deploymentConfig config.DeploymentConfig, availabilityProberImage string, apiServerPort *int32) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, image string, deploymentConfig config.DeploymentConfig, availabilityProberImage string) error {
 	// preserve existing resource requirements for main CPC container
 	mainContainer := util.FindContainer(cpcContainerMain().Name, deployment.Spec.Template.Spec.Containers)
 	if mainContainer != nil {
@@ -64,7 +64,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	deployment.Spec.Template.Spec.AutomountServiceAccountToken = pointer.Bool(false)
 	deploymentConfig.ApplyTo(deployment)
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiServerPort), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -290,7 +290,7 @@ func ReconcileServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef
 	return nil
 }
 
-func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) error {
+func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
 	params.OwnerRef.ApplyTo(dep)
 
 	dep.Spec.Replicas = utilpointer.Int32(1)
@@ -555,7 +555,7 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 	}
 
 	params.DeploymentConfig.ApplyTo(dep)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(dep.Namespace, apiPort), params.AvailabilityProberImage, &dep.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), params.AvailabilityProberImage, &dep.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "hosted-etc-kube"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operator.openshift.io", Version: "v1", Kind: "Network"},

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
@@ -30,7 +30,7 @@ func TestReconcileDeployment(t *testing.T) {
 			}
 
 			dep := &appsv1.Deployment{}
-			if err := ReconcileDeployment(dep, tc.params, nil); err != nil {
+			if err := ReconcileDeployment(dep, tc.params); err != nil {
 				t.Fatalf("ReconcileDeployment: %v", err)
 			}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -229,7 +229,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, deploymentConfig *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, apiInternalPort *int32, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, additionalTrustBundle *corev1.LocalObjectReference, hcp *hyperv1.HostedControlPlane, openShiftTrustedCABundleConfigMapForCPOExists bool, registryOverrides map[string]string, openShiftImageRegistryOverrides map[string][]string) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShiftVersion, kubeVersion string, ownerRef config.OwnerRef, deploymentConfig *config.DeploymentConfig, availabilityProberImage string, enableCIDebugOutput bool, platformType hyperv1.PlatformType, konnectivityAddress string, konnectivityPort int32, oauthAddress string, oauthPort int32, releaseImage string, additionalTrustBundle *corev1.LocalObjectReference, hcp *hyperv1.HostedControlPlane, openShiftTrustedCABundleConfigMapForCPOExists bool, registryOverrides map[string]string, openShiftImageRegistryOverrides map[string][]string) error {
 	// Before this change we did
 	// 		Selector: &metav1.LabelSelector{
 	//			MatchLabels: hccLabels,
@@ -287,7 +287,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 	}
 
 	deploymentConfig.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiInternalPort), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "imageregistry.operator.openshift.io", Version: "v1", Kind: "Config"},

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -108,7 +108,7 @@ func cvoLabels() map[string]string {
 
 var port int32 = 8443
 
-func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, controlPlaneImage, image, cliImage, availabilityProberImage, clusterID string, apiPort *int32, platformType hyperv1.PlatformType, oauthEnabled bool) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, controlPlaneImage, image, cliImage, availabilityProberImage, clusterID string, platformType hyperv1.PlatformType, oauthEnabled bool) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main CVO container
@@ -148,7 +148,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	}
 	deploymentConfig.ApplyTo(deployment)
 	util.AvailabilityProber(
-		kas.InClusterKASReadyURL(deployment.Namespace, apiPort),
+		kas.InClusterKASReadyURL(),
 		availabilityProberImage,
 		&deployment.Spec.Template.Spec,
 		func(o *util.AvailabilityProberOpts) {

--- a/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
@@ -104,7 +104,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 // hosted-cluster services, or external services, so the operator does not
 // require any special proxy configuration or permissions in the management
 // cluster.
-func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) {
+func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
 	dep.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{"name": "dns-operator"},
 	}
@@ -161,7 +161,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 		},
 	}}
 	util.AvailabilityProber(
-		kas.InClusterKASReadyURL(dep.Namespace, apiPort),
+		kas.InClusterKASReadyURL(),
 		params.AvailabilityProberImage,
 		&dep.Spec.Template.Spec,
 		func(o *util.AvailabilityProberOpts) {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -215,7 +215,7 @@ func TestBuildOAuthVolumeTemplates(t *testing.T) {
 
 func TestReconcileAPIServerService(t *testing.T) {
 	targetNamespace := "test"
-	apiPort := int32(1234)
+	apiPort := int32(config.KASSVCPort)
 	kasPort := "client"
 	hostname := "test.example.com"
 	allowCIDR := []hyperv1.CIDRBlock{"1.2.3.4/24"}
@@ -1055,7 +1055,7 @@ func TestReconcileRouter(t *testing.T) {
 	ingress.ReconcileRouterConfiguration(config.OwnerRefFrom(&hyperv1.HostedControlPlane{ObjectMeta: metav1.ObjectMeta{
 		Name:      "hcp",
 		Namespace: namespace,
-	}}), routerCfg, 6443, &routev1.RouteList{}, "172.30.0.10")
+	}}), routerCfg, &routev1.RouteList{}, "172.30.0.10")
 
 	testCases := []struct {
 		name                         string

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router_config.template
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router_config.template
@@ -43,5 +43,5 @@ backend {{ .Name }}
 {{ end -}}
 {{- if .HasKubeAPI }}
 backend kube_api
-  server kube_api kube-apiserver.{{ $ns }}.svc.cluster.local:{{ .KubeAPIPort }} check resolvers coredns init-addr last,libc,none
+  server kube_api kube-apiserver.{{ $ns }}.svc.cluster.local:{{ .KASSVCPort }} check resolvers coredns init-addr last,libc,none
 {{ end -}}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
@@ -61,7 +61,7 @@ func TestGenerateRouterConfig(t *testing.T) {
 		Items: []routev1.Route{*ignition, *konnectivity, *oauthInternal, *oauthExternalPrivate, *oauthExternalPublic, *ovnKube, *metricsForwarder, *kasPublic, *kasPrivate},
 	}
 
-	cfg, err := generateRouterConfig(testNS, 6443, routeList, "172.30.0.10")
+	cfg, err := generateRouterConfig(testNS, routeList, "172.30.0.10")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -96,7 +96,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	return p
 }
 
-func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) {
+func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
 	dep.Spec.Replicas = utilpointer.Int32(1)
 	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": operatorName}}
 	dep.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
@@ -203,7 +203,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, apiPort *int32) 
 	}
 
 	util.AvailabilityProber(
-		kas.InClusterKASReadyURL(dep.Namespace, apiPort),
+		kas.InClusterKASReadyURL(),
 		params.AvailabilityProberImage,
 		&dep.Spec.Template.Spec,
 		func(o *util.AvailabilityProberOpts) {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -117,7 +117,7 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 						KeyFile:  path.Join(volumeMounts.Path(kasContainerMain().Name, kasVolumeServerCert().Name), corev1.TLSPrivateKeyKey),
 					},
 					NamedCertificates: globalconfig.GetConfigNamedCertificates(p.NamedCertificates, kasNamedCertificateMountPathPrefix),
-					BindAddress:       fmt.Sprintf("0.0.0.0:%d", p.APIServerPort),
+					BindAddress:       fmt.Sprintf("0.0.0.0:%d", p.KASPodPort),
 					BindNetwork:       "tcp4",
 					CipherSuites:      hcpconfig.CipherSuites(p.TLSSecurityProfile),
 					MinTLSVersion:     hcpconfig.MinTLSVersion(p.TLSSecurityProfile),

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -51,11 +51,8 @@ type KubeAPIServerParams struct {
 	// This is used to build kas urls for generated internal kubeconfigs for example.
 	ExternalPort    int32  `json:"externalPort"`
 	InternalAddress string `json:"internalAddress"`
-	// InternalPort is the port that was used to expose the KAS SVC.
-	// This is used to build kas urls for generated external kubeconfigs for example.
-	InternalPort int32 `json:"internalPort"`
-	// APIServerPort is port to expose the KAS Pod.
-	APIServerPort        int32                        `json:"apiServerPort"`
+	// KASPodPort is the port to expose in the KAS Pod.
+	KASPodPort           int32                        `json:"apiServerPort"`
 	ExternalOAuthAddress string                       `json:"externalOAuthAddress"`
 	ExternalOAuthPort    int32                        `json:"externalOAuthPort"`
 	OIDCCAConfigMap      *corev1.LocalObjectReference `json:"oidcCAConfigMap"`
@@ -74,8 +71,6 @@ type KubeAPIServerParams struct {
 }
 
 type KubeAPIServerServiceParams struct {
-	// APIServerPort is the port used for the SVC.
-	APIServerPort     int
 	AllowedCIDRBlocks []string
 	OwnerReference    *metav1.OwnerReference
 }
@@ -93,7 +88,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		ExternalAddress:      externalAPIAddress,
 		ExternalPort:         externalAPIPort,
 		InternalAddress:      fmt.Sprintf("api.%s.hypershift.local", hcp.Name),
-		InternalPort:         util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort),
 		ExternalOAuthAddress: externalOAuthAddress,
 		ExternalOAuthPort:    externalOAuthPort,
 		ServiceAccountIssuer: hcp.Spec.IssuerURL,
@@ -124,7 +118,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 
 	params.AdvertiseAddress = util.GetAdvertiseAddress(hcp, config.DefaultAdvertiseIPv4Address, config.DefaultAdvertiseIPv6Address)
 
-	params.APIServerPort = util.BindAPIPortWithDefault(hcp)
+	params.KASPodPort = util.KASPodPort(hcp)
 	if _, ok := hcp.Annotations[hyperv1.PortierisImageAnnotation]; ok {
 		params.Images.Portieris = hcp.Annotations[hyperv1.PortierisImageAnnotation]
 	}
@@ -425,7 +419,7 @@ func (p *KubeAPIServerParams) ConfigParams() KubeAPIServerConfigParams {
 		ClusterNetwork:               p.ClusterNetwork(),
 		ServiceNetwork:               p.ServiceNetwork(),
 		NamedCertificates:            p.NamedCertificates(),
-		APIServerPort:                p.APIServerPort,
+		KASPodPort:                   p.KASPodPort,
 		TLSSecurityProfile:           p.TLSSecurityProfile(),
 		AdditionalCORSAllowedOrigins: p.AdditionalCORSAllowedOrigins(),
 		InternalRegistryHostName:     p.InternalRegistryHostName(),
@@ -451,7 +445,7 @@ type KubeAPIServerConfigParams struct {
 	ClusterNetwork               []string
 	ServiceNetwork               []string
 	NamedCertificates            []configv1.APIServerNamedServingCert
-	APIServerPort                int32
+	KASPodPort                   int32
 	TLSSecurityProfile           *configv1.TLSSecurityProfile
 	AdditionalCORSAllowedOrigins []string
 	InternalRegistryHostName     string
@@ -535,13 +529,11 @@ func (p *KubeAPIServerParams) ServiceNodePortRange() string {
 }
 
 func NewKubeAPIServerServiceParams(hcp *hyperv1.HostedControlPlane) *KubeAPIServerServiceParams {
-	port := util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort)
 	var allowedCIDRBlocks []string
 	for _, block := range util.AllowedCIDRBlocks(hcp) {
 		allowedCIDRBlocks = append(allowedCIDRBlocks, string(block))
 	}
 	return &KubeAPIServerServiceParams{
-		APIServerPort:     int(port),
 		AllowedCIDRBlocks: allowedCIDRBlocks,
 		OwnerReference:    config.ControllerOwnerRef(hcp),
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
@@ -29,14 +29,14 @@ func TestNewAPIServerParamsAPIAdvertiseAddressAndPort(t *testing.T) {
 			name:               "not specified",
 			expectedAddress:    config.DefaultAdvertiseIPv4Address,
 			serviceNetworkCIDR: "10.0.0.0/24",
-			expectedPort:       config.DefaultAPIServerPort,
+			expectedPort:       config.KASPodDefaultPort,
 		},
 		{
 			name:               "address specified",
 			advertiseAddress:   "1.2.3.4",
 			serviceNetworkCIDR: "10.0.0.0/24",
 			expectedAddress:    "1.2.3.4",
-			expectedPort:       config.DefaultAPIServerPort,
+			expectedPort:       config.KASPodDefaultPort,
 		},
 		{
 			name:               "port set for default service publishing strategies",
@@ -72,7 +72,7 @@ func TestNewAPIServerParamsAPIAdvertiseAddressAndPort(t *testing.T) {
 			if len(test.advertiseAddress) > 0 {
 				g.Expect(test.advertiseAddress).To(Equal(test.expectedAddress))
 			}
-			g.Expect(p.APIServerPort).To(Equal(test.expectedPort))
+			g.Expect(p.KASPodPort).To(Equal(test.expectedPort))
 		})
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -38,6 +38,8 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 	} else {
 		svc.Spec.Ports = []corev1.ServicePort{portSpec}
 	}
+
+	// TODO (alberto): if this port ever need to be configurable it should come from new field in the LB publishing strategy.
 	portSpec.Port = int32(apiServerServicePort)
 	portSpec.Protocol = corev1.ProtocolTCP
 	portSpec.TargetPort = intstr.FromString("client")
@@ -73,6 +75,38 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 		return fmt.Errorf("invalid publishing strategy for Kube API server service: %s", strategy.Type)
 	}
 	svc.Spec.LoadBalancerSourceRanges = apiAllowedCIDRBlocks
+	svc.Spec.Ports[0] = portSpec
+	return nil
+}
+
+func ReconcileServiceClusterIP(svc *corev1.Service, owner *metav1.OwnerReference) error {
+	util.EnsureOwnerRef(svc, owner)
+	if svc.Spec.Selector == nil {
+		svc.Spec.Selector = kasLabels()
+	}
+	// Ensure labels propagate to endpoints so service
+	// monitors can select them
+	if svc.Labels == nil {
+		svc.Labels = map[string]string{}
+	}
+	for k, v := range kasLabels() {
+		svc.Labels[k] = v
+	}
+
+	var portSpec corev1.ServicePort
+	if len(svc.Spec.Ports) > 0 {
+		portSpec = svc.Spec.Ports[0]
+	} else {
+		svc.Spec.Ports = []corev1.ServicePort{portSpec}
+	}
+
+	portSpec.Port = int32(config.KASSVCPort)
+	portSpec.Protocol = corev1.ProtocolTCP
+	portSpec.TargetPort = intstr.FromString("client")
+	if svc.Annotations == nil {
+		svc.Annotations = map[string]string{}
+	}
+	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.Ports[0] = portSpec
 	return nil
 }
@@ -116,7 +150,6 @@ func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublis
 }
 
 func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlane, owner *metav1.OwnerReference) error {
-	apiServerPort := util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort)
 	util.EnsureOwnerRef(svc, owner)
 	svc.Spec.Selector = kasLabels()
 	var portSpec corev1.ServicePort
@@ -125,7 +158,8 @@ func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlan
 	} else {
 		svc.Spec.Ports = []corev1.ServicePort{portSpec}
 	}
-	portSpec.Port = int32(apiServerPort)
+
+	portSpec.Port = int32(config.KASSVCPort)
 	portSpec.Protocol = corev1.ProtocolTCP
 	portSpec.TargetPort = intstr.FromString("client")
 	svc.Spec.Type = corev1.ServiceTypeLoadBalancer
@@ -138,10 +172,6 @@ func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlan
 	svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
 	svc.Spec.Ports[0] = portSpec
 	return nil
-}
-
-func ReconcilePrivateServiceStatus(hcp *hyperv1.HostedControlPlane) (host string, port int32, err error) {
-	return fmt.Sprintf("api.%s.hypershift.local", hcp.Name), util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort), nil
 }
 
 func ReconcileExternalPublicRoute(route *routev1.Route, owner *metav1.OwnerReference, hostname string) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -64,7 +64,7 @@ func kcmLabels() map[string]string {
 	}
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceServingCA *corev1.ConfigMap, p *KubeControllerManagerParams, apiPort *int32) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceServingCA *corev1.ConfigMap, p *KubeControllerManagerParams) error {
 	// preserve existing resource requirements for main KCM container
 	mainContainer := util.FindContainer(kcmContainerMain().Name, deployment.Spec.Template.Spec.Containers)
 	if mainContainer != nil {
@@ -128,7 +128,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceS
 	applyCloudConfigVolumeMount(&deployment.Spec.Template.Spec, p.CloudProviderConfig, p.CloudProvider)
 	util.ApplyCloudProviderCreds(&deployment.Spec.Template.Spec, p.CloudProvider, p.CloudProviderCreds, p.TokenMinterImage, kcmContainerMain().Name)
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), p.AvailabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), p.AvailabilityProberImage, &deployment.Spec.Template.Spec)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
@@ -199,7 +199,7 @@ func ReconcileMachineApproverDeployment(deployment *appsv1.Deployment, hcp *hype
 		},
 	}
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, util.APIPort(hcp)), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
 
 	deploymentConfig := config.DeploymentConfig{
 		Scheduling: config.Scheduling{

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/infra.go
@@ -24,6 +24,15 @@ const (
 	packageServerServiceName                = "packageserver"
 )
 
+func KubeAPIServerServiceAzureLB(hostedClusterNamespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KubeAPIServerServiceName + "lb",
+			Namespace: hostedClusterNamespace,
+		},
+	}
+}
+
 func KubeAPIServerService(hostedClusterNamespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -76,7 +76,7 @@ func openShiftAPIServerLabels() map[string]string {
 	}
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, auditWebhookRef *corev1.LocalObjectReference, ownerRef config.OwnerRef, config *corev1.ConfigMap, auditConfig *corev1.ConfigMap, serviceServingCA *corev1.ConfigMap, deploymentConfig config.DeploymentConfig, image string, socks5ProxyImage string, etcdURL string, availabilityProberImage string, apiPort *int32) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, auditWebhookRef *corev1.LocalObjectReference, ownerRef config.OwnerRef, config *corev1.ConfigMap, auditConfig *corev1.ConfigMap, serviceServingCA *corev1.ConfigMap, deploymentConfig config.DeploymentConfig, image string, socks5ProxyImage string, etcdURL string, availabilityProberImage string) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main OAS container
@@ -187,7 +187,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, auditWebhookRef *corev1.
 		applyOASAuditWebhookConfigFileVolume(&deployment.Spec.Template.Spec, auditWebhookRef)
 	}
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
 
 	deploymentConfig.ApplyTo(deployment)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -54,7 +54,7 @@ func openShiftOAuthAPIServerLabels() map[string]string {
 	}
 }
 
-func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, auditConfig *corev1.ConfigMap, p *OAuthDeploymentParams, apiPort *int32) error {
+func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, auditConfig *corev1.ConfigMap, p *OAuthDeploymentParams) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main oauth apiserver container
@@ -132,7 +132,7 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 		applyOauthAuditWebhookConfigFileVolume(&deployment.Spec.Template.Spec, p.AuditWebhookRef)
 	}
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), p.AvailabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), p.AvailabilityProberImage, &deployment.Spec.Template.Spec)
 	p.DeploymentConfig.ApplyTo(deployment)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -52,7 +52,7 @@ func oauthLabels() map[string]string {
 	}
 }
 
-func ReconcileDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment, ownerRef config.OwnerRef, config *corev1.ConfigMap, image string, deploymentConfig config.DeploymentConfig, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, availabilityProberImage string, apiPort *int32, namedCertificates []configv1.APIServerNamedServingCert, socks5ProxyImage string, noProxy []string, params *OAuthConfigParams) error {
+func ReconcileDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment, ownerRef config.OwnerRef, config *corev1.ConfigMap, image string, deploymentConfig config.DeploymentConfig, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, availabilityProberImage string, namedCertificates []configv1.APIServerNamedServingCert, socks5ProxyImage string, noProxy []string, params *OAuthConfigParams) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main oauth container
@@ -124,7 +124,7 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMountInfo.VolumeMounts.ContainerMounts(oauthContainerMain().Name)...)
 	}
 	globalconfig.ApplyNamedCertificateMounts(oauthContainerMain().Name, oauthNamedCertificateMountPathPrefix, namedCertificates, &deployment.Spec.Template.Spec)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -46,7 +46,7 @@ func ReconcileCatalogOperatorMetricsService(svc *corev1.Service, ownerRef config
 	return nil
 }
 
-func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, operatorRegistryImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, apiPort *int32, noProxy []string) error {
+func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, operatorRegistryImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = catalogOperatorDeployment.DeepCopy().Spec
 	for i, container := range deployment.Spec.Template.Spec.Containers {
@@ -75,7 +75,7 @@ func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef 
 		}
 	}
 	dc.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},
@@ -99,7 +99,7 @@ func ReconcileOLMOperatorMetricsService(svc *corev1.Service, ownerRef config.Own
 	return nil
 }
 
-func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, apiPort *int32, noProxy []string) error {
+func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = olmOperatorDeployment.DeepCopy().Spec
 	for i, container := range deployment.Spec.Template.Spec.Containers {
@@ -124,7 +124,7 @@ func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef conf
 		}
 	}
 	dc.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
@@ -18,7 +18,7 @@ var (
 	packageServerDeployment = assets.MustDeployment(content.ReadFile, "assets/packageserver-deployment.yaml")
 )
 
-func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, apiPort *int32, noProxy []string) error {
+func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string) error {
 	ownerRef.ApplyTo(deployment)
 	deployment.Spec = packageServerDeployment.DeepCopy().Spec
 	for i, container := range deployment.Spec.Template.Spec.Containers {
@@ -43,7 +43,7 @@ func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef co
 		}
 	}
 	dc.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -94,7 +94,7 @@ func ReconcileServiceAccountKubeconfig(secret, csrSigner *corev1.Secret, ca *cor
 	if err := reconcileSignedCert(secret, csrSigner, config.OwnerRef{}, cn, serviceaccount.MakeGroupNames(serviceAccountNamespace), X509UsageClientAuth); err != nil {
 		return fmt.Errorf("failed to reconcile serviceaccount client cert: %w", err)
 	}
-	svcURL := inClusterKASURL(hcp.Namespace, util.InternalAPIPortWithDefault(hcp, config.DefaultAPIServerPort))
+	svcURL := inClusterKASURL()
 
 	return ReconcileKubeConfig(secret, secret, ca, svcURL, "", manifests.KubeconfigScopeLocal, config.OwnerRef{})
 }
@@ -153,8 +153,8 @@ func generateKubeConfig(url string, crtBytes, keyBytes, caBytes []byte) ([]byte,
 	return clientcmd.Write(kubeCfg)
 }
 
-func inClusterKASURL(namespace string, apiServerPort int32) string {
-	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, apiServerPort)
+func inClusterKASURL() string {
+	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, config.KASSVCPort)
 }
 
 // addBracketsIfIPv6 function is needed to build the serverAPI url for every kubeconfig created.

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -47,7 +47,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, featureGates []string, policy configv1.ConfigMapNameReference, availabilityProberImage string, apiPort *int32, ciphers []string, tlsVersion string, disableProfiling bool, schedulerConfig *corev1.ConfigMap) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, featureGates []string, policy configv1.ConfigMapNameReference, availabilityProberImage string, ciphers []string, tlsVersion string, disableProfiling bool, schedulerConfig *corev1.ConfigMap) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main scheduler container
@@ -94,7 +94,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		},
 	}
 	config.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, apiPort), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator.go
@@ -45,7 +45,7 @@ func ReconcileOperatorDeployment(
 		}
 	}
 	params.DeploymentConfig.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, params.APIPort), params.AvailabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), params.AvailabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "guest-kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operator.openshift.io", Version: "v1", Kind: "CSISnapshotController"},

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/params.go
@@ -21,7 +21,6 @@ type Params struct {
 	SnapshotWebhookImage            string
 	AvailabilityProberImage         string
 	Version                         string
-	APIPort                         *int32
 	config.DeploymentConfig
 }
 
@@ -38,7 +37,6 @@ func NewParams(
 		SnapshotWebhookImage:            releaseImageProvider.GetImage(snapshotWebhookImageName),
 		AvailabilityProberImage:         releaseImageProvider.GetImage(util.AvailabilityProberImageName),
 		Version:                         version,
-		APIPort:                         util.APIPort(hcp),
 	}
 
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
@@ -33,7 +33,7 @@ func ReconcileOperatorDeployment(
 	}
 
 	params.DeploymentConfig.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(deployment.Namespace, params.APIPort), params.AvailabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), params.AvailabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "guest-kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operator.openshift.io", Version: "v1", Kind: "Storage"},

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
@@ -18,7 +18,6 @@ type Params struct {
 	ImageReplacer        *environmentReplacer
 
 	AvailabilityProberImage string
-	APIPort                 *int32
 	config.DeploymentConfig
 }
 
@@ -38,7 +37,6 @@ func NewParams(
 		StorageOperatorImage:    releaseImageProvider.GetImage(storageOperatorImageName),
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
 		ImageReplacer:           ir,
-		APIPort:                 util.APIPort(hcp),
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
 		AdditionalLabels: map[string]string{

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -989,10 +989,6 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	if err := r.defaultAPIPortIfNeeded(ctx, hcluster); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to default the apiserver port: %w", err)
-	}
-
 	// Set the infraID as Tag on all created AWS
 	if err := r.reconcileAWSResourceTags(ctx, hcluster); err != nil {
 		return ctrl.Result{}, err
@@ -4430,36 +4426,6 @@ func isUpgrading(hcluster *hyperv1.HostedCluster, releaseImage *releaseinfo.Rele
 	// Upgradeable is false and no exception criteria were met, cluster is not upgradable
 	return true, "", fmt.Errorf("cluster version is not upgradeable")
 
-}
-
-// defaultAPIPortIfNeeded defaults the apiserver port on Azure management clusters as a workaround
-// for https://bugzilla.redhat.com/show_bug.cgi?id=2060650: Azure LBs with port 6443 don't work
-func (r *HostedClusterReconciler) defaultAPIPortIfNeeded(ctx context.Context, hcluster *hyperv1.HostedCluster) error {
-	if hcluster.Spec.Networking.APIServer != nil && hcluster.Spec.Networking.APIServer.Port != nil {
-		return nil
-	}
-
-	if !r.ManagementClusterCapabilities.Has(capabilities.CapabilityInfrastructure) {
-		return nil
-	}
-	infra := &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(infra), infra); err != nil {
-		return fmt.Errorf("failed to retrieve infra: %w", err)
-	}
-
-	if infra.Spec.PlatformSpec.Type != configv1.AzurePlatformType {
-		return nil
-	}
-	if hcluster.Spec.Networking.APIServer == nil {
-		hcluster.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{}
-	}
-
-	hcluster.Spec.Networking.APIServer.Port = k8sutilspointer.Int32(7443)
-	if err := r.Update(ctx, hcluster); err != nil {
-		return fmt.Errorf("failed to update hostedcluster after defaulting the apiserver port: %w", err)
-	}
-
-	return nil
 }
 
 func (r *HostedClusterReconciler) defaultIngressDomain(ctx context.Context) (string, error) {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -230,7 +230,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 			},
 		},
 	}
-	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Namespace, util.APIPort(hcp)), p.utilitiesImage, &deploymentSpec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(), p.utilitiesImage, &deploymentSpec.Template.Spec)
 	return deploymentSpec, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/upsert"
-	hyperutil "github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,7 +147,7 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 }
 
 func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster, isOpenShiftDNS bool, managementClusterNetwork *configv1.Network) error {
-	port := intstr.FromInt(int(hyperutil.BindAPIPortWithDefaultFromHostedCluster(hcluster, config.DefaultAPIServerPort)))
+	port := intstr.FromInt32(config.KASSVCPort)
 	protocol := corev1.ProtocolTCP
 	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
 	policy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -114,7 +114,7 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 
 	// TODO (alberto): Technically this should call util.BindAPIPortWithDefaultFromHostedCluster and let 443 be an invalid value.
 	// How ever we allow it here to keep backward compatibility with existing clusters which defaulted .port to 443.
-	apiServerInternalPort := haproxyFrontendListenAddress(hcluster, config.DefaultAPIServerPort)
+	apiServerInternalPort := haproxyFrontendListenAddress(hcluster)
 	if hcluster.Spec.Networking.APIServer != nil {
 		if hcluster.Spec.Networking.APIServer.AdvertiseAddress != nil {
 			apiServerInternalAddress = *hcluster.Spec.Networking.APIServer.AdvertiseAddress
@@ -143,12 +143,13 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 	return buf.String(), false, nil
 }
 
-// TODO: this function can be removed when proper update to service Publish API for load balancer done
-func haproxyFrontendListenAddress(hc *hyperv1.HostedCluster, defaultValue int32) int32 {
+// TODO (alberto): Technically anything should be calling util.BindAPIPortWithDefaultFromHostedCluster and let 443 be an invalid value.
+// How ever we allow it here to keep backward compatibility with existing clusters which defaulted .port to 443.
+func haproxyFrontendListenAddress(hc *hyperv1.HostedCluster) int32 {
 	if hc.Spec.Networking.APIServer != nil && hc.Spec.Networking.APIServer.Port != nil {
 		return *hc.Spec.Networking.APIServer.Port
 	}
-	return defaultValue
+	return config.KASPodDefaultPort
 }
 
 func urlPort(u *url.URL) (int32, error) {

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -22,14 +22,19 @@ const (
 	DefaultAdvertiseIPv4Address  = "172.20.0.1"
 	DefaultAdvertiseIPv6Address  = "fd00::1"
 	DefaultEtcdURL               = "https://etcd-client:2379"
-	DefaultAPIServerPort         = 6443
-	DefaultServiceNodePortRange  = "30000-32767"
-	DefaultSecurityContextUser   = 1001
-	RecommendedLeaseDuration     = "137s"
-	RecommendedRenewDeadline     = "107s"
-	RecommendedRetryPeriod       = "26s"
-	KCMRecommendedRenewDeadline  = "12s"
-	KCMRecommendedRetryPeriod    = "3s"
+	// KASSVCLBAzurePort is needed because for Azure we currently hardcode 7443 for the SVC LB as 6443 collides with public LB rule for the management cluster.
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2060650
+	// TODO(alberto): explore exposing multiple Azure frontend IPs on the load balancer.
+	KASSVCLBAzurePort           = 7443
+	KASSVCPort                  = 6443
+	KASPodDefaultPort           = 6443
+	DefaultServiceNodePortRange = "30000-32767"
+	DefaultSecurityContextUser  = 1001
+	RecommendedLeaseDuration    = "137s"
+	RecommendedRenewDeadline    = "107s"
+	RecommendedRetryPeriod      = "26s"
+	KCMRecommendedRenewDeadline = "12s"
+	KCMRecommendedRetryPeriod   = "3s"
 
 	DefaultIngressDomainEnvVar = "DEFAULT_INGRESS_DOMAIN"
 )

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -52,16 +52,9 @@ func FirstClusterCIDR(clusterNetwork []hyperv1.ClusterNetworkEntry) string {
 	return ""
 }
 
-func APIPort(hcp *hyperv1.HostedControlPlane) *int32 {
-	if hcp != nil && hcp.Spec.Networking.APIServer != nil {
-		return hcp.Spec.Networking.APIServer.Port
-	}
-	return nil
-}
-
-// BindAPIPortWithDefault will retrieve the port the kube-apiserver binds on locally in the pod.
-// This comes from hcp.Spec.Networking.APIServer.Port if set and != 443
-func BindAPIPortWithDefault(hcp *hyperv1.HostedControlPlane) int32 {
+// KASPodPort will retrieve the port the kube-apiserver binds on locally in the pod.
+// This comes from hcp.Spec.Networking.APIServer.Port if set and != 443 or defaults to 6443.
+func KASPodPort(hcp *hyperv1.HostedControlPlane) int32 {
 	// Binding on 443 is not allowed. So returning default for that case.
 	// This provides backward compatibility for existing clusters which were defaulting to that value, ignoring it here and
 	// enforcing it in the data plane proxy by reconciling the endpoint. 443 API input is not allowed now.
@@ -72,9 +65,9 @@ func BindAPIPortWithDefault(hcp *hyperv1.HostedControlPlane) int32 {
 	return 6443
 }
 
-// BindAPIPortWithDefaultFromHostedCluster will retrieve the port the kube-apiserver binds on locally in the pod.
-// This comes from hcp.Spec.Networking.APIServer.Port if set and != 443
-func BindAPIPortWithDefaultFromHostedCluster(hc *hyperv1.HostedCluster, defaultValue int32) int32 {
+// KASPodPortFromHostedCluster will retrieve the port the kube-apiserver binds on locally in the pod.
+// This comes from hcp.Spec.Networking.APIServer.Port if set and != 443 or defaults to 6443.
+func KASPodPortFromHostedCluster(hc *hyperv1.HostedCluster) int32 {
 	// Binding on 443 is not allowed. So returning default for that case.
 	// This provides backward compatibility for existing clusters which were defaulting to that value, ignoring it here and
 	// enforcing it in the data plane proxy by reconciling the endpoint. 443 API input is not allowed now.
@@ -82,18 +75,7 @@ func BindAPIPortWithDefaultFromHostedCluster(hc *hyperv1.HostedCluster, defaultV
 	if hc.Spec.Networking.APIServer != nil && hc.Spec.Networking.APIServer.Port != nil && *hc.Spec.Networking.APIServer.Port != 443 {
 		return *hc.Spec.Networking.APIServer.Port
 	}
-	return defaultValue
-}
-
-// InternalAPIPortWithDefault will retrieve the port to use to contact the APIServer over the Kubernetes service domain
-// kube-apiserver.NAMESPACE.svc.cluster.local:INTERNAL_API_PORT
-func InternalAPIPortWithDefault(hcp *hyperv1.HostedControlPlane, defaultValue int32) int32 {
-	// TODO (alberto): Why is the exposed port for the SVC coming from .Spec.Networking.APIServer.Port?
-	// The API input is meant to be just the KAS Pod Port (and so the nodes haproxy).
-	if port := APIPort(hcp); port != nil {
-		return *port
-	}
-	return defaultValue
+	return 6443
 }
 
 func AdvertiseAddress(hcp *hyperv1.HostedControlPlane) *string {


### PR DESCRIPTION
**What this PR does / why we need it**:
The kas SVC port is an impl detail. Before this change their value was wrongly conflated with the spec.metworking.apiServer.port input.
If we ever require the dedicated KAS LB port to be a choice, that would be input in the LB publishing strategy.

Goes after https://github.com/openshift/hypershift/pull/3185

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.