### PR TITLE
CNV-23418: unsupported escape hatch mechanism custom HS/KV vms

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -224,8 +224,11 @@ const (
 	// See https://github.com/openshift/enhancements/blob/master/enhancements/authentication/pod-security-admission.md
 	PodSecurityAdmissionLabelOverrideAnnotation = "hypershift.openshift.io/pod-security-admission-label-override"
 
-	//DisableMonitoringServices introduces introduces an option to disable monitor services IBM Cloud do not use.
+	//DisableMonitoringServices introduces an option to disable monitor services IBM Cloud do not use.
 	DisableMonitoringServices = "hypershift.openshift.io/disable-monitoring-services"
+
+	// JSONPatchAnnotation allow modifying the kubevirt VM template using jsonpatch
+	JSONPatchAnnotation = "hypershift.openshift.io/kubevirt-vm-jsonpatch"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/clarketm/json v1.14.1
 	github.com/coreos/ignition/v2 v2.14.0
 	github.com/docker/distribution v2.8.2+incompatible
+	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/zapr v1.2.4
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
@@ -110,7 +111,6 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
-	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -1,16 +1,18 @@
 package kubevirt
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 
-	"k8s.io/utils/pointer"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	corev1 "k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -142,7 +144,6 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 
 	dvSource := bootImage.getDVSourceForVMTemplate()
 
-	runAlways := kubevirtv1.RunStrategyAlways
 	kvPlatform := nodePool.Spec.Platform.Kubevirt
 
 	if kvPlatform.Compute != nil {
@@ -159,7 +160,7 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 
 	template := &capikubevirt.VirtualMachineTemplateSpec{
 		Spec: kubevirtv1.VirtualMachineSpec{
-			RunStrategy: &runAlways,
+			RunStrategy: ptr.To(kubevirtv1.RunStrategyAlways),
 			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -273,13 +274,13 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 
 	if kvPlatform.NetworkInterfaceMultiQueue != nil &&
 		*nodePool.Spec.Platform.Kubevirt.NetworkInterfaceMultiQueue == hyperv1.MultiQueueEnable {
-		template.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.Bool(true)
+		template.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue = ptr.To(true)
 	}
 
 	return template
 }
 
-func MachineTemplateSpec(nodePool *hyperv1.NodePool, bootImage BootImage, hcluster *hyperv1.HostedCluster) *capikubevirt.KubevirtMachineTemplateSpec {
+func MachineTemplateSpec(nodePool *hyperv1.NodePool, bootImage BootImage, hcluster *hyperv1.HostedCluster) (*capikubevirt.KubevirtMachineTemplateSpec, error) {
 	vmTemplate := virtualMachineTemplateBase(nodePool, bootImage)
 
 	vmTemplate.Spec.Template.Spec.Affinity = &corev1.Affinity{
@@ -330,6 +331,10 @@ func MachineTemplateSpec(nodePool *hyperv1.NodePool, bootImage BootImage, hclust
 		vmTemplate.ObjectMeta.Namespace = hcluster.Spec.Platform.Kubevirt.Credentials.InfraNamespace
 	}
 
+	if err := applyJsonPatches(nodePool, hcluster, vmTemplate); err != nil {
+		return nil, err
+	}
+
 	return &capikubevirt.KubevirtMachineTemplateSpec{
 		Template: capikubevirt.KubevirtMachineTemplateResource{
 			Spec: capikubevirt.KubevirtMachineSpec{
@@ -337,5 +342,61 @@ func MachineTemplateSpec(nodePool *hyperv1.NodePool, bootImage BootImage, hclust
 				BootstrapCheckSpec:     capikubevirt.VirtualMachineBootstrapCheckSpec{CheckStrategy: "none"},
 			},
 		},
+	}, nil
+}
+
+func applyJsonPatches(nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, tmplt *capikubevirt.VirtualMachineTemplateSpec) error {
+	hcAnn, hcOK := hcluster.Annotations[hyperv1.JSONPatchAnnotation]
+	npAnn, npOK := nodePool.Annotations[hyperv1.JSONPatchAnnotation]
+
+	if !hcOK && !npOK { // nothing to do
+		return nil
 	}
+
+	//tmplt.Spec.Template.Spec.Networks[0].Multus.NetworkName
+	buff := &bytes.Buffer{}
+	dec := json.NewEncoder(buff)
+	err := dec.Encode(tmplt.Spec.Template)
+	if err != nil {
+		return fmt.Errorf("json: failed to encode the vm template: %w", err)
+	}
+
+	templateBytes := buff.Bytes()
+
+	if hcOK {
+		if err = applyJsonPatch(&templateBytes, hcAnn); err != nil {
+			return err
+		}
+	}
+
+	if npOK {
+		if err = applyJsonPatch(&templateBytes, npAnn); err != nil {
+			return err
+		}
+	}
+
+	buff = bytes.NewBuffer(templateBytes)
+	enc := json.NewDecoder(buff)
+
+	if err = enc.Decode(tmplt.Spec.Template); err != nil {
+		return fmt.Errorf("json: failed to decode the vm template: %w", err)
+	}
+
+	return nil
+}
+
+func applyJsonPatch(tmplt *[]byte, patch string) error {
+	patches, err := jsonpatch.DecodePatch([]byte(patch))
+	if err != nil {
+		return fmt.Errorf("failed to parse the %s annotation; wrong jsonpatch format: %w", hyperv1.JSONPatchAnnotation, err)
+	}
+
+	opts := jsonpatch.NewApplyOptions()
+	opts.EnsurePathExistsOnAdd = true
+	*tmplt, err = patches.ApplyWithOptions(*tmplt, opts)
+	if err != nil {
+		return fmt.Errorf("failed to apply json patch annotation: %w", err)
+	}
+
+	return nil
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2488,7 +2488,11 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 		}
 	case hyperv1.KubevirtPlatform:
 		template = &capikubevirt.KubevirtMachineTemplate{}
-		machineTemplateSpec = kubevirt.MachineTemplateSpec(nodePool, kubevirtBootImage, hcluster)
+		var err error
+		machineTemplateSpec, err = kubevirt.MachineTemplateSpec(nodePool, kubevirtBootImage, hcluster)
+		if err != nil {
+			return nil, nil, "", err
+		}
 		mutateTemplate = func(object client.Object) error {
 			o, _ := object.(*capikubevirt.KubevirtMachineTemplate)
 			o.Spec = *machineTemplateSpec.(*capikubevirt.KubevirtMachineTemplateSpec)

--- a/test/e2e/nodepool_kv_cache_image_test.go
+++ b/test/e2e/nodepool_kv_cache_image_test.go
@@ -5,20 +5,19 @@ package e2e
 
 import (
 	"context"
+	"k8s.io/utils/ptr"
 	"testing"
 	"time"
 
-	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"sigs.k8s.io/cluster-api/util"
-
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
 )
 
@@ -94,7 +93,7 @@ func (k KubeVirtCacheTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePoo
 		}
 	}
 
-	nodePool.Spec.Replicas = pointer.Int32(1)
+	nodePool.Spec.Replicas = ptr.To(int32(1))
 
 	return nodePool, nil
 }

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -104,6 +104,10 @@ func TestNodePool(t *testing.T) {
 				name: "KubeVirtQoSClassGuaranteedTest",
 				test: NewKubeVirtQoSClassGuaranteedTest(ctx, mgtClient, hostedCluster),
 			},
+			{
+				name: "KubeKubeVirtJsonPatchTest",
+				test: NewKubeKubeVirtJsonPatchTest(ctx, mgtClient, hostedCluster),
+			},
 		}
 
 		for _, testCase := range nodePoolTests {


### PR DESCRIPTION
Suport the new HostedCluster/NodePool annotation
"hypershift.openshift.io/kubevirt-vm-jsonpatch", to modify the KubeVirt VM template using jsonpatch string.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.