### PR TITLE
CNV-29003: Re-enable NodePoolUpgradeTest for KubeVirt (Replace Only)

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -46,7 +46,7 @@ func TestNodePool(t *testing.T) {
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		hostedClusterClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
 
-		// Get the newly created defautlt NodePool
+		// Get the newly created default NodePool
 		nodepools := &hyperv1.NodePoolList{}
 		if err := mgtClient.List(ctx, nodepools, crclient.InNamespace(hostedCluster.Namespace)); err != nil {
 			t.Fatalf("failed to list nodepools in namespace %s: %v", hostedCluster.Namespace, err)
@@ -134,11 +134,11 @@ func nodePoolScaleDownToZero(ctx context.Context, client crclient.Client, nodePo
 // The situation should not happen in CI but it's useful in local testing.
 func nodePoolRecreate(t *testing.T, ctx context.Context, nodePool *hyperv1.NodePool, mgmtClient crclient.Client) error {
 	g := NewWithT(t)
-	existantNodePool := &hyperv1.NodePool{}
-	err := mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(nodePool), existantNodePool)
-	g.Expect(err).NotTo(HaveOccurred(), "failed getting existant nodepool")
-	err = mgmtClient.Delete(ctx, existantNodePool)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to Delete the existant NodePool")
+	existingNodePool := &hyperv1.NodePool{}
+	err := mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(nodePool), existingNodePool)
+	g.Expect(err).NotTo(HaveOccurred(), "failed getting existent nodepool")
+	err = mgmtClient.Delete(ctx, existingNodePool)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to Delete the existent NodePool")
 	t.Logf("waiting for NodePools to be recreated")
 	err = wait.PollImmediateWithContext(ctx, 10*time.Second, 15*time.Minute, func(ctx context.Context) (bool, error) {
 		if ctx.Err() != nil {

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-
 	"io"
 	"os"
 	"testing"
@@ -97,14 +96,13 @@ func NewNodePoolUpgradeTest(ctx context.Context, mgmtClient crclient.Client, hos
 }
 
 func (ru *NodePoolUpgradeTest) Setup(t *testing.T) {
-
-	// TODO re-enable this for KubeVirt platform once the new KubeVirt rhcos
-	// image is available in a previous release. Right now we can't test updating
-	// because the KubeVirt rhcos variant is only in latest.
-	// Tracking this here, https://issues.redhat.com/browse/CNV-29003
-	if globalOpts.Platform == hyperv1.KubevirtPlatform {
-		t.Skip("test can't run for the platform KubeVirt")
+	// Currently, only ReplaceUpgrade strategy test passes for the kubevirt platform.
+	// TODO: Enable InPlace upgrade test as well once the issue is identified and fixed.
+	if globalOpts.Platform == hyperv1.KubevirtPlatform && t.Name() == "TestNodePool/Main/TestNodePoolInPlaceUpgrade" {
+		t.Skip("InPlace Upgrade test currently can't run for the KubeVirt platform")
 	}
+
+	t.Log("starting test NodePoolUpgradeTest")
 }
 
 func (ru *NodePoolUpgradeTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -65,7 +65,7 @@ func (h *hypershiftTest) Execute(opts *core.CreateOptions, platform hyperv1.Plat
 		h.postTeardown(hostedCluster, opts)
 	}()
 
-	// fail safe to gurantee teardown() is always executed.
+	// fail safe to guarantee teardown() is always executed.
 	// defer funcs will be skipped if any subtest panics
 	h.Cleanup(func() { h.teardown(hostedCluster, opts, artifactDir, true) })
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -371,7 +371,7 @@ func WaitForNodePoolVersion(t *testing.T, ctx context.Context, client crclient.C
 	start := time.Now()
 
 	t.Logf("Waiting for nodepool %s/%s to report version %s (currently %s)", nodePool.Namespace, nodePool.Name, version, nodePool.Status.Version)
-	// TestInPlaceUpgradeNodePool must update nodes in the pool squentially and it takes about 5m per node
+	// TestInPlaceUpgradeNodePool must update nodes in the pool sequentially and it takes about 5m per node
 	// TestInPlaceUpgradeNodePool currently uses a single nodepool with 2 replicas so 20m should be enough time (2x expected)
 	err := wait.PollImmediateWithContext(ctx, 10*time.Second, 20*time.Minute, func(ctx context.Context) (done bool, err error) {
 		latest := nodePool.DeepCopy()
@@ -1621,7 +1621,7 @@ func EnsureHCPPodsAffinitiesAndTolerations(t *testing.T, ctx context.Context, cl
 				continue
 			}
 
-			//aws-ebs-csi-driver-operator tolerations are set through CSO and are different from the ones in the DC
+			// aws-ebs-csi-driver-operator tolerations are set through CSO and are different from the ones in the DC
 			if strings.Contains(pod.Name, awsEbsCsiDriverOperatorPodSubstring) {
 				g.Expect(pod.Spec.Tolerations).To(ContainElements(awsEbsCsiDriverOperatorTolerations))
 			} else {


### PR DESCRIPTION
Now that we have branched out to 4.15, we have a previous release that contains a kubevirt RHCOS image, thus we can test the node pool upgrade flow.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
fixes #[CNV-29003]( https://issues.redhat.com/browse/CNV-29003)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.