### PR TITLE
HOSTEDCP-1306: Bump Golang builder to 1.20 for RHTAP dockerfile

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.19 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
 
 COPY . .
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Golang builder to 1.20 for RHTAP dockerfile

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1306](https://issues.redhat.com/browse/HOSTEDCP-1306)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.