### PR TITLE
CNV-23418: Validate jsonpatch annotation + add condition on wrong patch

### DIFF
--- a/api/hypershift/v1beta1/nodepool_conditions.go
+++ b/api/hypershift/v1beta1/nodepool_conditions.go
@@ -61,6 +61,9 @@ const (
 	// If the security group is specified for the NodePool, this condition is always true. If no security group is specified
 	// for the NodePool, the status of this condition depends on the availability of the default security group in the HostedCluster.
 	NodePoolAWSSecurityGroupAvailableConditionType = "AWSSecurityGroupAvailable"
+
+	// NodePoolValidMachineTemplateConditionType signal that the machine template created by the node pool is valid
+	NodePoolValidMachineTemplateConditionType = "ValidMachineTemplate"
 )
 
 // Reasons
@@ -75,4 +78,5 @@ const (
 	DefaultAWSSecurityGroupNotReadyReason = "DefaultSGNotReady"
 	NodePoolValidArchPlatform             = "ValidArchPlatform"
 	NodePoolInvalidArchPlatform           = "InvalidArchPlatform"
+	InvalidKubevirtMachineTemplate        = "InvalidKubevirtMachineTemplate"
 )

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -3,6 +3,7 @@ package assets
 import (
 	_ "embed"
 	"fmt"
+	"k8s.io/utils/ptr"
 
 	"github.com/google/uuid"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -1588,7 +1589,6 @@ func (o HyperShiftValidatingWebhookConfiguration) Build() *admissionregistration
 	npPath := "/validate-hypershift-openshift-io-v1beta1-nodepool"
 	sideEffects := admissionregistrationv1.SideEffectClassNone
 	timeout := int32(15)
-	failurePolicy := admissionregistrationv1.Fail
 
 	return &admissionregistrationv1.ValidatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
@@ -1609,6 +1609,7 @@ func (o HyperShiftValidatingWebhookConfiguration) Build() *admissionregistration
 					{
 						Operations: []admissionregistrationv1.OperationType{
 							admissionregistrationv1.Create,
+							admissionregistrationv1.Update,
 						},
 						Rule: admissionregistrationv1.Rule{
 							APIGroups:   []string{"hypershift.openshift.io"},
@@ -1628,7 +1629,7 @@ func (o HyperShiftValidatingWebhookConfiguration) Build() *admissionregistration
 				SideEffects:             &sideEffects,
 				AdmissionReviewVersions: []string{"v1"},
 				TimeoutSeconds:          &timeout,
-				FailurePolicy:           &failurePolicy,
+				FailurePolicy:           ptr.To(admissionregistrationv1.Fail),
 			},
 			{
 				Name: "nodepools.hypershift.openshift.io",
@@ -1636,6 +1637,7 @@ func (o HyperShiftValidatingWebhookConfiguration) Build() *admissionregistration
 					{
 						Operations: []admissionregistrationv1.OperationType{
 							admissionregistrationv1.Create,
+							admissionregistrationv1.Update,
 						},
 						Rule: admissionregistrationv1.Rule{
 							APIGroups:   []string{"hypershift.openshift.io"},
@@ -1655,7 +1657,7 @@ func (o HyperShiftValidatingWebhookConfiguration) Build() *admissionregistration
 				SideEffects:             &sideEffects,
 				AdmissionReviewVersions: []string{"v1"},
 				TimeoutSeconds:          &timeout,
-				FailurePolicy:           &failurePolicy,
+				FailurePolicy:           ptr.To(admissionregistrationv1.Fail),
 			},
 		},
 	}


### PR DESCRIPTION
## What this PR does / why we need it
* validate the jsonpatch annotation in webhook. Make sure the jsonpatch string is a valid standard jsonpatch
* If the creation of a kubevirt machine template fails, add a new condition to the node pool to reflect this error.

### Which issue(s) this PR fixes
Fixes #[CNV-23418](https://issues.redhat.com//browse/CNV-23418)

### Checklist
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.