### PR TITLE
OCPBUGS-22912: Set value of elb tag to 1 instead of true

### DIFF
--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -224,7 +224,7 @@ func (o *CreateInfraOptions) CreateSubnet(l logr.Logger, client ec2iface.EC2API,
 	tagSpec := o.ec2TagSpecifications("subnet", name)
 	tagSpec[0].Tags = append(tagSpec[0].Tags, &ec2.Tag{
 		Key:   aws.String(scopeTag),
-		Value: aws.String("true"),
+		Value: aws.String("1"),
 	})
 
 	result, err := client.CreateSubnet(&ec2.CreateSubnetInput{


### PR DESCRIPTION
**What this PR does / why we need it**:
The value of the kubernetes.io/role/elb and
kubernetes.io/role/internal-elb tag should be '1' and not 'true'. Ref:
https://github.com/openshift/aws-load-balancer-operator/blob/main/docs/prerequisites.md#subnets

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-22912

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.