### PR TITLE
[release-4.14] CNV-23418: unsupported escape hatch mechanism custom HS/KV vms

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -222,6 +222,9 @@ const (
 	// hosted control plane namespacces. The default is 'Restricted'. Valid values are 'Restricted', 'Baseline', or 'Privileged'
 	// See https://github.com/openshift/enhancements/blob/master/enhancements/authentication/pod-security-admission.md
 	PodSecurityAdmissionLabelOverrideAnnotation = "hypershift.openshift.io/pod-security-admission-label-override"
+
+	// JSONPatchAnnotation allow modifying the kubevirt VM template using jsonpatch
+	JSONPatchAnnotation = "hypershift.openshift.io/kubevirt-vm-jsonpatch"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/clarketm/json v1.14.1
 	github.com/coreos/ignition/v2 v2.14.0
 	github.com/docker/distribution v2.8.2+incompatible
+	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/zapr v1.2.3
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
@@ -63,7 +64,7 @@ require (
 	k8s.io/kube-scheduler v0.23.1
 	k8s.io/kubectl v0.25.0
 	k8s.io/pod-security-admission v0.23.5
-	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	kubevirt.io/api v0.58.0
 	kubevirt.io/containerized-data-importer-api v1.50.0
 	sigs.k8s.io/apiserver-network-proxy v0.0.24
@@ -103,7 +104,6 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
-	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1750,8 +1750,8 @@ k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 h1:qY1Ad8PODbnymg2pRbkyMT/ylpTrCM8P2RJ0yroCyIk=
-k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 kubevirt.io/api v0.58.0 h1:qeNeRtD6AIJ5WVJuRXajmmXtnrO5dYchy+hpCm6QwhE=
 kubevirt.io/api v0.58.0/go.mod h1:U0CQlZR0JoJCaC+Va0wz4dMOtYDdVywJ98OT1KmOkzI=
 kubevirt.io/controller-lifecycle-operator-sdk v0.2.1 h1:I1b14fnhwrVvQLmgksMo9vgje42hmH4QN5kqyYDqbMA=

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -81,7 +81,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 			expected: &capikubevirt.KubevirtMachineTemplateSpec{
 				Template: capikubevirt.KubevirtMachineTemplateResource{
 					Spec: capikubevirt.KubevirtMachineSpec{
-						VirtualMachineTemplate: *generateNodeTemplate("5Gi", 4, "32Gi", false),
+						VirtualMachineTemplate: *generateNodeTemplate("5Gi", 4, "32Gi", false, nil),
 					},
 				},
 			},
@@ -119,7 +119,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 			expected: &capikubevirt.KubevirtMachineTemplateSpec{
 				Template: capikubevirt.KubevirtMachineTemplateResource{
 					Spec: capikubevirt.KubevirtMachineSpec{
-						VirtualMachineTemplate: *generateNodeTemplate("5Gi", 4, "32Gi", false),
+						VirtualMachineTemplate: *generateNodeTemplate("5Gi", 4, "32Gi", false, nil),
 					},
 				},
 			},
@@ -157,7 +157,7 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 			expected: &capikubevirt.KubevirtMachineTemplateSpec{
 				Template: capikubevirt.KubevirtMachineTemplateResource{
 					Spec: capikubevirt.KubevirtMachineSpec{
-						VirtualMachineTemplate: *generateNodeTemplate("5Gi", 4, "32Gi", true),
+						VirtualMachineTemplate: *generateNodeTemplate("5Gi", 4, "32Gi", true, nil),
 					},
 				},
 			},
@@ -171,7 +171,8 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 
 			bootImage := newCachedBootImage(bootImageName, imageHash, hostedClusterNamespace, false)
 			bootImage.dvName = bootImageNamePrefix + "12345"
-			result := MachineTemplateSpec(tc.nodePool, bootImage, tc.hcluster)
+			result, err := MachineTemplateSpec(tc.nodePool, bootImage, tc.hcluster)
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(result).To(Equal(tc.expected), "Comparison failed\n%v", cmp.Diff(tc.expected, result))
 		})
 	}
@@ -319,6 +320,407 @@ func TestCacheImage(t *testing.T) {
 	}
 }
 
+func TestJsonPatch(t *testing.T) {
+	testCases := []struct {
+		name     string
+		nodePool *hyperv1.NodePool
+		hcluster *hyperv1.HostedCluster
+		expected *capikubevirt.KubevirtMachineTemplateSpec
+	}{
+		{
+			name: "single json patch in the nodepool",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						hyperv1.JSONPatchAnnotation: `[{"op": "add","path": "/spec/networks/-","value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}}]`,
+					},
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Replicas:    nil,
+					Config:      nil,
+					Management:  hyperv1.NodePoolManagement{},
+					AutoScaling: nil,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							"5Gi",
+							4,
+							"testimage",
+							"32Gi",
+							nil,
+						),
+					},
+					Release: hyperv1.Release{},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "1234",
+				},
+			},
+
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						VirtualMachineTemplate: *generateNodeTemplate(
+							"5Gi",
+							4,
+							"32Gi",
+							false,
+							&kubevirtv1.Network{
+								Name: "secondary",
+								NetworkSource: kubevirtv1.NetworkSource{
+									Multus: &kubevirtv1.MultusNetwork{
+										NetworkName: "mynetwork",
+									},
+								},
+							},
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "several json patches in the nodepool",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						hyperv1.JSONPatchAnnotation: `[
+                            {
+                                "op": "add",
+                                "path": "/spec/networks/-",
+                                "value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/spec/domain/cpu/cores",
+                                "value": 5
+                            }
+                        ]`,
+					},
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Replicas:    nil,
+					Config:      nil,
+					Management:  hyperv1.NodePoolManagement{},
+					AutoScaling: nil,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							"5Gi",
+							4,
+							"testimage",
+							"32Gi",
+							nil,
+						),
+					},
+					Release: hyperv1.Release{},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "1234",
+				},
+			},
+
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						VirtualMachineTemplate: *generateNodeTemplate(
+							"5Gi",
+							5,
+							"32Gi",
+							false,
+							&kubevirtv1.Network{Name: "secondary", NetworkSource: kubevirtv1.NetworkSource{Multus: &kubevirtv1.MultusNetwork{NetworkName: "mynetwork"}}},
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "single json patch in the hosted cluster",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Replicas:    nil,
+					Config:      nil,
+					Management:  hyperv1.NodePoolManagement{},
+					AutoScaling: nil,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							"5Gi",
+							4,
+							"testimage",
+							"32Gi",
+							nil,
+						),
+					},
+					Release: hyperv1.Release{},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+					Annotations: map[string]string{
+						hyperv1.JSONPatchAnnotation: `[{"op": "add","path": "/spec/networks/1","value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}}]`,
+					},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "1234",
+				},
+			},
+
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						VirtualMachineTemplate: *generateNodeTemplate(
+							"5Gi",
+							4,
+							"32Gi",
+							false,
+							&kubevirtv1.Network{Name: "secondary", NetworkSource: kubevirtv1.NetworkSource{Multus: &kubevirtv1.MultusNetwork{NetworkName: "mynetwork"}}},
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "several json patches in the hosted cluster",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Replicas:    nil,
+					Config:      nil,
+					Management:  hyperv1.NodePoolManagement{},
+					AutoScaling: nil,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							"5Gi",
+							4,
+							"testimage",
+							"32Gi",
+							nil,
+						),
+					},
+					Release: hyperv1.Release{},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+					Annotations: map[string]string{
+						hyperv1.JSONPatchAnnotation: `[
+                            {
+                                "op": "add",
+                                "path": "/spec/networks/-",
+                                "value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/spec/domain/cpu/cores",
+                                "value": 5
+                            }
+                        ]`,
+					},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "1234",
+				},
+			},
+
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						VirtualMachineTemplate: *generateNodeTemplate(
+							"5Gi",
+							5,
+							"32Gi",
+							false,
+							&kubevirtv1.Network{Name: "secondary", NetworkSource: kubevirtv1.NetworkSource{Multus: &kubevirtv1.MultusNetwork{NetworkName: "mynetwork"}}},
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "json patches both in the hosted cluster and the nodepool",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						hyperv1.JSONPatchAnnotation: `[
+                            {
+                                "op": "replace",
+                                "path": "/spec/domain/cpu/cores",
+                                "value": 5
+                            }
+                        ]`,
+					},
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Replicas:    nil,
+					Config:      nil,
+					Management:  hyperv1.NodePoolManagement{},
+					AutoScaling: nil,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							"5Gi",
+							4,
+							"testimage",
+							"32Gi",
+							nil,
+						),
+					},
+					Release: hyperv1.Release{},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+					Annotations: map[string]string{
+						hyperv1.JSONPatchAnnotation: `[
+                            {
+                                "op": "add",
+                                "path": "/spec/networks/-",
+                                "value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}
+                            }
+                        ]`,
+					},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "1234",
+				},
+			},
+
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						VirtualMachineTemplate: *generateNodeTemplate(
+							"5Gi",
+							5,
+							"32Gi",
+							false,
+							&kubevirtv1.Network{Name: "secondary", NetworkSource: kubevirtv1.NetworkSource{Multus: &kubevirtv1.MultusNetwork{NetworkName: "mynetwork"}}},
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "json patches in the hosted cluster, overrode by the one in the nodepool",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      poolName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						hyperv1.JSONPatchAnnotation: `[
+                            {
+                                "op": "replace",
+                                "path": "/spec/domain/cpu/cores",
+                                "value": 5
+                            }
+                        ]`,
+					},
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: clusterName,
+					Replicas:    nil,
+					Config:      nil,
+					Management:  hyperv1.NodePoolManagement{},
+					AutoScaling: nil,
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: generateKubevirtPlatform(
+							"5Gi",
+							4,
+							"testimage",
+							"32Gi",
+							nil,
+						),
+					},
+					Release: hyperv1.Release{},
+				},
+			},
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-hostedcluster",
+					Namespace: "clusters",
+					Annotations: map[string]string{
+						hyperv1.JSONPatchAnnotation: `[
+                            {
+                                "op": "replace",
+                                "path": "/spec/domain/cpu/cores",
+                                "value": 6
+                            }
+                        ]`,
+					},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "1234",
+				},
+			},
+
+			expected: &capikubevirt.KubevirtMachineTemplateSpec{
+				Template: capikubevirt.KubevirtMachineTemplateResource{
+					Spec: capikubevirt.KubevirtMachineSpec{
+						VirtualMachineTemplate: *generateNodeTemplate(
+							"5Gi",
+							5,
+							"32Gi",
+							false,
+							nil,
+						),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(PlatformValidation(tc.nodePool)).To(Succeed())
+
+			bootImage := newCachedBootImage(bootImageName, imageHash, hostedClusterNamespace, false)
+			bootImage.dvName = bootImageNamePrefix + "12345"
+			result, err := MachineTemplateSpec(tc.nodePool, bootImage, tc.hcluster)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(tc.expected), "Comparison failed\n%v", cmp.Diff(tc.expected, result))
+		})
+	}
+}
+
 func assertDV(g Gomega, dvs []v1beta1.DataVolume, expectedDVNamePrefix string, bootImage *cachedBootImage) {
 	g.ExpectWithOffset(1, dvs).Should(HaveLen(1), "failed to read the DataVolume back; No matched DataVolume")
 	g.ExpectWithOffset(1, dvs[0].Name).Should(HavePrefix(expectedDVNamePrefix))
@@ -352,7 +754,7 @@ func generateKubevirtPlatform(memory string, cores uint32, image string, volumeS
 	return exampleTemplate
 }
 
-func generateNodeTemplate(memory string, cpu uint32, volumeSize string, NetworkInterfaceMultiQueue bool) *capikubevirt.VirtualMachineTemplateSpec {
+func generateNodeTemplate(memory string, cpu uint32, volumeSize string, NetworkInterfaceMultiQueue bool, nw *kubevirtv1.Network) *capikubevirt.VirtualMachineTemplateSpec {
 	runAlways := kubevirtv1.RunStrategyAlways
 	guestQuantity := apiresource.MustParse(memory)
 	var multiQueue *bool
@@ -360,7 +762,7 @@ func generateNodeTemplate(memory string, cpu uint32, volumeSize string, NetworkI
 		multiQueue = pointer.Bool(true)
 	}
 
-	return &capikubevirt.VirtualMachineTemplateSpec{
+	template := &capikubevirt.VirtualMachineTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				hyperv1.NodePoolNameLabel: "my-pool",
@@ -475,4 +877,10 @@ func generateNodeTemplate(memory string, cpu uint32, volumeSize string, NetworkI
 			},
 		},
 	}
+
+	if nw != nil {
+		template.Spec.Template.Spec.Networks = append(template.Spec.Template.Spec.Networks, *nw)
+	}
+
+	return template
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2511,7 +2511,11 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 		}
 	case hyperv1.KubevirtPlatform:
 		template = &capikubevirt.KubevirtMachineTemplate{}
-		machineTemplateSpec = kubevirt.MachineTemplateSpec(nodePool, kubevirtBootImage, hcluster)
+		var err error
+		machineTemplateSpec, err = kubevirt.MachineTemplateSpec(nodePool, kubevirtBootImage, hcluster)
+		if err != nil {
+			return nil, nil, "", err
+		}
 		mutateTemplate = func(object client.Object) error {
 			o, _ := object.(*capikubevirt.KubevirtMachineTemplate)
 			o.Spec = *machineTemplateSpec.(*capikubevirt.KubevirtMachineTemplateSpec)

--- a/test/e2e/nodepool_kv_cache_image_test.go
+++ b/test/e2e/nodepool_kv_cache_image_test.go
@@ -8,17 +8,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"sigs.k8s.io/cluster-api/util"
+	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
 )
 
@@ -94,7 +94,7 @@ func (k KubeVirtCacheTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePoo
 		}
 	}
 
-	nodePool.Spec.Replicas = pointer.Int32(1)
+	nodePool.Spec.Replicas = ptr.To(int32(1))
 
 	return nodePool, nil
 }

--- a/test/e2e/nodepool_kv_jsonpatch_test.go
+++ b/test/e2e/nodepool_kv_jsonpatch_test.go
@@ -1,0 +1,110 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/util"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
+)
+
+type KubeVirtJsonPatchTest struct {
+	ctx           context.Context
+	client        crclient.Client
+	hostedCluster *hyperv1.HostedCluster
+}
+
+func NewKubeKubeVirtJsonPatchTest(ctx context.Context, cl crclient.Client, hc *hyperv1.HostedCluster) *KubeVirtJsonPatchTest {
+	return &KubeVirtJsonPatchTest{
+		ctx:           ctx,
+		client:        cl,
+		hostedCluster: hc,
+	}
+}
+
+func (k KubeVirtJsonPatchTest) Setup(t *testing.T) {
+	if globalOpts.Platform != hyperv1.KubevirtPlatform {
+		t.Skip("test only supported on platform KubeVirt")
+	}
+
+	t.Log("Starting test KubeKubeVirtJsonPatchTest")
+}
+
+func (k KubeVirtJsonPatchTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []corev1.Node) {
+	g := NewWithT(t)
+
+	np := &hyperv1.NodePool{}
+	g.Eventually(func(gg Gomega) {
+		gg.Expect(k.client.Get(k.ctx, util.ObjectKey(&nodePool), np)).Should(Succeed())
+		gg.Expect(np.Spec.Platform).ToNot(BeNil())
+		gg.Expect(np.Spec.Platform.Type).To(Equal(hyperv1.KubevirtPlatform))
+		gg.Expect(np.Spec.Platform.Kubevirt).ToNot(BeNil())
+	}).Within(5 * time.Minute).WithPolling(time.Second).Should(Succeed())
+
+	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name).Name
+	var guestNamespace string
+	if np.Status.Platform != nil &&
+		np.Status.Platform.KubeVirt != nil &&
+		np.Status.Platform.KubeVirt.Credentials != nil &&
+		len(np.Status.Platform.KubeVirt.Credentials.InfraNamespace) > 0 {
+
+		guestNamespace = np.Status.Platform.KubeVirt.Credentials.InfraNamespace
+		g.Expect(np.Status.Platform.KubeVirt.Credentials.InfraKubeConfigSecret).ToNot(BeNil())
+		g.Expect(np.Status.Platform.KubeVirt.Credentials.InfraKubeConfigSecret.Key).Should(Equal("kubeconfig"))
+	} else {
+		guestNamespace = localInfraNS
+	}
+
+	cm := kvinfra.NewKubevirtInfraClientMap()
+	var creds *hyperv1.KubevirtPlatformCredentials
+	if np.Status.Platform != nil && np.Status.Platform.KubeVirt != nil {
+		creds = np.Status.Platform.KubeVirt.Credentials
+	}
+	infraClient, err := cm.DiscoverKubevirtClusterClient(k.ctx, k.client, k.hostedCluster.Spec.InfraID, creds, localInfraNS, np.GetNamespace())
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	vmis := &kubevirtv1.VirtualMachineInstanceList{}
+	labelSelector := labels.SelectorFromValidatedSet(labels.Set{hyperv1.NodePoolNameLabel: np.Name})
+	g.Eventually(func(gg Gomega) {
+		gg.Expect(
+			infraClient.GetInfraClient().List(k.ctx, vmis, &crclient.ListOptions{Namespace: guestNamespace, LabelSelector: labelSelector}),
+		).To(Succeed())
+
+		gg.Expect(vmis.Items).To(HaveLen(1))
+		vmi := vmis.Items[0]
+
+		gg.Expect(vmi.Spec.Domain.CPU).ToNot(BeNil())
+		gg.Expect(vmi.Spec.Domain.CPU.Cores).To(Equal(uint32(3)))
+	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+}
+
+func (k KubeVirtJsonPatchTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k.hostedCluster.Name + "-" + "test-kv-json-patch",
+			Namespace: k.hostedCluster.Namespace,
+			Annotations: map[string]string{
+				hyperv1.JSONPatchAnnotation: `[{"op": "replace","path": "/spec/domain/cpu/cores","value": 3}]`,
+			},
+		},
+	}
+	defaultNodepool.Spec.DeepCopyInto(&nodePool.Spec)
+
+	nodePool.Spec.Replicas = ptr.To(int32(1))
+
+	return nodePool, nil
+}

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -101,6 +101,10 @@ func TestNodePool(t *testing.T) {
 				name: "TestRollingUpgrade",
 				test: NewRollingUpgradeTest(ctx, mgtClient, hostedCluster),
 			},
+			{
+				name: "KubeKubeVirtJsonPatchTest",
+				test: NewKubeKubeVirtJsonPatchTest(ctx, mgtClient, hostedCluster),
+			},
 		}
 
 		for _, testCase := range nodePoolTests {

--- a/vendor/k8s.io/utils/pointer/pointer.go
+++ b/vendor/k8s.io/utils/pointer/pointer.go
@@ -14,12 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Deprecated: Use functions in k8s.io/utils/ptr instead: ptr.To to obtain
+// a pointer, ptr.Deref to dereference a pointer, ptr.Equal to compare
+// dereferenced pointers.
 package pointer
 
 import (
-	"fmt"
-	"reflect"
 	"time"
+
+	"k8s.io/utils/ptr"
 )
 
 // AllPtrFieldsNil tests whether all pointer fields in a struct are nil.  This is useful when,
@@ -28,383 +31,219 @@ import (
 //
 // This function is only valid for structs and pointers to structs.  Any other
 // type will cause a panic.  Passing a typed nil pointer will return true.
-func AllPtrFieldsNil(obj interface{}) bool {
-	v := reflect.ValueOf(obj)
-	if !v.IsValid() {
-		panic(fmt.Sprintf("reflect.ValueOf() produced a non-valid Value for %#v", obj))
-	}
-	if v.Kind() == reflect.Ptr {
-		if v.IsNil() {
-			return true
-		}
-		v = v.Elem()
-	}
-	for i := 0; i < v.NumField(); i++ {
-		if v.Field(i).Kind() == reflect.Ptr && !v.Field(i).IsNil() {
-			return false
-		}
-	}
-	return true
-}
+//
+// Deprecated: Use ptr.AllPtrFieldsNil instead.
+var AllPtrFieldsNil = ptr.AllPtrFieldsNil
 
-// Int returns a pointer to an int
-func Int(i int) *int {
-	return &i
-}
+// Int returns a pointer to an int.
+var Int = ptr.To[int]
 
 // IntPtr is a function variable referring to Int.
 //
-// Deprecated: Use Int instead.
+// Deprecated: Use ptr.To instead.
 var IntPtr = Int // for back-compat
 
 // IntDeref dereferences the int ptr and returns it if not nil, or else
 // returns def.
-func IntDeref(ptr *int, def int) int {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var IntDeref = ptr.Deref[int]
 
 // IntPtrDerefOr is a function variable referring to IntDeref.
 //
-// Deprecated: Use IntDeref instead.
+// Deprecated: Use ptr.Deref instead.
 var IntPtrDerefOr = IntDeref // for back-compat
 
 // Int32 returns a pointer to an int32.
-func Int32(i int32) *int32 {
-	return &i
-}
+var Int32 = ptr.To[int32]
 
 // Int32Ptr is a function variable referring to Int32.
 //
-// Deprecated: Use Int32 instead.
+// Deprecated: Use ptr.To instead.
 var Int32Ptr = Int32 // for back-compat
 
 // Int32Deref dereferences the int32 ptr and returns it if not nil, or else
 // returns def.
-func Int32Deref(ptr *int32, def int32) int32 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Int32Deref = ptr.Deref[int32]
 
 // Int32PtrDerefOr is a function variable referring to Int32Deref.
 //
-// Deprecated: Use Int32Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Int32PtrDerefOr = Int32Deref // for back-compat
 
 // Int32Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Int32Equal(a, b *int32) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Int32Equal = ptr.Equal[int32]
 
 // Uint returns a pointer to an uint
-func Uint(i uint) *uint {
-	return &i
-}
+var Uint = ptr.To[uint]
 
 // UintPtr is a function variable referring to Uint.
 //
-// Deprecated: Use Uint instead.
+// Deprecated: Use ptr.To instead.
 var UintPtr = Uint // for back-compat
 
 // UintDeref dereferences the uint ptr and returns it if not nil, or else
 // returns def.
-func UintDeref(ptr *uint, def uint) uint {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var UintDeref = ptr.Deref[uint]
 
 // UintPtrDerefOr is a function variable referring to UintDeref.
 //
-// Deprecated: Use UintDeref instead.
+// Deprecated: Use ptr.Deref instead.
 var UintPtrDerefOr = UintDeref // for back-compat
 
 // Uint32 returns a pointer to an uint32.
-func Uint32(i uint32) *uint32 {
-	return &i
-}
+var Uint32 = ptr.To[uint32]
 
 // Uint32Ptr is a function variable referring to Uint32.
 //
-// Deprecated: Use Uint32 instead.
+// Deprecated: Use ptr.To instead.
 var Uint32Ptr = Uint32 // for back-compat
 
 // Uint32Deref dereferences the uint32 ptr and returns it if not nil, or else
 // returns def.
-func Uint32Deref(ptr *uint32, def uint32) uint32 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Uint32Deref = ptr.Deref[uint32]
 
 // Uint32PtrDerefOr is a function variable referring to Uint32Deref.
 //
-// Deprecated: Use Uint32Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Uint32PtrDerefOr = Uint32Deref // for back-compat
 
 // Uint32Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Uint32Equal(a, b *uint32) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Uint32Equal = ptr.Equal[uint32]
 
 // Int64 returns a pointer to an int64.
-func Int64(i int64) *int64 {
-	return &i
-}
+var Int64 = ptr.To[int64]
 
 // Int64Ptr is a function variable referring to Int64.
 //
-// Deprecated: Use Int64 instead.
+// Deprecated: Use ptr.To instead.
 var Int64Ptr = Int64 // for back-compat
 
 // Int64Deref dereferences the int64 ptr and returns it if not nil, or else
 // returns def.
-func Int64Deref(ptr *int64, def int64) int64 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Int64Deref = ptr.Deref[int64]
 
 // Int64PtrDerefOr is a function variable referring to Int64Deref.
 //
-// Deprecated: Use Int64Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Int64PtrDerefOr = Int64Deref // for back-compat
 
 // Int64Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Int64Equal(a, b *int64) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Int64Equal = ptr.Equal[int64]
 
 // Uint64 returns a pointer to an uint64.
-func Uint64(i uint64) *uint64 {
-	return &i
-}
+var Uint64 = ptr.To[uint64]
 
 // Uint64Ptr is a function variable referring to Uint64.
 //
-// Deprecated: Use Uint64 instead.
+// Deprecated: Use ptr.To instead.
 var Uint64Ptr = Uint64 // for back-compat
 
 // Uint64Deref dereferences the uint64 ptr and returns it if not nil, or else
 // returns def.
-func Uint64Deref(ptr *uint64, def uint64) uint64 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Uint64Deref = ptr.Deref[uint64]
 
 // Uint64PtrDerefOr is a function variable referring to Uint64Deref.
 //
-// Deprecated: Use Uint64Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Uint64PtrDerefOr = Uint64Deref // for back-compat
 
 // Uint64Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Uint64Equal(a, b *uint64) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Uint64Equal = ptr.Equal[uint64]
 
 // Bool returns a pointer to a bool.
-func Bool(b bool) *bool {
-	return &b
-}
+var Bool = ptr.To[bool]
 
 // BoolPtr is a function variable referring to Bool.
 //
-// Deprecated: Use Bool instead.
+// Deprecated: Use ptr.To instead.
 var BoolPtr = Bool // for back-compat
 
 // BoolDeref dereferences the bool ptr and returns it if not nil, or else
 // returns def.
-func BoolDeref(ptr *bool, def bool) bool {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var BoolDeref = ptr.Deref[bool]
 
 // BoolPtrDerefOr is a function variable referring to BoolDeref.
 //
-// Deprecated: Use BoolDeref instead.
+// Deprecated: Use ptr.Deref instead.
 var BoolPtrDerefOr = BoolDeref // for back-compat
 
 // BoolEqual returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func BoolEqual(a, b *bool) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var BoolEqual = ptr.Equal[bool]
 
 // String returns a pointer to a string.
-func String(s string) *string {
-	return &s
-}
+var String = ptr.To[string]
 
 // StringPtr is a function variable referring to String.
 //
-// Deprecated: Use String instead.
+// Deprecated: Use ptr.To instead.
 var StringPtr = String // for back-compat
 
 // StringDeref dereferences the string ptr and returns it if not nil, or else
 // returns def.
-func StringDeref(ptr *string, def string) string {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var StringDeref = ptr.Deref[string]
 
 // StringPtrDerefOr is a function variable referring to StringDeref.
 //
-// Deprecated: Use StringDeref instead.
+// Deprecated: Use ptr.Deref instead.
 var StringPtrDerefOr = StringDeref // for back-compat
 
 // StringEqual returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func StringEqual(a, b *string) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var StringEqual = ptr.Equal[string]
 
 // Float32 returns a pointer to a float32.
-func Float32(i float32) *float32 {
-	return &i
-}
+var Float32 = ptr.To[float32]
 
 // Float32Ptr is a function variable referring to Float32.
 //
-// Deprecated: Use Float32 instead.
+// Deprecated: Use ptr.To instead.
 var Float32Ptr = Float32
 
 // Float32Deref dereferences the float32 ptr and returns it if not nil, or else
 // returns def.
-func Float32Deref(ptr *float32, def float32) float32 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Float32Deref = ptr.Deref[float32]
 
 // Float32PtrDerefOr is a function variable referring to Float32Deref.
 //
-// Deprecated: Use Float32Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Float32PtrDerefOr = Float32Deref // for back-compat
 
 // Float32Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Float32Equal(a, b *float32) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Float32Equal = ptr.Equal[float32]
 
 // Float64 returns a pointer to a float64.
-func Float64(i float64) *float64 {
-	return &i
-}
+var Float64 = ptr.To[float64]
 
 // Float64Ptr is a function variable referring to Float64.
 //
-// Deprecated: Use Float64 instead.
+// Deprecated: Use ptr.To instead.
 var Float64Ptr = Float64
 
 // Float64Deref dereferences the float64 ptr and returns it if not nil, or else
 // returns def.
-func Float64Deref(ptr *float64, def float64) float64 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Float64Deref = ptr.Deref[float64]
 
 // Float64PtrDerefOr is a function variable referring to Float64Deref.
 //
-// Deprecated: Use Float64Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Float64PtrDerefOr = Float64Deref // for back-compat
 
 // Float64Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Float64Equal(a, b *float64) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Float64Equal = ptr.Equal[float64]
 
 // Duration returns a pointer to a time.Duration.
-func Duration(d time.Duration) *time.Duration {
-	return &d
-}
+var Duration = ptr.To[time.Duration]
 
 // DurationDeref dereferences the time.Duration ptr and returns it if not nil, or else
 // returns def.
-func DurationDeref(ptr *time.Duration, def time.Duration) time.Duration {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var DurationDeref = ptr.Deref[time.Duration]
 
 // DurationEqual returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func DurationEqual(a, b *time.Duration) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var DurationEqual = ptr.Equal[time.Duration]

--- a/vendor/k8s.io/utils/ptr/OWNERS
+++ b/vendor/k8s.io/utils/ptr/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- apelisse
+- stewart-yu
+- thockin
+reviewers:
+- apelisse
+- stewart-yu
+- thockin

--- a/vendor/k8s.io/utils/ptr/README.md
+++ b/vendor/k8s.io/utils/ptr/README.md
@@ -1,0 +1,3 @@
+# Pointer
+
+This package provides some functions for pointer-based operations.

--- a/vendor/k8s.io/utils/ptr/ptr.go
+++ b/vendor/k8s.io/utils/ptr/ptr.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ptr
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// AllPtrFieldsNil tests whether all pointer fields in a struct are nil.  This is useful when,
+// for example, an API struct is handled by plugins which need to distinguish
+// "no plugin accepted this spec" from "this spec is empty".
+//
+// This function is only valid for structs and pointers to structs.  Any other
+// type will cause a panic.  Passing a typed nil pointer will return true.
+func AllPtrFieldsNil(obj interface{}) bool {
+	v := reflect.ValueOf(obj)
+	if !v.IsValid() {
+		panic(fmt.Sprintf("reflect.ValueOf() produced a non-valid Value for %#v", obj))
+	}
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return true
+		}
+		v = v.Elem()
+	}
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).Kind() == reflect.Ptr && !v.Field(i).IsNil() {
+			return false
+		}
+	}
+	return true
+}
+
+// To returns a pointer to the given value.
+func To[T any](v T) *T {
+	return &v
+}
+
+// Deref dereferences ptr and returns the value it points to if no nil, or else
+// returns def.
+func Deref[T any](ptr *T, def T) T {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+// Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Equal[T comparable](a, b *T) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1267,7 +1267,7 @@ k8s.io/kubectl/pkg/validation
 k8s.io/pod-security-admission/admission/api
 k8s.io/pod-security-admission/admission/api/v1beta1
 k8s.io/pod-security-admission/api
-# k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
+# k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 ## explicit; go 1.18
 k8s.io/utils/buffer
 k8s.io/utils/clock
@@ -1277,6 +1277,7 @@ k8s.io/utils/integer
 k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/net
 k8s.io/utils/pointer
+k8s.io/utils/ptr
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
 # kubevirt.io/api v0.58.0


### PR DESCRIPTION
This is a backport of #3187

We need this escape hatch mechanism in order to grant support exceptions for users who need to modify the KubeVirt VMs outside the bounds of what the NodePool api can express.