### PR TITLE
CNV-23418: fix the jsonpath annotation implemetation

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -356,7 +356,7 @@ func applyJsonPatches(nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluste
 	//tmplt.Spec.Template.Spec.Networks[0].Multus.NetworkName
 	buff := &bytes.Buffer{}
 	dec := json.NewEncoder(buff)
-	err := dec.Encode(tmplt.Spec.Template)
+	err := dec.Encode(tmplt)
 	if err != nil {
 		return fmt.Errorf("json: failed to encode the vm template: %w", err)
 	}
@@ -378,7 +378,7 @@ func applyJsonPatches(nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluste
 	buff = bytes.NewBuffer(templateBytes)
 	enc := json.NewDecoder(buff)
 
-	if err = enc.Decode(tmplt.Spec.Template); err != nil {
+	if err = enc.Decode(tmplt); err != nil {
 		return fmt.Errorf("json: failed to decode the vm template: %w", err)
 	}
 

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -416,7 +416,7 @@ func TestJsonPatch(t *testing.T) {
 					Name:      poolName,
 					Namespace: namespace,
 					Annotations: map[string]string{
-						hyperv1.JSONPatchAnnotation: `[{"op": "add","path": "/spec/networks/-","value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}}]`,
+						hyperv1.JSONPatchAnnotation: `[{"op": "add","path": "/spec/template/spec/networks/-","value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}}]`,
 					},
 				},
 				Spec: hyperv1.NodePoolSpec{
@@ -471,12 +471,12 @@ func TestJsonPatch(t *testing.T) {
 						hyperv1.JSONPatchAnnotation: `[
                             {
                                 "op": "add",
-                                "path": "/spec/networks/-",
+                                "path": "/spec/template/spec/networks/-",
                                 "value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}
                             },
                             {
                                 "op": "replace",
-                                "path": "/spec/domain/cpu/cores",
+                                "path": "/spec/template/spec/domain/cpu/cores",
                                 "value": 5
                             }
                         ]`,
@@ -554,7 +554,7 @@ func TestJsonPatch(t *testing.T) {
 					Name:      "my-hostedcluster",
 					Namespace: "clusters",
 					Annotations: map[string]string{
-						hyperv1.JSONPatchAnnotation: `[{"op": "add","path": "/spec/networks/1","value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}}]`,
+						hyperv1.JSONPatchAnnotation: `[{"op": "add","path": "/spec/template/spec/networks/1","value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}}]`,
 					},
 				},
 				Spec: hyperv1.HostedClusterSpec{
@@ -609,12 +609,12 @@ func TestJsonPatch(t *testing.T) {
 						hyperv1.JSONPatchAnnotation: `[
                             {
                                 "op": "add",
-                                "path": "/spec/networks/-",
+                                "path": "/spec/template/spec/networks/-",
                                 "value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}
                             },
                             {
                                 "op": "replace",
-                                "path": "/spec/domain/cpu/cores",
+                                "path": "/spec/template/spec/domain/cpu/cores",
                                 "value": 5
                             }
                         ]`,
@@ -649,7 +649,7 @@ func TestJsonPatch(t *testing.T) {
 						hyperv1.JSONPatchAnnotation: `[
                             {
                                 "op": "replace",
-                                "path": "/spec/domain/cpu/cores",
+                                "path": "/spec/template/spec/domain/cpu/cores",
                                 "value": 5
                             }
                         ]`,
@@ -681,7 +681,7 @@ func TestJsonPatch(t *testing.T) {
 						hyperv1.JSONPatchAnnotation: `[
                             {
                                 "op": "add",
-                                "path": "/spec/networks/-",
+                                "path": "/spec/template/spec/networks/-",
                                 "value": {"name": "secondary", "multus": {"networkName": "mynetwork"}}
                             }
                         ]`,
@@ -716,7 +716,7 @@ func TestJsonPatch(t *testing.T) {
 						hyperv1.JSONPatchAnnotation: `[
                             {
                                 "op": "replace",
-                                "path": "/spec/domain/cpu/cores",
+                                "path": "/spec/template/spec/domain/cpu/cores",
                                 "value": 5
                             }
                         ]`,
@@ -748,7 +748,7 @@ func TestJsonPatch(t *testing.T) {
 						hyperv1.JSONPatchAnnotation: `[
                             {
                                 "op": "replace",
-                                "path": "/spec/domain/cpu/cores",
+                                "path": "/spec/template/spec/domain/cpu/cores",
                                 "value": 6
                             }
                         ]`,

--- a/test/e2e/nodepool_kv_jsonpatch_test.go
+++ b/test/e2e/nodepool_kv_jsonpatch_test.go
@@ -98,7 +98,7 @@ func (k KubeVirtJsonPatchTest) BuildNodePoolManifest(defaultNodepool hyperv1.Nod
 			Name:      k.hostedCluster.Name + "-" + "test-kv-json-patch",
 			Namespace: k.hostedCluster.Namespace,
 			Annotations: map[string]string{
-				hyperv1.JSONPatchAnnotation: `[{"op": "replace","path": "/spec/domain/cpu/cores","value": 3}]`,
+				hyperv1.JSONPatchAnnotation: `[{"op": "replace","path": "/spec/template/spec/domain/cpu/cores","value": 3}]`,
 			},
 		},
 	}


### PR DESCRIPTION
## What this PR does / why we need it
The Virtual Machine Instance (VMI) template is one field in the Virtual Machine (VM) template.

The current implementation only patch the VMI template, instead of the whole VM template.

This PR fixes the wrong implementation and allow modifiying the VM template.


### Which issue(s) this PR fixes
Fixes #[CNV-23418](https://issues.redhat.com//browse/CNV-23418)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.