### PR TITLE
"[release-4.14] CNV-35326: unsupported escape hatch mechanism custom HS/KV vms"

### DIFF
--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -222,6 +222,9 @@ const (
 	// hosted control plane namespacces. The default is 'Restricted'. Valid values are 'Restricted', 'Baseline', or 'Privileged'
 	// See https://github.com/openshift/enhancements/blob/master/enhancements/authentication/pod-security-admission.md
 	PodSecurityAdmissionLabelOverrideAnnotation = "hypershift.openshift.io/pod-security-admission-label-override"
+
+	// JSONPatchAnnotation allow modifying the kubevirt VM template using jsonpatch
+	JSONPatchAnnotation = "hypershift.openshift.io/kubevirt-vm-jsonpatch"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/clarketm/json v1.14.1
 	github.com/coreos/ignition/v2 v2.14.0
 	github.com/docker/distribution v2.8.2+incompatible
+	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/zapr v1.2.3
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
@@ -103,7 +104,6 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
-	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2511,7 +2511,11 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 		}
 	case hyperv1.KubevirtPlatform:
 		template = &capikubevirt.KubevirtMachineTemplate{}
-		machineTemplateSpec = kubevirt.MachineTemplateSpec(nodePool, kubevirtBootImage, hcluster)
+		var err error
+		machineTemplateSpec, err = kubevirt.MachineTemplateSpec(nodePool, kubevirtBootImage, hcluster)
+		if err != nil {
+			return nil, nil, "", err
+		}
 		mutateTemplate = func(object client.Object) error {
 			o, _ := object.(*capikubevirt.KubevirtMachineTemplate)
 			o.Spec = *machineTemplateSpec.(*capikubevirt.KubevirtMachineTemplateSpec)

--- a/test/e2e/nodepool_kv_cache_image_test.go
+++ b/test/e2e/nodepool_kv_cache_image_test.go
@@ -5,20 +5,19 @@ package e2e
 
 import (
 	"context"
+	"k8s.io/utils/pointer"
 	"testing"
 	"time"
 
-	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"sigs.k8s.io/cluster-api/util"
-
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
 )
 

--- a/test/e2e/nodepool_kv_jsonpatch_test.go
+++ b/test/e2e/nodepool_kv_jsonpatch_test.go
@@ -1,0 +1,110 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"k8s.io/utils/pointer"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/util"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
+)
+
+type KubeVirtJsonPatchTest struct {
+	ctx           context.Context
+	client        crclient.Client
+	hostedCluster *hyperv1.HostedCluster
+}
+
+func NewKubeKubeVirtJsonPatchTest(ctx context.Context, cl crclient.Client, hc *hyperv1.HostedCluster) *KubeVirtJsonPatchTest {
+	return &KubeVirtJsonPatchTest{
+		ctx:           ctx,
+		client:        cl,
+		hostedCluster: hc,
+	}
+}
+
+func (k KubeVirtJsonPatchTest) Setup(t *testing.T) {
+	if globalOpts.Platform != hyperv1.KubevirtPlatform {
+		t.Skip("test only supported on platform KubeVirt")
+	}
+
+	t.Log("Starting test KubeKubeVirtJsonPatchTest")
+}
+
+func (k KubeVirtJsonPatchTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []corev1.Node) {
+	g := NewWithT(t)
+
+	np := &hyperv1.NodePool{}
+	g.Eventually(func(gg Gomega) {
+		gg.Expect(k.client.Get(k.ctx, util.ObjectKey(&nodePool), np)).Should(Succeed())
+		gg.Expect(np.Spec.Platform).ToNot(BeNil())
+		gg.Expect(np.Spec.Platform.Type).To(Equal(hyperv1.KubevirtPlatform))
+		gg.Expect(np.Spec.Platform.Kubevirt).ToNot(BeNil())
+	}).Within(5 * time.Minute).WithPolling(time.Second).Should(Succeed())
+
+	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name).Name
+	var guestNamespace string
+	if np.Status.Platform != nil &&
+		np.Status.Platform.KubeVirt != nil &&
+		np.Status.Platform.KubeVirt.Credentials != nil &&
+		len(np.Status.Platform.KubeVirt.Credentials.InfraNamespace) > 0 {
+
+		guestNamespace = np.Status.Platform.KubeVirt.Credentials.InfraNamespace
+		g.Expect(np.Status.Platform.KubeVirt.Credentials.InfraKubeConfigSecret).ToNot(BeNil())
+		g.Expect(np.Status.Platform.KubeVirt.Credentials.InfraKubeConfigSecret.Key).Should(Equal("kubeconfig"))
+	} else {
+		guestNamespace = localInfraNS
+	}
+
+	cm := kvinfra.NewKubevirtInfraClientMap()
+	var creds *hyperv1.KubevirtPlatformCredentials
+	if np.Status.Platform != nil && np.Status.Platform.KubeVirt != nil {
+		creds = np.Status.Platform.KubeVirt.Credentials
+	}
+	infraClient, err := cm.DiscoverKubevirtClusterClient(k.ctx, k.client, k.hostedCluster.Spec.InfraID, creds, localInfraNS, np.GetNamespace())
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	vmis := &kubevirtv1.VirtualMachineInstanceList{}
+	labelSelector := labels.SelectorFromValidatedSet(labels.Set{hyperv1.NodePoolNameLabel: np.Name})
+	g.Eventually(func(gg Gomega) {
+		gg.Expect(
+			infraClient.GetInfraClient().List(k.ctx, vmis, &crclient.ListOptions{Namespace: guestNamespace, LabelSelector: labelSelector}),
+		).To(Succeed())
+
+		gg.Expect(vmis.Items).To(HaveLen(1))
+		vmi := vmis.Items[0]
+
+		gg.Expect(vmi.Spec.Domain.CPU).ToNot(BeNil())
+		gg.Expect(vmi.Spec.Domain.CPU.Cores).To(Equal(uint32(3)))
+	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+}
+
+func (k KubeVirtJsonPatchTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k.hostedCluster.Name + "-" + "test-kv-json-patch",
+			Namespace: k.hostedCluster.Namespace,
+			Annotations: map[string]string{
+				hyperv1.JSONPatchAnnotation: `[{"op": "replace","path": "/spec/template/spec/domain/cpu/cores","value": 3}]`,
+			},
+		},
+	}
+	defaultNodepool.Spec.DeepCopyInto(&nodePool.Spec)
+
+	nodePool.Spec.Replicas = pointer.Int32(1)
+
+	return nodePool, nil
+}

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -101,6 +101,10 @@ func TestNodePool(t *testing.T) {
 				name: "TestRollingUpgrade",
 				test: NewRollingUpgradeTest(ctx, mgtClient, hostedCluster),
 			},
+			{
+				name: "KubeKubeVirtJsonPatchTest",
+				test: NewKubeKubeVirtJsonPatchTest(ctx, mgtClient, hostedCluster),
+			},
 		}
 
 		for _, testCase := range nodePoolTests {


### PR DESCRIPTION
This is a backport of #3187 and #3201 

We need this escape hatch mechanism in order to grant support exceptions for users who need to modify the KubeVirt VMs outside the bounds of what the NodePool api can express.