### PR TITLE
OCPBUGS-23397: Set shutdown-delay-duration to 15s

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/config.go
@@ -56,7 +56,7 @@ func reconcileConfigObject(cfg *openshiftcpv1.OpenShiftAPIServerConfig, auditWeb
 		return path.Join(dir, file)
 	}
 	cfg.APIServerArguments = map[string][]string{
-		"shutdown-delay-duration": {"3s"},
+		"shutdown-delay-duration": {"15s"},
 		"audit-log-format":        {"json"},
 		"audit-log-maxsize":       {"100"},
 		"audit-log-maxbackup":     {"10"},


### PR DESCRIPTION
**What this PR does / why we need it**: Matching the value for core openshift

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-23397

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.