### PR TITLE
OCPBUGS-22473: Added OLMCatalogPlacement option to the CLI

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -79,6 +79,7 @@ type ExampleOptions struct {
 	ExternalDNSDomain                string
 	Arch                             string
 	PausedUntil                      string
+	OLMCatalogPlacement              hyperv1.OLMCatalogPlacement
 	AWS                              *ExampleAWSOptions
 	None                             *ExampleNoneOptions
 	Agent                            *ExampleAgentOptions
@@ -465,6 +466,10 @@ func (o ExampleOptions) Resources() *ExampleResources {
 
 	if len(o.PausedUntil) > 0 {
 		cluster.Spec.PausedUntil = &o.PausedUntil
+	}
+
+	if len(o.OLMCatalogPlacement) > 0 {
+		cluster.Spec.OLMCatalogPlacement = hyperv1.OLMCatalogPlacement(o.OLMCatalogPlacement)
 	}
 
 	if o.BaseDomainPrefix == "none" {

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1,6 +1,9 @@
 package v1beta1
 
 import (
+	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -449,6 +452,26 @@ const (
 	// the guest cluster.
 	GuestOLMCatalogPlacement OLMCatalogPlacement = "guest"
 )
+
+func (olm *OLMCatalogPlacement) String() string {
+	return string(*olm)
+}
+
+func (olm *OLMCatalogPlacement) Set(s string) error {
+	switch strings.ToLower(s) {
+	case "guest":
+		*olm = GuestOLMCatalogPlacement
+	case "management":
+		*olm = ManagementOLMCatalogPlacement
+	default:
+		return fmt.Errorf("unknown OLMCatalogPlacement type used '%s'", s)
+	}
+	return nil
+}
+
+func (olm *OLMCatalogPlacement) Type() string {
+	return "OLMCatalogPlacement"
+}
 
 // ImageContentSource specifies image mirrors that can be used by cluster nodes
 // to pull content. For cluster workloads, if a container image registry host of

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -40,6 +40,7 @@ func NewCreateCommands() *cobra.Command {
 		NodeDrainTimeout:               0,
 		NodeUpgradeType:                v1beta1.UpgradeTypeReplace,
 		Arch:                           "amd64",
+		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -78,6 +79,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
+	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olmCatalogPlacement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
 	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The default processor architecture for the NodePool (e.g. arm64, amd64)")
 	cmd.PersistentFlags().StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -78,6 +78,7 @@ type CreateOptions struct {
 	CredentialSecretName             string
 	NodeUpgradeType                  hyperv1.UpgradeType
 	PausedUntil                      string
+	OLMCatalogPlacement              hyperv1.OLMCatalogPlacement
 
 	// BeforeApply is called immediately before resources are applied to the
 	// server, giving the user an opportunity to inspect or mutate the resources.
@@ -295,6 +296,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		NodeSelector:                     opts.NodeSelector,
 		UpgradeType:                      opts.NodeUpgradeType,
 		PausedUntil:                      opts.PausedUntil,
+		OLMCatalogPlacement:              opts.OLMCatalogPlacement,
 	}, nil
 }
 

--- a/docs/content/how-to/disconnected/known-issues.md
+++ b/docs/content/how-to/disconnected/known-issues.md
@@ -1,0 +1,12 @@
+# Known Issues
+
+## OLM default catalog sources in ImagePullBackOff state
+
+When you work in a disconnected environment the OLM catalog sources will be still pointing to their original source, so all of these container images will keep it in ImagePullBackOff state even if the OLMCatalogPlacement is set to `Management` or `Guest`. From this point you have some options ahead:
+
+1. Disable those OLM default catalog sources and using the oc-mirror binary, mirror the desired images into your private registry, creating a new Custom Catalog Source.
+2. Mirror all the Container Images from all the catalog sources and apply an ImageContentSourcePolicy to request those images from the private registry.
+
+The most practical one is the first choice. To proceed with this option, you will need to follow [these instructions](https://docs.openshift.com/container-platform/4.14/installing/disconnected_install/installing-mirroring-disconnected.html). The process will make sure all the images get mirrored and also the ICSP will be generated properly.
+
+Additionally when you're provisioning the HostedCluster you will need to add a flag to indicate that the OLMCatalogPlacement is set to `Guest` because if that's not set, you will not be able to disable them.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
     - how-to/disconnected/automatically-initialize-registry-overrides.md
     - how-to/disconnected/image-content-sources.md
     - how-to/disconnected/disconnected-workarounds.md
+    - how-to/disconnected/known-issues.md
   - 'Kubevirt':
     - how-to/kubevirt/create-kubevirt-cluster.md
     - how-to/kubevirt/ingress-and-dns.md

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -34,6 +34,7 @@ func NewCreateCommands() *cobra.Command {
 		Timeout:                        0,
 		Wait:                           false,
 		PausedUntil:                    "",
+		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
 	}
 
 	cmd := &cobra.Command{
@@ -60,6 +61,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If set to 0 or greater, NodePools will be created with that many replicas. If set to less than 0, no NodePools will be created.")
 	cmd.PersistentFlags().StringToStringVar(&opts.NodeSelector, "node-selector", opts.NodeSelector, "A comma separated list of key=value pairs to use as the node selector for the Hosted Control Plane pods to stick to. (e.g. role=cp,disk=fast)")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
+	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olmCatalogPlacement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
 	cmd.PersistentFlags().StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other.")
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Filepath to a pull secret.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the HostedCluster.")


### PR DESCRIPTION
This PR adds the OLMCatalogPlacement capability to be set from the CLI.

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-22473](https://issues.redhat.com/browse/OCPBUGS-22473)