### PR TITLE
OCPBUGS-20246: Added brackets to IPv6 KAS address on kubeconfig

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/util"
@@ -382,12 +383,12 @@ func (p *KubeAPIServerParams) AuditPolicyConfig() configv1.Audit {
 }
 
 func (p *KubeAPIServerParams) ExternalURL() string {
-	return fmt.Sprintf("https://%s:%d", p.ExternalAddress, p.ExternalPort)
+	return fmt.Sprintf("https://%s:%d", pki.AddBracketsIfIPv6(p.ExternalAddress), p.ExternalPort)
 }
 
 // InternalURL is used by ReconcileBootstrapKubeconfigSecret.
 func (p *KubeAPIServerParams) InternalURL() string {
-	return fmt.Sprintf("https://%s:%d", p.InternalAddress, 443)
+	return fmt.Sprintf("https://%s:%d", pki.AddBracketsIfIPv6(p.InternalAddress), 443)
 }
 
 func (p *KubeAPIServerParams) ExternalKubeconfigKey() string {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -132,7 +132,7 @@ func generateKubeConfig(url string, crtBytes, keyBytes, caBytes []byte) ([]byte,
 	}
 	kubeCfg.Clusters = map[string]*clientcmdapi.Cluster{
 		"cluster": {
-			Server:                   addBracketsIfIPv6(url),
+			Server:                   AddBracketsIfIPv6(url),
 			CertificateAuthorityData: caBytes,
 		},
 	}
@@ -157,11 +157,11 @@ func inClusterKASURL() string {
 	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, config.KASSVCPort)
 }
 
-// addBracketsIfIPv6 function is needed to build the serverAPI url for every kubeconfig created.
+// AddBracketsIfIPv6 function is needed to build the serverAPI url for every kubeconfig created.
 // The function returns a string in 3 ways.
 // - Without brackets if it's an URL or an IPv4
 // - With brackets if it's a valid IPv6
-func addBracketsIfIPv6(apiAddress string) string {
+func AddBracketsIfIPv6(apiAddress string) string {
 
 	if utilsnet.IsIPv6String(apiAddress) {
 		return fmt.Sprintf("[%s]", apiAddress)

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas_test.go
@@ -46,9 +46,9 @@ func TestAddBracketsIfIPv6(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := addBracketsIfIPv6(tt.apiAddress)
+			got := AddBracketsIfIPv6(tt.apiAddress)
 			if got != tt.want {
-				t.Errorf("addBracketsIfIPv6() = %v, want %v", got, tt.want)
+				t.Errorf("AddBracketsIfIPv6() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
In there first approach [here](https://github.com/openshift/hypershift/pull/3117) I've missed the situation where the URLs passed to the function contains already the port.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-20246](https://issues.redhat.com/browse/OCPBUGS-20246)