### PR TITLE
OCPBUGS-23472: unset ServiceAccount on ignition-server-proxy

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -812,6 +812,7 @@ haproxy -f /tmp/haproxy.conf
 						},
 					},
 				},
+				ServiceAccountName: "",
 				Volumes: []corev1.Volume{
 					{
 						Name: "serving-cert",


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-23472

https://github.com/openshift/hypershift/pull/2778 broke y-stream upgrade 4.13 -> 4.14 because `ignition-server-proxy` deployment was configured with a ServiceAccount but then removed in 4.14.  However, we didn't explicitly unset it in the reconciliation so a deployment created in 4.13 will retain the removed ServiceAccount when upgraded to 4.14.