### PR TITLE
HOSTEDCP-1256: api/v1beta1: annotate hostedcontrolplane conditions

### DIFF
--- a/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/api/hypershift/v1beta1/hosted_controlplane.go
@@ -267,6 +267,10 @@ type HostedControlPlaneStatus struct {
 	// Condition contains details for one aspect of the current state of the HostedControlPlane.
 	// Current condition types are: "Available"
 	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Platform contains platform-specific status of the HostedCluster

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -7457,6 +7457,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint contains the endpoint information
                   by which external clients can access the control plane.  This is

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -49716,6 +49716,9 @@ objects:
                     - type
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                  - type
+                  x-kubernetes-list-type: map
                 controlPlaneEndpoint:
                   description: ControlPlaneEndpoint contains the endpoint information
                     by which external clients can access the control plane.  This


### PR DESCRIPTION
Clients using PATCH or SSA require fields to be properly annotated when they are maps-as-lists, in the Kubernetes convention. These annotations allow individual clients to update and have opinions on only a subset of the list, rather than all of it at once.
