### PR TITLE
OCPBUGS-23921: Use correct kubeconfig in CCM and remove CCMs access t…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
@@ -93,6 +93,8 @@ func buildCCMContainer(controllerManagerImage string) func(c *corev1.Container) 
 			fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
 			fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
 			"--leader-elect-resource-namespace=openshift-cloud-controller-manager",
+			"--authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+			"--authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
 		}
 		c.VolumeMounts = podVolumeMounts().ContainerMounts(c.Name)
 	}
@@ -126,7 +128,6 @@ func ccmLabels() map[string]string {
 
 func additionalLabels() map[string]string {
 	return map[string]string{
-		hyperv1.ControlPlaneComponent:       "cloud-controller-manager",
-		config.NeedManagementKASAccessLabel: "true",
+		hyperv1.ControlPlaneComponent: "cloud-controller-manager",
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:  
- CCM used in cluster config to retrieve the client rather than guest kubeconfig which causes CCM to rely on management KAS access. This PR adds args to use guest kubeconfig to retrieve the client which doesnt need management KAS.

**Which issue(s) this PR fixes** 
Fixes #[HOSTEDCP-1282](https://issues.redhat.com/browse/HOSTEDCP-1282)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.