### PR TITLE
OCPBUGS-23569: Added IPFamilyPolicy to services exposed at the HCP in DualStack mode

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -412,6 +412,10 @@ func ReconcileService(svc *corev1.Service, owner config.OwnerRef) error {
 	owner.ApplyTo(svc)
 	svc.Spec.Selector = cvoLabels()
 
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
+
 	// Ensure labels propagate to endpoints so service monitors can select them
 	if svc.Labels == nil {
 		svc.Labels = map[string]string{}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -152,6 +152,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 	hostname := "test.example.com"
 	allowCIDR := []hyperv1.CIDRBlock{"1.2.3.4/24"}
 	allowCIDRString := []string{"1.2.3.4/24"}
+	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 
 	ownerRef := metav1.OwnerReference{
 		APIVersion:         "hypershift.openshift.io/v1beta1",
@@ -176,7 +177,8 @@ func TestReconcileAPIServerService(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{ownerRef},
 			},
 			Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeLoadBalancer,
+				Type:           corev1.ServiceTypeLoadBalancer,
+				IPFamilyPolicy: &ipFamilyPolicy,
 				Ports: []corev1.ServicePort{
 					{
 						Protocol:   corev1.ProtocolTCP,

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -39,6 +39,10 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 		svc.Spec.Ports = []corev1.ServicePort{portSpec}
 	}
 
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
+
 	// TODO (alberto): if this port ever need to be configurable it should come from new field in the LB publishing strategy.
 	portSpec.Port = int32(apiServerServicePort)
 	portSpec.Protocol = corev1.ProtocolTCP
@@ -152,6 +156,11 @@ func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublis
 func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlane, owner *metav1.OwnerReference) error {
 	util.EnsureOwnerRef(svc, owner)
 	svc.Spec.Selector = kasLabels()
+
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
+
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/service.go
@@ -18,6 +18,10 @@ func ReconcileService(svc *corev1.Service, owner config.OwnerRef) error {
 		svc.Labels[k] = v
 	}
 
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
+
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 
 	if len(svc.Spec.Ports) == 0 {

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -36,6 +36,11 @@ func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *h
 	} else {
 		svc.Spec.Ports = []corev1.ServicePort{portSpec}
 	}
+
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
+
 	portSpec.Port = int32(OAuthServerPort)
 	portSpec.Protocol = corev1.ProtocolTCP
 	portSpec.TargetPort = intstr.FromInt(OAuthServerPort)

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/service.go
@@ -11,6 +11,9 @@ func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef) error {
 	ownerRef.ApplyTo(svc)
 	svc.Labels = openShiftControllerManagerLabels()
 	svc.Spec.Selector = openShiftControllerManagerLabels()
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -411,6 +411,9 @@ func buildVolumeWebIdentityToken(v *corev1.Volume) {
 
 func ReconcileService(svc *corev1.Service) {
 	svc.Spec.ClusterIP = "None"
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
 	var port corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		port = svc.Spec.Ports[0]

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/service.go
@@ -11,6 +11,9 @@ func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef) error {
 	ownerRef.ApplyTo(svc)
 	svc.Labels = openShiftRouteControllerManagerLabels()
 	svc.Spec.Selector = openShiftRouteControllerManagerLabels()
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]


### PR DESCRIPTION
This is a manual backport from https://github.com/openshift/hypershift/pull/3210 

Added IPFamilyPolicy to HostedCluster exposed services with the default setting of PreferDualStack. This means that services exposed in the HCP namespace will use dual-stack if the MGMT Cluster is configured as such. If the MGMT cluster is set to Single Stack, HCP will expose the services accordingly.

**Which issue(s) this PR fixes** : 
Backport Bug #[OCPBUGS-23569](https://issues.redhat.com/browse/OCPBUGS-23569)
Fixes#[OCPBUGS-23350](https://issues.redhat.com/browse/OCPBUGS-23350)


