### PR TITLE
OCPBUGS-23126: Fix a bug on deletion of a hostedcluster

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -3,6 +3,7 @@ package fixtures
 import (
 	"crypto/rand"
 	"fmt"
+	"github.com/openshift/hypershift/cmd/util"
 	"strings"
 	"time"
 
@@ -111,6 +112,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace.Name,
 			Name:      o.Name + "-pull-secret",
+			Labels:    map[string]string{util.DeleteWithClusterLabelName: "true"},
 		},
 		Data: map[string][]byte{
 			".dockerconfigjson": o.PullSecret,
@@ -128,6 +130,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace.Name,
 				Name:      o.Name + "-ssh-key",
+				Labels:    map[string]string{util.DeleteWithClusterLabelName: "true"},
 			},
 			Data: map[string][]byte{
 				"id_rsa.pub": o.SSHPublicKey,
@@ -286,6 +289,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      o.Name + "-infra-credentials",
 					Namespace: o.Namespace,
+					Labels:    map[string]string{util.DeleteWithClusterLabelName: "true"},
 				},
 				Data: map[string][]byte{
 					"kubeconfig": o.Kubevirt.InfraKubeConfig,
@@ -803,6 +807,7 @@ func (o ExampleOptions) EtcdEncryptionKeySecret() *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      o.Name + "-etcd-encryption-key",
 			Namespace: o.Namespace,
+			Labels:    map[string]string{util.DeleteWithClusterLabelName: "true"},
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -338,7 +338,14 @@ func apply(ctx context.Context, l logr.Logger, exampleOptions *apifixtures.Examp
 	var hostedCluster *hyperv1.HostedCluster
 	for _, object := range exampleObjects {
 		key := crclient.ObjectKeyFromObject(object)
-		object.SetLabels(map[string]string{util.AutoInfraLabelName: exampleOptions.InfraID})
+
+		labels := object.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[util.AutoInfraLabelName] = exampleOptions.InfraID
+		object.SetLabels(labels)
+
 		var err error
 		if object.GetObjectKind().GroupVersionKind().Kind == "HostedCluster" {
 			hostedCluster = &hyperv1.HostedCluster{ObjectMeta: metav1.ObjectMeta{Namespace: object.GetNamespace(), Name: object.GetName()}}

--- a/cmd/cluster/none/destroy.go
+++ b/cmd/cluster/none/destroy.go
@@ -44,5 +44,5 @@ func DestroyCluster(ctx context.Context, o *core.DestroyOptions) error {
 	if err := errors.NewAggregate(inputErrors); err != nil {
 		return fmt.Errorf("required inputs are missing: %w", err)
 	}
-	return core.DestroyCluster(ctx, hostedCluster, o, core.DestroyPlatformSpecificsNoop)
+	return core.DestroyCluster(ctx, hostedCluster, o, nil)
 }

--- a/cmd/util/client.go
+++ b/cmd/util/client.go
@@ -16,6 +16,8 @@ import (
 
 const (
 	AutoInfraLabelName = "hypershift.openshift.io/auto-created-for-infra"
+	// DeleteWithClusterLabelName marks CLI created secrets, to be safely removed on hosted cluster deletion
+	DeleteWithClusterLabelName = "hypershift.openshift.io/safe-to-delete-with-cluster"
 )
 
 // GetConfig creates a REST config from current context


### PR DESCRIPTION
## What this PR does / why we need it
A user destroying a HostedCluster can cause the HostedCluster to hang indefinitely if the destroy command times out during execution.

This is due to the hcp cli placing a finalizer on the HostedCluster during deletion which the cli tool later removes after waiting for some clean up actions to occur. If a user cancels the `hcp destroy cluster` command (or the command times out) while the cli is waiting for cleanup, then the HostedCluster will hang indefinitely with a DeletionTimestamp != nil.

This PR only performs the additional cleaning logic, including the setting and removing the special finalizer, for platform that actually creates additional resources. Also, this PR sets the hostedCluster as the owner for these secrets, so they will be deleted with the HostedCluster.

### Which issue(s) this PR fixes
Fixes #OCPBUGS-23126

### Checklist
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.