### PR TITLE
OCPBUGS-19834: add watch for HCP pullsecret to HCCO

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -200,6 +200,15 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 	if err := c.Watch(source.Kind(opts.CPCluster.GetCache(), &hyperv1.HostedControlPlane{}), eventHandler()); err != nil {
 		return fmt.Errorf("failed to watch HostedControlPlane: %w", err)
 	}
+
+	if err := c.Watch(source.Kind(opts.CPCluster.GetCache(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      manifests.PullSecret(opts.Namespace).Name,
+		Namespace: opts.Namespace,
+	},
+	}), eventHandler()); err != nil {
+		return fmt.Errorf("failed to watch HCP pullsecret: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:  
-  Adds a watch for HCP pullsecret  to HCCO


**Which issue(s) this PR fixes** 
Fixes # [OCPBUGS-19834](https://issues.redhat.com/browse/OCPBUGS-19834)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.