### PR TITLE
HOSTEDCP-1316 Add 'hypershift.openshift.io/hcp: true' label for nodeSelectors

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -25,6 +25,7 @@ const (
 
 	ControlPlaneServingComponentLabel = "hypershift.openshift.io/control-plane-serving-component"
 	OSDFleetManagerPairedNodesLabel   = "osd-fleet-manager.openshift.io/paired-nodes"
+	HostedClusterLabel                = "hypershift.openshift.io/hcp"
 	HostedClusterNameLabel            = "hypershift.openshift.io/cluster-name"
 	HostedClusterNamespaceLabel       = "hypershift.openshift.io/cluster-namespace"
 )
@@ -228,6 +229,7 @@ func (r *DedicatedServingComponentScheduler) Reconcile(ctx context.Context, req 
 			})
 		}
 		node.Labels[hyperv1.HostedClusterLabel] = hcNameValue
+		node.Labels[HostedClusterLabel] = "true"
 		node.Labels[HostedClusterNameLabel] = hcluster.Name
 		node.Labels[HostedClusterNamespaceLabel] = hcluster.Namespace
 

--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes_test.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes_test.go
@@ -34,6 +34,7 @@ func TestNodeReaper(t *testing.T) {
 			n.Labels[hyperv1.HostedClusterLabel] = fmt.Sprintf("%s-%s", clusterNamespace, name)
 			n.Labels[HostedClusterNamespaceLabel] = clusterNamespace
 			n.Labels[HostedClusterNameLabel] = name
+			n.Labels[HostedClusterLabel] = "true"
 		}
 	}
 	cluster := func(name string) *hyperv1.HostedCluster {
@@ -140,6 +141,7 @@ func TestHostedClusterScheduler(t *testing.T) {
 			n.Labels[HostedClusterNameLabel] = hc.Name
 			n.Labels[HostedClusterNamespaceLabel] = hc.Namespace
 			n.Labels[hyperv1.HostedClusterLabel] = fmt.Sprintf("%s-%s", hc.Namespace, hc.Name)
+			n.Labels[HostedClusterLabel] = "true"
 		}
 	}
 
@@ -266,6 +268,7 @@ func TestHostedClusterScheduler(t *testing.T) {
 						g.Expect(node.Labels[hyperv1.HostedClusterLabel]).To(Equal(fmt.Sprintf("%s-%s", hc.Namespace, hc.Name)))
 						g.Expect(node.Labels[HostedClusterNameLabel]).To(Equal(hc.Name))
 						g.Expect(node.Labels[HostedClusterNamespaceLabel]).To(Equal(hc.Namespace))
+						g.Expect(node.Labels[HostedClusterLabel]).To(Equal("true"))
 						g.Expect(node.Spec.Taints).To(ContainElement(corev1.Taint{
 							Key:    HostedClusterTaint,
 							Value:  fmt.Sprintf("%s-%s", hc.Namespace, hc.Name),


### PR DESCRIPTION
There is a use-case where a CRD generating a Daemonset needs to run on management clusters and be able to select request-serving nodes that expect to have HCP pods running on them with a nodeSelector, which requires a fixed key-value pair as a label.

The existing label, hypershift.openshift.io/cluster= ${HCP_NS} unfortunately does not work until nodeAffinity is supported in the other use-case. When that is true, this label is free to be removed.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1316](https://issues.redhat.com//browse/HOSTEDCP-1316)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.