### PR TITLE
OCPBUGS-24062: fix(cpo): Set restart annotation on network-node-identity

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2921,6 +2921,12 @@ func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx conte
 		return fmt.Errorf("failed to restart multus admission controller: %w", err)
 	}
 
+	// CNO manages overall network-node-identity deployment. CPO manages restarts.
+	networkNodeIdentityDeployment := manifests.NetworkNodeIdentityDeployment(hcp.Namespace)
+	if err := cno.SetRestartAnnotationAndPatch(ctx, r.Client, networkNodeIdentityDeployment, p.DeploymentConfig); err != nil {
+		return fmt.Errorf("failed to restart network node identity: %w", err)
+	}
+
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
@@ -10,6 +10,7 @@ import (
 
 const clusterNetworkOperator = "cluster-network-operator"
 const multusAdmissionController = "multus-admission-controller"
+const networkNodeIdentity = "network-node-identity"
 
 func ClusterNetworkOperatorDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
@@ -52,6 +53,15 @@ func MultusAdmissionControllerDeployment(namespace string) *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      multusAdmissionController,
+		},
+	}
+}
+
+func NetworkNodeIdentityDeployment(namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      networkNodeIdentity,
 		},
 	}
 }


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
With network-node-identity in the CP side for 4.14, it does not cycle when the HC/HCP restart annotation is applied. This change makes it so that CPO will set the restart annotation. Similar to https://github.com/openshift/hypershift/pull/2150.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #376

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.