### PR TITLE
OCPBUGS-22459: Add prestop to konnectiviy server

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -940,6 +940,17 @@ func buildKonnectivityServerContainer(image string, serverCount int) func(c *cor
 			strconv.Itoa(serverCount),
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+		c.Lifecycle = &corev1.Lifecycle{
+			PreStop: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/bin/sh",
+						"-c",
+						"sleep 70",
+					},
+				},
+			},
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: This allows the rest of the KAS pod to clean up before dropping network connections, resulting in fewer interruptions on restarts.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-22459

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.