### PR TITLE
OCPBUGS-19834: use pull secret content for config hash generation in …

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -588,8 +588,13 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		return ctrl.Result{}, err
 	}
 
+	pullSecretContent, err := r.getPullSecretBytes(ctx, hcluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Check if config needs to be updated.
-	targetConfigHash := supportutil.HashStruct(config + pullSecretName)
+	targetConfigHash := supportutil.HashStruct(config + pullSecretName + string(pullSecretContent))
 	isUpdatingConfig := isUpdatingConfig(nodePool, targetConfigHash)
 	if isUpdatingConfig {
 		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{


### PR DESCRIPTION

**What this PR does / why we need it**: use pull secret contents to create config hash for node pool, this allows for nodes to redeploy using the updated pullsecret

**Which issue(s) this PR fixes** 
Fixes #  [OCPBUGS-19834](https://issues.redhat.com/browse/OCPBUGS-19834)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.