### PR TITLE
cmd/cluster/core/dump: Gather PodDisruptionBudgets too

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -24,6 +24,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -340,6 +341,7 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 		&capikubevirt.KubevirtMachine{},
 		&capikubevirt.KubevirtMachineTemplate{},
 		&capikubevirt.KubevirtCluster{},
+		&policyv1.PodDisruptionBudget{},
 		&routev1.Route{},
 		&imagev1.ImageStream{},
 		&networkingv1.NetworkPolicy{},


### PR DESCRIPTION
**What this PR does / why we need it**:

Pod disruption budgets are important enough to be [included in Insights tarballs][1], and they aren't all that big, so we should pick them up as a standard part of interesting namespaces too.  This will help with things like auditing issues where we failed to drain (PDB too strict) or disrupted a core workload (PDB too weak or missing).  Similar to openshift/oc@c32fac0143 (openshift/oc#750).

[1]: https://github.com/openshift/insights-operator/pull/185

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.