### PR TITLE
[release-4.14] OCPBUGS-23997: add watch for HCP pullsecret to HCCO

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -198,6 +198,16 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 	if err := c.Watch(source.NewKindWithCache(&hyperv1.HostedControlPlane{}, opts.CPCluster.GetCache()), eventHandler()); err != nil {
 		return fmt.Errorf("failed to watch HostedControlPlane: %w", err)
 	}
+
+	if err := c.Watch(source.NewKindWithCache(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      manifests.PullSecret(opts.Namespace).Name,
+			Namespace: opts.Namespace,
+		},
+	}, opts.CPCluster.GetCache()), eventHandler()); err != nil {
+		return fmt.Errorf("failed to watch HCP pullsecret: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of https://github.com/openshift/hypershift/pull/3237 with small change to fix too many arguments in conversion to source.Kind that was seen in automated [cherry pick](https://github.com/openshift/hypershift/pull/3241/files)