### PR TITLE
HOSTEDCP-1272: Added CLI support to create DualStack clusters using default values

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/none"
 	"github.com/openshift/hypershift/cmd/cluster/powervs"
 	"github.com/openshift/hypershift/cmd/log"
+	"github.com/openshift/hypershift/support/globalconfig"
 )
 
 func NewCreateCommands() *cobra.Command {
@@ -28,8 +29,9 @@ func NewCreateCommands() *cobra.Command {
 		Render:                         false,
 		InfrastructureJSON:             "",
 		InfraID:                        "",
-		ServiceCIDR:                    []string{"172.31.0.0/16"},
-		ClusterCIDR:                    []string{"10.132.0.0/14"},
+		ServiceCIDR:                    []string{globalconfig.DefaultIPv4ServiceCIDR},
+		ClusterCIDR:                    []string{globalconfig.DefaultIPv4ClusterCIDR},
+		DefaultDual:                    false,
 		Wait:                           false,
 		Timeout:                        0,
 		ExternalDNSDomain:              "",
@@ -75,6 +77,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Infrastructure ID to use for hosted cluster resources.")
 	cmd.PersistentFlags().StringArrayVar(&opts.ServiceCIDR, "service-cidr", opts.ServiceCIDR, "The CIDR of the service network. Can be specified multiple times.")
 	cmd.PersistentFlags().StringArrayVar(&opts.ClusterCIDR, "cluster-cidr", opts.ClusterCIDR, "The CIDR of the cluster network. Can be specified multiple times.")
+	cmd.PersistentFlags().BoolVar(&opts.DefaultDual, "default-dual", opts.DefaultDual, "Defines the Service and Cluster CIDRs as dual-stack default values. Cannot be defined with service-cidr or cluster-cidr flag.")
 	cmd.PersistentFlags().StringToStringVar(&opts.NodeSelector, "node-selector", opts.NodeSelector, "A comma separated list of key=value to use as node selector for the Hosted Control Plane pods to stick to. E.g. role=cp,disk=fast")
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
@@ -82,6 +85,9 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olmCatalogPlacement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
 	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The default processor architecture for the NodePool (e.g. arm64, amd64)")
 	cmd.PersistentFlags().StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
+
+	cmd.MarkFlagsMutuallyExclusive("service-cidr", "default-dual")
+	cmd.MarkFlagsMutuallyExclusive("cluster-cidr", "default-dual")
 
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(none.NewCreateCommand(opts))

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/cmd/version"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/releaseinfo"
 )
 
@@ -62,6 +63,7 @@ type CreateOptions struct {
 	SSHKeyFile                       string
 	ServiceCIDR                      []string
 	ClusterCIDR                      []string
+	DefaultDual                      bool
 	ExternalDNSDomain                string
 	Arch                             string
 	NodeSelector                     map[string]string
@@ -239,6 +241,16 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate ssh keys: %w", err)
 		}
+	}
+
+	if opts.DefaultDual {
+		// Using this AgentNamespace field because I cannot infer the Provider we are using at this point
+		// TODO (jparrill): Refactor this to use generic validations as same as we use the ApplyPlatformSpecificsValues in a follow up PR
+		if len(opts.AgentPlatform.AgentNamespace) <= 0 {
+			return nil, fmt.Errorf("--default-dual is only supported on Agent platform")
+		}
+		opts.ClusterCIDR = []string{globalconfig.DefaultIPv4ClusterCIDR, globalconfig.DefaultIPv6ClusterCIDR}
+		opts.ServiceCIDR = []string{globalconfig.DefaultIPv4ServiceCIDR, globalconfig.DefaultIPv6ServiceCIDR}
 	}
 
 	var userCABundle []byte

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -11,13 +11,14 @@ import (
 	"github.com/openshift/hypershift/product-cli/cmd/cluster/agent"
 	"github.com/openshift/hypershift/product-cli/cmd/cluster/aws"
 	"github.com/openshift/hypershift/product-cli/cmd/cluster/kubevirt"
+	"github.com/openshift/hypershift/support/globalconfig"
 )
 
 func NewCreateCommands() *cobra.Command {
 	opts := &core.CreateOptions{
 		AdditionalTrustBundle:          "",
 		Arch:                           "amd64",
-		ClusterCIDR:                    []string{"10.132.0.0/14"},
+		ClusterCIDR:                    []string{globalconfig.DefaultIPv4ClusterCIDR},
 		ControlPlaneAvailabilityPolicy: "HighlyAvailable",
 		ImageContentSources:            "",
 		InfraID:                        "",
@@ -30,7 +31,8 @@ func NewCreateCommands() *cobra.Command {
 		PullSecretFile:                 "",
 		ReleaseImage:                   "",
 		Render:                         false,
-		ServiceCIDR:                    []string{"172.31.0.0/16"},
+		ServiceCIDR:                    []string{globalconfig.DefaultIPv4ServiceCIDR},
+		DefaultDual:                    false,
 		Timeout:                        0,
 		Wait:                           false,
 		PausedUntil:                    "",
@@ -67,11 +69,14 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the HostedCluster.")
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", opts.Render, "Renders the HostedCluster manifest output as YAML to stdout instead of automatically applying the manifests to the management cluster.")
 	cmd.PersistentFlags().StringArrayVar(&opts.ServiceCIDR, "service-cidr", opts.ServiceCIDR, "The CIDR of the service network. Can be specified multiple times.")
+	cmd.PersistentFlags().BoolVar(&opts.DefaultDual, "default-dual", opts.DefaultDual, "Defines the Service and Cluster CIDRs as dual-stack default values. This flag is ignored if service-cidr or cluster-cidr are set. Cannot be defined with service-cidr or cluster-cidr flag.")
 	cmd.PersistentFlags().StringVar(&opts.SSHKeyFile, "ssh-key", opts.SSHKeyFile, "Filepath to an SSH key file.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the duration of the wait (Examples: 30s, 1h30m45s, etc.) 0 means no timeout.")
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If true, the create command will block until the HostedCluster is up. Requires at least one NodePool with at least one node.")
 	cmd.PersistentFlags().StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 
+	cmd.MarkFlagsMutuallyExclusive("service-cidr", "default-dual")
+	cmd.MarkFlagsMutuallyExclusive("cluster-cidr", "default-dual")
 	cmd.AddCommand(agent.NewCreateCommand(opts))
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))

--- a/support/globalconfig/network.go
+++ b/support/globalconfig/network.go
@@ -11,8 +11,12 @@ import (
 )
 
 const (
-	defaultIPv4HostPrefix = 23
-	defaultIPv6HostPrefix = 64
+	defaultIPv4HostPrefix  = 23
+	defaultIPv6HostPrefix  = 64
+	DefaultIPv4ServiceCIDR = "172.31.0.0/16"
+	DefaultIPv6ServiceCIDR = "fd02::/112"
+	DefaultIPv4ClusterCIDR = "10.132.0.0/14"
+	DefaultIPv6ClusterCIDR = "fd01::/48"
 )
 
 func NetworkConfig() *configv1.Network {


### PR DESCRIPTION
This feature is only supported for now in Agent provider.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-1272](https://issues.redhat.com/browse/HOSTEDCP-1272)