### PR TITLE
HOSTEDCP-1329: Allow user to specify resource group for NodePool resources

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -6,20 +6,18 @@ import (
 	"strings"
 	"time"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/api/util/ipnet"
 	"github.com/openshift/hypershift/cmd/util"
 
-	rbacv1 "k8s.io/api/rbac/v1"
-
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
-
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/api/util/ipnet"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/openshift/api/config/v1"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ExampleResources struct {

--- a/api/fixtures/example_azure.go
+++ b/api/fixtures/example_azure.go
@@ -1,7 +1,9 @@
 package fixtures
 
+import "github.com/openshift/hypershift/cmd/util"
+
 type ExampleAzureOptions struct {
-	Creds             AzureCreds
+	Creds             util.AzureCreds
 	Location          string
 	ResourceGroupName string
 	VnetName          string
@@ -15,16 +17,6 @@ type ExampleAzureOptions struct {
 	AvailabilityZones []string
 
 	EncryptionKey *AzureEncryptionKey
-}
-
-// AzureCreds is the fileformat we expect for credentials. It is copied from the installer
-// to allow using the same crededentials file for both:
-// https://github.com/openshift/installer/blob/8fca1ade5b096d9b2cd312c4599881d099439288/pkg/asset/installconfig/azure/session.go#L36
-type AzureCreds struct {
-	SubscriptionID string `json:"subscriptionId,omitempty"`
-	ClientID       string `json:"clientId,omitempty"`
-	ClientSecret   string `json:"clientSecret,omitempty"`
-	TenantID       string `json:"tenantId,omitempty"`
 }
 
 type AzureEncryptionKey struct {

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -36,9 +36,10 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AzurePlatform.InstanceType, "instance-type", opts.AzurePlatform.InstanceType, "The instance type to use for nodes")
 	cmd.Flags().Int32Var(&opts.AzurePlatform.DiskSizeGB, "root-disk-size", opts.AzurePlatform.DiskSizeGB, "The size of the root disk for machines in the NodePool (minimum 16)")
 	cmd.Flags().StringSliceVar(&opts.AzurePlatform.AvailabilityZones, "availablity-zones", opts.AzurePlatform.AvailabilityZones, "The availablity zones in which NodePools will be created. Must be left unspecified if the region does not support AZs. If set, one nodepool per zone will be created.")
+	cmd.Flags().StringVar(&opts.AzurePlatform.ResourceGroupName, "resource-group-name", opts.AzurePlatform.ResourceGroupName, "A resource group name to create the HostedCluster infrastructure resources under.")
 
-	cmd.MarkFlagRequired("azure-creds")
-	cmd.MarkPersistentFlagRequired("pull-secret")
+	_ = cmd.MarkFlagRequired("azure-creds")
+	_ = cmd.MarkPersistentFlagRequired("pull-secret")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -89,12 +90,13 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 
 		infraID := infraid.New(opts.Name)
 		infra, err = (&azureinfra.CreateInfraOptions{
-			Name:            opts.Name,
-			Location:        opts.AzurePlatform.Location,
-			InfraID:         infraID,
-			CredentialsFile: opts.AzurePlatform.CredentialsFile,
-			BaseDomain:      opts.BaseDomain,
-			RHCOSImage:      rhcosImage,
+			Name:              opts.Name,
+			Location:          opts.AzurePlatform.Location,
+			InfraID:           infraID,
+			CredentialsFile:   opts.AzurePlatform.CredentialsFile,
+			BaseDomain:        opts.BaseDomain,
+			RHCOSImage:        rhcosImage,
+			ResourceGroupName: opts.AzurePlatform.ResourceGroupName,
 		}).Run(ctx, opts.Log)
 		if err != nil {
 			return fmt.Errorf("failed to create infra: %w", err)

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -167,6 +167,7 @@ type AzurePlatformOptions struct {
 	InstanceType      string
 	DiskSizeGB        int32
 	AvailabilityZones []string
+	ResourceGroupName string
 }
 
 func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures.ExampleOptions, error) {

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -51,8 +51,9 @@ type AWSPlatformDestroyOptions struct {
 }
 
 type AzurePlatformDestroyOptions struct {
-	CredentialsFile string
-	Location        string
+	CredentialsFile   string
+	Location          string
+	ResourceGroupName string
 }
 
 type PowerVSPlatformDestroyOptions struct {

--- a/cmd/util/azure.go
+++ b/cmd/util/azure.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/yaml"
+)
+
+// AzureCreds is the file format we expect for credentials. It is copied from the installer
+// to allow using the same credentials file for both:
+// https://github.com/openshift/installer/blob/8fca1ade5b096d9b2cd312c4599881d099439288/pkg/asset/installconfig/azure/session.go#L36
+type AzureCreds struct {
+	SubscriptionID string `json:"subscriptionId,omitempty"`
+	ClientID       string `json:"clientId,omitempty"`
+	ClientSecret   string `json:"clientSecret,omitempty"`
+	TenantID       string `json:"tenantId,omitempty"`
+}
+
+// SetupAzureCredentials creates the Azure credentials needed to create Azure resources from credentials passed in from the user or from a credentials file
+func SetupAzureCredentials(l logr.Logger, credentials *AzureCreds, credentialsFile string) (string, *azidentity.DefaultAzureCredential, error) {
+	creds := credentials
+	if creds == nil {
+		var err error
+		creds, err = ReadCredentials(credentialsFile)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to read the credentials: %w", err)
+		}
+		l.Info("Using credentials from file", "path", credentialsFile)
+	}
+
+	_ = os.Setenv("AZURE_TENANT_ID", creds.TenantID)
+	_ = os.Setenv("AZURE_CLIENT_ID", creds.ClientID)
+	_ = os.Setenv("AZURE_CLIENT_SECRET", creds.ClientSecret)
+	azureCreds, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create Azure credentials to create image gallery: %w", err)
+	}
+
+	return creds.SubscriptionID, azureCreds, nil
+}
+
+// ReadCredentials reads a file with azure credentials and returns it as a struct
+func ReadCredentials(path string) (*AzureCreds, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from %s: %w", path, err)
+	}
+
+	var result AzureCreds
+	if err := yaml.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal credentials: %w", err)
+	}
+
+	return &result, nil
+}

--- a/cmd/util/azure_test.go
+++ b/cmd/util/azure_test.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
+	"github.com/openshift/hypershift/cmd/log"
+)
+
+func Test_SetupAzureCredentials(t *testing.T) {
+	tests := map[string]struct {
+		testName               string
+		credentials            *AzureCreds
+		credentialsFile        string
+		expectedSubscriptionID string
+		expectedAzureCreds     *azidentity.DefaultAzureCredential
+		expectedError          bool
+	}{
+		"valid credentials": {
+			credentialsFile: "../../test/setup/fake_credentials",
+			credentials: &AzureCreds{
+				SubscriptionID: "89a",
+				TenantID:       "60e",
+				ClientID:       "f70",
+				ClientSecret:   "8Q~",
+			},
+			expectedSubscriptionID: "89a",
+			expectedError:          false,
+		},
+		"invalid credentials": {
+			credentialsFile: "../../test/setup/fake_credential",
+			credentials: &AzureCreds{
+				SubscriptionID: "89a",
+				TenantID:       "60e",
+				ClientID:       "f70",
+				ClientSecret:   "8Q~",
+			},
+			expectedSubscriptionID: "89a",
+			expectedError:          false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			subscriptionID, _, err := SetupAzureCredentials(log.Log, test.credentials, test.credentialsFile)
+			if test.expectedError {
+				g.Expect(err).To(MatchError(test.expectedError))
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(subscriptionID).To(Equal(test.expectedSubscriptionID))
+			}
+		})
+	}
+}
+
+func Test_ReadCredentials(t *testing.T) {
+	tests := map[string]struct {
+		path               string
+		expectedAzureCreds *AzureCreds
+		expectedError      bool
+	}{
+		"valid file": {
+			path: "../../test/setup/fake_credentials",
+			expectedAzureCreds: &AzureCreds{
+				SubscriptionID: "89a",
+				TenantID:       "60e",
+				ClientID:       "f70",
+				ClientSecret:   "8Q~",
+			},
+			expectedError: false,
+		},
+		"invalid file": {
+			path:          "../../test/setup/fake_credential",
+			expectedError: true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			azureCreds, err := ReadCredentials(test.path)
+			if test.expectedError {
+				g.Expect(err).To(Not(BeNil()))
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(azureCreds).To(Equal(test.expectedAzureCreds))
+			}
+		})
+	}
+}

--- a/docs/content/how-to/azure/create-azure-cluster.md
+++ b/docs/content/how-to/azure/create-azure-cluster.md
@@ -1,12 +1,10 @@
- # Create an Azure cluster
-
+# Create an Azure cluster
 This document describes how to set up an Azure cluster with Hypershift.
 
 ## Prerequisites
-
 In order to authenticate with Azure, an Application must be created through the web portal. Follow [this guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) to create one.
 
-Afterwards, create a credentials file that looks like this:
+Afterward, create a credentials file that looks like this:
 
 ```
 subscriptionId: <your_subscription_id>
@@ -16,6 +14,7 @@ clientSecret: <your_client_secret>
 ```
 
 ## Install the Hypershift Operator
+This example uses optional external dns flags to set up external dns.
 
 ```
 hypershift install --external-dns-provider=azure \
@@ -25,10 +24,8 @@ hypershift install --external-dns-provider=azure \
 
 See [external DNS docs](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md#creating-a-configuration-file-for-the-service-principal) for the format of the azure.json file.
 
-## Creating the cluster
-
+## Creating the Cluster
 After the credentials file was set up, creating a cluster is a simple matter of invoking the `hypershift` cli:
-
 
 ```
 hypershift create cluster azure --pull-secret <pull_secret_file> \
@@ -39,3 +36,29 @@ hypershift create cluster azure --pull-secret <pull_secret_file> \
 --node-pool-replicas 3 \
 --external-dns-domain=<service_provider_domain>
 ```
+
+## Creating the Cluster in an Existing Resource Group
+If you want to use an existing resource group you've created in Azure, you can pass the name into the `--resource-group-name` flag. This will create all needed Azure infrastructure in specified resource group.
+
+```
+hypershift create cluster azure --pull-secret <pull_secret_file> \
+--name <cluster_name> \
+--azure-creds <path_to_azure_credentials_file> \
+--location eastus --base-domain <base_domain> \
+--release-image <release_image> \
+--node-pool-replicas 3 \
+--resource-group-name <my_existing_resource_group>
+```
+
+If you need to delete your hosted cluster, you will need to also use the `--resource-group-name` flag on the delete command.
+
+```
+hypershift destroy cluster azure \
+--name $CLUSTER_NAME \ 
+--azure-creds $AZURE_CREDS \
+--resource-group-name <my_existing_resource_group>
+```
+
+!!! note
+    
+    If you delete your hosted cluster, it will end up deleting any existing resources prior to when the hosted cluster was created as well as the resource group itself.

--- a/test/setup/fake_credentials
+++ b/test/setup/fake_credentials
@@ -1,0 +1,4 @@
+subscriptionId: 89a
+tenantId: 60e
+clientId: f70
+clientSecret: 8Q~


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows a user to bring their own resource group to be used to contain all the created Azure infrastructure needed for their hosted cluster. Also allows a user to specify the resource group they brought when deleting a hosted cluster.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1329](https://issues.redhat.com/browse/HOSTEDCP-1329)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.