### PR TITLE
ACM-8466: Add Kubernetes SCC V2 options to HO containers

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -46,6 +46,14 @@ var (
 	// allowPrivilegeEscalation is used to set the status of the
 	// privilegeEscalation on SeccompProfile
 	allowPrivilegeEscalation = false
+
+	// readOnlyRootFilesystem is used to set the container security
+	// context to mount the root filesystem as read-only.
+	readOnlyRootFilesystem = true
+
+	// privileged is used to set the container security
+	// context to run container as unprivileged.
+	privileged = false
 )
 
 type HyperShiftNamespace struct {
@@ -231,6 +239,10 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 									corev1.ResourceMemory: resource.MustParse("20Mi"),
 									corev1.ResourceCPU:    resource.MustParse("5m"),
 								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
+								Privileged:             &privileged,
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -553,7 +565,9 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 							Command:         []string{"/usr/bin/hypershift-operator"},
 							Args:            []string{"init"},
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: k8sutilspointer.Int64(1000),
+								RunAsUser:              k8sutilspointer.Int64(1000),
+								ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
+								Privileged:             &privileged,
 							},
 							VolumeMounts: initVolumeMounts,
 						},
@@ -573,6 +587,8 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 								SeccompProfile: &corev1.SeccompProfile{
 									Type: corev1.SeccompProfileTypeRuntimeDefault,
 								},
+								ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
+								Privileged:             &privileged,
 							},
 							Image:           image,
 							ImagePullPolicy: corev1.PullIfNotPresent,

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -414,6 +414,9 @@ objects:
             requests:
               cpu: 5m
               memory: 20Mi
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
           volumeMounts:
           - mountPath: /etc/provider
             name: credentials
@@ -528,6 +531,8 @@ objects:
             capabilities:
               drop:
               - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
@@ -553,6 +558,8 @@ objects:
           name: init-environment
           resources: {}
           securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
             runAsUser: 1000
           volumeMounts:
           - mountPath: /var/run/ca-trust


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to guarantee that all pods running within the ACM (Advanced Cluster Management) cluster adhere to Kubernetes Security Context Constraints (SCC) to ensure that containers run with the 'readonlyrootfilesystem' and 'privileged' settings, in order to enhance the security and functionality.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/ACM-8466

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.