### PR TITLE
ACM-8917: Add agentLabelSelector to nodepool agent create to CLI

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -3,9 +3,10 @@ package fixtures
 import (
 	"crypto/rand"
 	"fmt"
-	"github.com/openshift/hypershift/cmd/util"
 	"strings"
 	"time"
+
+	"github.com/openshift/hypershift/cmd/util"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 
@@ -656,10 +657,24 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			}
 			nodePool.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation] = val
 		}
-	case hyperv1.NonePlatform, hyperv1.AgentPlatform:
+	case hyperv1.NonePlatform:
 		nodePool := defaultNodePool(cluster.Name)
 		if nodePool.Spec.Management.UpgradeType == "" {
 			nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeInPlace
+		}
+		nodePools = append(nodePools, nodePool)
+	case hyperv1.AgentPlatform:
+		nodePool := defaultNodePool(cluster.Name)
+		nodePool.Spec.Platform.Agent = &hyperv1.AgentNodePoolPlatform{}
+		if nodePool.Spec.Management.UpgradeType == "" {
+			nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeInPlace
+		}
+		if o.Agent.AgentLabelSelector != "" {
+			agentSelector, err := metav1.ParseToLabelSelector(o.Agent.AgentLabelSelector)
+			if err != nil {
+				panic(fmt.Sprintf("Failed to parse AgentLabelSelector: %s", err))
+			}
+			nodePool.Spec.Platform.Agent.AgentLabelSelector = agentSelector
 		}
 		nodePools = append(nodePools, nodePool)
 	case hyperv1.AzurePlatform:

--- a/api/fixtures/example_agent.go
+++ b/api/fixtures/example_agent.go
@@ -6,8 +6,9 @@ import (
 )
 
 type ExampleAgentOptions struct {
-	APIServerAddress string
-	AgentNamespace   string
+	APIServerAddress   string
+	AgentNamespace     string
+	AgentLabelSelector string
 }
 
 type ExampleAgentResources struct {

--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -28,6 +28,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.AgentPlatform.APIServerAddress, "api-server-address", opts.AgentPlatform.APIServerAddress, "The API server address is the IP address for Kubernetes API communication")
 	cmd.Flags().StringVar(&opts.AgentPlatform.AgentNamespace, "agent-namespace", opts.AgentPlatform.AgentNamespace, "The namespace in which to search for Agents")
+	cmd.Flags().StringVar(&opts.AgentPlatform.AgentLabelSelector, "agentLabelSelector", opts.AgentPlatform.AgentLabelSelector, "A LabelSelector for selecting Agents according to their labels, e.g., 'size=large,zone notin (az1,az2)'")
 	_ = cmd.MarkFlagRequired("agent-namespace")
 	_ = cmd.MarkPersistentFlagRequired("pull-secret")
 
@@ -69,8 +70,9 @@ func ApplyPlatformSpecificsValues(ctx context.Context, exampleOptions *fixtures.
 	}
 
 	exampleOptions.Agent = &fixtures.ExampleAgentOptions{
-		APIServerAddress: opts.AgentPlatform.APIServerAddress,
-		AgentNamespace:   opts.AgentPlatform.AgentNamespace,
+		APIServerAddress:   opts.AgentPlatform.APIServerAddress,
+		AgentNamespace:     opts.AgentPlatform.AgentNamespace,
+		AgentLabelSelector: opts.AgentPlatform.AgentLabelSelector,
 	}
 
 	// Validate that the agent namespace exists

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -106,8 +106,9 @@ type PowerVSPlatformOptions struct {
 }
 
 type AgentPlatformCreateOptions struct {
-	APIServerAddress string
-	AgentNamespace   string
+	APIServerAddress   string
+	AgentNamespace     string
+	AgentLabelSelector string
 }
 
 type NonePlatformCreateOptions struct {

--- a/cmd/nodepool/agent/create.go
+++ b/cmd/nodepool/agent/create.go
@@ -2,18 +2,24 @@ package agent
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type AgentPlatformCreateOptions struct{}
+type AgentPlatformCreateOptions struct {
+	AgentLabelSelector string
+}
 
 func NewAgentPlatformCreateOptions(_ *cobra.Command) *AgentPlatformCreateOptions {
-	platformOpts := &AgentPlatformCreateOptions{}
+	platformOpts := &AgentPlatformCreateOptions{
+		AgentLabelSelector: "",
+	}
 
 	return platformOpts
 }
@@ -26,20 +32,23 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	}
 
 	platformOpts := NewAgentPlatformCreateOptions(cmd)
-
+	cmd.Flags().StringVar(&platformOpts.AgentLabelSelector, "agentLabelSelector", platformOpts.AgentLabelSelector, "A LabelSelector for selecting Agents according to their labels, e.g., 'size=large,zone notin (az1,az2)'")
 	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
 
 	return cmd
 }
 
-func (o *AgentPlatformCreateOptions) UpdateNodePool(_ context.Context, _ *hyperv1.NodePool, _ *hyperv1.HostedCluster, _ crclient.Client) error {
+func (o *AgentPlatformCreateOptions) UpdateNodePool(_ context.Context, nodePool *hyperv1.NodePool, _ *hyperv1.HostedCluster, _ crclient.Client) error {
+	agentSelector, err := metav1.ParseToLabelSelector(o.AgentLabelSelector)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to parse AgentLabelSelector: %s", err))
+	}
+	nodePool.Spec.Platform.Agent = &hyperv1.AgentNodePoolPlatform{
+		AgentLabelSelector: agentSelector,
+	}
 	return nil
 }
 
 func (o *AgentPlatformCreateOptions) Type() hyperv1.PlatformType {
 	return hyperv1.AgentPlatform
-}
-
-func (o *AgentPlatformCreateOptions) Validate() error {
-	return nil
 }

--- a/product-cli/cmd/cluster/agent/create.go
+++ b/product-cli/cmd/cluster/agent/create.go
@@ -16,12 +16,14 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	}
 
 	opts.AgentPlatform = core.AgentPlatformCreateOptions{
-		APIServerAddress: "",
-		AgentNamespace:   "",
+		APIServerAddress:   "",
+		AgentNamespace:     "",
+		AgentLabelSelector: "",
 	}
 
 	cmd.Flags().StringVar(&opts.AgentPlatform.APIServerAddress, "api-server-address", opts.AgentPlatform.APIServerAddress, "The API server address is the IP address for Kubernetes API communication")
 	cmd.Flags().StringVar(&opts.AgentPlatform.AgentNamespace, "agent-namespace", opts.AgentPlatform.AgentNamespace, "The namespace in which to search for Agents")
+	cmd.Flags().StringVar(&opts.AgentPlatform.AgentLabelSelector, "agentLabelSelector", opts.AgentPlatform.AgentLabelSelector, "A LabelSelector used to select Agents according to their labels, in JSON format")
 	_ = cmd.MarkFlagRequired("agent-namespace")
 	_ = cmd.MarkPersistentFlagRequired("pull-secret")
 

--- a/product-cli/cmd/nodepool/agent/create.go
+++ b/product-cli/cmd/nodepool/agent/create.go
@@ -15,6 +15,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	}
 
 	platformOpts := hypershiftagent.NewAgentPlatformCreateOptions(cmd)
+	cmd.Flags().StringVar(&platformOpts.AgentLabelSelector, "agentLabelSelector", platformOpts.AgentLabelSelector, "A LabelSelector for selecting Agents according to their labels, e.g., 'size=large,zone notin (az1,az2)'")
 	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
 
 	return cmd


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit allows specifying agentLabelSelector via hypershift CLI as part of 'create nodepool' and 'create cluster'.

The labelselector is passed as a JSON string, for example: ./bin/hypershift create nodepool agent \
--cluster-name for \
--name bar \
--node-count 2 \
--agentLabelSelector 'size=large,zone notin (az1,az2)'


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[ACM-8917](https://issues.redhat.com//browse/ACM-8917)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.