### PR TITLE
remove confusing deployment code

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -79,7 +79,6 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 	}
 
 	deployment.Spec = appsv1.DeploymentSpec{
-		Replicas: k8sutilspointer.Int32(1),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: selector,
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
@@ -25,9 +25,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedContr
 		Selector: &metav1.LabelSelector{
 			MatchLabels: ccmLabels(),
 		},
-		Strategy: appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
-		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: ccmLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
@@ -26,9 +26,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedContr
 		Selector: &metav1.LabelSelector{
 			MatchLabels: ccmLabels(),
 		},
-		Strategy: appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
-		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: ccmLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
@@ -110,9 +110,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedContr
 		Selector: &metav1.LabelSelector{
 			MatchLabels: ccmLabels(),
 		},
-		Strategy: appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
-		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: ccmLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/powervs/powervs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/powervs/powervs.go
@@ -98,7 +98,6 @@ func ReconcileCCMDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedCo
 	}
 
 	deployment.Spec = appsv1.DeploymentSpec{
-		Replicas: utilpointer.Int32(int32(replicas)),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{"k8s-app": deployment.Name},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
@@ -7,7 +7,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
@@ -37,14 +36,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	mainContainer := util.FindContainer(cpcContainerMain().Name, deployment.Spec.Template.Spec.Containers)
 	if mainContainer != nil {
 		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
-	}
-
-	maxSurge := intstr.FromInt(1)
-	maxUnavailable := intstr.FromInt(0)
-	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
-	deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-		MaxSurge:       &maxSurge,
-		MaxUnavailable: &maxUnavailable,
 	}
 	if deployment.Spec.Selector == nil {
 		deployment.Spec.Selector = &metav1.LabelSelector{

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -293,9 +293,7 @@ func ReconcileServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef
 func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
 	params.OwnerRef.ApplyTo(dep)
 
-	dep.Spec.Replicas = utilpointer.Int32(1)
 	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": operatorName}}
-	dep.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
 	if dep.Spec.Template.Annotations == nil {
 		dep.Spec.Template.Annotations = map[string]string{}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -251,9 +251,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 		Selector: &metav1.LabelSelector{
 			MatchLabels: selectorLabels,
 		},
-		Strategy: appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
-		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				// We copy the map here, otherwise this .Labels would point to the same address that .MatchLabels

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -99,7 +99,6 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
 	dep.Spec.Replicas = utilpointer.Int32(1)
 	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": operatorName}}
-	dep.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
 	if dep.Spec.Template.Annotations == nil {
 		dep.Spec.Template.Annotations = map[string]string{}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -9,7 +9,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud"
@@ -77,13 +76,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceS
 		}
 	}
 	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
-	maxSurge := intstr.FromInt(3)
-	maxUnavailable := intstr.FromInt(1)
 	args := kcmArgs(p)
-	deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-		MaxSurge:       &maxSurge,
-		MaxUnavailable: &maxUnavailable,
-	}
 	if deployment.Spec.Template.ObjectMeta.Labels == nil {
 		deployment.Spec.Template.ObjectMeta.Labels = map[string]string{}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
@@ -102,7 +102,6 @@ func ReconcileMachineApproverDeployment(deployment *appsv1.Deployment, hcp *hype
 		"app": "machine-approver",
 	}
 	deployment.Spec = appsv1.DeploymentSpec{
-		Replicas: k8sutilspointer.Int32(1),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: selector,
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
@@ -97,16 +96,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, auditWebhookRef *corev1.
 	}
 	auditConfigHash := util.ComputeHash(auditConfigBytes)
 
-	maxUnavailable := intstr.FromInt(1)
-	maxSurge := intstr.FromInt(3)
-
-	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
-		Type: appsv1.RollingUpdateDeploymentStrategyType,
-		RollingUpdate: &appsv1.RollingUpdateDeployment{
-			MaxUnavailable: &maxUnavailable,
-			MaxSurge:       &maxSurge,
-		},
-	}
 	if deployment.Spec.Selector == nil {
 		deployment.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: openShiftAPIServerLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -63,22 +63,12 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 		p.DeploymentConfig.SetContainerResourcesIfPresent(mainContainer)
 	}
 
-	maxUnavailable := intstr.FromInt(1)
-	maxSurge := intstr.FromInt(3)
-
 	auditConfigBytes, ok := auditConfig.Data[auditPolicyConfigMapKey]
 	if !ok {
 		return fmt.Errorf("openshift-oauth-apiserver audit configuration is not expected to be empty")
 	}
 	auditConfigHash := util.ComputeHash(auditConfigBytes)
 
-	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
-		Type: appsv1.RollingUpdateDeploymentStrategyType,
-		RollingUpdate: &appsv1.RollingUpdateDeployment{
-			MaxUnavailable: &maxUnavailable,
-			MaxSurge:       &maxSurge,
-		},
-	}
 	if deployment.Spec.Selector == nil {
 		deployment.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: openShiftOAuthAPIServerLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -64,13 +63,6 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 		deployment.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: oauthLabels(),
 		}
-	}
-	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
-	maxSurge := intstr.FromInt(3)
-	maxUnavailable := intstr.FromInt(1)
-	deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-		MaxSurge:       &maxSurge,
-		MaxUnavailable: &maxUnavailable,
 	}
 	if deployment.Spec.Template.ObjectMeta.Labels == nil {
 		deployment.Spec.Template.ObjectMeta.Labels = map[string]string{}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/deployment.go
@@ -8,7 +8,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
@@ -54,13 +53,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
 	}
 
-	maxSurge := intstr.FromInt(1)
-	maxUnavailable := intstr.FromInt(0)
-	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
-	deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-		MaxSurge:       &maxSurge,
-		MaxUnavailable: &maxUnavailable,
-	}
 	if deployment.Spec.Selector == nil {
 		deployment.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: openShiftControllerManagerLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/pkioperator/testdata/zz_fixture_TestReconcileControlPlanePKIOperatorDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/pkioperator/testdata/zz_fixture_TestReconcileControlPlanePKIOperatorDeployment.yaml
@@ -18,7 +18,11 @@ spec:
   selector:
     matchLabels:
       name: control-plane-pki-operator
-  strategy: {}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -181,9 +181,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, params Params) error {
 		Selector: &metav1.LabelSelector{
 			MatchLabels: selectorLabels(),
 		},
-		Strategy: appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
-		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: selectorLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -12,7 +12,10 @@ spec:
     matchLabels:
       name: cluster-image-registry-operator
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/deployment.go
@@ -8,7 +8,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
@@ -55,13 +54,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image string, config *co
 		deploymentConfig.SetContainerResourcesIfPresent(mainContainer)
 	}
 
-	maxSurge := intstr.FromInt(0)
-	maxUnavailable := intstr.FromInt(1)
-	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
-	deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-		MaxSurge:       &maxSurge,
-		MaxUnavailable: &maxUnavailable,
-	}
 	if deployment.Spec.Selector == nil {
 		deployment.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: openShiftRouteControllerManagerLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -10,7 +10,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -56,8 +55,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		config.SetContainerResourcesIfPresent(mainContainer)
 	}
 
-	maxSurge := intstr.FromInt(3)
-	maxUnavailable := intstr.FromInt(1)
 	s := deployment.Spec.Selector
 	if deployment.Spec.Selector == nil {
 		s = &metav1.LabelSelector{
@@ -66,13 +63,6 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	}
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: s,
-		Strategy: appsv1.DeploymentStrategy{
-			Type: appsv1.RollingUpdateDeploymentStrategyType,
-			RollingUpdate: &appsv1.RollingUpdateDeployment{
-				MaxSurge:       &maxSurge,
-				MaxUnavailable: &maxUnavailable,
-			},
-		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
@@ -18,7 +18,11 @@ spec:
   selector:
     matchLabels:
       app: csi-snapshot-controller-operator
-  strategy: {}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -79,18 +79,21 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 		deployment.Spec.Replicas = pointer.Int32(int32(c.Replicas))
 	}
 	// there are two standard cases currently with hypershift: HA mode where there are 3 replicas spread across
-	// zones and then non ha with one replica. When only 3 zones are available you need to be able to set maxUnavailable
+	// zones and then non ha with 1 replica. When only 3 zones are available you need to be able to set maxUnavailable
 	// in order to progress the rollout. However, you do not want to set that in the single replica case because it will
 	// result in downtime.
+	maxSurge := intstr.FromInt(1)
+	maxUnavailable := intstr.FromInt(0)
 	if c.Replicas > 1 {
-		maxSurge := intstr.FromInt(0)
-		maxUnavailable := intstr.FromInt(1)
-		if deployment.Spec.Strategy.RollingUpdate == nil {
-			deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{}
-		}
-		deployment.Spec.Strategy.RollingUpdate.MaxSurge = &maxSurge
-		deployment.Spec.Strategy.RollingUpdate.MaxUnavailable = &maxUnavailable
+		maxSurge = intstr.FromInt(0)
+		maxUnavailable = intstr.FromInt(1)
 	}
+	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
+	if deployment.Spec.Strategy.RollingUpdate == nil {
+		deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{}
+	}
+	deployment.Spec.Strategy.RollingUpdate.MaxSurge = &maxSurge
+	deployment.Spec.Strategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 
 	// set default security context for pod
 	if c.SetDefaultSecurityContext {


### PR DESCRIPTION
`DeploymentConfig` `ApplyTo()` is the authoritative setter of deployment `replicas` and `strategy`.

The PR removes any setting of `replicas` and `strategy` directly in the deployment spec only to be overwritten by `ApplyTo()` later.

It also switches all Deployments that were using `Recreate` strategy type to `RollingUpdate`.  There is no reason that any pod in the HCP should need to wait for the previous version to fully terminate before starting the new version.

EDIT, this might not be true for HCP pods that mount PV storage

Also, `ApplyTo()` was only setting RollingUpdate `maxSurge` and `maxUnavailable` for HA deployments, leaving whatever was set in the Deployment untouched (many set `maxSurge` to 3 for some unknown reason).  `ApplyTo()` should authoritatively set `strategy` settings for single replica deployments as well.

HA deployments should have `maxSurge` of 0 and `maxUnavailable` of 1.  SR deployments should have a `maxSurge` of `1` and `maxUnavailable` of 0.