### PR TITLE
NO-JIRA: Fix wrong annotation on cluster deletion

### DIFF
--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -255,7 +255,7 @@ func waitForClusterDeletion(ctx context.Context, hostedCluster *hyperv1.HostedCl
 
 		// don't wait for grace period. Nothing happens after grace period in the controller, but it's only
 		// for debug. So it's safe to continue in case of grace period.
-		if _, ok := hostedCluster.Annotations[hyperv1.CleanupCloudResourcesAnnotation]; ok {
+		if _, ok := hostedCluster.Annotations[hyperv1.HCDestroyGracePeriodAnnotation]; ok {
 			if meta.FindStatusCondition(hostedCluster.Status.Conditions, string(hyperv1.HostedClusterDestroyed)) != nil {
 				return true, nil
 			}


### PR DESCRIPTION
## What this PR does / why we need it
PR #3234 used the wrong HostedCluster annotation to check if the cluster may be considered as already deleted.

This PR fixes the annotation name to `"hypershift.openshift.io/destroy-grace-period"`

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.