### PR TITLE
OCPBUGS-23362: Set new condition on SG deletion.

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -146,6 +146,12 @@ const (
 	// blocked from creating machines.
 	AWSDefaultSecurityGroupCreated ConditionType = "AWSDefaultSecurityGroupCreated"
 
+	// AWSDefaultSecurityGroupDeleted indicates whether the default security group
+	// for AWS workers has been deleted.
+	// A failure here indicates that the Security Group has some dependencies that
+	// there are still pending cloud resources to be deleted that are using that SG.
+	AWSDefaultSecurityGroupDeleted ConditionType = "AWSDefaultSecurityGroupDeleted"
+
 	// PlatformCredentialsFound indicates that credentials required for the
 	// desired platform are valid.
 	// A failure here is unlikely to resolve without the changing user input.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2981,6 +2981,12 @@ for AWS workers has been created.
 A failure here indicates that NodePools without a security group will be
 blocked from creating machines.</p>
 </td>
+</tr><tr><td><p>&#34;AWSDefaultSecurityGroupDeleted&#34;</p></td>
+<td><p>AWSDefaultSecurityGroupDeleted indicates whether the default security group
+for AWS workers has been deleted.
+A failure here indicates that the Security Group has some dependencies that
+there are still pending cloud resources to be deleted that are using that SG.</p>
+</td>
 </tr><tr><td><p>&#34;AWSEndpointAvailable&#34;</p></td>
 <td><p>AWSEndpointServiceAvailable indicates whether the AWS Endpoint has been
 created in the guest VPC</p>


### PR DESCRIPTION
Set a new `status.condition` when CPO deletes the SecurityGroup.

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-23362](https://issues.redhat.com/browse/OCPBUGS-23362)

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>
