### PR TITLE
OCPBUGS-23457: Add e2e check for OpenShift APIService availability during upgrade

### DIFF
--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -43,7 +43,19 @@ func TestUpgradeControlPlane(t *testing.T) {
 
 		// Wait for the new rollout to be complete
 		t.Logf("waiting for updated cluster image rollout. Image: %s", globalOpts.LatestReleaseImage)
+		doneUpgrading := make(chan struct{})
+		restConfig, err := e2eutil.WaitForGuestRESTConfig(t, ctx, mgtClient, hostedCluster)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get guest rest config")
+
+		apiServiceHealthResult := &e2eutil.APIServerHealthResult{}
+		e2eutil.WatchOpenShiftAPIServiceHealth(t, ctx, restConfig, apiServiceHealthResult, doneUpgrading)
 		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster, globalOpts.LatestReleaseImage)
+		close(doneUpgrading)
+
+		if apiServiceHealthResult.WasUnhealthy() {
+			t.Errorf("API services were unavailable during upgrade.\n%s", apiServiceHealthResult.Report())
+		}
+
 		err = mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 

--- a/test/e2e/util/apiservice.go
+++ b/test/e2e/util/apiservice.go
@@ -1,0 +1,134 @@
+package util
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type TimeSegment struct {
+	Start time.Time
+	End   time.Time
+}
+
+func (t TimeSegment) String() string {
+	if t.End.IsZero() {
+		return fmt.Sprintf("%s - present", t.Start)
+	}
+	return fmt.Sprintf("%s - %s (%s)", t.Start, t.End, t.End.Sub(t.Start))
+}
+
+type APIServerHealthResult struct {
+	// Unavailable keeps track of the time segments that APIServices were unavailable during
+	// the upgrade.
+	Unavailable map[string][]TimeSegment
+}
+
+func (r *APIServerHealthResult) isAvailable(serviceName string) bool {
+	if r.Unavailable == nil {
+		return true
+	}
+	segments, ok := r.Unavailable[serviceName]
+	if !ok {
+		return true
+	}
+	// If the last segment is still open, the service is unavailable
+	lastSegment := segments[len(segments)-1]
+	return !lastSegment.End.IsZero()
+}
+
+func (r *APIServerHealthResult) ReportAvailability(serviceName string, available bool) {
+	// If the service is already in the desired state, do nothing
+	if available == r.isAvailable(serviceName) {
+		return
+	}
+	if r.Unavailable == nil {
+		r.Unavailable = make(map[string][]TimeSegment)
+	}
+	if available {
+		// If the service is available, close the last segment
+		if segments, ok := r.Unavailable[serviceName]; ok {
+			lastSegment := segments[len(segments)-1]
+			lastSegment.End = time.Now()
+			segments[len(segments)-1] = lastSegment
+		}
+	} else {
+		// If the service is unavailable, start a new segment
+		r.Unavailable[serviceName] = append(r.Unavailable[serviceName], TimeSegment{
+			Start: time.Now(),
+		})
+	}
+}
+
+func (r *APIServerHealthResult) WasUnhealthy() bool {
+	return r.Unavailable != nil && len(r.Unavailable) > 0
+}
+
+func (r *APIServerHealthResult) Report() string {
+	if r.Unavailable == nil {
+		return ""
+	}
+	b := &bytes.Buffer{}
+	for serviceName, segments := range r.Unavailable {
+		for _, segment := range segments {
+			fmt.Fprintf(b, "%s was unavailable: %s\n", serviceName, segment.String())
+		}
+	}
+	return b.String()
+}
+
+// WatchOpenShiftAPIServiceHealth watches the OpenShift API services to ensure they are available
+func WatchOpenShiftAPIServiceHealth(t *testing.T, ctx context.Context, cfg *rest.Config, result *APIServerHealthResult, done <-chan struct{}) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	// Watch the OpenShift API services to ensure they are available
+	t.Logf("Watching health of OpenShift API services")
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create manager")
+	r := func(rCtx context.Context, req reconcile.Request) (ctrl.Result, error) {
+		client := mgr.GetClient()
+		apiService := &apiregistrationv1.APIService{}
+		err := client.Get(rCtx, req.NamespacedName, apiService)
+		if err != nil && !errors.IsNotFound(err) {
+			t.Logf("failed to get APIService %s: %v", req.NamespacedName, err)
+			return ctrl.Result{}, err
+		}
+		if apiService.Spec.Service != nil && apiService.Spec.Service.Namespace == "default" &&
+			(apiService.Spec.Service.Name == "openshift-apiserver" || apiService.Spec.Service.Name == "openshift-oauth-apiserver") {
+			for _, cond := range apiService.Status.Conditions {
+				if cond.Type == apiregistrationv1.Available {
+					t.Logf("Reporting availability of %s: %v, lastTransitionTime: %v, message: %s", apiService.Name, cond.Status == apiregistrationv1.ConditionTrue, cond.LastTransitionTime, cond.Message)
+					result.ReportAvailability(apiService.Name, cond.Status == apiregistrationv1.ConditionTrue)
+				}
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+	err = ctrl.NewControllerManagedBy(mgr).For(&apiregistrationv1.APIService{}).Complete(reconcile.Func(r))
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create controller")
+	mgrCtx, mgrCancel := context.WithCancel(ctx)
+	go func() {
+		err := mgr.Start(mgrCtx)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to start manager")
+	}()
+	go func() {
+		<-done
+		mgrCancel()
+	}()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Starts a controller to watch APIServices in guest cluster during a control plane upgrade. Fails the test if an OpenShift APIService goes unavailable.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-23457](https://issues.redhat.com/browse/OCPBUGS-23457)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.