### PR TITLE
HOSTEDCP-1273: Added support for OLM Disable default sources on HC creation

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -3,9 +3,10 @@ package fixtures
 import (
 	"crypto/rand"
 	"fmt"
-	"github.com/openshift/hypershift/cmd/util"
 	"strings"
 	"time"
+
+	"github.com/openshift/hypershift/cmd/util"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 
@@ -81,6 +82,7 @@ type ExampleOptions struct {
 	Arch                             string
 	PausedUntil                      string
 	OLMCatalogPlacement              hyperv1.OLMCatalogPlacement
+	OperatorHub                      *configv1.OperatorHubSpec
 	AWS                              *ExampleAWSOptions
 	None                             *ExampleNoneOptions
 	Agent                            *ExampleAgentOptions
@@ -514,6 +516,14 @@ func (o ExampleOptions) Resources() *ExampleResources {
 
 	if len(o.PausedUntil) > 0 {
 		cluster.Spec.PausedUntil = &o.PausedUntil
+	}
+
+	if cluster.Spec.Configuration == nil {
+		cluster.Spec.Configuration = &hyperv1.ClusterConfiguration{}
+	}
+
+	if o.OperatorHub != nil {
+		cluster.Spec.Configuration.OperatorHub = o.OperatorHub
 	}
 
 	if len(o.OLMCatalogPlacement) > 0 {

--- a/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -2115,6 +2115,12 @@ type ClusterConfiguration struct {
 	// +optional
 	OAuth *configv1.OAuthSpec `json:"oauth,omitempty"`
 
+	// OperatorHub specifies the configuration for the Operator Lifecycle Manager in the HostedCluster. This is only configured at deployment time but the controller are not reconcilling over it.
+	// The OperatorHub configuration will be constantly reconciled if catalog placement is management, but only on cluster creation otherwise.
+	//
+	// +optional
+	OperatorHub *configv1.OperatorHubSpec `json:"operatorhub,omitempty"`
+
 	// Scheduler holds cluster-wide config information to run the Kubernetes Scheduler
 	// and influence its placement decisions. The canonical name for this config is `cluster`.
 	// +optional

--- a/api/hypershift/v1alpha1/zz_generated.deepcopy.go
+++ b/api/hypershift/v1alpha1/zz_generated.deepcopy.go
@@ -628,6 +628,11 @@ func (in *ClusterConfiguration) DeepCopyInto(out *ClusterConfiguration) {
 		*out = new(configv1.OAuthSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.OperatorHub != nil {
+		in, out := &in.OperatorHub, &out.OperatorHub
+		*out = new(configv1.OperatorHubSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Scheduler != nil {
 		in, out := &in.Scheduler, &out.Scheduler
 		*out = new(configv1.SchedulerSpec)

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -2170,6 +2170,12 @@ type ClusterConfiguration struct {
 	// +kubebuilder:validation:XValidation:rule="!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout) || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds() >= 300", message="spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout minimum acceptable token timeout value is 300 seconds"
 	OAuth *configv1.OAuthSpec `json:"oauth,omitempty"`
 
+	// OperatorHub specifies the configuration for the Operator Lifecycle Manager in the HostedCluster. This is only configured at deployment time but the controller are not reconcilling over it.
+	// The OperatorHub configuration will be constantly reconciled if catalog placement is management, but only on cluster creation otherwise.
+	//
+	// +optional
+	OperatorHub *configv1.OperatorHubSpec `json:"operatorhub,omitempty"`
+
 	// Scheduler holds cluster-wide config information to run the Kubernetes Scheduler
 	// and influence its placement decisions. The canonical name for this config is `cluster`.
 	// +optional

--- a/api/hypershift/v1beta1/zz_generated.deepcopy.go
+++ b/api/hypershift/v1beta1/zz_generated.deepcopy.go
@@ -691,6 +691,11 @@ func (in *ClusterConfiguration) DeepCopyInto(out *ClusterConfiguration) {
 		*out = new(configv1.OAuthSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.OperatorHub != nil {
+		in, out := &in.OperatorHub, &out.OperatorHub
+		*out = new(configv1.OperatorHubSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Scheduler != nil {
 		in, out := &in.Scheduler, &out.Scheduler
 		*out = new(configv1.SchedulerSpec)

--- a/client/applyconfiguration/hypershift/v1alpha1/clusterconfiguration.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/clusterconfiguration.go
@@ -36,6 +36,7 @@ type ClusterConfigurationApplyConfiguration struct {
 	Ingress        *configv1.IngressSpec        `json:"ingress,omitempty"`
 	Network        *configv1.NetworkSpec        `json:"network,omitempty"`
 	OAuth          *configv1.OAuthSpec          `json:"oauth,omitempty"`
+	OperatorHub    *configv1.OperatorHubSpec    `json:"operatorhub,omitempty"`
 	Scheduler      *configv1.SchedulerSpec      `json:"scheduler,omitempty"`
 	Proxy          *configv1.ProxySpec          `json:"proxy,omitempty"`
 }
@@ -129,6 +130,14 @@ func (b *ClusterConfigurationApplyConfiguration) WithNetwork(value configv1.Netw
 // If called multiple times, the OAuth field is set to the value of the last call.
 func (b *ClusterConfigurationApplyConfiguration) WithOAuth(value configv1.OAuthSpec) *ClusterConfigurationApplyConfiguration {
 	b.OAuth = &value
+	return b
+}
+
+// WithOperatorHub sets the OperatorHub field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the OperatorHub field is set to the value of the last call.
+func (b *ClusterConfigurationApplyConfiguration) WithOperatorHub(value configv1.OperatorHubSpec) *ClusterConfigurationApplyConfiguration {
+	b.OperatorHub = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/clusterconfiguration.go
+++ b/client/applyconfiguration/hypershift/v1beta1/clusterconfiguration.go
@@ -31,6 +31,7 @@ type ClusterConfigurationApplyConfiguration struct {
 	Ingress        *v1.IngressSpec        `json:"ingress,omitempty"`
 	Network        *v1.NetworkSpec        `json:"network,omitempty"`
 	OAuth          *v1.OAuthSpec          `json:"oauth,omitempty"`
+	OperatorHub    *v1.OperatorHubSpec    `json:"operatorhub,omitempty"`
 	Scheduler      *v1.SchedulerSpec      `json:"scheduler,omitempty"`
 	Proxy          *v1.ProxySpec          `json:"proxy,omitempty"`
 }
@@ -94,6 +95,14 @@ func (b *ClusterConfigurationApplyConfiguration) WithNetwork(value v1.NetworkSpe
 // If called multiple times, the OAuth field is set to the value of the last call.
 func (b *ClusterConfigurationApplyConfiguration) WithOAuth(value v1.OAuthSpec) *ClusterConfigurationApplyConfiguration {
 	b.OAuth = &value
+	return b
+}
+
+// WithOperatorHub sets the OperatorHub field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the OperatorHub field is set to the value of the last call.
+func (b *ClusterConfigurationApplyConfiguration) WithOperatorHub(value v1.OperatorHubSpec) *ClusterConfigurationApplyConfiguration {
+	b.OperatorHub = &value
 	return b
 }
 

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -43,6 +43,7 @@ func NewCreateCommands() *cobra.Command {
 		NodeUpgradeType:                "",
 		Arch:                           "amd64",
 		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
+		OLMDisableDefaultSources:       false,
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -82,7 +83,8 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
-	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olmCatalogPlacement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
+	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olm-catalog-placement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
+	cmd.PersistentFlags().BoolVar(&opts.OLMDisableDefaultSources, "olm-disable-default-sources", opts.OLMDisableDefaultSources, "Disables the OLM default catalog sources for the HostedCluster.")
 	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The default processor architecture for the NodePool (e.g. arm64, amd64)")
 	cmd.PersistentFlags().StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +82,7 @@ type CreateOptions struct {
 	NodeUpgradeType                  hyperv1.UpgradeType
 	PausedUntil                      string
 	OLMCatalogPlacement              hyperv1.OLMCatalogPlacement
+	OLMDisableDefaultSources         bool
 
 	// BeforeApply is called immediately before resources are applied to the
 	// server, giving the user an opportunity to inspect or mutate the resources.
@@ -285,6 +287,13 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		}
 	}
 
+	var operatorHub *configv1.OperatorHubSpec
+	if opts.OLMDisableDefaultSources {
+		operatorHub = &configv1.OperatorHubSpec{
+			DisableAllDefaultSources: true,
+		}
+	}
+
 	return &apifixtures.ExampleOptions{
 		AdditionalTrustBundle:            string(userCABundle),
 		ImageContentSources:              imageContentSources,
@@ -311,6 +320,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		UpgradeType:                      opts.NodeUpgradeType,
 		PausedUntil:                      opts.PausedUntil,
 		OLMCatalogPlacement:              opts.OLMCatalogPlacement,
+		OperatorHub:                      operatorHub,
 	}, nil
 }
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -2029,6 +2029,47 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.
@@ -6126,6 +6167,47 @@ spec:
                       rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                         || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                         >= 300'
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -2015,6 +2015,47 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.
@@ -6100,6 +6141,47 @@ spec:
                       rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                         || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                         >= 300'
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -95,6 +95,10 @@ var (
 		// TODO: Remove when cluster-csi-snapshot-controller-operator stops shipping
 		// its ibm-cloud-managed deployment.
 		"0000_50_cluster-csi-snapshot-controller-operator_07_deployment-ibm-cloud-managed.yaml",
+		// Omited this file in order to allow the HCCO to create the resource. This allow us to reconcile and sync
+		// the HCP.Configuration.operatorhub with OperatorHub object in the HostedCluster. This will only occur once.
+		// From that point the HCCO will use the OperatorHub object in the HostedCluster as a source of truth.
+		"0000_03_marketplace-operator_02_operatorhub.cr.yaml",
 	}
 )
 

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/deployments.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/deployments.go
@@ -1,0 +1,43 @@
+package olm
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type OLMDeployment struct {
+	Name       string
+	Manifest   *appsv1.Deployment
+	Reconciler func(*appsv1.Deployment, config.OwnerRef, config.DeploymentConfig, string) error
+	Image      string
+}
+
+func OLMDeployments(p *OperatorLifecycleManagerParams, hcpNamespace string) []OLMDeployment {
+	return []OLMDeployment{
+		{
+			Name:       "certifiedOperatorsDeployment",
+			Manifest:   manifests.CertifiedOperatorsDeployment(hcpNamespace),
+			Reconciler: ReconcileCertifiedOperatorsDeployment,
+			Image:      p.CertifiedOperatorsCatalogImageOverride,
+		},
+		{
+			Name:       "communityOperatorsDeployment",
+			Manifest:   manifests.CommunityOperatorsDeployment(hcpNamespace),
+			Reconciler: ReconcileCommunityOperatorsDeployment,
+			Image:      p.CommunityOperatorsCatalogImageOverride,
+		},
+		{
+			Name:       "marketplaceOperatorsDeployment",
+			Manifest:   manifests.RedHatMarketplaceOperatorsDeployment(hcpNamespace),
+			Reconciler: ReconcileRedHatMarketplaceOperatorsDeployment,
+			Image:      p.RedHatMarketplaceCatalogImageOverride,
+		},
+		{
+			Name:       "redHatOperatorsDeployment",
+			Manifest:   manifests.RedHatOperatorsDeployment(hcpNamespace),
+			Reconciler: ReconcileRedHatOperatorsDeployment,
+			Image:      p.RedHatOperatorsCatalogImageOverride,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/services.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/services.go
@@ -1,0 +1,38 @@
+package olm
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type OLMService struct {
+	Name       string
+	Manifest   *corev1.Service
+	Reconciler func(*corev1.Service, config.OwnerRef) error
+}
+
+func OLMServices(hcpNamespace string) []OLMService {
+	return []OLMService{
+		{
+			Name:       "certifiedOperatorsService",
+			Manifest:   manifests.CertifiedOperatorsService(hcpNamespace),
+			Reconciler: ReconcileCertifiedOperatorsService,
+		},
+		{
+			Name:       "communityOperatorsService",
+			Manifest:   manifests.CommunityOperatorsService(hcpNamespace),
+			Reconciler: ReconcileCommunityOperatorsService,
+		},
+		{
+			Name:       "marketplaceOperatorsService",
+			Manifest:   manifests.RedHatMarketplaceOperatorsService(hcpNamespace),
+			Reconciler: ReconcileRedHatMarketplaceOperatorsService,
+		},
+		{
+			Name:       "redHatOperatorsService",
+			Manifest:   manifests.RedHatOperatorsService(hcpNamespace),
+			Reconciler: ReconcileRedHatOperatorsService,
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/olm.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/olm.go
@@ -1,11 +1,11 @@
 package manifests
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
 func CertifiedOperatorsCatalogSource() *operatorsv1alpha1.CatalogSource {
@@ -75,6 +75,14 @@ func OLMPackageServerEndpoints() *corev1.Endpoints {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "packageserver",
 			Namespace: "default",
+		},
+	}
+}
+
+func OperatorHub() *configv1.OperatorHub {
+	return &configv1.OperatorHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
 		},
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1338,17 +1338,49 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 	return errs
 }
 
+// reconcileOperatorHub gets the OperatorHubConfig from the HCP, for now the controller only reconcile over the DisableAllDefaultSources field and only once.
+// After that the HCCO checks the OperatorHub object in the HC to manage the OLM resources.
+// TODO (jparrill): Include in the reconciliation the OperatorHub.Sources to disable only the selected sources.
+func (r *reconciler) reconcileOperatorHub(ctx context.Context, operatorHub *configv1.OperatorHub, hcp *hyperv1.HostedControlPlane) []error {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Reconciling HCP OperatorHub config")
+	if operatorHub.ResourceVersion == "" {
+		if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.OperatorHub != nil {
+			operatorHub.Spec.DisableAllDefaultSources = hcp.Spec.Configuration.OperatorHub.DisableAllDefaultSources
+		}
+	}
+
+	return nil
+}
+
 func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedControlPlane) []error {
 	var errs []error
+
+	operatorHub := manifests.OperatorHub()
+
+	if hcp.Spec.OLMCatalogPlacement == hyperv1.ManagementOLMCatalogPlacement {
+		// Management OLM Placement
+		if _, err := r.CreateOrUpdate(ctx, r.client, operatorHub, func() error {
+			if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.OperatorHub != nil {
+				operatorHub.Spec.DisableAllDefaultSources = hcp.Spec.Configuration.OperatorHub.DisableAllDefaultSources
+			}
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile OperatorHub configuration: %w", err))
+		}
+	} else {
+		// Guest OLM Placement
+		if _, err := r.CreateOrUpdate(ctx, r.client, operatorHub, func() error {
+			r.reconcileOperatorHub(ctx, operatorHub, hcp)
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile OperatorHub configuration: %w", err))
+		}
+	}
 
 	p := olm.NewOperatorLifecycleManagerParams(hcp)
 
 	// Check if the defaultSources are disabled
-	operatorHub := &configv1.OperatorHub{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster",
-		},
-	}
 	if err := r.client.Get(ctx, client.ObjectKeyFromObject(operatorHub), operatorHub); err != nil {
 		if !apierrors.IsNotFound(err) {
 			errs = append(errs, fmt.Errorf("failed to get OperatorHub %s: %w", client.ObjectKeyFromObject(operatorHub).String(), err))
@@ -1368,7 +1400,7 @@ func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedContro
 	for _, catalog := range catalogs {
 		cs := catalog.manifest()
 		if operatorHub.Spec.DisableAllDefaultSources {
-			if err := r.client.Delete(ctx, cs); err != nil {
+			if _, err := util.DeleteIfNeeded(ctx, r.client, cs); err != nil {
 				if !apierrors.IsNotFound(err) {
 					errs = append(errs, fmt.Errorf("failed to delete catalogSource %s/%s: %w", cs.Namespace, cs.Name, err))
 				}

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2679,6 +2679,21 @@ This configuration is only honored when the top level Authentication config has 
 </tr>
 <tr>
 <td>
+<code>operatorhub</code></br>
+<em>
+<a href="https://docs.openshift.com/container-platform/4.10/rest_api/config_apis/config-apis-index.html">
+github.com/openshift/api/config/v1.OperatorHubSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OperatorHub specifies the configuration for the Operator Lifecycle Manager in the HostedCluster. This is only configured at deployment time but the controller are not reconcilling over it.
+The OperatorHub configuration will be constantly reconciled if catalog placement is management, but only on cluster creation otherwise.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>scheduler</code></br>
 <em>
 <a href="https://docs.openshift.com/container-platform/4.10/rest_api/config_apis/config-apis-index.html">

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -36392,6 +36392,47 @@ objects:
                               type: integer
                           type: object
                       type: object
+                    operatorhub:
+                      description: OperatorHub specifies the configuration for the
+                        Operator Lifecycle Manager in the HostedCluster. This is only
+                        configured at deployment time but the controller are not reconcilling
+                        over it. The OperatorHub configuration will be constantly
+                        reconciled if catalog placement is management, but only on
+                        cluster creation otherwise.
+                      properties:
+                        disableAllDefaultSources:
+                          description: disableAllDefaultSources allows you to disable
+                            all the default hub sources. If this is true, a specific
+                            entry in sources can be used to enable a default source.
+                            If this is false, a specific entry in sources can be used
+                            to disable or enable a default source.
+                          type: boolean
+                        sources:
+                          description: sources is the list of default hub sources
+                            and their configuration. If the list is empty, it implies
+                            that the default hub sources are enabled on the cluster
+                            unless disableAllDefaultSources is true. If disableAllDefaultSources
+                            is true and sources is not empty, the configuration present
+                            in sources will take precedence. The list of default hub
+                            sources and their current state will always be reflected
+                            in the status block.
+                          items:
+                            description: HubSource is used to specify the hub source
+                              and its configuration
+                            properties:
+                              disabled:
+                                description: disabled is used to disable a default
+                                  hub source on cluster
+                                type: boolean
+                              name:
+                                description: name is the name of one of the default
+                                  hub sources
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            type: object
+                          type: array
+                      type: object
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.
@@ -40568,6 +40609,47 @@ objects:
                         rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                           || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                           >= 300'
+                    operatorhub:
+                      description: OperatorHub specifies the configuration for the
+                        Operator Lifecycle Manager in the HostedCluster. This is only
+                        configured at deployment time but the controller are not reconcilling
+                        over it. The OperatorHub configuration will be constantly
+                        reconciled if catalog placement is management, but only on
+                        cluster creation otherwise.
+                      properties:
+                        disableAllDefaultSources:
+                          description: disableAllDefaultSources allows you to disable
+                            all the default hub sources. If this is true, a specific
+                            entry in sources can be used to enable a default source.
+                            If this is false, a specific entry in sources can be used
+                            to disable or enable a default source.
+                          type: boolean
+                        sources:
+                          description: sources is the list of default hub sources
+                            and their configuration. If the list is empty, it implies
+                            that the default hub sources are enabled on the cluster
+                            unless disableAllDefaultSources is true. If disableAllDefaultSources
+                            is true and sources is not empty, the configuration present
+                            in sources will take precedence. The list of default hub
+                            sources and their current state will always be reflected
+                            in the status block.
+                          items:
+                            description: HubSource is used to specify the hub source
+                              and its configuration
+                            properties:
+                              disabled:
+                                description: disabled is used to disable a default
+                                  hub source on cluster
+                                type: boolean
+                              name:
+                                description: name is the name of one of the default
+                                  hub sources
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            type: object
+                          type: array
+                      type: object
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.
@@ -44702,6 +44784,47 @@ objects:
                               format: int32
                               type: integer
                           type: object
+                      type: object
+                    operatorhub:
+                      description: OperatorHub specifies the configuration for the
+                        Operator Lifecycle Manager in the HostedCluster. This is only
+                        configured at deployment time but the controller are not reconcilling
+                        over it. The OperatorHub configuration will be constantly
+                        reconciled if catalog placement is management, but only on
+                        cluster creation otherwise.
+                      properties:
+                        disableAllDefaultSources:
+                          description: disableAllDefaultSources allows you to disable
+                            all the default hub sources. If this is true, a specific
+                            entry in sources can be used to enable a default source.
+                            If this is false, a specific entry in sources can be used
+                            to disable or enable a default source.
+                          type: boolean
+                        sources:
+                          description: sources is the list of default hub sources
+                            and their configuration. If the list is empty, it implies
+                            that the default hub sources are enabled on the cluster
+                            unless disableAllDefaultSources is true. If disableAllDefaultSources
+                            is true and sources is not empty, the configuration present
+                            in sources will take precedence. The list of default hub
+                            sources and their current state will always be reflected
+                            in the status block.
+                          items:
+                            description: HubSource is used to specify the hub source
+                              and its configuration
+                            properties:
+                              disabled:
+                                description: disabled is used to disable a default
+                                  hub source on cluster
+                                type: boolean
+                              name:
+                                description: name is the name of one of the default
+                                  hub sources
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     proxy:
                       description: Proxy holds cluster-wide information on how to
@@ -48868,6 +48991,47 @@ objects:
                         rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                           || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                           >= 300'
+                    operatorhub:
+                      description: OperatorHub specifies the configuration for the
+                        Operator Lifecycle Manager in the HostedCluster. This is only
+                        configured at deployment time but the controller are not reconcilling
+                        over it. The OperatorHub configuration will be constantly
+                        reconciled if catalog placement is management, but only on
+                        cluster creation otherwise.
+                      properties:
+                        disableAllDefaultSources:
+                          description: disableAllDefaultSources allows you to disable
+                            all the default hub sources. If this is true, a specific
+                            entry in sources can be used to enable a default source.
+                            If this is false, a specific entry in sources can be used
+                            to disable or enable a default source.
+                          type: boolean
+                        sources:
+                          description: sources is the list of default hub sources
+                            and their configuration. If the list is empty, it implies
+                            that the default hub sources are enabled on the cluster
+                            unless disableAllDefaultSources is true. If disableAllDefaultSources
+                            is true and sources is not empty, the configuration present
+                            in sources will take precedence. The list of default hub
+                            sources and their current state will always be reflected
+                            in the status block.
+                          items:
+                            description: HubSource is used to specify the hub source
+                              and its configuration
+                            properties:
+                              disabled:
+                                description: disabled is used to disable a default
+                                  hub source on cluster
+                                type: boolean
+                              name:
+                                description: name is the name of one of the default
+                                  hub sources
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            type: object
+                          type: array
+                      type: object
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -37,6 +37,7 @@ func NewCreateCommands() *cobra.Command {
 		Wait:                           false,
 		PausedUntil:                    "",
 		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
+		OLMDisableDefaultSources:       false,
 	}
 
 	cmd := &cobra.Command{
@@ -63,7 +64,8 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If set to 0 or greater, NodePools will be created with that many replicas. If set to less than 0, no NodePools will be created.")
 	cmd.PersistentFlags().StringToStringVar(&opts.NodeSelector, "node-selector", opts.NodeSelector, "A comma separated list of key=value pairs to use as the node selector for the Hosted Control Plane pods to stick to. (e.g. role=cp,disk=fast)")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
-	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olmCatalogPlacement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
+	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olm-catalog-placement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
+	cmd.PersistentFlags().BoolVar(&opts.OLMDisableDefaultSources, "olm-disable-default-sources", opts.OLMDisableDefaultSources, "Disables the OLM default catalog sources for the HostedCluster.")
 	cmd.PersistentFlags().StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other.")
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Filepath to a pull secret.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the HostedCluster.")


### PR DESCRIPTION
Post-reverted PR:
- Original: https://github.com/openshift/hypershift/pull/3283
- Revert: https://github.com/openshift/hypershift/pull/3306

The pull request (PR) embeds the OperatorHubSpec field into the hostedcluster.Spec.Configuration API field. This allows us to disable/enable default sources in Management or Guest placement only during creation.

This functionality is also incorporated into the CLIs through a flag called olmDisableDefaultSources.

However, it's important to note that the OperatorHub capability to disable/enable individual default sources is not covered in this PR. As a result, that field will be disregarded in the CPO and HCCO reconciliation.

Signed-off-by: Juan Manuel Parrilla Madrid [jparrill@redhat.com](mailto:jparrill@redhat.com)

Which issue(s) this PR fixes:
Fixes #[HOSTEDCP-1273](https://issues.redhat.com/browse/HOSTEDCP-1273)