### PR TITLE
HOSTEDCP-1262: Add additional CEL to Arch in NodePoolSpec

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -72,6 +72,7 @@ type NodePool struct {
 
 // NodePoolSpec is the desired behavior of a NodePool.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.arch) || has(self.arch)", message="Arch is required once set"
+// +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws)", message="Setting Arch to arm64 is only supported for AWS"
 type NodePoolSpec struct {
 	// ClusterName is the name of the HostedCluster this NodePool belongs to.
 	//

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1856,6 +1856,8 @@ spec:
             x-kubernetes-validations:
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
+            - message: Setting Arch to arm64 is only supported for AWS
+              rule: self.arch != 'arm64' || has(self.platform.aws)
           status:
             description: Status is the latest observed status of the NodePool.
             properties:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -52986,6 +52986,8 @@ objects:
               x-kubernetes-validations:
               - message: Arch is required once set
                 rule: '!has(oldSelf.arch) || has(self.arch)'
+              - message: Setting Arch to arm64 is only supported for AWS
+                rule: self.arch != 'arm64' || has(self.platform.aws)
             status:
               description: Status is the latest observed status of the NodePool.
               properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow on to #3072. Adds additional CEL to the Arch field in the NodePoolSpec to ensure Arch can only be set to arm64 when the platform is AWS.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1262](https://issues.redhat.com/browse/HOSTEDCP-1262)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.