### PR TITLE
OCPBUGS-24308: Add PodDisruptionBudget for router deployment

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3500,6 +3500,14 @@ func (r *HostedControlPlaneReconciler) reconcileRouter(ctx context.Context, hcp 
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile router deployment: %w", err)
 		}
+
+		pdb := manifests.RouterPodDisruptionBudget(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r.Client, pdb, func() error {
+			ingress.ReconcileRouterPodDisruptionBudget(pdb, hcp.Spec.ControllerAvailabilityPolicy, config.OwnerRefFrom(hcp))
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile router pod disruption budget: %w", err)
+		}
 	}
 
 	// "Admit" routes that we manage so that other code depending on routes continues

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -9,6 +9,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -299,4 +300,22 @@ func ReconcileRouteStatus(route *routev1.Route, externalHostname, internalHostna
 		}
 	}
 	route.Status.Ingress = []routev1.RouteIngress{ingress}
+}
+
+func ReconcileRouterPodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, availability hyperv1.AvailabilityPolicy, ownerRef config.OwnerRef) {
+	if pdb.CreationTimestamp.IsZero() {
+		pdb.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: hcpRouterLabels(),
+		}
+	}
+	ownerRef.ApplyTo(pdb)
+	var minAvailable intstr.IntOrString
+	switch availability {
+	case hyperv1.SingleReplica:
+		minAvailable = intstr.FromInt(0)
+	case hyperv1.HighlyAvailable:
+		minAvailable = intstr.FromInt(1)
+	}
+	pdb.Spec.MinAvailable = &minAvailable
+
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/ingress.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/ingress.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -158,6 +159,15 @@ func MetricsForwarderRoute(ns string) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "metrics-forwarder",
+			Namespace: ns,
+		},
+	}
+}
+
+func RouterPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router",
 			Namespace: ns,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The router deployment is in the request serving path and should be protected from outages by a PDB like the other request serving components

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-24308](https://issues.redhat.com/browse/OCPBUGS-24308)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.