### PR TITLE
OCPBUGS-25342: Add extra resources to be encrypted.

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/aws.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/aws.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -120,7 +121,7 @@ func (p *awsKMSProvider) GenerateKMSEncryptionConfig() (*v1.EncryptionConfigurat
 		},
 		Resources: []v1.ResourceConfiguration{
 			{
-				Resources: []string{"secrets"},
+				Resources: config.KMSEncryptedObjects(),
 				Providers: providerConfiguration,
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
@@ -7,6 +7,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -81,7 +82,7 @@ func (p *azureKMSProvider) GenerateKMSEncryptionConfig() (*v1.EncryptionConfigur
 		},
 		Resources: []v1.ResourceConfiguration{
 			{
-				Resources: []string{"secrets"},
+				Resources: config.KMSEncryptedObjects(),
 				Providers: providerConfiguration,
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/ibmcloud.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/ibmcloud.go
@@ -9,6 +9,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -88,7 +89,7 @@ func (p *ibmCloudKMSProvider) GenerateKMSEncryptionConfig() (*v1.EncryptionConfi
 		},
 		Resources: []v1.ResourceConfiguration{
 			{
-				Resources: []string{"secrets"},
+				Resources: config.KMSEncryptedObjects(),
 				Providers: providerConfiguration,
 			},
 		},

--- a/support/config/kms.go
+++ b/support/config/kms.go
@@ -1,0 +1,11 @@
+package config
+
+func KMSEncryptedObjects() []string {
+	return []string{
+		"secrets",
+		"configmaps",
+		"routes.route.openshift.io",
+		"oauthaccesstokens.oauth.openshift.io",
+		"oauthauthorizetokens.oauth.openshift.io",
+	}
+}


### PR DESCRIPTION
Standalone OCP encrypts various resources at rest in etcd including routes, oauth access tokens etc.  This change makes HCP also encrypt those objects.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.