### PR TITLE
HOSTEDCP-1364: kubevirt,  use selector less services for ingress

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1006,7 +1006,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"kubevirt.io"},
-				Resources: []string{"virtualmachineinstances", "virtualmachines"},
+				Resources: []string{"virtualmachineinstances", "virtualmachines", "virtualmachines/finalizers"},
 				Verbs:     []string{rbacv1.VerbAll},
 			},
 			{
@@ -1041,8 +1041,11 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"discovery.k8s.io"},
-				Resources: []string{"endpointslices"},
-				Verbs:     []string{"list", "watch"},
+				Resources: []string{
+					"endpointslices",
+					"endpointslices/restricted",
+				},
+				Verbs: []string{rbacv1.VerbAll},
 			},
 			{
 				APIGroups:     []string{"admissionregistration.k8s.io"},

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -179,6 +180,35 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef, platform hyperv1
 				Verbs: []string{
 					"create",
 				},
+			},
+			{
+				APIGroups: []string{discoveryv1.SchemeGroupVersion.Group},
+				Resources: []string{
+					"endpointslices",
+					"endpointslices/restricted",
+				},
+				Verbs: []string{
+					"create",
+					"get",
+					"patch",
+					"update",
+					"list",
+					"watch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{"virtualmachines"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{"virtualmachines/finalizers"},
+				Verbs:     []string{"update"},
 			},
 			{
 				APIGroups: []string{corev1.SchemeGroupVersion.Group},

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/drainer"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/machine"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/node"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
@@ -61,6 +62,7 @@ var controllerFuncs = map[string]operator.ControllerSetupFunc{
 	resources.ControllerName: resources.Setup,
 	"inplaceupgrader":        inplaceupgrader.Setup,
 	"node":                   node.Setup,
+	"machine":                machine.Setup,
 	"drainer":                drainer.Setup,
 	hcpstatus.ControllerName: hcpstatus.Setup,
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
@@ -1,0 +1,182 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hcpmanifests "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Reconciling")
+	machine := &capiv1.Machine{}
+	if err := r.client.Get(ctx, client.ObjectKey(req.NamespacedName), machine); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("not found", "Machine", r)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get Machine: %w", err)
+	}
+
+	hcp := &hyperv1.HostedControlPlane{}
+	if err := r.client.Get(ctx, r.hcpKey, hcp); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("not found", "HostedControlPlane", r.hcpKey)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get HostedControlPlane: %w", err)
+	}
+	switch hcp.Spec.Platform.Type {
+	case hyperv1.KubevirtPlatform:
+		if hcp.Spec.Platform.Kubevirt != nil && (hcp.Spec.Platform.Kubevirt.BaseDomainPassthrough != nil && *hcp.Spec.Platform.Kubevirt.BaseDomainPassthrough) {
+			if err := r.reconcileKubevirtDefaultIngressEndpoints(ctx, hcp, machine); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed reconciling kubevirt default ingress passthrough service endpoints: %w", err)
+			}
+		}
+	}
+	log.Info("Reconciled Machine")
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) reconcileKubevirtDefaultIngressEndpoints(ctx context.Context, hcp *hyperv1.HostedControlPlane, machine *capiv1.Machine) error {
+	log := ctrl.LoggerFrom(ctx)
+	var namespace string
+	if hcp.Spec.Platform.Kubevirt.Credentials != nil {
+		namespace = hcp.Spec.Platform.Kubevirt.Credentials.InfraNamespace
+	} else {
+		namespace = hcp.Namespace
+	}
+
+	// Manifests for infra/mgmt cluster passthrough service
+	cpService := hcpmanifests.IngressDefaultIngressPassthroughService(namespace)
+
+	cpService.Name = fmt.Sprintf("%s-%s",
+		hcpmanifests.IngressDefaultIngressPassthroughServiceName,
+		hcp.Spec.Platform.Kubevirt.GenerateID)
+
+	if err := r.kubevirtInfraClient.Get(ctx, client.ObjectKeyFromObject(cpService), cpService); err != nil {
+		return fmt.Errorf("failed to get default ingress passthrough Service: %w", err)
+	}
+
+	// If there is a selector endpoints should not be generated
+	if len(cpService.Spec.Selector) > 0 {
+		return nil
+	}
+
+	if len(cpService.Spec.Ports) == 0 {
+		return fmt.Errorf("missing default ingress passthrough Service %s/%s ports", cpService.Namespace, cpService.Name)
+	}
+
+	ipv4MachineAddresses := []string{}
+	ipv6MachineAddresses := []string{}
+	ports := []discoveryv1.EndpointPort{}
+
+	// If machine is back to not ready we should reset the endpointslice
+	if machine.Status.GetTypedPhase() == capiv1.MachinePhaseRunning {
+		for _, machineAddress := range machine.Status.Addresses {
+			if machineAddress.Type == capiv1.MachineInternalIP {
+				if netip.MustParseAddr(machineAddress.Address).Is4() {
+					ipv4MachineAddresses = append(ipv4MachineAddresses, machineAddress.Address)
+				} else {
+					ipv6MachineAddresses = append(ipv6MachineAddresses, machineAddress.Address)
+				}
+			}
+		}
+		for _, port := range cpService.Spec.Ports {
+			ports = append(ports, discoveryv1.EndpointPort{
+				Protocol: &port.Protocol,
+				Port:     pointer.Int32(int32(port.TargetPort.IntValue())),
+			})
+		}
+	}
+
+	ipAddressesByFamily := map[corev1.IPFamily][]string{
+		corev1.IPv4Protocol: ipv4MachineAddresses,
+		corev1.IPv6Protocol: ipv6MachineAddresses,
+	}
+	for _, ipFamily := range []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol} {
+		if !serviceHasIPFamily(cpService, ipFamily) {
+			continue
+		}
+		err := r.reconcileKubevirtDefaultIngressEndpointsByIPFamily(ctx, machine, cpService, ipFamily, ipAddressesByFamily[ipFamily], ports)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info(fmt.Sprintf("waiting for kubevirt VM to be created before processing default ingress %s endpoints", ipFamily))
+				return nil
+			} else {
+				return fmt.Errorf("failed to reconcile kubevirt default ingress %s endpoints: %w", ipFamily, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) reconcileKubevirtDefaultIngressEndpointsByIPFamily(ctx context.Context, machine *capiv1.Machine, cpService *corev1.Service, ipFamily corev1.IPFamily, machineAddresses []string, ports []discoveryv1.EndpointPort) error {
+	log := ctrl.LoggerFrom(ctx)
+	endpointSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cpService.Namespace,
+			Name:      cpService.Name + "-" + machine.Name + "-" + strings.ToLower(string(ipFamily)),
+		},
+	}
+	result, err := r.CreateOrUpdate(ctx, r.kubevirtInfraClient, endpointSlice, func() error {
+		if len(endpointSlice.OwnerReferences) == 0 {
+			// Machine infra ref is the KubevirtMachine wich has the same name
+			// as the kubevirt VirtualMachine CRD, but the namespace ca
+			// can be different if kubevirt infra cluster is external
+			vmKey := client.ObjectKey{
+				Namespace: cpService.Namespace,
+				Name:      machine.Spec.InfrastructureRef.Name,
+			}
+			vm := kubevirtv1.VirtualMachine{}
+			if err := r.kubevirtInfraClient.Get(ctx, vmKey, &vm); err != nil {
+				return err
+			}
+			ownerRef := config.OwnerRefFrom(&vm)
+			ownerRef.ApplyTo(endpointSlice)
+		}
+
+		if endpointSlice.Labels == nil {
+			endpointSlice.Labels = map[string]string{}
+		}
+		endpointSlice.Labels["kubernetes.io/service-name"] = cpService.Name
+		endpointSlice.Labels["endpointslice.kubernetes.io/managed-by"] = "control-plane-operator.hypershift.openshift.io"
+		endpointSlice.AddressType = discoveryv1.AddressType(ipFamily)
+		if len(machineAddresses) > 0 {
+			endpointSlice.Endpoints = []discoveryv1.Endpoint{{Addresses: machineAddresses}}
+		} else {
+			endpointSlice.Endpoints = []discoveryv1.Endpoint{}
+		}
+		endpointSlice.Ports = ports
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile kubevirt default ingress %s endpoints: %w", ipFamily, err)
+	}
+	log.Info(fmt.Sprintf("Reconciled kubevirt default ingress %s endpoints", ipFamily), "result", result)
+	return nil
+}
+
+func serviceHasIPFamily(service *corev1.Service, ipFamilyToFind corev1.IPFamily) bool {
+	for _, ipFamily := range service.Spec.IPFamilies {
+		if ipFamily == ipFamilyToFind {
+			return true
+		}
+	}
+	return false
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
@@ -1,0 +1,481 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/openshift/hypershift/client/clientset/clientset/scheme"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestReconcileDefaultIngressEndpoints(t *testing.T) {
+	machineTypeMeta := metav1.TypeMeta{
+		Kind:       "Machine",
+		APIVersion: capiv1.GroupVersion.String(),
+	}
+	virtualmachineTypeMeta := metav1.TypeMeta{
+		Kind:       "VirtualMachine",
+		APIVersion: kubevirtv1.GroupVersion.String(),
+	}
+	newMachineMeta := func(namespace, name string) metav1.ObjectMeta {
+		return metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			UID:             types.UID(name + "-uid"),
+			ResourceVersion: fmt.Sprintf("%d", rand.Intn(100)),
+		}
+	}
+
+	worker1Meta := newMachineMeta("ns1-cluster1", "worker1")
+	vm1Meta := newMachineMeta("ns1-cluster1", "workervm1")
+
+	protocolTCP := corev1.ProtocolTCP
+
+	hyperv1.AddToScheme(scheme.Scheme)
+	kubevirtv1.AddToScheme(scheme.Scheme)
+	discoveryv1.AddToScheme(scheme.Scheme)
+	corev1.AddToScheme(scheme.Scheme)
+	testCases := []struct {
+		name                          string
+		virtualmachine                *kubevirtv1.VirtualMachine
+		machine                       *capiv1.Machine
+		ingressSvc                    *corev1.Service
+		ingressEndpointSlices         []discoveryv1.EndpointSlice
+		hcp                           *hyperv1.HostedControlPlane
+		expectedIngressEndpointSlices []discoveryv1.EndpointSlice
+		error                         bool
+	}{
+		{
+			name:       "Without service",
+			ingressSvc: nil,
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "foobar",
+						},
+					},
+				},
+			},
+			error: true,
+		},
+		{
+			name: "With selector at ingress service",
+			ingressSvc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "default-ingress-passthrough-service-foobar",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						TargetPort: intstr.FromInt(2222),
+					}},
+					Selector: map[string]string{
+						"key1": "value1",
+					},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "foobar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Without virtual machine",
+			machine: &capiv1.Machine{
+				TypeMeta:   machineTypeMeta,
+				ObjectMeta: worker1Meta,
+				Spec: capiv1.MachineSpec{
+					InfrastructureRef: corev1.ObjectReference{
+						Kind:       virtualmachineTypeMeta.Kind,
+						APIVersion: virtualmachineTypeMeta.APIVersion,
+						Namespace:  vm1Meta.Namespace,
+						Name:       vm1Meta.Name,
+					},
+				},
+			},
+			ingressSvc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "default-ingress-passthrough-service-foobar",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						TargetPort: intstr.FromInt(2222),
+					}},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "foobar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "With Running machine with internal ipv4 and service with target port and no endpoints",
+			virtualmachine: &kubevirtv1.VirtualMachine{
+				ObjectMeta: vm1Meta,
+			},
+			machine: &capiv1.Machine{
+				TypeMeta:   machineTypeMeta,
+				ObjectMeta: worker1Meta,
+				Spec: capiv1.MachineSpec{
+					InfrastructureRef: corev1.ObjectReference{
+						Kind:       virtualmachineTypeMeta.Kind,
+						APIVersion: virtualmachineTypeMeta.APIVersion,
+						Namespace:  vm1Meta.Namespace,
+						Name:       vm1Meta.Name,
+					},
+				},
+				Status: capiv1.MachineStatus{
+					Phase: string(capiv1.MachinePhaseRunning),
+					Addresses: []capiv1.MachineAddress{{
+						Type:    capiv1.MachineInternalIP,
+						Address: "192.168.1.3",
+					}},
+				},
+			},
+			ingressSvc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "default-ingress-passthrough-service-foobar",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						TargetPort: intstr.FromInt(2222),
+						Protocol:   corev1.ProtocolTCP,
+					}},
+					IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+				},
+			},
+			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv4",
+					Labels: map[string]string{
+						"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
+						"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
+					},
+					ResourceVersion: "1",
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         virtualmachineTypeMeta.APIVersion,
+						Kind:               virtualmachineTypeMeta.Kind,
+						UID:                vm1Meta.UID,
+						Name:               vm1Meta.Name,
+						Controller:         pointer.Bool(true),
+						BlockOwnerDeletion: pointer.Bool(true),
+					}},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"192.168.1.3"},
+				}},
+				Ports: []discoveryv1.EndpointPort{{
+					Port:     pointer.Int32(2222),
+					Protocol: &protocolTCP,
+				}},
+			}},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "foobar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "With Failing machine with internal ipv4 and service with target port and endpoints",
+			virtualmachine: &kubevirtv1.VirtualMachine{
+				ObjectMeta: vm1Meta,
+			},
+			machine: &capiv1.Machine{
+				TypeMeta:   machineTypeMeta,
+				ObjectMeta: worker1Meta,
+				Spec: capiv1.MachineSpec{
+					InfrastructureRef: corev1.ObjectReference{
+						Kind:       virtualmachineTypeMeta.Kind,
+						APIVersion: virtualmachineTypeMeta.APIVersion,
+						Namespace:  vm1Meta.Namespace,
+						Name:       vm1Meta.Name,
+					},
+				},
+				Status: capiv1.MachineStatus{
+					Phase: string(capiv1.MachinePhaseFailed),
+					Addresses: []capiv1.MachineAddress{{
+						Type:    capiv1.MachineInternalIP,
+						Address: "192.168.1.3",
+					}},
+				},
+			},
+			ingressSvc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "default-ingress-passthrough-service-foobar",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						TargetPort: intstr.FromInt(2222),
+						Protocol:   corev1.ProtocolTCP,
+					}},
+					IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+				},
+			},
+			ingressEndpointSlices: []discoveryv1.EndpointSlice{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv4",
+					Labels: map[string]string{
+						"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
+						"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
+					},
+					ResourceVersion: "1",
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         machineTypeMeta.APIVersion,
+						Kind:               machineTypeMeta.Kind,
+						UID:                worker1Meta.UID,
+						Name:               worker1Meta.Name,
+						Controller:         pointer.Bool(true),
+						BlockOwnerDeletion: pointer.Bool(true),
+					}},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"192.168.1.3"},
+				}},
+				Ports: []discoveryv1.EndpointPort{{
+					Port:     pointer.Int32(2222),
+					Protocol: &protocolTCP,
+				}},
+			}},
+			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv4",
+					Labels: map[string]string{
+						"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
+						"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
+					},
+					ResourceVersion: "2",
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         machineTypeMeta.APIVersion,
+						Kind:               machineTypeMeta.Kind,
+						UID:                worker1Meta.UID,
+						Name:               worker1Meta.Name,
+						Controller:         pointer.Bool(true),
+						BlockOwnerDeletion: pointer.Bool(true),
+					}},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints:   []discoveryv1.Endpoint{},
+				Ports:       []discoveryv1.EndpointPort{},
+			}},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "foobar",
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "With Running machine with internal dual stack address and service with target port and no endpoints",
+			virtualmachine: &kubevirtv1.VirtualMachine{
+				ObjectMeta: vm1Meta,
+			},
+			machine: &capiv1.Machine{
+				TypeMeta:   machineTypeMeta,
+				ObjectMeta: worker1Meta,
+				Spec: capiv1.MachineSpec{
+					InfrastructureRef: corev1.ObjectReference{
+						Kind:       virtualmachineTypeMeta.Kind,
+						APIVersion: virtualmachineTypeMeta.APIVersion,
+						Namespace:  vm1Meta.Namespace,
+						Name:       vm1Meta.Name,
+					},
+				},
+				Status: capiv1.MachineStatus{
+					Phase: string(capiv1.MachinePhaseRunning),
+					Addresses: []capiv1.MachineAddress{
+						{
+							Type:    capiv1.MachineInternalIP,
+							Address: "192.168.1.3",
+						},
+						{
+							Type:    capiv1.MachineInternalIP,
+							Address: "2001:db8:a0b:12f0::3",
+						},
+					},
+				},
+			},
+			ingressSvc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "default-ingress-passthrough-service-foobar",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						TargetPort: intstr.FromInt(2222),
+						Protocol:   corev1.ProtocolTCP,
+					}},
+					IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+				},
+			},
+			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1-cluster1",
+						Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv4",
+						Labels: map[string]string{
+							"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
+							"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
+						},
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion:         virtualmachineTypeMeta.APIVersion,
+							Kind:               virtualmachineTypeMeta.Kind,
+							UID:                vm1Meta.UID,
+							Name:               vm1Meta.Name,
+							Controller:         pointer.Bool(true),
+							BlockOwnerDeletion: pointer.Bool(true),
+						}},
+					},
+					AddressType: discoveryv1.AddressTypeIPv4,
+					Endpoints: []discoveryv1.Endpoint{{
+						Addresses: []string{"192.168.1.3"},
+					}},
+					Ports: []discoveryv1.EndpointPort{{
+						Port:     pointer.Int32(2222),
+						Protocol: &protocolTCP,
+					}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1-cluster1",
+						Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv6",
+						Labels: map[string]string{
+							"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
+							"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
+						},
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion:         virtualmachineTypeMeta.APIVersion,
+							Kind:               virtualmachineTypeMeta.Kind,
+							UID:                vm1Meta.UID,
+							Name:               vm1Meta.Name,
+							Controller:         pointer.Bool(true),
+							BlockOwnerDeletion: pointer.Bool(true),
+						}},
+					},
+					AddressType: discoveryv1.AddressTypeIPv6,
+					Endpoints: []discoveryv1.Endpoint{{
+						Addresses: []string{"2001:db8:a0b:12f0::3"},
+					}},
+					Ports: []discoveryv1.EndpointPort{{
+						Port:     pointer.Int32(2222),
+						Protocol: &protocolTCP,
+					}},
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1-cluster1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "foobar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := []client.Object{}
+			if tc.ingressSvc != nil {
+				objects = append(objects, tc.ingressSvc)
+			}
+			for _, ingressEndpointSlice := range tc.ingressEndpointSlices {
+				objects = append(objects, &ingressEndpointSlice)
+			}
+			if tc.virtualmachine != nil {
+				objects = append(objects, tc.virtualmachine)
+			}
+			g := NewWithT(t)
+			r := &reconciler{
+				client:                 fake.NewClientBuilder().Build(),
+				kubevirtInfraClient:    fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objects...).Build(),
+				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
+			}
+			err := r.reconcileKubevirtDefaultIngressEndpoints(context.Background(), tc.hcp, tc.machine)
+			g.Expect(err != nil).To(Equal(tc.error), func() string {
+				if !tc.error {
+					return fmt.Sprintf("unexpected error: %v", err)
+				} else {
+					return "missing expected error"
+				}
+			})
+			obtainedEndpointSliceList := discoveryv1.EndpointSliceList{}
+			g.Expect(r.kubevirtInfraClient.List(context.Background(), &obtainedEndpointSliceList)).To(Succeed())
+			g.Expect(obtainedEndpointSliceList.Items).To(ConsistOf(tc.expectedIngressEndpointSlices))
+		})
+	}
+}
+
+type simpleCreateOrUpdater struct{}
+
+func (*simpleCreateOrUpdater) CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	return controllerutil.CreateOrUpdate(ctx, c, obj, f)
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/setup.go
@@ -1,0 +1,75 @@
+package machine
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
+	"github.com/openshift/hypershift/support/upsert"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+type reconciler struct {
+	client              client.Client
+	kubevirtInfraClient client.Client
+	hcpKey              client.ObjectKey
+	upsert.CreateOrUpdateProvider
+}
+
+func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
+	kubevirtScheme := runtime.NewScheme()
+	corev1.AddToScheme(kubevirtScheme)
+	kubevirtv1.AddToScheme(kubevirtScheme)
+	discoveryv1.AddToScheme(kubevirtScheme)
+
+	kubevirtHttpClient, err := rest.HTTPClientFor(opts.KubevirtInfraConfig)
+	if err != nil {
+		return fmt.Errorf("failed creating kubevirt cluster http client: %w", err)
+	}
+
+	kubevirtMapper, err := apiutil.NewDynamicRESTMapper(opts.KubevirtInfraConfig, kubevirtHttpClient)
+	if err != nil {
+		return fmt.Errorf("failed creating kubevirt cluster rest mapper: %w", err)
+	}
+
+	// if kubevirt infra config is not used, it is being set the same as the mgmt config
+	kubevirtInfraClient, err := client.New(opts.KubevirtInfraConfig, client.Options{
+		Scheme: kubevirtScheme,
+		Mapper: kubevirtMapper,
+		WarningHandler: client.WarningHandlerOptions{
+			SuppressWarnings: true,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create kubevirt infra uncached client: %w", err)
+	}
+	r := &reconciler{
+		client:              opts.CPCluster.GetClient(),
+		kubevirtInfraClient: kubevirtInfraClient,
+		hcpKey: client.ObjectKey{
+			Namespace: opts.Namespace,
+			Name:      opts.HCPName,
+		},
+		CreateOrUpdateProvider: opts.TargetCreateOrUpdateProvider,
+	}
+	c, err := controller.New("machine", opts.Manager, controller.Options{Reconciler: r})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	if err := c.Watch(source.Kind(opts.CPCluster.GetCache(), &capiv1.Machine{}), &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("failed to watch Machines: %w", err)
+	}
+
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -136,10 +136,11 @@ func ReconcileDefaultIngressPassthroughService(service *corev1.Service, defaultN
 			TargetPort: intstr.FromInt(int(detectedHTTPSNodePort)),
 		},
 	}
-	service.Spec.Selector = map[string]string{
-		"kubevirt.io":        "virt-launcher",
-		hyperv1.InfraIDLabel: hcp.Spec.InfraID,
-	}
+
+	// The endpoints reconciliation is done at nodepool controller to support
+	// secondary networks.
+	service.Spec.Selector = map[string]string{}
+
 	service.Spec.Type = corev1.ServiceTypeClusterIP
 	service.Labels[hyperv1.InfraIDLabel] = hcp.Spec.InfraID
 

--- a/docs/content/how-to/kubevirt/external-infrastructure.md
+++ b/docs/content/how-to/kubevirt/external-infrastructure.md
@@ -57,8 +57,11 @@ It isn't necessary for the user defined in the kubeconfig used for the external 
 The user or service account used in the provided kubeconfig should have full permissions over the following resources:
 * `virtualmachines.kubevirt.io`
 * `virtualmachineinstances.kubevirt.io`
+* `virtualmachines.kubevirt.io/finalizers`
 * `datavolumes.cdi.kubevirt.io`
 * `services`
+* `endpointslices`
+* `endpointslices/restricted`
 * `routes`
 
 All of these permissions are needed only on the target namespace on the infra cluster (passed through the `--infra-namespace` command-line argument).
@@ -74,6 +77,7 @@ rules:
       - kubevirt.io
     resources:
       - virtualmachines
+      - virtualmachines/finalizers
       - virtualmachineinstances
     verbs:
       - '*'
@@ -94,6 +98,13 @@ rules:
     resources:
       - routes
       - routes/custom-host
+    verbs:
+      - '*'
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+      - endpointslices/restricted
     verbs:
       - '*'
   - apiGroups:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -221,6 +221,7 @@ objects:
     resources:
     - virtualmachineinstances
     - virtualmachines
+    - virtualmachines/finalizers
     verbs:
     - '*'
   - apiGroups:
@@ -266,9 +267,9 @@ objects:
     - discovery.k8s.io
     resources:
     - endpointslices
+    - endpointslices/restricted
     verbs:
-    - list
-    - watch
+    - '*'
   - apiGroups:
     - admissionregistration.k8s.io
     resourceNames:

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2801,10 +2801,10 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role, enableCVOManagementClu
 			},
 			Resources: []string{
 				"endpointslices",
+				"endpointslices/restricted",
 			},
 			Verbs: []string{
-				"list",
-				"watch",
+				"*",
 			},
 		},
 		{
@@ -2834,7 +2834,7 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role, enableCVOManagementClu
 		},
 		{
 			APIGroups: []string{"kubevirt.io"},
-			Resources: []string{"virtualmachines", "virtualmachineinstances"},
+			Resources: []string{"virtualmachines", "virtualmachines/finalizers", "virtualmachineinstances"},
 			Verbs:     []string{rbacv1.VerbAll},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
The KubeVirt provider default ingress uses a passthrow service to
connect to the hosted cluster ingress using it's ingress service
nodeport, this works fine with pod network but when using secondary
networks custom endpoints has to be created and maintained. This change
remove the selector from the service and maintain the endpoints at a
reconcile cycle at nodepool controller, this is done for unconditionally
to pod network attachment configuration.

Depends on:
- https://github.com/openshift/release/pull/47850

**Which issue(s) this PR fixes** 
Fixes #[HOSTEDCP-1364](https://issues.redhat.com//browse/HOSTEDCP-1364)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.