### PR TITLE
NO-JIRA: Approvers update

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,9 @@ approvers:
 - csrwng
 - sjenning
 - davidvossel
+- muraee
+- bryan-cox
+- jparrill
 options: {}
 reviewers:
 - enxebre


### PR DESCRIPTION
In order to increase the team ability to do general release tasks of tagging, cutting releases and modifying bot automated PRs, we should increase the amount of contributors that have access to such functions.

Adding the following members to approvers:

* bryan-cox
* jparrill
* muraee

jparrill will have an additional approving focus on self-managed PRs.
muraee will have a more general approving focus.