### PR TITLE
OCPBUGS-25974: Do not use CPO image from status if it's not a valid image reference

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/util"
 	tokenminter "github.com/openshift/hypershift/token-minter"
 	"go.uber.org/zap/zapcore"
@@ -270,7 +271,11 @@ func NewStartCommand() *cobra.Command {
 				for _, container := range me.Status.ContainerStatuses {
 					// TODO: could use downward API for this too, overkill?
 					if container.Name == "control-plane-operator" {
-						return strings.TrimPrefix(container.ImageID, "docker-pullable://"), nil
+						image := strings.TrimPrefix(container.ImageID, "docker-pullable://")
+						// Only return image if it is a valid reference
+						if ref, err := reference.Parse(image); err == nil && ref.Registry != "" {
+							return image, nil
+						}
 					}
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
On management clusters 4.15 and newer, the container ID in the CPO pod status is not a valid image reference and should not be used to determine the CPO image.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-25974](https://issues.redhat.com/browse/OCPBUGS-25974)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.