### PR TITLE
CNV-36656: Documenting the mimimum RBAC required for External Infra cluster with KubeVirt provider

### DIFF
--- a/docs/content/how-to/kubevirt/external-infrastructure.md
+++ b/docs/content/how-to/kubevirt/external-infrastructure.md
@@ -52,3 +52,47 @@ This command will result in the control plane pods being hosted on the
 management cluster that the HyperShift Operator runs on, while the KubeVirt
 VMs will be hosted on a separate infrastructure cluster.
 
+## Required RBAC for the external infrastructure cluster
+It isn't necessary for the user defined in the kubeconfig used for the external infra cluster to be a cluster-admin.  
+The user or service account used in the provided kubeconfig should have full permissions over the following resources:
+* `virtualmachines.kubevirt.io`
+* `virtualmachineinstances.kubevirt.io`
+* `datavolumes.cdi.kubevirt.io`
+* `services`
+* `routes`
+
+All of these permissions are needed only on the target namespace on the infra cluster (passed through the `--infra-namespace` command-line argument).
+This can be achieved by binding the following Role to the user used in the external infra kubeconfig:
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kv-external-infra-role
+  namespace: clusters-example
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs:
+      - '*'
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datavolumes
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - '*'
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - '*'
+```


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Documenting the minimal set of permissions needed to create an hosted cluster on an external infrastructure cluster with kubevirt provider.

**Which issue(s) this PR fixes**
Fixes # https://issues.redhat.com/browse/CNV-36656

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.