### PR TITLE
HOSTEDCP-1374: external OIDC: copy Authentication OIDC client secrets through to guest

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1428,6 +1428,35 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	// For each client secret in the Authentication OIDC global config, copy the secret into the control plane namespace.
+	if !hyperutil.HCOAuthEnabled(hcluster) &&
+		len(hcluster.Spec.Configuration.Authentication.OIDCProviders) != 0 &&
+		len(hcluster.Spec.Configuration.Authentication.OIDCProviders[0].OIDCClients) > 0 {
+		for _, oidcClient := range hcluster.Spec.Configuration.Authentication.OIDCProviders[0].OIDCClients {
+			var src corev1.Secret
+			err = r.Client.Get(ctx, client.ObjectKey{Namespace: hcluster.Namespace, Name: oidcClient.ClientSecret.Name}, &src)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to get hostedcluster OIDCClient secret %s: %w", oidcClient.ClientSecret.Name, err)
+			}
+			dest := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      oidcClient.ClientSecret.Name,
+					Namespace: controlPlaneNamespace.Name,
+				},
+			}
+			_, err = createOrUpdate(ctx, r.Client, &dest, func() error {
+				if dest.Data == nil {
+					dest.Data = map[string][]byte{}
+				}
+				dest.Data["clientSecret"] = src.Data["clientSecret"]
+				return nil
+			})
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to reconcile controlplane OIDCClient secret %s: %w", dest.Name, err)
+			}
+		}
+	}
+
 	// Reconcile the service account signing key if set
 	if hcluster.Spec.ServiceAccountSigningKey != nil {
 		if err := r.reconcileServiceAccountSigningKey(ctx, hcluster, controlPlaneNamespace.Name, createOrUpdate); err != nil {


### PR DESCRIPTION
https://issues.redhat.com/browse/HOSTEDCP-1374

Worth noting there is a bug enabling `TechPreviewNoUpgrade` feature gate in the HC to allow Authentication type `OIDC`.  The HCP fails to rollout with crash loop in the KAS.  This will need to be solved before QE can verify this.

Update:
Found the issue with HCP rollout https://github.com/openshift/hypershift/pull/3377