### PR TITLE
OCPBUGS-25696: Apply Scheduling Configuration for kCCM

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
@@ -106,12 +106,10 @@ func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedContr
 		isExternalInfra = true
 	}
 	deploymentConfig := newDeploymentConfig()
+	deploymentConfig.SetDefaults(hcp, nil, nil)
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: ccmLabels(),
-		},
-		Strategy: appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

kCCM deployment was not respecting the node selector configured at `hcp.spec.nodeSelector` that was set with `--node-selector` flag in the create cli command. This PR fixes the issue, by applying `SetDefaults()` to the `deploymentConfig`, which sets the node selector along with other required configurations (e.g. tolerations, affinity, replica count, etc.)

**Which issue(s) this PR fixes** 
Fixes # https://issues.redhat.com/browse/OCPBUGS-25696

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.