### PR TITLE
HOSTEDCP-1309: Add GC knobs for KAS

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -232,6 +232,15 @@ const (
 
 	// JSONPatchAnnotation allow modifying the kubevirt VM template using jsonpatch
 	JSONPatchAnnotation = "hypershift.openshift.io/kubevirt-vm-jsonpatch"
+
+	// KubeAPIServerGOGCAnnotation allows modifying the kube-apiserver GOGC environment variable to impact how often
+	// the GO garbage collector runs. This can be used to reduce the memory footprint of the kube-apiserver.
+	KubeAPIServerGOGCAnnotation = "hypershift.openshift.io/kube-apiserver-gogc"
+
+	// KubeAPIServerGOMemoryLimitAnnotation allows modifying the kube-apiserver GOMEMLIMIT environment variable to increase
+	// the frequency of memory collection when memory used rises above a particular threshhold. This can be used to reduce
+	// the memory footprint of the kube-apiserver during upgrades.
+	KubeAPIServerGOMemoryLimitAnnotation = "hypershift.openshift.io/kube-apiserver-gomemlimit"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -191,7 +191,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 			},
 			Containers: []corev1.Container{
 				util.BuildContainer(kasContainerApplyBootstrap(), buildKASContainerApplyBootstrap(images.CLI)),
-				util.BuildContainer(kasContainerMain(), buildKASContainerMain(images.HyperKube, port, additionalNoProxyCIDRS)),
+				util.BuildContainer(kasContainerMain(), buildKASContainerMain(images.HyperKube, port, additionalNoProxyCIDRS, hcp)),
 				util.BuildContainer(konnectivityServerContainer(), buildKonnectivityServerContainer(images.KonnectivityServer, deploymentConfig.Replicas)),
 				{
 					Name:            "audit-logs",
@@ -407,7 +407,7 @@ func kasContainerMain() *corev1.Container {
 	}
 }
 
-func buildKASContainerMain(image string, port int32, noProxyCIDRs []string) func(c *corev1.Container) {
+func buildKASContainerMain(image string, port int32, noProxyCIDRs []string, hcp *hyperv1.HostedControlPlane) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
@@ -437,6 +437,20 @@ func buildKASContainerMain(image string, port int32, noProxyCIDRs []string) func
 		// Using a CIDR is not supported by Go's default ProxyFunc, but Kube uses a custom one by default that does support it:
 		// https://github.com/kubernetes/kubernetes/blob/ab13c85316015cf9f115e29923ba9740bd1564fd/staging/src/k8s.io/apimachinery/pkg/util/net/http.go#L112-L114
 		proxy.SetEnvVars(&c.Env, noProxyCIDRs...)
+
+		if hcp.Annotations[hyperv1.KubeAPIServerGOGCAnnotation] != "" {
+			c.Env = append(c.Env, corev1.EnvVar{
+				Name:  "GOGC",
+				Value: hcp.Annotations[hyperv1.KubeAPIServerGOGCAnnotation],
+			})
+		}
+
+		if hcp.Annotations[hyperv1.KubeAPIServerGOMemoryLimitAnnotation] != "" {
+			c.Env = append(c.Env, corev1.EnvVar{
+				Name:  "GOMEMLIMIT",
+				Value: hcp.Annotations[hyperv1.KubeAPIServerGOMemoryLimitAnnotation],
+			})
+		}
 
 		c.WorkingDir = volumeMounts.Path(c.Name, kasVolumeWorkLogs().Name)
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1809,6 +1809,8 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.RedHatMarketplaceCatalogImageAnnotation,
 		hyperv1.RedHatOperatorsCatalogImageAnnotation,
 		hyperv1.OLMCatalogsISRegistryOverridesAnnotation,
+		hyperv1.KubeAPIServerGOGCAnnotation,
+		hyperv1.KubeAPIServerGOMemoryLimitAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes GOMEMLIMIT and GOGC for kube-apiserver via annotations in HostedCluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1309](https://issues.redhat.com/browse/HOSTEDCP-1309)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.