### PR TITLE
OCPBUGS-23228: Add storage, csisnapshotcontroller and clustercsidrive…

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -127,6 +127,9 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 				&operatorv1.CloudCredential{}: allSelector,
 				&admissionregistrationv1.ValidatingWebhookConfiguration{}: allSelector,
 				&admissionregistrationv1.MutatingWebhookConfiguration{}:   allSelector,
+				&operatorv1.Storage{}:               allSelector,
+				&operatorv1.CSISnapshotController{}: allSelector,
+				&operatorv1.ClusterCSIDriver{}:      allSelector,
 
 				// Needed for inplace upgrader.
 				&corev1.Node{}: allSelector,


### PR DESCRIPTION

**What this PR does / why we need it**:

Add storage, csisnapshotcontroller and clustercsidriver objects to HCCO cache. This fixes the a bug where creation requests were being spammed during the reconcile even though the resources already existed.

**Which issue(s) this PR fixes** 
Fixes # [OCPBUGS-23228](https://issues.redhat.com/browse/OCPBUGS-23228)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.