### PR TITLE
OCPBUGS-26757: Change KAS bootstrap image to cluster-config-api

### DIFF
--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -6,7 +6,7 @@ COPY . .
 
 RUN make control-plane-operator control-plane-pki-operator
 
-FROM registry.ci.openshift.org/ocp/4.16:base
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -183,9 +183,9 @@ func ReconcileIgnitionServer(ctx context.Context,
 		"app":                         ignitionserver.ResourceName,
 		hyperv1.ControlPlaneComponent: ignitionserver.ResourceName,
 	}
-	configOperatorImage := componentImages["cluster-config-operator"]
-	if configOperatorImage == "" {
-		return fmt.Errorf("cluster-config-operator image not found in payload images")
+	configAPIImage := componentImages["cluster-config-api"]
+	if configAPIImage == "" {
+		return fmt.Errorf("cluster-config-api image not found in payload images")
 	}
 	machineConfigOperatorImage := componentImages["machine-config-operator"]
 	if machineConfigOperatorImage == "" {
@@ -199,7 +199,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 	// Determine if we need to override the machine config operator and cluster config operator
 	// images based on image mappings present in management cluster.
 	ocpRegistryMapping := util.ConvertImageRegistryOverrideStringToMap(openShiftRegistryOverrides)
-	overrideConfigOperatorImage, err := lookupMappedImage(ocpRegistryMapping, configOperatorImage)
+	overrideConfigAPIImage, err := lookupMappedImage(ocpRegistryMapping, configAPIImage)
 	if err != nil {
 		return err
 	}
@@ -215,8 +215,8 @@ func ReconcileIgnitionServer(ctx context.Context,
 		}
 	}
 
-	if overrideConfigOperatorImage != configOperatorImage {
-		imageOverrides[configOperatorImage] = overrideConfigOperatorImage
+	if overrideConfigAPIImage != configAPIImage {
+		imageOverrides[configAPIImage] = overrideConfigAPIImage
 	}
 
 	if overrideMachineConfigOperatorImage != machineConfigOperatorImage {
@@ -228,7 +228,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 		return reconcileDeployment(ignitionServerDeployment,
 			releaseVersion,
 			utilitiesImage,
-			configOperatorImage,
+			configAPIImage,
 			hcp,
 			defaultIngressDomain,
 			hasHealthzHandler,
@@ -463,7 +463,7 @@ func reconcileRoleBinding(roleBinding *rbacv1.RoleBinding, role *rbacv1.Role, sa
 func reconcileDeployment(deployment *appsv1.Deployment,
 	releaseVersion string,
 	utilitiesImage string,
-	configOperatorImage string,
+	configAPIImage string,
 	hcp *hyperv1.HostedControlPlane,
 	defaultIngressDomain string,
 	hasHealthzHandler bool,
@@ -588,7 +588,7 @@ func reconcileDeployment(deployment *appsv1.Deployment,
 				InitContainers: []corev1.Container{
 					{
 						Name:            "fetch-feature-gate",
-						Image:           configOperatorImage,
+						Image:           configAPIImage,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Command: []string{
 							"/bin/bash",

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -740,11 +740,9 @@ cat <<EOF >/tmp/manifests/99_feature-gate.yaml
 %[3]s
 EOF
 
-/usr/bin/cluster-config-operator render \
-   --config-output-file config \
-   --asset-input-dir /tmp/input \
+/usr/bin/render \
    --asset-output-dir /tmp/output \
-   --rendered-manifest-files=/tmp/manifests \
+   --rendered-manifest-dir=/tmp/manifests \
    --payload-version=%[2]s
 cp /tmp/output/manifests/* %[1]s
 cp /tmp/manifests/* %[1]s

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -101,7 +101,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		Images: KubeAPIServerImages{
 			HyperKube:                  releaseImageProvider.GetImage("hyperkube"),
 			CLI:                        releaseImageProvider.GetImage("cli"),
-			ClusterConfigOperator:      releaseImageProvider.GetImage("cluster-config-operator"),
+			ClusterConfigOperator:      releaseImageProvider.GetImage("cluster-config-api"),
 			TokenMinterImage:           releaseImageProvider.GetImage("token-minter"),
 			AWSKMS:                     releaseImageProvider.GetImage("aws-kms-provider"),
 			AWSPodIdentityWebhookImage: releaseImageProvider.GetImage("aws-pod-identity-webhook"),

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -258,18 +258,18 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 			}
 		}
 
-		component = "cluster-config-operator"
-		clusterConfigOperatorImage, ok := imageProvider.ImageExist(component)
+		component = "cluster-config-api"
+		clusterConfigAPIImage, ok := imageProvider.ImageExist(component)
 		if !ok {
-			return fmt.Errorf("release image does not contain cluster-config-operator (images: %v)", imageProvider.ComponentImages())
+			return fmt.Errorf("release image does not contain cluster-config-api (images: %v)", imageProvider.ComponentImages())
 		}
 
-		clusterConfigOperatorImage, err = registryclient.GetCorrectArchImage(ctx, component, clusterConfigOperatorImage, pullSecret)
+		clusterConfigAPIImage, err = registryclient.GetCorrectArchImage(ctx, component, clusterConfigAPIImage, pullSecret)
 		if err != nil {
 			return err
 		}
 
-		log.Info("discovered cluster config operator image", "image", clusterConfigOperatorImage)
+		log.Info("discovered cluster config api image", "image", clusterConfigAPIImage)
 
 		file, err := os.Create(filepath.Join(binDir, component))
 		if err != nil {
@@ -278,7 +278,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 		if err := file.Chmod(0777); err != nil {
 			return fmt.Errorf("failed to chmod file: %w", err)
 		}
-		if err := p.ImageFileCache.extractImageFile(ctx, clusterConfigOperatorImage, pullSecret, filepath.Join("usr/bin/", component), file); err != nil {
+		if err := p.ImageFileCache.extractImageFile(ctx, clusterConfigAPIImage, pullSecret, filepath.Join("usr/bin/", component), file); err != nil {
 			return fmt.Errorf("failed to extract image file: %w", err)
 		}
 		if err := file.Close(); err != nil {
@@ -307,19 +307,19 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 
 		args := []string{
 			"-c",
-			invokeFeatureGateRenderScript(filepath.Join(binDir, "cluster-config-operator"), filepath.Join(workDir, "cco"), mccBaseDir, payloadVersion, string(featureGateBytes)),
+			invokeFeatureGateRenderScript(filepath.Join(binDir, "cluster-config-api"), filepath.Join(workDir, "cca"), mccBaseDir, payloadVersion, string(featureGateBytes)),
 		}
 
 		cmd := exec.CommandContext(ctx, "/bin/bash", args...)
 		out, err := cmd.CombinedOutput()
-		log.Info("cluster-config-operator process completed", "time", time.Since(start).Round(time.Second).String(), "output", string(out))
+		log.Info("cluster-config-api process completed", "time", time.Since(start).Round(time.Second).String(), "output", string(out))
 		if err != nil {
-			return fmt.Errorf("cluster-config-operator process failed: %s: %w", string(out), err)
+			return fmt.Errorf("cluster-config-api process failed: %s: %w", string(out), err)
 		}
 		return nil
 	}()
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute cluster-config-operator: %w", err)
+		return nil, fmt.Errorf("failed to execute cluster-config-api: %w", err)
 	}
 
 	// First, run the MCO using templates and image refs as input. This generates
@@ -659,36 +659,12 @@ cat <<EOF >%[2]s/manifests/99_feature-gate.yaml
 %[5]s
 EOF
 
-%[1]s render \
-   --config-output-file config \
-   --asset-input-dir %[2]s/input \
+/usr/bin/render \
    --asset-output-dir %[2]s/output \
-   --rendered-manifest-files=%[2]s/manifests \
+   --rendered-manifest-dir=%[2]s/manifests \
    --payload-version=%[4]s 
 cp %[2]s/manifests/99_feature-gate.yaml %[3]s/99_feature-gate.yaml
 `
-
-	// Depending on the version, we need different args.
-	if payloadVersion.Minor < 14 {
-		script = `#!/bin/bash
-set -e
-mkdir -p %[2]s
-
-cd %[2]s
-mkdir -p input output manifests
-
-touch %[2]s/manifests/99_feature-gate.yaml
-cat <<EOF >%[2]s/manifests/99_feature-gate.yaml
-%[5]s
-EOF
-
-%[1]s render \
-   --config-output-file config \
-   --asset-input-dir %[2]s/input \
-   --asset-output-dir %[2]s/output
-cp %[2]s/manifests/99_feature-gate.yaml %[3]s/99_feature-gate.yaml
-`
-	}
 
 	return fmt.Sprintf(script, binary, workDir, outputDir, payloadVersion, featureGateYAML)
 }

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -278,7 +278,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 		if err := file.Chmod(0777); err != nil {
 			return fmt.Errorf("failed to chmod file: %w", err)
 		}
-		if err := p.ImageFileCache.extractImageFile(ctx, clusterConfigAPIImage, pullSecret, filepath.Join("usr/bin/", component), file); err != nil {
+		if err := p.ImageFileCache.extractImageFile(ctx, clusterConfigAPIImage, pullSecret, "usr/bin/render", file); err != nil {
 			return fmt.Errorf("failed to extract image file: %w", err)
 		}
 		if err := file.Close(); err != nil {
@@ -312,10 +312,10 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 
 		cmd := exec.CommandContext(ctx, "/bin/bash", args...)
 		out, err := cmd.CombinedOutput()
-		log.Info("cluster-config-api process completed", "time", time.Since(start).Round(time.Second).String(), "output", string(out))
 		if err != nil {
 			return fmt.Errorf("cluster-config-api process failed: %s: %w", string(out), err)
 		}
+		log.Info("cluster-config-api process completed", "time", time.Since(start).Round(time.Second).String(), "output", string(out))
 		return nil
 	}()
 	if err != nil {
@@ -659,7 +659,7 @@ cat <<EOF >%[2]s/manifests/99_feature-gate.yaml
 %[5]s
 EOF
 
-/usr/bin/render \
+%[1]s \
    --asset-output-dir %[2]s/output \
    --rendered-manifest-dir=%[2]s/manifests \
    --payload-version=%[4]s 


### PR DESCRIPTION
**What this PR does / why we need it**: 
Change KAS bootstrap image to cluster-config-api.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-26757](https://issues.redhat.com/browse/OCPBUGS-26757)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.