### PR TITLE
HOSTEDCP-1382: [Subtask] Restore Ability to Create HCPs on Azure

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	configv1 "github.com/openshift/api/config/v1"
+	kcpv1 "github.com/openshift/api/kubecontrolplane/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,10 +16,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	podsecurityadmissionv1beta1 "k8s.io/pod-security-admission/admission/api/v1beta1"
 
-	configv1 "github.com/openshift/api/config/v1"
-	kcpv1 "github.com/openshift/api/kubecontrolplane/v1"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/certs"
@@ -146,10 +147,10 @@ func generateConfig(p KubeAPIServerConfigParams, version semver.Version) *kcpv1.
 	args.Set("audit-policy-file", cpath(kasVolumeAuditConfig().Name, AuditPolicyConfigMapKey))
 	args.Set("authorization-mode", "Scope", "SystemMasters", "RBAC", "Node")
 	args.Set("client-ca-file", cpath(common.VolumeTotalClientCA().Name, certs.CASignerCertMapKey))
-	if p.CloudProviderConfigRef != nil {
+	if p.CloudProviderConfigRef != nil && p.CloudProvider != azure.Provider {
 		args.Set("cloud-config", cloudProviderConfig(p.CloudProviderConfigRef.Name, p.CloudProvider))
 	}
-	if p.CloudProvider != "" && p.CloudProvider != aws.Provider {
+	if p.CloudProvider != "" && p.CloudProvider != aws.Provider && p.CloudProvider != azure.Provider {
 		args.Set("cloud-provider", p.CloudProvider)
 	}
 	if p.AuditWebhookEnabled {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -49,6 +49,12 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 		ClusterCIDR:             util.FirstClusterCIDR(hcp.Spec.Networking.ClusterNetwork),
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
 	}
+
+	// This value comes from the Cloud Provider Azure documentation: https://cloud-provider-azure.sigs.k8s.io/install/azure-ccm/#kube-controller-manager
+	if hcp.Spec.Platform.Type == hyperv1.AzurePlatform {
+		params.CloudProvider = "external"
+	}
+
 	if hcp.Spec.Configuration != nil {
 		params.FeatureGate = hcp.Spec.Configuration.FeatureGate
 		params.APIServer = hcp.Spec.Configuration.APIServer


### PR DESCRIPTION
**What this PR does / why we need it**:
We regressed on our ability to create HCPs on Azure on the k8s bump to v1.29. 

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1382](https://issues.redhat.com//browse/HOSTEDCP-1382)-subtask

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.