### PR TITLE
 OCPBUGS-26547: fix up external-dns flags

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -221,8 +221,6 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
 								"--interval=1m",
 								"--service-type-filter=LoadBalancer",
-								"--aws-zone-type=public",
-								"--aws-zones-cache-duration=1h",
 								"--txt-cache-interval=1h",
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
@@ -290,6 +288,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
 			"--aws-zone-type=public",
 			"--aws-batch-change-interval=10s",
+			"--aws-zones-cache-duration=1h",
 		)
 	case "azure":
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -427,11 +427,10 @@ objects:
           - --label-filter=hypershift.openshift.io/route-visibility!=private
           - --interval=1m
           - --service-type-filter=LoadBalancer
-          - --aws-zone-type=public
-          - --aws-zones-cache-duration=1h
           - --txt-cache-interval=1h
           - --aws-zone-type=public
           - --aws-batch-change-interval=10s
+          - --aws-zones-cache-duration=1h
           command:
           - /external-dns
           env:


### PR DESCRIPTION
Getting error in external-dns `time="2024-01-11T12:34:55Z" level=fatal msg="flag parsing error: flag 'aws-zone-type' cannot be repeated"`

