### PR TITLE
OCPBUGS-27027: availability-prober: wait for infrastructure name to be set

### DIFF
--- a/availability-prober/availability_prober.go
+++ b/availability-prober/availability_prober.go
@@ -149,6 +149,10 @@ func check(log logr.Logger, target *url.URL, requestTimeout time.Duration, sleep
 				log.Info("cluster infrastructure resource not yet available", "err", err)
 				continue
 			}
+			if clusterInfrastructure.Status.InfrastructureName == "" {
+				log.Info("cluster infrastructure name is not yet set")
+				continue
+			}
 		}
 
 		if waitForLabeledPodsGone != "" {


### PR DESCRIPTION
[OCPBUGS-27027](https://issues.redhat.com/browse/OCPBUGS-27027)