### PR TITLE
OCPBUGS-26547: remove LoadBalancer filter from external-dns

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -220,7 +220,6 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								fmt.Sprintf("--txt-owner-id=%s", txtOwnerId),
 								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
 								"--interval=1m",
-								"--service-type-filter=LoadBalancer",
 								"--txt-cache-interval=1h",
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -426,7 +426,6 @@ objects:
           - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
           - --label-filter=hypershift.openshift.io/route-visibility!=private
           - --interval=1m
-          - --service-type-filter=LoadBalancer
           - --txt-cache-interval=1h
           - --aws-zone-type=public
           - --aws-batch-change-interval=10s


### PR DESCRIPTION
This is causing the oauth private route to not be registered