### PR TITLE
OCPBUGS-23457: Move konnectivity-server out of KAS pod

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -6,6 +6,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/konnectivity"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
@@ -136,11 +137,11 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
 			{Name: "KUBECONFIG", Value: "/etc/kubernetes/kubeconfig"},
 			{
 				Name:  "HTTP_PROXY",
-				Value: fmt.Sprintf("socks5://127.0.0.1:%d", kas.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("socks5://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
 			},
 			{
 				Name:  "HTTPS_PROXY",
-				Value: fmt.Sprintf("socks5://127.0.0.1:%d", kas.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("socks5://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
 			},
 			{
 				Name:  "NO_PROXY",

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"path"
-	"strconv"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/api"
-	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
@@ -61,11 +59,6 @@ var (
 			kasVolumeKubeletClientCA().Name:        "/etc/kubernetes/certs/kubelet-ca",
 			kasVolumeKonnectivityClientCert().Name: "/etc/kubernetes/certs/konnectivity-client",
 			kasVolumeEgressSelectorConfig().Name:   "/etc/kubernetes/egress-selector",
-		},
-		konnectivityServerContainer().Name: util.ContainerVolumeMounts{
-			konnectivityVolumeServerCerts().Name:  "/etc/konnectivity/server",
-			konnectivityVolumeClusterCerts().Name: "/etc/konnectivity/cluster",
-			kasVolumeKonnectivityCA().Name:        "/etc/konnectivity/ca",
 		},
 	}
 
@@ -192,7 +185,6 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 			Containers: []corev1.Container{
 				util.BuildContainer(kasContainerApplyBootstrap(), buildKASContainerApplyBootstrap(images.CLI)),
 				util.BuildContainer(kasContainerMain(), buildKASContainerMain(images.HyperKube, port, additionalNoProxyCIDRS, hcp)),
-				util.BuildContainer(konnectivityServerContainer(), buildKonnectivityServerContainer(images.KonnectivityServer, deploymentConfig.Replicas)),
 				{
 					Name:            "audit-logs",
 					Image:           images.CLI,
@@ -236,8 +228,6 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 				util.BuildVolume(kasVolumeKonnectivityClientCert(), buildKASVolumeKonnectivityClientCert),
 				util.BuildVolume(kasVolumeEgressSelectorConfig(), buildKASVolumeEgressSelectorConfig),
 				util.BuildVolume(kasVolumeKubeconfig(), buildKASVolumeKubeconfig),
-				util.BuildVolume(konnectivityVolumeServerCerts(), buildKonnectivityVolumeServerCerts),
-				util.BuildVolume(konnectivityVolumeClusterCerts(), buildKonnectivityVolumeClusterCerts),
 			},
 		},
 	}
@@ -878,92 +868,6 @@ func kasVolumeKubeconfig() *corev1.Volume {
 func buildKASVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
 		SecretName:  manifests.KASLocalhostKubeconfigSecret("").Name,
-		DefaultMode: pointer.Int32(0640),
-	}
-}
-
-func konnectivityServerContainer() *corev1.Container {
-	return &corev1.Container{
-		Name: "konnectivity-server",
-	}
-}
-
-func buildKonnectivityServerContainer(image string, serverCount int) func(c *corev1.Container) {
-	cpath := func(volume, file string) string {
-		return path.Join(volumeMounts.Path(konnectivityServerContainer().Name, volume), file)
-	}
-	return func(c *corev1.Container) {
-		c.Image = image
-		c.ImagePullPolicy = corev1.PullIfNotPresent
-		c.Command = []string{
-			"/usr/bin/proxy-server",
-		}
-		c.Args = []string{
-			"--logtostderr=true",
-			"--log-file-max-size=0",
-			"--cluster-cert",
-			cpath(konnectivityVolumeClusterCerts().Name, corev1.TLSCertKey),
-			"--cluster-key",
-			cpath(konnectivityVolumeClusterCerts().Name, corev1.TLSPrivateKeyKey),
-			"--server-cert",
-			cpath(konnectivityVolumeServerCerts().Name, corev1.TLSCertKey),
-			"--server-key",
-			cpath(konnectivityVolumeServerCerts().Name, corev1.TLSPrivateKeyKey),
-			"--server-ca-cert",
-			cpath(kasVolumeKonnectivityCA().Name, certs.CASignerCertMapKey),
-			"--server-port",
-			strconv.Itoa(KonnectivityServerLocalPort),
-			"--agent-port",
-			strconv.Itoa(KonnectivityServerPort),
-			"--health-port",
-			strconv.Itoa(KonnectivityHealthPort),
-			"--admin-port=8093",
-			"--mode=http-connect",
-			"--proxy-strategies=destHost,defaultRoute",
-			"--keepalive-time",
-			"30s",
-			"--frontend-keepalive-time",
-			"30s",
-			"--server-count",
-			strconv.Itoa(serverCount),
-		}
-		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
-		c.Lifecycle = &corev1.Lifecycle{
-			PreStop: &corev1.LifecycleHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						"/bin/sh",
-						"-c",
-						"sleep 70",
-					},
-				},
-			},
-		}
-	}
-}
-
-func konnectivityVolumeServerCerts() *corev1.Volume {
-	return &corev1.Volume{
-		Name: "server-certs",
-	}
-}
-
-func buildKonnectivityVolumeServerCerts(v *corev1.Volume) {
-	v.Secret = &corev1.SecretVolumeSource{
-		SecretName:  manifests.KonnectivityServerSecret("").Name,
-		DefaultMode: pointer.Int32(0640),
-	}
-}
-
-func konnectivityVolumeClusterCerts() *corev1.Volume {
-	return &corev1.Volume{
-		Name: "cluster-certs",
-	}
-}
-
-func buildKonnectivityVolumeClusterCerts(v *corev1.Volume) {
-	v.Secret = &corev1.SecretVolumeSource{
-		SecretName:  manifests.KonnectivityClusterSecret("").Name,
 		DefaultMode: pointer.Int32(0640),
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/egresscfg.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/egresscfg.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/konnectivity"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/certs"
 	hcpconfig "github.com/openshift/hypershift/support/config"
@@ -41,7 +43,7 @@ func egressSelectorConfiguration() *kasv1beta1.EgressSelectorConfiguration {
 					ProxyProtocol: kasv1beta1.ProtocolHTTPConnect,
 					Transport: &kasv1beta1.Transport{
 						TCP: &kasv1beta1.TCPTransport{
-							URL: fmt.Sprintf("https://127.0.0.1:%d", KonnectivityServerLocalPort),
+							URL: fmt.Sprintf("https://%s:%d", manifests.KonnectivityServerLocalService("").Name, konnectivity.KonnectivityServerLocalPort),
 							TLSConfig: &kasv1beta1.TLSConfig{
 								CABundle:   cpath(kasVolumeKonnectivityCA().Name, certs.CASignerCertMapKey),
 								ClientCert: cpath(kasVolumeKonnectivityClientCert().Name, corev1.TLSCertKey),

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -29,7 +29,6 @@ type KubeAPIServerImages struct {
 	Portieris                  string `json:"portieris"`
 	TokenMinterImage           string
 	AWSPodIdentityWebhookImage string
-	KonnectivityServer         string
 }
 
 type KubeAPIServerParams struct {
@@ -76,12 +75,6 @@ type KubeAPIServerServiceParams struct {
 	OwnerReference    *metav1.OwnerReference
 }
 
-const (
-	KonnectivityHealthPort      = 2041
-	KonnectivityServerLocalPort = 8090
-	KonnectivityServerPort      = 8091
-)
-
 func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, externalAPIAddress string, externalAPIPort int32, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {
 	dns := globalconfig.DNSConfig()
 	globalconfig.ReconcileDNSConfig(dns, hcp)
@@ -105,7 +98,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			TokenMinterImage:           releaseImageProvider.GetImage("token-minter"),
 			AWSKMS:                     releaseImageProvider.GetImage("aws-kms-provider"),
 			AWSPodIdentityWebhookImage: releaseImageProvider.GetImage("aws-pod-identity-webhook"),
-			KonnectivityServer:         releaseImageProvider.GetImage("apiserver-network-proxy"),
 		},
 	}
 	if hcp.Spec.Configuration != nil {
@@ -195,20 +187,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			FailureThreshold:    3,
 			SuccessThreshold:    1,
 		},
-		konnectivityServerContainer().Name: {
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Scheme: corev1.URISchemeHTTP,
-					Port:   intstr.FromInt(int(KonnectivityHealthPort)),
-					Path:   "healthz",
-				},
-			},
-			InitialDelaySeconds: 120,
-			TimeoutSeconds:      30,
-			PeriodSeconds:       60,
-			FailureThreshold:    3,
-			SuccessThreshold:    1,
-		},
 	}
 	params.ReadinessProbes = config.ReadinessProbes{
 		kasContainerMain().Name: {
@@ -224,20 +202,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			TimeoutSeconds:      120,
 			FailureThreshold:    6,
 			SuccessThreshold:    1,
-		},
-		konnectivityServerContainer().Name: {
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Scheme: corev1.URISchemeHTTP,
-					Port:   intstr.FromInt(int(KonnectivityHealthPort)),
-					Path:   "healthz",
-				},
-			},
-			InitialDelaySeconds: 15,
-			PeriodSeconds:       60,
-			SuccessThreshold:    1,
-			FailureThreshold:    3,
-			TimeoutSeconds:      5,
 		},
 	}
 	params.Resources = map[string]corev1.ResourceRequirements{
@@ -257,12 +221,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("20Mi"),
 				corev1.ResourceCPU:    resource.MustParse("5m"),
-			},
-		},
-		konnectivityServerContainer().Name: {
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
-				corev1.ResourceCPU:    resource.MustParse("10m"),
 			},
 		},
 	}
@@ -289,9 +247,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 	if _, ok := hcp.Annotations[hyperv1.IBMCloudKMSProviderImage]; ok {
 		params.Images.IBMCloudKMS = hcp.Annotations[hyperv1.IBMCloudKMSProviderImage]
-	}
-	if _, ok := hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]; ok {
-		params.Images.KonnectivityServer = hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]
 	}
 
 	params.KubeConfigRef = hcp.Spec.KubeConfig

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -2,12 +2,9 @@ package kas
 
 import (
 	"fmt"
-	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -224,134 +221,4 @@ func ReconcileInternalRoute(route *routev1.Route, owner *metav1.OwnerReference) 
 	route.Spec.Host = fmt.Sprintf("api.%s.hypershift.local", owner.Name)
 	// Assumes owner is the HCP
 	return util.ReconcileInternalRoute(route, "", manifests.KubeAPIServerService("").Name)
-}
-
-func ReconcileKonnectivityServerLocalService(svc *corev1.Service, ownerRef config.OwnerRef) error {
-	ownerRef.ApplyTo(svc)
-	svc.Spec.Selector = kasLabels()
-	var portSpec corev1.ServicePort
-	if len(svc.Spec.Ports) > 0 {
-		portSpec = svc.Spec.Ports[0]
-	} else {
-		svc.Spec.Ports = []corev1.ServicePort{portSpec}
-	}
-	portSpec.Port = int32(KonnectivityServerLocalPort)
-	portSpec.Protocol = corev1.ProtocolTCP
-	portSpec.TargetPort = intstr.FromInt(KonnectivityServerLocalPort)
-	svc.Spec.Type = corev1.ServiceTypeClusterIP
-	svc.Spec.Ports[0] = portSpec
-	return nil
-}
-
-func ReconcileKonnectivityServerService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy) error {
-	ownerRef.ApplyTo(svc)
-	svc.Spec.Selector = kasLabels()
-	var portSpec corev1.ServicePort
-	if len(svc.Spec.Ports) > 0 {
-		portSpec = svc.Spec.Ports[0]
-	} else {
-		svc.Spec.Ports = []corev1.ServicePort{portSpec}
-	}
-	portSpec.Port = int32(KonnectivityServerPort)
-	portSpec.Protocol = corev1.ProtocolTCP
-	portSpec.TargetPort = intstr.FromInt(KonnectivityServerPort)
-	switch strategy.Type {
-	case hyperv1.LoadBalancer:
-		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-		if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
-			if svc.Annotations == nil {
-				svc.Annotations = map[string]string{}
-			}
-			svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
-		}
-	case hyperv1.NodePort:
-		svc.Spec.Type = corev1.ServiceTypeNodePort
-		if portSpec.NodePort == 0 && strategy.NodePort != nil {
-			portSpec.NodePort = strategy.NodePort.Port
-		}
-	case hyperv1.Route:
-		svc.Spec.Type = corev1.ServiceTypeClusterIP
-	default:
-		return fmt.Errorf("invalid publishing strategy for Konnectivity service: %s", strategy.Type)
-	}
-	svc.Spec.Ports[0] = portSpec
-	return nil
-}
-
-func ReconcileKonnectivityExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
-	ownerRef.ApplyTo(route)
-	if err := util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.KonnectivityServerService(route.Namespace).Name); err != nil {
-		return err
-	}
-	if route.Annotations == nil {
-		route.Annotations = map[string]string{}
-	}
-	route.Annotations["haproxy.router.openshift.io/balance"] = "roundrobin"
-	return nil
-}
-
-func ReconcileKonnectivityInternalRoute(route *routev1.Route, ownerRef config.OwnerRef) error {
-	ownerRef.ApplyTo(route)
-	// Assumes ownerRef is the HCP
-	if err := util.ReconcileInternalRoute(route, ownerRef.Reference.Name, manifests.KonnectivityServerService(route.Namespace).Name); err != nil {
-		return err
-	}
-	if route.Annotations == nil {
-		route.Annotations = map[string]string{}
-	}
-	route.Annotations["haproxy.router.openshift.io/balance"] = "roundrobin"
-	return nil
-}
-
-func ReconcileKonnectivityServerServiceStatus(svc *corev1.Service, route *routev1.Route, strategy *hyperv1.ServicePublishingStrategy, messageCollector events.MessageCollector) (host string, port int32, message string, err error) {
-	switch strategy.Type {
-	case hyperv1.LoadBalancer:
-		if len(svc.Status.LoadBalancer.Ingress) == 0 {
-			message = fmt.Sprintf("Konnectivity load balancer is not provisioned; %v since creation", duration.ShortHumanDuration(time.Since(svc.ObjectMeta.CreationTimestamp.Time)))
-			var messages []string
-			messages, err = messageCollector.ErrorMessages(svc)
-			if err != nil {
-				err = fmt.Errorf("failed to get events for service %s/%s: %w", svc.Namespace, svc.Name, err)
-				return
-			}
-			if len(messages) > 0 {
-				message = fmt.Sprintf("Konnectivity load balancer is not provisioned: %s", strings.Join(messages, "; "))
-			}
-			return
-		}
-		port = int32(KonnectivityServerPort)
-		switch {
-		case strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "":
-			host = strategy.LoadBalancer.Hostname
-		case svc.Status.LoadBalancer.Ingress[0].Hostname != "":
-			host = svc.Status.LoadBalancer.Ingress[0].Hostname
-		case svc.Status.LoadBalancer.Ingress[0].IP != "":
-			host = svc.Status.LoadBalancer.Ingress[0].IP
-		}
-	case hyperv1.NodePort:
-		if strategy.NodePort == nil {
-			err = fmt.Errorf("strategy details not specified for Konnectivity nodeport type service")
-			return
-		}
-		if len(svc.Spec.Ports) == 0 {
-			return
-		}
-		if svc.Spec.Ports[0].NodePort == 0 {
-			return
-		}
-		port = svc.Spec.Ports[0].NodePort
-		host = strategy.NodePort.Address
-	case hyperv1.Route:
-		if strategy.Route != nil && strategy.Route.Hostname != "" {
-			host = strategy.Route.Hostname
-			port = 443
-			return
-		}
-		if route.Spec.Host == "" {
-			return
-		}
-		port = 443
-		host = route.Spec.Host
-	}
-	return
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -4,6 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
@@ -16,17 +17,70 @@ const (
 )
 
 type KonnectivityParams struct {
-	KonnectivityAgentImage string
-	OwnerRef               config.OwnerRef
-	AgentDeploymentConfig  config.DeploymentConfig
-	AgentDeamonSetConfig   config.DeploymentConfig
+	KonnectivityServerImage string
+	KonnectivityAgentImage  string
+	ExternalAddress         string
+	ExternalPort            int32
+	OwnerRef                config.OwnerRef
+	ServerDeploymentConfig  config.DeploymentConfig
+	AgentDeploymentConfig   config.DeploymentConfig
+	AgentDeamonSetConfig    config.DeploymentConfig
 }
 
 func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, externalAddress string, externalPort int32, setDefaultSecurityContext bool) *KonnectivityParams {
 	p := &KonnectivityParams{
-		KonnectivityAgentImage: releaseImageProvider.GetImage("konnectivity-agent"),
-		OwnerRef:               config.OwnerRefFrom(hcp),
+		KonnectivityServerImage: releaseImageProvider.GetImage("konnectivity-server"),
+		KonnectivityAgentImage:  releaseImageProvider.GetImage("konnectivity-agent"),
+		ExternalAddress:         externalAddress,
+		ExternalPort:            externalPort,
+		OwnerRef:                config.OwnerRefFrom(hcp),
 	}
+	p.ServerDeploymentConfig.LivenessProbes = config.LivenessProbes{
+		konnectivityServerContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			InitialDelaySeconds: 120,
+			TimeoutSeconds:      30,
+			PeriodSeconds:       60,
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+		},
+	}
+	p.ServerDeploymentConfig.ReadinessProbes = config.ReadinessProbes{
+		konnectivityServerContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       60,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+			TimeoutSeconds:      5,
+		},
+	}
+	p.ServerDeploymentConfig.Resources = config.ResourcesSpec{
+		konnectivityServerContainer().Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+		},
+	}
+	p.ServerDeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
+		p.ServerDeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
+	}
+	p.ServerDeploymentConfig.SetRequestServingDefaults(hcp, nil, pointer.Int(1))
+	p.ServerDeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 
 	p.AgentDeploymentConfig.Resources = config.ResourcesSpec{
 		konnectivityAgentContainer().Name: {
@@ -90,11 +144,16 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider
 	// non root security context if scc capability is missing
 	p.AgentDeamonSetConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	p.AgentDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
+	p.ServerDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	// check apiserver-network-proxy image in ocp payload and use it
 	if image, exist := releaseImageProvider.ImageExist("apiserver-network-proxy"); exist {
+		p.KonnectivityServerImage = image
 		p.KonnectivityAgentImage = image
 	}
 
+	if _, ok := hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]; ok {
+		p.KonnectivityServerImage = hcp.Annotations[hyperv1.KonnectivityServerImageAnnotation]
+	}
 	if _, ok := hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]; ok {
 		p.KonnectivityAgentImage = hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/reconcile.go
@@ -4,29 +4,53 @@ import (
 	"bytes"
 	"fmt"
 	"path"
+	"strconv"
+	"strings"
+	"time"
 
 	"k8s.io/utils/pointer"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
+	routev1 "github.com/openshift/api/route/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/util"
+)
+
+const (
+	KonnectivityServerLocalPort = 8090
+	KonnectivityServerPort      = 8091
+	KonnectivityHealthPort      = 2041
 )
 
 var (
 	volumeMounts = util.PodVolumeMounts{
+		konnectivityServerContainer().Name: util.ContainerVolumeMounts{
+			konnectivityVolumeServerCerts().Name:  "/etc/konnectivity/server",
+			konnectivityVolumeClusterCerts().Name: "/etc/konnectivity/cluster",
+			konnectivitySignerCA().Name:           "/etc/konnectivity/ca",
+		},
 		konnectivityAgentContainer().Name: util.ContainerVolumeMounts{
 			konnectivityVolumeAgentCerts().Name: "/etc/konnectivity/agent",
 			konnectivitySignerCA().Name:         "/etc/konnectivity/ca",
 		},
 	}
 )
+
+func konnectivityServerLabels() map[string]string {
+	return map[string]string{
+		"app":                         "konnectivity-server",
+		hyperv1.ControlPlaneComponent: "konnectivity-server",
+	}
+}
 
 func konnectivityAgentLabels() map[string]string {
 	return map[string]string{
@@ -38,6 +62,222 @@ func konnectivityAgentLabels() map[string]string {
 const (
 	KubeconfigKey = "kubeconfig"
 )
+
+func ReconcileServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, image string) error {
+	ownerRef.ApplyTo(deployment)
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: konnectivityServerLabels(),
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: konnectivityServerLabels(),
+			},
+			Spec: corev1.PodSpec{
+				AutomountServiceAccountToken: pointer.Bool(false),
+				Containers: []corev1.Container{
+					util.BuildContainer(konnectivityServerContainer(), buildKonnectivityServerContainer(image)),
+				},
+				Volumes: []corev1.Volume{
+					util.BuildVolume(konnectivityVolumeServerCerts(), buildKonnectivityVolumeServerCerts),
+					util.BuildVolume(konnectivityVolumeClusterCerts(), buildKonnectivityVolumeClusterCerts),
+					util.BuildVolume(konnectivitySignerCA(), buildKonnectivitySignerCAkonnectivitySignerCAVolume),
+				},
+			},
+		},
+	}
+	deploymentConfig.ApplyTo(deployment)
+	return nil
+}
+
+func konnectivityServerContainer() *corev1.Container {
+	return &corev1.Container{
+		Name: "konnectivity-server",
+	}
+}
+
+func buildKonnectivityServerContainer(image string) func(c *corev1.Container) {
+	cpath := func(volume, file string) string {
+		return path.Join(volumeMounts.Path(konnectivityServerContainer().Name, volume), file)
+	}
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.ImagePullPolicy = corev1.PullIfNotPresent
+		c.Command = []string{
+			"/usr/bin/proxy-server",
+		}
+		c.Args = []string{
+			"--logtostderr=true",
+			"--log-file-max-size=0",
+			"--cluster-cert",
+			cpath(konnectivityVolumeClusterCerts().Name, corev1.TLSCertKey),
+			"--cluster-key",
+			cpath(konnectivityVolumeClusterCerts().Name, corev1.TLSPrivateKeyKey),
+			"--server-cert",
+			cpath(konnectivityVolumeServerCerts().Name, corev1.TLSCertKey),
+			"--server-key",
+			cpath(konnectivityVolumeServerCerts().Name, corev1.TLSPrivateKeyKey),
+			"--server-ca-cert",
+			cpath(konnectivitySignerCA().Name, certs.CASignerCertMapKey),
+			"--server-port",
+			strconv.Itoa(KonnectivityServerLocalPort),
+			"--agent-port",
+			strconv.Itoa(KonnectivityServerPort),
+			"--health-port",
+			strconv.Itoa(healthPort),
+			"--admin-port=8093",
+			"--mode=http-connect",
+			"--proxy-strategies=destHost,defaultRoute",
+			"--keepalive-time",
+			"30s",
+			"--frontend-keepalive-time",
+			"30s",
+		}
+		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+	}
+}
+
+func konnectivityVolumeServerCerts() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "server-certs",
+	}
+}
+
+func buildKonnectivityVolumeServerCerts(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName:  manifests.KonnectivityServerSecret("").Name,
+		DefaultMode: pointer.Int32(0640),
+	}
+}
+
+func konnectivityVolumeClusterCerts() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "cluster-certs",
+	}
+}
+
+func buildKonnectivityVolumeClusterCerts(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{
+		SecretName:  manifests.KonnectivityClusterSecret("").Name,
+		DefaultMode: pointer.Int32(0640),
+	}
+}
+
+func ReconcileServerLocalService(svc *corev1.Service, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(svc)
+	svc.Spec.Selector = konnectivityServerLabels()
+	var portSpec corev1.ServicePort
+	if len(svc.Spec.Ports) > 0 {
+		portSpec = svc.Spec.Ports[0]
+	} else {
+		svc.Spec.Ports = []corev1.ServicePort{portSpec}
+	}
+	portSpec.Port = int32(KonnectivityServerLocalPort)
+	portSpec.Protocol = corev1.ProtocolTCP
+	portSpec.TargetPort = intstr.FromInt(KonnectivityServerLocalPort)
+	svc.Spec.Type = corev1.ServiceTypeClusterIP
+	svc.Spec.Ports[0] = portSpec
+	return nil
+}
+
+func ReconcileServerService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy) error {
+	ownerRef.ApplyTo(svc)
+	svc.Spec.Selector = konnectivityServerLabels()
+	var portSpec corev1.ServicePort
+	if len(svc.Spec.Ports) > 0 {
+		portSpec = svc.Spec.Ports[0]
+	} else {
+		svc.Spec.Ports = []corev1.ServicePort{portSpec}
+	}
+	portSpec.Port = int32(KonnectivityServerPort)
+	portSpec.Protocol = corev1.ProtocolTCP
+	portSpec.TargetPort = intstr.FromInt(KonnectivityServerPort)
+	switch strategy.Type {
+	case hyperv1.LoadBalancer:
+		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+		if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
+			if svc.Annotations == nil {
+				svc.Annotations = map[string]string{}
+			}
+			svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+		}
+	case hyperv1.NodePort:
+		svc.Spec.Type = corev1.ServiceTypeNodePort
+		if portSpec.NodePort == 0 && strategy.NodePort != nil {
+			portSpec.NodePort = strategy.NodePort.Port
+		}
+	case hyperv1.Route:
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+	default:
+		return fmt.Errorf("invalid publishing strategy for Konnectivity service: %s", strategy.Type)
+	}
+	svc.Spec.Ports[0] = portSpec
+	return nil
+}
+
+func ReconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
+	ownerRef.ApplyTo(route)
+	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.KonnectivityServerService(route.Namespace).Name)
+}
+
+func ReconcileInternalRoute(route *routev1.Route, ownerRef config.OwnerRef) error {
+	ownerRef.ApplyTo(route)
+	// Assumes ownerRef is the HCP
+	return util.ReconcileInternalRoute(route, ownerRef.Reference.Name, manifests.KonnectivityServerService(route.Namespace).Name)
+}
+
+func ReconcileServerServiceStatus(svc *corev1.Service, route *routev1.Route, strategy *hyperv1.ServicePublishingStrategy, messageCollector events.MessageCollector) (host string, port int32, message string, err error) {
+	switch strategy.Type {
+	case hyperv1.LoadBalancer:
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			message = fmt.Sprintf("Konnectivity load balancer is not provisioned; %v since creation", duration.ShortHumanDuration(time.Since(svc.ObjectMeta.CreationTimestamp.Time)))
+			var messages []string
+			messages, err = messageCollector.ErrorMessages(svc)
+			if err != nil {
+				err = fmt.Errorf("failed to get events for service %s/%s: %w", svc.Namespace, svc.Name, err)
+				return
+			}
+			if len(messages) > 0 {
+				message = fmt.Sprintf("Konnectivity load balancer is not provisioned: %s", strings.Join(messages, "; "))
+			}
+			return
+		}
+		port = int32(KonnectivityServerPort)
+		switch {
+		case strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "":
+			host = strategy.LoadBalancer.Hostname
+		case svc.Status.LoadBalancer.Ingress[0].Hostname != "":
+			host = svc.Status.LoadBalancer.Ingress[0].Hostname
+		case svc.Status.LoadBalancer.Ingress[0].IP != "":
+			host = svc.Status.LoadBalancer.Ingress[0].IP
+		}
+	case hyperv1.NodePort:
+		if strategy.NodePort == nil {
+			err = fmt.Errorf("strategy details not specified for Konnectivity nodeport type service")
+			return
+		}
+		if len(svc.Spec.Ports) == 0 {
+			return
+		}
+		if svc.Spec.Ports[0].NodePort == 0 {
+			return
+		}
+		port = svc.Spec.Ports[0].NodePort
+		host = strategy.NodePort.Address
+	case hyperv1.Route:
+		if strategy.Route != nil && strategy.Route.Hostname != "" {
+			host = strategy.Route.Hostname
+			port = 443
+			return
+		}
+		if route.Spec.Host == "" {
+			return
+		}
+		port = 443
+		host = route.Spec.Host
+	}
+	return
+}
 
 func konnectivitySignerCA() *corev1.Volume {
 	return &corev1.Volume{
@@ -124,9 +364,9 @@ func buildKonnectivityAgentContainer(image string, ips []string) func(c *corev1.
 			"--proxy-server-host",
 			manifests.KonnectivityServerService("").Name,
 			"--proxy-server-port",
-			fmt.Sprint(kas.KonnectivityServerPort),
+			fmt.Sprint(KonnectivityServerPort),
 			"--health-server-port",
-			fmt.Sprint(kas.KonnectivityHealthPort),
+			fmt.Sprint(KonnectivityHealthPort),
 			"--agent-identifiers",
 			agentIDs.String(),
 			"--keepalive-time",

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/konnectivity"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
@@ -272,11 +273,11 @@ func buildOASContainerMain(image string, etcdHostname string, port int32, intern
 		c.Env = []corev1.EnvVar{
 			{
 				Name:  "HTTP_PROXY",
-				Value: fmt.Sprintf("socks5://127.0.0.1:%d", kas.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("socks5://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
 			},
 			{
 				Name:  "HTTPS_PROXY",
-				Value: fmt.Sprintf("socks5://127.0.0.1:%d", kas.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("socks5://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
 			},
 			{
 				Name:  "NO_PROXY",

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -17,6 +17,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/konnectivity"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
@@ -146,15 +147,15 @@ func buildOAuthContainerMain(image string, noProxy []string) func(c *corev1.Cont
 		c.Env = []corev1.EnvVar{
 			{
 				Name:  "HTTP_PROXY",
-				Value: fmt.Sprintf("socks5://127.0.0.1:%d", kas.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("socks5://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
 			},
 			{
 				Name:  "HTTPS_PROXY",
-				Value: fmt.Sprintf("socks5://127.0.0.1:%d", kas.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("socks5://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
 			},
 			{
 				Name:  "ALL_PROXY",
-				Value: fmt.Sprintf("socks5://127.0.0.1:%d", kas.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("socks5://127.0.0.1:%d", konnectivity.KonnectivityServerLocalPort),
 			},
 			{
 				Name:  "NO_PROXY",


### PR DESCRIPTION
**What this PR does / why we need it**:
We had previously moved the konnectivity server to the Kube APIServer pod (https://github.com/openshift/hypershift/pull/2942) in order to support the case where communication between the nodes where the kube-apiserver lived could not talk to each other. However, moving the konnectivity-server container inside the kube-apiserver pod brings other problems with it. If exposed via a service, agents cannot establish a connection until the entire kube-apiserver pod is available. It also forces us to run the konnectivity-server in HA mode, which at this point is not fully fleshed out upstream. This PR reverts to having a single instance of konnectivity-server in its own deployment. Currently request serving nodes *are* able to talk to each other as they are paired by the scheduler (see https://github.com/openshift/hypershift/pull/3077)

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-23457](https://issues.redhat.com/browse/OCPBUGS-23457)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.