### PR TITLE
dockerfile: Use rhel9 for both files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 as builder
 
 WORKDIR /hypershift
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN make build
 
-FROM quay.io/openshift/origin-base:4.16
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /hypershift/bin/hypershift \
                     /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 
 WORKDIR /hypershift
 


### PR DESCRIPTION
**What this PR does / why we need it**:
openshift 4.16 is based on rhel-9 but the Dockerfile to hypershift operator was using rhel-8 image that may fail at ignition-server when it tries to run the release image control plane now that we have CGO enabled (related to fips).

This change use just rhel-9 images.

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.