### PR TITLE
OCPBUGS-27366: indicate cluster profile to render the correct manifests

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -757,6 +757,7 @@ EOF
 /usr/bin/render \
    --asset-output-dir /tmp/output \
    --rendered-manifest-dir=/tmp/manifests \
+   --cluster-profile=ibm-cloud-managed \
    --payload-version=%[2]s
 cp /tmp/output/manifests/* %[1]s
 cp /tmp/manifests/* %[1]s

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -662,6 +662,7 @@ EOF
 %[1]s \
    --asset-output-dir %[2]s/output \
    --rendered-manifest-dir=%[2]s/manifests \
+   --cluster-profile=ibm-cloud-managed \
    --payload-version=%[4]s 
 cp %[2]s/manifests/99_feature-gate.yaml %[3]s/99_feature-gate.yaml
 `


### PR DESCRIPTION
In order to get different schemas and featuregates for hypershift, it is necessary to indicate that we're rendering for hypershift.

/assign @sjenning 