### PR TITLE
HOSTEDCP-1283: Set outbound LoadBalancer name on AzureCluster

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -225,6 +225,9 @@ func reconcileAzureCluster(azureCluster *capiazure.AzureCluster, hcluster *hyper
 	azureCluster.Spec.NetworkSpec.Vnet.Name = hcluster.Spec.Platform.Azure.VnetName
 	azureCluster.Spec.NetworkSpec.Vnet.ResourceGroup = hcluster.Spec.Platform.Azure.ResourceGroupName
 	azureCluster.Spec.SubscriptionID = hcluster.Spec.Platform.Azure.SubscriptionID
+	azureCluster.Spec.NetworkSpec.NodeOutboundLB = &capiazure.LoadBalancerSpec{}
+	azureCluster.Spec.NetworkSpec.NodeOutboundLB.Name = hcluster.Spec.InfraID
+	azureCluster.Spec.NetworkSpec.NodeOutboundLB.BackendPool.Name = hcluster.Spec.InfraID
 
 	azureCluster.Spec.ControlPlaneEndpoint = capiv1.APIEndpoint{
 		Host: apiEndpoint.Host,


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the issue of Azure VMs not joining a HostedCluster as nodes because they were not getting added to the outbound LoadBalancer in their resource group. This change sets the name of the outbound LoadBalancer in the AzureCluster so that the CAPI provider can set the proper backend pool on VM NICs.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1283](https://issues.redhat.com/browse/HOSTEDCP-1283)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.