### PR TITLE
OCPBUGS-28741: Fix default release image lookup

### DIFF
--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -109,7 +109,7 @@ func LookupLatestSupportedRelease(ctx context.Context, hc *hyperv1.HostedCluster
 	minSupportedVersion := GetMinSupportedVersion(hc)
 
 	prefix := "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-multi/latest"
-	filter := fmt.Sprintf("in=>4.%d.%d+<+4.%d.0",
+	filter := fmt.Sprintf("in=>4.%d.%d+<+4.%d.0-a",
 		minSupportedVersion.Minor, minSupportedVersion.Patch, LatestSupportedVersion.Minor+1)
 
 	releaseURL := fmt.Sprintf("%s?%s", prefix, filter)


### PR DESCRIPTION
When no release image is provided on a HostedCluster, the backend hypershift operator picks the latest OCP release image within the operator's support windown.

Today this fails due to how the operator selects this default image. For example, hypershift operator 4.14 does not support 4.15, but the 4.15.0.rc.3 is picked as a default release image today. 

This is a result of not anticipating that release candidates would not be reported as the latest stable release. The filter used to pick the latest release needs to consider patch level releases before the next y stream release.