### PR TITLE
OCPBUGS-26940: Include OperatorHubSpec sync with HC when Config is empty

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1414,7 +1414,11 @@ func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedContro
 		// Management OLM Placement
 		if _, err := r.CreateOrUpdate(ctx, r.client, operatorHub, func() error {
 			if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.OperatorHub != nil {
+				// if spec.Configuration.OperatorHub is set, we need to sync it to the guest cluster
 				operatorHub.Spec.DisableAllDefaultSources = hcp.Spec.Configuration.OperatorHub.DisableAllDefaultSources
+			} else {
+				// If the spec.Configuration is nil or the spec.Configuration.OperatorHub is nil, then we need to set the OperatorHub.Spec to an empty struct
+				operatorHub.Spec = configv1.OperatorHubSpec{}
 			}
 			return nil
 		}); err != nil {


### PR DESCRIPTION
This PR Contains:
- [x] Fixed bug
- [x] Added ReconcileOLM unitTests

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-26940](https://issues.redhat.com/browse/OCPBUGS-26940)
