### PR TITLE
OCPBUGS-27161: reflect NodePool replica count nil in status

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -974,6 +974,10 @@ func (r *NodePoolReconciler) setAllNodesHealthyCondition(nodePool *hyperv1.NodeP
 		status = corev1.ConditionFalse
 		reason = hyperv1.NodePoolNotFoundReason
 		message = "No Machines are created"
+		if nodePool.Spec.Replicas != nil && *nodePool.Spec.Replicas == 0 {
+			reason = hyperv1.AsExpectedReason
+			message = "NodePool set to no replicas"
+		}
 	}
 
 	for _, machine := range machines {
@@ -1008,6 +1012,10 @@ func (r *NodePoolReconciler) setAllMachinesReadyCondition(nodePool *hyperv1.Node
 		status = corev1.ConditionFalse
 		reason = hyperv1.NodePoolNotFoundReason
 		message = "No Machines are created"
+		if nodePool.Spec.Replicas != nil && *nodePool.Spec.Replicas == 0 {
+			reason = hyperv1.AsExpectedReason
+			message = "NodePool set to no replicas"
+		}
 	} else {
 		// Aggregate conditions.
 		// TODO (alberto): consider bubbling failureReason / failureMessage.


### PR DESCRIPTION
**What this PR does / why we need it**: Updates AllMachinesReady and AllNodesHealthy status to false as expected with the message NodePool Replicas set to nil.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-27161](https://issues.redhat.com/browse/OCPBUGS-27161)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.