### PR TITLE
OCPBUGS-29179: [4.15] reflect NodePool replica count nil in status

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -730,6 +730,10 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		status = corev1.ConditionFalse
 		reason = hyperv1.NodePoolNotFoundReason
 		message = "No Machines are created"
+		if nodePool.Spec.Replicas != nil && *nodePool.Spec.Replicas == 0 {
+			reason = hyperv1.AsExpectedReason
+			message = "NodePool set to no replicas"
+		}
 	}
 
 	// Aggregate conditions.
@@ -779,6 +783,10 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		status = corev1.ConditionFalse
 		reason = hyperv1.NodePoolNotFoundReason
 		message = "No Machines are created"
+		if nodePool.Spec.Replicas != nil && *nodePool.Spec.Replicas == 0 {
+			reason = hyperv1.AsExpectedReason
+			message = "NodePool set to no replicas"
+		}
 	}
 
 	for _, machine := range machines {


### PR DESCRIPTION
**What this PR does / why we need it**: Updates AllMachinesReady and AllNodesHealthy status to false as expected with the message NodePool Replicas set to nil.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-29179](https://issues.redhat.com/browse/OCPBUGS-29179)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.