### PR TITLE
OCPBUGS-28607: feat(config): Default RevisionHistoryLimit to 2 for deployments

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cco/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cco/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -15,6 +15,7 @@ metadata:
     uid: ""
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: cloud-credential-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/pkioperator/testdata/zz_fixture_TestReconcileControlPlanePKIOperatorDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/pkioperator/testdata/zz_fixture_TestReconcileControlPlanePKIOperatorDeployment.yaml
@@ -15,6 +15,7 @@ metadata:
     uid: test-uid
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       name: control-plane-pki-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: test-namespace
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       name: cluster-image-registry-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
@@ -15,6 +15,7 @@ metadata:
     uid: ""
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: csi-snapshot-controller-operator

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -45,6 +45,7 @@ type DeploymentConfig struct {
 	DebugDeployments          sets.String
 	ResourceRequestOverrides  ResourceOverrides
 	IsolateAsRequestServing   bool
+	RevisionHistoryLimit      int
 }
 
 func (c *DeploymentConfig) SetContainerResourcesIfPresent(container *corev1.Container) {
@@ -91,6 +92,9 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 		deployment.Spec.Strategy.RollingUpdate.MaxSurge = &maxSurge
 		deployment.Spec.Strategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 	}
+
+	// set revision history limit
+	deployment.Spec.RevisionHistoryLimit = pointer.Int32(int32(c.RevisionHistoryLimit))
 
 	// set default security context for pod
 	if c.SetDefaultSecurityContext {
@@ -374,8 +378,8 @@ func (c *DeploymentConfig) SetDefaults(hcp *hyperv1.HostedControlPlane, multiZon
 		c.Replicas = *replicas
 	}
 	c.DebugDeployments = debugDeployments(hcp)
-
 	c.ResourceRequestOverrides = resourceRequestOverrides(hcp)
+	c.RevisionHistoryLimit = 2
 
 	c.setLocation(hcp, multiZoneSpreadLabels)
 	// TODO (alberto): make this private, atm is needed for the konnectivity agent daemonset.


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce default `RevisionHistoryLimit` to improve control plane scalability. The default of 10 is significantly impacting etcd load on management cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes/alleviates [OCPBUGS-28607](https://issues.redhat.com/browse/OCPBUGS-28607)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.