### PR TITLE
HOSTEDCP-1373: ARO HCP - Add capability for Azure VMs to be created with ephemeral disks

### DIFF
--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -886,6 +886,9 @@ type AzureNodePoolPlatform struct {
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs.
 	// +optional
 	DiskEncryptionSetID string `json:"diskEncryptionSetID,omitempty"`
+	// EnableEphemeralOSDisk enables ephemeral OS disk
+	// +optional
+	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -879,6 +879,9 @@ type AzureNodePoolPlatform struct {
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs.
 	// +optional
 	DiskEncryptionSetID string `json:"diskEncryptionSetID,omitempty"`
+	// EnableEphemeralOSDisk enables ephemeral OS disk
+	// +optional
+	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -855,7 +855,10 @@ type AzureNodePoolPlatform struct {
 	// subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
 	// +optional
 	ImageID string `json:"imageID,omitempty"`
-	// +kubebuilder:default:=120
+	// DiskSizeGB is the size in GB to assign to the OS disk
+	// CAPZ default is 30GB, https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/b3708019a67ff19407b87d63c402af94ca4246f6/api/v1beta1/types.go#L599
+	//
+	// +kubebuilder:default:=30
 	// +kubebuilder:validation:Minimum=16
 	// +optional
 	DiskSizeGB int32 `json:"diskSizeGB,omitempty"`

--- a/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
@@ -26,6 +26,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	DiskStorageAccountType *string `json:"diskStorageAccountType,omitempty"`
 	AvailabilityZone       *string `json:"availabilityZone,omitempty"`
 	DiskEncryptionSetID    *string `json:"diskEncryptionSetID,omitempty"`
+	EnableEphemeralOSDisk  *bool   `json:"enableEphemeralOSDisk,omitempty"`
 }
 
 // AzureNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AzureNodePoolPlatform type for use with
@@ -79,5 +80,13 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithAvailabilityZone(value str
 // If called multiple times, the DiskEncryptionSetID field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithDiskEncryptionSetID(value string) *AzureNodePoolPlatformApplyConfiguration {
 	b.DiskEncryptionSetID = &value
+	return b
+}
+
+// WithEnableEphemeralOSDisk sets the EnableEphemeralOSDisk field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EnableEphemeralOSDisk field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithEnableEphemeralOSDisk(value bool) *AzureNodePoolPlatformApplyConfiguration {
+	b.EnableEphemeralOSDisk = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
@@ -26,6 +26,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	DiskStorageAccountType *string `json:"diskStorageAccountType,omitempty"`
 	AvailabilityZone       *string `json:"availabilityZone,omitempty"`
 	DiskEncryptionSetID    *string `json:"diskEncryptionSetID,omitempty"`
+	EnableEphemeralOSDisk  *bool   `json:"enableEphemeralOSDisk,omitempty"`
 }
 
 // AzureNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AzureNodePoolPlatform type for use with
@@ -79,5 +80,13 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithAvailabilityZone(value str
 // If called multiple times, the DiskEncryptionSetID field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithDiskEncryptionSetID(value string) *AzureNodePoolPlatformApplyConfiguration {
 	b.DiskEncryptionSetID = &value
+	return b
+}
+
+// WithEnableEphemeralOSDisk sets the EnableEphemeralOSDisk field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EnableEphemeralOSDisk field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithEnableEphemeralOSDisk(value bool) *AzureNodePoolPlatformApplyConfiguration {
+	b.EnableEphemeralOSDisk = &value
 	return b
 }

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -48,6 +48,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AzurePlatform.ResourceGroupName, "resource-group-name", opts.AzurePlatform.ResourceGroupName, "A resource group name to create the HostedCluster infrastructure resources under.")
 	cmd.Flags().StringVar(&opts.AzurePlatform.DiskEncryptionSetID, "disk-encryption-set-id", opts.AzurePlatform.DiskEncryptionSetID, "The Disk Encryption Set ID to use to encrypt the OS disks for the VMs.")
 	cmd.Flags().StringVar(&opts.AzurePlatform.NetworkSecurityGroup, "network-security-group", opts.AzurePlatform.NetworkSecurityGroup, "The name of the Network Security Group to use in Virtual Network created for HostedCluster.")
+	cmd.Flags().BoolVar(&opts.AzurePlatform.EnableEphemeralOSDisk, "enable-ephemeral-disk", opts.AzurePlatform.EnableEphemeralOSDisk, "If enabled, the Azure VMs in the default NodePool will be setup with ephemeral OS disks")
 
 	_ = cmd.MarkFlagRequired("azure-creds")
 	_ = cmd.MarkPersistentFlagRequired("pull-secret")
@@ -121,18 +122,19 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	exampleOptions.InfraID = infra.InfraID
 	exampleOptions.ExternalDNSDomain = opts.ExternalDNSDomain
 	exampleOptions.Azure = &apifixtures.ExampleAzureOptions{
-		Location:            infra.Location,
-		ResourceGroupName:   infra.ResourceGroupName,
-		VnetName:            infra.VnetName,
-		VnetID:              infra.VNetID,
-		SubnetName:          infra.SubnetName,
-		BootImageID:         infra.BootImageID,
-		MachineIdentityID:   infra.MachineIdentityID,
-		InstanceType:        opts.AzurePlatform.InstanceType,
-		SecurityGroupName:   infra.SecurityGroupName,
-		DiskSizeGB:          opts.AzurePlatform.DiskSizeGB,
-		AvailabilityZones:   opts.AzurePlatform.AvailabilityZones,
-		DiskEncryptionSetID: opts.AzurePlatform.DiskEncryptionSetID,
+		Location:              infra.Location,
+		ResourceGroupName:     infra.ResourceGroupName,
+		VnetName:              infra.VnetName,
+		VnetID:                infra.VNetID,
+		SubnetName:            infra.SubnetName,
+		BootImageID:           infra.BootImageID,
+		MachineIdentityID:     infra.MachineIdentityID,
+		InstanceType:          opts.AzurePlatform.InstanceType,
+		SecurityGroupName:     infra.SecurityGroupName,
+		DiskSizeGB:            opts.AzurePlatform.DiskSizeGB,
+		AvailabilityZones:     opts.AzurePlatform.AvailabilityZones,
+		DiskEncryptionSetID:   opts.AzurePlatform.DiskEncryptionSetID,
+		EnableEphemeralOSDisk: opts.AzurePlatform.EnableEphemeralOSDisk,
 	}
 
 	if opts.AzurePlatform.EncryptionKeyID != "" {

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -162,15 +162,16 @@ type AWSPlatformOptions struct {
 }
 
 type AzurePlatformOptions struct {
-	CredentialsFile      string
-	Location             string
-	EncryptionKeyID      string
-	InstanceType         string
-	DiskSizeGB           int32
-	AvailabilityZones    []string
-	ResourceGroupName    string
-	DiskEncryptionSetID  string
-	NetworkSecurityGroup string
+	CredentialsFile       string
+	Location              string
+	EncryptionKeyID       string
+	InstanceType          string
+	DiskSizeGB            int32
+	AvailabilityZones     []string
+	ResourceGroupName     string
+	DiskEncryptionSetID   string
+	NetworkSecurityGroup  string
+	EnableEphemeralOSDisk bool
 }
 
 func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures.ExampleOptions, error) {

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -162,16 +162,17 @@ type AWSPlatformOptions struct {
 }
 
 type AzurePlatformOptions struct {
-	CredentialsFile       string
-	Location              string
-	EncryptionKeyID       string
-	InstanceType          string
-	DiskSizeGB            int32
-	AvailabilityZones     []string
-	ResourceGroupName     string
-	DiskEncryptionSetID   string
-	NetworkSecurityGroup  string
-	EnableEphemeralOSDisk bool
+	CredentialsFile        string
+	Location               string
+	EncryptionKeyID        string
+	InstanceType           string
+	DiskSizeGB             int32
+	AvailabilityZones      []string
+	ResourceGroupName      string
+	DiskEncryptionSetID    string
+	NetworkSecurityGroup   string
+	EnableEphemeralOSDisk  bool
+	DiskStorageAccountType string
 }
 
 func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures.ExampleOptions, error) {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1475,7 +1475,9 @@ spec:
                           resource to use to encrypt the OS disks for the VMs.
                         type: string
                       diskSizeGB:
-                        default: 120
+                        default: 30
+                        description: DiskSizeGB is the size in GB to assign to the
+                          OS disk CAPZ default is 30GB, https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/b3708019a67ff19407b87d63c402af94ca4246f6/api/v1beta1/types.go#L599
                         format: int32
                         minimum: 16
                         type: integer

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -506,6 +506,9 @@ spec:
                         - Premium_LRS
                         - UltraSSD_LRS
                         type: string
+                      enableEphemeralOSDisk:
+                        description: EnableEphemeralOSDisk enables ephemeral OS disk
+                        type: boolean
                       imageID:
                         description: 'ImageID is the id of the image to boot from.
                           If unset, the default image at the location below will be
@@ -1489,6 +1492,9 @@ spec:
                         - Premium_LRS
                         - UltraSSD_LRS
                         type: string
+                      enableEphemeralOSDisk:
+                        description: EnableEphemeralOSDisk enables ephemeral OS disk
+                        type: boolean
                       imageID:
                         description: 'ImageID is the id of the image to boot from.
                           If unset, the default image at the location below will be

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -12,11 +12,12 @@ import (
 )
 
 type AzurePlatformCreateOptions struct {
-	InstanceType        string
-	DiskSize            int32
-	AvailabilityZone    string
-	ResourceGroupName   string
-	DiskEncryptionSetID string
+	InstanceType          string
+	DiskSize              int32
+	AvailabilityZone      string
+	ResourceGroupName     string
+	DiskEncryptionSetID   string
+	EnableEphemeralOSDisk bool
 }
 
 func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
@@ -36,6 +37,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	cmd.Flags().StringVar(&platformOpts.AvailabilityZone, "availability-zone", platformOpts.AvailabilityZone, "The availabilityZone for the nodepool. Must be left unspecified if in a region that doesn't support AZs")
 	cmd.Flags().StringVar(&platformOpts.ResourceGroupName, "resource-group-name", platformOpts.ResourceGroupName, "A resource group name to create the HostedCluster infrastructure resources under.")
 	cmd.Flags().StringVar(&platformOpts.DiskEncryptionSetID, "disk-encryption-set-id", platformOpts.DiskEncryptionSetID, "The Disk Encryption Set ID to use to encrypt the OS disks for the VMs.")
+	cmd.Flags().BoolVar(&platformOpts.EnableEphemeralOSDisk, "enable-ephemeral-disk", platformOpts.EnableEphemeralOSDisk, "If enabled, the Azure VMs in the NodePool will be setup with ephemeral OS disks")
 
 	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
 
@@ -50,10 +52,11 @@ func (o *AzurePlatformCreateOptions) UpdateNodePool(_ context.Context, nodePool 
 
 	nodePool.Spec.Platform.Type = hyperv1.AzurePlatform
 	nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-		VMSize:              o.InstanceType,
-		DiskSizeGB:          o.DiskSize,
-		AvailabilityZone:    o.AvailabilityZone,
-		DiskEncryptionSetID: o.DiskEncryptionSetID,
+		VMSize:                o.InstanceType,
+		DiskSizeGB:            o.DiskSize,
+		AvailabilityZone:      o.AvailabilityZone,
+		DiskEncryptionSetID:   o.DiskEncryptionSetID,
+		EnableEphemeralOSDisk: o.EnableEphemeralOSDisk,
 	}
 	return nil
 }

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -12,12 +12,13 @@ import (
 )
 
 type AzurePlatformCreateOptions struct {
-	InstanceType          string
-	DiskSize              int32
-	AvailabilityZone      string
-	ResourceGroupName     string
-	DiskEncryptionSetID   string
-	EnableEphemeralOSDisk bool
+	InstanceType           string
+	DiskSize               int32
+	AvailabilityZone       string
+	ResourceGroupName      string
+	DiskEncryptionSetID    string
+	EnableEphemeralOSDisk  bool
+	DiskStorageAccountType string
 }
 
 func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
@@ -38,6 +39,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	cmd.Flags().StringVar(&platformOpts.ResourceGroupName, "resource-group-name", platformOpts.ResourceGroupName, "A resource group name to create the HostedCluster infrastructure resources under.")
 	cmd.Flags().StringVar(&platformOpts.DiskEncryptionSetID, "disk-encryption-set-id", platformOpts.DiskEncryptionSetID, "The Disk Encryption Set ID to use to encrypt the OS disks for the VMs.")
 	cmd.Flags().BoolVar(&platformOpts.EnableEphemeralOSDisk, "enable-ephemeral-disk", platformOpts.EnableEphemeralOSDisk, "If enabled, the Azure VMs in the NodePool will be setup with ephemeral OS disks")
+	cmd.Flags().StringVar(&platformOpts.DiskStorageAccountType, "disk-storage-account-type", platformOpts.DiskStorageAccountType, "The disk storage account type for the OS disks for the VMs.")
 
 	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
 
@@ -52,11 +54,12 @@ func (o *AzurePlatformCreateOptions) UpdateNodePool(_ context.Context, nodePool 
 
 	nodePool.Spec.Platform.Type = hyperv1.AzurePlatform
 	nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-		VMSize:                o.InstanceType,
-		DiskSizeGB:            o.DiskSize,
-		AvailabilityZone:      o.AvailabilityZone,
-		DiskEncryptionSetID:   o.DiskEncryptionSetID,
-		EnableEphemeralOSDisk: o.EnableEphemeralOSDisk,
+		VMSize:                 o.InstanceType,
+		DiskSizeGB:             o.DiskSize,
+		AvailabilityZone:       o.AvailabilityZone,
+		DiskEncryptionSetID:    o.DiskEncryptionSetID,
+		EnableEphemeralOSDisk:  o.EnableEphemeralOSDisk,
+		DiskStorageAccountType: o.DiskStorageAccountType,
 	}
 	return nil
 }

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -47,7 +47,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 func (o *AzurePlatformCreateOptions) UpdateNodePool(_ context.Context, nodePool *hyperv1.NodePool, _ *hyperv1.HostedCluster, _ crclient.Client) error {
 	// Resource group name is required when using DiskEncryptionSetID
 	if o.DiskEncryptionSetID != "" && o.ResourceGroupName == "" {
-		return fmt.Errorf("UpdateNodePool: resource-group-name is required when using disk-encryption-set-id")
+		return fmt.Errorf("resource-group-name is required when using disk-encryption-set-id")
 	}
 
 	nodePool.Spec.Platform.Type = hyperv1.AzurePlatform

--- a/docs/content/how-to/azure/create-azure-cluster-with-options.md
+++ b/docs/content/how-to/azure/create-azure-cluster-with-options.md
@@ -100,3 +100,44 @@ spec:
 status:
   replicas: 0
 ```
+
+## Enabling Ephemeral OS Disks on Azure VMs
+To enable the ephemeral OS disk option on the Azure VMs in your HostedCluster, set the `enable-ephemeral-disk` flag to true.
+
+!!! important
+
+    Ephermeral OS disks are not available in every region or for every instance type. 
+
+    You may need to adjust the disk storage account type; to adjust the disk storage account type, 
+    use the `disk-storage-account-type` flag as shown in the example below.
+    
+    You may need to adjust the disk size depending on the instance type used; to adjust the disk size, use the 
+    `root-disk-size` flag.
+
+    See [Ephemeral OS disks for Azure VMs](https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks) for more details.
+
+```
+hypershift create cluster azure \
+--name <cluster_name> \
+--pull-secret <pull_secret_file> \
+--azure-creds <path_to_azure_credentials_file> \
+--location <location> \
+--base-domain <base_domain> \
+--release-image <release_image> \
+--node-pool-replicas <number_of_replicas> \
+--enable-ephemeral-disk true \
+--instance-type Standard_DS2_v2 \
+--disk-storage-account-type Standard_LRS
+```
+
+You can also set the `enable-ephemeral-disk` flag when creating a NodePool.
+```
+hypershift create nodepool azure \
+--name <name_of_nodepool> \
+--cluster-name <cluster_name> \
+--node-count <number_of_replicas> \
+--release-image <release_image> \
+--enable-ephemeral-disk true \
+--instance-type Standard_DS2_v2 \
+--disk-storage-account-type Standard_LRS
+```

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2304,6 +2304,8 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
+<p>DiskSizeGB is the size in GB to assign to the OS disk
+CAPZ default is 30GB, <a href="https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/b3708019a67ff19407b87d63c402af94ca4246f6/api/v1beta1/types.go#L599">https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/b3708019a67ff19407b87d63c402af94ca4246f6/api/v1beta1/types.go#L599</a></p>
 </td>
 </tr>
 <tr>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2349,6 +2349,18 @@ string
 <p>DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>enableEphemeralOSDisk</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableEphemeralOSDisk enables ephemeral OS disk</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###AzurePlatformSpec { #hypershift.openshift.io/v1beta1.AzurePlatformSpec }

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -692,11 +692,12 @@ func (o ExampleOptions) Resources() *ExampleResources {
 					nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
 				}
 				nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-					VMSize:              o.Azure.InstanceType,
-					ImageID:             o.Azure.BootImageID,
-					DiskSizeGB:          o.Azure.DiskSizeGB,
-					AvailabilityZone:    availabilityZone,
-					DiskEncryptionSetID: o.Azure.DiskEncryptionSetID,
+					VMSize:                o.Azure.InstanceType,
+					ImageID:               o.Azure.BootImageID,
+					DiskSizeGB:            o.Azure.DiskSizeGB,
+					AvailabilityZone:      availabilityZone,
+					DiskEncryptionSetID:   o.Azure.DiskEncryptionSetID,
+					EnableEphemeralOSDisk: o.Azure.EnableEphemeralOSDisk,
 				}
 				nodePools = append(nodePools, nodePool)
 			}
@@ -707,10 +708,11 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
 			}
 			nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-				VMSize:              o.Azure.InstanceType,
-				ImageID:             o.Azure.BootImageID,
-				DiskSizeGB:          o.Azure.DiskSizeGB,
-				DiskEncryptionSetID: o.Azure.DiskEncryptionSetID,
+				VMSize:                o.Azure.InstanceType,
+				ImageID:               o.Azure.BootImageID,
+				DiskSizeGB:            o.Azure.DiskSizeGB,
+				DiskEncryptionSetID:   o.Azure.DiskEncryptionSetID,
+				EnableEphemeralOSDisk: o.Azure.EnableEphemeralOSDisk,
 			}
 			nodePools = append(nodePools, nodePool)
 		}

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -692,12 +692,13 @@ func (o ExampleOptions) Resources() *ExampleResources {
 					nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
 				}
 				nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-					VMSize:                o.Azure.InstanceType,
-					ImageID:               o.Azure.BootImageID,
-					DiskSizeGB:            o.Azure.DiskSizeGB,
-					AvailabilityZone:      availabilityZone,
-					DiskEncryptionSetID:   o.Azure.DiskEncryptionSetID,
-					EnableEphemeralOSDisk: o.Azure.EnableEphemeralOSDisk,
+					VMSize:                 o.Azure.InstanceType,
+					ImageID:                o.Azure.BootImageID,
+					DiskSizeGB:             o.Azure.DiskSizeGB,
+					AvailabilityZone:       availabilityZone,
+					DiskEncryptionSetID:    o.Azure.DiskEncryptionSetID,
+					EnableEphemeralOSDisk:  o.Azure.EnableEphemeralOSDisk,
+					DiskStorageAccountType: o.Azure.DiskStorageAccountType,
 				}
 				nodePools = append(nodePools, nodePool)
 			}
@@ -708,11 +709,12 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
 			}
 			nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-				VMSize:                o.Azure.InstanceType,
-				ImageID:               o.Azure.BootImageID,
-				DiskSizeGB:            o.Azure.DiskSizeGB,
-				DiskEncryptionSetID:   o.Azure.DiskEncryptionSetID,
-				EnableEphemeralOSDisk: o.Azure.EnableEphemeralOSDisk,
+				VMSize:                 o.Azure.InstanceType,
+				ImageID:                o.Azure.BootImageID,
+				DiskSizeGB:             o.Azure.DiskSizeGB,
+				DiskEncryptionSetID:    o.Azure.DiskEncryptionSetID,
+				EnableEphemeralOSDisk:  o.Azure.EnableEphemeralOSDisk,
+				DiskStorageAccountType: o.Azure.DiskStorageAccountType,
 			}
 			nodePools = append(nodePools, nodePool)
 		}

--- a/examples/fixtures/example_azure.go
+++ b/examples/fixtures/example_azure.go
@@ -3,21 +3,22 @@ package fixtures
 import "github.com/openshift/hypershift/cmd/util"
 
 type ExampleAzureOptions struct {
-	Creds                 util.AzureCreds
-	Location              string
-	ResourceGroupName     string
-	VnetName              string
-	VnetID                string
-	SubnetName            string
-	BootImageID           string
-	MachineIdentityID     string
-	InstanceType          string
-	SecurityGroupName     string
-	DiskSizeGB            int32
-	AvailabilityZones     []string
-	DiskEncryptionSetID   string
-	EnableEphemeralOSDisk bool
-	EncryptionKey         *AzureEncryptionKey
+	Creds                  util.AzureCreds
+	Location               string
+	ResourceGroupName      string
+	VnetName               string
+	VnetID                 string
+	SubnetName             string
+	BootImageID            string
+	MachineIdentityID      string
+	InstanceType           string
+	SecurityGroupName      string
+	DiskSizeGB             int32
+	AvailabilityZones      []string
+	DiskEncryptionSetID    string
+	EnableEphemeralOSDisk  bool
+	DiskStorageAccountType string
+	EncryptionKey          *AzureEncryptionKey
 }
 
 type AzureEncryptionKey struct {

--- a/examples/fixtures/example_azure.go
+++ b/examples/fixtures/example_azure.go
@@ -3,20 +3,21 @@ package fixtures
 import "github.com/openshift/hypershift/cmd/util"
 
 type ExampleAzureOptions struct {
-	Creds               util.AzureCreds
-	Location            string
-	ResourceGroupName   string
-	VnetName            string
-	VnetID              string
-	SubnetName          string
-	BootImageID         string
-	MachineIdentityID   string
-	InstanceType        string
-	SecurityGroupName   string
-	DiskSizeGB          int32
-	AvailabilityZones   []string
-	DiskEncryptionSetID string
-	EncryptionKey       *AzureEncryptionKey
+	Creds                 util.AzureCreds
+	Location              string
+	ResourceGroupName     string
+	VnetName              string
+	VnetID                string
+	SubnetName            string
+	BootImageID           string
+	MachineIdentityID     string
+	InstanceType          string
+	SecurityGroupName     string
+	DiskSizeGB            int32
+	AvailabilityZones     []string
+	DiskEncryptionSetID   string
+	EnableEphemeralOSDisk bool
+	EncryptionKey         *AzureEncryptionKey
 }
 
 type AzureEncryptionKey struct {

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -54448,6 +54448,10 @@ objects:
                           - Premium_LRS
                           - UltraSSD_LRS
                           type: string
+                        enableEphemeralOSDisk:
+                          description: EnableEphemeralOSDisk enables ephemeral OS
+                            disk
+                          type: boolean
                         imageID:
                           description: 'ImageID is the id of the image to boot from.
                             If unset, the default image at the location below will
@@ -55442,6 +55446,10 @@ objects:
                           - Premium_LRS
                           - UltraSSD_LRS
                           type: string
+                        enableEphemeralOSDisk:
+                          description: EnableEphemeralOSDisk enables ephemeral OS
+                            disk
+                          type: boolean
                         imageID:
                           description: 'ImageID is the id of the image to boot from.
                             If unset, the default image at the location below will

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -55429,7 +55429,9 @@ objects:
                             resource to use to encrypt the OS disks for the VMs.
                           type: string
                         diskSizeGB:
-                          default: 120
+                          default: 30
+                          description: DiskSizeGB is the size in GB to assign to the
+                            OS disk CAPZ default is 30GB, https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/b3708019a67ff19407b87d63c402af94ca4246f6/api/v1beta1/types.go#L599
                           format: int32
                           minimum: 16
                           type: integer

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -52,6 +52,13 @@ func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1
 		}
 	}
 
+	if nodePool.Spec.Platform.Azure.EnableEphemeralOSDisk {
+		// This is set to "None" if not explicitly set - https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/f44d953844de58e4b6fe8f51d88b0bf75a04e9ec/api/v1beta1/azuremachine_default.go#L54
+		// "VMs and VM Scale Set Instances using an ephemeral OS disk support only Readonly caching."
+		azureMachineTemplate.Template.Spec.OSDisk.CachingType = "ReadOnly"
+		azureMachineTemplate.Template.Spec.OSDisk.DiffDiskSettings = &capiazure.DiffDiskSettings{Option: "Local"}
+	}
+
 	return azureMachineTemplate, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the capability to enable ephemeral disks for the OS disks in the Azure VMs. In addition, the ability to set the disk storage account type for the OS disks through the CLI was added in this PR as part of the prerequisite work.

**Which issue(s) this PR fixes**:
[HOSTEDCP-1373](https://issues.redhat.com/browse/HOSTEDCP-1373)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.