### PR TITLE
[release-4.14] OCPBUGS-28249: Required RBAC for network-node-identity is not created when hosted cluster networkType is set to Other.

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -136,7 +136,8 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 
 func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef, networkType hyperv1.NetworkType) error {
 	ownerRef.ApplyTo(role)
-	if networkType == hyperv1.Calico {
+	// The RBAC below is required when the networkType is not OVNKubernetes https://issues.redhat.com/browse/OCPBUGS-26977
+	if networkType != hyperv1.OVNKubernetes {
 		role.Rules = []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{corev1.SchemeGroupVersion.Group},
@@ -161,6 +162,9 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef, networkType hype
 					"ovnkube-identity-cm",
 				},
 				Verbs: []string{
+					"list",
+					"get",
+					"watch",
 					"create",
 					"patch",
 					"update",

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
@@ -4,7 +4,13 @@ import (
 	"strconv"
 	"testing"
 
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 func TestReconcileDeployment(t *testing.T) {
@@ -49,4 +55,197 @@ func TestReconcileDeployment(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileRole(t *testing.T) {
+	type args struct {
+		role        *rbacv1.Role
+		ownerRef    config.OwnerRef
+		networkType hyperv1.NetworkType
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Network type OVNKubernetes",
+			args: args{
+				role:        &rbacv1.Role{},
+				ownerRef:    config.OwnerRef{},
+				networkType: hyperv1.OVNKubernetes,
+			},
+		},
+		{
+			name: "Network type OpenShiftSDN",
+			args: args{
+				role:        &rbacv1.Role{},
+				ownerRef:    config.OwnerRef{},
+				networkType: hyperv1.OpenShiftSDN,
+			},
+		},
+		{
+			name: "Network type Calico",
+			args: args{
+				role:        &rbacv1.Role{},
+				ownerRef:    config.OwnerRef{},
+				networkType: hyperv1.Calico,
+			},
+		},
+		{
+			name: "Network type Other",
+			args: args{
+				role:        &rbacv1.Role{},
+				ownerRef:    config.OwnerRef{},
+				networkType: hyperv1.Other,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			g := NewGomegaWithT(t)
+			err := ReconcileRole(tt.args.role, tt.args.ownerRef, tt.args.networkType)
+			g.Expect(err).To(BeNil())
+			g.Expect(tt.args.role.Rules).To(BeEquivalentTo(expectedRules(tt.args.networkType)))
+		})
+	}
+}
+
+func expectedRules(networkType hyperv1.NetworkType) []rbacv1.PolicyRule {
+
+	ovnRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{corev1.SchemeGroupVersion.Group},
+			Resources: []string{
+				"events",
+				"configmaps",
+				"pods",
+				"secrets",
+				"services",
+			},
+			Verbs: []string{"*"},
+		},
+		{
+			APIGroups: []string{"policy"},
+			Resources: []string{"poddisruptionbudgets"},
+			Verbs:     []string{"*"},
+		},
+		{
+			APIGroups: []string{appsv1.SchemeGroupVersion.Group},
+			Resources: []string{"statefulsets", "deployments"},
+			Verbs:     []string{"*"},
+		},
+		{
+			APIGroups: []string{routev1.SchemeGroupVersion.Group},
+			Resources: []string{"routes", "routes/custom-host"},
+			Verbs:     []string{"*"},
+		},
+		{
+			APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs"},
+			Resources: []string{
+				"servicemonitors",
+				"prometheusrules",
+			},
+			Verbs: []string{"*"},
+		},
+		{
+			APIGroups: []string{hyperv1.GroupVersion.Group},
+			Resources: []string{
+				"hostedcontrolplanes",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{hyperv1.GroupVersion.Group},
+			Resources: []string{
+				"hostedcontrolplanes/status",
+			},
+			Verbs: []string{"*"},
+		},
+	}
+
+	otherNetworkRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{corev1.SchemeGroupVersion.Group},
+			Resources: []string{
+				"configmaps",
+			},
+			ResourceNames: []string{
+				"openshift-service-ca.crt",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{corev1.SchemeGroupVersion.Group},
+			Resources: []string{
+				"configmaps",
+			},
+			ResourceNames: []string{
+				"ovnkube-identity-cm",
+			},
+			Verbs: []string{
+				"list",
+				"get",
+				"watch",
+				"create",
+				"patch",
+				"update",
+			},
+		},
+		{
+			APIGroups: []string{appsv1.SchemeGroupVersion.Group},
+			Resources: []string{"statefulsets", "deployments"},
+			Verbs:     []string{"list", "watch"},
+		},
+		{
+			APIGroups: []string{appsv1.SchemeGroupVersion.Group},
+			Resources: []string{"deployments"},
+			ResourceNames: []string{
+				"multus-admission-controller",
+				"network-node-identity",
+			},
+			Verbs: []string{"*"},
+		},
+		{
+			APIGroups: []string{corev1.SchemeGroupVersion.Group},
+			Resources: []string{"services"},
+			ResourceNames: []string{
+				"multus-admission-controller",
+				"network-node-identity",
+			},
+			Verbs: []string{"*"},
+		},
+		{
+			APIGroups: []string{hyperv1.GroupVersion.Group},
+			Resources: []string{
+				"hostedcontrolplanes",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{hyperv1.GroupVersion.Group},
+			Resources: []string{
+				"hostedcontrolplanes/status",
+			},
+			Verbs: []string{"*"},
+		},
+	}
+
+	if networkType != hyperv1.OVNKubernetes {
+		return otherNetworkRules
+	}
+
+	return ovnRules
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/hypershift/pull/3403

/assign csrwng