### PR TITLE
OCPBUGS-28659: Add ValidatingAdmissionPolicy to KAS config

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -313,6 +313,7 @@ func admissionPlugins() []string {
 		"ServiceAccount",
 		"StorageObjectInUseProtection",
 		"TaintNodesByCondition",
+		"ValidatingAdmissionPolicy",
 		"ValidatingAdmissionWebhook",
 		"authorization.openshift.io/RestrictSubjectBindings",
 		"authorization.openshift.io/ValidateRoleBindingRestriction",


### PR DESCRIPTION
**What this PR does / why we need it**: This plugin is in base OpenShift KAS config, but missing in HyperShift

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #28659

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.