### PR TITLE
NO-JIRA: remove PrivateIngressController cleanup

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -862,14 +862,6 @@ func (r *HostedControlPlaneReconciler) update(ctx context.Context, hostedControl
 
 	createOrUpdate := r.createOrUpdate(hostedControlPlane)
 
-	if util.IsPrivateHCP(hostedControlPlane) {
-		r.Log.Info("Removing private IngressController")
-		// Ensure that if an ingress controller exists from a previous version, it is removed
-		if err := r.reconcilePrivateIngressController(ctx, hostedControlPlane); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to reconcile private ingresscontroller: %w", err)
-		}
-	}
-
 	r.Log.Info("Reconciling infrastructure services")
 	if err := r.reconcileInfrastructure(ctx, hostedControlPlane, createOrUpdate); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to ensure infrastructure: %w", err)
@@ -3769,18 +3761,6 @@ func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.C
 		return fmt.Errorf("failed to reconcile image content source policy ignition config: %w", err)
 	}
 
-	return nil
-}
-
-func (r *HostedControlPlaneReconciler) reconcilePrivateIngressController(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
-	ic := manifests.IngressPrivateIngressController(hcp.Namespace)
-	if err := r.Get(ctx, client.ObjectKeyFromObject(ic), ic); err == nil {
-		if err = r.Delete(ctx, ic); err != nil {
-			return fmt.Errorf("failed to delete private ingress controller: %w", err)
-		}
-	} else if !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get private ingress controller: %w", err)
-	}
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/ingress.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/ingress.go
@@ -20,15 +20,6 @@ func IngressDefaultIngressController() *operatorv1.IngressController {
 	}
 }
 
-func IngressPrivateIngressController(name string) *operatorv1.IngressController {
-	return &operatorv1.IngressController{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "openshift-ingress-operator",
-		},
-	}
-}
-
 func RouterServiceAccount(ns string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -49,8 +49,6 @@ import (
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
@@ -219,9 +217,6 @@ func NewStartCommand() *cobra.Command {
 			HealthProbeBindAddress:        healthProbeAddr,
 			Cache: cache.Options{
 				DefaultFieldSelector: fields.OneTermEqualSelector("metadata.namespace", namespace),
-				ByObject: map[crclient.Object]cache.ByObject{
-					&operatorv1.IngressController{}: {Field: fields.OneTermEqualSelector("metadata.namespace", manifests.IngressPrivateIngressController("").Namespace)},
-				},
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
Old cleanup code watching `v1.IngressController` which is not available for vanilla kube.  This code is only used for removing an IngressController we used to create long ago.  No modern HC should require this cleanup.

Remove to increase compatibility.