### PR TITLE
MULTIARCH-4084: Reduce the policy access scope to specific instance

### DIFF
--- a/cmd/infra/powervs/service_id.go
+++ b/cmd/infra/powervs/service_id.go
@@ -1,10 +1,13 @@
 package powervs
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
+	"text/template"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"strings"
 
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 
@@ -12,6 +15,10 @@ import (
 	cco "github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning/ibmcloud"
 	ccoibmcloud "github.com/openshift/cloud-credential-operator/pkg/ibmcloud"
 )
+
+type PolicyParams struct {
+	CloudInstanceID string
+}
 
 var kubeCloudControllerManagerCR = `
 apiVersion: cloudcredential.openshift.io/v1
@@ -44,6 +51,9 @@ spec:
     - attributes:
       - name: serviceName
         value: power-iaas
+      - name: serviceInstance
+        value: {{.CloudInstanceID}}
+        operator: stringEquals
       roles:
       - crn:v1:bluemix:public:iam::::role:Viewer
       - crn:v1:bluemix:public:iam::::serviceRole:Reader
@@ -63,6 +73,9 @@ spec:
     - attributes:
       - name: serviceName
         value: power-iaas
+      - name: serviceInstance
+        value: {{.CloudInstanceID}}
+        operator: stringEquals
       roles:
       - crn:v1:bluemix:public:iam::::serviceRole:Manager
       - crn:v1:bluemix:public:iam::::role:Editor
@@ -101,6 +114,9 @@ spec:
     - attributes:
       - name: serviceName
         value: power-iaas
+      - name: serviceInstance
+        value: {{.CloudInstanceID}}
+        operator: stringEquals
       roles:
       - crn:v1:bluemix:public:iam::::serviceRole:Manager
       - crn:v1:bluemix:public:iam::::role:Editor
@@ -186,6 +202,23 @@ func deleteServiceID(name, APIKey, accountID, resourceGroupID, crYaml, secretRef
 	}
 
 	return nil
+}
+
+func updateCRYaml(crYaml, templateName string, serviceInstanceValue string) (string, error) {
+	params := PolicyParams{
+		CloudInstanceID: serviceInstanceValue,
+	}
+
+	tmpl, err := template.New(templateName).Parse(crYaml)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse the template %s, err: %w", templateName, err)
+	}
+
+	b := &bytes.Buffer{}
+	if err = tmpl.Execute(b, params); err != nil {
+		return "", fmt.Errorf("failed to execute %s: err: %w", templateName, err)
+	}
+	return b.String(), nil
 }
 
 func extractServiceIDFromCRN(crn string) string {

--- a/cmd/infra/powervs/service_id_test.go
+++ b/cmd/infra/powervs/service_id_test.go
@@ -52,6 +52,7 @@ func TestCreateServiceIDClient(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
+			test.input.crYaml, _ = updateCRYaml(test.input.crYaml, "crYaml_template", "cloud_ins_id_1234")
 			_, err := createServiceIDClient(test.input.name, test.input.apiKey, test.input.account, test.input.resourceGroupID, test.input.crYaml, test.input.secretRefName, test.input.secretRefNamespace)
 			if test.errExpected {
 				g.Expect(err).ToNot(BeNil())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reduces the permission access scope to Service Instance for various CRs.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://issues.redhat.com/browse/MULTIARCH-4084

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.