### PR TITLE
HOSTEDCP-1408: Update CAPZ Identity Type to Service Principal

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -251,7 +251,7 @@ func reconcileAzureClusterIdentity(ctx context.Context, c client.Client, hcluste
 		ClientID:     string(credentialsSecret.Data["AZURE_CLIENT_ID"]),
 		ClientSecret: corev1.SecretReference{Name: "azure-client-secret", Namespace: controlPlaneNamespace},
 		TenantID:     string(credentialsSecret.Data["AZURE_TENANT_ID"]),
-		Type:         capiazure.ManualServicePrincipal,
+		Type:         capiazure.ServicePrincipal,
 		AllowedNamespaces: &capiazure.AllowedNamespaces{
 			NamespaceList: []string{
 				controlPlaneNamespace,


### PR DESCRIPTION
**What this PR does / why we need it**:
We were previously using Manual Service Principal in the AzureClusterIdentity, which is now deprecated. This was causing lots of warning messages in the capi provider pod in the control plane. This PR updates the AzureClusterIdentity to now use Service Principal which is identical. 

See [this page](https://capz.sigs.k8s.io/topics/identities#deprecated-identity-types) in the CAPZ book for further details.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1408](https://issues.redhat.com/browse/HOSTEDCP-1408)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.