### PR TITLE
NO-JIRA: manifests: Skip pod anti affinity for nil labels

### DIFF
--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -190,6 +190,9 @@ func (c *DeploymentConfig) setMultizoneSpread(labels map[string]string) {
 // setNodeSpread sets PodAntiAffinity with corev1.LabelHostname as the topology key for a given set of labels.
 // This is useful to e.g ensure pods are spread across nodes.
 func (c *DeploymentConfig) setNodeSpread(labels map[string]string) {
+	if labels == nil {
+		return
+	}
 	if c.Scheduling.Affinity == nil {
 		c.Scheduling.Affinity = &corev1.Affinity{}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
At kubevirt provider we pass "nil" labels to the deployment defaults configurator, that should skip pod anti affinity, but a bit was missing to do so.

Whitout this the kccm deployement end up with 
```yaml
 podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector: {}
        topologyKey: kubernetes.io/hostname
```

Which prevent it from schedule.

The pod anti affinity feature was introduced by https://github.com/openshift/hypershift/pull/3286

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.