### PR TITLE
NO-JIRA: Add app labels to KubeVirt CCM component

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
@@ -106,7 +106,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedContr
 		isExternalInfra = true
 	}
 	deploymentConfig := newDeploymentConfig()
-	deploymentConfig.SetDefaults(hcp, nil, nil)
+	deploymentConfig.SetDefaults(hcp, ccmLabels(), nil)
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: ccmLabels(),


### PR DESCRIPTION
Previously the kubevirt cloud controller manager  did not have an `app` label associated with it. The outcome of this is the component would not be guaranteed to be spread out according to our anti-affinity rules. With the labels, anti-affinity rules are applied.