### PR TITLE
NO-JIRA: remove unneeded code to copy Authentication refs

### DIFF
--- a/api/util/configrefs/refs_test.go
+++ b/api/util/configrefs/refs_test.go
@@ -87,6 +87,24 @@ func TestConfigMapRefs(t *testing.T) {
 			refs: []string{"oauthmetadataref"},
 		},
 		{
+			name: "oidc provider",
+			config: &hyperv1.ClusterConfiguration{
+				Authentication: &configv1.AuthenticationSpec{
+					Type: configv1.AuthenticationTypeOIDC,
+					OIDCProviders: []configv1.OIDCProvider{
+						{
+							Issuer: configv1.TokenIssuer{
+								CertificateAuthority: configv1.ConfigMapNameReference{
+									Name: "issuercaref",
+								},
+							},
+						},
+					},
+				},
+			},
+			refs: []string{"issuercaref"},
+		},
+		{
 			name: "image ca",
 			config: &hyperv1.ClusterConfiguration{
 				Image: &configv1.ImageSpec{
@@ -365,6 +383,26 @@ func TestSecretRefs(t *testing.T) {
 				},
 			},
 			refs: []string{"serving-cert1", "serving-cert2"},
+		},
+		{
+			name: "oidc client secret",
+			config: &hyperv1.ClusterConfiguration{
+				Authentication: &configv1.AuthenticationSpec{
+					Type: configv1.AuthenticationTypeOIDC,
+					OIDCProviders: []configv1.OIDCProvider{
+						{
+							OIDCClients: []configv1.OIDCClientConfig{
+								{
+									ClientSecret: configv1.SecretNameReference{
+										Name: "clientsecretref",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			refs: []string{"clientsecretref"},
 		},
 		{
 			name: "idp refs",

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2794,7 +2794,15 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 	if !util.HCPOAuthEnabled(hcp) &&
 		len(hcp.Spec.Configuration.Authentication.OIDCProviders) != 0 &&
 		hcp.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.CertificateAuthority.Name != "" {
-		oidcCA = &corev1.LocalObjectReference{Name: manifests.OIDCCAConfigMap("").Name}
+		// This is needed for version skew between HO and CPO.  Older versions of the HO wrote the CA to a fixed
+		// oidc-ca configmap.  Newer versions just copy the configmap with its original name.
+		name := hcp.Spec.Configuration.Authentication.OIDCProviders[0].Issuer.CertificateAuthority.Name
+		err := r.Get(ctx, client.ObjectKey{Namespace: hcp.Namespace, Name: name}, &corev1.ConfigMap{})
+		if err != nil {
+			oidcCA = &corev1.LocalObjectReference{Name: manifests.OIDCCAConfigMap("").Name}
+		} else {
+			oidcCA = &corev1.LocalObjectReference{Name: name}
+		}
 	}
 
 	if _, err := createOrUpdate(ctx, r, kubeAPIServerDeployment, func() error {


### PR DESCRIPTION
Copying of the Authentication configmap and secret refs is already handled here https://github.com/openshift/hypershift/blob/96cc2066d61627252bdb66782cb5b922b80cae2c/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go#L1498-L1542

No reason to do it twice.