### PR TITLE
OCPBUGS-27282: Make ControllerAvailabilityPolicy immutable

### DIFF
--- a/api/hypershift/v1alpha1/hosted_controlplane.go
+++ b/api/hypershift/v1alpha1/hosted_controlplane.go
@@ -119,6 +119,8 @@ type HostedControlPlaneSpec struct {
 	// critical control plane components. The default value is SingleReplica.
 	//
 	// +optional
+	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ControllerAvailabilityPolicy is immutable"
 	// +kubebuilder:default:="SingleReplica"
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
 

--- a/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/api/hypershift/v1beta1/hosted_controlplane.go
@@ -79,6 +79,8 @@ type HostedControlPlaneSpec struct {
 	// critical control plane components. The default value is SingleReplica.
 	//
 	// +optional
+	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ControllerAvailabilityPolicy is immutable"
 	// +kubebuilder:default:="SingleReplica"
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -2288,6 +2288,9 @@ spec:
                   ControllerAvailabilityPolicy specifies the availability policy applied to
                   critical control plane components. The default value is SingleReplica.
                 type: string
+                x-kubernetes-validations:
+                - message: ControllerAvailabilityPolicy is immutable
+                  rule: self == oldSelf
               dns:
                 description: DNSSpec specifies the DNS configuration in the cluster.
                 properties:
@@ -6641,6 +6644,9 @@ spec:
                   ControllerAvailabilityPolicy specifies the availability policy applied to
                   critical control plane components. The default value is SingleReplica.
                 type: string
+                x-kubernetes-validations:
+                - message: ControllerAvailabilityPolicy is immutable
+                  rule: self == oldSelf
               dns:
                 description: DNSSpec specifies the DNS configuration in the cluster.
                 properties:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -47159,6 +47159,9 @@ objects:
                     ControllerAvailabilityPolicy specifies the availability policy applied to
                     critical control plane components. The default value is SingleReplica.
                   type: string
+                  x-kubernetes-validations:
+                  - message: ControllerAvailabilityPolicy is immutable
+                    rule: self == oldSelf
                 dns:
                   description: DNSSpec specifies the DNS configuration in the cluster.
                   properties:
@@ -51529,6 +51532,9 @@ objects:
                     ControllerAvailabilityPolicy specifies the availability policy applied to
                     critical control plane components. The default value is SingleReplica.
                   type: string
+                  x-kubernetes-validations:
+                  - message: ControllerAvailabilityPolicy is immutable
+                    rule: self == oldSelf
                 dns:
                   description: DNSSpec specifies the DNS configuration in the cluster.
                   properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets ControllerAvailabilityPolicy field immutable so a customer cannot go between SingleReplica to HighAvailability and vice versa.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-27282](https://issues.redhat.com/browse/OCPBUGS-27282)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.