### PR TITLE
CNV-36608: Enable InPlace NodePool upgrade test for kubevirt

### DIFF
--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -96,12 +96,6 @@ func NewNodePoolUpgradeTest(ctx context.Context, mgmtClient crclient.Client, hos
 }
 
 func (ru *NodePoolUpgradeTest) Setup(t *testing.T) {
-	// Currently, only ReplaceUpgrade strategy test passes for the kubevirt platform.
-	// TODO: Enable InPlace upgrade test as well once the issue is identified and fixed.
-	if globalOpts.Platform == hyperv1.KubevirtPlatform && t.Name() == "TestNodePool/Main/TestNodePoolInPlaceUpgrade" {
-		t.Skip("InPlace Upgrade test currently can't run for the KubeVirt platform")
-	}
-
 	t.Log("starting test NodePoolUpgradeTest")
 }
 


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Due to an issue in nmstate in which files on the ostree filesystem have been modified, MCO could not drain the node and apply an RHCOS rollout in place.
This has been [fixed](https://github.com/nmstate/nmstate/pull/2499) in a recent release of RHCOS, thus we can enable it now.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/CNV-36608

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.