### PR TITLE
OCPBUGS-29020: reduce external-dns route53 call volume

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -220,8 +220,6 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
 								"--interval=1m",
 								"--service-type-filter=LoadBalancer",
-								"--aws-zone-type=public",
-								"--aws-zones-cache-duration=1h",
 								"--txt-cache-interval=1h",
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
@@ -289,6 +287,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
 			"--aws-zone-type=public",
 			"--aws-batch-change-interval=10s",
+			"--aws-zones-cache-duration=1h",
 		)
 	case "azure":
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -219,6 +219,10 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								fmt.Sprintf("--txt-owner-id=%s", txtOwnerId),
 								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
 								"--interval=1m",
+								"--service-type-filter=LoadBalancer",
+								"--aws-zone-type=public",
+								"--aws-zones-cache-duration=1h",
+								"--txt-cache-interval=1h",
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},
 							LivenessProbe: &corev1.Probe{

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -219,7 +219,6 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 								fmt.Sprintf("--txt-owner-id=%s", txtOwnerId),
 								fmt.Sprintf("--label-filter=%s!=%s", hyperv1.RouteVisibilityLabel, hyperv1.RouteVisibilityPrivate),
 								"--interval=1m",
-								"--service-type-filter=LoadBalancer",
 								"--txt-cache-interval=1h",
 							},
 							Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 7979}},

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -425,11 +425,10 @@ objects:
           - --label-filter=hypershift.openshift.io/route-visibility!=private
           - --interval=1m
           - --service-type-filter=LoadBalancer
-          - --aws-zone-type=public
-          - --aws-zones-cache-duration=1h
           - --txt-cache-interval=1h
           - --aws-zone-type=public
           - --aws-batch-change-interval=10s
+          - --aws-zones-cache-duration=1h
           command:
           - /external-dns
           env:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -424,6 +424,10 @@ objects:
           - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
           - --label-filter=hypershift.openshift.io/route-visibility!=private
           - --interval=1m
+          - --service-type-filter=LoadBalancer
+          - --aws-zone-type=public
+          - --aws-zones-cache-duration=1h
+          - --txt-cache-interval=1h
           - --aws-zone-type=public
           - --aws-batch-change-interval=10s
           command:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -424,7 +424,6 @@ objects:
           - --txt-owner-id=${EXTERNAL_DNS_TXT_OWNER_ID}
           - --label-filter=hypershift.openshift.io/route-visibility!=private
           - --interval=1m
-          - --service-type-filter=LoadBalancer
           - --txt-cache-interval=1h
           - --aws-zone-type=public
           - --aws-batch-change-interval=10s


### PR DESCRIPTION
Ideally, we would not need to backport this.  However, release-4.15 across the org currently use the HO built from the release-4.15 branch and it is not trivial to change this.  release-4.15 jobs are still creating route53 throttling situation so let's backport this fix.

Contains https://github.com/openshift/hypershift/pull/3394 and follow up fix https://github.com/openshift/hypershift/pull/3408