### PR TITLE
HOSTEDCP-1420: Set a fixed minimum supported version

### DIFF
--- a/hypershift-operator/controllers/supportedversion/reconciler_test.go
+++ b/hypershift-operator/controllers/supportedversion/reconciler_test.go
@@ -32,5 +32,5 @@ func TestEnsureSupportedVersionConfigMap(t *testing.T) {
 	data := &supportedVersions{}
 	err = json.Unmarshal([]byte(cfgMap.Data[configMapKey]), data)
 	g.Expect(err).To(BeNil())
-	g.Expect(len(data.Versions)).To(Equal(supportedversion.SupportedPreviousMinorVersions + 1))
+	g.Expect(len(data.Versions)).To(Equal(len(supportedversion.Supported())))
 }

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSupportedVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
-	g.Expect(Supported()).To(Equal([]string{"4.16", "4.15", "4.14"}))
+	g.Expect(Supported()).To(Equal([]string{"4.16", "4.15", "4.14", "4.13"}))
 }
 
 func TestIsValidReleaseVersion(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to support a set of known OCP versions, we are setting a fixed minimum supported version, instead of a number of previous versions.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1420](https://issues.redhat.com/browse/HOSTEDCP-1420)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.