### PR TITLE
HOSTEDCP-1365: kubevirt, Generate kccm lb endpointslices

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/providerconfig.go
@@ -3,6 +3,7 @@ package kubevirt
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"gopkg.in/yaml.v2"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -24,6 +25,9 @@ type LoadBalancerConfig struct {
 	Enabled bool `yaml:"enabled"`
 	// CreationPollInterval determines how many seconds to wait for the load balancer creation
 	CreationPollInterval int `yaml:"creationPollInterval"`
+	// Selectorless delegate endpointslices creation on third party by
+	// skipping service selector creation
+	Selectorless *bool `yaml:"selectorless,omitempty"`
 }
 
 type InstancesV2Config struct {
@@ -44,7 +48,8 @@ func (c *CloudConfig) serialize() (string, error) {
 func cloudConfig(hcp *hyperv1.HostedControlPlane, namespace string, kubeconfigPath string) CloudConfig {
 	return CloudConfig{
 		LoadBalancer: LoadBalancerConfig{
-			Enabled: true,
+			Enabled:      true,
+			Selectorless: pointer.Bool(true),
 		},
 		InstancesV2: InstancesV2Config{
 			Enabled:              true,

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -193,6 +193,7 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef, platform hyperv1
 					"endpointslices/restricted",
 				},
 				Verbs: []string{
+					"delete",
 					"create",
 					"get",
 					"patch",
@@ -206,7 +207,7 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef, platform hyperv1
 					"kubevirt.io",
 				},
 				Resources: []string{"virtualmachines"},
-				Verbs:     []string{"get"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/cmca/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/cmca/setup.go
@@ -20,7 +20,7 @@ const (
 	ControllerManagerAdditionalCAConfigMap = "controller-manager-additional-ca"
 )
 
-func Setup(cfg *operator.HostedClusterConfigOperatorConfig) error {
+func Setup(ctx context.Context, cfg *operator.HostedClusterConfigOperatorConfig) error {
 	if err := setupConfigMapObserver(cfg); err != nil {
 		return err
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/setup.go
@@ -1,6 +1,7 @@
 package drainer
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
@@ -11,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
+func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig) error {
 	targetKubeClient, err := kubeclient.NewForConfig(opts.TargetConfig)
 	if err != nil {
 		return err

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
@@ -22,7 +22,7 @@ import (
 
 const ControllerName = "hcpstatus"
 
-func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
+func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig) error {
 	r := &hcpStatusReconciler{
 		mgtClusterClient:    opts.CPCluster.GetClient(),
 		hostedClusterClient: opts.Manager.GetClient(),

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/setup.go
@@ -1,6 +1,7 @@
 package inplaceupgrader
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
@@ -11,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
+func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig) error {
 	r := &Reconciler{
 		client:                 opts.CPCluster.GetClient(),
 		guestClusterClient:     opts.Manager.GetClient(),

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
@@ -13,6 +13,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -21,17 +22,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	managedByValue = "control-plane-operator.hypershift.openshift.io"
+)
+
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Reconciling")
-	machine := &capiv1.Machine{}
-	if err := r.client.Get(ctx, client.ObjectKey(req.NamespacedName), machine); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("not found", "Machine", r)
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to get Machine: %w", err)
-	}
 
 	hcp := &hyperv1.HostedControlPlane{}
 	if err := r.client.Get(ctx, r.hcpKey, hcp); err != nil {
@@ -43,9 +40,18 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.KubevirtPlatform:
-		if hcp.Spec.Platform.Kubevirt != nil && (hcp.Spec.Platform.Kubevirt.BaseDomainPassthrough != nil && *hcp.Spec.Platform.Kubevirt.BaseDomainPassthrough) {
-			if err := r.reconcileKubevirtDefaultIngressEndpoints(ctx, hcp, machine); err != nil {
-				return reconcile.Result{}, fmt.Errorf("failed reconciling kubevirt default ingress passthrough service endpoints: %w", err)
+		if hcp.Spec.Platform.Kubevirt != nil {
+			kubevirtPassthroughServices, err := r.findKubevirtPassthroughServices(ctx, hcp)
+			if err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed finding kubevirt passthrough services: %w", err)
+			}
+			for _, kubevirtPassthroughService := range kubevirtPassthroughServices {
+				if err := r.reconcileKubevirtPassthroughService(ctx, hcp, req.NamespacedName, &kubevirtPassthroughService); err != nil {
+					return reconcile.Result{}, fmt.Errorf("failed reconciling kubevirt infra passthrough service endpoint slices: %w", err)
+				}
+			}
+			if err := r.removeOrphanKubevirtPassthroughEndpointSlices(ctx, hcp); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed removing orphan kubevirt passthrough endpoint slices: %w", err)
 			}
 		}
 	}
@@ -53,25 +59,37 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return reconcile.Result{}, nil
 }
 
-func (r *reconciler) reconcileKubevirtDefaultIngressEndpoints(ctx context.Context, hcp *hyperv1.HostedControlPlane, machine *capiv1.Machine) error {
-	log := ctrl.LoggerFrom(ctx)
-	var namespace string
-	if hcp.Spec.Platform.Kubevirt.Credentials != nil {
-		namespace = hcp.Spec.Platform.Kubevirt.Credentials.InfraNamespace
-	} else {
-		namespace = hcp.Namespace
-	}
+func (r *reconciler) findKubevirtPassthroughServices(ctx context.Context, hcp *hyperv1.HostedControlPlane) ([]corev1.Service, error) {
+	kubevirtPassthroughServices := []corev1.Service{}
 
 	// Manifests for infra/mgmt cluster passthrough service
-	cpService := hcpmanifests.IngressDefaultIngressPassthroughService(namespace)
+	cpService := hcpmanifests.IngressDefaultIngressPassthroughService(kubevirtInfraNamespace(hcp))
 
 	cpService.Name = fmt.Sprintf("%s-%s",
 		hcpmanifests.IngressDefaultIngressPassthroughServiceName,
 		hcp.Spec.Platform.Kubevirt.GenerateID)
 
-	if err := r.kubevirtInfraClient.Get(ctx, client.ObjectKeyFromObject(cpService), cpService); err != nil {
-		return fmt.Errorf("failed to get default ingress passthrough Service: %w", err)
+	err := r.kubevirtInfraClient.Get(ctx, client.ObjectKeyFromObject(cpService), cpService)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get default ingress passthrough Service: %w", err)
 	}
+	if !apierrors.IsNotFound(err) {
+		kubevirtPassthroughServices = append(kubevirtPassthroughServices, *cpService)
+	}
+
+	kccmServiceList := &corev1.ServiceList{}
+	if err := r.kubevirtInfraClient.List(ctx, kccmServiceList, client.InNamespace(kubevirtInfraNamespace(hcp)),
+		client.HasLabels{tenantServiceNameLabelKey},
+		client.MatchingLabels{clusterNameLabelKey: hcp.Labels[clusterNameLabelKey]},
+	); err != nil {
+		return nil, fmt.Errorf("failed listing kccm services: %w", err)
+	}
+	kubevirtPassthroughServices = append(kubevirtPassthroughServices, kccmServiceList.Items...)
+	return kubevirtPassthroughServices, nil
+}
+
+func (r *reconciler) reconcileKubevirtPassthroughService(ctx context.Context, hcp *hyperv1.HostedControlPlane, machineKey types.NamespacedName, cpService *corev1.Service) error {
+	log := ctrl.LoggerFrom(ctx)
 
 	// If there is a selector endpoints should not be generated
 	if len(cpService.Spec.Selector) > 0 {
@@ -82,27 +100,34 @@ func (r *reconciler) reconcileKubevirtDefaultIngressEndpoints(ctx context.Contex
 		return fmt.Errorf("missing default ingress passthrough Service %s/%s ports", cpService.Namespace, cpService.Name)
 	}
 
+	machine := &capiv1.Machine{}
+	if err := r.client.Get(ctx, client.ObjectKey(machineKey), machine); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("not found", "Machine", r)
+			return nil
+		}
+		return fmt.Errorf("failed to get Machine: %w", err)
+	}
+
 	ipv4MachineAddresses := []string{}
 	ipv6MachineAddresses := []string{}
 	ports := []discoveryv1.EndpointPort{}
 
-	// If machine is back to not ready we should reset the endpointslice
-	if machine.Status.GetTypedPhase() == capiv1.MachinePhaseRunning {
-		for _, machineAddress := range machine.Status.Addresses {
-			if machineAddress.Type == capiv1.MachineInternalIP {
-				if netip.MustParseAddr(machineAddress.Address).Is4() {
-					ipv4MachineAddresses = append(ipv4MachineAddresses, machineAddress.Address)
-				} else {
-					ipv6MachineAddresses = append(ipv6MachineAddresses, machineAddress.Address)
-				}
+	for _, machineAddress := range machine.Status.Addresses {
+		if machineAddress.Type == capiv1.MachineInternalIP {
+			if netip.MustParseAddr(machineAddress.Address).Is4() {
+				ipv4MachineAddresses = append(ipv4MachineAddresses, machineAddress.Address)
+			} else {
+				ipv6MachineAddresses = append(ipv6MachineAddresses, machineAddress.Address)
 			}
 		}
-		for _, port := range cpService.Spec.Ports {
-			ports = append(ports, discoveryv1.EndpointPort{
-				Protocol: &port.Protocol,
-				Port:     pointer.Int32(int32(port.TargetPort.IntValue())),
-			})
-		}
+	}
+	for _, port := range cpService.Spec.Ports {
+		ports = append(ports, discoveryv1.EndpointPort{
+			Name:     &port.Name,
+			Protocol: &port.Protocol,
+			Port:     pointer.Int32(int32(port.TargetPort.IntValue())),
+		})
 	}
 
 	ipAddressesByFamily := map[corev1.IPFamily][]string{
@@ -113,7 +138,7 @@ func (r *reconciler) reconcileKubevirtDefaultIngressEndpoints(ctx context.Contex
 		if !serviceHasIPFamily(cpService, ipFamily) {
 			continue
 		}
-		err := r.reconcileKubevirtDefaultIngressEndpointsByIPFamily(ctx, machine, cpService, ipFamily, ipAddressesByFamily[ipFamily], ports)
+		err := r.reconcileKubevirtPassthroughServiceEndpointsByIPFamily(ctx, machine, cpService, ipFamily, ipAddressesByFamily[ipFamily], ports)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Info(fmt.Sprintf("waiting for kubevirt VM to be created before processing default ingress %s endpoints", ipFamily))
@@ -126,7 +151,7 @@ func (r *reconciler) reconcileKubevirtDefaultIngressEndpoints(ctx context.Contex
 	return nil
 }
 
-func (r *reconciler) reconcileKubevirtDefaultIngressEndpointsByIPFamily(ctx context.Context, machine *capiv1.Machine, cpService *corev1.Service, ipFamily corev1.IPFamily, machineAddresses []string, ports []discoveryv1.EndpointPort) error {
+func (r *reconciler) reconcileKubevirtPassthroughServiceEndpointsByIPFamily(ctx context.Context, machine *capiv1.Machine, cpService *corev1.Service, ipFamily corev1.IPFamily, machineAddresses []string, ports []discoveryv1.EndpointPort) error {
 	log := ctrl.LoggerFrom(ctx)
 	endpointSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
@@ -143,22 +168,25 @@ func (r *reconciler) reconcileKubevirtDefaultIngressEndpointsByIPFamily(ctx cont
 				Namespace: cpService.Namespace,
 				Name:      machine.Spec.InfrastructureRef.Name,
 			}
-			vm := kubevirtv1.VirtualMachine{}
-			if err := r.kubevirtInfraClient.Get(ctx, vmKey, &vm); err != nil {
+			vm := &kubevirtv1.VirtualMachine{}
+			if err := r.kubevirtInfraClient.Get(ctx, vmKey, vm); err != nil {
 				return err
 			}
-			ownerRef := config.OwnerRefFrom(&vm)
+			ownerRef := config.OwnerRefFrom(vm)
 			ownerRef.ApplyTo(endpointSlice)
 		}
 
 		if endpointSlice.Labels == nil {
 			endpointSlice.Labels = map[string]string{}
 		}
-		endpointSlice.Labels["kubernetes.io/service-name"] = cpService.Name
-		endpointSlice.Labels["endpointslice.kubernetes.io/managed-by"] = "control-plane-operator.hypershift.openshift.io"
+		endpointSlice.Labels[discoveryv1.LabelServiceName] = cpService.Name
+		endpointSlice.Labels[discoveryv1.LabelManagedBy] = managedByValue
 		endpointSlice.AddressType = discoveryv1.AddressType(ipFamily)
 		if len(machineAddresses) > 0 {
-			endpointSlice.Endpoints = []discoveryv1.Endpoint{{Addresses: machineAddresses}}
+			endpointSlice.Endpoints = []discoveryv1.Endpoint{{
+				Addresses:  machineAddresses,
+				Conditions: machinePhaseToEndpointConditions(machine),
+			}}
 		} else {
 			endpointSlice.Endpoints = []discoveryv1.Endpoint{}
 		}
@@ -179,4 +207,52 @@ func serviceHasIPFamily(service *corev1.Service, ipFamilyToFind corev1.IPFamily)
 		}
 	}
 	return false
+}
+
+func kubevirtInfraNamespace(hcp *hyperv1.HostedControlPlane) string {
+	if hcp.Spec.Platform.Kubevirt.Credentials != nil {
+		return hcp.Spec.Platform.Kubevirt.Credentials.InfraNamespace
+	}
+	return hcp.Namespace
+}
+
+func (r *reconciler) removeOrphanKubevirtPassthroughEndpointSlices(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	namespace := kubevirtInfraNamespace(hcp)
+	endpointSliceList := discoveryv1.EndpointSliceList{}
+	managedByControlPlaneOperator := client.MatchingLabels{discoveryv1.LabelManagedBy: managedByValue}
+	if err := r.kubevirtInfraClient.List(ctx, &endpointSliceList, client.InNamespace(namespace), managedByControlPlaneOperator); err != nil {
+		return fmt.Errorf("failed finding endpoint slices managed by control plane operator: %w", err)
+	}
+
+	for _, endpointSlice := range endpointSliceList.Items {
+		serviceName := endpointSlice.Labels[discoveryv1.LabelServiceName]
+		if serviceName == "" {
+			continue
+		}
+		err := r.kubevirtInfraClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: serviceName}, &corev1.Service{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed looking for service referencing endpoint slices managed by control plane operator: %w", err)
+		}
+		if apierrors.IsNotFound(err) {
+			if err := r.kubevirtInfraClient.Delete(ctx, &endpointSlice); err != nil {
+				return fmt.Errorf("failed deleting orphan kubevirt passthrough endpoint slice: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func machinePhaseToEndpointConditions(machine *capiv1.Machine) discoveryv1.EndpointConditions {
+	if machine.Status.GetTypedPhase() == capiv1.MachinePhaseRunning {
+		return discoveryv1.EndpointConditions{
+			Ready:       pointer.Bool(true),
+			Serving:     pointer.Bool(true),
+			Terminating: pointer.Bool(false),
+		}
+	}
+	return discoveryv1.EndpointConditions{
+		Ready:       pointer.Bool(false),
+		Serving:     pointer.Bool(false),
+		Terminating: pointer.Bool(false),
+	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
@@ -3,11 +3,12 @@ package machine
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	"github.com/openshift/hypershift/client/clientset/clientset/scheme"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,460 +17,494 @@ import (
 	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 )
 
 func TestReconcileDefaultIngressEndpoints(t *testing.T) {
+	format.MaxLength = 0
+
 	machineTypeMeta := metav1.TypeMeta{
 		Kind:       "Machine",
 		APIVersion: capiv1.GroupVersion.String(),
 	}
-	virtualmachineTypeMeta := metav1.TypeMeta{
+	vmTypeMeta := metav1.TypeMeta{
 		Kind:       "VirtualMachine",
 		APIVersion: kubevirtv1.GroupVersion.String(),
 	}
-	newMachineMeta := func(namespace, name string) metav1.ObjectMeta {
+	newObjectMeta := func(namespace, name string) metav1.ObjectMeta {
 		return metav1.ObjectMeta{
-			Namespace:       namespace,
-			Name:            name,
-			UID:             types.UID(name + "-uid"),
-			ResourceVersion: fmt.Sprintf("%d", rand.Intn(100)),
+			Namespace: namespace,
+			Name:      name,
+			UID:       types.UID(name + "-uid"),
+		}
+	}
+	kubevirtHCP := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "cluster1",
+			Labels: map[string]string{
+				clusterNameLabelKey: "cluster1",
+			},
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.KubevirtPlatform,
+				Kubevirt: &hyperv1.KubevirtPlatformSpec{
+					GenerateID: "foobar",
+				},
+			},
+		},
+	}
+
+	worker1Meta := newObjectMeta("ns1", "worker1")
+	vmWorker1Meta := newObjectMeta("ns1", "vm-worker1")
+	worker2Meta := newObjectMeta("ns1", "worker2")
+	vmWorker2Meta := newObjectMeta("ns1", "vm-worker2")
+
+	addressesByMachine := map[string][]string{
+		worker1Meta.Name: []string{"192.168.1.3", "2001:db8:a0b:12f0::3"},
+		worker2Meta.Name: []string{"192.168.1.4", "2001:db8:a0b:12f0::4"},
+	}
+
+	protocolTCP := corev1.ProtocolTCP
+	pairOfVirtualMachines := []kubevirtv1.VirtualMachine{
+		{
+			TypeMeta:   vmTypeMeta,
+			ObjectMeta: vmWorker1Meta,
+		},
+		{
+			TypeMeta:   vmTypeMeta,
+			ObjectMeta: vmWorker2Meta,
+		},
+	}
+	pairOfDualStackMachines := func(phaseWorker1, phaseWorker2 capiv1.MachinePhase) []capiv1.Machine {
+		return []capiv1.Machine{
+			{
+				TypeMeta:   machineTypeMeta,
+				ObjectMeta: worker1Meta,
+				Spec: capiv1.MachineSpec{
+					InfrastructureRef: corev1.ObjectReference{
+						Name: vmWorker1Meta.Name,
+					},
+				},
+				Status: capiv1.MachineStatus{
+					Phase: string(phaseWorker1),
+					Addresses: []capiv1.MachineAddress{
+						{
+							Type:    capiv1.MachineInternalIP,
+							Address: addressesByMachine[worker1Meta.Name][0],
+						},
+						{
+							Type:    capiv1.MachineInternalIP,
+							Address: addressesByMachine[worker1Meta.Name][1],
+						},
+					},
+				},
+			},
+			{
+				TypeMeta:   machineTypeMeta,
+				ObjectMeta: worker2Meta,
+				Spec: capiv1.MachineSpec{
+					InfrastructureRef: corev1.ObjectReference{
+						Name: vmWorker2Meta.Name,
+					},
+				},
+				Status: capiv1.MachineStatus{
+					Phase: string(phaseWorker2),
+					Addresses: []capiv1.MachineAddress{
+						{
+							Type:    capiv1.MachineInternalIP,
+							Address: addressesByMachine[worker2Meta.Name][0],
+						},
+						{
+							Type:    capiv1.MachineInternalIP,
+							Address: addressesByMachine[worker2Meta.Name][1],
+						},
+					},
+				},
+			},
 		}
 	}
 
-	worker1Meta := newMachineMeta("ns1-cluster1", "worker1")
-	vm1Meta := newMachineMeta("ns1-cluster1", "workervm1")
+	pairOfDualStackRunningMachines := pairOfDualStackMachines(capiv1.MachinePhaseRunning, capiv1.MachinePhaseRunning)
 
-	protocolTCP := corev1.ProtocolTCP
+	defaultIngressService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "default-ingress-passthrough-service-foobar",
+			UID:       types.UID("test-svc-1-uid"),
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				TargetPort: intstr.FromInt(2222),
+				Protocol:   corev1.ProtocolTCP,
+				Name:       "port1",
+			}},
+			IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+		},
+	}
+	normalService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "normal-service",
+			UID:       types.UID("test-svc-2-uid"),
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				TargetPort: intstr.FromInt(3333),
+				Protocol:   corev1.ProtocolTCP,
+				Name:       "port1",
+			}},
+			IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+		},
+	}
+	kccmService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "kccm-service-cluster1",
+			UID:       types.UID("test-svc-3-uid"),
+			Labels: map[string]string{
+				tenantServiceNameLabelKey: "svc-3",
+				clusterNameLabelKey:       "cluster1",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				TargetPort: intstr.FromInt(4444),
+				Protocol:   corev1.ProtocolTCP,
+				Name:       "port1",
+			}},
+			IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+		},
+	}
+	kccmServiceDifferentCluster := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "kccm-service-cluster2",
+			UID:       types.UID("test-svc-3-uid"),
+			Labels: map[string]string{
+				tenantServiceNameLabelKey: "svc-3",
+				clusterNameLabelKey:       "cluster2",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				TargetPort: intstr.FromInt(4444),
+				Protocol:   corev1.ProtocolTCP,
+				Name:       "port1",
+			}},
+			IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+		},
+	}
 
+	readyAndServing := func(ready, serving bool) func(eps discoveryv1.EndpointSlice) discoveryv1.EndpointSlice {
+		return func(eps discoveryv1.EndpointSlice) discoveryv1.EndpointSlice {
+			eps.Endpoints[0].Conditions.Ready = &ready
+			eps.Endpoints[0].Conditions.Serving = &serving
+			return eps
+		}
+	}
+
+	defaultIngressEndpointSliceIPv4 := func(machine capiv1.Machine, vm kubevirtv1.VirtualMachine, endpointSliceTransform ...func(discoveryv1.EndpointSlice) discoveryv1.EndpointSlice) discoveryv1.EndpointSlice {
+		endpointSlice := discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns1",
+				Name:      "default-ingress-passthrough-service-foobar-" + machine.Name + "-ipv4",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "default-ingress-passthrough-service-foobar",
+					discoveryv1.LabelManagedBy:   "control-plane-operator.hypershift.openshift.io",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         vmTypeMeta.APIVersion,
+					Kind:               vmTypeMeta.Kind,
+					UID:                vm.UID,
+					Name:               vm.Name,
+					Controller:         pointer.Bool(true),
+					BlockOwnerDeletion: pointer.Bool(true),
+				}},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{{
+				Addresses: []string{addressesByMachine[machine.Name][0]},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready:       pointer.Bool(true),
+					Serving:     pointer.Bool(true),
+					Terminating: pointer.Bool(false),
+				},
+			}},
+			Ports: []discoveryv1.EndpointPort{{
+				Port:     pointer.Int32(2222),
+				Protocol: &protocolTCP,
+				Name:     pointer.String("port1"),
+			}},
+		}
+		for _, t := range endpointSliceTransform {
+			endpointSlice = t(endpointSlice)
+		}
+		return endpointSlice
+	}
+
+	defaultIngressEndpointSliceIPv6 := func(machine capiv1.Machine, vm kubevirtv1.VirtualMachine, endpointSliceTransform ...func(discoveryv1.EndpointSlice) discoveryv1.EndpointSlice) discoveryv1.EndpointSlice {
+		endpointSlice := discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns1",
+				Name:      "default-ingress-passthrough-service-foobar-" + machine.Name + "-ipv6",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "default-ingress-passthrough-service-foobar",
+					discoveryv1.LabelManagedBy:   "control-plane-operator.hypershift.openshift.io",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         vmTypeMeta.APIVersion,
+					Kind:               vmTypeMeta.Kind,
+					UID:                vm.UID,
+					Name:               vm.Name,
+					Controller:         pointer.Bool(true),
+					BlockOwnerDeletion: pointer.Bool(true),
+				}},
+			},
+			AddressType: discoveryv1.AddressTypeIPv6,
+			Endpoints: []discoveryv1.Endpoint{{
+				Addresses: []string{addressesByMachine[machine.Name][1]},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready:       pointer.Bool(true),
+					Serving:     pointer.Bool(true),
+					Terminating: pointer.Bool(false),
+				},
+			}},
+			Ports: []discoveryv1.EndpointPort{{
+				Port:     pointer.Int32(2222),
+				Protocol: &protocolTCP,
+				Name:     pointer.String("port1"),
+			}},
+		}
+
+		for _, t := range endpointSliceTransform {
+			endpointSlice = t(endpointSlice)
+		}
+		return endpointSlice
+	}
+
+	kccmEndpointSliceIPv4WithNamespace := func(namespace string, machine capiv1.Machine, vm kubevirtv1.VirtualMachine) discoveryv1.EndpointSlice {
+		return discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "kccm-service-cluster1-" + machine.Name + "-ipv4",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "kccm-service-cluster1",
+					discoveryv1.LabelManagedBy:   "control-plane-operator.hypershift.openshift.io",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         vmTypeMeta.APIVersion,
+					Kind:               vmTypeMeta.Kind,
+					UID:                vm.UID,
+					Name:               vm.Name,
+					Controller:         pointer.Bool(true),
+					BlockOwnerDeletion: pointer.Bool(true),
+				}},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{{
+				Addresses: []string{addressesByMachine[machine.Name][0]},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready:       pointer.Bool(true),
+					Serving:     pointer.Bool(true),
+					Terminating: pointer.Bool(false),
+				},
+			}},
+			Ports: []discoveryv1.EndpointPort{{
+				Port:     pointer.Int32(4444),
+				Protocol: &protocolTCP,
+				Name:     pointer.String("port1"),
+			}},
+		}
+	}
+
+	kccmEndpointSliceIPv4 := func(machine capiv1.Machine, vm kubevirtv1.VirtualMachine) discoveryv1.EndpointSlice {
+		return kccmEndpointSliceIPv4WithNamespace("ns1", machine, vm)
+	}
+
+	kccmEndpointSliceIPv6 := func(machine capiv1.Machine, vm kubevirtv1.VirtualMachine) discoveryv1.EndpointSlice {
+		return discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns1",
+				Name:      "kccm-service-cluster1-" + machine.Name + "-ipv6",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "kccm-service-cluster1",
+					discoveryv1.LabelManagedBy:   "control-plane-operator.hypershift.openshift.io",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         vmTypeMeta.APIVersion,
+					Kind:               vmTypeMeta.Kind,
+					UID:                vm.UID,
+					Name:               vm.Name,
+					Controller:         pointer.Bool(true),
+					BlockOwnerDeletion: pointer.Bool(true),
+				}},
+			},
+			AddressType: discoveryv1.AddressTypeIPv6,
+			Endpoints: []discoveryv1.Endpoint{{
+				Addresses: []string{addressesByMachine[machine.Name][1]},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready:       pointer.Bool(true),
+					Serving:     pointer.Bool(true),
+					Terminating: pointer.Bool(false),
+				},
+			}},
+			Ports: []discoveryv1.EndpointPort{{
+				Port:     pointer.Int32(4444),
+				Protocol: &protocolTCP,
+				Name:     pointer.String("port1"),
+			}},
+		}
+	}
+
+	withSelector := func(service corev1.Service) corev1.Service {
+		service.Spec.Selector = map[string]string{"key1": "value1"}
+		return service
+	}
+
+	capiv1.AddToScheme(scheme.Scheme)
 	hyperv1.AddToScheme(scheme.Scheme)
 	kubevirtv1.AddToScheme(scheme.Scheme)
 	discoveryv1.AddToScheme(scheme.Scheme)
 	corev1.AddToScheme(scheme.Scheme)
 	testCases := []struct {
 		name                          string
-		virtualmachine                *kubevirtv1.VirtualMachine
-		machine                       *capiv1.Machine
-		ingressSvc                    *corev1.Service
-		ingressEndpointSlices         []discoveryv1.EndpointSlice
+		machines                      []capiv1.Machine
+		virtualMachines               []kubevirtv1.VirtualMachine
+		services                      []corev1.Service
+		endpointSlices                []discoveryv1.EndpointSlice
 		hcp                           *hyperv1.HostedControlPlane
 		expectedIngressEndpointSlices []discoveryv1.EndpointSlice
+		expectedServices              []corev1.Service
 		error                         bool
 	}{
 		{
-			name:       "Without service",
-			ingressSvc: nil,
-			hcp: &hyperv1.HostedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Kubevirt: &hyperv1.KubevirtPlatformSpec{
-							GenerateID: "foobar",
-						},
-					},
-				},
-			},
-			error: true,
+			name:     "Without passthrow services",
+			hcp:      kubevirtHCP,
+			machines: pairOfDualStackRunningMachines,
 		},
 		{
-			name: "With selector at ingress service",
-			ingressSvc: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "default-ingress-passthrough-service-foobar",
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{{
-						TargetPort: intstr.FromInt(2222),
-					}},
-					Selector: map[string]string{
-						"key1": "value1",
-					},
-				},
-			},
-			hcp: &hyperv1.HostedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Kubevirt: &hyperv1.KubevirtPlatformSpec{
-							GenerateID: "foobar",
-						},
-					},
-				},
-			},
+			name:             "With selector at passthrow service",
+			services:         []corev1.Service{withSelector(defaultIngressService)},
+			expectedServices: []corev1.Service{withSelector(defaultIngressService)},
+			hcp:              kubevirtHCP,
+			machines:         pairOfDualStackRunningMachines,
 		},
 		{
-			name: "Without virtual machine",
-			machine: &capiv1.Machine{
-				TypeMeta:   machineTypeMeta,
-				ObjectMeta: worker1Meta,
-				Spec: capiv1.MachineSpec{
-					InfrastructureRef: corev1.ObjectReference{
-						Kind:       virtualmachineTypeMeta.Kind,
-						APIVersion: virtualmachineTypeMeta.APIVersion,
-						Namespace:  vm1Meta.Namespace,
-						Name:       vm1Meta.Name,
-					},
-				},
+			name:             "With Running machines with internal addresses and passthrow services should create ready/serving enpodintslices",
+			machines:         pairOfDualStackRunningMachines,
+			virtualMachines:  pairOfVirtualMachines,
+			services:         []corev1.Service{defaultIngressService, normalService, kccmService, kccmServiceDifferentCluster},
+			expectedServices: []corev1.Service{defaultIngressService, kccmService, normalService, kccmServiceDifferentCluster},
+			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{
+				defaultIngressEndpointSliceIPv4(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
+				defaultIngressEndpointSliceIPv4(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1]),
+				defaultIngressEndpointSliceIPv6(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
+				defaultIngressEndpointSliceIPv6(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1]),
+				kccmEndpointSliceIPv4(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
+				kccmEndpointSliceIPv4(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1]),
+				kccmEndpointSliceIPv6(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
+				kccmEndpointSliceIPv6(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1]),
 			},
-			ingressSvc: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "default-ingress-passthrough-service-foobar",
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{{
-						TargetPort: intstr.FromInt(2222),
-					}},
-				},
-			},
-			hcp: &hyperv1.HostedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Kubevirt: &hyperv1.KubevirtPlatformSpec{
-							GenerateID: "foobar",
-						},
-					},
-				},
-			},
+			hcp: kubevirtHCP,
 		},
 		{
-			name: "With Running machine with internal ipv4 and service with target port and no endpoints",
-			virtualmachine: &kubevirtv1.VirtualMachine{
-				ObjectMeta: vm1Meta,
+			name:             "With Failing machine with internal addresses and passthrow service should mark endpointslices as not ready/not serving",
+			machines:         pairOfDualStackMachines(capiv1.MachinePhaseRunning, capiv1.MachinePhaseFailed),
+			virtualMachines:  pairOfVirtualMachines,
+			services:         []corev1.Service{defaultIngressService},
+			expectedServices: []corev1.Service{defaultIngressService},
+			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{
+				defaultIngressEndpointSliceIPv4(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0], readyAndServing(true, true)),
+				defaultIngressEndpointSliceIPv4(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1], readyAndServing(false, false)),
+				defaultIngressEndpointSliceIPv6(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0], readyAndServing(true, true)),
+				defaultIngressEndpointSliceIPv6(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1], readyAndServing(false, false)),
 			},
-			machine: &capiv1.Machine{
-				TypeMeta:   machineTypeMeta,
-				ObjectMeta: worker1Meta,
-				Spec: capiv1.MachineSpec{
-					InfrastructureRef: corev1.ObjectReference{
-						Kind:       virtualmachineTypeMeta.Kind,
-						APIVersion: virtualmachineTypeMeta.APIVersion,
-						Namespace:  vm1Meta.Namespace,
-						Name:       vm1Meta.Name,
-					},
-				},
-				Status: capiv1.MachineStatus{
-					Phase: string(capiv1.MachinePhaseRunning),
-					Addresses: []capiv1.MachineAddress{{
-						Type:    capiv1.MachineInternalIP,
-						Address: "192.168.1.3",
-					}},
-				},
-			},
-			ingressSvc: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "default-ingress-passthrough-service-foobar",
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{{
-						TargetPort: intstr.FromInt(2222),
-						Protocol:   corev1.ProtocolTCP,
-					}},
-					IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
-				},
-			},
-			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv4",
-					Labels: map[string]string{
-						"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
-						"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
-					},
-					ResourceVersion: "1",
-					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion:         virtualmachineTypeMeta.APIVersion,
-						Kind:               virtualmachineTypeMeta.Kind,
-						UID:                vm1Meta.UID,
-						Name:               vm1Meta.Name,
-						Controller:         pointer.Bool(true),
-						BlockOwnerDeletion: pointer.Bool(true),
-					}},
-				},
-				AddressType: discoveryv1.AddressTypeIPv4,
-				Endpoints: []discoveryv1.Endpoint{{
-					Addresses: []string{"192.168.1.3"},
-				}},
-				Ports: []discoveryv1.EndpointPort{{
-					Port:     pointer.Int32(2222),
-					Protocol: &protocolTCP,
-				}},
-			}},
-			hcp: &hyperv1.HostedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Kubevirt: &hyperv1.KubevirtPlatformSpec{
-							GenerateID: "foobar",
-						},
-					},
-				},
-			},
+			hcp: kubevirtHCP,
 		},
 		{
-			name: "With Failing machine with internal ipv4 and service with target port and endpoints",
-			virtualmachine: &kubevirtv1.VirtualMachine{
-				ObjectMeta: vm1Meta,
-			},
-			machine: &capiv1.Machine{
-				TypeMeta:   machineTypeMeta,
-				ObjectMeta: worker1Meta,
-				Spec: capiv1.MachineSpec{
-					InfrastructureRef: corev1.ObjectReference{
-						Kind:       virtualmachineTypeMeta.Kind,
-						APIVersion: virtualmachineTypeMeta.APIVersion,
-						Namespace:  vm1Meta.Namespace,
-						Name:       vm1Meta.Name,
-					},
-				},
-				Status: capiv1.MachineStatus{
-					Phase: string(capiv1.MachinePhaseFailed),
-					Addresses: []capiv1.MachineAddress{{
-						Type:    capiv1.MachineInternalIP,
-						Address: "192.168.1.3",
-					}},
-				},
-			},
-			ingressSvc: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "default-ingress-passthrough-service-foobar",
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{{
-						TargetPort: intstr.FromInt(2222),
-						Protocol:   corev1.ProtocolTCP,
-					}},
-					IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
-				},
-			},
-			ingressEndpointSlices: []discoveryv1.EndpointSlice{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv4",
-					Labels: map[string]string{
-						"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
-						"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
-					},
-					ResourceVersion: "1",
-					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion:         machineTypeMeta.APIVersion,
-						Kind:               machineTypeMeta.Kind,
-						UID:                worker1Meta.UID,
-						Name:               worker1Meta.Name,
-						Controller:         pointer.Bool(true),
-						BlockOwnerDeletion: pointer.Bool(true),
-					}},
-				},
-				AddressType: discoveryv1.AddressTypeIPv4,
-				Endpoints: []discoveryv1.Endpoint{{
-					Addresses: []string{"192.168.1.3"},
-				}},
-				Ports: []discoveryv1.EndpointPort{{
-					Port:     pointer.Int32(2222),
-					Protocol: &protocolTCP,
-				}},
-			}},
-			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv4",
-					Labels: map[string]string{
-						"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
-						"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
-					},
-					ResourceVersion: "2",
-					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion:         machineTypeMeta.APIVersion,
-						Kind:               machineTypeMeta.Kind,
-						UID:                worker1Meta.UID,
-						Name:               worker1Meta.Name,
-						Controller:         pointer.Bool(true),
-						BlockOwnerDeletion: pointer.Bool(true),
-					}},
-				},
-				AddressType: discoveryv1.AddressTypeIPv4,
-				Endpoints:   []discoveryv1.Endpoint{},
-				Ports:       []discoveryv1.EndpointPort{},
-			}},
-			hcp: &hyperv1.HostedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Kubevirt: &hyperv1.KubevirtPlatformSpec{
-							GenerateID: "foobar",
-						},
-					},
-				},
-			},
-		},
-
-		{
-			name: "With Running machine with internal dual stack address and service with target port and no endpoints",
-			virtualmachine: &kubevirtv1.VirtualMachine{
-				ObjectMeta: vm1Meta,
-			},
-			machine: &capiv1.Machine{
-				TypeMeta:   machineTypeMeta,
-				ObjectMeta: worker1Meta,
-				Spec: capiv1.MachineSpec{
-					InfrastructureRef: corev1.ObjectReference{
-						Kind:       virtualmachineTypeMeta.Kind,
-						APIVersion: virtualmachineTypeMeta.APIVersion,
-						Namespace:  vm1Meta.Namespace,
-						Name:       vm1Meta.Name,
-					},
-				},
-				Status: capiv1.MachineStatus{
-					Phase: string(capiv1.MachinePhaseRunning),
-					Addresses: []capiv1.MachineAddress{
-						{
-							Type:    capiv1.MachineInternalIP,
-							Address: "192.168.1.3",
-						},
-						{
-							Type:    capiv1.MachineInternalIP,
-							Address: "2001:db8:a0b:12f0::3",
-						},
-					},
-				},
-			},
-			ingressSvc: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "default-ingress-passthrough-service-foobar",
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{{
-						TargetPort: intstr.FromInt(2222),
-						Protocol:   corev1.ProtocolTCP,
-					}},
-					IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
-				},
+			name:            "Should remove orphan endpoint slices",
+			machines:        pairOfDualStackRunningMachines,
+			virtualMachines: pairOfVirtualMachines,
+			endpointSlices: []discoveryv1.EndpointSlice{
+				defaultIngressEndpointSliceIPv4(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
+				defaultIngressEndpointSliceIPv4(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1]),
+				defaultIngressEndpointSliceIPv6(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
+				defaultIngressEndpointSliceIPv6(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1]),
+				kccmEndpointSliceIPv4(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
+				kccmEndpointSliceIPv4(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1]),
+				kccmEndpointSliceIPv6(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
+				kccmEndpointSliceIPv6(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1]),
+				kccmEndpointSliceIPv4WithNamespace("ns2", pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
 			},
 			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns1-cluster1",
-						Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv4",
-						Labels: map[string]string{
-							"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
-							"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
-						},
-						ResourceVersion: "1",
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion:         virtualmachineTypeMeta.APIVersion,
-							Kind:               virtualmachineTypeMeta.Kind,
-							UID:                vm1Meta.UID,
-							Name:               vm1Meta.Name,
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
-						}},
-					},
-					AddressType: discoveryv1.AddressTypeIPv4,
-					Endpoints: []discoveryv1.Endpoint{{
-						Addresses: []string{"192.168.1.3"},
-					}},
-					Ports: []discoveryv1.EndpointPort{{
-						Port:     pointer.Int32(2222),
-						Protocol: &protocolTCP,
-					}},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns1-cluster1",
-						Name:      "default-ingress-passthrough-service-foobar-" + worker1Meta.Name + "-ipv6",
-						Labels: map[string]string{
-							"kubernetes.io/service-name":             "default-ingress-passthrough-service-foobar",
-							"endpointslice.kubernetes.io/managed-by": "control-plane-operator.hypershift.openshift.io",
-						},
-						ResourceVersion: "1",
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion:         virtualmachineTypeMeta.APIVersion,
-							Kind:               virtualmachineTypeMeta.Kind,
-							UID:                vm1Meta.UID,
-							Name:               vm1Meta.Name,
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
-						}},
-					},
-					AddressType: discoveryv1.AddressTypeIPv6,
-					Endpoints: []discoveryv1.Endpoint{{
-						Addresses: []string{"2001:db8:a0b:12f0::3"},
-					}},
-					Ports: []discoveryv1.EndpointPort{{
-						Port:     pointer.Int32(2222),
-						Protocol: &protocolTCP,
-					}},
-				},
+				kccmEndpointSliceIPv4WithNamespace("ns2", pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0]),
 			},
-			hcp: &hyperv1.HostedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1-cluster1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Kubevirt: &hyperv1.KubevirtPlatformSpec{
-							GenerateID: "foobar",
-						},
-					},
-				},
-			},
+			hcp: kubevirtHCP,
 		},
 	}
 
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			objects := []client.Object{}
-			if tc.ingressSvc != nil {
-				objects = append(objects, tc.ingressSvc)
+			kubevirtInfraClusterObjects := []client.Object{}
+			for _, vm := range tc.virtualMachines {
+				virtualMachine := vm // golang bug referencing for loop vars
+				kubevirtInfraClusterObjects = append(kubevirtInfraClusterObjects, &virtualMachine)
 			}
-			for _, ingressEndpointSlice := range tc.ingressEndpointSlices {
-				objects = append(objects, &ingressEndpointSlice)
+			for _, svc := range tc.services {
+				service := svc // golang bug referencing for loop vars
+				kubevirtInfraClusterObjects = append(kubevirtInfraClusterObjects, &service)
 			}
-			if tc.virtualmachine != nil {
-				objects = append(objects, tc.virtualmachine)
+			for _, eps := range tc.endpointSlices {
+				endpointSlice := eps // golang bug referencing for loop vars
+				kubevirtInfraClusterObjects = append(kubevirtInfraClusterObjects, &endpointSlice)
+			}
+			mgmtClusterObjects := []client.Object{tc.hcp}
+			for _, m := range tc.machines {
+				machine := m
+				mgmtClusterObjects = append(mgmtClusterObjects, &machine)
 			}
 			g := NewWithT(t)
 			r := &reconciler{
-				client:                 fake.NewClientBuilder().Build(),
-				kubevirtInfraClient:    fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objects...).Build(),
+				client:                 fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(mgmtClusterObjects...).Build(),
+				kubevirtInfraClient:    fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(kubevirtInfraClusterObjects...).Build(),
 				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
 			}
-			err := r.reconcileKubevirtDefaultIngressEndpoints(context.Background(), tc.hcp, tc.machine)
-			g.Expect(err != nil).To(Equal(tc.error), func() string {
-				if !tc.error {
-					return fmt.Sprintf("unexpected error: %v", err)
-				} else {
-					return "missing expected error"
-				}
-			})
+			if tc.hcp != nil {
+				r.hcpKey = client.ObjectKeyFromObject(tc.hcp)
+			}
+			for _, m := range tc.machines {
+				_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: m.Namespace,
+					Name:      m.Name,
+				}})
+				g.Expect(err != nil).To(Equal(tc.error), func() string {
+					if !tc.error {
+						return fmt.Sprintf("unexpected error: %v", err)
+					} else {
+						return "missing expected error"
+					}
+				})
+			}
 			obtainedEndpointSliceList := discoveryv1.EndpointSliceList{}
 			g.Expect(r.kubevirtInfraClient.List(context.Background(), &obtainedEndpointSliceList)).To(Succeed())
-			g.Expect(obtainedEndpointSliceList.Items).To(ConsistOf(tc.expectedIngressEndpointSlices))
+			yaml.Marshal(obtainedEndpointSliceList)
+			g.Expect(obtainedEndpointSliceList.Items).To(WithTransform(resetResourceVersionFromEndpointSlices, ConsistOf(tc.expectedIngressEndpointSlices)))
+
+			obtainedServicesList := corev1.ServiceList{}
+			g.Expect(r.kubevirtInfraClient.List(context.Background(), &obtainedServicesList)).To(Succeed())
+			yaml.Marshal(obtainedServicesList)
+			g.Expect(obtainedServicesList.Items).To(WithTransform(resetResourceVersionFromServices, ConsistOf(tc.expectedServices)))
+
 		})
 	}
 }
@@ -478,4 +513,18 @@ type simpleCreateOrUpdater struct{}
 
 func (*simpleCreateOrUpdater) CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
 	return controllerutil.CreateOrUpdate(ctx, c, obj, f)
+}
+
+func resetResourceVersionFromServices(services []corev1.Service) []corev1.Service {
+	for i := range services {
+		services[i].ResourceVersion = ""
+	}
+	return services
+}
+
+func resetResourceVersionFromEndpointSlices(endpointSlices []discoveryv1.EndpointSlice) []discoveryv1.EndpointSlice {
+	for i := range endpointSlices {
+		endpointSlices[i].ResourceVersion = ""
+	}
+	return endpointSlices
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/setup.go
@@ -1,22 +1,34 @@
 package machine
 
 import (
+	"context"
 	"fmt"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
 	"github.com/openshift/hypershift/support/upsert"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+const (
+	tenantServiceNameLabelKey = "cluster.x-k8s.io/tenant-service-name"
+	clusterNameLabelKey       = "cluster.x-k8s.io/cluster-name"
 )
 
 type reconciler struct {
@@ -26,7 +38,15 @@ type reconciler struct {
 	upsert.CreateOrUpdateProvider
 }
 
-func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
+func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig) error {
+	// This controller is just needed at kubevirt to manage passthrough
+	// endpointslices
+	if opts.PlatformType != hyperv1.KubevirtPlatform {
+		return nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Setup")
 	kubevirtScheme := runtime.NewScheme()
 	corev1.AddToScheme(kubevirtScheme)
 	kubevirtv1.AddToScheme(kubevirtScheme)
@@ -42,10 +62,32 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 		return fmt.Errorf("failed creating kubevirt cluster rest mapper: %w", err)
 	}
 
+	hcpKey := client.ObjectKey{
+		Namespace: opts.Namespace,
+		Name:      opts.HCPName,
+	}
+	hcp := &hyperv1.HostedControlPlane{}
+	// Use uncached client so we don't have to start the cache before read
+	// hcp, this is done only at hosted cluster startup so we are not going
+	// to hit api server too much.
+	if err := opts.CPCluster.GetAPIReader().Get(ctx, hcpKey, hcp); err != nil {
+		return fmt.Errorf("failed to get HostedControlPlane: %w", err)
+	}
+
+	kubevirtInfraCache, err := cache.New(opts.KubevirtInfraConfig, cache.Options{
+		Scheme: kubevirtScheme,
+		Mapper: kubevirtMapper,
+		DefaultNamespaces: map[string]cache.Config{
+			kubevirtInfraNamespace(hcp): cache.Config{}},
+	})
+	if err != nil {
+		return fmt.Errorf("failed building kubevirt infra cache: %w", err)
+	}
 	// if kubevirt infra config is not used, it is being set the same as the mgmt config
 	kubevirtInfraClient, err := client.New(opts.KubevirtInfraConfig, client.Options{
 		Scheme: kubevirtScheme,
 		Mapper: kubevirtMapper,
+		Cache:  &client.CacheOptions{Reader: kubevirtInfraCache},
 		WarningHandler: client.WarningHandlerOptions{
 			SuppressWarnings: true,
 		},
@@ -54,12 +96,9 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 		return fmt.Errorf("failed to create kubevirt infra uncached client: %w", err)
 	}
 	r := &reconciler{
-		client:              opts.CPCluster.GetClient(),
-		kubevirtInfraClient: kubevirtInfraClient,
-		hcpKey: client.ObjectKey{
-			Namespace: opts.Namespace,
-			Name:      opts.HCPName,
-		},
+		client:                 opts.CPCluster.GetClient(),
+		kubevirtInfraClient:    kubevirtInfraClient,
+		hcpKey:                 hcpKey,
 		CreateOrUpdateProvider: opts.TargetCreateOrUpdateProvider,
 	}
 	c, err := controller.New("machine", opts.Manager, controller.Options{Reconciler: r})
@@ -69,6 +108,42 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 
 	if err := c.Watch(source.Kind(opts.CPCluster.GetCache(), &capiv1.Machine{}), &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("failed to watch Machines: %w", err)
+	}
+	go kubevirtInfraCache.Start(ctx)
+	allNodes := func(watchContext context.Context, obj client.Object) []reconcile.Request {
+		machineList := &capiv1.MachineList{}
+		if err := r.client.List(watchContext, machineList); err != nil {
+			log.Error(err, "failed listing machines at kubevirt service watch function")
+			return nil
+		}
+		requests := []reconcile.Request{}
+		for _, machine := range machineList.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: machine.Namespace,
+					Name:      machine.Name,
+				},
+			})
+		}
+		return requests
+	}
+	isKCCMService := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		serviceLabels := obj.GetLabels()
+		if len(serviceLabels) == 0 {
+			return false
+		}
+		_, ok := serviceLabels[tenantServiceNameLabelKey]
+		if !ok {
+			return false
+		}
+		obtainedClusterName, ok := serviceLabels[clusterNameLabelKey]
+		if !ok || obtainedClusterName != hcp.Labels[clusterNameLabelKey] {
+			return false
+		}
+		return true
+	})
+	if err := c.Watch(source.Kind(kubevirtInfraCache, &corev1.Service{}), handler.EnqueueRequestsFromMapFunc(allNodes), isKCCMService); err != nil {
+		return fmt.Errorf("failed to watch kubevirt services: %w", err)
 	}
 
 	return nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/node/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/node/setup.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
@@ -10,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
+func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig) error {
 	r := &reconciler{
 		client:                 opts.CPCluster.GetClient(),
 		guestClusterClient:     opts.Manager.GetClient(),

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/nodecount/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/nodecount/setup.go
@@ -1,6 +1,7 @@
 package nodecount
 
 import (
+	"context"
 	"time"
 
 	hypershiftclient "github.com/openshift/hypershift/client/clientset/clientset"
@@ -14,7 +15,7 @@ import (
 
 const ControllerName = "nodecount"
 
-func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
+func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig) error {
 	hypershiftClient, err := hypershiftclient.NewForConfig(opts.CPCluster.GetConfig())
 	if err != nil {
 		return err

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -123,7 +123,7 @@ func eventHandler() handler.EventHandler {
 		})
 }
 
-func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
+func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig) error {
 	if err := imageregistryv1.Install(opts.Manager.GetScheme()); err != nil {
 		return fmt.Errorf("failed to add to scheme: %w", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -45,7 +45,7 @@ func cacheLabelSelector() labels.Selector {
 	return selector
 }
 
-type ControllerSetupFunc func(*HostedClusterConfigOperatorConfig) error
+type ControllerSetupFunc func(context.Context, *HostedClusterConfigOperatorConfig) error
 
 type HostedClusterConfigOperatorConfig struct {
 	Manager                      ctrl.Manager
@@ -187,7 +187,7 @@ func (c *HostedClusterConfigOperatorConfig) Fatal(err error, msg string) {
 func (c *HostedClusterConfigOperatorConfig) Start(ctx context.Context) error {
 	for controllerName, setupFunc := range c.ControllerFuncs {
 		c.Logger.Info("setting up controller", "controller", controllerName)
-		if err := setupFunc(c); err != nil {
+		if err := setupFunc(ctx, c); err != nil {
 			return fmt.Errorf("cannot setup controller %s: %v", controllerName, err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
With kubevirt cluster use selectorless cloud-provider-kubevirt and reconcile endpointslices pointing to all the VMs. 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.