### PR TITLE
Revert "CNV-36608: Enable InPlace NodePool upgrade test for kubevirt"

### DIFF
--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -96,6 +96,12 @@ func NewNodePoolUpgradeTest(ctx context.Context, mgmtClient crclient.Client, hos
 }
 
 func (ru *NodePoolUpgradeTest) Setup(t *testing.T) {
+	// Currently, only ReplaceUpgrade strategy test passes for the kubevirt platform.
+	// TODO: Enable InPlace upgrade test as well once the issue is identified and fixed.
+	if globalOpts.Platform == hyperv1.KubevirtPlatform && t.Name() == "TestNodePool/Main/TestNodePoolInPlaceUpgrade" {
+		t.Skip("InPlace Upgrade test currently can't run for the KubeVirt platform")
+	}
+
 	t.Log("starting test NodePoolUpgradeTest")
 }
 


### PR DESCRIPTION
Reverts openshift/hypershift#3517

There is a suspicion that this test causes flakes for the entire kubevirt nodepool test suite and reduces the job's pass rate.