### PR TITLE
NO-JIRA: Remove CLI inspection of release image

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -44,6 +44,7 @@ func NewCreateCommands() *cobra.Command {
 		Arch:                           "amd64",
 		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
 		OLMDisableDefaultSources:       false,
+		NetworkType:                    string(v1beta1.OVNKubernetes),
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -23,7 +23,6 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/util"
@@ -31,7 +30,6 @@ import (
 	apifixtures "github.com/openshift/hypershift/examples/fixtures"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/globalconfig"
-	"github.com/openshift/hypershift/support/releaseinfo"
 )
 
 // ApplyPlatformSpecifics can be used to create platform specific values as well as enriching the fixture with additional values
@@ -207,10 +205,6 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 			return nil, fmt.Errorf("release image is required when unable to lookup default OCP version: %w", err)
 		}
 		opts.ReleaseImage = defaultVersion.PullSpec
-	}
-
-	if err := defaultNetworkType(ctx, opts, &releaseinfo.RegistryClientProvider{}, os.ReadFile); err != nil {
-		return nil, fmt.Errorf("failed to default network: %w", err)
 	}
 
 	annotations := map[string]string{}
@@ -523,54 +517,4 @@ func CreateCluster(ctx context.Context, opts *CreateOptions, platformSpecificApp
 
 	// Otherwise, apply the objects
 	return apply(ctx, opts.Log, exampleOptions, opts.Wait, opts.BeforeApply)
-}
-
-func defaultNetworkType(ctx context.Context, opts *CreateOptions, releaseProvider releaseinfo.Provider, readFile func(string) ([]byte, error)) error {
-	if opts.NetworkType != "" {
-		return nil
-	} else if opts.ReleaseImage == "" {
-		opts.NetworkType = string(hyperv1.OVNKubernetes)
-		return nil
-	}
-
-	version, err := getReleaseSemanticVersion(ctx, opts, releaseProvider, readFile)
-	if err != nil {
-		return fmt.Errorf("failed to get version for release image %s: %w", opts.ReleaseImage, err)
-	}
-	if version.Minor > 10 {
-		opts.NetworkType = string(hyperv1.OVNKubernetes)
-	} else {
-		opts.NetworkType = string(hyperv1.OpenShiftSDN)
-	}
-
-	return nil
-}
-
-func getReleaseSemanticVersion(ctx context.Context, opts *CreateOptions, provider releaseinfo.Provider, readFile func(string) ([]byte, error)) (*semver.Version, error) {
-	var pullSecretBytes []byte
-	var err error
-	if len(opts.CredentialSecretName) > 0 {
-		pullSecretBytes, err = util.GetPullSecret(opts.CredentialSecretName, opts.Namespace)
-		if err != nil {
-			return nil, err
-		}
-	}
-	// overrides secret if set
-	if len(opts.PullSecretFile) > 0 {
-		pullSecretBytes, err = readFile(opts.PullSecretFile)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read pull secret file %s: %w", opts.PullSecretFile, err)
-		}
-
-	}
-
-	releaseImage, err := provider.Lookup(ctx, opts.ReleaseImage, pullSecretBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get version information from %s: %w", opts.ReleaseImage, err)
-	}
-	semanticVersion, err := semver.Parse(releaseImage.Version())
-	if err != nil {
-		return nil, err
-	}
-	return &semanticVersion, nil
 }

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -38,6 +38,7 @@ func NewCreateCommands() *cobra.Command {
 		PausedUntil:                    "",
 		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
 		OLMDisableDefaultSources:       false,
+		NetworkType:                    string(v1beta1.OVNKubernetes),
 	}
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
Previously, the hcp client tool would dynamically inspect the release image to determine what the version was in use, and use that information to default the network type.

That inspection of the release image causes issues in the disconnected use case. It's possible that the machine someone is executing the client on can't directly access the image registry. In this situation, the client fails and prevents a user from being able to create a cluster.

Moving forward, we need the client to only require access to the api server of the mgmt cluster.