### PR TITLE
NO-JIRA: Developer namespace template for CI clusters

### DIFF
--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -30,3 +30,25 @@ Store the kubeconfig in Vault [under the clusters directory](https://vault.ci.op
 }
 ```
 
+## Template for developer namespaces
+
+Deploy the template for developer namespaces (only needs to be done one time per CI cluster):
+
+```shell
+oc apply -f dev-namespace-template.yaml
+```
+
+
+## Using the developer namespace template
+
+This will enable developers to create their own namespace (and kubeconfig) for their cluster using the following command:
+
+```shell
+NAME=your-name
+oc new-app developer-namespace -p NAME=$NAME
+token=$(oc get secrets -n $NAME -o name | grep $NAME-dev-token | xargs oc get -o jsonpath='{.data.token}' -n $NAME | base64 -d)
+oc login --token=$token
+```
+
+After doing this, the default context on your kubeconfig will be the low-privilege service account in your namespace, useful
+for creating HostedClusters and NodePools. If you still need privileged access, you can pass `--context=admin` to any `oc` command.

--- a/contrib/ci/dev-namespace-template.yaml
+++ b/contrib/ci/dev-namespace-template.yaml
@@ -1,0 +1,94 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+metadata:
+  name: developer-namespace
+  namespace: openshift
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: ${NAME}
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ${NAME}-dev
+    namespace: ${NAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: hypershift
+    namespace: ${NAME}
+  rules:
+  - apiGroups:
+    - hypershift.openshift.io
+    resources:
+    - hostedclusters
+    - nodepools
+    - nodepools/scale
+    - nodepools/admin
+    verbs:
+    - "*"
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    - configmaps
+    verbs:
+    - "*"
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: hypershift
+    namespace: ${NAME}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: hypershift
+  subjects:
+  - kind: ServiceAccount
+    name: ${NAME}-dev
+    namespace: ${NAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: edit-0
+    namespace: ${NAME}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: edit
+  subjects:
+  - kind: ServiceAccount
+    name: ${NAME}-dev
+    namespace: ${NAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: ${NAME}-namespace-patcher
+  rules:
+  - apiGroups:
+    - ""
+    resourceNames:
+    - ${NAME}
+    resources:
+    - namespaces
+    verbs:
+    - patch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ${NAME}-namespace-patcher
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: ${NAME}-namespace-patcher
+  subjects:
+  - kind: ServiceAccount
+    name: ${NAME}-dev
+    namespace: ${NAME}
+parameters:
+- description: Name of developer namespace
+  displayName: Name
+  name: NAME
+  required: true


### PR DESCRIPTION
Adds a template for developers to use in creating their own management clusters on a CI cluster.