### PR TITLE
NO-JIRA: Reduce nodepool test cases for KubeVirt due to infra perf issues

### DIFF
--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -52,6 +52,9 @@ func NewNodePoolMachineconfigRolloutTest(ctx context.Context, mgmtClient crclien
 }
 
 func (mc *NodePoolMachineconfigRolloutTest) Setup(t *testing.T) {
+	if globalOpts.Platform == hyperv1.KubevirtPlatform {
+		t.Skip("test is being skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
+	}
 	t.Log("Starting test NodePoolMachineconfigRolloutTest")
 }
 

--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -72,8 +72,8 @@ func NewNTOMachineConfigRolloutTest(ctx context.Context, mgmtClient crclient.Cli
 func (mc *NTOMachineConfigRolloutTest) Setup(t *testing.T) {
 	t.Log("Starting test NTOMachineConfigRolloutTest")
 
-	if mc.inplace && globalOpts.Platform == hyperv1.KubevirtPlatform {
-		t.Skip("test can't run for the platform kubevirt")
+	if globalOpts.Platform == hyperv1.KubevirtPlatform {
+		t.Skip("test is being skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
 	}
 }
 


### PR DESCRIPTION
The increase in KubeVirt specific nodepool tests has introduced instability into the test suite. This instability is a result of increasing the number of parallel VMs that are created during the nodepool tests to account for the KubeVirt unique test cases. The infra is performing inconsistently which results in unpredictable variations in the VM startup time.

For now, we're reducing some of the generic test cases that were previously exercised for the KubeVirt platform. The aws lane covers these generic cases and the kubevirt lane covers the kubevirt unique nodepool cases.

Related to: https://issues.redhat.com/browse/CNV-38196