### PR TITLE
OCPBUGS-23997: add HCP pullsecret to HCCO cache

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"k8s.io/apimachinery/pkg/fields"
 	"os"
 	"time"
 
@@ -123,6 +125,13 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 				&operatorv1.CloudCredential{}: allSelector,
 				&admissionregistrationv1.ValidatingWebhookConfiguration{}: allSelector,
 				&admissionregistrationv1.MutatingWebhookConfiguration{}:   allSelector,
+
+				&corev1.Secret{}: cache.ObjectSelector{
+					Field: fields.AndSelectors(
+						fields.OneTermEqualSelector("metadata.namespace", namespace),
+						fields.OneTermEqualSelector("metadata.name", manifests.PullSecret(namespace).Name),
+					),
+				},
 
 				// Needed for inplace upgrader.
 				&corev1.Node{}: allSelector,


### PR DESCRIPTION
**What this PR does / why we need it**: Adds pull secret to HCCO cache so that a watch on the  pull secret can operate properly

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-23997](https://issues.redhat.com/browse/OCPBUGS-23997)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.