### PR TITLE
OCPBUGS-29586: use 2040 for apiserver svc in IBM provider

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -192,7 +192,7 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 		},
 	}
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Spec.Platform.Type), availabilityProberImage, &deployment.Spec.Template.Spec)
 
 	deploymentConfig := config.DeploymentConfig{
 		AdditionalLabels: map[string]string{

--- a/control-plane-operator/controllers/hostedcontrolplane/cco/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cco/reconcile.go
@@ -85,7 +85,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	return params
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, params Params) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, params Params, platformType hyperv1.PlatformType) error {
 	params.OwnerRef.ApplyTo(deployment)
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
@@ -111,7 +111,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, params Params) error {
 	}
 
 	params.deploymentConfig.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), params.availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), params.availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = volumeServiceAccountKubeconfig().Name
 		o.WaitForInfrastructureResource = true
 		o.RequiredAPIs = []schema.GroupVersionKind{

--- a/control-plane-operator/controllers/hostedcontrolplane/cco/reconcile_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cco/reconcile_test.go
@@ -37,7 +37,7 @@ func TestReconcileDeployment(t *testing.T) {
 	deployment := manifests.CloudCredentialOperatorDeployment("test-namespace")
 	imageProvider := imageprovider.NewFromImages(images)
 	params := NewParams(hcp, "1.0.0", imageProvider, true)
-	if err := ReconcileDeployment(deployment, params); err != nil {
+	if err := ReconcileDeployment(deployment, params, hcp.Spec.Platform.Type); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	deploymentYaml, err := util.SerializeResource(deployment, hyperapi.Scheme)

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/deployment.go
@@ -32,7 +32,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, image string, deploymentConfig config.DeploymentConfig, availabilityProberImage string) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, image string, deploymentConfig config.DeploymentConfig, availabilityProberImage string, platformType hyperv1.PlatformType) error {
 	// preserve existing resource requirements for main CPC container
 	mainContainer := util.FindContainer(cpcContainerMain().Name, deployment.Spec.Template.Spec.Containers)
 	if mainContainer != nil {
@@ -64,7 +64,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	deployment.Spec.Template.Spec.AutomountServiceAccountToken = pointer.Bool(false)
 	deploymentConfig.ApplyTo(deployment)
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), availabilityProberImage, &deployment.Spec.Template.Spec)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -294,7 +294,7 @@ func ReconcileServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef
 	return nil
 }
 
-func ReconcileDeployment(dep *appsv1.Deployment, params Params) error {
+func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyperv1.PlatformType) error {
 	params.OwnerRef.ApplyTo(dep)
 
 	cnoResources := corev1.ResourceRequirements{
@@ -568,7 +568,7 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 	}
 
 	params.DeploymentConfig.ApplyTo(dep)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), params.AvailabilityProberImage, &dep.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), params.AvailabilityProberImage, &dep.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "hosted-etc-kube"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operator.openshift.io", Version: "v1", Kind: "Network"},

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
@@ -36,7 +36,7 @@ func TestReconcileDeployment(t *testing.T) {
 			}
 
 			dep := &appsv1.Deployment{}
-			if err := ReconcileDeployment(dep, tc.params); err != nil {
+			if err := ReconcileDeployment(dep, tc.params, hyperv1.NonePlatform); err != nil {
 				t.Fatalf("ReconcileDeployment: %v", err)
 			}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -328,7 +328,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 	}
 
 	deploymentConfig.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Spec.Platform.Type), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "imageregistry.operator.openshift.io", Version: "v1", Kind: "Config"},

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -158,7 +158,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 	}
 	deploymentConfig.ApplyTo(deployment)
 	util.AvailabilityProber(
-		kas.InClusterKASReadyURL(),
+		kas.InClusterKASReadyURL(platformType),
 		availabilityProberImage,
 		&deployment.Spec.Template.Spec,
 		func(o *util.AvailabilityProberOpts) {

--- a/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
@@ -104,7 +104,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 // hosted-cluster services, or external services, so the operator does not
 // require any special proxy configuration or permissions in the management
 // cluster.
-func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
+func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyperv1.PlatformType) {
 	dep.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{"name": "dns-operator"},
 	}
@@ -161,7 +161,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
 		},
 	}}
 	util.AvailabilityProber(
-		kas.InClusterKASReadyURL(),
+		kas.InClusterKASReadyURL(platformType),
 		params.AvailabilityProberImage,
 		&dep.Spec.Template.Spec,
 		func(o *util.AvailabilityProberOpts) {

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -96,7 +96,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	return p
 }
 
-func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
+func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyperv1.PlatformType) {
 	ingressOpResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("80Mi"),
@@ -110,6 +110,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
 			ingressOpResources = mainContainer.Resources
 		}
 	}
+
 	dep.Spec.Replicas = utilpointer.Int32(1)
 	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"name": operatorName}}
 	dep.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
@@ -213,7 +214,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params) {
 	}
 
 	util.AvailabilityProber(
-		kas.InClusterKASReadyURL(),
+		kas.InClusterKASReadyURL(platformType),
 		params.AvailabilityProberImage,
 		&dep.Spec.Template.Spec,
 		func(o *util.AvailabilityProberOpts) {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -169,6 +169,9 @@ func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlan
 	}
 
 	portSpec.Port = int32(config.KASSVCPort)
+	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+		portSpec.Port = int32(config.KASSVCIBMCloudPort)
+	}
 	portSpec.Protocol = corev1.ProtocolTCP
 	portSpec.TargetPort = intstr.FromString("client")
 	svc.Spec.Type = corev1.ServiceTypeLoadBalancer

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -64,7 +64,7 @@ func kcmLabels() map[string]string {
 	}
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceServingCA *corev1.ConfigMap, p *KubeControllerManagerParams) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceServingCA *corev1.ConfigMap, p *KubeControllerManagerParams, platformType hyperv1.PlatformType) error {
 	// preserve existing resource requirements for main KCM container
 	mainContainer := util.FindContainer(kcmContainerMain().Name, deployment.Spec.Template.Spec.Containers)
 	if mainContainer != nil {
@@ -128,7 +128,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, config, rootCA, serviceS
 	applyCloudConfigVolumeMount(&deployment.Spec.Template.Spec, p.CloudProviderConfig, p.CloudProvider)
 	util.ApplyCloudProviderCreds(&deployment.Spec.Template.Spec, p.CloudProvider, p.CloudProviderCreds, p.TokenMinterImage, kcmContainerMain().Name)
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), p.AvailabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), p.AvailabilityProberImage, &deployment.Spec.Template.Spec)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
@@ -183,7 +183,7 @@ func ReconcileMachineApproverDeployment(deployment *appsv1.Deployment, hcp *hype
 		},
 	}
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Spec.Platform.Type), availabilityProberImage, &deployment.Spec.Template.Spec)
 
 	deploymentConfig := config.DeploymentConfig{
 		Scheduling: config.Scheduling{

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -76,7 +76,7 @@ func openShiftAPIServerLabels() map[string]string {
 	}
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, auditWebhookRef *corev1.LocalObjectReference, ownerRef config.OwnerRef, config *corev1.ConfigMap, auditConfig *corev1.ConfigMap, serviceServingCA *corev1.ConfigMap, deploymentConfig config.DeploymentConfig, image string, socks5ProxyImage string, etcdURL string, availabilityProberImage string, internalOAuthDisable bool) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, auditWebhookRef *corev1.LocalObjectReference, ownerRef config.OwnerRef, config *corev1.ConfigMap, auditConfig *corev1.ConfigMap, serviceServingCA *corev1.ConfigMap, deploymentConfig config.DeploymentConfig, image string, socks5ProxyImage string, etcdURL string, availabilityProberImage string, internalOAuthDisable bool, platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main OAS container
@@ -187,7 +187,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, auditWebhookRef *corev1.
 		applyOASAuditWebhookConfigFileVolume(&deployment.Spec.Template.Spec, auditWebhookRef)
 	}
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), availabilityProberImage, &deployment.Spec.Template.Spec)
 
 	deploymentConfig.ApplyTo(deployment)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -54,7 +54,7 @@ func openShiftOAuthAPIServerLabels() map[string]string {
 	}
 }
 
-func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, auditConfig *corev1.ConfigMap, p *OAuthDeploymentParams) error {
+func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, auditConfig *corev1.ConfigMap, p *OAuthDeploymentParams, platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main oauth apiserver container
@@ -132,7 +132,7 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 		applyOauthAuditWebhookConfigFileVolume(&deployment.Spec.Template.Spec, p.AuditWebhookRef)
 	}
 
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), p.AvailabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), p.AvailabilityProberImage, &deployment.Spec.Template.Spec)
 	p.DeploymentConfig.ApplyTo(deployment)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -52,7 +52,7 @@ func oauthLabels() map[string]string {
 	}
 }
 
-func ReconcileDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment, ownerRef config.OwnerRef, config *corev1.ConfigMap, image string, deploymentConfig config.DeploymentConfig, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, availabilityProberImage string, namedCertificates []configv1.APIServerNamedServingCert, socks5ProxyImage string, noProxy []string, params *OAuthConfigParams) error {
+func ReconcileDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment, ownerRef config.OwnerRef, config *corev1.ConfigMap, image string, deploymentConfig config.DeploymentConfig, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, availabilityProberImage string, namedCertificates []configv1.APIServerNamedServingCert, socks5ProxyImage string, noProxy []string, params *OAuthConfigParams, platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main oauth container
@@ -124,7 +124,7 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMountInfo.VolumeMounts.ContainerMounts(oauthContainerMain().Name)...)
 	}
 	globalconfig.ApplyNamedCertificateMounts(oauthContainerMain().Name, oauthNamedCertificateMountPathPrefix, namedCertificates, &deployment.Spec.Template.Spec)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), availabilityProberImage, &deployment.Spec.Template.Spec)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/assets"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -13,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
@@ -51,7 +51,7 @@ func ReconcileCatalogOperatorMetricsService(svc *corev1.Service, ownerRef config
 	return nil
 }
 
-func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, operatorRegistryImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string) error {
+func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, operatorRegistryImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string, platformType hyperv1.PlatformType) error {
 	// preserve existing resource requirements
 	mainContainer := util.FindContainer(catalogOperatorName, deployment.Spec.Template.Spec.Containers)
 	if mainContainer != nil {
@@ -85,7 +85,7 @@ func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef 
 		}
 	}
 	dc.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},
@@ -109,7 +109,7 @@ func ReconcileOLMOperatorMetricsService(svc *corev1.Service, ownerRef config.Own
 	return nil
 }
 
-func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string) error {
+func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string, platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements
@@ -141,7 +141,7 @@ func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef conf
 		}
 	}
 	dc.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
@@ -3,13 +3,14 @@ package olm
 import (
 	"strings"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/support/assets"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 )
@@ -22,7 +23,7 @@ var (
 	packageServerDeployment = assets.MustDeployment(content.ReadFile, "assets/packageserver-deployment.yaml")
 )
 
-func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string) error {
+func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, olmImage, socks5ProxyImage, releaseVersion string, dc config.DeploymentConfig, availabilityProberImage string, noProxy []string, platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements
@@ -54,7 +55,7 @@ func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef co
 		}
 	}
 	dc.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), availabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/deployment.go
@@ -47,7 +47,7 @@ var (
 	}
 )
 
-func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, featureGates []string, policy configv1.ConfigMapNameReference, availabilityProberImage string, ciphers []string, tlsVersion string, disableProfiling bool, schedulerConfig *corev1.ConfigMap) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, config config.DeploymentConfig, image string, featureGates []string, policy configv1.ConfigMapNameReference, availabilityProberImage string, ciphers []string, tlsVersion string, disableProfiling bool, schedulerConfig *corev1.ConfigMap, platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main scheduler container
@@ -94,7 +94,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 		},
 	}
 	config.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), availabilityProberImage, &deployment.Spec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), availabilityProberImage, &deployment.Spec.Template.Spec)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator.go
@@ -1,6 +1,7 @@
 package snapshotcontroller
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets"
@@ -21,7 +22,8 @@ var (
 
 func ReconcileOperatorDeployment(
 	deployment *appsv1.Deployment,
-	params *Params) error {
+	params *Params,
+	platformType hyperv1.PlatformType) error {
 
 	params.OwnerRef.ApplyTo(deployment)
 	deployment.Spec = operatorDeployment.DeepCopy().Spec
@@ -45,7 +47,7 @@ func ReconcileOperatorDeployment(
 		}
 	}
 	params.DeploymentConfig.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), params.AvailabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), params.AvailabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "guest-kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operator.openshift.io", Version: "v1", Kind: "CSISnapshotController"},

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator_test.go
@@ -35,7 +35,7 @@ func TestReconcileOperatorDeployment(t *testing.T) {
 	deployment := manifests.CSISnapshotControllerOperatorDeployment("test-namespace")
 	imageProvider := imageprovider.NewFromImages(images)
 	params := NewParams(hcp, "1.0.0", imageProvider, true)
-	if err := ReconcileOperatorDeployment(deployment, params); err != nil {
+	if err := ReconcileOperatorDeployment(deployment, params, hyperv1.NonePlatform); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	deploymentYaml, err := util.SerializeResource(deployment, api.Scheme)

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/storage/assets"
@@ -20,7 +21,8 @@ var (
 
 func ReconcileOperatorDeployment(
 	deployment *appsv1.Deployment,
-	params *Params) error {
+	params *Params,
+	platformType hyperv1.PlatformType) error {
 
 	params.OwnerRef.ApplyTo(deployment)
 	deployment.Spec = operatorDeployment.DeepCopy().Spec
@@ -33,7 +35,7 @@ func ReconcileOperatorDeployment(
 	}
 
 	params.DeploymentConfig.ApplyTo(deployment)
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), params.AvailabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
+	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), params.AvailabilityProberImage, &deployment.Spec.Template.Spec, func(o *util.AvailabilityProberOpts) {
 		o.KubeconfigVolumeName = "guest-kubeconfig"
 		o.RequiredAPIs = []schema.GroupVersionKind{
 			{Group: "operator.openshift.io", Version: "v1", Kind: "Storage"},

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -230,7 +230,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 			},
 		},
 	}
-	util.AvailabilityProber(kas.InClusterKASReadyURL(), p.utilitiesImage, &deploymentSpec.Template.Spec)
+	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Spec.Platform.Type), p.utilitiesImage, &deploymentSpec.Template.Spec)
 	return deploymentSpec, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -158,6 +158,9 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 
 func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster, isOpenShiftDNS bool, managementClusterNetwork *configv1.Network) error {
 	port := intstr.FromInt32(config.KASSVCPort)
+	if hcluster.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+		port = intstr.FromInt32(config.KASSVCIBMCloudPort)
+	}
 	protocol := corev1.ProtocolTCP
 	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
 	policy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -32,6 +32,7 @@ const (
 	KASSVCLBAzurePort           = 7443
 	KASSVCPort                  = 6443
 	KASPodDefaultPort           = 6443
+	KASSVCIBMCloudPort          = 2040
 	DefaultServiceNodePortRange = "30000-32767"
 	DefaultSecurityContextUser  = 1001
 	RecommendedLeaseDuration    = "137s"


### PR DESCRIPTION
**What this PR does / why we need it**:
A recent [PR](https://github.com/openshift/hypershift/commit/c030ab66d897815e16d15c987456deab8d0d6da0) updated the kube-apiserver service port to `6443`. That change causes a small outage when upgrading from a 4.13 cluster in IBMCloud. This PR makes changes to remain on `2040` as the kube-apiserver  service.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/OCPBUGS-29586

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.