### PR TITLE
OCPBUGS-29440: Add additional K8s RBAC to control-plane-operator

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2852,6 +2852,21 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role, enableCVOManagementClu
 				"update",
 			},
 		},
+		{ // Needed for the CPO PKI controller to approve certificate signing requests
+			APIGroups: []string{"certificates.hypershift.openshift.io"},
+			Resources: []string{"certificatesigningrequestapprovals"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{ // Needed for the CPO PKI controller to perform certificate revocation
+			APIGroups: []string{"certificates.hypershift.openshift.io"},
+			Resources: []string{"certificaterevocationrequests"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{ // Needed for the CPO PKI controller to perform certificate revocation
+			APIGroups: []string{"certificates.hypershift.openshift.io"},
+			Resources: []string{"certificaterevocationrequests/status"},
+			Verbs:     []string{"patch"},
+		},
 	}
 	if enableCVOManagementClusterMetricsAccess {
 		role.Rules = append(role.Rules,


### PR DESCRIPTION
**What this PR does / why we need it**:

In #3339, additional K8s RBAC was granted to the
control-plane-pki-operator role, however since the control-plane-operator role itself does not have the "elevate" verb on role resources, it cannot grant these additional permissions unless it has the permissions itself.

**Which issue(s) this PR fixes**:
OCPBUGS-29440

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.