### PR TITLE
OCPBUGS-29115: Default NodeUpgradeType on day2 nodepool creation

### DIFF
--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -72,6 +72,26 @@ func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts
 		releaseImage = hcluster.Spec.Release.Image
 	}
 
+	// Set default upgrade type when the flag is empty
+	if o.NodeUpgradeType == "" {
+		switch hcluster.Spec.Platform.Type {
+		case hyperv1.AWSPlatform:
+			o.NodeUpgradeType = hyperv1.UpgradeTypeReplace
+		case hyperv1.KubevirtPlatform:
+			o.NodeUpgradeType = hyperv1.UpgradeTypeReplace
+		case hyperv1.NonePlatform:
+			o.NodeUpgradeType = hyperv1.UpgradeTypeInPlace
+		case hyperv1.AgentPlatform:
+			o.NodeUpgradeType = hyperv1.UpgradeTypeInPlace
+		case hyperv1.AzurePlatform:
+			o.NodeUpgradeType = hyperv1.UpgradeTypeReplace
+		case hyperv1.PowerVSPlatform:
+			o.NodeUpgradeType = hyperv1.UpgradeTypeReplace
+		default:
+			panic("Unsupported platform")
+		}
+	}
+
 	nodePool = &hyperv1.NodePool{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NodePool",


### PR DESCRIPTION
This bug regards on a day2 nodepool creation. If you creates a cluster using the CLI, it defaults the NodepoolUpgradeType according to the HostedCluster Platform Type. With this PR we also covers the day 2 Nodepool creation which is not using the default fixtures.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-29115](https://issues.redhat.com/browse/OCPBUGS-29115)