### PR TITLE
NO-JIRA: Ignore kubectl version mistmaches in Component Versions

### DIFF
--- a/support/releaseinfo/releaseinfo.go
+++ b/support/releaseinfo/releaseinfo.go
@@ -148,7 +148,6 @@ func readComponentVersions(is *imageapi.ImageStream) (ComponentVersions, []error
 	var errs []error
 	combined := make(map[string]sets.String)
 	combinedDisplayNames := make(map[string]sets.String)
-	kubectlVersions := sets.New[string]()
 	for _, tag := range is.Spec.Tags {
 		versions, ok := tag.Annotations[annotationBuildVersions]
 		if !ok {
@@ -160,7 +159,6 @@ func readComponentVersions(is *imageapi.ImageStream) (ComponentVersions, []error
 		}
 		for k, v := range all {
 			if k == "kubectl" {
-				kubectlVersions.Insert(v.Version)
 				if tag.Name != "cli" && tag.Name != "cli-artifacts" {
 					continue
 				}
@@ -182,9 +180,6 @@ func readComponentVersions(is *imageapi.ImageStream) (ComponentVersions, []error
 	}
 
 	multiples := sets.NewString()
-	if kubectlVersions.Len() > 2 {
-		multiples.Insert("kubectl")
-	}
 	var out ComponentVersions
 	var keys []string
 	for k := range combined {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR incorporates the changes in openshift/oc#1685 in Hypershift but with a slight 
differences. Since oc uses all the component versions, we are printing a warning to a user
about kubectl mismatches. On the other hand, Hypershift only deals with [version](https://github.com/openshift/hypershift/blob/b4209f3c421a319efa0a350737edc17318fd87ae/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go#L2073) and
[kubernetes](https://github.com/openshift/hypershift/blob/e8a0c300a659d8d3cb0507b842771ee820a9554e/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go#L3954) fields in component versions and there is no benefit of a kubectl version mismatch warning. 
Besides, printing a warning would require parameter changes in functions to pass `ErrOut`.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.