### PR TITLE
HOSTEDCP-1424: ARO HCP Support Disabling Outbound SNAT

### DIFF
--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -88,7 +88,11 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			return fmt.Errorf("failed to retrieve RHCOS image: %w", err)
 		}
 
-		infraID := infraid.New(opts.Name)
+		infraID := opts.InfraID
+		if len(infraID) == 0 {
+			infraID = infraid.New(opts.Name)
+		}
+
 		infra, err = (&azureinfra.CreateInfraOptions{
 			Name:                 opts.Name,
 			Location:             opts.AzurePlatform.Location,

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -58,6 +58,7 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 		VnetResourceGroup:            hcp.Spec.Platform.Azure.ResourceGroupName,
 		SubnetName:                   hcp.Spec.Platform.Azure.SubnetName,
 		SecurityGroupName:            hcp.Spec.Platform.Azure.SecurityGroupName,
+		LoadBalancerName:             hcp.Spec.InfraID,
 		CloudProviderBackoff:         true,
 		CloudProviderBackoffDuration: 6,
 		UseInstanceMetadata:          true,
@@ -90,4 +91,5 @@ type AzureConfig struct {
 	UseInstanceMetadata          bool   `json:"useInstanceMetadata"`
 	LoadBalancerSku              string `json:"loadBalancerSku"`
 	DisableOutboundSNAT          bool   `json:"disableOutboundSNAT"`
+	LoadBalancerName             string `json:"loadBalancerName"`
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -62,6 +62,7 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 		CloudProviderBackoffDuration: 6,
 		UseInstanceMetadata:          true,
 		LoadBalancerSku:              "standard",
+		DisableOutboundSNAT:          true,
 	}
 }
 
@@ -88,4 +89,5 @@ type AzureConfig struct {
 	CloudProviderBackoffDuration int    `json:"cloudProviderBackoffDuration"`
 	UseInstanceMetadata          bool   `json:"useInstanceMetadata"`
 	LoadBalancerSku              string `json:"loadBalancerSku"`
+	DisableOutboundSNAT          bool   `json:"disableOutboundSNAT"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides support for disabling outbound SNAT through the Azure Cloud Provider configuration. This is accomplished by providing the Azure Cloud Provider configuration a load balancer to use and setting the flag to disable outbound SNAT.

In addition, this PR updates the HyperShift CLI by creating a load balancer, with an outbound rule, and public IP address when creating Azure infrastructure. The Azure Cloud Provider will use the load balancer to add an additional public IP address and the appropriate load balancer rules.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1424](https://issues.redhat.com/browse/HOSTEDCP-1424)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.