### PR TITLE
NO-JIRA: Re-enable InPlace NodePool upgrade test for kubevirt (CNV-36608)

### DIFF
--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -96,12 +96,6 @@ func NewNodePoolUpgradeTest(ctx context.Context, mgmtClient crclient.Client, hos
 }
 
 func (ru *NodePoolUpgradeTest) Setup(t *testing.T) {
-	// Currently, only ReplaceUpgrade strategy test passes for the kubevirt platform.
-	// TODO: Enable InPlace upgrade test as well once the issue is identified and fixed.
-	if globalOpts.Platform == hyperv1.KubevirtPlatform && t.Name() == "TestNodePool/Main/TestNodePoolInPlaceUpgrade" {
-		t.Skip("InPlace Upgrade test currently can't run for the KubeVirt platform")
-	}
-
 	t.Log("starting test NodePoolUpgradeTest")
 }
 


### PR DESCRIPTION
Reverts openshift/hypershift#3547

The fix for the inplace upgrade has been fixed on MCO side and merged at https://github.com/openshift/machine-config-operator/pull/4190

Re-enabling the test to validate kubevirt provider can now perform NodePool InPlace upgrades.