### PR TITLE
OCPBUGS-29855: feat(ho): Add flag for dedicated request serving isolation

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -344,6 +344,7 @@ type HyperShiftOperatorDeployment struct {
 	MonitoringDashboards                    bool
 	CertRotationScale                       time.Duration
 	EnableCVOManagementClusterMetricsAccess bool
+	EnableDedicatedRequestServingIsolation  bool
 }
 
 func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
@@ -352,6 +353,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 		"--namespace=$(MY_NAMESPACE)",
 		"--pod-name=$(MY_NAME)",
 		"--metrics-addr=:9000",
+		fmt.Sprintf("--enable-dedicated-request-serving-isolation=%t", o.EnableDedicatedRequestServingIsolation),
 		fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", o.EnableOCPClusterMonitoring),
 		fmt.Sprintf("--enable-ci-debug-output=%t", o.EnableCIDebugOutput),
 		fmt.Sprintf("--private-platform=%s", o.PrivatePlatform),

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -42,6 +42,7 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 				"--namespace=$(MY_NAMESPACE)",
 				"--pod-name=$(MY_NAME)",
 				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-dedicated-request-serving-isolation=%t", false),
 				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
 				fmt.Sprintf("--enable-ci-debug-output=%t", false),
 				fmt.Sprintf("--private-platform=%s", string(hyperv1.NonePlatform)),
@@ -91,6 +92,7 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 				"--namespace=$(MY_NAMESPACE)",
 				"--pod-name=$(MY_NAME)",
 				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-dedicated-request-serving-isolation=%t", false),
 				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
 				fmt.Sprintf("--enable-ci-debug-output=%t", false),
 				fmt.Sprintf("--private-platform=%s", string(hyperv1.NonePlatform)),
@@ -125,6 +127,7 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 				"--namespace=$(MY_NAMESPACE)",
 				"--pod-name=$(MY_NAME)",
 				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-dedicated-request-serving-isolation=%t", false),
 				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
 				fmt.Sprintf("--enable-ci-debug-output=%t", false),
 				fmt.Sprintf("--private-platform=%s", string(hyperv1.NonePlatform)),
@@ -185,6 +188,7 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 				"--namespace=$(MY_NAMESPACE)",
 				"--pod-name=$(MY_NAME)",
 				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-dedicated-request-serving-isolation=%t", false),
 				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
 				fmt.Sprintf("--enable-ci-debug-output=%t", false),
 				fmt.Sprintf("--private-platform=%s", string(hyperv1.AWSPlatform)),
@@ -238,6 +242,66 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		"specify dedicated request serving isolation parameter (true) result in appropriate arguments": {
+			inputBuildParameters: HyperShiftOperatorDeployment{
+				Namespace: &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNamespace,
+					},
+				},
+				OperatorImage: testOperatorImage,
+				ServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hypershift",
+					},
+				},
+				Replicas:                               3,
+				PrivatePlatform:                        string(hyperv1.NonePlatform),
+				EnableDedicatedRequestServingIsolation: true,
+			},
+			expectedVolumeMounts: nil,
+			expectedVolumes:      nil,
+			expectedArgs: []string{
+				"run",
+				"--namespace=$(MY_NAMESPACE)",
+				"--pod-name=$(MY_NAME)",
+				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-dedicated-request-serving-isolation=%t", true),
+				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
+				fmt.Sprintf("--enable-ci-debug-output=%t", false),
+				fmt.Sprintf("--private-platform=%s", string(hyperv1.NonePlatform)),
+			},
+		},
+		"specify dedicated request serving isolation parameter (false) result in appropriate arguments": {
+			inputBuildParameters: HyperShiftOperatorDeployment{
+				Namespace: &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNamespace,
+					},
+				},
+				OperatorImage: testOperatorImage,
+				ServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hypershift",
+					},
+				},
+				Replicas:                               3,
+				PrivatePlatform:                        string(hyperv1.NonePlatform),
+				EnableDedicatedRequestServingIsolation: false,
+			},
+			expectedVolumeMounts: nil,
+			expectedVolumes:      nil,
+			expectedArgs: []string{
+				"run",
+				"--namespace=$(MY_NAMESPACE)",
+				"--pod-name=$(MY_NAME)",
+				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-dedicated-request-serving-isolation=%t", false),
+				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
+				fmt.Sprintf("--enable-ci-debug-output=%t", false),
+				fmt.Sprintf("--private-platform=%s", string(hyperv1.NonePlatform)),
 			},
 		},
 	}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -93,6 +93,7 @@ type Options struct {
 	SLOsAlerts                                bool
 	MonitoringDashboards                      bool
 	CertRotationScale                         time.Duration
+	EnableDedicatedRequestServingIsolation    bool
 }
 
 func (o *Options) Validate() error {
@@ -208,6 +209,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.SLOsAlerts, "slos-alerts", opts.SLOsAlerts, "If true, HyperShift will generate and use the prometheus alerts for monitoring HostedCluster and NodePools")
 	cmd.PersistentFlags().BoolVar(&opts.MonitoringDashboards, "monitoring-dashboards", opts.MonitoringDashboards, "If true, HyperShift will generate a monitoring dashboard for every HostedCluster that it creates")
 	cmd.PersistentFlags().DurationVar(&opts.CertRotationScale, "cert-rotation-scale", opts.CertRotationScale, "The scaling factor for certificate rotation. It is not supported to set this to anything other than 24h.")
+	cmd.PersistentFlags().BoolVar(&opts.EnableDedicatedRequestServingIsolation, "enable-dedicated-request-serving-isolation", true, "If true, enables scheduling of request serving components to dedicated nodes")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		opts.ApplyDefaults()
@@ -604,6 +606,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 		MonitoringDashboards:                    opts.MonitoringDashboards,
 		CertRotationScale:                       opts.CertRotationScale,
 		EnableCVOManagementClusterMetricsAccess: opts.EnableCVOManagementClusterMetricsAccess,
+		EnableDedicatedRequestServingIsolation:  opts.EnableDedicatedRequestServingIsolation,
 	}.Build()
 	objects = append(objects, operatorDeployment)
 

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -514,6 +514,7 @@ objects:
           - --namespace=$(MY_NAMESPACE)
           - --pod-name=$(MY_NAME)
           - --metrics-addr=:9000
+          - --enable-dedicated-request-serving-isolation=true
           - --enable-ocp-cluster-monitoring=false
           - --enable-ci-debug-output=false
           - --private-platform=AWS


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding HO flag to support disabling dedicated request serving isolation controllers.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.