### PR TITLE
OCPBUGS-29464: Add cache to HCCO for resource informers

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -16,7 +16,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"k8s.io/apimachinery/pkg/fields"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
@@ -214,6 +216,9 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 	cpCluster, err := cluster.New(cpConfig, func(opt *cluster.Options) {
 		opt.Namespace = o.Namespace
 		opt.Scheme = api.Scheme
+		opt.NewCache = cache.BuilderWithOptions(cache.Options{
+			DefaultSelector: cache.ObjectSelector{Field: fields.OneTermEqualSelector("metadata.namespace", o.Namespace)},
+		})
 	})
 	if err != nil {
 		return fmt.Errorf("cannot create control plane cluster: %v", err)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -199,15 +199,6 @@ func Setup(opts *operator.HostedClusterConfigOperatorConfig) error {
 		return fmt.Errorf("failed to watch HostedControlPlane: %w", err)
 	}
 
-	if err := c.Watch(source.NewKindWithCache(&corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifests.PullSecret(opts.Namespace).Name,
-			Namespace: opts.Namespace,
-		},
-	}, opts.CPCluster.GetCache()), eventHandler()); err != nil {
-		return fmt.Errorf("failed to watch HCP pullsecret: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:      In 4.14 HCCO doesnt cache resources which prevents resource informers such as the watch for pull secret changes from working.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #  [OCPBUGS-29464](https://issues.redhat.com/browse/OCPBUGS-29464)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.