### PR TITLE
OCPBUGS-29613: test: add a test for invalid CSRs

### DIFF
--- a/test/integration/control_plane_pki_operator.go
+++ b/test/integration/control_plane_pki_operator.go
@@ -71,7 +71,6 @@ func RunTestControlPlanePKIOperatorBreakGlassCredentials(t *testing.T, ctx conte
 
 				t.Run("CSR flow", func(t *testing.T) {
 					t.Run("invalid CN flagged in status", func(t *testing.T) {
-						t.Skip("TODO(skuznets): enable these tests when we're running against KAS 1.29+")
 						validateInvalidCN(t, ctx, hostedCluster, mgmt, guest, testCase.signer)
 					})
 					signedCrt := validateCSRFlow(t, ctx, hostedCluster, mgmt, guest, testCase.signer)


### PR DESCRIPTION
This works for newer k8s API servers. Bug is reported against 4.15 ... wondering if the 1.28->1.29 bump is the fix?