### PR TITLE
OCPBUGS-29723: CLI: create nodepool aws - remove sg requirement

### DIFF
--- a/cmd/nodepool/aws/create.go
+++ b/cmd/nodepool/aws/create.go
@@ -59,27 +59,6 @@ func (o *AWSPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool 
 			return fmt.Errorf("subnet ID was not specified and cannot be determined from HostedCluster")
 		}
 	}
-	if len(o.SecurityGroupID) == 0 {
-		nodePoolList := &hyperv1.NodePoolList{}
-		if err := client.List(ctx, nodePoolList, &crclient.ListOptions{Namespace: hcluster.Namespace}); err != nil {
-			return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool: %v", err)
-		}
-		var defaultNodePool *hyperv1.NodePool
-		for i, nodePool := range nodePoolList.Items {
-			if nodePool.Spec.ClusterName == hcluster.Name {
-				defaultNodePool = &nodePoolList.Items[i]
-				break
-			}
-		}
-		if defaultNodePool == nil {
-			return fmt.Errorf("--securitygroup-id flag is required when there are no existing nodepools")
-		}
-		if defaultNodePool.Spec.Platform.AWS == nil || len(defaultNodePool.Spec.Platform.AWS.SecurityGroups) == 0 ||
-			defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID == nil {
-			return fmt.Errorf("security group ID was not specified and cannot be determined from default nodepool")
-		}
-		o.SecurityGroupID = *defaultNodePool.Spec.Platform.AWS.SecurityGroups[0].ID
-	}
 
 	var instanceType string
 	if o.InstanceType != "" {
@@ -100,17 +79,17 @@ func (o *AWSPlatformCreateOptions) UpdateNodePool(ctx context.Context, nodePool 
 		Subnet: hyperv1.AWSResourceReference{
 			ID: &o.SubnetID,
 		},
-		SecurityGroups: []hyperv1.AWSResourceReference{
-			{
-				ID: &o.SecurityGroupID,
-			},
-		},
 		RootVolume: &hyperv1.Volume{
 			Type:          o.RootVolumeType,
 			Size:          o.RootVolumeSize,
 			IOPS:          o.RootVolumeIOPS,
 			EncryptionKey: o.RootVolumeEncryptionKey,
 		},
+	}
+	if len(o.SecurityGroupID) > 0 {
+		nodePool.Spec.Platform.AWS.SecurityGroups = []hyperv1.AWSResourceReference{
+			{ID: &o.SecurityGroupID},
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
A security group is no longer created by the CLI when creating a new cluster since we rely on the default one created by the control plane operator. This fix removes the requirement to specify a security group when creating a new nodepool through the CLI, otherwise creation fails when one is not specified.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-29723](https://issues.redhat.com/browse/OCPBUGS-29723)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.