### PR TITLE
NO-JIRA: always set minAvailable on PDBs to 1

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/certs"
@@ -710,14 +709,7 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *EtcdPara
 
 	p.OwnerRef.ApplyTo(pdb)
 
-	var minAvailable int
-	switch p.Availability {
-	case hyperv1.SingleReplica:
-		minAvailable = 0
-	case hyperv1.HighlyAvailable:
-		// For HA clusters, only tolerate disruption of a minority of members
-		minAvailable = p.DeploymentConfig.Replicas/2 + 1
-	}
+	minAvailable := 1
 	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -309,13 +309,6 @@ func ReconcileRouterPodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, avail
 		}
 	}
 	ownerRef.ApplyTo(pdb)
-	var minAvailable intstr.IntOrString
-	switch availability {
-	case hyperv1.SingleReplica:
-		minAvailable = intstr.FromInt(0)
-	case hyperv1.HighlyAvailable:
-		minAvailable = intstr.FromInt(1)
-	}
+	minAvailable := intstr.FromInt(1)
 	pdb.Spec.MinAvailable = &minAvailable
-
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/pdb.go
@@ -1,7 +1,6 @@
 package kas
 
 import (
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -16,13 +15,7 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *KubeAPIS
 
 	p.OwnerRef.ApplyTo(pdb)
 
-	var minAvailable int
-	switch p.Availability {
-	case hyperv1.SingleReplica:
-		minAvailable = 0
-	case hyperv1.HighlyAvailable:
-		minAvailable = 1
-	}
+	minAvailable := 1
 	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/pdb.go
@@ -1,7 +1,6 @@
 package oapi
 
 import (
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -16,13 +15,7 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OpenShif
 
 	p.OwnerRef.ApplyTo(pdb)
 
-	var minAvailable int
-	switch p.Availability {
-	case hyperv1.SingleReplica:
-		minAvailable = 0
-	case hyperv1.HighlyAvailable:
-		minAvailable = 1
-	}
+	minAvailable := 1
 	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/pdb.go
@@ -1,7 +1,6 @@
 package oauth
 
 import (
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -16,13 +15,7 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OAuthSer
 
 	p.OwnerRef.ApplyTo(pdb)
 
-	var minAvailable int
-	switch p.Availability {
-	case hyperv1.SingleReplica:
-		minAvailable = 0
-	case hyperv1.HighlyAvailable:
-		minAvailable = 1
-	}
+	minAvailable := 1
 	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
 
 	return nil


### PR DESCRIPTION
We are currently experiencing issues in CI when the autoscaler scales down the cluster and evicts pods from actively running mgmt clusters running prow jobs.  These mgmt clusters run `SingleReplica` to save on resources and can not tolerate being evicted without control plane downtime.  Depending on when this downtime occurs during the job, it frequently causes flakes.

Setting `minAvailable` to `1` on deployments that are required for smooth running of the KAS (etcd, kas itself, aggregated apiservers, and ingress to the kas) will prevent these pods from being evicted until the jobs complete.