### PR TITLE
OCPBUGS-29773: set Konnectivity cipher suites

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2848,6 +2848,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 			userReleaseImageProvider.Version(),
 			p.FeatureGate,
 			oidcCA,
+			p.CipherSuites(),
 		)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile api server deployment: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
@@ -120,6 +121,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	payloadVersion string,
 	featureGateSpec *configv1.FeatureGateSpec,
 	oidcCA *corev1.LocalObjectReference,
+	cipherSuites []string,
 ) error {
 
 	secretEncryptionData := hcp.Spec.SecretEncryption
@@ -199,7 +201,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 			Containers: []corev1.Container{
 				util.BuildContainer(kasContainerApplyBootstrap(), buildKASContainerApplyBootstrap(images.CLI)),
 				util.BuildContainer(kasContainerMain(), buildKASContainerMain(images.HyperKube, port, additionalNoProxyCIDRS, hcp)),
-				util.BuildContainer(konnectivityServerContainer(), buildKonnectivityServerContainer(images.KonnectivityServer, deploymentConfig.Replicas)),
+				util.BuildContainer(konnectivityServerContainer(), buildKonnectivityServerContainer(images.KonnectivityServer, deploymentConfig.Replicas, cipherSuites)),
 				{
 					Name:            "audit-logs",
 					Image:           images.CLI,
@@ -909,7 +911,7 @@ func konnectivityServerContainer() *corev1.Container {
 	}
 }
 
-func buildKonnectivityServerContainer(image string, serverCount int) func(c *corev1.Container) {
+func buildKonnectivityServerContainer(image string, serverCount int, cipherSuites []string) func(c *corev1.Container) {
 	cpath := func(volume, file string) string {
 		return path.Join(volumeMounts.Path(konnectivityServerContainer().Name, volume), file)
 	}
@@ -938,7 +940,6 @@ func buildKonnectivityServerContainer(image string, serverCount int) func(c *cor
 			strconv.Itoa(KonnectivityServerPort),
 			"--health-port",
 			strconv.Itoa(KonnectivityHealthPort),
-			"--tls-cipher-suites=" + KonnectivityServerCipherSuites,
 			"--admin-port=8093",
 			"--mode=http-connect",
 			"--proxy-strategies=destHost,defaultRoute",
@@ -949,6 +950,11 @@ func buildKonnectivityServerContainer(image string, serverCount int) func(c *cor
 			"--server-count",
 			strconv.Itoa(serverCount),
 		}
+
+		if len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
+
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 		c.Lifecycle = &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -938,6 +938,7 @@ func buildKonnectivityServerContainer(image string, serverCount int) func(c *cor
 			strconv.Itoa(KonnectivityServerPort),
 			"--health-port",
 			strconv.Itoa(KonnectivityHealthPort),
+			"--tls-cipher-suites=" + KonnectivityServerCipherSuites,
 			"--admin-port=8093",
 			"--mode=http-connect",
 			"--proxy-strategies=destHost,defaultRoute",

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -77,9 +77,10 @@ type KubeAPIServerServiceParams struct {
 }
 
 const (
-	KonnectivityHealthPort      = 2041
-	KonnectivityServerLocalPort = 8090
-	KonnectivityServerPort      = 8091
+	KonnectivityHealthPort         = 2041
+	KonnectivityServerLocalPort    = 8090
+	KonnectivityServerPort         = 8091
+	KonnectivityServerCipherSuites = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384"
 )
 
 func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, externalAPIAddress string, externalAPIPort int32, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -77,10 +77,9 @@ type KubeAPIServerServiceParams struct {
 }
 
 const (
-	KonnectivityHealthPort         = 2041
-	KonnectivityServerLocalPort    = 8090
-	KonnectivityServerPort         = 8091
-	KonnectivityServerCipherSuites = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384"
+	KonnectivityHealthPort      = 2041
+	KonnectivityServerLocalPort = 8090
+	KonnectivityServerPort      = 8091
 )
 
 func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, externalAPIAddress string, externalAPIPort int32, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {
@@ -460,6 +459,13 @@ func (p *KubeAPIServerParams) FeatureGates() []string {
 			FeatureSet: configv1.Default,
 		})
 	}
+}
+
+func (p *KubeAPIServerParams) CipherSuites() []string {
+	if p.APIServer != nil {
+		return config.CipherSuites(p.APIServer.TLSSecurityProfile)
+	}
+	return config.CipherSuites(nil)
 }
 
 func (p *KubeAPIServerParams) ServiceNodePortRange() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the cipher suite parameter for Konnectivity server

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-29773

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.