### PR TITLE
HOSTEDCP-1442: Split AWS security groups for workers and for VPC endpoint

### DIFF
--- a/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1991,6 +1991,12 @@ type AWSPlatformStatus struct {
 	// addition to any security groups specified in the NodePool.
 	// +optional
 	DefaultWorkerSecurityGroupID string `json:"defaultWorkerSecurityGroupID,omitempty"`
+
+	// VPCEendpointSecurityGroup is the ID of a security group created by
+	// the control plane operator. It is used to control access to the VPC
+	// endpoint in Private and PublicAndPrivate clusters.
+	// +optional
+	VPCEndpointSecurityGroupID string `json:"vpcEndpointSecurityGroupID,omitempty"`
 }
 
 // ClusterVersionStatus reports the status of the cluster versioning,

--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -144,13 +144,23 @@ const (
 	// for AWS workers has been created.
 	// A failure here indicates that NodePools without a security group will be
 	// blocked from creating machines.
+	// +deprecated
 	AWSDefaultSecurityGroupCreated ConditionType = "AWSDefaultSecurityGroupCreated"
 
 	// AWSDefaultSecurityGroupDeleted indicates whether the default security group
 	// for AWS workers has been deleted.
 	// A failure here indicates that the Security Group has some dependencies that
 	// there are still pending cloud resources to be deleted that are using that SG.
+	// +deprecated
 	AWSDefaultSecurityGroupDeleted ConditionType = "AWSDefaultSecurityGroupDeleted"
+
+	// AWSSecurityGroupsReconciled indicates whether the security groups for AWS
+	// have been reconciled.
+	AWSSecurityGroupsReconciled ConditionType = "AWSSecurityGroupsReconciled"
+
+	// AWSSecurityGroupsDeleted indicates whether the security groups for AWS
+	// have been deleted.
+	AWSSecurityGroupsDeleted ConditionType = "AWSSecurityGroupsDeleted"
 
 	// PlatformCredentialsFound indicates that credentials required for the
 	// desired platform are valid.

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -2093,6 +2093,12 @@ type AWSPlatformStatus struct {
 	// addition to any security groups specified in the NodePool.
 	// +optional
 	DefaultWorkerSecurityGroupID string `json:"defaultWorkerSecurityGroupID,omitempty"`
+
+	// VPCEendpointSecurityGroup is the ID of a security group created by
+	// the control plane operator. It is used to control access to the VPC
+	// endpoint in Private and PublicAndPrivate clusters.
+	// +optional
+	VPCEndpointSecurityGroupID string `json:"vpcEndpointSecurityGroupID,omitempty"`
 }
 
 // ClusterVersionStatus reports the status of the cluster versioning,

--- a/client/applyconfiguration/hypershift/v1alpha1/awsplatformstatus.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/awsplatformstatus.go
@@ -21,6 +21,7 @@ package v1alpha1
 // with apply.
 type AWSPlatformStatusApplyConfiguration struct {
 	DefaultWorkerSecurityGroupID *string `json:"defaultWorkerSecurityGroupID,omitempty"`
+	VPCEndpointSecurityGroupID   *string `json:"vpcEndpointSecurityGroupID,omitempty"`
 }
 
 // AWSPlatformStatusApplyConfiguration constructs an declarative configuration of the AWSPlatformStatus type for use with
@@ -34,5 +35,13 @@ func AWSPlatformStatus() *AWSPlatformStatusApplyConfiguration {
 // If called multiple times, the DefaultWorkerSecurityGroupID field is set to the value of the last call.
 func (b *AWSPlatformStatusApplyConfiguration) WithDefaultWorkerSecurityGroupID(value string) *AWSPlatformStatusApplyConfiguration {
 	b.DefaultWorkerSecurityGroupID = &value
+	return b
+}
+
+// WithVPCEndpointSecurityGroupID sets the VPCEndpointSecurityGroupID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the VPCEndpointSecurityGroupID field is set to the value of the last call.
+func (b *AWSPlatformStatusApplyConfiguration) WithVPCEndpointSecurityGroupID(value string) *AWSPlatformStatusApplyConfiguration {
+	b.VPCEndpointSecurityGroupID = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1beta1/awsplatformstatus.go
+++ b/client/applyconfiguration/hypershift/v1beta1/awsplatformstatus.go
@@ -21,6 +21,7 @@ package v1beta1
 // with apply.
 type AWSPlatformStatusApplyConfiguration struct {
 	DefaultWorkerSecurityGroupID *string `json:"defaultWorkerSecurityGroupID,omitempty"`
+	VPCEndpointSecurityGroupID   *string `json:"vpcEndpointSecurityGroupID,omitempty"`
 }
 
 // AWSPlatformStatusApplyConfiguration constructs an declarative configuration of the AWSPlatformStatus type for use with
@@ -34,5 +35,13 @@ func AWSPlatformStatus() *AWSPlatformStatusApplyConfiguration {
 // If called multiple times, the DefaultWorkerSecurityGroupID field is set to the value of the last call.
 func (b *AWSPlatformStatusApplyConfiguration) WithDefaultWorkerSecurityGroupID(value string) *AWSPlatformStatusApplyConfiguration {
 	b.DefaultWorkerSecurityGroupID = &value
+	return b
+}
+
+// WithVPCEndpointSecurityGroupID sets the VPCEndpointSecurityGroupID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the VPCEndpointSecurityGroupID field is set to the value of the last call.
+func (b *AWSPlatformStatusApplyConfiguration) WithVPCEndpointSecurityGroupID(value string) *AWSPlatformStatusApplyConfiguration {
+	b.VPCEndpointSecurityGroupID = &value
 	return b
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -4061,6 +4061,12 @@ spec:
                           the control plane operator. It is always added to worker machines in
                           addition to any security groups specified in the NodePool.
                         type: string
+                      vpcEndpointSecurityGroupID:
+                        description: |-
+                          VPCEendpointSecurityGroup is the ID of a security group created by
+                          the control plane operator. It is used to control access to the VPC
+                          endpoint in Private and PublicAndPrivate clusters.
+                        type: string
                     type: object
                 type: object
               version:
@@ -8341,6 +8347,12 @@ spec:
                           DefaultWorkerSecurityGroupID is the ID of a security group created by
                           the control plane operator. It is always added to worker machines in
                           addition to any security groups specified in the NodePool.
+                        type: string
+                      vpcEndpointSecurityGroupID:
+                        description: |-
+                          VPCEendpointSecurityGroup is the ID of a security group created by
+                          the control plane operator. It is used to control access to the VPC
+                          endpoint in Private and PublicAndPrivate clusters.
                         type: string
                     type: object
                 type: object

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -4063,6 +4063,12 @@ spec:
                           the control plane operator. It is always added to worker machines in
                           addition to any security groups specified in the NodePool.
                         type: string
+                      vpcEndpointSecurityGroupID:
+                        description: |-
+                          VPCEendpointSecurityGroup is the ID of a security group created by
+                          the control plane operator. It is used to control access to the VPC
+                          endpoint in Private and PublicAndPrivate clusters.
+                        type: string
                     type: object
                 type: object
               ready:
@@ -8316,6 +8322,12 @@ spec:
                           DefaultWorkerSecurityGroupID is the ID of a security group created by
                           the control plane operator. It is always added to worker machines in
                           addition to any security groups specified in the NodePool.
+                        type: string
+                      vpcEndpointSecurityGroupID:
+                        description: |-
+                          VPCEendpointSecurityGroup is the ID of a security group created by
+                          the control plane operator. It is used to control access to the VPC
+                          endpoint in Private and PublicAndPrivate clusters.
                         type: string
                     type: object
                 type: object

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -454,7 +454,7 @@ func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointService(ctx context.C
 		for _, group := range output.VpcEndpoints[0].Groups {
 			exitingSG = append(exitingSG, group.GroupId)
 		}
-		addedSG, removedSG := diffIDs([]string{hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID}, exitingSG)
+		addedSG, removedSG := diffIDs([]string{hcp.Status.Platform.AWS.VPCEndpointSecurityGroupID}, exitingSG)
 
 		if addedSubnet != nil || removedSubnet != nil || addedSG != nil || removedSG != nil {
 			log.Info("endpoint subnets or security groups have changed")
@@ -520,11 +520,11 @@ func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointService(ctx context.C
 				subnetIDs = append(subnetIDs, &awsEndpointService.Spec.SubnetIDs[i])
 			}
 
-			if hcp.Status.Platform == nil || hcp.Status.Platform.AWS == nil || hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID == "" {
-				return fmt.Errorf("DefaultWorkerSecurityGroupID doesn't exist yet for the endpoint to use")
+			if hcp.Status.Platform == nil || hcp.Status.Platform.AWS == nil || hcp.Status.Platform.AWS.VPCEndpointSecurityGroupID == "" {
+				return fmt.Errorf("VPCEndpointSecurityGroupID doesn't exist yet for the endpoint to use")
 			}
 			output, err := ec2Client.CreateVpcEndpointWithContext(ctx, &ec2.CreateVpcEndpointInput{
-				SecurityGroupIds: []*string{aws.String(hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID)},
+				SecurityGroupIds: []*string{aws.String(hcp.Status.Platform.AWS.VPCEndpointSecurityGroupID)},
 				ServiceName:      aws.String(awsEndpointService.Status.EndpointServiceName),
 				VpcId:            aws.String(hcp.Spec.Platform.AWS.CloudProviderConfig.VPC),
 				VpcEndpointType:  aws.String(ec2.VpcEndpointTypeInterface),

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1489,6 +1489,20 @@ the control plane operator. It is always added to worker machines in
 addition to any security groups specified in the NodePool.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>vpcEndpointSecurityGroupID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VPCEendpointSecurityGroup is the ID of a security group created by
+the control plane operator. It is used to control access to the VPC
+endpoint in Private and PublicAndPrivate clusters.</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###AWSResourceReference { #hypershift.openshift.io/v1beta1.AWSResourceReference }
@@ -3021,6 +3035,14 @@ created in the guest VPC</p>
 </tr><tr><td><p>&#34;AWSEndpointServiceAvailable&#34;</p></td>
 <td><p>AWSEndpointServiceAvailable indicates whether the AWS Endpoint Service
 has been created for the specified NLB in the management VPC</p>
+</td>
+</tr><tr><td><p>&#34;AWSSecurityGroupsDeleted&#34;</p></td>
+<td><p>AWSSecurityGroupsDeleted indicates whether the security groups for AWS
+have been deleted.</p>
+</td>
+</tr><tr><td><p>&#34;AWSSecurityGroupsReconciled&#34;</p></td>
+<td><p>AWSSecurityGroupsReconciled indicates whether the security groups for AWS
+have been reconciled.</p>
 </td>
 </tr><tr><td><p>&#34;CVOScaledDown&#34;</p></td>
 <td></td>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -40495,6 +40495,12 @@ objects:
                             the control plane operator. It is always added to worker machines in
                             addition to any security groups specified in the NodePool.
                           type: string
+                        vpcEndpointSecurityGroupID:
+                          description: |-
+                            VPCEendpointSecurityGroup is the ID of a security group created by
+                            the control plane operator. It is used to control access to the VPC
+                            endpoint in Private and PublicAndPrivate clusters.
+                          type: string
                       type: object
                   type: object
                 version:
@@ -44792,6 +44798,12 @@ objects:
                             DefaultWorkerSecurityGroupID is the ID of a security group created by
                             the control plane operator. It is always added to worker machines in
                             addition to any security groups specified in the NodePool.
+                          type: string
+                        vpcEndpointSecurityGroupID:
+                          description: |-
+                            VPCEendpointSecurityGroup is the ID of a security group created by
+                            the control plane operator. It is used to control access to the VPC
+                            endpoint in Private and PublicAndPrivate clusters.
                           type: string
                       type: object
                   type: object
@@ -49282,6 +49294,12 @@ objects:
                             the control plane operator. It is always added to worker machines in
                             addition to any security groups specified in the NodePool.
                           type: string
+                        vpcEndpointSecurityGroupID:
+                          description: |-
+                            VPCEendpointSecurityGroup is the ID of a security group created by
+                            the control plane operator. It is used to control access to the VPC
+                            endpoint in Private and PublicAndPrivate clusters.
+                          type: string
                       type: object
                   type: object
                 ready:
@@ -53552,6 +53570,12 @@ objects:
                             DefaultWorkerSecurityGroupID is the ID of a security group created by
                             the control plane operator. It is always added to worker machines in
                             addition to any security groups specified in the NodePool.
+                          type: string
+                        vpcEndpointSecurityGroupID:
+                          description: |-
+                            VPCEendpointSecurityGroup is the ID of a security group created by
+                            the control plane operator. It is used to control access to the VPC
+                            endpoint in Private and PublicAndPrivate clusters.
                           type: string
                       type: object
                   type: object

--- a/support/awsutil/sg.go
+++ b/support/awsutil/sg.go
@@ -139,49 +139,58 @@ func DefaultWorkerSGIngressRules(vpcCIDRBlock, sgGroupID, sgUserID string) []*ec
 				},
 			},
 		},
+	}
+}
+
+func VPCEndpointIngressRules(defaultSGGroupID, defaultSGUserID string) []*ec2.IpPermission {
+	return []*ec2.IpPermission{
 		{
 			// This is for the private link endpoint.
 			IpProtocol: aws.String("tcp"),
-			IpRanges: []*ec2.IpRange{
+			FromPort:   aws.Int64(6443),
+			ToPort:     aws.Int64(6443),
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
 				{
-					CidrIp: aws.String(vpcCIDRBlock),
+					GroupId: aws.String(defaultSGGroupID),
+					UserId:  aws.String(defaultSGUserID),
 				},
 			},
-			FromPort: aws.Int64(6443),
-			ToPort:   aws.Int64(6443),
 		},
 		{
 			// This is for the private link endpoint.
 			IpProtocol: aws.String("tcp"),
-			IpRanges: []*ec2.IpRange{
+			FromPort:   aws.Int64(443),
+			ToPort:     aws.Int64(443),
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
 				{
-					CidrIp: aws.String(vpcCIDRBlock),
+					GroupId: aws.String(defaultSGGroupID),
+					UserId:  aws.String(defaultSGUserID),
 				},
 			},
-			FromPort: aws.Int64(443),
-			ToPort:   aws.Int64(443),
 		},
 		{
 			// This is for the private link endpoint.
 			IpProtocol: aws.String("udp"),
-			IpRanges: []*ec2.IpRange{
+			FromPort:   aws.Int64(6443),
+			ToPort:     aws.Int64(6443),
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
 				{
-					CidrIp: aws.String(vpcCIDRBlock),
+					GroupId: aws.String(defaultSGGroupID),
+					UserId:  aws.String(defaultSGUserID),
 				},
 			},
-			FromPort: aws.Int64(6443),
-			ToPort:   aws.Int64(6443),
 		},
 		{
 			// This is for the private link endpoint.
 			IpProtocol: aws.String("udp"),
-			IpRanges: []*ec2.IpRange{
+			FromPort:   aws.Int64(443),
+			ToPort:     aws.Int64(443),
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
 				{
-					CidrIp: aws.String(vpcCIDRBlock),
+					GroupId: aws.String(defaultSGGroupID),
+					UserId:  aws.String(defaultSGUserID),
 				},
 			},
-			FromPort: aws.Int64(443),
-			ToPort:   aws.Int64(443),
 		},
 	}
 }

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -23,7 +23,7 @@ func ExpectedHCConditions() map[hyperv1.ConditionType]metav1.ConditionStatus {
 		hyperv1.ReconciliationSucceeded:              metav1.ConditionTrue,
 		hyperv1.ValidOIDCConfiguration:               metav1.ConditionTrue,
 		hyperv1.ValidAWSIdentityProvider:             metav1.ConditionTrue,
-		hyperv1.AWSDefaultSecurityGroupCreated:       metav1.ConditionTrue,
+		hyperv1.AWSSecurityGroupsReconciled:          metav1.ConditionTrue,
 		hyperv1.ValidHostedControlPlaneConfiguration: metav1.ConditionTrue,
 		hyperv1.ValidReleaseImage:                    metav1.ConditionTrue,
 		hyperv1.PlatformCredentialsFound:             metav1.ConditionTrue,

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1991,6 +1991,12 @@ type AWSPlatformStatus struct {
 	// addition to any security groups specified in the NodePool.
 	// +optional
 	DefaultWorkerSecurityGroupID string `json:"defaultWorkerSecurityGroupID,omitempty"`
+
+	// VPCEendpointSecurityGroup is the ID of a security group created by
+	// the control plane operator. It is used to control access to the VPC
+	// endpoint in Private and PublicAndPrivate clusters.
+	// +optional
+	VPCEndpointSecurityGroupID string `json:"vpcEndpointSecurityGroupID,omitempty"`
 }
 
 // ClusterVersionStatus reports the status of the cluster versioning,

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -144,13 +144,23 @@ const (
 	// for AWS workers has been created.
 	// A failure here indicates that NodePools without a security group will be
 	// blocked from creating machines.
+	// +deprecated
 	AWSDefaultSecurityGroupCreated ConditionType = "AWSDefaultSecurityGroupCreated"
 
 	// AWSDefaultSecurityGroupDeleted indicates whether the default security group
 	// for AWS workers has been deleted.
 	// A failure here indicates that the Security Group has some dependencies that
 	// there are still pending cloud resources to be deleted that are using that SG.
+	// +deprecated
 	AWSDefaultSecurityGroupDeleted ConditionType = "AWSDefaultSecurityGroupDeleted"
+
+	// AWSSecurityGroupsReconciled indicates whether the security groups for AWS
+	// have been reconciled.
+	AWSSecurityGroupsReconciled ConditionType = "AWSSecurityGroupsReconciled"
+
+	// AWSSecurityGroupsDeleted indicates whether the security groups for AWS
+	// have been deleted.
+	AWSSecurityGroupsDeleted ConditionType = "AWSSecurityGroupsDeleted"
 
 	// PlatformCredentialsFound indicates that credentials required for the
 	// desired platform are valid.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -2093,6 +2093,12 @@ type AWSPlatformStatus struct {
 	// addition to any security groups specified in the NodePool.
 	// +optional
 	DefaultWorkerSecurityGroupID string `json:"defaultWorkerSecurityGroupID,omitempty"`
+
+	// VPCEendpointSecurityGroup is the ID of a security group created by
+	// the control plane operator. It is used to control access to the VPC
+	// endpoint in Private and PublicAndPrivate clusters.
+	// +optional
+	VPCEndpointSecurityGroupID string `json:"vpcEndpointSecurityGroupID,omitempty"`
 }
 
 // ClusterVersionStatus reports the status of the cluster versioning,


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this commit, a single security group was used for both workers and VPC endpoint. Now we create a separate security group for each and continually reconcile them.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1442](https://issues.redhat.com/browse/HOSTEDCP-1442)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.