### PR TITLE
OCPBUGS-30029: sync AuthenticationConfiguration type with o/k 1.28 carry

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/auth_types.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/auth_types.go
@@ -40,13 +40,6 @@ type JWTAuthenticator struct {
 	// claimMappings points claims of a token to be treated as user attributes.
 	// +required
 	ClaimMappings ClaimMappings `json:"claimMappings"`
-
-	// userValidationRules are rules that are applied to final user before completing authentication.
-	// These allow invariants to be applied to incoming identities such as preventing the
-	// use of the system: prefix that is commonly used by Kubernetes components.
-	// The validation rules are logically ANDed together and must all return true for the validation to pass.
-	// +optional
-	UserValidationRules []UserValidationRule `json:"userValidationRules,omitempty"`
 }
 
 // Issuer provides the configuration for a external provider specific settings.
@@ -104,36 +97,14 @@ type ClaimValidationRule struct {
 	// claim is the name of a required claim.
 	// Same as --oidc-required-claim flag.
 	// Only string claim keys are supported.
-	// Mutually exclusive with expression and message.
-	// +optional
-	Claim string `json:"claim,omitempty"`
+	// +required
+	Claim string `json:"claim"`
 	// requiredValue is the value of a required claim.
 	// Same as --oidc-required-claim flag.
 	// Only string claim values are supported.
 	// If claim is set and requiredValue is not set, the claim must be present with a value set to the empty string.
-	// Mutually exclusive with expression and message.
 	// +optional
-	RequiredValue string `json:"requiredValue,omitempty"`
-
-	// expression represents the expression which will be evaluated by CEL.
-	// Must produce a boolean.
-	//
-	// CEL expressions have access to the contents of the token claims, organized into CEL variable:
-	// - 'claims' is a map of claim names to claim values.
-	//   For example, a variable named 'sub' can be accessed as 'claims.sub'.
-	//   Nested claims can be accessed using dot notation, e.g. 'claims.email.verified'.
-	// Must return true for the validation to pass.
-	//
-	// Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
-	//
-	// Mutually exclusive with claim and requiredValue.
-	// +optional
-	Expression string `json:"expression,omitempty"`
-	// message customizes the returned error message when expression returns false.
-	// message is a literal string.
-	// Mutually exclusive with claim and requiredValue.
-	// +optional
-	Message string `json:"message,omitempty"`
+	RequiredValue string `json:"requiredValue"`
 }
 
 // ClaimMappings provides the configuration for claim mapping
@@ -141,7 +112,6 @@ type ClaimMappings struct {
 	// username represents an option for the username attribute.
 	// The claim's value must be a singular string.
 	// Same as the --oidc-username-claim and --oidc-username-prefix flags.
-	// If username.expression is set, the expression must produce a string value.
 	//
 	// In the flag based approach, the --oidc-username-claim and --oidc-username-prefix are optional. If --oidc-username-claim is not set,
 	// the default value is "sub". For the authentication config, there is no defaulting for claim or prefix. The claim and prefix must be set explicitly.
@@ -156,134 +126,17 @@ type ClaimMappings struct {
 	Username PrefixedClaimOrExpression `json:"username"`
 	// groups represents an option for the groups attribute.
 	// The claim's value must be a string or string array claim.
-	// If groups.claim is set, the prefix must be specified (and can be the empty string).
-	// If groups.expression is set, the expression must produce a string or string array value.
-	//  "", [], and null values are treated as the group mapping not being present.
+	// // If groups.claim is set, the prefix must be specified (and can be the empty string).
 	// +optional
 	Groups PrefixedClaimOrExpression `json:"groups,omitempty"`
-
-	// uid represents an option for the uid attribute.
-	// Claim must be a singular string claim.
-	// If uid.expression is set, the expression must produce a string value.
-	// +optional
-	UID ClaimOrExpression `json:"uid"`
-
-	// extra represents an option for the extra attribute.
-	// expression must produce a string or string array value.
-	// If the value is empty, the extra mapping will not be present.
-	//
-	// hard-coded extra key/value
-	// - key: "foo"
-	//   valueExpression: "'bar'"
-	// This will result in an extra attribute - foo: ["bar"]
-	//
-	// hard-coded key, value copying claim value
-	// - key: "foo"
-	//   valueExpression: "claims.some_claim"
-	// This will result in an extra attribute - foo: [value of some_claim]
-	//
-	// hard-coded key, value derived from claim value
-	// - key: "admin"
-	//   valueExpression: '(has(claims.is_admin) && claims.is_admin) ? "true":""'
-	// This will result in:
-	//  - if is_admin claim is present and true, extra attribute - admin: ["true"]
-	//  - if is_admin claim is present and false or is_admin claim is not present, no extra attribute will be added
-	//
-	// +optional
-	Extra []ExtraMapping `json:"extra,omitempty"`
 }
 
 // PrefixedClaimOrExpression provides the configuration for a single prefixed claim or expression.
 type PrefixedClaimOrExpression struct {
 	// claim is the JWT claim to use.
-	// Mutually exclusive with expression.
 	// +optional
-	Claim string `json:"claim,omitempty"`
+	Claim string `json:"claim"`
 	// prefix is prepended to claim's value to prevent clashes with existing names.
-	// prefix needs to be set if claim is set and can be the empty string.
-	// Mutually exclusive with expression.
-	// +optional
-	Prefix *string `json:"prefix,omitempty"`
-
-	// expression represents the expression which will be evaluated by CEL.
-	//
-	// CEL expressions have access to the contents of the token claims, organized into CEL variable:
-	// - 'claims' is a map of claim names to claim values.
-	//   For example, a variable named 'sub' can be accessed as 'claims.sub'.
-	//   Nested claims can be accessed using dot notation, e.g. 'claims.email.verified'.
-	//
-	// Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
-	//
-	// Mutually exclusive with claim and prefix.
-	// +optional
-	Expression string `json:"expression,omitempty"`
-}
-
-// ClaimOrExpression provides the configuration for a single claim or expression.
-type ClaimOrExpression struct {
-	// claim is the JWT claim to use.
-	// Either claim or expression must be set.
-	// Mutually exclusive with expression.
-	// +optional
-	Claim string `json:"claim,omitempty"`
-
-	// expression represents the expression which will be evaluated by CEL.
-	//
-	// CEL expressions have access to the contents of the token claims, organized into CEL variable:
-	// - 'claims' is a map of claim names to claim values.
-	//   For example, a variable named 'sub' can be accessed as 'claims.sub'.
-	//   Nested claims can be accessed using dot notation, e.g. 'claims.email.verified'.
-	//
-	// Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
-	//
-	// Mutually exclusive with claim.
-	// +optional
-	Expression string `json:"expression,omitempty"`
-}
-
-// ExtraMapping provides the configuration for a single extra mapping.
-type ExtraMapping struct {
-	// key is a string to use as the extra attribute key.
-	// key must be a domain-prefix path (e.g. example.org/foo). All characters before the first "/" must be a valid
-	// subdomain as defined by RFC 1123. All characters trailing the first "/" must
-	// be valid HTTP Path characters as defined by RFC 3986.
-	// key must be lowercase.
 	// +required
-	Key string `json:"key"`
-
-	// valueExpression is a CEL expression to extract extra attribute value.
-	// valueExpression must produce a string or string array value.
-	// "", [], and null values are treated as the extra mapping not being present.
-	// Empty string values contained within a string array are filtered out.
-	//
-	// CEL expressions have access to the contents of the token claims, organized into CEL variable:
-	// - 'claims' is a map of claim names to claim values.
-	//   For example, a variable named 'sub' can be accessed as 'claims.sub'.
-	//   Nested claims can be accessed using dot notation, e.g. 'claims.email.verified'.
-	//
-	// Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
-	//
-	// +required
-	ValueExpression string `json:"valueExpression"`
-}
-
-// UserValidationRule provides the configuration for a single user info validation rule.
-type UserValidationRule struct {
-	// expression represents the expression which will be evaluated by CEL.
-	// Must return true for the validation to pass.
-	//
-	// CEL expressions have access to the contents of UserInfo, organized into CEL variable:
-	// - 'user' - authentication.k8s.io/v1, Kind=UserInfo object
-	//    Refer to https://github.com/kubernetes/api/blob/release-1.28/authentication/v1/types.go#L105-L122 for the definition.
-	//    API documentation: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#userinfo-v1-authentication-k8s-io
-	//
-	// Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
-	//
-	// +required
-	Expression string `json:"expression"`
-
-	// message customizes the returned error message when rule returns false.
-	// message is a literal string.
-	// +optional
-	Message string `json:"message,omitempty"`
+	Prefix *string `json:"prefix"`
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-30029

Fixes an issue in `release-4.15` that does not exist in `main`

Sync source:
https://github.com/openshift/kubernetes/pull/1884/files#diff-6c0eb218aff9987eeae38d64283b622250d4c1e2275e4dba11477d9e6ba64083