### PR TITLE
OCPBUGS-30030: rollout kas on auth config change

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2668,12 +2668,9 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 		return fmt.Errorf("failed to reconcile api server config: %w", err)
 	}
 
-	authConfig := manifests.AuthConfig(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, authConfig, func() error {
-		return kas.ReconcileAuthConfig(authConfig,
-			p.OwnerRef,
-			p.ConfigParams(),
-		)
+	kubeAPIServerAuthConfig := manifests.AuthConfig(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, kubeAPIServerAuthConfig, func() error {
+		return kas.ReconcileAuthConfig(kubeAPIServerAuthConfig, p.OwnerRef, p.ConfigParams())
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile api server authentication config: %w", err)
 	}
@@ -2686,7 +2683,9 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 	}
 
 	userOauthMetadata := ""
-	if hcp.Spec.Configuration.Authentication != nil && len(hcp.Spec.Configuration.Authentication.OAuthMetadata.Name) > 0 {
+	if hcp.Spec.Configuration != nil &&
+		hcp.Spec.Configuration.Authentication != nil &&
+		len(hcp.Spec.Configuration.Authentication.OAuthMetadata.Name) > 0 {
 		var userOauthMetadataConfigMap corev1.ConfigMap
 		err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcp.Namespace, Name: hcp.Spec.Configuration.Authentication.OAuthMetadata.Name}, &userOauthMetadataConfigMap)
 		if err != nil {
@@ -2847,6 +2846,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 			p.Images,
 			kubeAPIServerConfig,
 			kubeAPIServerAuditConfig,
+			kubeAPIServerAuthConfig,
 			p.AuditWebhookRef,
 			aesCBCActiveKey,
 			aesCBCBackupKey,

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/auth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/auth.go
@@ -12,6 +12,10 @@ import (
 	hcpconfig "github.com/openshift/hypershift/support/config"
 )
 
+const (
+	AuthConfigMapKey = "auth.json"
+)
+
 func ReconcileAuthConfig(config *corev1.ConfigMap, ownerRef hcpconfig.OwnerRef, p KubeAPIServerConfigParams) error {
 	ownerRef.ApplyTo(config)
 	if config.Data == nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	kasNamedCertificateMountPathPrefix         = "/etc/kubernetes/certs/named"
+	authConfigHashAnnotation                   = "kube-apiserver.hypershift.openshift.io/auth-config-hash"
 	auditConfigHashAnnotation                  = "kube-apiserver.hypershift.openshift.io/audit-config-hash"
 	configHashAnnotation                       = "kube-apiserver.hypershift.openshift.io/config-hash"
 	awsPodIdentityWebhookServingCertVolumeName = "aws-pod-identity-webhook-serving-certs"
@@ -113,6 +114,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 	images KubeAPIServerImages,
 	config *corev1.ConfigMap,
 	auditConfig *corev1.ConfigMap,
+	authConfig *corev1.ConfigMap,
 	auditWebhookRef *corev1.LocalObjectReference,
 	aesCBCActiveKey []byte,
 	aesCBCBackupKey []byte,
@@ -139,6 +141,12 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 		return fmt.Errorf("kube apiserver audit configuration is not expected to be empty")
 	}
 	auditConfigHash := util.ComputeHash(auditConfigBytes)
+
+	authConfigBytes, ok := authConfig.Data[AuthConfigMapKey]
+	if !ok {
+		return fmt.Errorf("kube apiserver authentication configuration is not expected to be empty")
+	}
+	authConfigHash := util.ComputeHash(authConfigBytes)
 
 	// preserve existing resource requirements for main KAS container
 	kasContainer := util.FindContainer(kasContainerMain().Name, deployment.Spec.Template.Spec.Containers)
@@ -181,6 +189,7 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 			Annotations: map[string]string{
 				configHashAnnotation:      configHash,
 				auditConfigHashAnnotation: auditConfigHash,
+				authConfigHashAnnotation:  authConfigHash,
 			},
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
KEP on structured authentication config states that KAS will reload the config when it changes
https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/3331-structured-authentication-configuration/README.md?plain=1#L115

However, this does not seem to be true.

If the Authentication config is changed, the auth-config configmap is updated and the projected file in the KAS pod is also updated. However, the KAS does not reload the config dynamically.

Working on a solution that manually triggers a KAS rollout on authentication config changes.