### PR TITLE
OCPBUGS-30088: rollout kas on auth config change

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2416,12 +2416,9 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 		return fmt.Errorf("failed to reconcile api server config: %w", err)
 	}
 
-	authConfig := manifests.AuthConfig(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, authConfig, func() error {
-		return kas.ReconcileAuthConfig(authConfig,
-			p.OwnerRef,
-			p.ConfigParams(),
-		)
+	kubeAPIServerAuthConfig := manifests.AuthConfig(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, kubeAPIServerAuthConfig, func() error {
+		return kas.ReconcileAuthConfig(kubeAPIServerAuthConfig, p.OwnerRef, p.ConfigParams())
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile api server authentication config: %w", err)
 	}
@@ -2434,7 +2431,9 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 	}
 
 	userOauthMetadata := ""
-	if hcp.Spec.Configuration.Authentication != nil && len(hcp.Spec.Configuration.Authentication.OAuthMetadata.Name) > 0 {
+	if hcp.Spec.Configuration != nil &&
+		hcp.Spec.Configuration.Authentication != nil &&
+		len(hcp.Spec.Configuration.Authentication.OAuthMetadata.Name) > 0 {
 		var userOauthMetadataConfigMap corev1.ConfigMap
 		err := r.Client.Get(ctx, client.ObjectKey{Namespace: hcp.Namespace, Name: hcp.Spec.Configuration.Authentication.OAuthMetadata.Name}, &userOauthMetadataConfigMap)
 		if err != nil {
@@ -2595,6 +2594,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 			p.Images,
 			kubeAPIServerConfig,
 			kubeAPIServerAuditConfig,
+			kubeAPIServerAuthConfig,
 			p.AuditWebhookRef,
 			aesCBCActiveKey,
 			aesCBCBackupKey,

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/auth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/auth.go
@@ -12,6 +12,10 @@ import (
 	hcpconfig "github.com/openshift/hypershift/support/config"
 )
 
+const (
+	AuthConfigMapKey = "auth.json"
+)
+
 func ReconcileAuthConfig(config *corev1.ConfigMap, ownerRef hcpconfig.OwnerRef, p KubeAPIServerConfigParams) error {
 	ownerRef.ApplyTo(config)
 	if config.Data == nil {


### PR DESCRIPTION
Clean pick of https://github.com/openshift/hypershift/pull/3647

Automated cherry-pick failed because https://github.com/openshift/hypershift/pull/3522 had not yet merged, but now it has.