### PR TITLE
HOSTEDCP-1459: Replace CI build image with multi-arch version

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  name: release
-  namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  name: builder
+  namespace: ocp
+  tag: rhel-9-golang-1.21-ci-build-root-multi-openshift-4.16

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 WORKDIR /hypershift
 

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 AS builder
 
 WORKDIR /hypershift
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace the ci-operator root build image and the Golang builder image in Dockerfile and Dockerfile.control-plane with the multi-arch version.

This will allow the HyperShift Operator to be created for other CPU architectures other than amd64.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1459](https://issues.redhat.com/browse/HOSTEDCP-1459)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.