### PR TITLE
OCPBUGS-28370: Use correct return error when destroying AWS SG

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -314,7 +314,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 			Type: string(hyperv1.AWSDefaultSecurityGroupDeleted),
 		}
 		if shouldCleanupCloudResources(r.Log, hostedControlPlane) {
-			if code, destroyErr := r.destroyAWSDefaultSecurityGroup(ctx, hostedControlPlane); err != nil {
+			if code, destroyErr := r.destroyAWSDefaultSecurityGroup(ctx, hostedControlPlane); destroyErr != nil {
 				condition.Message = "failed to delete AWS default security group"
 				if code == "DependencyViolation" {
 					condition.Message = destroyErr.Error()


### PR DESCRIPTION
**What this PR does / why we need it**:  Fixes use of incorrect error return when deleting AWS SG

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-28370](https://issues.redhat.com/browse/OCPBUGS-28370)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [] This change includes docs. 
- [ ] This change includes unit tests.