### PR TITLE
OCPBUGS-30060: Set OPERATOR_IMAGE environment variable

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -271,6 +271,10 @@ func buildMainContainer(image, registryImage, prunerImage, releaseVersion string
 				Value: operatorName,
 			},
 			{
+				Name:  "OPERATOR_IMAGE",
+				Value: image,
+			},
+			{
 				Name:  "IMAGE",
 				Value: registryImage,
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -81,6 +81,8 @@ spec:
           value: openshift-image-registry
         - name: OPERATOR_NAME
           value: cluster-image-registry-operator
+        - name: OPERATOR_IMAGE
+          value: quay.io/openshift/cluster-image-registry-operator:latest
         - name: IMAGE
           value: quay.io/openshift/docker-registry:latest
         - name: IMAGE_PRUNER


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the operator image environment variable so that the image-registy cluster operator can proceed. This is a newer requirement coming from [here](https://github.com/openshift/cluster-image-registry-operator/blob/master/manifests/07-operator.yaml#L71).

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-30060](https://issues.redhat.com/browse/OCPBUGS-30060)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.