### PR TITLE
OCPBUGS-30124: set issuer URL correctly for external OIDC

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/oauth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/oauth.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileOauthMetadata(cfg *corev1.ConfigMap, ownerRef config.OwnerRef, userOauthMetadata string, externalOAuthAddress string, externalOAuthPort int32) error {
+func ReconcileOauthMetadata(cfg *corev1.ConfigMap, ownerRef config.OwnerRef, userOauthMetadata string, oauthIssuerURL string) error {
 	ownerRef.ApplyTo(cfg)
 	if cfg.Data == nil {
 		cfg.Data = map[string]string{}
@@ -21,8 +21,7 @@ func ReconcileOauthMetadata(cfg *corev1.ConfigMap, ownerRef config.OwnerRef, use
 		cfg.Data[OauthMetadataConfigKey] = userOauthMetadata
 		return nil
 	}
-	oauthURL := fmt.Sprintf("https://%s:%d", externalOAuthAddress, externalOAuthPort)
-	cfg.Data[OauthMetadataConfigKey] = fmt.Sprintf(oauthMetadata, oauthURL)
+	cfg.Data[OauthMetadataConfigKey] = fmt.Sprintf(oauthMetadata, oauthIssuerURL)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -53,15 +53,14 @@ type KubeAPIServerParams struct {
 	ExternalPort    int32  `json:"externalPort"`
 	InternalAddress string `json:"internalAddress"`
 	// KASPodPort is the port to expose in the KAS Pod.
-	KASPodPort           int32                        `json:"apiServerPort"`
-	ExternalOAuthAddress string                       `json:"externalOAuthAddress"`
-	ExternalOAuthPort    int32                        `json:"externalOAuthPort"`
-	OIDCCAConfigMap      *corev1.LocalObjectReference `json:"oidcCAConfigMap"`
-	EtcdURL              string                       `json:"etcdAddress"`
-	KubeConfigRef        *hyperv1.KubeconfigSecretRef `json:"kubeConfigRef"`
-	AuditWebhookRef      *corev1.LocalObjectReference `json:"auditWebhookRef"`
-	ConsolePublicURL     string                       `json:"consolePublicURL"`
-	DisableProfiling     bool                         `json:"disableProfiling"`
+	KASPodPort       int32                        `json:"apiServerPort"`
+	OAuthIssuerURL   string                       `json:"oauthIssuerURL"`
+	OIDCCAConfigMap  *corev1.LocalObjectReference `json:"oidcCAConfigMap"`
+	EtcdURL          string                       `json:"etcdAddress"`
+	KubeConfigRef    *hyperv1.KubeconfigSecretRef `json:"kubeConfigRef"`
+	AuditWebhookRef  *corev1.LocalObjectReference `json:"auditWebhookRef"`
+	ConsolePublicURL string                       `json:"consolePublicURL"`
+	DisableProfiling bool                         `json:"disableProfiling"`
 	config.DeploymentConfig
 	config.OwnerRef
 
@@ -82,15 +81,14 @@ const (
 	KonnectivityServerPort      = 8091
 )
 
-func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, externalAPIAddress string, externalAPIPort int32, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {
+func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, externalAPIAddress string, externalAPIPort int32, oauthIssuerURL string, setDefaultSecurityContext bool) *KubeAPIServerParams {
 	dns := globalconfig.DNSConfig()
 	globalconfig.ReconcileDNSConfig(dns, hcp)
 	params := &KubeAPIServerParams{
 		ExternalAddress:      externalAPIAddress,
 		ExternalPort:         externalAPIPort,
 		InternalAddress:      fmt.Sprintf("api.%s.hypershift.local", hcp.Name),
-		ExternalOAuthAddress: externalOAuthAddress,
-		ExternalOAuthPort:    externalOAuthPort,
+		OAuthIssuerURL:       oauthIssuerURL,
 		ServiceAccountIssuer: hcp.Spec.IssuerURL,
 		ServiceCIDRs:         util.ServiceCIDRs(hcp.Spec.Networking.ServiceNetwork),
 		ClusterCIDRs:         util.ClusterCIDRs(hcp.Spec.Networking.ClusterNetwork),

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
@@ -68,7 +68,7 @@ func TestNewAPIServerParamsAPIAdvertiseAddressAndPort(t *testing.T) {
 			hcp.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{test.apiServiceMapping}
 			hcp.Spec.Networking.ServiceNetwork = append(hcp.Spec.Networking.ServiceNetwork, hyperv1.ServiceNetworkEntry{CIDR: *ipnet.MustParseCIDR(test.serviceNetworkCIDR)})
 			hcp.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{Port: test.port, AdvertiseAddress: pointer.String(test.advertiseAddress)}
-			p := NewKubeAPIServerParams(context.Background(), hcp, imageProvider, "", 0, "", 0, false)
+			p := NewKubeAPIServerParams(context.Background(), hcp, imageProvider, "", 0, "", false)
 			if len(test.advertiseAddress) > 0 {
 				g.Expect(test.advertiseAddress).To(Equal(test.expectedAddress))
 			}


### PR DESCRIPTION
We should encourage the `oc` user to provide the `--issuer-url` directly since, in the future, there can be multiple `oidcProviders`.  However, currently the `issuer` in `.well-known/oauth-authorization-server` provided by the KAS is `https://:0` which is obviously wrong.