### PR TITLE
OCPBUGS-30301: [kubevirt] Fix virt-launcher netpol to allow missing access

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -500,6 +500,22 @@ func reconcileVirtLauncherNetworkPolicy(policy *networkingv1.NetworkPolicy, hclu
 					},
 				},
 				{
+					// Allow access to the oauth server (from the console pod on the virtual machine)
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"hypershift.openshift.io/control-plane-component": "oauth-openshift",
+						},
+					},
+				},
+				{
+					// Allow access to the ignition server
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "ignition-server-proxy",
+						},
+					},
+				},
+				{
 					// Allow access to the management cluster ingress (for ignition server)
 					PodSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{


### PR DESCRIPTION
When creating an HostedCluster with 'NodePort' service publishing strategy, the VMs (guest nodes) are trying to contact HCP services, such as ignition and oauth. If these services are colocated on the same infra node, they can't be reached via NodePort because the 'virt-launcher' NetworkPolicy is blocking it. Explicitly adding access to oauth and ignition-server-proxy pods so they can be reached from the virtual machines on the same node.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.