### PR TITLE
OCPBUGS-28634: Update agentserviceconfig.md to remove PUBLIC_CONTAINER_REGISTRIES

### DIFF
--- a/docs/content/labs/common/mce/agentserviceconfig.md
+++ b/docs/content/labs/common/mce/agentserviceconfig.md
@@ -61,7 +61,6 @@ metadata:
   name: assisted-service-config
   namespace: multicluster-engine
 data:
-  PUBLIC_CONTAINER_REGISTRIES: "quay.io,registry.ci.openshift.org,registry.redhat.io"
   ALLOW_CONVERGED_FLOW: "false"
 ```
 
@@ -104,6 +103,8 @@ spec:
     url: http://registry.hypershiftbm.lab:8080/images/rhcos-414.92.202308281054-0-live.x86_64.iso
     version: 414.92.202308281054-0
 ```
+
+If your mirror registry doesn't require authentication in your pull secret, see [this document](https://github.com/openshift/assisted-service/blob/master/docs/operator.md#image-registries-without-authentication) on how to add it to the unauthenticated list in the AgentServiceConfig CR.
 
 In this section, we will emphasize the important aspects:
 


### PR DESCRIPTION
Instructing customers to override PUBLIC_CONTAINER_REGISTRIES is not ideal since the value specified for that override will completely wipe the default list and they could run into issues getting their images pulled (see https://issues.redhat.com/browse/OCPBUGS-28634). Instead we should provide the option to just add their registry to the default list.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Modifies the document for setting up assisted service to add a customer's registry as a "public" registry (one that doesn't require authentication). Prevents customers from using PUBLIC_CONTAINER_REGISTRIES which will override the default list.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-28634

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

/cc @jparrill 