### PR TITLE
HOSTEDCP-1220: Add multi-arch flag to CLI & associated validation

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -183,6 +183,7 @@ type AWSPlatformOptions struct {
 	EtcdKMSKeyARN           string
 	EnableProxy             bool
 	SingleNATGateway        bool
+	MultiArch               bool
 }
 
 type AzurePlatformOptions struct {

--- a/docs/content/how-to/aws/create-heterogeneous-nodepools.md
+++ b/docs/content/how-to/aws/create-heterogeneous-nodepools.md
@@ -1,0 +1,38 @@
+---
+title: Create Heterogeneous NodePools on AWS HostedClusters
+---
+
+# Create Heterogeneous NodePools on AWS HostedClusters
+## Create Heterogeneous NodePools Through the HyperShift CLI
+The `multi-arch` flag was added to the HyperShift CLI in OCP 4.16. The `multi-arch` flag indicates an expectation that the Hosted Cluster will support both amd64 and arm64 NodePools.
+
+When this flag is set, it will ensure:
+
+* if a release image is supplied, the release image must be a multi-arch release image
+* if a release stream is supplied, the release stream must be a multi-arch stream
+
+
+!!! note 
+
+    An individual NodePool only supports one CPU architecture and cannot support multiple CPU archiectures within the same NodePool.
+
+
+```shell linenums="1"
+REGION=us-east-1
+CLUSTER_NAME=example
+BASE_DOMAIN=example.com
+AWS_CREDS="$HOME/.aws/credentials"
+PULL_SECRET="$HOME/pull-secret"
+RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.16.0-ec.3-multi
+
+hypershift create cluster aws \
+  --name $CLUSTER_NAME \
+  --node-pool-replicas=3 \
+  --base-domain $BASE_DOMAIN \
+  --pull-secret $PULL_SECRET \
+  --aws-creds $AWS_CREDS \
+  --region $REGION \
+  --release-image $RELEASE_IMAGE \
+  --generate-ssh \
+  --multi-arch
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
     - how-to/automated-machine-management/performance-profiling.md
   - 'AWS':
     - how-to/aws/create-aws-hosted-cluster-arm-workers.md
+    - how-to/aws/create-heterogeneous-nodepools.md
     - how-to/aws/create-infra-iam-separately.md
     - how-to/aws/create-aws-hosted-cluster-multiple-zones.md
     - how-to/aws/deploy-aws-private-clusters.md

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -313,8 +313,8 @@ func GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distr
 	return digestsManifest, nil
 }
 
-// isMultiArchManifestList determines whether an image is a manifest listed image and contains manifests the following processor architectures: amd64, arm64, s390x, ppc64le
-func isMultiArchManifestList(ctx context.Context, imageRef string, pullSecret []byte) (bool, error) {
+// IsMultiArchManifestList determines whether an image is a manifest listed image and contains manifests the following processor architectures: amd64, arm64, s390x, ppc64le
+func IsMultiArchManifestList(ctx context.Context, imageRef string, pullSecret []byte) (bool, error) {
 	srcManifest, err := GetManifest(ctx, imageRef, pullSecret)
 	if err != nil {
 		return false, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
@@ -424,7 +424,7 @@ func findMatchingManifest(ctx context.Context, imageRef string, deserializedMani
 func GetCorrectArchImage(ctx context.Context, component string, imageRef string, pullSecret []byte) (manifestImageRef string, err error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	isMultiArchImage, err := isMultiArchManifestList(ctx, imageRef, pullSecret)
+	isMultiArchImage, err := IsMultiArchManifestList(ctx, imageRef, pullSecret)
 	if err != nil {
 		return "", fmt.Errorf("failed to determine if image is manifest listed: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the multi-arch flag to the HyperShift CLI to trigger additional validation to ensure a multi-arch release image or stream was used.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1220](https://issues.redhat.com/browse/HOSTEDCP-1220)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.