### PR TITLE
OCPBUGS-30061: fix nodecount controller going over mutation budget

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/nodecount/controller.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/nodecount/controller.go
@@ -51,8 +51,11 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return ctrl.Result{}, fmt.Errorf("failed to get Nodes: %w", err)
 	}
 
-	cfg := hypershiftv1beta1applyconfigurations.HostedControlPlane(r.hcpName, r.hcpNamespace)
-	cfg.Status = hypershiftv1beta1applyconfigurations.HostedControlPlaneStatus().WithNodeCount(len(nodes.Items))
-	_, err := r.client.HypershiftV1beta1().HostedControlPlanes(r.hcpNamespace).ApplyStatus(ctx, cfg, metav1.ApplyOptions{FieldManager: ControllerName})
-	return reconcile.Result{}, err
+	if hcp.Status.NodeCount == nil || *hcp.Status.NodeCount != len(nodes.Items) {
+		cfg := hypershiftv1beta1applyconfigurations.HostedControlPlane(r.hcpName, r.hcpNamespace)
+		cfg.Status = hypershiftv1beta1applyconfigurations.HostedControlPlaneStatus().WithNodeCount(len(nodes.Items))
+		_, err := r.client.HypershiftV1beta1().HostedControlPlanes(r.hcpNamespace).ApplyStatus(ctx, cfg, metav1.ApplyOptions{FieldManager: ControllerName})
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -707,7 +707,7 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 			{
 				name:   "control-plane-operator mutate",
 				query:  fmt.Sprintf(`sum by (pod) (max_over_time(hypershift:controlplane:component_api_requests_total{app="control-plane-operator", method!="GET", namespace=~"%s"}[%dm]))`, namespace, clusterAgeMinutes),
-				budget: 4000,
+				budget: 3000,
 			},
 			{
 				name:   "control-plane-operator no 404 deletes",


### PR DESCRIPTION
hcco: only send mutating apply call when necessary

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Revert "Merge pull request #3649 from sjenning/increase-cpo-mutate-budget"

This reverts commit 39fb1ddddc24b9412b964b0587426d5d80be06bc, reversing
changes made to 003a8d966aeea75a6bd7f8cf8791f5187b0feac0.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @sjenning 