### PR TITLE
NO-JIRA: cleanup: nilness check failures

### DIFF
--- a/availability-prober/availability_prober.go
+++ b/availability-prober/availability_prober.go
@@ -172,7 +172,7 @@ func check(log logr.Logger, target *url.URL, requestTimeout time.Duration, sleep
 				log.Error(err, fmt.Sprintf("failed to get pods with label %s in namespace %s, retrying...", labelSelectors, namespace))
 				continue
 			}
-			if pods != nil && len(pods.Items) > 0 {
+			if len(pods.Items) > 0 {
 				var retry bool
 				for _, pod := range pods.Items {
 					if pod.DeletionTimestamp == nil || time.Since(pod.DeletionTimestamp.Time).Minutes() < float64(10) {

--- a/cmd/infra/powervs/destroy.go
+++ b/cmd/infra/powervs/destroy.go
@@ -466,7 +466,7 @@ func destroyPowerVsCloudConnection(ctx context.Context, options *DestroyInfraOpt
 		for _, cloudConn := range cloudConnL.CloudConnections {
 			if *cloudConn.Name == cloudConnName {
 				// De-linking the VPC in cloud connection
-				var vpc *models.CloudConnectionEndpointVPC
+				var vpc models.CloudConnectionEndpointVPC
 				var vpcL []*models.CloudConnectionVPC
 				if cloudConn.Vpc != nil && cloudConn.Vpc.Enabled {
 					for _, v := range cloudConn.Vpc.Vpcs {
@@ -480,7 +480,7 @@ func destroyPowerVsCloudConnection(ctx context.Context, options *DestroyInfraOpt
 					vpc.Vpcs = vpcL
 				}
 
-				if _, _, err = client.Update(*cloudConn.CloudConnectionID, &models.CloudConnectionUpdate{Name: cloudConn.Name, Vpc: vpc}); err != nil {
+				if _, _, err = client.Update(*cloudConn.CloudConnectionID, &models.CloudConnectionUpdate{Name: cloudConn.Name, Vpc: &vpc}); err != nil {
 					return err
 				}
 

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -745,9 +745,6 @@ func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointSe
 	}
 
 	zoneID := awsEndpointService.Status.DNSZoneID
-	if err != nil {
-		return false, err
-	}
 
 	for _, fqdn := range awsEndpointService.Status.DNSNames {
 		if fqdn != "" && zoneID != "" {

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -518,9 +518,6 @@ func ReconcileInfra(client crclient.Client, hcp *hyperv1.HostedControlPlane, ctx
 		return fmt.Errorf("failed to get csr signer cert secret: %w", err)
 	}
 
-	if err != nil {
-		return err
-	}
 	tenantControllerKubeconfigSecret := manifests.KubevirtCSIDriverTenantKubeConfig(infraNamespace)
 	_, err = createOrUpdate(ctx, client, tenantControllerKubeconfigSecret, func() error {
 		return pki.ReconcileServiceAccountKubeconfig(tenantControllerKubeconfigSecret, csrSigner, rootCA, hcp, manifests.KubevirtCSIDriverTenantNamespaceStr, "kubevirt-csi-controller-sa")

--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
@@ -871,7 +871,7 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 			// this is OK, things are just propagating still
 			return true, nil, true, nil // we need to synthetically re-queue since nothing about KAS loading will trigger us
 		}
-		if err != nil && !apierrors.IsUnauthorized(err) {
+		if !apierrors.IsUnauthorized(err) {
 			return true, nil, false, fmt.Errorf("couldn't send SSR to guest cluster: %w", err)
 		}
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -621,9 +621,6 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		if hcpCVOConditions[conditionType] == nil {
 			unknownStatusMessage = "Condition not found in the CVO."
 		}
-		if err != nil {
-			unknownStatusMessage = fmt.Sprintf("failed to get clusterVersion: %v", err)
-		}
 
 		hcCVOCondition = &metav1.Condition{
 			Type:               string(conditionType),
@@ -876,7 +873,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 						return ctrl.Result{}, fmt.Errorf("failed to get ignitionServerRoute: %w", err)
 					}
 				}
-				if err == nil && ignitionServerRoute.Spec.Host != "" {
+				if ignitionServerRoute.Spec.Host != "" {
 					hcluster.Status.IgnitionEndpoint = ignitionServerRoute.Spec.Host
 				}
 			}

--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -516,7 +516,7 @@ func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointSe
 	})
 	if err != nil {
 		log.Info("failed to delete endpoint service, attempting to reject connections", "serviceID", serviceID)
-		if rejectErr := r.rejectVpcEndpointConnections(ctx, serviceID); err != nil {
+		if rejectErr := r.rejectVpcEndpointConnections(ctx, serviceID); rejectErr != nil {
 			return false, unwrapError(log, rejectErr)
 		}
 

--- a/hypershift-operator/init.go
+++ b/hypershift-operator/init.go
@@ -80,7 +80,7 @@ func runInit(ctx context.Context, log logr.Logger) error {
 		if err != nil {
 			return fmt.Errorf("unable to read ocm CA trust bundle file: %w", err)
 		}
-	} else if err != nil && errors.Is(err, os.ErrNotExist) {
+	} else if errors.Is(err, os.ErrNotExist) {
 		ocmTrustedCABundle, err = os.ReadFile("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
 		if err != nil {
 			return fmt.Errorf("unable to read ocm CA trust bundle file: %w", err)
@@ -120,7 +120,7 @@ func getImageRegistryCABundle(ctx context.Context, client crclient.Client) (*byt
 	if err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, img); err != nil {
 		return nil, err
 	}
-	if img == nil || img.Spec.AdditionalTrustedCA.Name == "" {
+	if img.Spec.AdditionalTrustedCA.Name == "" {
 		return nil, nil
 	}
 	configmap := &corev1.ConfigMap{}

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -244,9 +244,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		}
 		return true, nil
 	}); err != nil {
-		if err != nil {
-			return fmt.Errorf("failed to find operator image: %w", err)
-		}
+		return fmt.Errorf("failed to find operator image: %w", err)
 	}
 
 	log.Info("using hosted control plane operator image", "operator-image", operatorImage)

--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -72,9 +72,6 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to get kubernetes client: %w", err)
 	}
-	if err != nil {
-		return err
-	}
 	token := &corev1.Secret{}
 	if err := cl.Get(ctx, client.ObjectKey{Namespace: o.Namespace, Name: o.TokenSecret}, token); err != nil {
 		return err


### PR DESCRIPTION
This analyzer was recently added to `gopls`.  We should look at adding this to `make verify`.

```
$ go install golang.org/x/tools/go/analysis/passes/nilness/cmd/nilness@latest

$ go vet -vettool $(which nilness) ./...
# github.com/openshift/hypershift/cmd/infra/powervs
cmd/infra/powervs/destroy.go:479:10: nil dereference in field selection
cmd/infra/powervs/destroy.go:480:10: nil dereference in field selection
# github.com/openshift/hypershift/availability-prober
availability-prober/availability_prober.go:175:12: tautological condition: non-nil != nil
# github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt
control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go:521:9: impossible condition: nil != nil
# github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink
control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go:748:9: impossible condition: nil != nil
# github.com/openshift/hypershift/ignition-server/cmd
ignition-server/cmd/run_local_ignitionprovider.go:75:9: impossible condition: nil != nil
# github.com/openshift/hypershift/control-plane-pki-operator/certificaterevocationcontroller
control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go:874:10: tautological condition: non-nil != nil
# github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster
hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go:624:10: impossible condition: nil != nil
hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go:879:12: tautological condition: nil == nil
# github.com/openshift/hypershift/hypershift-operator/controllers/platform/aws
hypershift-operator/controllers/platform/aws/controller.go:519:71: tautological condition: non-nil != nil
# github.com/openshift/hypershift/hypershift-operator
hypershift-operator/init.go:83:16: tautological condition: non-nil != nil
hypershift-operator/init.go:123:9: impossible condition: non-nil == nil
hypershift-operator/main.go:247:10: tautological condition: non-nil != nil
```