### PR TITLE
STOR-1805: Set env var when the mgmt cluster supports SCC 

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -4367,7 +4367,7 @@ func (r *HostedControlPlaneReconciler) reconcileCSISnapshotControllerOperator(ct
 
 	deployment := manifests.CSISnapshotControllerOperatorDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return snapshotcontroller.ReconcileOperatorDeployment(deployment, params, hcp.Spec.Platform.Type)
+		return snapshotcontroller.ReconcileOperatorDeployment(deployment, params, hcp.Spec.Platform.Type, r.SetDefaultSecurityContext)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile CSI snapshot controller operator deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator_test.go
@@ -35,7 +35,7 @@ func TestReconcileOperatorDeployment(t *testing.T) {
 	deployment := manifests.CSISnapshotControllerOperatorDeployment("test-namespace")
 	imageProvider := imageprovider.NewFromImages(images)
 	params := NewParams(hcp, "1.0.0", imageProvider, true)
-	if err := ReconcileOperatorDeployment(deployment, params, hyperv1.NonePlatform); err != nil {
+	if err := ReconcileOperatorDeployment(deployment, params, hyperv1.NonePlatform, true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	deploymentYaml, err := util.SerializeResource(deployment, api.Scheme)

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
@@ -74,6 +74,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: HYPERSHIFT_SUPPORTS_SCC
+          value: "false"
         image: quay.io/openshift/cluster-csi-snapshot-controller-operator:latest
         imagePullPolicy: IfNotPresent
         name: csi-snapshot-controller-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets an environment variable when the management cluster the HCP is on supports SCC. This is needed to let the CSI operators not run their pod images as non-root.

**Which issue(s) this PR fixes**:
Fixes [STOR-1805](https://issues.redhat.com/browse/STOR-1805)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.