### PR TITLE
HOSTEDCP-1513: Support annotation scoping for hostedcluster resources

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -119,7 +120,7 @@ func (r *DedicatedServingComponentScheduler) SetupWithManager(mgr ctrl.Manager, 
 
 	r.createOrUpdate = createOrUpdateProvider.CreateOrUpdate
 	builder := ctrl.NewControllerManagedBy(mgr).
-		For(&hyperv1.HostedCluster{}).
+		For(&hyperv1.HostedCluster{}, builder.WithPredicates(util.PredicatesForHostedClusterAnnotationScoping())).
 		WithOptions(controller.Options{
 			RateLimiter:             workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 10*time.Second),
 			MaxConcurrentReconciles: 10,

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -24,12 +25,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const (
 	// DebugDeploymentsAnnotation contains a comma separated list of deployment names which should always be scaled to 0
 	// for development.
-	DebugDeploymentsAnnotation = "hypershift.openshift.io/debug-deployments"
+	DebugDeploymentsAnnotation               = "hypershift.openshift.io/debug-deployments"
+	EnableHostedClustersAnnotationScopingEnv = "ENABLE_HOSTEDCLUSTERS_ANNOTATION_SCOPING"
+	HostedClustersScopeAnnotationEnv         = "HOSTEDCLUSTERS_SCOPE_ANNOTATION"
+	HostedClustersScopeAnnotation            = "hypershift.openshift.io/scope"
+	HostedClusterAnnotation                  = "hypershift.openshift.io/cluster"
 )
 
 // ParseNamespacedName expects a string with the format "namespace/name"
@@ -385,4 +391,70 @@ func GetMgmtClusterCPUArch(ctx context.Context) (string, error) {
 	}
 
 	return platformParts[1], nil
+}
+
+// PredicatesForHostedClusterAnnotationScoping returns predicate filters for all event types that will ignore incoming
+// event requests for hostedcluster resources that do not match the "scope" annotation
+// specified in the HOSTEDCLUSTERS_SCOPE_ANNOTATION env var.  If not defined or empty, the default behavior is to accept all events for hostedclusters that do not have the annotation.
+// The ENABLE_HOSTEDCLUSTERS_ANNOTATION_SCOPING env var must also be set to "true" to enable the scoping feature.
+func PredicatesForHostedClusterAnnotationScoping() predicate.Predicate {
+	hcAnnotationScopingEnabledEnvVal := os.Getenv(EnableHostedClustersAnnotationScopingEnv)
+	hcScopeAnnotationEnvVal := os.Getenv(HostedClustersScopeAnnotationEnv)
+	filter := func(obj client.Object) bool {
+		if hcAnnotationScopingEnabledEnvVal != "true" {
+			return true
+		}
+		hostedClusterScopeAnnotation := ""
+		if obj.GetAnnotations() != nil {
+			hostedClusterScopeAnnotation = obj.GetAnnotations()[HostedClustersScopeAnnotation]
+		}
+		if hostedClusterScopeAnnotation == "" && hcScopeAnnotationEnvVal == "" {
+			return true
+		}
+		if hostedClusterScopeAnnotation != hcScopeAnnotationEnvVal {
+			return false // ignore event; the hostedcluster has a scope annotation that does not match what is defined in HOSTEDCLUSTERS_SCOPE_ANNOTATION
+		}
+		return true
+	}
+	return predicate.NewPredicateFuncs(filter)
+}
+
+// PredicatesForHostedClusterChildResourcesAnnotationScoping returns predicate filters for all event types that will ignore incoming
+// event requests for resources in which the parent hostedcluster does not
+// match the "scope" annotation specified in the HOSTEDCLUSTERS_SCOPE_ANNOTATION env var.  If not defined or empty, the
+// default behavior is to accept all events for hostedclusters that do not have the annotation.
+// The ENABLE_HOSTEDCLUSTERS_ANNOTATION_SCOPING env var must also be set to "true" to enable the scoping feature.
+func PredicatesForHostedClusterChildResourcesAnnotationScoping(r client.Reader) predicate.Predicate {
+	hcAnnotationScopingEnabledEnvVal := os.Getenv(EnableHostedClustersAnnotationScopingEnv)
+	hcScopeAnnotationEnvVal := os.Getenv(HostedClustersScopeAnnotationEnv)
+	filter := func(obj client.Object) bool {
+		if hcAnnotationScopingEnabledEnvVal != "true" {
+			return true
+		}
+		hostedClusterName := ""
+		if obj.GetAnnotations() != nil {
+			hostedClusterName = obj.GetAnnotations()[HostedClusterAnnotation]
+		}
+		if hostedClusterName == "" {
+			return false // ignore event; unable to find associated hostedcluster annotation
+		}
+		namespacedName := ParseNamespacedName(hostedClusterName)
+		hcluster := &hyperv1.HostedCluster{}
+		err := r.Get(context.Background(), namespacedName, hcluster)
+		if err != nil {
+			return true
+		}
+		hostedClusterScopeAnnotation := ""
+		if hcluster.GetAnnotations() != nil {
+			hostedClusterScopeAnnotation = hcluster.GetAnnotations()[HostedClustersScopeAnnotation]
+		}
+		if hostedClusterScopeAnnotation == "" && hcScopeAnnotationEnvVal == "" {
+			return true
+		}
+		if hostedClusterScopeAnnotation != hcScopeAnnotationEnvVal {
+			return false // ignore event; the parent hostedcluster's scope annotation does not match what is defined in HOSTEDCLUSTERS_SCOPE_ANNOTATION
+		}
+		return true
+	}
+	return predicate.NewPredicateFuncs(filter)
 }


### PR DESCRIPTION
Allow the operator to manage a select group of hostedcluster resources that contain a specified annotation.  This feature can be useful for situations in which you want to test a new version of the operator without affecting an existing workload that is being managed by the current production-level operator.  In a dual operator setup like this, the "production" operator would be configured to ignore events for all `scope` annotated hostedclusters, while the "test" operator would ignore events for all hostedclusters that do not have the annotation.  Thus each operator would only process/reconcile hostedclusters that it manages.  The exact annotation to match in the test operator would be defined in the env var `HOSTEDCLUSTERS_SCOPE_ANNOTATION`, while the production operator wouldn't need to define anything.

The feature would NOT be enabled by default, as it requires the `ENABLE_HOSTEDCLUSTERS_ANNOTATION_SCOPING` to be set to go down that path.  Without that set, the operator would function as it does today.