### PR TITLE
OCPBUGS-30574: Update OLM Default Catalog Sources to 4.16 on main

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -118,11 +118,11 @@ func findTagReference(tags []imagev1.TagReference, name string) *imagev1.TagRefe
 	return nil
 }
 
-var CatalogToImage map[string]string = map[string]string{
-	"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.14",
-	"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.14",
-	"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.14",
-	"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.14",
+var CatalogToImage = map[string]string{
+	"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.16",
+	"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.16",
+	"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.16",
+	"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.16",
 }
 
 func ReconcileCatalogsImageStream(imageStream *imagev1.ImageStream, ownerRef config.OwnerRef, isImageRegistryOverrides map[string][]string) error {


### PR DESCRIPTION
4.16 default olm catalog sources are available already, so we can now update the default catalog sources to point to 4.16 indices instead of 4.14.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.