### PR TITLE
HOSTEDCP-1466: support/metrics: don't filter HCCO metrics

### DIFF
--- a/support/metrics/sets.go
+++ b/support/metrics/sets.go
@@ -406,20 +406,8 @@ func CatalogOperatorRelabelConfigs(set MetricsSet) []*prometheusoperatorv1.Relab
 }
 
 func HostedClusterConfigOperatorRelabelConfigs(set MetricsSet) []*prometheusoperatorv1.RelabelConfig {
-	switch set {
-	case MetricsSetTelemetry:
-		return []*prometheusoperatorv1.RelabelConfig{
-			{
-				Action:       "keep",
-				Regex:        "(cluster_infrastructure_provider|cluster_feature_set)",
-				SourceLabels: []prometheusoperatorv1.LabelName{"__name__"},
-			},
-		}
-	case MetricsSetSRE:
-		return sreMetricsSetConfig.HostedClusterConfigOperator
-	default:
-		return nil
-	}
+	// For now, no filtering will occur for the HCCO
+	return nil
 }
 
 func ControlPlaneOperatorRelabelConfigs(set MetricsSet) []*prometheusoperatorv1.RelabelConfig {


### PR DESCRIPTION
The HCCO emits very few metrics, all of which are central to understanding how the controller is running. We don't need to omit anything from the HCCO, for the same reasons that we don't omit anything from the CPO.
