### PR TITLE
OCPBUGS-30242: consider nigthly images in payoad version check

### DIFF
--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -248,7 +248,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 	clusterConfigComponentShort := "cca"
 	clusterConfigFile := "usr/bin/render"
 
-	if payloadVersion.LT(semver.Version{Major: 4, Minor: 15}) {
+	if payloadVersion.Major == 4 && payloadVersion.Minor < 15 {
 		clusterConfigComponent = "cluster-config-operator"
 		clusterConfigComponentShort = "cco"
 		clusterConfigFile = "usr/bin/cluster-config-operator"
@@ -679,7 +679,7 @@ cp %[2]s/manifests/99_feature-gate.yaml %[3]s/99_feature-gate.yaml
 `
 
 	// Depending on the version, we need different args.
-	if payloadVersion.LT(semver.Version{Major: 4, Minor: 15}) {
+	if payloadVersion.Major == 4 && payloadVersion.Minor < 15 {
 		script = `#!/bin/bash
 set -e
 mkdir -p %[2]s
@@ -700,7 +700,7 @@ cp %[2]s/manifests/99_feature-gate.yaml %[3]s/99_feature-gate.yaml
 	}
 
 	// Depending on the version, we need different args.
-	if payloadVersion.LT(semver.Version{Major: 4, Minor: 14}) {
+	if payloadVersion.Major == 4 && payloadVersion.Minor < 14 {
 		script = `#!/bin/bash
 set -e
 mkdir -p %[2]s


### PR DESCRIPTION
**What this PR does / why we need it**:  Reverts checks to simple major and minor checks that will work with nighlty images

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-30242](https://issues.redhat.com/browse/OCPBUGS-30242)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.