### PR TITLE
HOSTEDCP-1462: Enable TestNodePool and CreateCluster tests on Azure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,10 @@ ci-install-hypershift-private:
 ci-test-e2e:
 	hack/ci-test-e2e.sh ${CI_TESTS_RUN}
 
+.PHONY: ci-test-e2e-azure
+ci-test-e2e-azure:
+	hack/ci-test-e2e-azure.sh
+
 .PHONY: regenerate-pki
 regenerate-pki:
 	REGENERATE_PKI=1 $(GO) test ./control-plane-pki-operator/...

--- a/hack/ci-test-e2e-azure.sh
+++ b/hack/ci-test-e2e-azure.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# This script takes the first argument and use it as the input for -test.run.
+
+set -euo pipefail
+
+set -o monitor
+
+set -x
+
+generate_junit() {
+  # propagate SIGTERM to the `test-e2e` process
+  for child in $( jobs -p ); do
+    kill "${child}"
+  done
+  # wait until `test-e2e` finishes gracefully
+  wait
+
+  cat  /tmp/test_out | go tool test2json -t > /tmp/test_out.json
+  gotestsum --raw-command --junitfile="${ARTIFACT_DIR}/junit.xml" --format=standard-verbose -- cat /tmp/test_out.json
+  # Ensure generated junit has a useful suite name
+  sed -i 's/\(<testsuite.*\)name=""/\1 name="hypershift-e2e"/' "${ARTIFACT_DIR}/junit.xml"
+}
+trap generate_junit EXIT
+
+bin/test-e2e \
+  -test.v \
+  -test.timeout=2h10m \
+  -test.run='^TestCreateCluster.*|^TestNodePool.*' \
+  -test.parallel=20 \
+  --e2e.platform=Azure \
+  --e2e.azure-credentials-file=/etc/hypershift-ci-jobs-azurecreds/credentials.json \
+  --e2e.pull-secret-file=/etc/ci-pull-credentials/.dockerconfigjson \
+  --e2e.base-domain=hypershift.azure.devcluster.openshift.com \
+  --e2e.latest-release-image="${OCP_IMAGE_LATEST}" \
+  --e2e.previous-release-image="${OCP_IMAGE_PREVIOUS}" \
+  | tee /tmp/test_out &
+
+wait $!

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -161,6 +161,9 @@ func TestNoneCreateCluster(t *testing.T) {
 
 // TestCreateClusterProxy implements a test that creates a cluster behind a proxy with the code under test.
 func TestCreateClusterProxy(t *testing.T) {
+	if globalOpts.Platform != hyperv1.AWSPlatform {
+		t.Skip("test only supported on platform AWS")
+	}
 	t.Parallel()
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
@@ -177,6 +180,9 @@ func TestCreateClusterProxy(t *testing.T) {
 // Validations requiring guest cluster client are dropped here since the kas is not accessible when private.
 // In the future we might want to leverage https://issues.redhat.com/browse/HOSTEDCP-697 to access guest cluster.
 func TestCreateClusterPrivate(t *testing.T) {
+	if globalOpts.Platform != hyperv1.AWSPlatform {
+		t.Skip("test only supported on platform AWS")
+	}
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(testContext)
@@ -197,6 +203,9 @@ func TestCreateClusterPrivate(t *testing.T) {
 func testSwitchFromPrivateToPublic(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *core.CreateOptions) func(t *testing.T) {
 	return func(t *testing.T) {
 		g := NewWithT(t)
+		if globalOpts.Platform != hyperv1.AWSPlatform {
+			t.Skip("test only supported on platform AWS")
+		}
 
 		err := e2eutil.UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.Platform.AWS.EndpointAccess = hyperv1.PublicAndPrivate
@@ -210,6 +219,10 @@ func testSwitchFromPrivateToPublic(ctx context.Context, client crclient.Client, 
 func testSwitchFromPublicToPrivate(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *core.CreateOptions) func(t *testing.T) {
 	return func(t *testing.T) {
 		g := NewWithT(t)
+		if globalOpts.Platform != hyperv1.AWSPlatform {
+			t.Skip("test only supported on platform AWS")
+		}
+
 		err := e2eutil.UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.Platform.AWS.EndpointAccess = hyperv1.Private
 		})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -493,7 +493,7 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 	}
 
 	// Arch is only currently valid for aws platform
-	if o.Platform == hyperv1.AWSPlatform {
+	if o.Platform == hyperv1.AWSPlatform || o.Platform == hyperv1.AzurePlatform {
 		createOption.Arch = "amd64"
 	}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -462,6 +462,7 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 			CredentialsFile: o.configurableClusterOptions.AzureCredentialsFile,
 			Location:        o.configurableClusterOptions.AzureLocation,
 			InstanceType:    "Standard_D4s_v4",
+			SubnetName:      "default",
 			DiskSizeGB:      120,
 		},
 		PowerVSPlatform: core.PowerVSPlatformOptions{


### PR DESCRIPTION
**What this PR does / why we need it**: getting TestCreateCluster and TestNodePool to work with Azure so we can use them as presubmits to get started with.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1462](https://issues.redhat.com/browse/HOSTEDCP-1462)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.