### PR TITLE
HOSTEDCP-1487: Add ability to set managed service type in HO

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -356,6 +356,7 @@ type HyperShiftOperatorDeployment struct {
 	CertRotationScale                       time.Duration
 	EnableCVOManagementClusterMetricsAccess bool
 	EnableDedicatedRequestServingIsolation  bool
+	ManagedService                          string
 }
 
 func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
@@ -448,6 +449,13 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  config.EnableCVOManagementClusterMetricsAccessEnvVar,
 			Value: "1",
+		})
+	}
+
+	if len(o.ManagedService) > 0 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "MANAGED_SERVICE",
+			Value: o.ManagedService,
 		})
 	}
 

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -95,6 +95,7 @@ type Options struct {
 	CertRotationScale                         time.Duration
 	EnableDedicatedRequestServingIsolation    bool
 	PullSecretFile                            string
+	ManagedService                            string
 }
 
 func (o *Options) Validate() error {
@@ -212,6 +213,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().DurationVar(&opts.CertRotationScale, "cert-rotation-scale", opts.CertRotationScale, "The scaling factor for certificate rotation. It is not supported to set this to anything other than 24h.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableDedicatedRequestServingIsolation, "enable-dedicated-request-serving-isolation", true, "If true, enables scheduling of request serving components to dedicated nodes")
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "File path to a pull secret.")
+	cmd.PersistentFlags().StringVar(&opts.ManagedService, "managed-service", opts.ManagedService, "The type of managed service the HyperShift Operator is installed on; this is used to configure different HostedCluster options depending on the managed service. Examples: ARO HCP, ROSA HCP")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		opts.ApplyDefaults()
@@ -622,6 +624,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, error) {
 		CertRotationScale:                       opts.CertRotationScale,
 		EnableCVOManagementClusterMetricsAccess: opts.EnableCVOManagementClusterMetricsAccess,
 		EnableDedicatedRequestServingIsolation:  opts.EnableDedicatedRequestServingIsolation,
+		ManagedService:                          opts.ManagedService,
 	}.Build()
 	objects = append(objects, operatorDeployment)
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -126,7 +126,8 @@ const (
 	controlPlanePKIOperatorSignsCSRsLabel                      = "io.openshift.hypershift.control-plane-pki-operator-signs-csrs"
 	useRestrictedPodSecurityLabel                              = "io.openshift.hypershift.restricted-psa"
 
-	etcdEncKeyPostfix = "-etcd-encryption-key"
+	etcdEncKeyPostfix    = "-etcd-encryption-key"
+	managedServiceEnvVar = "MANAGED_SERVICE"
 )
 
 var (
@@ -2588,6 +2589,16 @@ func reconcileControlPlaneOperatorDeployment(
 			corev1.EnvVar{
 				Name:  config.EnableCVOManagementClusterMetricsAccessEnvVar,
 				Value: "1",
+			},
+		)
+	}
+
+	managedServiceType, ok := os.LookupEnv(managedServiceEnvVar)
+	if ok {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  managedServiceEnvVar,
+				Value: managedServiceType,
 			},
 		)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to set managed service type in HO

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1487](https://issues.redhat.com/browse/HOSTEDCP-1487)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.