### PR TITLE
[release-4.15] OCPBUGS-30651: Remove EnsurePSANotPrivileged

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -99,7 +99,6 @@ func TestCreateClusterRequestServingIsolation(t *testing.T) {
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		guestClient := e2eutil.WaitForGuestClient(t, testContext, mgtClient, hostedCluster)
-		e2eutil.EnsurePSANotPrivileged(t, ctx, guestClient)
 		e2eutil.EnsureAllReqServingPodsLandOnReqServingNodes(t, ctx, guestClient)
 		e2eutil.EnsureOnlyRequestServingPodsOnRequestServingNodes(t, ctx, guestClient)
 		e2eutil.EnsureNoHCPPodsLandOnDefaultNode(t, ctx, guestClient, hostedCluster)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -37,7 +37,6 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	kapierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -537,42 +536,6 @@ func EnsureMachineDeploymentGeneration(t *testing.T, ctx context.Context, hostCl
 			if machineDeployment.Generation != expectedGeneration {
 				t.Errorf("machineDeployment %s does not have expected generation %d but %d", crclient.ObjectKeyFromObject(&machineDeployment), expectedGeneration, machineDeployment.Generation)
 			}
-		}
-	})
-}
-
-func EnsurePSANotPrivileged(t *testing.T, ctx context.Context, guestClient crclient.Client) {
-	t.Run("EnsurePSANotPrivileged", func(t *testing.T) {
-		testNamespaceName := "e2e-psa-check"
-		namespace := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: testNamespaceName,
-			},
-		}
-		if err := guestClient.Create(ctx, namespace); err != nil {
-			t.Fatalf("failed to create namespace: %v", err)
-		}
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: testNamespaceName,
-			},
-			Spec: corev1.PodSpec{
-				NodeSelector: map[string]string{
-					"e2e.openshift.io/unschedulable": "should-not-run",
-				},
-				Containers: []corev1.Container{
-					{Name: "first", Image: "something-innocuous"},
-				},
-				HostPID: true, // enforcement of restricted or baseline policy should reject this
-			},
-		}
-		err := guestClient.Create(ctx, pod)
-		if err == nil {
-			t.Errorf("pod admitted when rejection was expected")
-		}
-		if !kapierror.IsForbidden(err) {
-			t.Errorf("forbidden error expected, got %s", err)
 		}
 	})
 }


### PR DESCRIPTION
Full revert of [1] and partial revert of [2].

[1] https://github.com/openshift/hypershift/pull/3107
[2] https://github.com/openshift/hypershift/pull/3137

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-30651](https://issues.redhat.com/browse/OCPBUGS-30651)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.