### PR TITLE
NO-JIRA:Bump CPO Read API budget to 4000 in EnsureApiBudget

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -702,7 +702,7 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 			{
 				name:   "control-plane-operator read",
 				query:  fmt.Sprintf(`sum by (pod) (max_over_time(hypershift:controlplane:component_api_requests_total{app="control-plane-operator", method="GET", namespace=~"%s"}[%dm]))`, namespace, clusterAgeMinutes),
-				budget: 3000,
+				budget: 4000,
 			},
 			{
 				name:   "control-plane-operator mutate",


### PR DESCRIPTION
Bump CPO Read API budget to 4000 in EnsureApiBudget to stay in sync with 4.15