### PR TITLE
OCPBUGS-30260: Support specifying AWS LB subnets

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -260,6 +260,10 @@ const (
 	// the frequency of memory collection when memory used rises above a particular threshhold. This can be used to reduce
 	// the memory footprint of the kube-apiserver during upgrades.
 	KubeAPIServerGOMemoryLimitAnnotation = "hypershift.openshift.io/kube-apiserver-gomemlimit"
+
+	// AWSLoadBalancerSubnetsAnnotation allows specifying the subnets to use for control plane load balancers
+	// in the AWS platform.
+	AWSLoadBalancerSubnetsAnnotation = "hypershift.openshift.io/aws-load-balancer-subnets"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1492,7 +1492,7 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Con
 		apiServerService = manifests.KubeAPIServerServiceAzureLB(hcp.Namespace)
 	}
 	if _, err := createOrUpdate(ctx, r.Client, apiServerService, func() error {
-		return kas.ReconcileService(apiServerService, serviceStrategy, p.OwnerReference, kasSVCPort, p.AllowedCIDRBlocks, util.IsPublicHCP(hcp), util.IsPrivateHCP(hcp))
+		return kas.ReconcileService(apiServerService, serviceStrategy, p.OwnerReference, kasSVCPort, p.AllowedCIDRBlocks, hcp)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile API server service: %w", err)
 	}
@@ -1584,7 +1584,7 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivityServerService(ctx co
 	}
 	konnectivityServerService := manifests.KonnectivityServerService(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, konnectivityServerService, func() error {
-		return kas.ReconcileKonnectivityServerService(konnectivityServerService, p.OwnerRef, serviceStrategy)
+		return kas.ReconcileKonnectivityServerService(konnectivityServerService, p.OwnerRef, serviceStrategy, hcp)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile Konnectivity service: %w", err)
 	}
@@ -1726,7 +1726,7 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	if util.IsPrivateHCP(hcp) {
 		svc := manifests.PrivateRouterService(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r.Client, svc, func() error {
-			return ingress.ReconcileRouterService(svc, true, true)
+			return ingress.ReconcileRouterService(svc, true, true, hcp)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile private router service: %w", err)
 		}
@@ -1748,7 +1748,7 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	// When Public access endpoint we need to create a Service type LB external for the KAS.
 	if util.IsPublicHCP(hcp) && exposeKASThroughRouter {
 		if _, err := createOrUpdate(ctx, r.Client, pubSvc, func() error {
-			return ingress.ReconcileRouterService(pubSvc, false, util.IsPrivateHCP(hcp))
+			return ingress.ReconcileRouterService(pubSvc, false, util.IsPrivateHCP(hcp), hcp)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile router service: %w", err)
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -224,16 +224,19 @@ func buildHCPRouterContainerMain(image string) func(*corev1.Container) {
 	}
 }
 
-func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancingEnabled bool) error {
-	if svc.Annotations == nil {
-		svc.Annotations = map[string]string{}
-	}
-	svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
-	if internal {
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
-	}
-	if crossZoneLoadBalancingEnabled {
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancingEnabled bool, hcp *hyperv1.HostedControlPlane) error {
+	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
+		if svc.Annotations == nil {
+			svc.Annotations = map[string]string{}
+		}
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+		if internal {
+			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
+		}
+		if crossZoneLoadBalancingEnabled {
+			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+		}
+		util.ApplyAWSLoadBalancerSubnetsAnnotation(svc, hcp)
 	}
 
 	if svc.Labels == nil {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1783,6 +1783,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.KubeAPIServerGOGCAnnotation,
 		hyperv1.KubeAPIServerGOMemoryLimitAnnotation,
 		hyperv1.RequestServingNodeAdditionalSelectorAnnotation,
+		hyperv1.AWSLoadBalancerSubnetsAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -28,6 +28,7 @@ const (
 	HostedClusterNameLabel            = "hypershift.openshift.io/cluster-name"
 	HostedClusterNamespaceLabel       = "hypershift.openshift.io/cluster-namespace"
 	goMemLimitLabel                   = "hypershift.openshift.io/request-serving-gomemlimit"
+	lbSubnetsLabel                    = "hypershift.openshift.io/request-serving-subnets"
 )
 
 type DedicatedServingComponentNodeReaper struct {
@@ -209,11 +210,15 @@ func (r *DedicatedServingComponentScheduler) Reconcile(ctx context.Context, req 
 	}
 
 	nodeGoMemLimit := ""
+	lbSubnets := ""
 	for _, node := range nodesToUse {
 		originalNode := node.DeepCopy()
 
 		if node.Labels[goMemLimitLabel] != "" && nodeGoMemLimit == "" {
 			nodeGoMemLimit = node.Labels[goMemLimitLabel]
+		}
+		if node.Labels[lbSubnetsLabel] != "" && lbSubnets == "" {
+			lbSubnets = node.Labels[lbSubnetsLabel]
 		}
 
 		// Add taint and labels for specific hosted cluster
@@ -250,6 +255,9 @@ func (r *DedicatedServingComponentScheduler) Reconcile(ctx context.Context, req 
 	hcluster.Annotations[hyperv1.HostedClusterScheduledAnnotation] = "true"
 	if nodeGoMemLimit != "" {
 		hcluster.Annotations[hyperv1.KubeAPIServerGOMemoryLimitAnnotation] = nodeGoMemLimit
+	}
+	if lbSubnets != "" {
+		hcluster.Annotations[hyperv1.AWSLoadBalancerSubnetsAnnotation] = lbSubnets
 	}
 	if err := r.Patch(ctx, hcluster, client.MergeFrom(originalHcluster)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update hostedcluster annotation: %w", err)

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -305,3 +305,16 @@ func ParseNodeSelector(str string) map[string]string {
 	}
 	return result
 }
+
+func ApplyAWSLoadBalancerSubnetsAnnotation(svc *corev1.Service, hcp *hyperv1.HostedControlPlane) {
+	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform {
+		return
+	}
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	subnets, ok := hcp.Annotations[hyperv1.AWSLoadBalancerSubnetsAnnotation]
+	if ok {
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-subnets"] = subnets
+	}
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -260,6 +260,10 @@ const (
 	// the frequency of memory collection when memory used rises above a particular threshhold. This can be used to reduce
 	// the memory footprint of the kube-apiserver during upgrades.
 	KubeAPIServerGOMemoryLimitAnnotation = "hypershift.openshift.io/kube-apiserver-gomemlimit"
+
+	// AWSLoadBalancerSubnetsAnnotation allows specifying the subnets to use for control plane load balancers
+	// in the AWS platform.
+	AWSLoadBalancerSubnetsAnnotation = "hypershift.openshift.io/aws-load-balancer-subnets"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces an annotation to HostedClusters
(hypershift.openshift.io/aws-load-balancer-subnets) that will drive the service.beta.kubernetes.io/aws-load-balancer-subnets annotation on services of type LoadBalancer created by a hosted control plane.

Modifies the request serving node scheduler to automatically set the above annotation if the label
hypershift.openshift.io/request-serving-subnets is set on request serving nodes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-30260](https://issues.redhat.com/browse/OCPBUGS-30260)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.