### PR TITLE
HOSTEDCP-1467: ARO HCP - Add ability to specify subnet at nodepool level

### DIFF
--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -897,6 +897,11 @@ type AzureNodePoolPlatform struct {
 	// EnableEphemeralOSDisk enables ephemeral OS disk
 	// +optional
 	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
+	// SubnetName is the name of the subnet to place the Nodes into
+	//
+	// +kubebuilder:default:=default
+	// +kubebuilder:validation:Required
+	SubnetName string `json:"subnetName"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -895,6 +895,11 @@ type AzureNodePoolPlatform struct {
 	// EnableEphemeralOSDisk enables ephemeral OS disk
 	// +optional
 	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
+	// SubnetName is the name of the subnet to place the Nodes into
+	//
+	// +kubebuilder:default:=default
+	// +kubebuilder:validation:Required
+	SubnetName string `json:"subnetName"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
@@ -27,6 +27,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	AvailabilityZone       *string `json:"availabilityZone,omitempty"`
 	DiskEncryptionSetID    *string `json:"diskEncryptionSetID,omitempty"`
 	EnableEphemeralOSDisk  *bool   `json:"enableEphemeralOSDisk,omitempty"`
+	SubnetName             *string `json:"subnetName,omitempty"`
 }
 
 // AzureNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AzureNodePoolPlatform type for use with
@@ -88,5 +89,13 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithDiskEncryptionSetID(value 
 // If called multiple times, the EnableEphemeralOSDisk field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithEnableEphemeralOSDisk(value bool) *AzureNodePoolPlatformApplyConfiguration {
 	b.EnableEphemeralOSDisk = &value
+	return b
+}
+
+// WithSubnetName sets the SubnetName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the SubnetName field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithSubnetName(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.SubnetName = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
@@ -27,6 +27,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	AvailabilityZone       *string `json:"availabilityZone,omitempty"`
 	DiskEncryptionSetID    *string `json:"diskEncryptionSetID,omitempty"`
 	EnableEphemeralOSDisk  *bool   `json:"enableEphemeralOSDisk,omitempty"`
+	SubnetName             *string `json:"subnetName,omitempty"`
 }
 
 // AzureNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AzureNodePoolPlatform type for use with
@@ -88,5 +89,13 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithDiskEncryptionSetID(value 
 // If called multiple times, the EnableEphemeralOSDisk field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithEnableEphemeralOSDisk(value bool) *AzureNodePoolPlatformApplyConfiguration {
 	b.EnableEphemeralOSDisk = &value
+	return b
+}
+
+// WithSubnetName sets the SubnetName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the SubnetName field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithSubnetName(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.SubnetName = &value
 	return b
 }

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -29,6 +29,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	opts.AzurePlatform.Location = "eastus"
 	opts.AzurePlatform.InstanceType = "Standard_D4s_v4"
 	opts.AzurePlatform.DiskSizeGB = 120
+	opts.AzurePlatform.SubnetName = "default"
 
 	cmd.Flags().StringVar(&opts.AzurePlatform.CredentialsFile, "azure-creds", opts.AzurePlatform.CredentialsFile, "Path to an Azure credentials file (required)")
 	cmd.Flags().StringVar(&opts.AzurePlatform.Location, "location", opts.AzurePlatform.Location, "Location for the cluster")
@@ -42,6 +43,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.AzurePlatform.EnableEphemeralOSDisk, "enable-ephemeral-disk", opts.AzurePlatform.EnableEphemeralOSDisk, "If enabled, the Azure VMs in the default NodePool will be setup with ephemeral OS disks")
 	cmd.Flags().StringVar(&opts.AzurePlatform.DiskStorageAccountType, "disk-storage-account-type", opts.AzurePlatform.DiskStorageAccountType, "The disk storage account type for the OS disks for the VMs.")
 	cmd.Flags().StringToStringVarP(&opts.AzurePlatform.ResourceGroupTags, "resource-group-tags", "t", opts.AzurePlatform.ResourceGroupTags, "Additional tags to apply to the resource group created (e.g. 'key1=value1,key2=value2')")
+	cmd.Flags().StringVar(&opts.AzurePlatform.SubnetName, "subnet-name", opts.AzurePlatform.SubnetName, "The subnet name where the VMs will be placed.")
 
 	_ = cmd.MarkFlagRequired("azure-creds")
 	_ = cmd.MarkPersistentFlagRequired("pull-secret")
@@ -103,6 +105,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			ResourceGroupName:    opts.AzurePlatform.ResourceGroupName,
 			NetworkSecurityGroup: opts.AzurePlatform.NetworkSecurityGroup,
 			ResourceGroupTags:    opts.AzurePlatform.ResourceGroupTags,
+			SubnetName:           opts.AzurePlatform.SubnetName,
 		}).Run(ctx, opts.Log)
 		if err != nil {
 			return fmt.Errorf("failed to create infra: %w", err)
@@ -189,7 +192,7 @@ func lookupRHCOSImage(ctx context.Context, arch string, image string, pullSecret
 }
 
 // validateFlags validates the core create option flags passed in by the user
-func validateFlags(cmd *cobra.Command, args []string) error {
+func validateFlags(cmd *cobra.Command, _ []string) error {
 	// Check if the network security group is set and the resource group is not
 	nsg, err := cmd.Flags().GetString("network-security-group")
 	if err != nil {

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -198,6 +198,7 @@ type AzurePlatformOptions struct {
 	EnableEphemeralOSDisk  bool
 	DiskStorageAccountType string
 	ResourceGroupTags      map[string]string
+	SubnetName             string
 }
 
 func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures.ExampleOptions, error) {

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -36,7 +36,6 @@ import (
 )
 
 const (
-	SubnetName                        = "default"
 	VirtualNetworkAddressPrefix       = "10.0.0.0/16"
 	VirtualNetworkLinkLocation        = "global"
 	VirtualNetworkSubnetAddressPrefix = "10.0.0.0/24"
@@ -54,6 +53,7 @@ type CreateInfraOptions struct {
 	ResourceGroupName    string
 	NetworkSecurityGroup string
 	ResourceGroupTags    map[string]string
+	SubnetName           string
 }
 
 type CreateInfraOutput struct {
@@ -189,7 +189,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 	}
 
 	// Create virtual network
-	subnetName, vnetID, vnetName, err := createVirtualNetwork(ctx, subscriptionID, resourceGroupName, o.Name, o.InfraID, o.Location, securityGroupID, azureCreds)
+	subnetName, vnetID, vnetName, err := createVirtualNetwork(ctx, subscriptionID, resourceGroupName, o.Name, o.InfraID, o.Location, o.SubnetName, securityGroupID, azureCreds)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +404,7 @@ func createSecurityGroup(ctx context.Context, subscriptionID string, resourceGro
 }
 
 // createVirtualNetwork creates the virtual network
-func createVirtualNetwork(ctx context.Context, subscriptionID string, resourceGroupName string, name string, infraID string, location string, securityGroupID string, azureCreds azcore.TokenCredential) (string, string, string, error) {
+func createVirtualNetwork(ctx context.Context, subscriptionID string, resourceGroupName string, name string, infraID string, location string, subnetName string, securityGroupID string, azureCreds azcore.TokenCredential) (string, string, string, error) {
 	networksClient, err := armnetwork.NewVirtualNetworksClient(subscriptionID, azureCreds, nil)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to create new virtual networks client: %w", err)
@@ -419,7 +419,7 @@ func createVirtualNetwork(ctx context.Context, subscriptionID string, resourceGr
 				},
 			},
 			Subnets: []*armnetwork.Subnet{{
-				Name: ptr.To(SubnetName),
+				Name: ptr.To(subnetName),
 				Properties: &armnetwork.SubnetPropertiesFormat{
 					AddressPrefix:        ptr.To(VirtualNetworkSubnetAddressPrefix),
 					NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: &securityGroupID},

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -589,9 +589,15 @@ spec:
                           ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
                           subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
                         type: string
+                      subnetName:
+                        default: default
+                        description: SubnetName is the name of the subnet to place
+                          the Nodes into
+                        type: string
                       vmsize:
                         type: string
                     required:
+                    - subnetName
                     - vmsize
                     type: object
                   ibmcloud:
@@ -1671,9 +1677,15 @@ spec:
                           ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
                           subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
                         type: string
+                      subnetName:
+                        default: default
+                        description: SubnetName is the name of the subnet to place
+                          the Nodes into
+                        type: string
                       vmsize:
                         type: string
                     required:
+                    - subnetName
                     - vmsize
                     type: object
                   ibmcloud:

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -19,12 +19,14 @@ type AzurePlatformCreateOptions struct {
 	DiskEncryptionSetID    string
 	EnableEphemeralOSDisk  bool
 	DiskStorageAccountType string
+	SubnetName             string
 }
 
 func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	platformOpts := &AzurePlatformCreateOptions{
 		InstanceType: "Standard_D4s_v4",
 		DiskSize:     120,
+		SubnetName:   "default",
 	}
 
 	cmd := &cobra.Command{
@@ -40,6 +42,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	cmd.Flags().StringVar(&platformOpts.DiskEncryptionSetID, "disk-encryption-set-id", platformOpts.DiskEncryptionSetID, "The Disk Encryption Set ID to use to encrypt the OS disks for the VMs.")
 	cmd.Flags().BoolVar(&platformOpts.EnableEphemeralOSDisk, "enable-ephemeral-disk", platformOpts.EnableEphemeralOSDisk, "If enabled, the Azure VMs in the NodePool will be setup with ephemeral OS disks")
 	cmd.Flags().StringVar(&platformOpts.DiskStorageAccountType, "disk-storage-account-type", platformOpts.DiskStorageAccountType, "The disk storage account type for the OS disks for the VMs.")
+	cmd.Flags().StringVar(&platformOpts.SubnetName, "subnet-name", platformOpts.SubnetName, "The subnet name where the VMs will be placed.")
 
 	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
 
@@ -60,6 +63,7 @@ func (o *AzurePlatformCreateOptions) UpdateNodePool(_ context.Context, nodePool 
 		DiskEncryptionSetID:    o.DiskEncryptionSetID,
 		EnableEphemeralOSDisk:  o.EnableEphemeralOSDisk,
 		DiskStorageAccountType: o.DiskStorageAccountType,
+		SubnetName:             o.SubnetName,
 	}
 	return nil
 }

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2364,6 +2364,17 @@ bool
 <p>EnableEphemeralOSDisk enables ephemeral OS disk</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>subnetName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>SubnetName is the name of the subnet to place the Nodes into</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###AzurePlatformSpec { #hypershift.openshift.io/v1beta1.AzurePlatformSpec }

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -694,6 +694,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 					DiskEncryptionSetID:    o.Azure.DiskEncryptionSetID,
 					EnableEphemeralOSDisk:  o.Azure.EnableEphemeralOSDisk,
 					DiskStorageAccountType: o.Azure.DiskStorageAccountType,
+					SubnetName:             o.Azure.SubnetName,
 				}
 				nodePools = append(nodePools, nodePool)
 			}
@@ -710,6 +711,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				DiskEncryptionSetID:    o.Azure.DiskEncryptionSetID,
 				EnableEphemeralOSDisk:  o.Azure.EnableEphemeralOSDisk,
 				DiskStorageAccountType: o.Azure.DiskStorageAccountType,
+				SubnetName:             o.Azure.SubnetName,
 			}
 			nodePools = append(nodePools, nodePool)
 		}

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -55596,9 +55596,15 @@ objects:
                             ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
                             subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
                           type: string
+                        subnetName:
+                          default: default
+                          description: SubnetName is the name of the subnet to place
+                            the Nodes into
+                          type: string
                         vmsize:
                           type: string
                       required:
+                      - subnetName
                       - vmsize
                       type: object
                     ibmcloud:
@@ -56682,9 +56688,15 @@ objects:
                             ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
                             subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
                           type: string
+                        subnetName:
+                          default: default
+                          description: SubnetName is the name of the subnet to place
+                            the Nodes into
+                          type: string
                         vmsize:
                           type: string
                       required:
+                      - subnetName
                       - vmsize
                       type: object
                     ibmcloud:

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -36,7 +36,7 @@ func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1
 			},
 		},
 		NetworkInterfaces: []capiazure.NetworkInterface{{
-			SubnetName: hcluster.Spec.Platform.Azure.SubnetName,
+			SubnetName: nodePool.Spec.Platform.Azure.SubnetName,
 		}},
 		Identity:               capiazure.VMIdentityUserAssigned,
 		UserAssignedIdentities: []capiazure.UserAssignedIdentity{{ProviderID: hcluster.Spec.Platform.Azure.MachineIdentityID}},

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
@@ -897,6 +897,11 @@ type AzureNodePoolPlatform struct {
 	// EnableEphemeralOSDisk enables ephemeral OS disk
 	// +optional
 	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
+	// SubnetName is the name of the subnet to place the Nodes into
+	//
+	// +kubebuilder:default:=default
+	// +kubebuilder:validation:Required
+	SubnetName string `json:"subnetName"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -895,6 +895,11 @@ type AzureNodePoolPlatform struct {
 	// EnableEphemeralOSDisk enables ephemeral OS disk
 	// +optional
 	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
+	// SubnetName is the name of the subnet to place the Nodes into
+	//
+	// +kubebuilder:default:=default
+	// +kubebuilder:validation:Required
+	SubnetName string `json:"subnetName"`
 }
 
 // We define our own condition type since metav1.Condition has validation


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the subnet to be set on a NodePool basis rather than just at the Hosted Cluster level. 

This PR also adds a flag to define the initial NodePool's subnet name when creating an Azure cluster, and it adds a flag when creating Azure NodePools to the HyperShift CLI.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1467](https://issues.redhat.com/browse/HOSTEDCP-1467)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.