### PR TITLE
NO-JIRA: Increase stability in autoscaled environments

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1217,9 +1217,10 @@ func HyperShiftControlPlanePriorityClass() *schedulingv1.PriorityClass {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: DefaultPriorityClass,
 		},
-		Value:         100000000,
-		GlobalDefault: false,
-		Description:   "This priority class should be used for hypershift control plane pods not critical to serving the API.",
+		Value:            100000000,
+		GlobalDefault:    false,
+		Description:      "This priority class should be used for hypershift control plane pods not critical to serving the API.",
+		PreemptionPolicy: ptr.To(corev1.PreemptNever),
 	}
 }
 
@@ -1232,9 +1233,10 @@ func HyperShiftAPICriticalPriorityClass() *schedulingv1.PriorityClass {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: APICriticalPriorityClass,
 		},
-		Value:         100001000,
-		GlobalDefault: false,
-		Description:   "This priority class should be used for hypershift control plane pods critical to serving the API.",
+		Value:            100001000,
+		GlobalDefault:    false,
+		Description:      "This priority class should be used for hypershift control plane pods critical to serving the API.",
+		PreemptionPolicy: ptr.To(corev1.PreemptNever),
 	}
 }
 
@@ -1247,9 +1249,10 @@ func HyperShiftEtcdPriorityClass() *schedulingv1.PriorityClass {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: EtcdPriorityClass,
 		},
-		Value:         100002000,
-		GlobalDefault: false,
-		Description:   "This priority class should be used for hypershift etcd pods.",
+		Value:            100002000,
+		GlobalDefault:    false,
+		Description:      "This priority class should be used for hypershift etcd pods.",
+		PreemptionPolicy: ptr.To(corev1.PreemptNever),
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -707,10 +707,7 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *EtcdPara
 	}
 
 	p.OwnerRef.ApplyTo(pdb)
-
-	minAvailable := 1
-	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
-
+	util.ReconcilePodDisruptionBudget(pdb, p.Availability)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -312,6 +312,5 @@ func ReconcileRouterPodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, avail
 		}
 	}
 	ownerRef.ApplyTo(pdb)
-	minAvailable := intstr.FromInt(1)
-	pdb.Spec.MinAvailable = &minAvailable
+	util.ReconcilePodDisruptionBudget(pdb, availability)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/pdb.go
@@ -1,9 +1,9 @@
 package kas
 
 import (
+	"github.com/openshift/hypershift/support/util"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *KubeAPIServerParams) error {
@@ -14,9 +14,6 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *KubeAPIS
 	}
 
 	p.OwnerRef.ApplyTo(pdb)
-
-	minAvailable := 1
-	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
-
+	util.ReconcilePodDisruptionBudget(pdb, p.Availability)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -305,11 +305,7 @@ func ReconcileOpenShiftOAuthAPIServerPodDisruptionBudget(pdb *policyv1.PodDisrup
 			MatchLabels: openShiftOAuthAPIServerLabels(),
 		}
 	}
-
 	p.OwnerRef.ApplyTo(pdb)
-
-	minAvailable := 1
-	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
-
+	util.ReconcilePodDisruptionBudget(pdb, p.Availability)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/pdb.go
@@ -1,9 +1,9 @@
 package oapi
 
 import (
+	"github.com/openshift/hypershift/support/util"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OpenShiftAPIServerParams) error {
@@ -12,11 +12,7 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OpenShif
 			MatchLabels: openShiftAPIServerLabels(),
 		}
 	}
-
 	p.OwnerRef.ApplyTo(pdb)
-
-	minAvailable := 1
-	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
-
+	util.ReconcilePodDisruptionBudget(pdb, p.Availability)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/pdb.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/pdb.go
@@ -1,9 +1,9 @@
 package oauth
 
 import (
+	"github.com/openshift/hypershift/support/util"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OAuthServerParams) error {
@@ -12,11 +12,7 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, p *OAuthSer
 			MatchLabels: oauthLabels(),
 		}
 	}
-
 	p.OwnerRef.ApplyTo(pdb)
-
-	minAvailable := 1
-	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minAvailable)}
-
+	util.ReconcilePodDisruptionBudget(pdb, p.Availability)
 	return nil
 }

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -10,6 +10,7 @@ objects:
   metadata:
     creationTimestamp: null
     name: hypershift-control-plane
+  preemptionPolicy: Never
   value: 100000000
 - apiVersion: scheduling.k8s.io/v1
   description: This priority class should be used for hypershift etcd pods.
@@ -17,6 +18,7 @@ objects:
   metadata:
     creationTimestamp: null
     name: hypershift-etcd
+  preemptionPolicy: Never
   value: 100002000
 - apiVersion: scheduling.k8s.io/v1
   description: This priority class should be used for hypershift control plane pods
@@ -25,6 +27,7 @@ objects:
   metadata:
     creationTimestamp: null
     name: hypershift-api-critical
+  preemptionPolicy: Never
   value: 100001000
 - apiVersion: scheduling.k8s.io/v1
   description: This priority class is used for hypershift operator pods

--- a/support/util/pdb.go
+++ b/support/util/pdb.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, availability hyperv1.AvailabilityPolicy) {
+	var minAvailable *intstr.IntOrString
+	var maxUnavailable *intstr.IntOrString
+	switch availability {
+	case hyperv1.SingleReplica:
+		minAvailable = ptr.To(intstr.FromInt(1))
+	case hyperv1.HighlyAvailable:
+		maxUnavailable = ptr.To(intstr.FromInt(1))
+	}
+	pdb.Spec.MinAvailable = minAvailable
+	pdb.Spec.MaxUnavailable = maxUnavailable
+}


### PR DESCRIPTION
Two commits to increase stability in autoscaled environments:
* Set `MaxUnavailable: 1` on API critical component PDBs when `HighlyAvailable`
* Disable preemption for hypershift PriorityClasses