### PR TITLE
NO-JIRA: Bump HO read budget in e2e to 6000

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -726,7 +726,7 @@ func EnsureAPIBudget(t *testing.T, ctx context.Context, client crclient.Client, 
 			{
 				name:   "hypershift-operator read",
 				query:  `sum(hypershift:operator:component_api_requests_total{method="GET"})`,
-				budget: 5000,
+				budget: 6000,
 			},
 			{
 				name:   "hypershift-operator mutate",


### PR DESCRIPTION
Bump HO read budget in e2e to 6000