### PR TITLE
HOSTEDCP-1487: Add managed service constants to HyperShift API

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -264,6 +264,12 @@ const (
 	// AWSLoadBalancerSubnetsAnnotation allows specifying the subnets to use for control plane load balancers
 	// in the AWS platform.
 	AWSLoadBalancerSubnetsAnnotation = "hypershift.openshift.io/aws-load-balancer-subnets"
+
+	// AroHCP represents the ARO HCP managed service offering
+	AroHCP = "ARO-HCP"
+
+	//RosaHCP represents the ROSA HCP managed service offering
+	RosaHCP = "ROSA-HCP"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -150,6 +150,10 @@ func (o *Options) Validate() error {
 	if o.RHOBSMonitoring && o.EnableCVOManagementClusterMetricsAccess {
 		errs = append(errs, fmt.Errorf("when invoking this command with the --rhobs-monitoring flag, the --enable-cvo-management-cluster-metrics-access flag is not supported "))
 	}
+
+	if len(o.ManagedService) > 0 && o.ManagedService != hyperv1.AroHCP && o.ManagedService != hyperv1.RosaHCP {
+		errs = append(errs, fmt.Errorf("not a valid managed service type: %s", o.ManagedService))
+	}
 	return errors.NewAggregate(errs)
 }
 
@@ -217,7 +221,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().DurationVar(&opts.CertRotationScale, "cert-rotation-scale", opts.CertRotationScale, "The scaling factor for certificate rotation. It is not supported to set this to anything other than 24h.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableDedicatedRequestServingIsolation, "enable-dedicated-request-serving-isolation", true, "If true, enables scheduling of request serving components to dedicated nodes")
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "File path to a pull secret.")
-	cmd.PersistentFlags().StringVar(&opts.ManagedService, "managed-service", opts.ManagedService, "The type of managed service the HyperShift Operator is installed on; this is used to configure different HostedCluster options depending on the managed service. Examples: ARO HCP, ROSA HCP")
+	cmd.PersistentFlags().StringVar(&opts.ManagedService, "managed-service", opts.ManagedService, "The type of managed service the HyperShift Operator is installed on; this is used to configure different HostedCluster options depending on the managed service. Examples: ARO-HCP, ROSA-HCP")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		opts.ApplyDefaults()

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -264,6 +264,12 @@ const (
 	// AWSLoadBalancerSubnetsAnnotation allows specifying the subnets to use for control plane load balancers
 	// in the AWS platform.
 	AWSLoadBalancerSubnetsAnnotation = "hypershift.openshift.io/aws-load-balancer-subnets"
+
+	// AroHCP represents the ARO HCP managed service offering
+	AroHCP = "ARO-HCP"
+
+	//RosaHCP represents the ROSA HCP managed service offering
+	RosaHCP = "ROSA-HCP"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds managed service constants to HyperShift API

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1487](https://issues.redhat.com/browse/HOSTEDCP-1487)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.