### PR TITLE
OCPBUGS-31012: Disable audit-log container in kas when profile is None

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/auditcfg.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/auditcfg.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	AuditPolicyConfigMapKey = "policy.yaml"
+	AuditPolicyConfigMapKey  = "policy.yaml"
+	AuditPolicyProfileMapKey = "profile"
 )
 
 func ReconcileAuditConfig(auditCfgMap *corev1.ConfigMap, ownerRef config.OwnerRef, auditConfig configv1.Audit) error {
@@ -29,5 +30,6 @@ func ReconcileAuditConfig(auditCfgMap *corev1.ConfigMap, ownerRef config.OwnerRe
 		return err
 	}
 	auditCfgMap.Data[AuditPolicyConfigMapKey] = string(policyBytes)
+	auditCfgMap.Data[AuditPolicyProfileMapKey] = string(auditConfig.Profile)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -205,27 +205,6 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 				util.BuildContainer(kasContainerApplyBootstrap(), buildKASContainerApplyBootstrap(images.CLI)),
 				util.BuildContainer(kasContainerMain(), buildKASContainerMain(images.HyperKube, port, additionalNoProxyCIDRS, hcp)),
 				util.BuildContainer(konnectivityServerContainer(), buildKonnectivityServerContainer(images.KonnectivityServer, deploymentConfig.Replicas, cipherSuites)),
-				{
-					Name:            "audit-logs",
-					Image:           images.CLI,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command: []string{
-						"/usr/bin/tail",
-						"-c+1",
-						"-F",
-						fmt.Sprintf("%s/%s", volumeMounts.Path(kasContainerMain().Name, kasVolumeWorkLogs().Name), "audit.log"),
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("5m"),
-							corev1.ResourceMemory: resource.MustParse("10Mi"),
-						},
-					},
-					VolumeMounts: []corev1.VolumeMount{{
-						Name:      kasVolumeWorkLogs().Name,
-						MountPath: volumeMounts.Path(kasContainerMain().Name, kasVolumeWorkLogs().Name),
-					}},
-				},
 			},
 			Volumes: []corev1.Volume{
 				util.BuildVolume(kasVolumeBootstrapManifests(), buildKASVolumeBootstrapManifests),
@@ -253,6 +232,30 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 				util.BuildVolume(konnectivityVolumeClusterCerts(), buildKonnectivityVolumeClusterCerts),
 			},
 		},
+	}
+
+	if auditConfig.Data[AuditPolicyProfileMapKey] != string(configv1.NoneAuditProfileType) {
+		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, corev1.Container{
+			Name:            "audit-logs",
+			Image:           images.CLI,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command: []string{
+				"/usr/bin/tail",
+				"-c+1",
+				"-F",
+				fmt.Sprintf("%s/%s", volumeMounts.Path(kasContainerMain().Name, kasVolumeWorkLogs().Name), "audit.log"),
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("5m"),
+					corev1.ResourceMemory: resource.MustParse("10Mi"),
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      kasVolumeWorkLogs().Name,
+				MountPath: volumeMounts.Path(kasContainerMain().Name, kasVolumeWorkLogs().Name),
+			}},
+		})
 	}
 
 	// With managed etcd, we should wait for the known etcd client service name to

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/auditcfg.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/auditcfg.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	auditPolicyConfigMapKey = "policy.yaml"
+	auditPolicyConfigMapKey  = "policy.yaml"
+	auditPolicyProfileMapKey = "profile"
 )
 
 func ReconcileAuditConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef, auditConfig configv1.Audit) error {
@@ -28,5 +29,6 @@ func ReconcileAuditConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef, auditC
 		return err
 	}
 	cm.Data[auditPolicyConfigMapKey] = string(policyBytes)
+	cm.Data[auditPolicyProfileMapKey] = string(auditConfig.Profile)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -94,27 +95,6 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 		AutomountServiceAccountToken: pointer.Bool(false),
 		Containers: []corev1.Container{
 			util.BuildContainer(oauthContainerMain(), buildOAuthContainerMain(p)),
-			{
-				Name:            "audit-logs",
-				Image:           p.Image,
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command: []string{
-					"/usr/bin/tail",
-					"-c+1",
-					"-F",
-					fmt.Sprintf("%s/%s", oauthVolumeMounts.Path(oauthContainerMain().Name, oauthVolumeWorkLogs().Name), "audit.log"),
-				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("5m"),
-						corev1.ResourceMemory: resource.MustParse("10Mi"),
-					},
-				},
-				VolumeMounts: []corev1.VolumeMount{{
-					Name:      oauthVolumeWorkLogs().Name,
-					MountPath: oauthVolumeMounts.Path(oauthContainerMain().Name, oauthVolumeWorkLogs().Name),
-				}},
-			},
 		},
 		Volumes: []corev1.Volume{
 			util.BuildVolume(oauthVolumeWorkLogs(), buildOAuthVolumeWorkLogs),
@@ -126,6 +106,30 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 			util.BuildVolume(oauthVolumeEtcdClientCert(), buildOAuthVolumeEtcdClientCert),
 			util.BuildVolume(common.VolumeTotalClientCA(), common.BuildVolumeTotalClientCA),
 		},
+	}
+
+	if auditConfig.Data[auditPolicyProfileMapKey] != string(configv1.NoneAuditProfileType) {
+		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, corev1.Container{
+			Name:            "audit-logs",
+			Image:           p.Image,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command: []string{
+				"/usr/bin/tail",
+				"-c+1",
+				"-F",
+				fmt.Sprintf("%s/%s", oauthVolumeMounts.Path(oauthContainerMain().Name, oauthVolumeWorkLogs().Name), "audit.log"),
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("5m"),
+					corev1.ResourceMemory: resource.MustParse("10Mi"),
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      oauthVolumeWorkLogs().Name,
+				MountPath: oauthVolumeMounts.Path(oauthContainerMain().Name, oauthVolumeWorkLogs().Name),
+			}},
+		})
 	}
 
 	if p.AuditWebhookRef != nil {


### PR DESCRIPTION
Related: https://github.com/openshift/hypershift/issues/3764

I was able to test by build and running on existing ibm hypershift test cluster.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.