### PR TITLE
HOSTEDCP-1429: Add install flag to enable/disable size tagging

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -358,6 +358,7 @@ type HyperShiftOperatorDeployment struct {
 	EnableCVOManagementClusterMetricsAccess bool
 	EnableDedicatedRequestServingIsolation  bool
 	ManagedService                          string
+	EnableSizeTagging                       bool
 }
 
 func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
@@ -457,6 +458,13 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "MANAGED_SERVICE",
 			Value: o.ManagedService,
+		})
+	}
+
+	if o.EnableSizeTagging {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "ENABLE_SIZE_TAGGING",
+			Value: "1",
 		})
 	}
 

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -99,6 +99,7 @@ type Options struct {
 	EnableDedicatedRequestServingIsolation    bool
 	PullSecretFile                            string
 	ManagedService                            string
+	EnableSizeTagging                         bool
 }
 
 func (o *Options) Validate() error {
@@ -181,6 +182,7 @@ func NewCommand() *cobra.Command {
 	opts.EnableConversionWebhook = true // default to enabling the conversion webhook
 	opts.ExternalDNSImage = ExternalDNSImage
 	opts.CertRotationScale = 24 * time.Hour
+	opts.EnableSizeTagging = false
 
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", "hypershift", "The namespace in which to install HyperShift")
 	cmd.PersistentFlags().StringVar(&opts.HyperShiftImage, "hypershift-image", version.HyperShiftImage, "The HyperShift image to deploy")
@@ -222,6 +224,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.EnableDedicatedRequestServingIsolation, "enable-dedicated-request-serving-isolation", true, "If true, enables scheduling of request serving components to dedicated nodes")
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "File path to a pull secret.")
 	cmd.PersistentFlags().StringVar(&opts.ManagedService, "managed-service", opts.ManagedService, "The type of managed service the HyperShift Operator is installed on; this is used to configure different HostedCluster options depending on the managed service. Examples: ARO-HCP, ROSA-HCP")
+	cmd.PersistentFlags().BoolVar(&opts.EnableSizeTagging, "enable-size-tagging", opts.EnableSizeTagging, "If true, HyperShift will tag the HostedCluster with a size label corresponding to the number of worker nodes")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		opts.ApplyDefaults()
@@ -675,6 +678,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, []crclient.Ob
 		EnableCVOManagementClusterMetricsAccess: opts.EnableCVOManagementClusterMetricsAccess,
 		EnableDedicatedRequestServingIsolation:  opts.EnableDedicatedRequestServingIsolation,
 		ManagedService:                          opts.ManagedService,
+		EnableSizeTagging:                       opts.EnableSizeTagging,
 	}.Build()
 	objects = append(objects, operatorDeployment)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -2,6 +2,7 @@ package configoperator
 
 import (
 	"fmt"
+	"os"
 	"path"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -427,6 +428,14 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 			},
 		}
 		proxy.SetEnvVars(&c.Env)
+		if os.Getenv("ENABLE_SIZE_TAGGING") == "1" {
+			c.Env = append(c.Env,
+				corev1.EnvVar{
+					Name:  "ENABLE_SIZE_TAGGING",
+					Value: "1",
+				},
+			)
+		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -163,6 +163,9 @@ func newHostedClusterConfigOperator() *HostedClusterConfigOperator {
 func allControllers() []string {
 	controllers := make([]string, 0, len(controllerFuncs))
 	for name := range controllerFuncs {
+		if name == nodecount.ControllerName && os.Getenv("ENABLE_SIZE_TAGGING") != "1" {
+			continue
+		}
 		controllers = append(controllers, name)
 	}
 	return controllers

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2560,6 +2560,15 @@ func reconcileControlPlaneOperatorDeployment(
 		)
 	}
 
+	if os.Getenv("ENABLE_SIZE_TAGGING") == "1" {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  "ENABLE_SIZE_TAGGING",
+				Value: "1",
+			},
+		)
+	}
+
 	if envImage := os.Getenv(images.KonnectivityEnvVar); len(envImage) > 0 {
 		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{

--- a/test/integration/framework/install.go
+++ b/test/integration/framework/install.go
@@ -147,6 +147,7 @@ func InstallHyperShiftOperator(ctx context.Context, logger logr.Logger, opts *Op
 		"--enable-conversion-webhook=false",
 		"--enable-defaulting-webhook=false",
 		"--enable-validating-webhook=false",
+		"--enable-size-tagging",
 	)
 	yamlPath := filepath.Join("install", "hypershift-install.yaml")
 	yamlFile, err := Artifact(opts, yamlPath)


### PR DESCRIPTION
**What this PR does / why we need it**:
Controls whether the controller that labels clusters based on size is enabled. Default is disabled.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1429](https://issues.redhat.com//browse/HOSTEDCP-1429)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.