### PR TITLE
OCPBUGS-30260: Support subnet labels separated by periods

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -236,6 +237,8 @@ func (r *DedicatedServingComponentScheduler) Reconcile(ctx context.Context, req 
 		}
 		if node.Labels[lbSubnetsLabel] != "" && lbSubnets == "" {
 			lbSubnets = node.Labels[lbSubnetsLabel]
+			// If subnets are separated by periods, replace them with commas
+			lbSubnets = strings.ReplaceAll(lbSubnets, ".", ",")
 		}
 
 		// Add taint and labels for specific hosted cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
If node subnets label value is separated by periods, interpret it as separated by commas.
Fleet manager is not able to use commas in node label values, so it will use periods.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-30260](https://issues.redhat.com/browse/OCPBUGS-30260)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.