### PR TITLE
HOSTEDCP-1104: Validate mgmt & nodepool CPU arch match in CLI

### DIFF
--- a/docs/content/how-to/aws/create-heterogeneous-nodepools.md
+++ b/docs/content/how-to/aws/create-heterogeneous-nodepools.md
@@ -17,6 +17,11 @@ When this flag is set, it will ensure:
     An individual NodePool only supports one CPU architecture and cannot support multiple CPU archiectures within the same NodePool.
 
 
+!!! note
+
+    If a multi-arch release image or stream is used and the multi-arch flag is not set, if the management cluster and NodePool CPU arches do not match, the CLI will throw a validation error and not create the Hosted Cluster.
+
+
 ```shell linenums="1"
 REGION=us-east-1
 CLUSTER_NAME=example


### PR DESCRIPTION
**What this PR does / why we need it**:
Validate management and nodepool CPU arches match in the CLI if the multi-arch flag is not set.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1104](https://issues.redhat.com/browse/HOSTEDCP-1104)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.