### PR TITLE
HOSTEDCP-1104,HOSTEDCP-1105: Validate multi-arch aspects in an AWS Hosted Cluster

### DIFF
--- a/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1115,6 +1115,12 @@ type AWSPlatformSpec struct {
 	//
 	// +optional
 	AdditionalAllowedPrincipals []string `json:"additionalAllowedPrincipals,omitempty"`
+
+	// MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+	// CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+	// +kubebuilder:default=false
+	// +optional
+	MultiArch bool `json:"multiArch"`
 }
 
 type AWSRoleCredentials struct {

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1223,6 +1223,12 @@ type AWSPlatformSpec struct {
 	//
 	// +optional
 	AdditionalAllowedPrincipals []string `json:"additionalAllowedPrincipals,omitempty"`
+
+	// MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+	// CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+	// +kubebuilder:default=false
+	// +optional
+	MultiArch bool `json:"multiArch"`
 }
 
 type AWSRoleCredentials struct {

--- a/client/applyconfiguration/hypershift/v1alpha1/awsplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/awsplatformspec.go
@@ -36,6 +36,7 @@ type AWSPlatformSpecApplyConfiguration struct {
 	ResourceTags                []AWSResourceTagApplyConfiguration        `json:"resourceTags,omitempty"`
 	EndpointAccess              *hypershiftv1alpha1.AWSEndpointAccessType `json:"endpointAccess,omitempty"`
 	AdditionalAllowedPrincipals []string                                  `json:"additionalAllowedPrincipals,omitempty"`
+	MultiArch                   *bool                                     `json:"multiArch,omitempty"`
 }
 
 // AWSPlatformSpecApplyConfiguration constructs an declarative configuration of the AWSPlatformSpec type for use with
@@ -146,5 +147,13 @@ func (b *AWSPlatformSpecApplyConfiguration) WithAdditionalAllowedPrincipals(valu
 	for i := range values {
 		b.AdditionalAllowedPrincipals = append(b.AdditionalAllowedPrincipals, values[i])
 	}
+	return b
+}
+
+// WithMultiArch sets the MultiArch field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the MultiArch field is set to the value of the last call.
+func (b *AWSPlatformSpecApplyConfiguration) WithMultiArch(value bool) *AWSPlatformSpecApplyConfiguration {
+	b.MultiArch = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1beta1/awsplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/awsplatformspec.go
@@ -31,6 +31,7 @@ type AWSPlatformSpecApplyConfiguration struct {
 	ResourceTags                []AWSResourceTagApplyConfiguration        `json:"resourceTags,omitempty"`
 	EndpointAccess              *hypershiftv1beta1.AWSEndpointAccessType  `json:"endpointAccess,omitempty"`
 	AdditionalAllowedPrincipals []string                                  `json:"additionalAllowedPrincipals,omitempty"`
+	MultiArch                   *bool                                     `json:"multiArch,omitempty"`
 }
 
 // AWSPlatformSpecApplyConfiguration constructs an declarative configuration of the AWSPlatformSpec type for use with
@@ -104,5 +105,13 @@ func (b *AWSPlatformSpecApplyConfiguration) WithAdditionalAllowedPrincipals(valu
 	for i := range values {
 		b.AdditionalAllowedPrincipals = append(b.AdditionalAllowedPrincipals, values[i])
 	}
+	return b
+}
+
+// WithMultiArch sets the MultiArch field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the MultiArch field is set to the value of the last call.
+func (b *AWSPlatformSpecApplyConfiguration) WithMultiArch(value bool) *AWSPlatformSpecApplyConfiguration {
+	b.MultiArch = &value
 	return b
 }

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -240,6 +240,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		ResourceTags:            tags,
 		EndpointAccess:          opts.AWSPlatform.EndpointAccess,
 		ProxyAddress:            infra.ProxyAddr,
+		MultiArch:               opts.AWSPlatform.MultiArch,
 	}
 	return nil
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -2813,6 +2813,12 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                      multiArch:
+                        default: false
+                        description: |-
+                          MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+                          CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+                        type: boolean
                       nodePoolManagementCreds:
                         description: |-
                           Deprecated
@@ -7147,6 +7153,12 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      multiArch:
+                        default: false
+                        description: |-
+                          MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+                          CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+                        type: boolean
                       region:
                         description: |-
                           Region is the AWS region in which the cluster resides. This configures the

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -2799,6 +2799,12 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                      multiArch:
+                        default: false
+                        description: |-
+                          MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+                          CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+                        type: boolean
                       nodePoolManagementCreds:
                         description: |-
                           Deprecated
@@ -7116,6 +7122,12 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      multiArch:
+                        default: false
+                        description: |-
+                          MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+                          CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+                        type: boolean
                       region:
                         description: |-
                           Region is the AWS region in which the cluster resides. This configures the

--- a/docs/content/how-to/aws/create-heterogeneous-nodepools.md
+++ b/docs/content/how-to/aws/create-heterogeneous-nodepools.md
@@ -17,6 +17,11 @@ When this flag is set, it will ensure:
     An individual NodePool only supports one CPU architecture and cannot support multiple CPU archiectures within the same NodePool.
 
 
+!!! note
+
+    If a multi-arch release image or stream is used and the multi-arch flag is not set, if the management cluster and NodePool CPU arches do not match, the CLI will throw a validation error and not create the Hosted Cluster.
+
+
 ```shell linenums="1"
 REGION=us-east-1
 CLUSTER_NAME=example

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1457,6 +1457,19 @@ See <a href="https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoi
 for more details around VPC Endpoint Service allowed principals.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>multiArch</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###AWSPlatformStatus { #hypershift.openshift.io/v1beta1.AWSPlatformStatus }

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -164,6 +164,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 					Zone: o.AWS.Zones[0].Name,
 				},
 				ResourceTags:   o.AWS.ResourceTags,
+				MultiArch:      o.AWS.MultiArch,
 				EndpointAccess: endpointAccess,
 			},
 		}

--- a/examples/fixtures/example_aws.go
+++ b/examples/fixtures/example_aws.go
@@ -20,6 +20,7 @@ type ExampleAWSOptions struct {
 	ResourceTags            []hyperv1.AWSResourceTag
 	EndpointAccess          string
 	ProxyAddress            string
+	MultiArch               bool
 }
 
 type ExampleAWSOptionsZones struct {

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -40490,6 +40490,12 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        multiArch:
+                          default: false
+                          description: |-
+                            MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+                            CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+                          type: boolean
                         nodePoolManagementCreds:
                           description: |-
                             Deprecated
@@ -44841,6 +44847,12 @@ objects:
                           - PublicAndPrivate
                           - Private
                           type: string
+                        multiArch:
+                          default: false
+                          description: |-
+                            MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+                            CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+                          type: boolean
                         region:
                           description: |-
                             Region is the AWS region in which the cluster resides. This configures the
@@ -49260,6 +49272,12 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        multiArch:
+                          default: false
+                          description: |-
+                            MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+                            CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+                          type: boolean
                         nodePoolManagementCreds:
                           description: |-
                             Deprecated
@@ -53594,6 +53612,12 @@ objects:
                           - PublicAndPrivate
                           - Private
                           type: string
+                        multiArch:
+                          default: false
+                          description: |-
+                            MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+                            CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+                          type: boolean
                         region:
                           description: |-
                             Region is the AWS region in which the cluster resides. This configures the

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -317,4 +318,14 @@ func ApplyAWSLoadBalancerSubnetsAnnotation(svc *corev1.Service, hcp *hyperv1.Hos
 	if ok {
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-subnets"] = subnets
 	}
+}
+
+func DoesMgmtClusterAndNodePoolCPUArchMatch(nodePoolArch string) error {
+	mgmtClusterCPUArch := runtime.GOARCH
+
+	if mgmtClusterCPUArch != nodePoolArch {
+		return fmt.Errorf("multi-arch hosted cluster is not enabled and management cluster and nodepool cpu arches do not match - management cluster cpu arch: %s, nodepool cpu arch: %s", mgmtClusterCPUArch, nodePoolArch)
+	}
+
+	return nil
 }

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1115,6 +1115,12 @@ type AWSPlatformSpec struct {
 	//
 	// +optional
 	AdditionalAllowedPrincipals []string `json:"additionalAllowedPrincipals,omitempty"`
+
+	// MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+	// CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+	// +kubebuilder:default=false
+	// +optional
+	MultiArch bool `json:"multiArch"`
 }
 
 type AWSRoleCredentials struct {

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1223,6 +1223,12 @@ type AWSPlatformSpec struct {
 	//
 	// +optional
 	AdditionalAllowedPrincipals []string `json:"additionalAllowedPrincipals,omitempty"`
+
+	// MultiArch specifies whether the Hosted Cluster will be expected to support NodePools with different
+	// CPU architectures, i.e., supporting arm64 NodePools and supporting amd64 NodePools on the same Hosted Cluster.
+	// +kubebuilder:default=false
+	// +optional
+	MultiArch bool `json:"multiArch"`
 }
 
 type AWSRoleCredentials struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Validate a multi-arch release image is used when an AWS Hosted Cluster
is set up for multi-arch. Validate management and nodepool CPU arches
match in the CLI if the multi-arch flag is not set. Also, validate each
NodePool CPU arch matches the management cluster's CPU arch when an AWS
Hosted Cluster is not setup for multi-arch.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1105](https://issues.redhat.com/browse/HOSTEDCP-1105)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.