### PR TITLE
OCPBUGS-31089: Fix empty resourceGroupName error when deleting Azure infra

### DIFF
--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -37,6 +37,7 @@ func NewDestroyCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.CredentialsFile, "azure-creds", opts.CredentialsFile, "Path to a credentials file (required)")
 	cmd.Flags().StringVar(&opts.Location, "location", opts.Location, "Location where cluster infra should be created")
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A name for the cluster")
+	cmd.Flags().StringVar(&opts.ResourceGroupName, "resource-group-name", opts.ResourceGroupName, "The name of the resource group containing the HostedCluster infrastructure resources that need to be destroyed.")
 
 	_ = cmd.MarkFlagRequired("infra-id")
 	_ = cmd.MarkFlagRequired("azure-creds")
@@ -70,8 +71,7 @@ func (o *DestroyInfraOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to create new resource groups client: %w", err)
 	}
 
-	destroyFuture, err = resourceGroupClient.BeginDelete(ctx, o.ResourceGroupName, nil)
-
+	destroyFuture, err = resourceGroupClient.BeginDelete(ctx, o.GetResourceGroupName(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to start deletion: %w", err)
 	}
@@ -81,4 +81,11 @@ func (o *DestroyInfraOptions) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (o *DestroyInfraOptions) GetResourceGroupName() string {
+	if len(o.ResourceGroupName) > 0 {
+		return o.ResourceGroupName
+	}
+	return o.Name + "-" + o.InfraID
 }


### PR DESCRIPTION
Fix the following error:
```bash
$ hypershift destroy infra azure --azure-creds $HOME/.azure/osServicePrincipal.json --location eastus --infra-id $INFRA_ID --name $CLUSTER_NAME 
2024-03-20T03:48:24+08:00	INFO	Using credentials from file	{"path": "/Users/fxie/.azure/osServicePrincipal.json"}
2024-03-20T03:48:24+08:00	ERROR	Failed to destroy infrastructure	{"error": "failed to start deletion: parameter resourceGroupName cannot be empty"}
github.com/openshift/hypershift/cmd/infra/azure.NewDestroyCommand.func1
	/Users/fxie/Projects/hypershift/cmd/infra/azure/destroy.go:47
github.com/spf13/cobra.(*Command).execute
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:983
github.com/spf13/cobra.(*Command).ExecuteC
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:1115
github.com/spf13/cobra.(*Command).Execute
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:1032
main.main
	/Users/fxie/Projects/hypershift/main.go:78
runtime.main
	/usr/local/go/src/runtime/proc.go:267
Error: failed to start deletion: parameter resourceGroupName cannot be empty
failed to start deletion: parameter resourceGroupName cannot be empty
```