### PR TITLE
HOSTEDCP-1478: Request serving node scheduler that uses HC size label

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -270,6 +270,12 @@ const (
 
 	//RosaHCP represents the ROSA HCP managed service offering
 	RosaHCP = "ROSA-HCP"
+
+	// HostedClusterSizeLabel is a label on HostedClusters indicating a size based on the number of nodes.
+	HostedClusterSizeLabel = "hypershift.openshift.io/hosted-cluster-size"
+
+	// NodeSizeLabel is a label on nodes used to match cluster size to a node size.
+	NodeSizeLabel = "hypershift.openshift.io/cluster-size"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -7,11 +7,20 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	"github.com/openshift/hypershift/support/upsert"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corev1applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -20,12 +29,11 @@ import (
 )
 
 const (
-	ControlPlaneTaint                              = "hypershift.openshift.io/control-plane"
-	ControlPlaneServingComponentTaint              = "hypershift.openshift.io/control-plane-serving-component"
-	HostedClusterTaint                             = "hypershift.openshift.io/cluster"
-	ControlPlaneServingComponentAvailableNodeTaint = "hypershift.openshift.io/control-plane-serving-component-available"
+	ControlPlaneTaint                 = "hypershift.openshift.io/control-plane"
+	ControlPlaneServingComponentTaint = "hypershift.openshift.io/request-serving-component"
+	HostedClusterTaint                = "hypershift.openshift.io/cluster"
 
-	ControlPlaneServingComponentLabel = "hypershift.openshift.io/control-plane-serving-component"
+	ControlPlaneServingComponentLabel = "hypershift.openshift.io/request-serving-component"
 	OSDFleetManagerPairedNodesLabel   = "osd-fleet-manager.openshift.io/paired-nodes"
 	HostedClusterNameLabel            = "hypershift.openshift.io/cluster-name"
 	HostedClusterNamespaceLabel       = "hypershift.openshift.io/cluster-namespace"
@@ -34,6 +42,8 @@ const (
 
 	// PlaceholderLabel is used as a label on Deployments that are used to keep nodes warm.
 	PlaceholderLabel = "hypershift.openshift.io/placeholder"
+
+	autoSizerNamespace = "hypershift-request-serving-autosizing-placeholder"
 )
 
 type DedicatedServingComponentNodeReaper struct {
@@ -76,19 +86,15 @@ func (r *DedicatedServingComponentNodeReaper) Reconcile(ctx context.Context, req
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get node %q: %w", req.NamespacedName.String(), err)
 	}
-	log.Info("Reconciling node")
 
 	if _, hasServingComponentLabel := node.Labels[hyperv1.RequestServingComponentLabel]; !hasServingComponentLabel {
-		log.Info("Skipping node because it doesn't have the control plane serving component label")
 		return ctrl.Result{}, nil
 	}
 
 	if _, hasHostedClusterLabel := node.Labels[hyperv1.HostedClusterLabel]; !hasHostedClusterLabel {
-		log.Info("Skipping node because it has not been allocated to a hosted cluster")
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("Node has been allocated to a hosted cluster, checking whether hosted cluster still exists.")
 	name := node.Labels[HostedClusterNameLabel]
 	namespace := node.Labels[HostedClusterNamespaceLabel]
 	hc := &hyperv1.HostedCluster{}
@@ -96,11 +102,10 @@ func (r *DedicatedServingComponentNodeReaper) Reconcile(ctx context.Context, req
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, fmt.Errorf("failed to get hosted cluster %s/%s: %w", namespace, name, err)
 		}
-		log.Info("The hosted cluster is not found. Deleting node.")
+		log.Info("Hosted cluster is not found for node. Deleting node.")
 		if err := r.Delete(ctx, node); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to delete node: %w", err)
 		}
-		log.Info("Node deleted")
 	}
 	return ctrl.Result{}, nil
 }
@@ -284,4 +289,517 @@ func (r *DedicatedServingComponentScheduler) Reconcile(ctx context.Context, req 
 	}
 
 	return ctrl.Result{}, nil
+}
+
+const requestServingSchedulerAndSizerName = "DedicatedServingComponentSchedulerAndSizer"
+
+type DedicatedServingComponentSchedulerAndSizer struct {
+	client.Client
+	createOrUpdate upsert.CreateOrUpdateFN
+}
+
+func (r *DedicatedServingComponentSchedulerAndSizer) SetupWithManager(ctx context.Context, mgr ctrl.Manager, createOrUpdateProvider upsert.CreateOrUpdateProvider) error {
+	r.Client = mgr.GetClient()
+	r.createOrUpdate = createOrUpdateProvider.CreateOrUpdate
+	kubernetesClient, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return err
+	}
+	if _, err := kubernetesClient.CoreV1().Namespaces().Apply(ctx, corev1applyconfigurations.Namespace(autoSizerNamespace), metav1.ApplyOptions{FieldManager: requestServingSchedulerAndSizerName}); err != nil {
+		return fmt.Errorf("couldn't set up namespace: %w", err)
+	}
+	builder := ctrl.NewControllerManagedBy(mgr).
+		For(&hyperv1.HostedCluster{}).
+		WithOptions(controller.Options{
+			RateLimiter:             workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 10*time.Second),
+			MaxConcurrentReconciles: 10,
+		}).
+		Watches(&corev1.Node{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+			node := obj.(*corev1.Node)
+			if _, isReqServing := node.Labels[hyperv1.RequestServingComponentLabel]; !isReqServing {
+				return nil
+			}
+			if _, hasHCLabel := node.Labels[hyperv1.HostedClusterLabel]; !hasHCLabel {
+				return nil
+			}
+			name := node.Labels[HostedClusterNameLabel]
+			namespace := node.Labels[HostedClusterNamespaceLabel]
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}}}
+		})).
+		Watches(&schedulingv1alpha1.ClusterSizingConfiguration{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+			hostedClusters := &hyperv1.HostedClusterList{}
+			if err := r.List(ctx, hostedClusters); err != nil {
+				return nil
+			}
+			var out []reconcile.Request
+			for _, hc := range hostedClusters.Items {
+				out = append(out, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: hc.Namespace, Name: hc.Name}})
+			}
+			return out
+		})).
+		Watches(&appsv1.Deployment{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+			deployment := obj.(*appsv1.Deployment)
+			if deployment.Namespace != autoSizerNamespace {
+				return nil
+			}
+			name := deployment.Labels[HostedClusterNameLabel]
+			namespace := deployment.Labels[HostedClusterNamespaceLabel]
+			if name == "" || namespace == "" {
+				return nil
+			}
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}}}
+		})).
+		Named(requestServingSchedulerAndSizerName)
+	return builder.Complete(r)
+}
+
+func (r *DedicatedServingComponentSchedulerAndSizer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	hc := &hyperv1.HostedCluster{}
+	log := ctrl.LoggerFrom(ctx)
+	err := r.Get(ctx, req.NamespacedName, hc)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("hostedcluster not found, aborting reconcile")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get cluster %q: %w", req.NamespacedName, err)
+	}
+	if !hc.DeletionTimestamp.IsZero() {
+		log.Info("hostedcluster is deleted, nothing to do")
+		return ctrl.Result{}, nil
+	}
+	if hcTopology := hc.Annotations[hyperv1.TopologyAnnotation]; hcTopology != hyperv1.DedicatedRequestServingComponentsTopology {
+		log.Info("hostedcluster does not use isolated request serving components, nothing to do")
+		return ctrl.Result{}, nil
+	}
+	isPaused, duration, err := util.ProcessPausedUntilField(hc.Spec.PausedUntil, time.Now())
+	if err != nil {
+		log.Error(err, "error processing hosted cluster paused field")
+		return ctrl.Result{}, nil // user needs to reformat the field, returning error is useless
+	}
+	if isPaused {
+		log.Info("Reconciliation paused", "pausedUntil", *hc.Spec.PausedUntil)
+		return ctrl.Result{RequeueAfter: duration}, nil
+	}
+
+	desiredSize := hc.Labels[hyperv1.HostedClusterSizeLabel]
+	if desiredSize == "" {
+		log.Info("HostedCluster does not have a size label, skipping for now")
+		return ctrl.Result{}, nil
+	}
+
+	config := schedulingv1alpha1.ClusterSizingConfiguration{}
+	if err := r.Get(ctx, types.NamespacedName{Name: "cluster"}, &config); err != nil {
+		return ctrl.Result{}, fmt.Errorf("could not get cluster sizing configuration: %w", err)
+	}
+
+	if condition := meta.FindStatusCondition(config.Status.Conditions, schedulingv1alpha1.ClusterSizingConfigurationValidType); condition == nil || condition.Status != metav1.ConditionTrue {
+		log.Info("Cluster sizing configuration is not valid, skipping for now")
+		return ctrl.Result{}, nil
+	}
+
+	// Find existing dedicated serving content Nodes for this HC.
+	dedicatedNodes := &corev1.NodeList{}
+	if err := r.List(ctx, dedicatedNodes,
+		client.HasLabels{hyperv1.RequestServingComponentLabel},
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	var goalNodes, availableNodes []corev1.Node
+	var pairLabel string
+	for _, node := range dedicatedNodes.Items {
+		if node.Labels[hyperv1.HostedClusterLabel] == clusterKey(hc) {
+			if node.Labels[OSDFleetManagerPairedNodesLabel] != "" && pairLabel == "" {
+				pairLabel = node.Labels[OSDFleetManagerPairedNodesLabel]
+			}
+			if node.Labels[hyperv1.NodeSizeLabel] == desiredSize && pairLabel != "" && node.Labels[OSDFleetManagerPairedNodesLabel] == pairLabel {
+				goalNodes = append(goalNodes, node)
+			}
+		} else if node.Labels[hyperv1.HostedClusterLabel] == "" {
+			availableNodes = append(availableNodes, node)
+		}
+	}
+
+	// Find any nodes that are in the same fleet manager group and have the right size
+	// but are not labeled with the hosted cluster label. Ensure that these nodes are labeled
+	// and tainted with the hosted cluster label. This can happen if not all nodes were labeled/tainted
+	// when they were initially selected.
+	if pairLabel != "" {
+		var needClusterLabel []corev1.Node
+		for _, node := range availableNodes {
+			if node.Labels[hyperv1.NodeSizeLabel] == desiredSize && node.Labels[OSDFleetManagerPairedNodesLabel] == pairLabel {
+				needClusterLabel = append(needClusterLabel, node)
+			}
+		}
+		if len(needClusterLabel) > 0 {
+			for _, node := range needClusterLabel {
+				if err := r.ensureHostedClusterLabelAndTaint(ctx, hc, &node); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+			return ctrl.Result{Requeue: true}, nil
+		}
+	} else {
+		// If there isn't a current pair label, then we can select from available nodes selected by placeholders.
+		sizeConfig := sizeConfiguration(&config, desiredSize)
+		if sizeConfig == nil {
+			return ctrl.Result{}, fmt.Errorf("could not find size configuration for size %s", desiredSize)
+		}
+
+		// If placeholders are present, use those
+		if sizeConfig.Management != nil && sizeConfig.Management.Placeholders > 0 {
+			candidateNodes, err := r.nodesFromPlaceholders(ctx, desiredSize)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to get nodes from placeholders: %w", err)
+			}
+			if len(candidateNodes) > 0 {
+				for _, node := range candidateNodes {
+					if err := r.ensureHostedClusterLabelAndTaint(ctx, hc, &node); err != nil {
+						return ctrl.Result{}, err
+					}
+				}
+				return ctrl.Result{Requeue: true}, nil
+			}
+		}
+	}
+
+	nodesByZone := map[string]corev1.Node{}
+	for _, node := range goalNodes {
+		if zone := node.Labels[corev1.LabelTopologyZone]; zone != "" {
+			if _, hasNode := nodesByZone[zone]; !hasNode {
+				nodesByZone[zone] = node
+			}
+		}
+	}
+
+	if len(nodesByZone) > 1 {
+		// If we have enough nodes, update the hosted cluster.
+		if err := r.updateHostedCluster(ctx, hc, desiredSize, &config, goalNodes); err != nil {
+			return ctrl.Result{}, err
+		}
+		// Ensure we don't have a placeholder deployment, since we have nodes
+		if err := r.deletePlaceholderDeployment(ctx, hc); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Create a deployment to ensure nodes of the right size are created
+	nodesNeeded := max(2-len(nodesByZone), 0)
+	deployment, err := r.ensurePlaceholderDeployment(ctx, hc, desiredSize, pairLabel, nodesNeeded)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if deployment != nil && util.IsDeploymentReady(ctx, deployment) {
+		nodes, err := r.deploymentNodes(ctx, deployment)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		for _, node := range nodes {
+			if err := r.ensureHostedClusterLabelAndTaint(ctx, hc, &node); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		if err := r.deletePlaceholderDeployment(ctx, hc); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *DedicatedServingComponentSchedulerAndSizer) nodesFromPlaceholders(ctx context.Context, size string) ([]corev1.Node, error) {
+	placeHolderDeployments := &appsv1.DeploymentList{}
+	if err := r.List(ctx, placeHolderDeployments, client.InNamespace(placeholderNamespace)); err != nil {
+		return nil, fmt.Errorf("failed to list placeholder deployments: %w", err)
+	}
+	var deployment *appsv1.Deployment
+	for i := range placeHolderDeployments.Items {
+		d := &placeHolderDeployments.Items[i]
+		if d.Labels[hyperv1.HostedClusterSizeLabel] != size {
+			continue
+		}
+		if util.IsDeploymentReady(ctx, d) {
+			deployment = d
+			break
+		}
+	}
+	return r.deploymentNodes(ctx, deployment)
+}
+
+func (r *DedicatedServingComponentSchedulerAndSizer) deploymentNodes(ctx context.Context, deployment *appsv1.Deployment) ([]corev1.Node, error) {
+	if deployment == nil {
+		return nil, nil
+	}
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods, client.InNamespace(deployment.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels)); err != nil {
+		return nil, fmt.Errorf("failed to list pods: %w", err)
+	}
+	var nodes []corev1.Node
+	for i := range pods.Items {
+		node := &corev1.Node{}
+		pod := &pods.Items[i]
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		if err := r.Get(ctx, client.ObjectKey{Name: pod.Spec.NodeName}, node); err != nil {
+			return nil, fmt.Errorf("failed to get node: %w", err)
+		}
+		nodes = append(nodes, *node)
+	}
+	return nodes, nil
+}
+
+func (r *DedicatedServingComponentSchedulerAndSizer) ensureHostedClusterLabelAndTaint(ctx context.Context, hc *hyperv1.HostedCluster, node *corev1.Node) error {
+	original := node.DeepCopy()
+	foundTaint := false
+	for i := range node.Spec.Taints {
+		if node.Spec.Taints[i].Key == HostedClusterTaint {
+			node.Spec.Taints[i].Value = clusterKey(hc)
+			node.Spec.Taints[i].Effect = corev1.TaintEffectNoSchedule
+			foundTaint = true
+			break
+		}
+	}
+	if !foundTaint {
+		node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+			Key:    HostedClusterTaint,
+			Value:  clusterKey(hc),
+			Effect: corev1.TaintEffectNoSchedule,
+		})
+	}
+	node.Labels[hyperv1.HostedClusterLabel] = clusterKey(hc)
+	node.Labels[HostedClusterNameLabel] = hc.Name
+	node.Labels[HostedClusterNamespaceLabel] = hc.Namespace
+
+	if err := r.Patch(ctx, node, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("failed to update labels and taints on node %s: %w", node.Name, err)
+	}
+	return nil
+}
+
+func (r *DedicatedServingComponentSchedulerAndSizer) updateHostedCluster(ctx context.Context, hc *hyperv1.HostedCluster, size string, config *schedulingv1alpha1.ClusterSizingConfiguration, nodes []corev1.Node) error {
+	original := hc.DeepCopy()
+	hc.Annotations[hyperv1.HostedClusterScheduledAnnotation] = "true"
+	sizeConfig := sizeConfiguration(config, size)
+	if sizeConfig == nil {
+		return fmt.Errorf("could not find size configuration for size %s", size)
+	}
+
+	goMemLimit := ""
+	if sizeConfig.Effects != nil && sizeConfig.Effects.KASGoMemLimit != nil {
+		goMemLimit = sizeConfig.Effects.KASGoMemLimit.String()
+	}
+	for _, node := range nodes {
+		if node.Labels[goMemLimitLabel] != "" {
+			goMemLimit = node.Labels[goMemLimitLabel]
+			break
+		}
+	}
+	if goMemLimit != "" {
+		hc.Annotations[hyperv1.KubeAPIServerGOMemoryLimitAnnotation] = goMemLimit
+	}
+
+	if sizeConfig.Effects != nil && sizeConfig.Effects.KASMemoryRequest != nil {
+		hc.Annotations[fmt.Sprintf("%s/kube-apiserver.kube-apiserver", hyperv1.ResourceRequestOverrideAnnotationPrefix)] = fmt.Sprintf("memory=%s", sizeConfig.Effects.KASMemoryRequest.String())
+	}
+	if sizeConfig.Effects != nil && sizeConfig.Effects.ControlPlanePriorityClassName != nil {
+		hc.Annotations[hyperv1.ControlPlanePriorityClass] = *sizeConfig.Effects.ControlPlanePriorityClassName
+	}
+	if sizeConfig.Effects != nil && sizeConfig.Effects.EtcdPriorityClassName != nil {
+		hc.Annotations[hyperv1.EtcdPriorityClass] = *sizeConfig.Effects.EtcdPriorityClassName
+	}
+	if sizeConfig.Effects != nil && sizeConfig.Effects.APICriticalPriorityClassName != nil {
+		hc.Annotations[hyperv1.APICriticalPriorityClass] = *sizeConfig.Effects.APICriticalPriorityClassName
+	}
+
+	lbSubnets := ""
+	for _, node := range nodes {
+		if node.Labels[lbSubnetsLabel] != "" {
+			lbSubnets = node.Labels[lbSubnetsLabel]
+			break
+		}
+	}
+	if lbSubnets != "" {
+		hc.Annotations[hyperv1.AWSLoadBalancerSubnetsAnnotation] = lbSubnets
+	}
+
+	hc.Annotations[hyperv1.RequestServingNodeAdditionalSelectorAnnotation] = fmt.Sprintf("%s=%s", hyperv1.NodeSizeLabel, size)
+
+	if !equality.Semantic.DeepEqual(hc, original) {
+		if err := r.Patch(ctx, hc, client.MergeFrom(original)); err != nil {
+			return fmt.Errorf("failed to update hostedcluster: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *DedicatedServingComponentSchedulerAndSizer) deletePlaceholderDeployment(ctx context.Context, hc *hyperv1.HostedCluster) error {
+	deployment := placeholderDeployment(hc)
+	_, err := util.DeleteIfNeeded(ctx, r, deployment)
+	return err
+}
+
+func (r *DedicatedServingComponentSchedulerAndSizer) takenNodePairLabels(ctx context.Context) ([]string, error) {
+	nodes := &corev1.NodeList{}
+	if err := r.List(ctx, nodes, client.HasLabels{hyperv1.HostedClusterLabel, OSDFleetManagerPairedNodesLabel}); err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+	var result []string
+	for _, node := range nodes.Items {
+		labelValue := node.Labels[OSDFleetManagerPairedNodesLabel]
+		result = append(result, labelValue)
+	}
+	return result, nil
+}
+
+func (r *DedicatedServingComponentSchedulerAndSizer) ensurePlaceholderDeployment(ctx context.Context, hc *hyperv1.HostedCluster, size, pairLabel string, nodesNeeded int) (*appsv1.Deployment, error) {
+	deployment := placeholderDeployment(hc)
+	nodeSelector := map[string]string{
+		hyperv1.RequestServingComponentLabel: "true",
+		hyperv1.NodeSizeLabel:                size,
+	}
+	var nodeAffinity *corev1.NodeAffinity
+	var podAffinity *corev1.PodAffinity
+
+	if deployment.Labels == nil {
+		deployment.Labels = map[string]string{}
+	}
+	deployment.Labels[HostedClusterNameLabel] = hc.Name
+	deployment.Labels[HostedClusterNamespaceLabel] = hc.Namespace
+
+	if pairLabel != "" {
+		nodeSelector[OSDFleetManagerPairedNodesLabel] = pairLabel
+	} else {
+		unavailableNodePairs, err := r.takenNodePairLabels(ctx)
+		if err != nil {
+			return nil, err
+		}
+		podAffinity = &corev1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							PlaceholderLabel: deployment.Name,
+						},
+					},
+					TopologyKey: OSDFleetManagerPairedNodesLabel,
+				},
+			},
+		}
+		nodeAffinity = &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      OSDFleetManagerPairedNodesLabel,
+								Operator: corev1.NodeSelectorOpNotIn,
+								Values:   unavailableNodePairs,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	podAntiAffinity := &corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						PlaceholderLabel: deployment.Name,
+					},
+				},
+				TopologyKey: "topology.kubernetes.io/zone",
+			},
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      PlaceholderLabel,
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	}
+	desiredSpec := appsv1.DeploymentSpec{
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		},
+		Replicas: ptr.To(int32(nodesNeeded)),
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				PlaceholderLabel: deployment.Name,
+			},
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					PlaceholderLabel: deployment.Name,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Affinity: &corev1.Affinity{
+					NodeAffinity:    nodeAffinity,
+					PodAffinity:     podAffinity,
+					PodAntiAffinity: podAntiAffinity,
+				},
+				NodeSelector: nodeSelector,
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      ControlPlaneServingComponentTaint,
+						Effect:   corev1.TaintEffectNoSchedule,
+						Operator: corev1.TolerationOpEqual,
+						Value:    "true",
+					},
+					{
+						Key:      ControlPlaneTaint,
+						Effect:   corev1.TaintEffectNoSchedule,
+						Operator: corev1.TolerationOpEqual,
+						Value:    "true",
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:  "placeholder",
+						Image: "quay.io/openshift/origin-hello-openshift:latest",
+					},
+				},
+			},
+		},
+	}
+	if _, err := r.createOrUpdate(ctx, r, deployment, func() error {
+		deployment.Spec = desiredSpec
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to ensure placeholder deployment: %w", err)
+	}
+	return deployment, nil
+}
+
+func placeholderDeployment(hc *hyperv1.HostedCluster) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterKey(hc),
+			Namespace: autoSizerNamespace,
+		},
+	}
+}
+
+func clusterKey(hc *hyperv1.HostedCluster) string {
+	return fmt.Sprintf("%s-%s", hc.Namespace, hc.Name)
+}
+
+func sizeConfiguration(config *schedulingv1alpha1.ClusterSizingConfiguration, size string) *schedulingv1alpha1.SizeConfiguration {
+	for i := range config.Spec.Sizes {
+		if config.Spec.Sizes[i].Name == size {
+			return &config.Spec.Sizes[i]
+		}
+	}
+	return nil
 }

--- a/support/util/deployment.go
+++ b/support/util/deployment.go
@@ -9,14 +9,14 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func IsDeploymentReady(ctx context.Context, deployment *appsv1.Deployment) bool {
-	if *deployment.Spec.Replicas != deployment.Status.AvailableReplicas ||
-		*deployment.Spec.Replicas != deployment.Status.ReadyReplicas ||
-		*deployment.Spec.Replicas != deployment.Status.UpdatedReplicas ||
-		*deployment.Spec.Replicas != deployment.Status.Replicas ||
+	if ptr.Deref(deployment.Spec.Replicas, 0) != deployment.Status.AvailableReplicas ||
+		ptr.Deref(deployment.Spec.Replicas, 0) != deployment.Status.ReadyReplicas ||
+		ptr.Deref(deployment.Spec.Replicas, 0) != deployment.Status.UpdatedReplicas ||
+		ptr.Deref(deployment.Spec.Replicas, 0) != deployment.Status.Replicas ||
 		deployment.Status.UnavailableReplicas != 0 ||
 		deployment.ObjectMeta.Generation != deployment.Status.ObservedGeneration {
 		return false
@@ -26,10 +26,10 @@ func IsDeploymentReady(ctx context.Context, deployment *appsv1.Deployment) bool 
 }
 
 func IsStatefulSetReady(ctx context.Context, statefulSet *appsv1.StatefulSet) bool {
-	if *statefulSet.Spec.Replicas != statefulSet.Status.AvailableReplicas ||
-		*statefulSet.Spec.Replicas != statefulSet.Status.ReadyReplicas ||
-		*statefulSet.Spec.Replicas != statefulSet.Status.UpdatedReplicas ||
-		*statefulSet.Spec.Replicas != statefulSet.Status.Replicas ||
+	if ptr.Deref(statefulSet.Spec.Replicas, 0) != statefulSet.Status.AvailableReplicas ||
+		ptr.Deref(statefulSet.Spec.Replicas, 0) != statefulSet.Status.ReadyReplicas ||
+		ptr.Deref(statefulSet.Spec.Replicas, 0) != statefulSet.Status.UpdatedReplicas ||
+		ptr.Deref(statefulSet.Spec.Replicas, 0) != statefulSet.Status.Replicas ||
 		statefulSet.ObjectMeta.Generation != statefulSet.Status.ObservedGeneration {
 		return false
 	}
@@ -74,7 +74,7 @@ func DeploymentAddOpenShiftTrustedCABundleConfigMap(deployment *appsv1.Deploymen
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{Name: "openshift-config-managed-trusted-ca-bundle"},
 				Items:                []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"}},
-				Optional:             pointer.Bool(true),
+				Optional:             ptr.To(true),
 			},
 		},
 	})

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -270,6 +270,12 @@ const (
 
 	//RosaHCP represents the ROSA HCP managed service offering
 	RosaHCP = "ROSA-HCP"
+
+	// HostedClusterSizeLabel is a label on HostedClusters indicating a size based on the number of nodes.
+	HostedClusterSizeLabel = "hypershift.openshift.io/hosted-cluster-size"
+
+	// NodeSizeLabel is a label on nodes used to match cluster size to a node size.
+	NodeSizeLabel = "hypershift.openshift.io/cluster-size"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a new scheduler that is only enabled if cluster size tagging is enabled. It takes into consideration the size label of a particular hosted cluster to select nodes where the cluster's request serving pods are scheduled and applies settings configured in the cluster sizing configuration to the hosted cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1478](https://issues.redhat.com/browse/HOSTEDCP-1478)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.