### PR TITLE
OCPBUGS-31090: Fix empty subnet name error when creating Azure infrastructure

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -89,7 +89,8 @@ func NewCreateCommand() *cobra.Command {
 	}
 
 	opts := CreateInfraOptions{
-		Location: "eastus",
+		Location:   "eastus",
+		SubnetName: "default",
 	}
 
 	cmd.Flags().StringVar(&opts.InfraID, "infra-id", opts.InfraID, "Cluster ID(required)")
@@ -100,6 +101,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ResourceGroupName, "resource-group-name", opts.ResourceGroupName, "A resource group name to create the HostedCluster infrastructure resources under.")
 	cmd.Flags().StringVar(&opts.OutputFile, "output-file", opts.OutputFile, "Path to file that will contain output information from infra resources (optional)")
 	cmd.Flags().StringVar(&opts.NetworkSecurityGroup, "network-security-group", opts.NetworkSecurityGroup, "The name of the Network Security Group to use in Virtual Network")
+	cmd.Flags().StringVar(&opts.SubnetName, "subnet-name", opts.SubnetName, "The subnet name where the VMs will be placed.")
 	cmd.Flags().StringToStringVarP(&opts.ResourceGroupTags, "resource-group-tags", "t", opts.ResourceGroupTags, "Additional tags to apply to the resource group created (e.g. 'key1=value1,key2=value2')")
 
 	_ = cmd.MarkFlagRequired("infra-id")


### PR DESCRIPTION
Fix the following error encountered when creating Azure infrastructure:
```bash
hypershift create infra azure --name $CLUSTER_NAME --azure-creds $HOME/.azure/osServicePrincipal.json --base-domain $BASE_DOMAIN --infra-id $INFRA_ID --location eastus --output-file $OUTPUT_INFRA_FILE --resource-group-tags 'foo=bar,baz=quux' --resource-group-tags 'abc=def'
2024-03-20T13:38:36+08:00	INFO	Using credentials from file	{"path": "/Users/fxie/.azure/osServicePrincipal.json"}
2024-03-20T13:38:42+08:00	INFO	Successfully created resource group	{"name": "fxie-hcp-1-fxie-hcp-1-13639"}
2024-03-20T13:38:45+08:00	INFO	Successfully created managed identity	{"name": "/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourcegroups/fxie-hcp-1-fxie-hcp-1-13639/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fxie-hcp-1-fxie-hcp-1-13639"}
2024-03-20T13:38:45+08:00	INFO	Assigning role to managed identity, this may take some time
2024-03-20T13:38:58+08:00	INFO	Successfully assigned contributor role to managed identity	{"name": "/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourcegroups/fxie-hcp-1-fxie-hcp-1-13639/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fxie-hcp-1-fxie-hcp-1-13639"}
2024-03-20T13:39:03+08:00	INFO	Successfully created network security group	{"name": "fxie-hcp-1-fxie-hcp-1-13639-nsg"}
2024-03-20T13:39:05+08:00	ERROR	Failed to create infrastructure	{"error": "failed to create vnet: PUT https://management.azure.com/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/fxie-hcp-1-fxie-hcp-1-13639/providers/Microsoft.Network/virtualNetworks/fxie-hcp-1-fxie-hcp-1-13639\n--------------------------------------------------------------------------------\nRESPONSE 400: 400 Bad Request\nERROR CODE: InvalidResourceName\n--------------------------------------------------------------------------------\n{\n  \"error\": {\n    \"code\": \"InvalidResourceName\",\n    \"message\": \"Resource name  is invalid. The name can be up to 80 characters long. It must begin with a word character, and it must end with a word character or with '_'. The name may contain word characters or '.', '-', '_'.\",\n    \"details\": []\n  }\n}\n--------------------------------------------------------------------------------\n"}
github.com/openshift/hypershift/cmd/infra/azure.NewCreateCommand.func2
	/Users/fxie/Projects/hypershift/cmd/infra/azure/create.go:112
github.com/spf13/cobra.(*Command).execute
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:983
github.com/spf13/cobra.(*Command).ExecuteC
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:1115
github.com/spf13/cobra.(*Command).Execute
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:1032
main.main
	/Users/fxie/Projects/hypershift/main.go:78
runtime.main
	/usr/local/go/src/runtime/proc.go:267
Error: failed to create vnet: PUT https://management.azure.com/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/fxie-hcp-1-fxie-hcp-1-13639/providers/Microsoft.Network/virtualNetworks/fxie-hcp-1-fxie-hcp-1-13639
```