### PR TITLE
OCPBUGS-31110: Fix empty RHCOSImage error when creating Azure Infrastructure

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -102,11 +102,13 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.OutputFile, "output-file", opts.OutputFile, "Path to file that will contain output information from infra resources (optional)")
 	cmd.Flags().StringVar(&opts.NetworkSecurityGroup, "network-security-group", opts.NetworkSecurityGroup, "The name of the Network Security Group to use in Virtual Network")
 	cmd.Flags().StringVar(&opts.SubnetName, "subnet-name", opts.SubnetName, "The subnet name where the VMs will be placed.")
+	cmd.Flags().StringVar(&opts.RHCOSImage, "rhcos-image", opts.RHCOSImage, `RHCOS image to be used for the NodePool. Could be obtained using podman run --rm -it --entrypoint cat $RELEASE_IMAGE release-manifests/0000_50_installer_coreos-bootimages.yaml | yq .data.stream -r | yq '.architectures.x86_64["rhel-coreos-extensions"]["azure-disk"].url'`)
 	cmd.Flags().StringToStringVarP(&opts.ResourceGroupTags, "resource-group-tags", "t", opts.ResourceGroupTags, "Additional tags to apply to the resource group created (e.g. 'key1=value1,key2=value2')")
 
 	_ = cmd.MarkFlagRequired("infra-id")
 	_ = cmd.MarkFlagRequired("azure-creds")
 	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("rhcos-image")
 
 	l := log.Log
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Fix the following error:
```bash
$ hypershift create infra azure --name $CLUSTER_NAME --azure-creds $HOME/.azure/osServicePrincipal.json --base-domain $BASE_DOMAIN --infra-id $INFRA_ID --location eastus --output-file $OUTPUT_INFRA_FILE
2024-03-20T14:26:23+08:00	INFO	Using credentials from file	{"path": "/Users/fxie/.azure/osServicePrincipal.json"}
2024-03-20T14:26:30+08:00	INFO	Successfully created resource group	{"name": "fxie-hcp-1-fxie-hcp-1-13639"}
2024-03-20T14:26:32+08:00	INFO	Successfully created managed identity	{"name": "/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourcegroups/fxie-hcp-1-fxie-hcp-1-13639/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fxie-hcp-1-fxie-hcp-1-13639"}
2024-03-20T14:26:32+08:00	INFO	Assigning role to managed identity, this may take some time
2024-03-20T14:26:51+08:00	INFO	Successfully assigned contributor role to managed identity	{"name": "/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourcegroups/fxie-hcp-1-fxie-hcp-1-13639/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fxie-hcp-1-fxie-hcp-1-13639"}
2024-03-20T14:26:55+08:00	INFO	Successfully created network security group	{"name": "fxie-hcp-1-fxie-hcp-1-13639-nsg"}
2024-03-20T14:27:01+08:00	INFO	Successfully created vnet	{"name": "fxie-hcp-1-fxie-hcp-1-13639"}
2024-03-20T14:27:35+08:00	INFO	Successfully created private DNS zone	{"name": "fxie-hcp-1-azurecluster.qe.azure.devcluster.openshift.com"}
2024-03-20T14:28:09+08:00	INFO	Successfully created private DNS zone link
2024-03-20T14:28:12+08:00	INFO	Successfully created public IP address for guest cluster egress load balancer
2024-03-20T14:28:15+08:00	INFO	Successfully created guest cluster egress load balancer
2024-03-20T14:28:37+08:00	INFO	Successfully created storage account	{"name": "clusterzw22c"}
2024-03-20T14:28:38+08:00	INFO	Successfully created blob container	{"name": "vhd"}
2024-03-20T14:28:38+08:00	ERROR	Failed to create infrastructure	{"error": "failed to create RHCOS image: the image source url must be from an azure blob storage, otherwise upload will fail with an `One of the request inputs is out of range` error"}
github.com/openshift/hypershift/cmd/infra/azure.NewCreateCommand.func2
	/Users/fxie/Projects/hypershift/cmd/infra/azure/create.go:114
github.com/spf13/cobra.(*Command).execute
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:983
github.com/spf13/cobra.(*Command).ExecuteC
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:1115
github.com/spf13/cobra.(*Command).Execute
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext
	/Users/fxie/Projects/hypershift/vendor/github.com/spf13/cobra/command.go:1032
main.main
	/Users/fxie/Projects/hypershift/main.go:78
runtime.main
	/usr/local/go/src/runtime/proc.go:267
Error: failed to create RHCOS image: the image source url must be from an azure blob storage, otherwise upload will fail with an `One of the request inputs is out of range` error
failed to create RHCOS image: the image source url must be from an azure blob storage, otherwise upload will fail with an `One of the request inputs is out of range` error
```