### PR TITLE
OCPBUGS-31118: fix(ignition): Fix priority class override

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -726,6 +726,9 @@ func reconcileDeployment(deployment *appsv1.Deployment,
 		},
 	}
 	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
+		deploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
+	}
 	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	deploymentConfig.SetDefaults(hcp, ignitionServerLabels, nil)
 	deploymentConfig.ApplyTo(deployment)


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes priority class override feature that was accidentally removed for ignition server deployment by https://github.com/openshift/hypershift/pull/2668

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.