### PR TITLE
HOSTEDCP-1501: Create default ClusterSizingConfig CR on start

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	cmdutil "github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/pkg/version"
 	"github.com/openshift/hypershift/support/config"
@@ -1810,37 +1809,5 @@ func (o HyperShiftPullSecret) Build() *corev1.Secret {
 			".dockerconfigjson": o.PullSecretBytes,
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
-	}
-}
-
-func ClusterSizingConfiguration() *schedulingv1alpha1.ClusterSizingConfiguration {
-	return &schedulingv1alpha1.ClusterSizingConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster",
-		},
-		Spec: schedulingv1alpha1.ClusterSizingConfigurationSpec{
-			Sizes: []schedulingv1alpha1.SizeConfiguration{
-				{
-					Name: "small",
-					Criteria: schedulingv1alpha1.NodeCountCriteria{
-						From: 0,
-						To:   ptr.To(uint32(10)),
-					},
-				},
-				{
-					Name: "medium",
-					Criteria: schedulingv1alpha1.NodeCountCriteria{
-						From: 11,
-						To:   ptr.To(uint32(100)),
-					},
-				},
-				{
-					Name: "large",
-					Criteria: schedulingv1alpha1.NodeCountCriteria{
-						From: 101,
-					},
-				},
-			},
-		},
 	}
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -788,8 +788,6 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, []crclient.Ob
 		})
 	}
 
-	objects = append(objects, assets.ClusterSizingConfiguration())
-
 	for idx := range objects {
 		gvk, err := apiutil.GVKForObject(objects[idx], hyperapi.Scheme)
 		if err != nil {

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -986,30 +986,6 @@ objects:
     creationTimestamp: null
     name: oidc-storage-provider-s3-config
     namespace: kube-public
-- apiVersion: scheduling.hypershift.openshift.io/v1alpha1
-  kind: ClusterSizingConfiguration
-  metadata:
-    creationTimestamp: null
-    name: cluster
-  spec:
-    concurrency:
-      slidingWindow: 0s
-    sizes:
-    - criteria:
-        from: 0
-        to: 10
-      name: small
-    - criteria:
-        from: 11
-        to: 100
-      name: medium
-    - criteria:
-        from: 101
-      name: large
-    transitionDelay:
-      decrease: 0s
-      increase: 0s
-  status: {}
 - apiVersion: apiextensions.k8s.io/v1
   kind: CustomResourceDefinition
   metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this PR, the install command was creating the default cluster sizing config CR. This caused existing configuration to be overwritten on upgrade of the hypershift operator. Now it's created by the operator only if it doesn't exist.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1501](https://issues.redhat.com/browse/HOSTEDCP-1501)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.