### PR TITLE
NO-JIRA: Set control plane to HA by default

### DIFF
--- a/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -188,10 +188,10 @@ type HostedClusterSpec struct {
 	Platform PlatformSpec `json:"platform"`
 
 	// ControllerAvailabilityPolicy specifies the availability policy applied to
-	// critical control plane components. The default value is SingleReplica.
+	// critical control plane components. The default value is HighlyAvailable.
 	//
 	// +optional
-	// +kubebuilder:default:="SingleReplica"
+	// +kubebuilder:default:="HighlyAvailable"
 	// +immutable
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
 

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -325,10 +325,10 @@ type HostedClusterSpec struct {
 	Platform PlatformSpec `json:"platform"`
 
 	// ControllerAvailabilityPolicy specifies the availability policy applied to
-	// critical control plane components. The default value is SingleReplica.
+	// critical control plane components. The default value is HighlyAvailable.
 	//
 	// +optional
-	// +kubebuilder:default:="SingleReplica"
+	// +kubebuilder:default:="HighlyAvailable"
 	// +immutable
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -2329,10 +2329,10 @@ spec:
                 - image
                 type: object
               controllerAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   ControllerAvailabilityPolicy specifies the availability policy applied to
-                  critical control plane components. The default value is SingleReplica.
+                  critical control plane components. The default value is HighlyAvailable.
                 type: string
               dns:
                 description: DNS specifies DNS configuration for the cluster.
@@ -6713,10 +6713,10 @@ spec:
                 - image
                 type: object
               controllerAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   ControllerAvailabilityPolicy specifies the availability policy applied to
-                  critical control plane components. The default value is SingleReplica.
+                  critical control plane components. The default value is HighlyAvailable.
                 type: string
               dns:
                 description: DNS specifies DNS configuration for the cluster.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -264,7 +264,7 @@ AvailabilityPolicy
 <td>
 <em>(Optional)</em>
 <p>ControllerAvailabilityPolicy specifies the availability policy applied to
-critical control plane components. The default value is SingleReplica.</p>
+critical control plane components. The default value is HighlyAvailable.</p>
 </td>
 </tr>
 <tr>
@@ -3569,7 +3569,7 @@ AvailabilityPolicy
 <td>
 <em>(Optional)</em>
 <p>ControllerAvailabilityPolicy specifies the availability policy applied to
-critical control plane components. The default value is SingleReplica.</p>
+critical control plane components. The default value is HighlyAvailable.</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -39980,10 +39980,10 @@ objects:
                   - image
                   type: object
                 controllerAvailabilityPolicy:
-                  default: SingleReplica
+                  default: HighlyAvailable
                   description: |-
                     ControllerAvailabilityPolicy specifies the availability policy applied to
-                    critical control plane components. The default value is SingleReplica.
+                    critical control plane components. The default value is HighlyAvailable.
                   type: string
                 dns:
                   description: DNS specifies DNS configuration for the cluster.
@@ -44381,10 +44381,10 @@ objects:
                   - image
                   type: object
                 controllerAvailabilityPolicy:
-                  default: SingleReplica
+                  default: HighlyAvailable
                   description: |-
                     ControllerAvailabilityPolicy specifies the availability policy applied to
-                    critical control plane components. The default value is SingleReplica.
+                    critical control plane components. The default value is HighlyAvailable.
                   type: string
                 dns:
                   description: DNS specifies DNS configuration for the cluster.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -188,10 +188,10 @@ type HostedClusterSpec struct {
 	Platform PlatformSpec `json:"platform"`
 
 	// ControllerAvailabilityPolicy specifies the availability policy applied to
-	// critical control plane components. The default value is SingleReplica.
+	// critical control plane components. The default value is HighlyAvailable.
 	//
 	// +optional
-	// +kubebuilder:default:="SingleReplica"
+	// +kubebuilder:default:="HighlyAvailable"
 	// +immutable
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -325,10 +325,10 @@ type HostedClusterSpec struct {
 	Platform PlatformSpec `json:"platform"`
 
 	// ControllerAvailabilityPolicy specifies the availability policy applied to
-	// critical control plane components. The default value is SingleReplica.
+	// critical control plane components. The default value is HighlyAvailable.
 	//
 	// +optional
-	// +kubebuilder:default:="SingleReplica"
+	// +kubebuilder:default:="HighlyAvailable"
 	// +immutable
 	ControllerAvailabilityPolicy AvailabilityPolicy `json:"controllerAvailabilityPolicy,omitempty"`
 


### PR DESCRIPTION
Our recommendation for production is to always use Highly Available control planes, but our default (Single Replica) conflicts with this recommendation. as a result, we've had cases reported where users ended up inadvertently with single replica control planes (meaning no etcd replication) without understanding they needed to opt-in to HA mode.

The `hcp` cli defaults to HA mode. People using the API directly don't benefit from this default though. This PR makes the API default align with both the `hcp` cli and our recommendations for production. 