### PR TITLE
NO-JIRA: Remove unused ref to hostnetwork in cpo role

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2819,12 +2819,6 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role, enableCVOManagementClu
 				"*",
 			},
 		},
-		{
-			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"hostnetwork"},
-			Resources:     []string{"securitycontextconstraints"},
-			Verbs:         []string{"use"},
-		},
 		// This is needed for CPO to grant Autoscaler its RBAC policy.
 		{
 			APIGroups: []string{"cluster.x-k8s.io"},


### PR DESCRIPTION
**What this PR does / why we need it**:

The control-plane-operator Role has a rule to allow use of the hostnetwork SCC, but the control-plane-operator actually runs under the restricted-v2 SCC.

This change removes the unused rule.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.