### PR TITLE
HOSTEDCP-1104: Skip CPU Check on Render & Get Mgmt Cluster CPU from API Server

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -497,8 +497,13 @@ func Validate(ctx context.Context, opts *CreateOptions) error {
 
 	// Validate if mgmt cluster and NodePool CPU arches don't match, a multi-arch release image or stream was used
 	if !opts.AWSPlatform.MultiArch && !opts.Render {
-		if err := hyperutil.DoesMgmtClusterAndNodePoolCPUArchMatch(opts.Arch); err != nil {
+		mgmtClusterCPUArch, err := hyperutil.GetMgmtClusterCPUArch(ctx)
+		if err != nil {
 			return err
+		}
+
+		if err = hyperutil.DoesMgmtClusterAndNodePoolCPUArchMatch(mgmtClusterCPUArch, opts.Arch); err != nil {
+			opts.Log.Info(fmt.Sprintf("WARNING: %v", err))
 		}
 	}
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -496,7 +496,7 @@ func Validate(ctx context.Context, opts *CreateOptions) error {
 	}
 
 	// Validate if mgmt cluster and NodePool CPU arches don't match, a multi-arch release image or stream was used
-	if !opts.AWSPlatform.MultiArch {
+	if !opts.AWSPlatform.MultiArch && !opts.Render {
 		if err := hyperutil.DoesMgmtClusterAndNodePoolCPUArchMatch(opts.Arch); err != nil {
 			return err
 		}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -24,6 +24,7 @@ import (
 	"net/netip"
 	"os"
 	"reflect"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -3991,8 +3992,10 @@ func (r *HostedClusterReconciler) validateReleaseImage(ctx context.Context, hc *
 			return fmt.Errorf("failed to get list of nodepools for cpu arch validation: %w", err)
 		}
 
+		mgmtClusterCPUArch := runtime.GOARCH
+
 		for _, nodePool := range nodePoolList.Items {
-			if err := hyperutil.DoesMgmtClusterAndNodePoolCPUArchMatch(nodePool.Spec.Arch); err != nil {
+			if err := hyperutil.DoesMgmtClusterAndNodePoolCPUArchMatch(mgmtClusterCPUArch, nodePool.Spec.Arch); err != nil {
 				return err
 			}
 		}

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -405,3 +405,36 @@ func TestParseNodeSelector(t *testing.T) {
 		})
 	}
 }
+
+func TestDoesMgmtClusterAndNodePoolCPUArchMatch(t *testing.T) {
+	tests := []struct {
+		name           string
+		mgmtClusterCPU string
+		nodePoolCPU    string
+		wantErr        bool
+	}{
+		{
+			name:           "Mgmt cluster cpu and nodepool cpu don't match",
+			mgmtClusterCPU: "arm64",
+			nodePoolCPU:    "amd64",
+			wantErr:        true,
+		},
+		{
+			name:           "Mgmt cluster cpu and nodepool cpu match",
+			mgmtClusterCPU: "arm64",
+			nodePoolCPU:    "arm64",
+			wantErr:        false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := DoesMgmtClusterAndNodePoolCPUArchMatch(tc.mgmtClusterCPU, tc.nodePoolCPU)
+			if tc.wantErr {
+				g.Expect(err).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Skips the cluster/nodepool CPU check on render and properly gets the mgmt cluster CPU from the API Server version to check against the NodePool CPU.

We are also not blocking the CLI execution if these don't match now.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1104](https://issues.redhat.com/browse/HOSTEDCP-1104)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.