### PR TITLE
OCPBUGS-31265: inject built-in MCP selector for KubeletConfigs and ContainerRuntimeConfigs

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2035,12 +2035,12 @@ func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
 	_ = v1alpha1.Install(scheme)
 	_ = configv1.Install(scheme)
 
-	YamlSerializer := serializer.NewSerializerWithOptions(
+	yamlSerializer := serializer.NewSerializerWithOptions(
 		serializer.DefaultMetaFactory, scheme, scheme,
 		serializer.SerializerOptions{Yaml: true, Pretty: true, Strict: false},
 	)
 
-	cr, _, err := YamlSerializer.Decode(manifest, nil, nil)
+	cr, _, err := yamlSerializer.Decode(manifest, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding config: %w", err)
 	}
@@ -2052,14 +2052,34 @@ func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
 		}
 		obj.Labels["machineconfiguration.openshift.io/role"] = "worker"
 		buff := bytes.Buffer{}
-		if err := YamlSerializer.Encode(obj, &buff); err != nil {
+		if err := yamlSerializer.Encode(obj, &buff); err != nil {
 			return nil, fmt.Errorf("failed to encode config after defaulting it: %w", err)
 		}
 		manifest = buff.Bytes()
 	case *v1alpha1.ImageContentSourcePolicy:
 	case *configv1.ImageDigestMirrorSet:
 	case *mcfgv1.KubeletConfig:
+		obj.Spec.MachineConfigPoolSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"machineconfiguration.openshift.io/mco-built-in": "",
+			},
+		}
+		buff := bytes.Buffer{}
+		if err := yamlSerializer.Encode(obj, &buff); err != nil {
+			return nil, fmt.Errorf("failed to encode kubelet config after setting built-in MCP selector: %w", err)
+		}
+		manifest = buff.Bytes()
 	case *mcfgv1.ContainerRuntimeConfig:
+		obj.Spec.MachineConfigPoolSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"machineconfiguration.openshift.io/mco-built-in": "",
+			},
+		}
+		buff := bytes.Buffer{}
+		if err := yamlSerializer.Encode(obj, &buff); err != nil {
+			return nil, fmt.Errorf("failed to encode container runtime config after setting built-in MCP selector: %w", err)
+		}
+		manifest = buff.Bytes()
 	default:
 		return nil, fmt.Errorf("unsupported config type: %T", obj)
 	}


### PR DESCRIPTION
manual backport of https://github.com/openshift/hypershift/pull/3780 because 4.15 is missing https://github.com/openshift/hypershift/pull/1782