### PR TITLE
WIP: Allow CSI snapshot operator to use nonroot-v2 SCC

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/05_operator_role-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/05_operator_role-hypershift.yaml
@@ -75,6 +75,27 @@ rules:
   - list
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
   - hypershift.openshift.io
   resources:
   - hostedcontrolplanes

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/07_deployment-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/07_deployment-hypershift.yaml
@@ -47,6 +47,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: false
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig


### PR DESCRIPTION
**What this PR does / why we need it**:
To be able to run hosted control plane on non-OCP hosted control plane, we plan to set explicit non-root UID to all pods operated by the csi-snapshot-controller-operator.

On OCP we need to allow the operator to use nonroot-v2 SCC, because right now it uses restricted-v2.

This is complementary PR for https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/199

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.