### PR TITLE
NO-JIRA: Kubevirt on Azure: Change KAS LB Port to 7443

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -248,7 +248,7 @@ const (
 	// See https://github.com/openshift/enhancements/blob/master/enhancements/authentication/pod-security-admission.md
 	PodSecurityAdmissionLabelOverrideAnnotation = "hypershift.openshift.io/pod-security-admission-label-override"
 
-	//DisableMonitoringServices introduces an option to disable monitor services IBM Cloud do not use.
+	// DisableMonitoringServices introduces an option to disable monitor services IBM Cloud do not use.
 	DisableMonitoringServices = "hypershift.openshift.io/disable-monitoring-services"
 
 	// JSONPatchAnnotation allow modifying the kubevirt VM template using jsonpatch
@@ -275,7 +275,7 @@ const (
 	// AroHCP represents the ARO HCP managed service offering
 	AroHCP = "ARO-HCP"
 
-	//RosaHCP represents the ROSA HCP managed service offering
+	// RosaHCP represents the ROSA HCP managed service offering
 	RosaHCP = "ROSA-HCP"
 
 	// HostedClusterSizeLabel is a label on HostedClusters indicating a size based on the number of nodes.
@@ -283,6 +283,9 @@ const (
 
 	// NodeSizeLabel is a label on nodes used to match cluster size to a node size.
 	NodeSizeLabel = "hypershift.openshift.io/cluster-size"
+
+	// ManagementPlatformAnnotation specifies the infrastructure platform of the underlying management cluster
+	ManagementPlatformAnnotation = "hypershift.openshift.io/management-platform"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -810,8 +810,9 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 		if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
 			port = config.KASSVCIBMCloudPort
 		}
-		if hcp.Spec.Platform.Type == hyperv1.AzurePlatform {
-			// If Azure we get the SVC handling the LB.
+		if hcp.Spec.Platform.Type == hyperv1.AzurePlatform ||
+			hcp.Annotations[hyperv1.ManagementPlatformAnnotation] == string(hyperv1.AzurePlatform) {
+			// If Azure or Kubevirt on Azure we get the SVC handling the LB.
 			// TODO(alberto): remove this hack when having proper traffic management for Azure.
 			svc = manifests.KubeAPIServerServiceAzureLB(hcp.Namespace)
 			port = config.KASSVCLBAzurePort
@@ -1486,8 +1487,9 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Con
 	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
 		kasSVCPort = config.KASSVCIBMCloudPort
 	}
-	if serviceStrategy.Type == hyperv1.LoadBalancer && hcp.Spec.Platform.Type == hyperv1.AzurePlatform {
-		// For Azure we currently hardcode 7443 for the SVC LB as 6443 collides with public LB rule for the management cluster.
+	if serviceStrategy.Type == hyperv1.LoadBalancer && (hcp.Spec.Platform.Type == hyperv1.AzurePlatform ||
+		hcp.Annotations[hyperv1.ManagementPlatformAnnotation] == string(hyperv1.AzurePlatform)) {
+		// For Azure or Kubevirt on Azure we currently hardcode 7443 for the SVC LB as 6443 collides with public LB rule for the management cluster.
 		// https://bugzilla.redhat.com/show_bug.cgi?id=2060650
 		// TODO(alberto): explore exposing multiple Azure frontend IPs on the load balancer.
 		kasSVCPort = config.KASSVCLBAzurePort
@@ -1499,7 +1501,8 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Con
 		return fmt.Errorf("failed to reconcile API server service: %w", err)
 	}
 
-	if serviceStrategy.Type == hyperv1.LoadBalancer && hcp.Spec.Platform.Type == hyperv1.AzurePlatform {
+	if serviceStrategy.Type == hyperv1.LoadBalancer && (hcp.Spec.Platform.Type == hyperv1.AzurePlatform ||
+		hcp.Spec.Platform.Type == hyperv1.KubevirtPlatform && hcp.Annotations[hyperv1.ManagementPlatformAnnotation] == string(hyperv1.AzurePlatform)) {
 		// Create the svc clusterIP for Azure on config.KASSVCPort as expected by internal consumers.
 		kasSVC := manifests.KubeAPIServerService(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r.Client, kasSVC, func() error {
@@ -1912,8 +1915,9 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerServiceStatus(ctx conte
 	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
 		kasSVCLBPort = config.KASSVCIBMCloudPort
 	}
-	if serviceStrategy.Type == hyperv1.LoadBalancer && hcp.Spec.Platform.Type == hyperv1.AzurePlatform {
-		// If Azure we get the SVC handling the LB.
+	if serviceStrategy.Type == hyperv1.LoadBalancer && (hcp.Spec.Platform.Type == hyperv1.AzurePlatform ||
+		hcp.Annotations[hyperv1.ManagementPlatformAnnotation] == string(hyperv1.AzurePlatform)) {
+		// If Azure or Kubevirt on Azure we get the SVC handling the LB.
 		// TODO(alberto): remove this hack when having proper traffic management for Azure.
 		kasSVCLBPort = config.KASSVCLBAzurePort
 		svc = manifests.KubeAPIServerServiceAzureLB(hcp.Namespace)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1793,6 +1793,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.KubeAPIServerGOMemoryLimitAnnotation,
 		hyperv1.RequestServingNodeAdditionalSelectorAnnotation,
 		hyperv1.AWSLoadBalancerSubnetsAnnotation,
+		hyperv1.ManagementPlatformAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]
@@ -4982,6 +4983,24 @@ func (r *HostedClusterReconciler) reconcileKubevirtPlatformDefaultSettings(ctx c
 					Name: etcdEncSec.Name,
 				},
 			},
+		}
+	}
+
+	// Reconcile management infrastructure annotation
+	if _, exists := hc.Annotations[hyperv1.ManagementPlatformAnnotation]; !exists {
+		if hc.Annotations == nil {
+			hc.Annotations = map[string]string{}
+		}
+		mgmtInfraKey := client.ObjectKey{Name: "cluster"}
+		mgmtInfra := &configv1.Infrastructure{}
+
+		if err := r.Get(ctx, mgmtInfraKey, mgmtInfra); err != nil {
+			return fmt.Errorf("failed to get infrastructure.config.openshift.io status: %w", err)
+		}
+		mgmtPlatformType := mgmtInfra.Status.PlatformStatus.Type
+		hc.Annotations[hyperv1.ManagementPlatformAnnotation] = string(mgmtPlatformType)
+		if err := r.Client.Update(ctx, hc); err != nil {
+			return fmt.Errorf("failed to update hostedcluster %s annotation: %w", hc.Name, err)
 		}
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1032,6 +1032,16 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 				},
 			},
 		},
+		&configv1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster",
+			},
+			Status: configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+				},
+			},
+		},
 	}
 	for _, cluster := range hostedClusters {
 		cluster.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
@@ -3503,6 +3513,17 @@ func TestKubevirtETCDEncKey(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(tt *testing.T) {
 			testCase.objects = append(testCase.objects, testCase.hc)
+			infra := &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.KubevirtPlatformType,
+					},
+				},
+			}
+			testCase.objects = append(testCase.objects, infra)
 			client := &createTypeTrackingClient{Client: fake.NewClientBuilder().
 				WithScheme(api.Scheme).
 				WithObjects(testCase.objects...).

--- a/test/e2e/nodepool_kv_nodeselector_test.go
+++ b/test/e2e/nodepool_kv_nodeselector_test.go
@@ -59,6 +59,14 @@ func (k KubeVirtNodeSelectorTest) Setup(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		if len(nodes.Items) == 0 {
+			labelSelector := labels.SelectorFromValidatedSet(labels.Set{"cpu-vendor.node.kubevirt.io/AMD": "true"})
+			err = infraClient.GetInfraClient().List(k.ctx, nodes, &crclient.ListOptions{LabelSelector: labelSelector})
+			if err != nil {
+				return err
+			}
+		}
+		g.Expect(len(nodes.Items)).ToNot(Equal(0))
 		node := &nodes.Items[0]
 		nodeLabels := node.Labels
 		for key, value := range k.nodeSelector {

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -248,7 +248,7 @@ const (
 	// See https://github.com/openshift/enhancements/blob/master/enhancements/authentication/pod-security-admission.md
 	PodSecurityAdmissionLabelOverrideAnnotation = "hypershift.openshift.io/pod-security-admission-label-override"
 
-	//DisableMonitoringServices introduces an option to disable monitor services IBM Cloud do not use.
+	// DisableMonitoringServices introduces an option to disable monitor services IBM Cloud do not use.
 	DisableMonitoringServices = "hypershift.openshift.io/disable-monitoring-services"
 
 	// JSONPatchAnnotation allow modifying the kubevirt VM template using jsonpatch
@@ -275,7 +275,7 @@ const (
 	// AroHCP represents the ARO HCP managed service offering
 	AroHCP = "ARO-HCP"
 
-	//RosaHCP represents the ROSA HCP managed service offering
+	// RosaHCP represents the ROSA HCP managed service offering
 	RosaHCP = "ROSA-HCP"
 
 	// HostedClusterSizeLabel is a label on HostedClusters indicating a size based on the number of nodes.
@@ -283,6 +283,9 @@ const (
 
 	// NodeSizeLabel is a label on nodes used to match cluster size to a node size.
 	NodeSizeLabel = "hypershift.openshift.io/cluster-size"
+
+	// ManagementPlatformAnnotation specifies the infrastructure platform of the underlying management cluster
+	ManagementPlatformAnnotation = "hypershift.openshift.io/management-platform"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.


### PR DESCRIPTION


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
If the management cluster is Azure and the hosted cluster is created with the kubevirt-provider, the LB port of the kube-apiserver at the HCP can't be 6443 due to azure limitation. In such case, use port 7443 instead.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.