### PR TITLE
[release-4.14] HOSTEDCP-1322: NodeUpgradeType defaulted by provider

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -571,6 +571,9 @@ func (o ExampleOptions) Resources() *ExampleResources {
 	case hyperv1.AWSPlatform:
 		for _, zone := range o.AWS.Zones {
 			nodePool := defaultNodePool(fmt.Sprintf("%s-%s", cluster.Name, zone.Name))
+			if nodePool.Spec.Management.UpgradeType == "" {
+				nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
+			}
 			nodePool.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
 				InstanceType:    o.AWS.InstanceType,
 				InstanceProfile: o.AWS.InstanceProfile,
@@ -593,6 +596,9 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		}
 	case hyperv1.KubevirtPlatform:
 		nodePool := defaultNodePool(cluster.Name)
+		if nodePool.Spec.Management.UpgradeType == "" {
+			nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
+		}
 		nodePool.Spec.Platform.Kubevirt = ExampleKubeVirtTemplate(o.Kubevirt)
 		nodePools = append(nodePools, nodePool)
 		val, exists := o.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation]
@@ -603,11 +609,18 @@ func (o ExampleOptions) Resources() *ExampleResources {
 			nodePool.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation] = val
 		}
 	case hyperv1.NonePlatform, hyperv1.AgentPlatform:
-		nodePools = append(nodePools, defaultNodePool(cluster.Name))
+		nodePool := defaultNodePool(cluster.Name)
+		if nodePool.Spec.Management.UpgradeType == "" {
+			nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeInPlace
+		}
+		nodePools = append(nodePools, nodePool)
 	case hyperv1.AzurePlatform:
 		if len(o.Azure.AvailabilityZones) > 0 {
 			for _, availabilityZone := range o.Azure.AvailabilityZones {
 				nodePool := defaultNodePool(fmt.Sprintf("%s-%s", cluster.Name, availabilityZone))
+				if nodePool.Spec.Management.UpgradeType == "" {
+					nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
+				}
 				nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
 					VMSize:           o.Azure.InstanceType,
 					ImageID:          o.Azure.BootImageID,
@@ -619,6 +632,9 @@ func (o ExampleOptions) Resources() *ExampleResources {
 
 		} else {
 			nodePool := defaultNodePool(cluster.Name)
+			if nodePool.Spec.Management.UpgradeType == "" {
+				nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
+			}
 			nodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
 				VMSize:     o.Azure.InstanceType,
 				ImageID:    o.Azure.BootImageID,
@@ -628,6 +644,9 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		}
 	case hyperv1.PowerVSPlatform:
 		nodePool := defaultNodePool(cluster.Name)
+		if nodePool.Spec.Management.UpgradeType == "" {
+			nodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
+		}
 		nodePool.Spec.Platform.PowerVS = &hyperv1.PowerVSNodePoolPlatform{
 			SystemType:    o.PowerVS.SysType,
 			ProcessorType: o.PowerVS.ProcType,

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -40,7 +40,7 @@ func NewCreateCommands() *cobra.Command {
 		NodeSelector:                   nil,
 		Log:                            log.Log,
 		NodeDrainTimeout:               0,
-		NodeUpgradeType:                v1beta1.UpgradeTypeReplace,
+		NodeUpgradeType:                "",
 		Arch:                           "amd64",
 		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
 	}

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -27,7 +27,7 @@ func NewCreateCommands() *cobra.Command {
 		Namespace:                      "clusters",
 		NodeDrainTimeout:               0,
 		NodeSelector:                   nil,
-		NodeUpgradeType:                v1beta1.UpgradeTypeReplace,
+		NodeUpgradeType:                "",
 		PullSecretFile:                 "",
 		ReleaseImage:                   "",
 		Render:                         false,

--- a/product-cli/cmd/nodepool/create.go
+++ b/product-cli/cmd/nodepool/create.go
@@ -3,7 +3,6 @@ package nodepool
 import (
 	"github.com/spf13/cobra"
 
-	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
 	"github.com/openshift/hypershift/product-cli/cmd/nodepool/agent"
 	"github.com/openshift/hypershift/product-cli/cmd/nodepool/aws"
@@ -22,7 +21,7 @@ func NewCreateCommand() *cobra.Command {
 		ClusterName:     "example",
 		Namespace:       "clusters",
 		NodeCount:       2,
-		NodeUpgradeType: hyperv1.UpgradeTypeReplace,
+		NodeUpgradeType: "",
 		ReleaseImage:    "",
 	}
 


### PR DESCRIPTION
Manual backport from https://github.com/openshift/hypershift/pull/3273

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-1322](https://issues.redhat.com/browse/HOSTEDCP-1322)
