### PR TITLE
Add new permission required by CAPA

### DIFF
--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -125,6 +125,7 @@ const (
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress",
         "ec2:DescribeVpcs",
+		"ec2:DescribeDhcpOptions",
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",


### PR DESCRIPTION
A new permission required by CAPA is needed, `ec2:DescribeDhcpOptions`. This new permission was included in this PR https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4841 which is already merged and is required to make sure the node domain name is well set when a DHCPOption Set contains a custom domain name.

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-29391](https://issues.redhat.com/browse/OCPBUGS-29391)