### PR TITLE
CNF-11885: nto: add events resources under operator `Role`

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -145,6 +145,7 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
 			APIGroups: []string{corev1.SchemeGroupVersion.Group},
 			Resources: []string{
 				"configmaps",
+				"events",
 			},
 			Verbs: []string{"*"},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

PAO controller which is part of NTO, creates events as part of its reconciliation loop: https://github.com/openshift/cluster-node-tuning-operator/blob/master/pkg/performanceprofile/controller/performanceprofile_controller.go#L703

In order to performs operation on events, we should add the events under the role of the operator.

**Which issue(s) this PR fixes** 
Fixes # [CNF-11885](https://issues.redhat.com/browse/CNF-11885)