### PR TITLE
NO-JIRA: docs: fixing wrong key name

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -159,7 +159,7 @@ type NodePoolSpec struct {
 	PausedUntil *string `json:"pausedUntil,omitempty"`
 
 	// TuningConfig is a list of references to ConfigMaps containing serialized
-	// Tuned resources to define the tuning configuration to be applied to
+	// Tuned or PerformanceProfile resources to define the tuning configuration to be applied to
 	// nodes in the NodePool. The Tuned API is defined here:
 	//
 	// https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go
@@ -167,7 +167,7 @@ type NodePoolSpec struct {
 	// The PerformanceProfile API is defined here:
 	// https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2
 	//
-	// Each ConfigMap must have a single key named "tuned" whose value is the
+	// Each ConfigMap must have a single key named "tuning" whose value is the
 	// JSON or YAML of a serialized Tuned or PerformanceProfile.
 	// +kubebuilder:validation:Optional
 	TuningConfig []corev1.LocalObjectReference `json:"tuningConfig,omitempty"`

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -2037,7 +2037,7 @@ spec:
               tuningConfig:
                 description: |-
                   TuningConfig is a list of references to ConfigMaps containing serialized
-                  Tuned resources to define the tuning configuration to be applied to
+                  Tuned or PerformanceProfile resources to define the tuning configuration to be applied to
                   nodes in the NodePool. The Tuned API is defined here:
 
 
@@ -2048,7 +2048,7 @@ spec:
                   https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2
 
 
-                  Each ConfigMap must have a single key named "tuned" whose value is the
+                  Each ConfigMap must have a single key named "tuning" whose value is the
                   JSON or YAML of a serialized Tuned or PerformanceProfile.
                 items:
                   description: |-

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -826,12 +826,12 @@ provided: reconciliation is paused on the resource until the field is removed.</
 </td>
 <td>
 <p>TuningConfig is a list of references to ConfigMaps containing serialized
-Tuned resources to define the tuning configuration to be applied to
+Tuned or PerformanceProfile resources to define the tuning configuration to be applied to
 nodes in the NodePool. The Tuned API is defined here:</p>
 <p><a href="https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go">https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go</a></p>
 <p>The PerformanceProfile API is defined here:
 <a href="https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2">https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2</a></p>
-<p>Each ConfigMap must have a single key named &ldquo;tuned&rdquo; whose value is the
+<p>Each ConfigMap must have a single key named &ldquo;tuning&rdquo; whose value is the
 JSON or YAML of a serialized Tuned or PerformanceProfile.</p>
 </td>
 </tr>
@@ -6734,12 +6734,12 @@ provided: reconciliation is paused on the resource until the field is removed.</
 </td>
 <td>
 <p>TuningConfig is a list of references to ConfigMaps containing serialized
-Tuned resources to define the tuning configuration to be applied to
+Tuned or PerformanceProfile resources to define the tuning configuration to be applied to
 nodes in the NodePool. The Tuned API is defined here:</p>
 <p><a href="https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go">https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go</a></p>
 <p>The PerformanceProfile API is defined here:
 <a href="https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2">https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2</a></p>
-<p>Each ConfigMap must have a single key named &ldquo;tuned&rdquo; whose value is the
+<p>Each ConfigMap must have a single key named &ldquo;tuning&rdquo; whose value is the
 JSON or YAML of a serialized Tuned or PerformanceProfile.</p>
 </td>
 </tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -57341,7 +57341,7 @@ objects:
                 tuningConfig:
                   description: |-
                     TuningConfig is a list of references to ConfigMaps containing serialized
-                    Tuned resources to define the tuning configuration to be applied to
+                    Tuned or PerformanceProfile resources to define the tuning configuration to be applied to
                     nodes in the NodePool. The Tuned API is defined here:
 
 
@@ -57352,7 +57352,7 @@ objects:
                     https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2
 
 
-                    Each ConfigMap must have a single key named "tuned" whose value is the
+                    Each ConfigMap must have a single key named "tuning" whose value is the
                     JSON or YAML of a serialized Tuned or PerformanceProfile.
                   items:
                     description: |-

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -159,7 +159,7 @@ type NodePoolSpec struct {
 	PausedUntil *string `json:"pausedUntil,omitempty"`
 
 	// TuningConfig is a list of references to ConfigMaps containing serialized
-	// Tuned resources to define the tuning configuration to be applied to
+	// Tuned or PerformanceProfile resources to define the tuning configuration to be applied to
 	// nodes in the NodePool. The Tuned API is defined here:
 	//
 	// https://github.com/openshift/cluster-node-tuning-operator/blob/2c76314fb3cc8f12aef4a0dcd67ddc3677d5b54f/pkg/apis/tuned/v1/tuned_types.go
@@ -167,7 +167,7 @@ type NodePoolSpec struct {
 	// The PerformanceProfile API is defined here:
 	// https://github.com/openshift/cluster-node-tuning-operator/tree/b41042d42d4ba5bb2e99960248cf1d6ae4935018/pkg/apis/performanceprofile/v2
 	//
-	// Each ConfigMap must have a single key named "tuned" whose value is the
+	// Each ConfigMap must have a single key named "tuning" whose value is the
 	// JSON or YAML of a serialized Tuned or PerformanceProfile.
 	// +kubebuilder:validation:Optional
 	TuningConfig []corev1.LocalObjectReference `json:"tuningConfig,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
The key name in the ConfigMap is `tuning` and not `tuned`.
https://github.com/openshift/hypershift/blob/main/hypershift-operator/controllers/nodepool/nodepool_controller.go#L101 

**Which issue(s) this PR fixes** 
Fixes #
N/A
