### PR TITLE
OCPBUGS-14383: disable autoscaler when no nodepool requires it

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -265,6 +265,11 @@ const (
 	// in the AWS platform.
 	AWSLoadBalancerSubnetsAnnotation = "hypershift.openshift.io/aws-load-balancer-subnets"
 
+	// DisableClusterAutoscalerAnnotation allows disabling the cluster autoscaler for a hosted cluster.
+	// This annotation is only set by the hypershift-operator on HosterControlPlanes.
+	// It is not set by the end-user.
+	DisableClusterAutoscalerAnnotation = "hypershift.openshift.io/disable-cluster-autoscaler"
+
 	// AroHCP represents the ARO HCP managed service offering
 	AroHCP = "ARO-HCP"
 

--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -97,8 +97,12 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 		"app": autoscalerName,
 	}
 
+	replicas := k8sutilspointer.Int32(1)
+	if _, exists := hcp.Annotations[hyperv1.DisableClusterAutoscalerAnnotation]; exists {
+		replicas = k8sutilspointer.Int32(0)
+	}
 	deployment.Spec = appsv1.DeploymentSpec{
-		Replicas: k8sutilspointer.Int32(1),
+		Replicas: replicas,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: selector,
 		},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1484,9 +1484,13 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile the HostedControlPlane
+	isAutoscalingNeeded, err := r.isAutoscalingNeeded(ctx, hcluster)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to determine if autoscaler is needed: %w", err)
+	}
 	hcp = controlplaneoperator.HostedControlPlane(controlPlaneNamespace.Name, hcluster.Name)
 	_, err = createOrUpdate(ctx, r.Client, hcp, func() error {
-		return reconcileHostedControlPlane(hcp, hcluster)
+		return reconcileHostedControlPlane(hcp, hcluster, isAutoscalingNeeded)
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile hostedcontrolplane: %w", err)
@@ -1754,7 +1758,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 // reconcileHostedControlPlane reconciles the given HostedControlPlane, which
 // will be mutated.
-func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hyperv1.HostedCluster) error {
+func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hyperv1.HostedCluster, isAutoscalingNeeded bool) error {
 	hcp.Annotations = map[string]string{
 		HostedClusterAnnotation: client.ObjectKeyFromObject(hcluster).String(),
 	}
@@ -1802,6 +1806,11 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 			strings.HasPrefix(key, hyperv1.ResourceRequestOverrideAnnotationPrefix) {
 			hcp.Annotations[key] = val
 		}
+	}
+
+	// Set the DisableClusterAutoscalerAnnotation if autoscaling is not needed
+	if !isAutoscalingNeeded {
+		hcp.Annotations[hyperv1.DisableClusterAutoscalerAnnotation] = "true"
 	}
 
 	if hcp.Labels == nil {
@@ -4669,6 +4678,19 @@ func (r *HostedClusterReconciler) lookupReleaseImage(ctx context.Context, hclust
 		return nil, fmt.Errorf("expected %s key in pull secret", corev1.DockerConfigJsonKey)
 	}
 	return r.ReleaseProvider.Lookup(ctx, hyperutil.HCControlPlaneReleaseImage(hcluster), pullSecretBytes)
+}
+
+func (r *HostedClusterReconciler) isAutoscalingNeeded(ctx context.Context, hcluster *hyperv1.HostedCluster) (bool, error) {
+	nodePools, err := listNodePools(ctx, r.Client, hcluster.Namespace, hcluster.Name)
+	if err != nil {
+		return false, fmt.Errorf("failed to get nodePools by cluster name for cluster %q: %w", hcluster.Name, err)
+	}
+	for _, nodePool := range nodePools {
+		if nodePool.Spec.AutoScaling != nil {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // isUpgrading returns

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -261,7 +261,7 @@ func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			updated := test.ControlPlane.DeepCopy()
-			err := reconcileHostedControlPlane(updated, &test.Cluster)
+			err := reconcileHostedControlPlane(updated, &test.Cluster, true)
 			if err != nil {
 				t.Error(err)
 			}
@@ -393,7 +393,7 @@ func TestReconcileHostedControlPlaneAPINetwork(t *testing.T) {
 			hostedCluster := &hyperv1.HostedCluster{}
 			hostedCluster.Spec.Networking.APIServer = test.networking
 			hostedControlPlane := &hyperv1.HostedControlPlane{}
-			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster)
+			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster, true)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -451,7 +451,7 @@ func TestReconcileHostedControlPlaneConfiguration(t *testing.T) {
 			hostedControlPlane := &hyperv1.HostedControlPlane{}
 			g := NewGomegaWithT(t)
 
-			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster)
+			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster, true)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// DeepEqual to check that all ClusterConfiguration fields are deep copied to HostedControlPlane

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -265,6 +265,11 @@ const (
 	// in the AWS platform.
 	AWSLoadBalancerSubnetsAnnotation = "hypershift.openshift.io/aws-load-balancer-subnets"
 
+	// DisableClusterAutoscalerAnnotation allows disabling the cluster autoscaler for a hosted cluster.
+	// This annotation is only set by the hypershift-operator on HosterControlPlanes.
+	// It is not set by the end-user.
+	DisableClusterAutoscalerAnnotation = "hypershift.openshift.io/disable-cluster-autoscaler"
+
 	// AroHCP represents the ARO HCP managed service offering
 	AroHCP = "ARO-HCP"
 


### PR DESCRIPTION
Creates a new `DisableClusterAutoscalerAnnotation` set on the `HostedControlPlane` by the `hypershift-operator` when none of the `NodePools` for a particular `HostedCluster` have `spec.autoScaling` set.  When this annotation is set on the HCP, the CPO sets `replicas` on the `cluster-autoscaler` Deployment to 0.