### PR TITLE
NO-JIRA: update private cluster IAM policy doc

### DIFF
--- a/docs/content/how-to/aws/deploy-aws-private-clusters.md
+++ b/docs/content/how-to/aws/deploy-aws-private-clusters.md
@@ -37,6 +37,7 @@ following steps will reference elements of the steps you already performed.
                 "ec2:ModifyVpcEndpointServicePermissions",
                 "ec2:RejectVpcEndpointConnections",
                 "ec2:DescribeVpcEndpointConnections",
+                "ec2:DescribeInstanceTypes",
                 "ec2:CreateTags",
                 "elasticloadbalancing:DescribeLoadBalancers"
               ],
@@ -62,6 +63,8 @@ following steps will reference elements of the steps you already performed.
                 "ec2:DescribeVpcEndpointServicePermissions",
                 "ec2:ModifyVpcEndpointServicePermissions",
                 "ec2:RejectVpcEndpointConnections",
+                "ec2:DescribeVpcEndpointConnections",
+                "ec2:DescribeInstanceTypes",
                 "ec2:CreateTags",
                 "elasticloadbalancing:DescribeLoadBalancers"
               ],


### PR DESCRIPTION
<!--
update doc for private cluster IAM policy
-->

**What this PR does / why we need it**:
In the hypershift documentation, it would be helpful to provide clarification that the "ec2:DescribeInstanceTypes" policy is required. Otherwise, errors would occur in the HO logs.
```
{“level”:“error”,“ts”:“2024-04-07T12:59:39Z”,“msg”:“failed to call AWS to resolve the number of cores per node for the following EC2 instance type: m5.xlarge”,“error”:“UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:iam::301721915996:user/preserved-hypershift-ci is not authorized to perform: ec2:DescribeInstanceTypes because no identity-based policy allows the ec2:DescribeInstanceTypes action\n\tstatus code: 403, request id: 93a25aef-0936-4ce9-9d78-23c55f0aa49c”,“stacktrace”:“[github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics.(*nodePoolsMetricsCollector).resolveCoresCountPerNode](http://github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics.(*nodePoolsMetricsCollector).resolveCoresCountPerNode)\n\t/hypershift/hypershift-operator/controllers/nodepool/metrics/metrics.go:230\[ngithub.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics.(*nodePoolsMetricsCollector).Collect](http://ngithub.com/openshift/hypershift/hypershift-operator/controllers/nodepool/metrics.(*nodePoolsMetricsCollector).Collect)\n\t/hypershift/hypershift-operator/controllers/nodepool/metrics/metrics.go:366\[ngithub.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1](http://ngithub.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1)\n\t/hypershift/vendor/github.com/prometheus/client_golang/prometheus/registry.go:455"}
```

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ x] This change includes docs. 
- [ ] This change includes unit tests.