### PR TITLE
NO-JIRA: [e2e test framework] Add a flag to add an annotation to HostedCluster

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -115,6 +115,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.ManagementClusterNamespace, "e2e.management-cluster-namespace", "", "Namespace of the management cluster's HostedCluster (required to test request serving isolation)")
 	flag.StringVar(&globalOpts.ManagementClusterName, "e2e.management-cluster-name", "", "Name of the management cluster's HostedCluster (required to test request serving isolation)")
 	flag.BoolVar(&globalOpts.DisablePKIReconciliation, "e2e.disable-pki-reconciliation", false, "If set, TestUpgradeControlPlane will upgrade the control plane without reconciling the pki components")
+	flag.Var(&globalOpts.configurableClusterOptions.Annotations, "e2e.annotations", "Annotations to apply to the HostedCluster (key=value). Can be specified multiple times")
 
 	flag.Parse()
 
@@ -425,6 +426,7 @@ type configurableClusterOptions struct {
 	PowerVSTransitGatewayLocation string
 	PowerVSTransitGateway         string
 	EtcdStorageClass              string
+	Annotations                   stringMapVar
 }
 
 var nextAWSZoneIndex = 0
@@ -523,6 +525,12 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		createOption.SSHKeyFile = o.configurableClusterOptions.SSHKeyFile
 	}
 
+	if o.configurableClusterOptions.Annotations != nil {
+		for k, v := range o.configurableClusterOptions.Annotations {
+			createOption.Annotations = append(createOption.Annotations, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
 	return createOption
 }
 
@@ -608,3 +616,24 @@ type stringSliceVar []string
 
 func (s *stringSliceVar) String() string     { return strings.Join(*s, ",") }
 func (s *stringSliceVar) Set(v string) error { *s = append(*s, strings.Split(v, ",")...); return nil }
+
+type stringMapVar map[string]string
+
+func (s *stringMapVar) String() string {
+	if *s == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", *s)
+}
+
+func (s *stringMapVar) Set(value string) error {
+	split := strings.Split(value, "=")
+	if len(split) != 2 {
+		return fmt.Errorf("invalid argument: %s", value)
+	}
+	if *s == nil {
+		*s = map[string]string{}
+	}
+	map[string]string(*s)[split[0]] = split[1]
+	return nil
+}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This addition will allow us to insert a custom annotation needed for the e2e test suite for the HostedCluster.
In particular, specify the management platform type in case of kubevirt external infra testing.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.