### PR TITLE
CNV-40622: Docs: Avoid cidr Collisions b/w Infra &Guest cluster

### DIFF
--- a/docs/content/how-to/kubevirt/configuring-network.md
+++ b/docs/content/how-to/kubevirt/configuring-network.md
@@ -58,3 +58,57 @@ hcp create cluster kubevirt \
 --additional-network name:my-namespace/network1 \
 ```
 
+## Avoiding Network CIDR Collisions between Hosting and Guest Clusters.
+
+When creating a guest cluster, it's crucial to ensure that the hosting and guest clusters do not share the same subnet (cidr) for the cluster network.
+This prevents DNS-related conflicts and avoids issues during the deployment of guest clusters.
+
+
+### Guidelines to Avoid CIDR Collisions:
+
+
+1. Detecting Hosting Cluster Network CIDR Range.
+
+Determine the cluster network CIDR range from the underlying Hosting cluster using the command:
+
+```
+oc --kubeconfig <hosting cluster kubeconfig> get network cluster -o=jsonpath='{.spec.clusterNetwork}'
+```
+
+
+2. Identifying CIDR Conflicts with HCP Default Range
+
+Compare the default CIDR range used by HCP, which is typically set to 10.132.0.0/14,
+with the CIDR range obtained in Step 1 to detect any conflicts with the hosting CIDR range.
+
+
+3. Setting Custom Cluster CIDR Range:
+
+If a conflict is detected, use the HCP CLI to specify a custom CIDR range for the guest cluster using
+the --cluster-cidr flag. The default CIDR range used by the HCP CLI is designed to be offset from the
+typical OCP deployment range, so under normal operation, this offset should prevent collisions.
+
+For example, if the hosting cluster's clusterNetwork CIDR is set to 10.132.0.0/14, it's imperative to
+select a different CIDR range for the guest cluster to prevent conflicts.
+
+For instance, consider specifying a different CIDR range, such as 10.128.0.0/14 (this range is just an example),
+for the guest cluster.
+
+```
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+
+hcp create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas $WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU \
+--cluster-cidr 10.128.0.0/14
+```
+
+By following these guidelines, you can ensure successful deployment of guest clusters, avoid network CIDR collisions,
+and prevent DNS-related issues between hosting and guest clusters.


### PR DESCRIPTION
Added guidelines for avoiding network CIDR collisions and DNS-related issues between hosting and guest clusters.

When creating a guest cluster, it's crucial to ensure that the hosting and guest clusters do not share the same subnet (cidr) for the cluster network otherwise guest cluster deployment will not complete successfully.

Fixes # [CNV-40622](https://issues.redhat.com//browse/CNV-40622)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 