### PR TITLE
HOSTEDCP-1518: Preserve container resource requests and limits

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -30,7 +30,10 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 )
 
-const operatorName = "cluster-network-operator"
+const (
+	operatorName          = "cluster-network-operator"
+	konnectivityProxyName = "konnectivity-proxy"
+)
 
 type Images struct {
 	NetworkOperator              string
@@ -303,15 +306,29 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 
 	cnoResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
 			corev1.ResourceCPU:    resource.MustParse("10m"),
 		},
 	}
-	// preserve existing resource requirements
+	// preserve existing resource requirements for the CNO container
 	mainContainer := util.FindContainer(operatorName, dep.Spec.Template.Spec.Containers)
 	if mainContainer != nil {
 		if len(mainContainer.Resources.Requests) > 0 || len(mainContainer.Resources.Limits) > 0 {
 			cnoResources = mainContainer.Resources
+		}
+	}
+
+	kProxyResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+		},
+	}
+	// preserve existing resource requirements for the konnectivity-proxy container
+	kProxyContainer := util.FindContainer(konnectivityProxyName, dep.Spec.Template.Spec.Containers)
+	if kProxyContainer != nil {
+		if len(kProxyContainer.Resources.Requests) > 0 || len(kProxyContainer.Resources.Limits) > 0 {
+			kProxyResources = kProxyContainer.Resources
 		}
 	}
 
@@ -535,13 +552,10 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 			{Name: "SOCKS5_PROXY_IMAGE", Value: params.Images.Socks5Proxy},
 			{Name: "OPENSHIFT_RELEASE_IMAGE", Value: params.DeploymentConfig.AdditionalAnnotations[hyperv1.ReleaseImageAnnotation]},
 		}...),
-		Name:            operatorName,
-		Image:           params.Images.NetworkOperator,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("100Mi"),
-		}},
+		Name:                     operatorName,
+		Image:                    params.Images.NetworkOperator,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		Resources:                cnoResources,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "hosted-etc-kube", MountPath: "/etc/hosted-kubernetes"},
@@ -550,8 +564,7 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 	},
 		{
 			// CNO uses konnectivity-proxy to perform proxy readiness checks through the hosted cluster's network
-			// Disable the resolver to ensure that CNO connects to the exact proxy address provided
-			Name:    "konnectivity-proxy",
+			Name:    konnectivityProxyName,
 			Image:   params.Images.Socks5Proxy,
 			Command: []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy", "--disable-resolver"},
 			Args:    []string{"run"},
@@ -559,7 +572,7 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 				Name:  "KUBECONFIG",
 				Value: "/etc/kubernetes/kubeconfig",
 			}},
-			Resources: cnoResources,
+			Resources: kProxyResources,
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: "hosted-etc-kube", MountPath: "/etc/kubernetes"},
 				{Name: "konnectivity-proxy-cert", MountPath: "/etc/konnectivity/proxy-client"},

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -1,0 +1,200 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+spec:
+  replicas: 0
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      name: cluster-network-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      creationTimestamp: null
+      labels:
+        app: cluster-network-operator
+        hypershift.openshift.io/control-plane-component: cluster-network-operator
+        name: cluster-network-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - --listen=0.0.0.0:9104
+        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        - --namespace=openshift-network-operator
+        - --extra-clusters=management=/configs/management
+        command:
+        - /usr/bin/cluster-network-operator
+        env:
+        - name: OVN_SBDB_ROUTE_HOST
+        - name: PROXY_INTERNAL_APISERVER_ADDRESS
+          value: "true"
+        - name: HYPERSHIFT
+          value: "true"
+        - name: HOSTED_CLUSTER_NAME
+        - name: CA_CONFIG_MAP
+        - name: CA_CONFIG_MAP_KEY
+        - name: TOKEN_AUDIENCE
+        - name: RELEASE_VERSION
+          value: 4.11.0
+        - name: APISERVER_OVERRIDE_HOST
+        - name: APISERVER_OVERRIDE_PORT
+          value: "0"
+        - name: OVN_NB_RAFT_ELECTION_TIMER
+          value: "10"
+        - name: OVN_SB_RAFT_ELECTION_TIMER
+          value: "16"
+        - name: OVN_NORTHD_PROBE_INTERVAL
+          value: "5000"
+        - name: OVN_CONTROLLER_INACTIVITY_PROBE
+          value: "180000"
+        - name: OVN_NB_INACTIVITY_PROBE
+          value: "60000"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: HOSTED_CLUSTER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SDN_IMAGE
+        - name: KUBE_PROXY_IMAGE
+        - name: KUBE_RBAC_PROXY_IMAGE
+        - name: MULTUS_IMAGE
+        - name: MULTUS_ADMISSION_CONTROLLER_IMAGE
+        - name: CNI_PLUGINS_IMAGE
+        - name: BOND_CNI_PLUGIN_IMAGE
+        - name: WHEREABOUTS_CNI_IMAGE
+        - name: ROUTE_OVERRRIDE_CNI_IMAGE
+        - name: MULTUS_NETWORKPOLICY_IMAGE
+        - name: OVN_IMAGE
+        - name: OVN_CONTROL_PLANE_IMAGE
+        - name: EGRESS_ROUTER_CNI_IMAGE
+        - name: KURYR_DAEMON_IMAGE
+        - name: KURYR_CONTROLLER_IMAGE
+        - name: NETWORK_METRICS_DAEMON_IMAGE
+        - name: NETWORK_CHECK_SOURCE_IMAGE
+        - name: NETWORK_CHECK_TARGET_IMAGE
+        - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
+        - name: TOKEN_MINTER_IMAGE
+        - name: CLI_IMAGE
+        - name: SOCKS5_PROXY_IMAGE
+        - name: OPENSHIFT_RELEASE_IMAGE
+        imagePullPolicy: IfNotPresent
+        name: cluster-network-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-etc-kube
+        - mountPath: /configs
+          name: configs
+      - args:
+        - run
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-socks5-proxy
+        - --disable-resolver
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig
+        name: konnectivity-proxy
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: hosted-etc-kube
+        - mountPath: /etc/konnectivity/proxy-client
+          name: konnectivity-proxy-cert
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        - --kubeconfig=/var/kubeconfig/kubeconfig
+        - --required-api=operator.openshift.io,v1,Network
+        - --required-api=network.operator.openshift.io,v1,EgressRouter
+        - --required-api=network.operator.openshift.io,v1,OperatorPKI
+        - --wait-for-infrastructure-resource
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/kubeconfig
+          name: hosted-etc-kube
+      - args:
+        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        - -n=openshift-network-operator
+        - delete
+        - --ignore-not-found=true
+        - deployment
+        - network-operator
+        command:
+        - /usr/bin/kubectl
+        name: remove-old-cno
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-etc-kube
+      - args:
+        - -c
+        - |2-
+
+          set -xeuo pipefail
+          kc=/configs/management
+          kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+          kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubectl --kubeconfig $kc config set contexts.default.cluster default
+          kubectl --kubeconfig $kc config set contexts.default.user admin
+          kubectl --kubeconfig $kc config set contexts.default.namespace $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          kubectl --kubeconfig $kc config use-context default
+        command:
+        - /bin/bash
+        name: rewrite-config
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-etc-kube
+        - mountPath: /configs
+          name: configs
+      serviceAccountName: cluster-network-operator
+      volumes:
+      - name: hosted-etc-kube
+        secret:
+          secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: configs
+      - name: konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          defaultMode: 416
+          name: konnectivity-ca-bundle
+        name: konnectivity-proxy-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -1,0 +1,203 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+spec:
+  replicas: 0
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      name: cluster-network-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      creationTimestamp: null
+      labels:
+        app: cluster-network-operator
+        hypershift.openshift.io/control-plane-component: cluster-network-operator
+        name: cluster-network-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - --listen=0.0.0.0:9104
+        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        - --namespace=openshift-network-operator
+        - --extra-clusters=management=/configs/management
+        command:
+        - /usr/bin/cluster-network-operator
+        env:
+        - name: OVN_SBDB_ROUTE_HOST
+        - name: PROXY_INTERNAL_APISERVER_ADDRESS
+          value: "true"
+        - name: HYPERSHIFT
+          value: "true"
+        - name: HOSTED_CLUSTER_NAME
+        - name: CA_CONFIG_MAP
+        - name: CA_CONFIG_MAP_KEY
+        - name: TOKEN_AUDIENCE
+        - name: RELEASE_VERSION
+          value: 4.11.0
+        - name: APISERVER_OVERRIDE_HOST
+        - name: APISERVER_OVERRIDE_PORT
+          value: "0"
+        - name: OVN_NB_RAFT_ELECTION_TIMER
+          value: "10"
+        - name: OVN_SB_RAFT_ELECTION_TIMER
+          value: "16"
+        - name: OVN_NORTHD_PROBE_INTERVAL
+          value: "5000"
+        - name: OVN_CONTROLLER_INACTIVITY_PROBE
+          value: "180000"
+        - name: OVN_NB_INACTIVITY_PROBE
+          value: "60000"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: HOSTED_CLUSTER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SDN_IMAGE
+        - name: KUBE_PROXY_IMAGE
+        - name: KUBE_RBAC_PROXY_IMAGE
+        - name: MULTUS_IMAGE
+        - name: MULTUS_ADMISSION_CONTROLLER_IMAGE
+        - name: CNI_PLUGINS_IMAGE
+        - name: BOND_CNI_PLUGIN_IMAGE
+        - name: WHEREABOUTS_CNI_IMAGE
+        - name: ROUTE_OVERRRIDE_CNI_IMAGE
+        - name: MULTUS_NETWORKPOLICY_IMAGE
+        - name: OVN_IMAGE
+        - name: OVN_CONTROL_PLANE_IMAGE
+        - name: EGRESS_ROUTER_CNI_IMAGE
+        - name: KURYR_DAEMON_IMAGE
+        - name: KURYR_CONTROLLER_IMAGE
+        - name: NETWORK_METRICS_DAEMON_IMAGE
+        - name: NETWORK_CHECK_SOURCE_IMAGE
+        - name: NETWORK_CHECK_TARGET_IMAGE
+        - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
+        - name: TOKEN_MINTER_IMAGE
+        - name: CLI_IMAGE
+        - name: SOCKS5_PROXY_IMAGE
+        - name: OPENSHIFT_RELEASE_IMAGE
+        imagePullPolicy: IfNotPresent
+        name: cluster-network-operator
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1000Mi
+          requests:
+            cpu: 500m
+            memory: 500Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-etc-kube
+        - mountPath: /configs
+          name: configs
+      - args:
+        - run
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-socks5-proxy
+        - --disable-resolver
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig
+        name: konnectivity-proxy
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: hosted-etc-kube
+        - mountPath: /etc/konnectivity/proxy-client
+          name: konnectivity-proxy-cert
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        - --kubeconfig=/var/kubeconfig/kubeconfig
+        - --required-api=operator.openshift.io,v1,Network
+        - --required-api=network.operator.openshift.io,v1,EgressRouter
+        - --required-api=network.operator.openshift.io,v1,OperatorPKI
+        - --wait-for-infrastructure-resource
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/kubeconfig
+          name: hosted-etc-kube
+      - args:
+        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        - -n=openshift-network-operator
+        - delete
+        - --ignore-not-found=true
+        - deployment
+        - network-operator
+        command:
+        - /usr/bin/kubectl
+        name: remove-old-cno
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-etc-kube
+      - args:
+        - -c
+        - |2-
+
+          set -xeuo pipefail
+          kc=/configs/management
+          kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+          kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubectl --kubeconfig $kc config set contexts.default.cluster default
+          kubectl --kubeconfig $kc config set contexts.default.user admin
+          kubectl --kubeconfig $kc config set contexts.default.namespace $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          kubectl --kubeconfig $kc config use-context default
+        command:
+        - /bin/bash
+        name: rewrite-config
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-etc-kube
+        - mountPath: /configs
+          name: configs
+      serviceAccountName: cluster-network-operator
+      volumes:
+      - name: hosted-etc-kube
+        secret:
+          secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: configs
+      - name: konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          defaultMode: 416
+          name: konnectivity-ca-bundle
+        name: konnectivity-proxy-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -1,0 +1,201 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+spec:
+  replicas: 0
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      name: cluster-network-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      creationTimestamp: null
+      labels:
+        app: cluster-network-operator
+        hypershift.openshift.io/control-plane-component: cluster-network-operator
+        name: cluster-network-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - --listen=0.0.0.0:9104
+        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        - --namespace=openshift-network-operator
+        - --extra-clusters=management=/configs/management
+        command:
+        - /usr/bin/cluster-network-operator
+        env:
+        - name: OVN_SBDB_ROUTE_HOST
+          value: ovnkube-sbdb.apps..hypershift.local
+        - name: OVN_SBDB_ROUTE_LABELS
+          value: hypershift.openshift.io/hosted-control-plane=,hypershift.openshift.io/internal-route=true
+        - name: HYPERSHIFT
+          value: "true"
+        - name: HOSTED_CLUSTER_NAME
+        - name: CA_CONFIG_MAP
+        - name: CA_CONFIG_MAP_KEY
+        - name: TOKEN_AUDIENCE
+        - name: RELEASE_VERSION
+          value: 4.11.0
+        - name: APISERVER_OVERRIDE_HOST
+        - name: APISERVER_OVERRIDE_PORT
+          value: "0"
+        - name: OVN_NB_RAFT_ELECTION_TIMER
+          value: "10"
+        - name: OVN_SB_RAFT_ELECTION_TIMER
+          value: "16"
+        - name: OVN_NORTHD_PROBE_INTERVAL
+          value: "5000"
+        - name: OVN_CONTROLLER_INACTIVITY_PROBE
+          value: "180000"
+        - name: OVN_NB_INACTIVITY_PROBE
+          value: "60000"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: HOSTED_CLUSTER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SDN_IMAGE
+        - name: KUBE_PROXY_IMAGE
+        - name: KUBE_RBAC_PROXY_IMAGE
+        - name: MULTUS_IMAGE
+        - name: MULTUS_ADMISSION_CONTROLLER_IMAGE
+        - name: CNI_PLUGINS_IMAGE
+        - name: BOND_CNI_PLUGIN_IMAGE
+        - name: WHEREABOUTS_CNI_IMAGE
+        - name: ROUTE_OVERRRIDE_CNI_IMAGE
+        - name: MULTUS_NETWORKPOLICY_IMAGE
+        - name: OVN_IMAGE
+        - name: OVN_CONTROL_PLANE_IMAGE
+        - name: EGRESS_ROUTER_CNI_IMAGE
+        - name: KURYR_DAEMON_IMAGE
+        - name: KURYR_CONTROLLER_IMAGE
+        - name: NETWORK_METRICS_DAEMON_IMAGE
+        - name: NETWORK_CHECK_SOURCE_IMAGE
+        - name: NETWORK_CHECK_TARGET_IMAGE
+        - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
+        - name: TOKEN_MINTER_IMAGE
+        - name: CLI_IMAGE
+        - name: SOCKS5_PROXY_IMAGE
+        - name: OPENSHIFT_RELEASE_IMAGE
+        imagePullPolicy: IfNotPresent
+        name: cluster-network-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-etc-kube
+        - mountPath: /configs
+          name: configs
+      - args:
+        - run
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-socks5-proxy
+        - --disable-resolver
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig
+        name: konnectivity-proxy
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: hosted-etc-kube
+        - mountPath: /etc/konnectivity/proxy-client
+          name: konnectivity-proxy-cert
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        - --kubeconfig=/var/kubeconfig/kubeconfig
+        - --required-api=operator.openshift.io,v1,Network
+        - --required-api=network.operator.openshift.io,v1,EgressRouter
+        - --required-api=network.operator.openshift.io,v1,OperatorPKI
+        - --wait-for-infrastructure-resource
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/kubeconfig
+          name: hosted-etc-kube
+      - args:
+        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        - -n=openshift-network-operator
+        - delete
+        - --ignore-not-found=true
+        - deployment
+        - network-operator
+        command:
+        - /usr/bin/kubectl
+        name: remove-old-cno
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-etc-kube
+      - args:
+        - -c
+        - |2-
+
+          set -xeuo pipefail
+          kc=/configs/management
+          kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+          kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubectl --kubeconfig $kc config set contexts.default.cluster default
+          kubectl --kubeconfig $kc config set contexts.default.user admin
+          kubectl --kubeconfig $kc config set contexts.default.namespace $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          kubectl --kubeconfig $kc config use-context default
+        command:
+        - /bin/bash
+        name: rewrite-config
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-etc-kube
+        - mountPath: /configs
+          name: configs
+      serviceAccountName: cluster-network-operator
+      volumes:
+      - name: hosted-etc-kube
+        secret:
+          secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: configs
+      - name: konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          defaultMode: 416
+          name: konnectivity-ca-bundle
+        name: konnectivity-proxy-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator_test.go
@@ -1,0 +1,89 @@
+package olm
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestReconcileCatalogOperatorDeployment(t *testing.T) {
+	t.Run("Catalog operator resource preservation", func(t *testing.T) {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: catalogOperatorName,
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("100Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1000m"),
+										corev1.ResourceMemory: resource.MustParse("1000Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		if err := ReconcileCatalogOperatorDeployment(dep, config.OwnerRef{}, "", "", "", "", config.DeploymentConfig{}, "", []string{}, hyperv1.NonePlatform); err != nil {
+			t.Fatalf("ReconcileCatalogOperatorDeployment: %v", err)
+		}
+
+		// Verify the existing resources were preserved
+		if dep.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue() != 100 ||
+			dep.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value()/(1024*1024) != 100 ||
+			dep.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().MilliValue() != 1000 ||
+			dep.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()/(1024*1024) != 1000 {
+			t.Error("some or all existing deployment resources were not preserved")
+		}
+	})
+}
+
+func TestReconcileOLMOperatorDeployment(t *testing.T) {
+	t.Run("OLM operator resource preservation", func(t *testing.T) {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: olmOperatorName,
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("100Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1000m"),
+										corev1.ResourceMemory: resource.MustParse("1000Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		if err := ReconcileOLMOperatorDeployment(dep, config.OwnerRef{}, "", "", "", config.DeploymentConfig{}, "", []string{}, hyperv1.NonePlatform); err != nil {
+			t.Fatalf("ReconcileOLMOperatorDeployment: %v", err)
+		}
+
+		// Verify the existing resources were preserved
+		if dep.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue() != 100 ||
+			dep.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value()/(1024*1024) != 100 ||
+			dep.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().MilliValue() != 1000 ||
+			dep.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()/(1024*1024) != 1000 {
+			t.Error("some or all existing deployment resources were not preserved")
+		}
+	})
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver_test.go
@@ -1,0 +1,50 @@
+package olm
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestReconcilePackageServerDeployment(t *testing.T) {
+	t.Run("Packageserver resource preservation", func(t *testing.T) {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: packageServerName,
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("100Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1000m"),
+										corev1.ResourceMemory: resource.MustParse("1000Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		if err := ReconcilePackageServerDeployment(dep, config.OwnerRef{}, "", "", "", config.DeploymentConfig{}, "", []string{}, hyperv1.NonePlatform); err != nil {
+			t.Fatalf("ReconcilePackageServerDeployment: %v", err)
+		}
+
+		// Verify the existing resources were preserved
+		if dep.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue() != 100 ||
+			dep.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value()/(1024*1024) != 100 ||
+			dep.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().MilliValue() != 1000 ||
+			dep.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()/(1024*1024) != 1000 {
+			t.Error("some or all existing deployment resources were not preserved")
+		}
+	})
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileCatalogOperatorDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileCatalogOperatorDeployment_Preserve_existing_resources.yaml
@@ -1,0 +1,148 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+spec:
+  replicas: 0
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app: catalog-operator
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
+      creationTimestamp: null
+      labels:
+        app: catalog-operator
+        hypershift.openshift.io/control-plane-component: catalog-operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --namespace
+        - openshift-marketplace
+        - --configmapServerImage=$(OPERATOR_REGISTRY_IMAGE)
+        - --opmImage=$(OPERATOR_REGISTRY_IMAGE)
+        - --util-image
+        - $(OLM_OPERATOR_IMAGE)
+        - --writeStatusName
+        - operator-lifecycle-manager-catalog
+        - --tls-cert
+        - /srv-cert/tls.crt
+        - --tls-key
+        - /srv-cert/tls.key
+        - --client-ca
+        - /client-ca/ca.crt
+        - --kubeconfig
+        - /etc/openshift/kubeconfig/kubeconfig
+        command:
+        - /bin/catalog
+        env:
+        - name: RELEASE_VERSION
+        - name: KUBECONFIG
+          value: /etc/openshift/kubeconfig/kubeconfig
+        - name: OLM_OPERATOR_IMAGE
+        - name: OPERATOR_REGISTRY_IMAGE
+        - name: GRPC_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: NO_PROXY
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+        name: catalog-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1000Mi
+          requests:
+            cpu: 500m
+            memory: 500Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /srv-cert
+          name: srv-cert
+          readOnly: true
+        - mountPath: /client-ca
+          name: profile-collector
+          readOnly: true
+        - mountPath: /etc/openshift/kubeconfig
+          name: kubeconfig
+          readOnly: true
+      - args:
+        - run
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-socks5-proxy
+        env:
+        - name: KUBECONFIG
+          value: /etc/openshift/kubeconfig/kubeconfig
+        imagePullPolicy: IfNotPresent
+        name: socks5-proxy
+        ports:
+        - containerPort: 8090
+        resources:
+          requests:
+            cpu: 10m
+            memory: 15Mi
+        volumeMounts:
+        - mountPath: /etc/konnectivity/proxy-client
+          name: oas-konnectivity-proxy-cert
+          readOnly: true
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: oas-konnectivity-proxy-ca
+          readOnly: true
+        - mountPath: /etc/openshift/kubeconfig
+          name: kubeconfig
+          readOnly: true
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        - --kubeconfig=/var/kubeconfig/kubeconfig
+        - --required-api=operators.coreos.com,v1alpha1,CatalogSource
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/kubeconfig
+          name: kubeconfig
+      volumes:
+      - name: srv-cert
+        secret:
+          defaultMode: 416
+          secretName: catalog-operator-serving-cert
+      - name: profile-collector
+        secret:
+          defaultMode: 416
+          secretName: metrics-client
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - name: oas-konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          name: konnectivity-ca-bundle
+        name: oas-konnectivity-proxy-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileOLMOperatorDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileOLMOperatorDeployment_Preserve_existing_resources.yaml
@@ -1,0 +1,149 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+spec:
+  replicas: 0
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app: olm-operator
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: olm-operator
+        hypershift.openshift.io/control-plane-component: olm-operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --namespace
+        - $(OPERATOR_NAMESPACE)
+        - --writeStatusName
+        - operator-lifecycle-manager
+        - --writePackageServerStatusName=
+        - --tls-cert
+        - /srv-cert/tls.crt
+        - --tls-key
+        - /srv-cert/tls.key
+        - --client-ca
+        - /client-ca/ca.crt
+        command:
+        - /bin/olm
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPERATOR_NAME
+          value: olm-operator
+        - name: RELEASE_VERSION
+        - name: KUBECONFIG
+          value: /etc/openshift/kubeconfig/kubeconfig
+        - name: GRPC_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: NO_PROXY
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+        name: olm-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1000Mi
+          requests:
+            cpu: 500m
+            memory: 500Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /srv-cert
+          name: srv-cert
+          readOnly: true
+        - mountPath: /client-ca
+          name: client-ca
+          readOnly: true
+        - mountPath: /etc/openshift/kubeconfig
+          name: kubeconfig
+          readOnly: true
+      - args:
+        - run
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-socks5-proxy
+        env:
+        - name: KUBECONFIG
+          value: /etc/openshift/kubeconfig/kubeconfig
+        imagePullPolicy: IfNotPresent
+        name: socks5-proxy
+        ports:
+        - containerPort: 8090
+        resources:
+          requests:
+            cpu: 10m
+            memory: 15Mi
+        volumeMounts:
+        - mountPath: /etc/konnectivity/proxy-client
+          name: oas-konnectivity-proxy-cert
+          readOnly: true
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: oas-konnectivity-proxy-ca
+          readOnly: true
+        - mountPath: /etc/openshift/kubeconfig
+          name: kubeconfig
+          readOnly: true
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        - --kubeconfig=/var/kubeconfig/kubeconfig
+        - --required-api=operators.coreos.com,v1alpha1,CatalogSource
+        - --required-api=operators.coreos.com,v1alpha1,Subscription
+        - --required-api=operators.coreos.com,v2,OperatorCondition
+        - --required-api=operators.coreos.com,v1,OperatorGroup
+        - --required-api=operators.coreos.com,v1,OLMConfig
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/kubeconfig
+          name: kubeconfig
+      volumes:
+      - name: srv-cert
+        secret:
+          defaultMode: 416
+          secretName: olm-operator-serving-cert
+      - name: client-ca
+        secret:
+          defaultMode: 416
+          secretName: metrics-client
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - name: oas-konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          name: konnectivity-ca-bundle
+        name: oas-konnectivity-proxy-ca
+status: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
There are a few components leftover from the changes in https://github.com/openshift/hypershift/pull/3120 that still do not exhibit the expected resource preservation behavior.  The changes in this PR address these issues to ensure all control plane components preserve any externally sourced modifications to their resource requests/limits during their respective reconciliations.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/HOSTEDCP-1518