### PR TITLE
[release-4.14] OCPBUGS-32221: Added support for OLM Disable default sources on HC creation

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -8,6 +8,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hypershift/cmd/util"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,6 +78,7 @@ type ExampleOptions struct {
 	Arch                             string
 	PausedUntil                      string
 	OLMCatalogPlacement              hyperv1.OLMCatalogPlacement
+	OperatorHub                      *configv1.OperatorHubSpec
 	AWS                              *ExampleAWSOptions
 	None                             *ExampleNoneOptions
 	Agent                            *ExampleAgentOptions
@@ -466,6 +468,14 @@ func (o ExampleOptions) Resources() *ExampleResources {
 
 	if len(o.PausedUntil) > 0 {
 		cluster.Spec.PausedUntil = &o.PausedUntil
+	}
+
+	if cluster.Spec.Configuration == nil {
+		cluster.Spec.Configuration = &hyperv1.ClusterConfiguration{}
+	}
+
+	if o.OperatorHub != nil {
+		cluster.Spec.Configuration.OperatorHub = o.OperatorHub
 	}
 
 	if len(o.OLMCatalogPlacement) > 0 {

--- a/api/v1alpha1/hostedcluster_types.go
+++ b/api/v1alpha1/hostedcluster_types.go
@@ -2089,6 +2089,12 @@ type ClusterConfiguration struct {
 	// +optional
 	OAuth *configv1.OAuthSpec `json:"oauth,omitempty"`
 
+	// OperatorHub specifies the configuration for the Operator Lifecycle Manager in the HostedCluster. This is only configured at deployment time but the controller are not reconcilling over it.
+	// The OperatorHub configuration will be constantly reconciled if catalog placement is management, but only on cluster creation otherwise.
+	//
+	// +optional
+	OperatorHub *configv1.OperatorHubSpec `json:"operatorhub,omitempty"`
+
 	// Scheduler holds cluster-wide config information to run the Kubernetes Scheduler
 	// and influence its placement decisions. The canonical name for this config is `cluster`.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -613,6 +613,11 @@ func (in *ClusterConfiguration) DeepCopyInto(out *ClusterConfiguration) {
 		*out = new(configv1.OAuthSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.OperatorHub != nil {
+		in, out := &in.OperatorHub, &out.OperatorHub
+		*out = new(configv1.OperatorHubSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Scheduler != nil {
 		in, out := &in.Scheduler, &out.Scheduler
 		*out = new(configv1.SchedulerSpec)

--- a/api/v1beta1/hostedcluster_types.go
+++ b/api/v1beta1/hostedcluster_types.go
@@ -2136,6 +2136,12 @@ type ClusterConfiguration struct {
 	// +kubebuilder:validation:XValidation:rule="!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout) || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds() >= 300", message="spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout minimum acceptable token timeout value is 300 seconds"
 	OAuth *configv1.OAuthSpec `json:"oauth,omitempty"`
 
+	// OperatorHub specifies the configuration for the Operator Lifecycle Manager in the HostedCluster. This is only configured at deployment time but the controller are not reconcilling over it.
+	// The OperatorHub configuration will be constantly reconciled if catalog placement is management, but only on cluster creation otherwise.
+	//
+	// +optional
+	OperatorHub *configv1.OperatorHubSpec `json:"operatorhub,omitempty"`
+
 	// Scheduler holds cluster-wide config information to run the Kubernetes Scheduler
 	// and influence its placement decisions. The canonical name for this config is `cluster`.
 	// +optional

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -587,6 +587,11 @@ func (in *ClusterConfiguration) DeepCopyInto(out *ClusterConfiguration) {
 		*out = new(configv1.OAuthSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.OperatorHub != nil {
+		in, out := &in.OperatorHub, &out.OperatorHub
+		*out = new(configv1.OperatorHubSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Scheduler != nil {
 		in, out := &in.Scheduler, &out.Scheduler
 		*out = new(configv1.SchedulerSpec)

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -43,6 +43,7 @@ func NewCreateCommands() *cobra.Command {
 		NodeUpgradeType:                "",
 		Arch:                           "amd64",
 		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
+		OLMDisableDefaultSources:       false,
 	}
 	cmd := &cobra.Command{
 		Use:          "cluster",
@@ -82,7 +83,8 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Wait, "wait", opts.Wait, "If the create command should block until the cluster is up. Requires at least one node.")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
-	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olmCatalogPlacement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
+	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olm-catalog-placement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
+	cmd.PersistentFlags().BoolVar(&opts.OLMDisableDefaultSources, "olm-disable-default-sources", opts.OLMDisableDefaultSources, "Disables the OLM default catalog sources for the HostedCluster.")
 	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The default processor architecture for the NodePool (e.g. arm64, amd64)")
 	cmd.PersistentFlags().StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +82,7 @@ type CreateOptions struct {
 	NodeUpgradeType                  hyperv1.UpgradeType
 	PausedUntil                      string
 	OLMCatalogPlacement              hyperv1.OLMCatalogPlacement
+	OLMDisableDefaultSources         bool
 
 	// BeforeApply is called immediately before resources are applied to the
 	// server, giving the user an opportunity to inspect or mutate the resources.
@@ -280,6 +282,13 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		}
 	}
 
+	var operatorHub *configv1.OperatorHubSpec
+	if opts.OLMDisableDefaultSources {
+		operatorHub = &configv1.OperatorHubSpec{
+			DisableAllDefaultSources: true,
+		}
+	}
+
 	return &apifixtures.ExampleOptions{
 		AdditionalTrustBundle:            string(userCABundle),
 		ImageContentSources:              imageContentSources,
@@ -306,6 +315,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		UpgradeType:                      opts.NodeUpgradeType,
 		PausedUntil:                      opts.PausedUntil,
 		OLMCatalogPlacement:              opts.OLMCatalogPlacement,
+		OperatorHub:                      operatorHub,
 	}, nil
 }
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -1973,6 +1973,47 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.
@@ -5967,6 +6008,47 @@ spec:
                       rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                         || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                         >= 300'
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -1959,6 +1959,47 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.
@@ -5950,6 +5991,47 @@ spec:
                       rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                         || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                         >= 300'
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                   proxy:
                     description: Proxy holds cluster-wide information on how to configure
                       default proxies for the cluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -94,6 +94,10 @@ var (
 		// TODO: Remove when cluster-csi-snapshot-controller-operator stops shipping
 		// its ibm-cloud-managed deployment.
 		"0000_50_cluster-csi-snapshot-controller-operator_07_deployment-ibm-cloud-managed.yaml",
+		// Omited this file in order to allow the HCCO to create the resource. This allow us to reconcile and sync
+		// the HCP.Configuration.operatorhub with OperatorHub object in the HostedCluster. This will only occur once.
+		// From that point the HCCO will use the OperatorHub object in the HostedCluster as a source of truth.
+		"0000_03_marketplace-operator_02_operatorhub.cr.yaml",
 	}
 )
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3086,75 +3086,66 @@ func (r *HostedControlPlaneReconciler) reconcileIngressOperator(ctx context.Cont
 
 func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, createOrUpdate upsert.CreateOrUpdateFN) error {
 	p := olm.NewOperatorLifecycleManagerParams(hcp, releaseImageProvider, userReleaseImageProvider.Version(), r.SetDefaultSecurityContext)
-
-	if hcp.Spec.OLMCatalogPlacement == hyperv1.ManagementOLMCatalogPlacement {
-		overrideImages, err := checkCatalogImageOverides(p.CertifiedOperatorsCatalogImageOverride, p.CommunityOperatorsCatalogImageOverride, p.RedHatMarketplaceCatalogImageOverride, p.RedHatOperatorsCatalogImageOverride)
-		if err != nil {
-			return fmt.Errorf("failed to reconcile catalogs: %w", err)
-		}
-
-		catalogsImageStream := manifests.CatalogsImageStream(hcp.Namespace)
-		if !overrideImages {
-			isImageRegistryOverrides := util.ConvertImageRegistryOverrideStringToMap(p.OLMCatalogsISRegistryOverridesAnnotation)
-			if _, err := createOrUpdate(ctx, r, catalogsImageStream, func() error {
-				return olm.ReconcileCatalogsImageStream(catalogsImageStream, p.OwnerRef, isImageRegistryOverrides)
-			}); err != nil {
-				return fmt.Errorf("failed to reconcile catalogs image stream: %w", err)
-			}
-		} else {
-			if _, err := util.DeleteIfNeeded(ctx, r, catalogsImageStream); err != nil {
-				return fmt.Errorf("failed to remove OLM Catalog ImageStream: %w", err)
+	if (hcp.Spec.Configuration != nil && hcp.Spec.Configuration.OperatorHub != nil &&
+		hcp.Spec.Configuration.OperatorHub.DisableAllDefaultSources) ||
+		hcp.Spec.OLMCatalogPlacement != hyperv1.ManagementOLMCatalogPlacement {
+		// Disable all default sources
+		olmServices := olm.OLMServices(hcp.Namespace)
+		for _, svc := range olmServices {
+			if err := r.Client.Delete(ctx, svc.Manifest); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed to delete %s service on OLM reconcile: %w", svc.Name, err)
+				}
 			}
 		}
-
-		certifiedOperatorsService := manifests.CertifiedOperatorsService(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, certifiedOperatorsService, func() error {
-			return olm.ReconcileCertifiedOperatorsService(certifiedOperatorsService, p.OwnerRef)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile certified operators service: %w", err)
-		}
-		communityOperatorsService := manifests.CommunityOperatorsService(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, communityOperatorsService, func() error {
-			return olm.ReconcileCommunityOperatorsService(communityOperatorsService, p.OwnerRef)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile community operators service: %w", err)
-		}
-		marketplaceOperatorsService := manifests.RedHatMarketplaceOperatorsService(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, marketplaceOperatorsService, func() error {
-			return olm.ReconcileRedHatMarketplaceOperatorsService(marketplaceOperatorsService, p.OwnerRef)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile marketplace operators service: %w", err)
-		}
-		redHatOperatorsService := manifests.RedHatOperatorsService(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, redHatOperatorsService, func() error {
-			return olm.ReconcileRedHatOperatorsService(redHatOperatorsService, p.OwnerRef)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile red hat operators service: %w", err)
+		olmDeployments := olm.OLMDeployments(p, hcp.Namespace)
+		for _, dep := range olmDeployments {
+			if _, err := util.DeleteIfNeeded(ctx, r.Client, dep.Manifest); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed to delete %s deployment on OLM reconcile: %w", dep.Name, err)
+				}
+			}
 		}
 
-		certifiedOperatorsDeployment := manifests.CertifiedOperatorsDeployment(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, certifiedOperatorsDeployment, func() error {
-			return olm.ReconcileCertifiedOperatorsDeployment(certifiedOperatorsDeployment, p.OwnerRef, p.DeploymentConfig, p.CertifiedOperatorsCatalogImageOverride)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile certified operators deployment: %w", err)
-		}
-		communityOperatorsDeployment := manifests.CommunityOperatorsDeployment(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, communityOperatorsDeployment, func() error {
-			return olm.ReconcileCommunityOperatorsDeployment(communityOperatorsDeployment, p.OwnerRef, p.DeploymentConfig, p.CommunityOperatorsCatalogImageOverride)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile community operators deployment: %w", err)
-		}
-		marketplaceOperatorsDeployment := manifests.RedHatMarketplaceOperatorsDeployment(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, marketplaceOperatorsDeployment, func() error {
-			return olm.ReconcileRedHatMarketplaceOperatorsDeployment(marketplaceOperatorsDeployment, p.OwnerRef, p.DeploymentConfig, p.RedHatMarketplaceCatalogImageOverride)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile marketplace operators deployment: %w", err)
-		}
-		redHatOperatorsDeployment := manifests.RedHatOperatorsDeployment(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, redHatOperatorsDeployment, func() error {
-			return olm.ReconcileRedHatOperatorsDeployment(redHatOperatorsDeployment, p.OwnerRef, p.DeploymentConfig, p.RedHatOperatorsCatalogImageOverride)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile red hat operators deployment: %w", err)
+	} else {
+		// Enable all default sources
+		if hcp.Spec.OLMCatalogPlacement == hyperv1.ManagementOLMCatalogPlacement {
+			overrideImages, err := checkCatalogImageOverides(p.CertifiedOperatorsCatalogImageOverride, p.CommunityOperatorsCatalogImageOverride, p.RedHatMarketplaceCatalogImageOverride, p.RedHatOperatorsCatalogImageOverride)
+			if err != nil {
+				return fmt.Errorf("failed to reconcile catalogs: %w", err)
+			}
+
+			catalogsImageStream := manifests.CatalogsImageStream(hcp.Namespace)
+			if !overrideImages {
+				isImageRegistryOverrides := util.ConvertImageRegistryOverrideStringToMap(p.OLMCatalogsISRegistryOverridesAnnotation)
+				if _, err := createOrUpdate(ctx, r, catalogsImageStream, func() error {
+					return olm.ReconcileCatalogsImageStream(catalogsImageStream, p.OwnerRef, isImageRegistryOverrides)
+				}); err != nil {
+					return fmt.Errorf("failed to reconcile catalogs image stream: %w", err)
+				}
+			} else {
+				if _, err := util.DeleteIfNeeded(ctx, r, catalogsImageStream); err != nil {
+					return fmt.Errorf("failed to remove OLM Catalog ImageStream: %w", err)
+				}
+			}
+
+			olmServices := olm.OLMServices(hcp.Namespace)
+			for _, svc := range olmServices {
+				if _, err := createOrUpdate(ctx, r, svc.Manifest, func() error {
+					return svc.Reconciler(svc.Manifest, p.OwnerRef)
+				}); err != nil {
+					return fmt.Errorf("failed to reconcile %s service: %w", svc.Name, err)
+				}
+			}
+
+			olmDeployments := olm.OLMDeployments(p, hcp.Namespace)
+			for _, dep := range olmDeployments {
+				if _, err := createOrUpdate(ctx, r, dep.Manifest, func() error {
+					return dep.Reconciler(dep.Manifest, p.OwnerRef, p.DeploymentConfig, dep.Image)
+				}); err != nil {
+					return fmt.Errorf("failed to reconcile %s deployment with image %s: %w", dep.Name, dep.Image, err)
+				}
+			}
 		}
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/deployments.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/deployments.go
@@ -1,0 +1,43 @@
+package olm
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type OLMDeployment struct {
+	Name       string
+	Manifest   *appsv1.Deployment
+	Reconciler func(*appsv1.Deployment, config.OwnerRef, config.DeploymentConfig, string) error
+	Image      string
+}
+
+func OLMDeployments(p *OperatorLifecycleManagerParams, hcpNamespace string) []OLMDeployment {
+	return []OLMDeployment{
+		{
+			Name:       "certifiedOperatorsDeployment",
+			Manifest:   manifests.CertifiedOperatorsDeployment(hcpNamespace),
+			Reconciler: ReconcileCertifiedOperatorsDeployment,
+			Image:      p.CertifiedOperatorsCatalogImageOverride,
+		},
+		{
+			Name:       "communityOperatorsDeployment",
+			Manifest:   manifests.CommunityOperatorsDeployment(hcpNamespace),
+			Reconciler: ReconcileCommunityOperatorsDeployment,
+			Image:      p.CommunityOperatorsCatalogImageOverride,
+		},
+		{
+			Name:       "marketplaceOperatorsDeployment",
+			Manifest:   manifests.RedHatMarketplaceOperatorsDeployment(hcpNamespace),
+			Reconciler: ReconcileRedHatMarketplaceOperatorsDeployment,
+			Image:      p.RedHatMarketplaceCatalogImageOverride,
+		},
+		{
+			Name:       "redHatOperatorsDeployment",
+			Manifest:   manifests.RedHatOperatorsDeployment(hcpNamespace),
+			Reconciler: ReconcileRedHatOperatorsDeployment,
+			Image:      p.RedHatOperatorsCatalogImageOverride,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/services.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/services.go
@@ -1,0 +1,38 @@
+package olm
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type OLMService struct {
+	Name       string
+	Manifest   *corev1.Service
+	Reconciler func(*corev1.Service, config.OwnerRef) error
+}
+
+func OLMServices(hcpNamespace string) []OLMService {
+	return []OLMService{
+		{
+			Name:       "certifiedOperatorsService",
+			Manifest:   manifests.CertifiedOperatorsService(hcpNamespace),
+			Reconciler: ReconcileCertifiedOperatorsService,
+		},
+		{
+			Name:       "communityOperatorsService",
+			Manifest:   manifests.CommunityOperatorsService(hcpNamespace),
+			Reconciler: ReconcileCommunityOperatorsService,
+		},
+		{
+			Name:       "marketplaceOperatorsService",
+			Manifest:   manifests.RedHatMarketplaceOperatorsService(hcpNamespace),
+			Reconciler: ReconcileRedHatMarketplaceOperatorsService,
+		},
+		{
+			Name:       "redHatOperatorsService",
+			Manifest:   manifests.RedHatOperatorsService(hcpNamespace),
+			Reconciler: ReconcileRedHatOperatorsService,
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/olm.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/olm.go
@@ -1,11 +1,11 @@
 package manifests
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
 func CertifiedOperatorsCatalogSource() *operatorsv1alpha1.CatalogSource {
@@ -75,6 +75,14 @@ func OLMPackageServerEndpoints() *corev1.Endpoints {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "packageserver",
 			Namespace: "default",
+		},
+	}
+}
+
+func OperatorHub() *configv1.OperatorHub {
+	return &configv1.OperatorHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
 		},
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1338,17 +1338,49 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 	return errs
 }
 
+// reconcileOperatorHub gets the OperatorHubConfig from the HCP, for now the controller only reconcile over the DisableAllDefaultSources field and only once.
+// After that the HCCO checks the OperatorHub object in the HC to manage the OLM resources.
+// TODO (jparrill): Include in the reconciliation the OperatorHub.Sources to disable only the selected sources.
+func (r *reconciler) reconcileOperatorHub(ctx context.Context, operatorHub *configv1.OperatorHub, hcp *hyperv1.HostedControlPlane) []error {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Reconciling HCP OperatorHub config")
+	if operatorHub.ResourceVersion == "" {
+		if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.OperatorHub != nil {
+			operatorHub.Spec.DisableAllDefaultSources = hcp.Spec.Configuration.OperatorHub.DisableAllDefaultSources
+		}
+	}
+
+	return nil
+}
+
 func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedControlPlane) []error {
 	var errs []error
+
+	operatorHub := manifests.OperatorHub()
+
+	if hcp.Spec.OLMCatalogPlacement == hyperv1.ManagementOLMCatalogPlacement {
+		// Management OLM Placement
+		if _, err := r.CreateOrUpdate(ctx, r.client, operatorHub, func() error {
+			if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.OperatorHub != nil {
+				operatorHub.Spec.DisableAllDefaultSources = hcp.Spec.Configuration.OperatorHub.DisableAllDefaultSources
+			}
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile OperatorHub configuration: %w", err))
+		}
+	} else {
+		// Guest OLM Placement
+		if _, err := r.CreateOrUpdate(ctx, r.client, operatorHub, func() error {
+			r.reconcileOperatorHub(ctx, operatorHub, hcp)
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile OperatorHub configuration: %w", err))
+		}
+	}
 
 	p := olm.NewOperatorLifecycleManagerParams(hcp)
 
 	// Check if the defaultSources are disabled
-	operatorHub := &configv1.OperatorHub{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster",
-		},
-	}
 	if err := r.client.Get(ctx, client.ObjectKeyFromObject(operatorHub), operatorHub); err != nil {
 		if !apierrors.IsNotFound(err) {
 			errs = append(errs, fmt.Errorf("failed to get OperatorHub %s: %w", client.ObjectKeyFromObject(operatorHub).String(), err))
@@ -1368,7 +1400,7 @@ func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedContro
 	for _, catalog := range catalogs {
 		cs := catalog.manifest()
 		if operatorHub.Spec.DisableAllDefaultSources {
-			if err := r.client.Delete(ctx, cs); err != nil {
+			if _, err := util.DeleteIfNeeded(ctx, r.client, cs); err != nil {
 				if !apierrors.IsNotFound(err) {
 					errs = append(errs, fmt.Errorf("failed to delete catalogSource %s/%s: %w", cs.Namespace, cs.Name, err))
 				}

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2525,6 +2525,21 @@ This configuration is only honored when the top level Authentication config has 
 </tr>
 <tr>
 <td>
+<code>operatorhub</code></br>
+<em>
+<a href="https://docs.openshift.com/container-platform/4.10/rest_api/config_apis/config-apis-index.html">
+github.com/openshift/api/config/v1.OperatorHubSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OperatorHub specifies the configuration for the Operator Lifecycle Manager in the HostedCluster. This is only configured at deployment time but the controller are not reconcilling over it.
+The OperatorHub configuration will be constantly reconciled if catalog placement is management, but only on cluster creation otherwise.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>scheduler</code></br>
 <em>
 <a href="https://docs.openshift.com/container-platform/4.10/rest_api/config_apis/config-apis-index.html">

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -31881,6 +31881,47 @@ objects:
                               type: integer
                           type: object
                       type: object
+                    operatorhub:
+                      description: OperatorHub specifies the configuration for the
+                        Operator Lifecycle Manager in the HostedCluster. This is only
+                        configured at deployment time but the controller are not reconcilling
+                        over it. The OperatorHub configuration will be constantly
+                        reconciled if catalog placement is management, but only on
+                        cluster creation otherwise.
+                      properties:
+                        disableAllDefaultSources:
+                          description: disableAllDefaultSources allows you to disable
+                            all the default hub sources. If this is true, a specific
+                            entry in sources can be used to enable a default source.
+                            If this is false, a specific entry in sources can be used
+                            to disable or enable a default source.
+                          type: boolean
+                        sources:
+                          description: sources is the list of default hub sources
+                            and their configuration. If the list is empty, it implies
+                            that the default hub sources are enabled on the cluster
+                            unless disableAllDefaultSources is true. If disableAllDefaultSources
+                            is true and sources is not empty, the configuration present
+                            in sources will take precedence. The list of default hub
+                            sources and their current state will always be reflected
+                            in the status block.
+                          items:
+                            description: HubSource is used to specify the hub source
+                              and its configuration
+                            properties:
+                              disabled:
+                                description: disabled is used to disable a default
+                                  hub source on cluster
+                                type: boolean
+                              name:
+                                description: name is the name of one of the default
+                                  hub sources
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            type: object
+                          type: array
+                      type: object
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.
@@ -35954,6 +35995,47 @@ objects:
                         rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                           || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                           >= 300'
+                    operatorhub:
+                      description: OperatorHub specifies the configuration for the
+                        Operator Lifecycle Manager in the HostedCluster. This is only
+                        configured at deployment time but the controller are not reconcilling
+                        over it. The OperatorHub configuration will be constantly
+                        reconciled if catalog placement is management, but only on
+                        cluster creation otherwise.
+                      properties:
+                        disableAllDefaultSources:
+                          description: disableAllDefaultSources allows you to disable
+                            all the default hub sources. If this is true, a specific
+                            entry in sources can be used to enable a default source.
+                            If this is false, a specific entry in sources can be used
+                            to disable or enable a default source.
+                          type: boolean
+                        sources:
+                          description: sources is the list of default hub sources
+                            and their configuration. If the list is empty, it implies
+                            that the default hub sources are enabled on the cluster
+                            unless disableAllDefaultSources is true. If disableAllDefaultSources
+                            is true and sources is not empty, the configuration present
+                            in sources will take precedence. The list of default hub
+                            sources and their current state will always be reflected
+                            in the status block.
+                          items:
+                            description: HubSource is used to specify the hub source
+                              and its configuration
+                            properties:
+                              disabled:
+                                description: disabled is used to disable a default
+                                  hub source on cluster
+                                type: boolean
+                              name:
+                                description: name is the name of one of the default
+                                  hub sources
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            type: object
+                          type: array
+                      type: object
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.
@@ -39985,6 +40067,47 @@ objects:
                               format: int32
                               type: integer
                           type: object
+                      type: object
+                    operatorhub:
+                      description: OperatorHub specifies the configuration for the
+                        Operator Lifecycle Manager in the HostedCluster. This is only
+                        configured at deployment time but the controller are not reconcilling
+                        over it. The OperatorHub configuration will be constantly
+                        reconciled if catalog placement is management, but only on
+                        cluster creation otherwise.
+                      properties:
+                        disableAllDefaultSources:
+                          description: disableAllDefaultSources allows you to disable
+                            all the default hub sources. If this is true, a specific
+                            entry in sources can be used to enable a default source.
+                            If this is false, a specific entry in sources can be used
+                            to disable or enable a default source.
+                          type: boolean
+                        sources:
+                          description: sources is the list of default hub sources
+                            and their configuration. If the list is empty, it implies
+                            that the default hub sources are enabled on the cluster
+                            unless disableAllDefaultSources is true. If disableAllDefaultSources
+                            is true and sources is not empty, the configuration present
+                            in sources will take precedence. The list of default hub
+                            sources and their current state will always be reflected
+                            in the status block.
+                          items:
+                            description: HubSource is used to specify the hub source
+                              and its configuration
+                            properties:
+                              disabled:
+                                description: disabled is used to disable a default
+                                  hub source on cluster
+                                type: boolean
+                              name:
+                                description: name is the name of one of the default
+                                  hub sources
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     proxy:
                       description: Proxy holds cluster-wide information on how to
@@ -44057,6 +44180,47 @@ objects:
                         rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
                           || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
                           >= 300'
+                    operatorhub:
+                      description: OperatorHub specifies the configuration for the
+                        Operator Lifecycle Manager in the HostedCluster. This is only
+                        configured at deployment time but the controller are not reconcilling
+                        over it. The OperatorHub configuration will be constantly
+                        reconciled if catalog placement is management, but only on
+                        cluster creation otherwise.
+                      properties:
+                        disableAllDefaultSources:
+                          description: disableAllDefaultSources allows you to disable
+                            all the default hub sources. If this is true, a specific
+                            entry in sources can be used to enable a default source.
+                            If this is false, a specific entry in sources can be used
+                            to disable or enable a default source.
+                          type: boolean
+                        sources:
+                          description: sources is the list of default hub sources
+                            and their configuration. If the list is empty, it implies
+                            that the default hub sources are enabled on the cluster
+                            unless disableAllDefaultSources is true. If disableAllDefaultSources
+                            is true and sources is not empty, the configuration present
+                            in sources will take precedence. The list of default hub
+                            sources and their current state will always be reflected
+                            in the status block.
+                          items:
+                            description: HubSource is used to specify the hub source
+                              and its configuration
+                            properties:
+                              disabled:
+                                description: disabled is used to disable a default
+                                  hub source on cluster
+                                type: boolean
+                              name:
+                                description: name is the name of one of the default
+                                  hub sources
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            type: object
+                          type: array
+                      type: object
                     proxy:
                       description: Proxy holds cluster-wide information on how to
                         configure default proxies for the cluster.

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -37,6 +37,7 @@ func NewCreateCommands() *cobra.Command {
 		Wait:                           false,
 		PausedUntil:                    "",
 		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
+		OLMDisableDefaultSources:       false,
 	}
 
 	cmd := &cobra.Command{
@@ -63,7 +64,8 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If set to 0 or greater, NodePools will be created with that many replicas. If set to less than 0, no NodePools will be created.")
 	cmd.PersistentFlags().StringToStringVar(&opts.NodeSelector, "node-selector", opts.NodeSelector, "A comma separated list of key=value pairs to use as the node selector for the Hosted Control Plane pods to stick to. (e.g. role=cp,disk=fast)")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
-	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olmCatalogPlacement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
+	cmd.PersistentFlags().Var(&opts.OLMCatalogPlacement, "olm-catalog-placement", "The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest")
+	cmd.PersistentFlags().BoolVar(&opts.OLMDisableDefaultSources, "olm-disable-default-sources", opts.OLMDisableDefaultSources, "Disables the OLM default catalog sources for the HostedCluster.")
 	cmd.PersistentFlags().StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other.")
 	cmd.PersistentFlags().StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "Filepath to a pull secret.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the HostedCluster.")


### PR DESCRIPTION
This is a manual backport of https://github.com/openshift/hypershift/pull/3321.

The pull request (PR) embeds the OperatorHubSpec field into the hostedcluster.Spec.Configuration API field. This allows us to disable/enable default sources in Management or Guest placement only during creation.

This functionality is also incorporated into the CLIs through a flag called . However, it's important to note that the OperatorHub capability to disable/enable individual default sources is not covered in this PR. As a result, that field will be disregarded in the CPO and HCCO reconciliation.

Original bug [OCPBUGS-25782](https://issues.redhat.com/browse/OCPBUGS-25782)
