### PR TITLE
HOSTEDCP-1524: [release-4.15] Support additional node selectors for request serving nodes

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -222,6 +222,10 @@ const (
 	// components should be scheduled on dedicated nodes in the management cluster.
 	DedicatedRequestServingComponentsTopology = "dedicated-request-serving-components"
 
+	// RequestServingNodeAdditionalSelectorAnnotation is used to specify an additional node selector for
+	// request serving nodes. The value is a comma-separated list of key=value pairs.
+	RequestServingNodeAdditionalSelectorAnnotation = "hypershift.openshift.io/request-serving-node-additional-selector"
+
 	// DisableMachineManagement Disable deployments related to machine management that includes cluster-api, cluster-autoscaler, machine-approver.
 	DisableMachineManagement = "hypershift.openshift.io/disable-machine-management"
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1785,6 +1785,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.OLMCatalogsISRegistryOverridesAnnotation,
 		hyperv1.KubeAPIServerGOGCAnnotation,
 		hyperv1.KubeAPIServerGOMemoryLimitAnnotation,
+		hyperv1.RequestServingNodeAdditionalSelectorAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -301,3 +301,23 @@ func FirstUsableIP(cidr string) (string, error) {
 	ip[len(ipNet.IP)-1]++
 	return ip.String(), nil
 }
+
+// ParseNodeSelector parses a comma separated string of key=value pairs into a map
+func ParseNodeSelector(str string) map[string]string {
+	if len(str) == 0 {
+		return nil
+	}
+	parts := strings.Split(str, ",")
+	result := make(map[string]string)
+	for _, part := range parts {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		if len(kv[0]) == 0 || len(kv[1]) == 0 {
+			continue
+		}
+		result[kv[0]] = kv[1]
+	}
+	return result
+}

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -345,3 +345,63 @@ func TestFirstUsableIP(t *testing.T) {
 		})
 	}
 }
+
+func TestParseNodeSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		str  string
+		want map[string]string
+	}{
+		{
+			name: "Given a valid node selector string, it should return a map of key value pairs",
+			str:  "key1=value1,key2=value2,key3=value3",
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "Given a valid node selector string with empty values, it should return a map of key value pairs",
+			str:  "key1=,key2=value2,key3=",
+			want: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Given a valid node selector string with empty keys, it should return a map of key value pairs",
+			str:  "=value1,key2=value2,=value3",
+			want: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Given a valid node selector string with empty string, it should return an empty map",
+			str:  "",
+			want: nil,
+		},
+		{
+			name: "Given a valid node selector string with invalid key value pairs, it should return a map of key value pairs",
+			str:  "key1=value1,key2,key3=value3",
+			want: map[string]string{
+				"key1": "value1",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "Given a valid node selector string with values that include =, it should return a map of key value pairs",
+			str:  "key1=value1=one,key2,key3=value3=three",
+			want: map[string]string{
+				"key1": "value1=one",
+				"key3": "value3=three",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := ParseNodeSelector(tt.str)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds annotation to specify additional node selectors. This is needed for request serving nodes to request the corresponding size label.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1524](https://issues.redhat.com/browse/HOSTEDCP-1524)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.