### PR TITLE
OCPBUGS-32248: Replace periods with commas in subnet label value

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -625,6 +625,8 @@ func (r *DedicatedServingComponentSchedulerAndSizer) updateHostedCluster(ctx con
 		}
 	}
 	if lbSubnets != "" {
+		// If subnets are separated by periods, replace them with commas
+		lbSubnets = strings.ReplaceAll(lbSubnets, ".", ",")
 		hc.Annotations[hyperv1.AWSLoadBalancerSubnetsAnnotation] = lbSubnets
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this, the new scheduler was not setting the proper value for subnets in the HostedCluster annotation.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-32248](https://issues.redhat.com/browse/OCPBUGS-32248)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.