### PR TITLE
OCPBUGS-32255: Remove kube-scheduler readiness probe

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -66,21 +66,6 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			TimeoutSeconds:      5,
 		},
 	}
-	params.ReadinessProbes = config.ReadinessProbes{
-		schedulerContainerMain().Name: {
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/healthz",
-					Port:   intstr.FromInt(schedulerSecurePort),
-					Scheme: corev1.URISchemeHTTPS,
-				},
-			},
-			PeriodSeconds:    10,
-			SuccessThreshold: 1,
-			FailureThreshold: 3,
-			TimeoutSeconds:   5,
-		},
-	}
 	params.DeploymentConfig.SetDefaults(hcp, labels, nil)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.SetDefaultSecurityContext = setDefaultSecurityContext


### PR DESCRIPTION
**What this PR does / why we need it**:
This container doesn't have an associated service, so a readiness probe doesn't make sense. It can be removed.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://issues.redhat.com/browse/OCPBUGS-32255

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.