### PR TITLE
OCPNODE-2096: Add ClusterImagePolicy to the list of valid config manifests

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -126,6 +126,7 @@ type NodePoolSpec struct {
 	// KubeletConfig
 	// ContainerRuntimeConfig
 	// MachineConfig
+	// ClusterImagePolicy
 	// ImageContentSourcePolicy
 	// or
 	// ImageDigestMirrorSet

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1230,6 +1230,7 @@ spec:
                   KubeletConfig
                   ContainerRuntimeConfig
                   MachineConfig
+                  ClusterImagePolicy
                   ImageContentSourcePolicy
                   or
                   ImageDigestMirrorSet

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -749,6 +749,7 @@ JSON or YAML of a serialized Resource for machineconfiguration.openshift.io:
 KubeletConfig
 ContainerRuntimeConfig
 MachineConfig
+ClusterImagePolicy
 ImageContentSourcePolicy
 or
 ImageDigestMirrorSet</p>
@@ -6657,6 +6658,7 @@ JSON or YAML of a serialized Resource for machineconfiguration.openshift.io:
 KubeletConfig
 ContainerRuntimeConfig
 MachineConfig
+ClusterImagePolicy
 ImageContentSourcePolicy
 or
 ImageDigestMirrorSet</p>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -56532,6 +56532,7 @@ objects:
                     KubeletConfig
                     ContainerRuntimeConfig
                     MachineConfig
+                    ClusterImagePolicy
                     ImageContentSourcePolicy
                     or
                     ImageDigestMirrorSet

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	configv1 "github.com/openshift/api/config/v1"
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	"github.com/openshift/api/operator/v1alpha1"
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 	performanceprofilev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
@@ -2139,6 +2140,7 @@ func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
 	_ = mcfgv1.Install(scheme)
 	_ = v1alpha1.Install(scheme)
 	_ = configv1.Install(scheme)
+	_ = configv1alpha1.Install(scheme)
 
 	yamlSerializer := serializer.NewSerializerWithOptions(
 		serializer.DefaultMetaFactory, scheme, scheme,
@@ -2159,6 +2161,7 @@ func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
 		}
 	case *v1alpha1.ImageContentSourcePolicy:
 	case *configv1.ImageDigestMirrorSet:
+	case *configv1alpha1.ClusterImagePolicy:
 	case *mcfgv1.KubeletConfig:
 		obj.Spec.MachineConfigPoolSelector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -126,6 +126,7 @@ type NodePoolSpec struct {
 	// KubeletConfig
 	// ContainerRuntimeConfig
 	// MachineConfig
+	// ClusterImagePolicy
 	// ImageContentSourcePolicy
 	// or
 	// ImageDigestMirrorSet


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Add [ClusterImagePolicy](https://github.com/openshift/machine-config-operator/pull/4160) CRD to valid manifests as MCO bootstraps it. This cluster-wide CRD is for sigstore signature verification. IBM ROKS deployments will require this CRD to work through hypershift.
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPNODE-2096

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.