### PR TITLE
OCPBUGS-32333: [release-4.15] Support specifying AWS LB subnets

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -252,6 +252,10 @@ const (
 	// the frequency of memory collection when memory used rises above a particular threshhold. This can be used to reduce
 	// the memory footprint of the kube-apiserver during upgrades.
 	KubeAPIServerGOMemoryLimitAnnotation = "hypershift.openshift.io/kube-apiserver-gomemlimit"
+
+	// AWSLoadBalancerSubnetsAnnotation allows specifying the subnets to use for control plane load balancers
+	// in the AWS platform.
+	AWSLoadBalancerSubnetsAnnotation = "hypershift.openshift.io/aws-load-balancer-subnets"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1255,7 +1255,7 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerService(ctx context.Con
 		apiServerService = manifests.KubeAPIServerServiceAzureLB(hcp.Namespace)
 	}
 	if _, err := createOrUpdate(ctx, r.Client, apiServerService, func() error {
-		return kas.ReconcileService(apiServerService, serviceStrategy, p.OwnerReference, kasSVCPort, p.AllowedCIDRBlocks, util.IsPublicHCP(hcp), util.IsPrivateHCP(hcp))
+		return kas.ReconcileService(apiServerService, serviceStrategy, p.OwnerReference, kasSVCPort, p.AllowedCIDRBlocks, hcp)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile API server service: %w", err)
 	}
@@ -1347,7 +1347,7 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivityServerService(ctx co
 	}
 	konnectivityServerService := manifests.KonnectivityServerService(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, konnectivityServerService, func() error {
-		return kas.ReconcileKonnectivityServerService(konnectivityServerService, p.OwnerRef, serviceStrategy)
+		return kas.ReconcileKonnectivityServerService(konnectivityServerService, p.OwnerRef, serviceStrategy, hcp)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile Konnectivity service: %w", err)
 	}
@@ -1489,7 +1489,7 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	if util.IsPrivateHCP(hcp) {
 		svc := manifests.PrivateRouterService(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r.Client, svc, func() error {
-			return ingress.ReconcileRouterService(svc, true, true)
+			return ingress.ReconcileRouterService(svc, true, true, hcp)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile private router service: %w", err)
 		}
@@ -1511,7 +1511,7 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	// When Public access endpoint we need to create a Service type LB external for the KAS.
 	if util.IsPublicHCP(hcp) && exposeKASThroughRouter {
 		if _, err := createOrUpdate(ctx, r.Client, pubSvc, func() error {
-			return ingress.ReconcileRouterService(pubSvc, false, util.IsPrivateHCP(hcp))
+			return ingress.ReconcileRouterService(pubSvc, false, util.IsPrivateHCP(hcp), hcp)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile router service: %w", err)
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -224,16 +224,19 @@ func buildHCPRouterContainerMain(image string) func(*corev1.Container) {
 	}
 }
 
-func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancingEnabled bool) error {
-	if svc.Annotations == nil {
-		svc.Annotations = map[string]string{}
-	}
-	svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
-	if internal {
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
-	}
-	if crossZoneLoadBalancingEnabled {
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancingEnabled bool, hcp *hyperv1.HostedControlPlane) error {
+	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
+		if svc.Annotations == nil {
+			svc.Annotations = map[string]string{}
+		}
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+		if internal {
+			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
+		}
+		if crossZoneLoadBalancingEnabled {
+			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+		}
+		util.ApplyAWSLoadBalancerSubnetsAnnotation(svc, hcp)
 	}
 
 	if svc.Labels == nil {

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -321,3 +321,16 @@ func ParseNodeSelector(str string) map[string]string {
 	}
 	return result
 }
+
+func ApplyAWSLoadBalancerSubnetsAnnotation(svc *corev1.Service, hcp *hyperv1.HostedControlPlane) {
+	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform {
+		return
+	}
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	subnets, ok := hcp.Annotations[hyperv1.AWSLoadBalancerSubnetsAnnotation]
+	if ok {
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-subnets"] = subnets
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces an annotation to HostedClusters
(hypershift.openshift.io/aws-load-balancer-subnets) that will drive the service.beta.kubernetes.io/aws-load-balancer-subnets annotation on services of type LoadBalancer created by a hosted control plane.

Modifies the request serving node scheduler to automatically set the above annotation if the label
hypershift.openshift.io/request-serving-subnets is set on request serving nodes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.