### PR TITLE
OCPBUGS-31398: Recycler-pod image now points to the OCP Payload reference

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2894,7 +2894,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 
 	recyclerConfig := manifests.RecyclerConfigMap(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, recyclerConfig, func() error {
-		return kcm.ReconcileRecyclerConfig(recyclerConfig, p.OwnerRef)
+		return kcm.ReconcileRecyclerConfig(recyclerConfig, p.OwnerRef, releaseImageProvider)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile kcm recycler config: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
@@ -3,12 +3,16 @@ package kcm
 import (
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"path"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kcpv1 "github.com/openshift/api/kubecontrolplane/v1"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 
 	"github.com/openshift/hypershift/support/config"
 )
@@ -58,13 +62,20 @@ func generateConfig(serviceServingCA *corev1.ConfigMap) (string, error) {
 	return string(b), nil
 }
 
-func ReconcileRecyclerConfig(config *corev1.ConfigMap, ownerRef config.OwnerRef) error {
+func ReconcileRecyclerConfig(config *corev1.ConfigMap, ownerRef config.OwnerRef, releaseImageProvider *imageprovider.ReleaseImageProvider) error {
+	var result strings.Builder
+
 	ownerRef.ApplyTo(config)
 	if config.Data == nil {
 		config.Data = map[string]string{}
 	}
+
+	data := map[string]string{
+		"rhtoolsImageName": releaseImageProvider.GetImage("tools"),
+	}
+
 	// https://github.com/openshift/cluster-kube-controller-manager-operator/blob/64b4c1ba/bindata/assets/kube-controller-manager/recycler-cm.yaml
-	config.Data[RecyclerPodTemplateKey] = `apiVersion: v1
+	templateContent := `apiVersion: v1
 kind: Pod
 metadata:
   name: recycler-pod
@@ -77,7 +88,7 @@ spec:
   serviceAccountName: pv-recycler-controller
   containers:
   - name: recycler-container
-    image: quay.io/openshift/origin-tools:latest
+    image: {{.rhtoolsImageName}}
     command:
     - "/bin/bash"
     args:
@@ -96,5 +107,18 @@ spec:
   volumes:
   - name: vol
 `
+
+	tmpl, err := template.New("recycler-pod").Parse(templateContent)
+	if err != nil {
+		return fmt.Errorf("failed to parse recycler pod template: %w", err)
+	}
+
+	err = tmpl.Execute(&result, data)
+	if err != nil {
+		return fmt.Errorf("failed to render the recycler pod template: %w", err)
+	}
+
+	config.Data[RecyclerPodTemplateKey] = result.String()
+
 	return nil
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-31398](https://issues.redhat.com/browse/OCPBUGS-31398)