### PR TITLE
HOSTEDCP-1536: feat(install): expose hypershift-readers ClusterRole at install time

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -62,6 +62,9 @@ var (
 	// privileged is used to set the container security
 	// context to run container as unprivileged.
 	privileged = false
+
+	// readOnlyVerbs are RBAC related verbs limited to read actions
+	readOnlyVerbs = []string{"get", "list", "watch"}
 )
 
 type HyperShiftNamespace struct {
@@ -815,7 +818,7 @@ func (o ExternalDNSClusterRole) Build() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"route.openshift.io"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{""},
@@ -825,7 +828,7 @@ func (o ExternalDNSClusterRole) Build() *rbacv1.ClusterRole {
 					"nodes",
 					"pods",
 				},
-				Verbs: []string{"get", "list", "watch"},
+				Verbs: readOnlyVerbs,
 			},
 		},
 	}
@@ -912,7 +915,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"config.openshift.io"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"apiextensions.k8s.io"},
@@ -1046,7 +1049,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{cdicore.GroupName},
 				Resources: []string{"datavolumes"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{ // This allows the kubevirt csi driver to hotplug volumes to KubeVirt VMs.
 				APIGroups: []string{"subresources.kubevirt.io"},
@@ -1090,7 +1093,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"certificates.k8s.io"},
 				Resources: []string{"certificatesigningrequests"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"certificates.k8s.io"},
@@ -1296,7 +1299,7 @@ func (o HyperShiftPrometheusRole) Build() *rbacv1.Role {
 					"endpoints",
 					"pods",
 				},
-				Verbs: []string{"get", "list", "watch"},
+				Verbs: readOnlyVerbs,
 			},
 		},
 	}
@@ -1495,27 +1498,36 @@ func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hypershift-readers",
+			Labels: map[string]string{
+				"managed.openshift.io/aggregate-to-dedicated-readers": "true",
+				"managed.openshift.io/aggregate-to-backplane-srep":    "true",
+			},
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"hypershift.openshift.io"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
+			},
+			{
+				APIGroups: []string{"certificates.hypershift.openshift.io"},
+				Resources: []string{rbacv1.ResourceAll},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"config.openshift.io"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"apiextensions.k8s.io"},
 				Resources: []string{"customresourcedefinitions"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"networking.k8s.io"},
 				Resources: []string{"networkpolicies"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{
@@ -1529,17 +1541,17 @@ func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
 					"cluster.x-k8s.io",
 				},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"operator.openshift.io"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"route.openshift.io"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"security.openshift.io"},
@@ -1549,7 +1561,7 @@ func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"rbac.authorization.k8s.io"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{""},
@@ -1563,32 +1575,32 @@ func (o HyperShiftReaderClusterRole) Build() *rbacv1.ClusterRole {
 					"serviceaccounts",
 					"services",
 				},
-				Verbs: []string{"get", "list", "watch"},
+				Verbs: readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"apps"},
 				Resources: []string{"deployments"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"etcd.database.coreos.com"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"machine.openshift.io"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs"},
 				Resources: []string{"podmonitors"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 			{
 				APIGroups: []string{"capi-provider.agent-install.openshift.io"},
 				Resources: []string{rbacv1.ResourceAll},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     readOnlyVerbs,
 			},
 		},
 	}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -87,6 +87,7 @@ type Options struct {
 	ExternalDNSTxtOwnerId                     string
 	ExternalDNSImage                          string
 	EnableAdminRBACGeneration                 bool
+	EnableReaderRBACGeneration                bool
 	EnableUWMTelemetryRemoteWrite             bool
 	EnableCVOManagementClusterMetricsAccess   bool
 	MetricsSet                                metrics.MetricsSet
@@ -210,6 +211,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSTxtOwnerId, "external-dns-txt-owner-id", "", "external-dns TXT registry owner ID.")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSImage, "external-dns-image", opts.ExternalDNSImage, "Image to use for external-dns")
 	cmd.PersistentFlags().BoolVar(&opts.EnableAdminRBACGeneration, "enable-admin-rbac-generation", false, "Generate RBAC manifests for hosted cluster admins")
+	cmd.PersistentFlags().BoolVar(&opts.EnableReaderRBACGeneration, "enable-reader-rbac-generation", false, "Generate RBAC manifests for hypershift readers")
 	cmd.PersistentFlags().StringVar(&opts.ImageRefsFile, "image-refs", opts.ImageRefsFile, "Image references to user in Hypershift installation")
 	cmd.PersistentFlags().StringVar(&opts.AdditionalTrustBundle, "additional-trust-bundle", opts.AdditionalTrustBundle, "Path to a file with user CA bundle")
 	cmd.PersistentFlags().Var(&opts.MetricsSet, "metrics-set", "The set of metrics to produce for each HyperShift control plane. Valid values are: Telemetry, SRE, All")
@@ -773,6 +775,12 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, []crclient.Ob
 			GroupName:   "hypershift-readers",
 		}.Build()
 		objects = append(objects, readerRoleBinding)
+	}
+
+	if opts.EnableReaderRBACGeneration {
+		// add a ClusterRole that contains read-only resources for HyperShift resources
+		readerClusterRole := assets.HyperShiftReaderClusterRole{}.Build()
+		objects = append(objects, readerClusterRole)
 	}
 
 	if opts.OIDCStorageProviderS3BucketName != "" {

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -826,10 +826,21 @@ objects:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    labels:
+      managed.openshift.io/aggregate-to-backplane-srep: "true"
+      managed.openshift.io/aggregate-to-dedicated-readers: "true"
     name: hypershift-readers
   rules:
   - apiGroups:
     - hypershift.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - certificates.hypershift.openshift.io
     resources:
     - '*'
     verbs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Today, hypershift install exposes a flag:

```--enable-admin-rbac-generation```
which creates ClusterRoles and ClusterRoleBinding for Hosted cluster admins and readers.

We want to start using the hypershift-readers ClusterRole in ROSA HCP to replace the one currently deployed on the Management Clusters by OSDFM, as it was already agreed that this is better located in HO, as it is close to the resources and the logic.

To do that, we need to:
* add a new install flag
```--enable-reader-rbac-generation```
that creates only the hypershift-readers ClusterRole (as the binding will be handled elsewhere), to avoid creating useless resources that could impact the exposure
* align the ClusterRole with what we have on OSDFM in terms of role aggregation and also add the missing HyperShift API group for certificates which where added recently in HyperShift

The existing flag --enable-admin-rbac-generation is kept unchanged in case we want to deploy both personas including ClusterRoleBindings.

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-1536](https://issues.redhat.com//browse/HOSTEDCP-1536)

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.