### PR TITLE
OCPBUGS-32487: Fix OLM intilization args

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-operator-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - $(OPERATOR_NAMESPACE)
             - --writeStatusName
             - operator-lifecycle-manager
-            - --writePackageServerStatusName=""
+            - --writePackageServerStatusName=
             - --tls-cert
             - /srv-cert/tls.crt
             - --tls-key


### PR DESCRIPTION
**What this PR does / why we need it**:
This argument was being interpreted as \"\" rather than an empty string

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://issues.redhat.com/browse/OCPBUGS-32487

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.