### PR TITLE
Updates worker-role: Allow pulling private ECR images

### DIFF
--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -607,7 +607,19 @@ func (o *CreateIAMOptions) CreateWorkerInstanceProfile(client iamiface.IAMAPI, p
       "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeRegions",
+	"ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetRepositoryPolicy",
+        "ecr:DescribeRepositories",
+        "ecr:ListImages",
+        "ecr:DescribeImages",
+        "ecr:BatchGetImage",
+        "ecr:GetLifecyclePolicy",
+        "ecr:GetLifecyclePolicyPreview",
+        "ecr:ListTagsForResource",
+        "ecr:DescribeImageScanFindings"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
This change updates the worker-role to add the required permissions to pull private ECR images.

Currently when trying to pull images from a private ECR registry, the kubelet produces the following error: 

```bash
Error running credential provider plugin: AccessDeniedException: User: arn:aws:sts::<>:assumed-role/tbarberb-hosted-test-9jj2h-worker-role/i-<> is is not authorized to perform: ecr:GetAuthorizationToken on resource: * because no identity-based policy allows the ecr:GetAuthorizationToken action
```
In order to fix this, this change updates the `workerPolicy` to contain the contents of the IAM policy `arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly`.

In testing, this has fixed the issue (after editing the role, the issue is fixed).

