### PR TITLE
ACM-11259: Add mapping documentation for KubeVirt CSI driver snaphotting

### DIFF
--- a/docs/content/how-to/kubevirt/configuring-storage.md
+++ b/docs/content/how-to/kubevirt/configuring-storage.md
@@ -99,6 +99,89 @@ mapping that was configured during cluster creation.
     KubeVirt CSI only supports mapping an infrastructure storage class that is
     capable of `ReadWriteMany` (RWX) access.
 
+## KubeVirt CSI VolumeSnapshotClass Mapping
+
+KubeVirt CSI permits infra VolumeSnapshotClasses to be exposed to the guest
+cluster. Since VolumeSnapshotClasses are tied to a particular provisioner the
+mapping between VolumeSnapshotClasses and StorageClasses needs to expressed to
+hypershift during guest cluster creation. using the `hcp` cli tool and the 
+`--infra-volumesnapshot-class-mapping` cli argument.
+
+Below is an example of a simple setup with a single infra storage class and a
+single matching volume snapshot class in the infra cluster being mapped to a
+single storage class and single volume snapshot class in the guest cluster.
+
+```shell linenums="1"
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+
+hcp create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas $WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU \
+--infra-storage-class-mapping=infra-sc1/guest-sc1 \
+--infra-volumesnapshot-class-mapping=infra-vsc1/guest-vsc1
+```
+
+If you omit the `--infra-storage-class-mapping` and the 
+`--infra-volumesnapshot-class-mapping`. The system will use the default 
+storage class and the default volume snapshot class in the infra cluster. If 
+the default is not set, then the snapshot functionality will not work and the
+snapshot request will never reach ready state. This is because it not possible
+to create a correct snapshot in the infra cluster.
+
+A more complex setup could contain multiple storage classes with multiple
+volume snapshot classes. In particular in this setup one volume snapshot class
+is only compatible with certain storage classes but not all. So we have infra
+storage class a and b, and infra snapshot volume class a and b. Only the a's
+are compatible with each other and only the b's are compatible with each other.
+
+To properly group them together use the 'group' option of the
+`--infra-volumesnapshot-class-mapping` and `group` option of the
+`--infra-storage-class-mapping`.
+Below is an example of this setup
+
+```shell linenums="1"
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+
+hcp create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas $WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU \
+--infra-storage-class-mapping=infra-sca/guest-sca,group=a \
+--infra-storage-class-mapping=infra-scb/guest-scb,group=b \
+--infra-storage-class-mapping=infra-scc/guest-scc,group=a \
+--infra-volumesnapshot-class-mapping=infra-vsca/guest-vsca,group=a \
+--infra-volumesnapshot-class-mapping=infra-vscb/guest-vscb,group=b
+```
+
+Since both storage class `infra-sca` and volume snapshot class `infra-vsca`
+are in the same group, this indicates to KubeVirt CSI that they are 
+compatible and be used to create snapshots of volumes from storage class
+`guest-sca` using the guest volume snapshot class `guest-vsca`. The same
+is true with with the `b` grouping as well. Since `infra-scc` is also in
+the `a` group, creating snapshots of volumes from storage class `guest-scc`
+will use the same volume snapshot class in the infra cluster as making a
+snapshot of volumes that use storage class `guest-sca`
+
+!!! note
+
+   KubeVirt CSI passes snapshot requests to the underlying infra. This means
+   that snapshots will only work for compatible volumes. Please ensure the 
+   proper mapping is configured before attempting to create a snapshot in the
+   guest cluster.
+
 ## KubeVirt VM Root Volume Configuration
 
 The storage class used to host the KubeVirt Virtual Machine root volumes can be


### PR DESCRIPTION
Add documentation for the KubeVirt CSI driver
snapshotting feature. In particular how to map the storage classes and volume snapshot classes using
the hcp cli.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [X] This change includes docs. 
- [ ] This change includes unit tests.