### PR TITLE
OCPBUGS-32760: Request serving scheduler: omit deleting nodes

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -176,6 +176,10 @@ func (r *DedicatedServingComponentScheduler) Reconcile(ctx context.Context, req 
 	// first, find any existing nodes already labeled for this hostedcluster
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
+		if !node.DeletionTimestamp.IsZero() {
+			// Skip nodes that are being deleted
+			continue
+		}
 		zone, hasZoneLabel := node.Labels["topology.kubernetes.io/zone"]
 		if !hasZoneLabel {
 			continue
@@ -410,6 +414,9 @@ func (r *DedicatedServingComponentSchedulerAndSizer) Reconcile(ctx context.Conte
 	var goalNodes, availableNodes []corev1.Node
 	var pairLabel string
 	for _, node := range dedicatedNodes.Items {
+		if !node.DeletionTimestamp.IsZero() {
+			continue
+		}
 		if node.Labels[hyperv1.HostedClusterLabel] == clusterKey(hc) {
 			if node.Labels[OSDFleetManagerPairedNodesLabel] != "" && pairLabel == "" {
 				pairLabel = node.Labels[OSDFleetManagerPairedNodesLabel]


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid taking deleting nodes into consideration when making scheduling decisions.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-32760](https://issues.redhat.com/browse/OCPBUGS-32760)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.