### PR TITLE
OCPBUGS-32759: Fix invalid node selector in autosizing placeholder

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -693,20 +693,22 @@ func (r *DedicatedServingComponentSchedulerAndSizer) ensurePlaceholderDeployment
 				},
 			},
 		}
-		nodeAffinity = &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							{
-								Key:      OSDFleetManagerPairedNodesLabel,
-								Operator: corev1.NodeSelectorOpNotIn,
-								Values:   unavailableNodePairs,
+		if len(unavailableNodePairs) > 0 {
+			nodeAffinity = &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      OSDFleetManagerPairedNodesLabel,
+									Operator: corev1.NodeSelectorOpNotIn,
+									Values:   unavailableNodePairs,
+								},
 							},
 						},
 					},
 				},
-			},
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When there are no hosted clusters in the management cluster, the node affinity selector should not include an empty list.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-32759](https://issues.redhat.com/browse/OCPBUGS-32759)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.