### PR TITLE
OCPBUGS-32378: Ensure placeholder deployments are deleted

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -366,7 +366,11 @@ func (r *DedicatedServingComponentSchedulerAndSizer) Reconcile(ctx context.Conte
 		return ctrl.Result{}, fmt.Errorf("failed to get cluster %q: %w", req.NamespacedName, err)
 	}
 	if !hc.DeletionTimestamp.IsZero() {
-		log.Info("hostedcluster is deleted, nothing to do")
+		log.Info("hostedcluster is deleted")
+		// Ensure that any placeholder deployment is deleted
+		if err := r.deletePlaceholderDeployment(ctx, hc); err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
 	if hcTopology := hc.Annotations[hyperv1.TopologyAnnotation]; hcTopology != hyperv1.DedicatedRequestServingComponentsTopology {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a HostedCluster is deleted, make sure that there are no leftover placeholder deployments for it.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-32378](https://issues.redhat.com/browse/OCPBUGS-32378)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.