### PR TITLE
OCPBUGS-32492: Set ImportMode for catalog

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -143,7 +143,8 @@ func ReconcileCatalogsImageStream(imageStream *imagev1.ImageStream, ownerRef con
 					Type: imagev1.LocalTagReferencePolicy,
 				},
 				ImportPolicy: imagev1.TagImportPolicy{
-					Scheduled: true,
+					Scheduled:  true,
+					ImportMode: imagev1.ImportModePreserveOriginal,
 				},
 			})
 		} else {


### PR DESCRIPTION
Set `ImportMode` to `PreserveOriginal` for `catalogs` image

Ref: https://issues.redhat.com/browse/OCPBUGS-32492