### PR TITLE
OCPBUGS-30260: Ignore subnet annotations for control plane load balancers

### DIFF
--- a/support/util/util.go
+++ b/support/util/util.go
@@ -332,16 +332,19 @@ func ParseNodeSelector(str string) map[string]string {
 }
 
 func ApplyAWSLoadBalancerSubnetsAnnotation(svc *corev1.Service, hcp *hyperv1.HostedControlPlane) {
-	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform {
-		return
-	}
-	if svc.Annotations == nil {
-		svc.Annotations = make(map[string]string)
-	}
-	subnets, ok := hcp.Annotations[hyperv1.AWSLoadBalancerSubnetsAnnotation]
-	if ok {
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-subnets"] = subnets
-	}
+	// TODO: cewong - reenable when we fix loadbalancer subnet annotation
+	/*
+		if hcp.Spec.Platform.Type != hyperv1.AWSPlatform {
+			return
+		}
+		if svc.Annotations == nil {
+			svc.Annotations = make(map[string]string)
+		}
+		subnets, ok := hcp.Annotations[hyperv1.AWSLoadBalancerSubnetsAnnotation]
+		if ok {
+			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-subnets"] = subnets
+		}
+	*/
 }
 
 func DoesMgmtClusterAndNodePoolCPUArchMatch(mgmtClusterCPUArch, nodePoolArch string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Partially reverts behavior introduced with https://github.com/openshift/hypershift/pull/3746
We need to figure out why specifying subnets results in a broken load balancer.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-30260

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.