### PR TITLE
HOSTEDCP-1544: Allow user to specify subnet ID for Hosted Cluster & NodePool Creation

### DIFF
--- a/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1565,7 +1565,6 @@ type AzurePlatformSpec struct {
 	Cloud             string `json:"cloud,omitempty"`
 	Location          string `json:"location"`
 	ResourceGroupName string `json:"resourceGroup"`
-	VnetName          string `json:"vnetName"`
 	VnetID            string `json:"vnetID"`
 	SubnetID          string `json:"subnetID"`
 	SubscriptionID    string `json:"subscriptionID"`

--- a/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1570,7 +1570,7 @@ type AzurePlatformSpec struct {
 	SubnetID          string `json:"subnetID"`
 	SubscriptionID    string `json:"subscriptionID"`
 	MachineIdentityID string `json:"machineIdentityID"`
-	SecurityGroupName string `json:"securityGroupName"`
+	SecurityGroupID   string `json:"securityGroupID"`
 }
 
 // Release represents the metadata for an OCP release payload image.

--- a/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1567,7 +1567,7 @@ type AzurePlatformSpec struct {
 	ResourceGroupName string `json:"resourceGroup"`
 	VnetName          string `json:"vnetName"`
 	VnetID            string `json:"vnetID"`
-	SubnetName        string `json:"subnetName"`
+	SubnetID          string `json:"subnetID"`
 	SubscriptionID    string `json:"subscriptionID"`
 	MachineIdentityID string `json:"machineIdentityID"`
 	SecurityGroupName string `json:"securityGroupName"`

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1779,16 +1779,14 @@ type AzurePlatformSpec struct {
 	// +optional
 	MachineIdentityID string `json:"machineIdentityID,omitempty"`
 
-	// SecurityGroupName is the name of an existing security group on SubnetName. This field is provided as part of the
+	// SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
 	// configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
 	//
-	// Example: if your Network Security Group ID is /subscriptions/<subscriptionID>/resourcegroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<securityGroupName>,
-	//          your SecurityGroupName is <securityGroupName>
-	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SecurityGroupName is immutable"
-	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SecurityGroupID is immutable"
+	// +kubebuilder:validation:Required
+	// +required
 	// +immutable
-	SecurityGroupName string `json:"securityGroupName,omitempty"`
+	SecurityGroupID string `json:"securityGroupID,omitempty"`
 }
 
 // Release represents the metadata for an OCP release payload image.

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1736,18 +1736,6 @@ type AzurePlatformSpec struct {
 	// +immutable
 	ResourceGroupName string `json:"resourceGroup"`
 
-	// VnetName is the resource name of an existing VNET to use in creating VMs. If this field is included, it should
-	// be the resource name matching the VnetID.
-	// In ARO HCP, this will be the name of the customer provided VNET.
-	//
-	// Example: if your VNET ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>,
-	//          your VnetName is <vnetName>
-	//
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="VnetName is immutable"
-	// +immutable
-	VnetName string `json:"vnetName"`
-
 	// VnetID is the ID of an existing VNET to use in creating VMs.
 	// In ARO HCP, this will be the ID of the customer provided VNET.
 	//

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1758,15 +1758,14 @@ type AzurePlatformSpec struct {
 	// +immutable
 	VnetID string `json:"vnetID,omitempty"`
 
-	// SubnetName is the name of an existing subnet in VnetName / VnetID where Azure CCM will find an existing load
-	// balancer to be used for node egress.
+	// SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
+	// subnet ID is expected to be a subnet within the VnetID / VnetName.
+	// In ARO HCP, managed services will create the aforementioned load balancer.
 	//
-	// Example: if your SubnetID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>,
-	//          your SubnetName is <subnetName>
-	//
-	// +kubebuilder:default:=default
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="SubnetID is immutable"
 	// +kubebuilder:validation:Required
-	SubnetName string `json:"subnetName"`
+	// +required
+	SubnetID string `json:"subnetID"`
 
 	// SubscriptionID is a unique identifier for an Azure subscription used to manage resources.
 	//

--- a/client/applyconfiguration/hypershift/v1alpha1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azureplatformspec.go
@@ -30,7 +30,7 @@ type AzurePlatformSpecApplyConfiguration struct {
 	ResourceGroupName *string                  `json:"resourceGroup,omitempty"`
 	VnetName          *string                  `json:"vnetName,omitempty"`
 	VnetID            *string                  `json:"vnetID,omitempty"`
-	SubnetName        *string                  `json:"subnetName,omitempty"`
+	SubnetID          *string                  `json:"subnetID,omitempty"`
 	SubscriptionID    *string                  `json:"subscriptionID,omitempty"`
 	MachineIdentityID *string                  `json:"machineIdentityID,omitempty"`
 	SecurityGroupName *string                  `json:"securityGroupName,omitempty"`
@@ -90,11 +90,11 @@ func (b *AzurePlatformSpecApplyConfiguration) WithVnetID(value string) *AzurePla
 	return b
 }
 
-// WithSubnetName sets the SubnetName field in the declarative configuration to the given value
+// WithSubnetID sets the SubnetID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the SubnetName field is set to the value of the last call.
-func (b *AzurePlatformSpecApplyConfiguration) WithSubnetName(value string) *AzurePlatformSpecApplyConfiguration {
-	b.SubnetName = &value
+// If called multiple times, the SubnetID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithSubnetID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.SubnetID = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1alpha1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azureplatformspec.go
@@ -33,7 +33,7 @@ type AzurePlatformSpecApplyConfiguration struct {
 	SubnetID          *string                  `json:"subnetID,omitempty"`
 	SubscriptionID    *string                  `json:"subscriptionID,omitempty"`
 	MachineIdentityID *string                  `json:"machineIdentityID,omitempty"`
-	SecurityGroupName *string                  `json:"securityGroupName,omitempty"`
+	SecurityGroupID   *string                  `json:"securityGroupID,omitempty"`
 }
 
 // AzurePlatformSpecApplyConfiguration constructs an declarative configuration of the AzurePlatformSpec type for use with
@@ -114,10 +114,10 @@ func (b *AzurePlatformSpecApplyConfiguration) WithMachineIdentityID(value string
 	return b
 }
 
-// WithSecurityGroupName sets the SecurityGroupName field in the declarative configuration to the given value
+// WithSecurityGroupID sets the SecurityGroupID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the SecurityGroupName field is set to the value of the last call.
-func (b *AzurePlatformSpecApplyConfiguration) WithSecurityGroupName(value string) *AzurePlatformSpecApplyConfiguration {
-	b.SecurityGroupName = &value
+// If called multiple times, the SecurityGroupID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithSecurityGroupID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.SecurityGroupID = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1alpha1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azureplatformspec.go
@@ -28,7 +28,6 @@ type AzurePlatformSpecApplyConfiguration struct {
 	Cloud             *string                  `json:"cloud,omitempty"`
 	Location          *string                  `json:"location,omitempty"`
 	ResourceGroupName *string                  `json:"resourceGroup,omitempty"`
-	VnetName          *string                  `json:"vnetName,omitempty"`
 	VnetID            *string                  `json:"vnetID,omitempty"`
 	SubnetID          *string                  `json:"subnetID,omitempty"`
 	SubscriptionID    *string                  `json:"subscriptionID,omitempty"`
@@ -71,14 +70,6 @@ func (b *AzurePlatformSpecApplyConfiguration) WithLocation(value string) *AzureP
 // If called multiple times, the ResourceGroupName field is set to the value of the last call.
 func (b *AzurePlatformSpecApplyConfiguration) WithResourceGroupName(value string) *AzurePlatformSpecApplyConfiguration {
 	b.ResourceGroupName = &value
-	return b
-}
-
-// WithVnetName sets the VnetName field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the VnetName field is set to the value of the last call.
-func (b *AzurePlatformSpecApplyConfiguration) WithVnetName(value string) *AzurePlatformSpecApplyConfiguration {
-	b.VnetName = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
@@ -30,7 +30,7 @@ type AzurePlatformSpecApplyConfiguration struct {
 	ResourceGroupName *string                  `json:"resourceGroup,omitempty"`
 	VnetName          *string                  `json:"vnetName,omitempty"`
 	VnetID            *string                  `json:"vnetID,omitempty"`
-	SubnetName        *string                  `json:"subnetName,omitempty"`
+	SubnetID          *string                  `json:"subnetID,omitempty"`
 	SubscriptionID    *string                  `json:"subscriptionID,omitempty"`
 	MachineIdentityID *string                  `json:"machineIdentityID,omitempty"`
 	SecurityGroupName *string                  `json:"securityGroupName,omitempty"`
@@ -90,11 +90,11 @@ func (b *AzurePlatformSpecApplyConfiguration) WithVnetID(value string) *AzurePla
 	return b
 }
 
-// WithSubnetName sets the SubnetName field in the declarative configuration to the given value
+// WithSubnetID sets the SubnetID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the SubnetName field is set to the value of the last call.
-func (b *AzurePlatformSpecApplyConfiguration) WithSubnetName(value string) *AzurePlatformSpecApplyConfiguration {
-	b.SubnetName = &value
+// If called multiple times, the SubnetID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithSubnetID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.SubnetID = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
@@ -33,7 +33,7 @@ type AzurePlatformSpecApplyConfiguration struct {
 	SubnetID          *string                  `json:"subnetID,omitempty"`
 	SubscriptionID    *string                  `json:"subscriptionID,omitempty"`
 	MachineIdentityID *string                  `json:"machineIdentityID,omitempty"`
-	SecurityGroupName *string                  `json:"securityGroupName,omitempty"`
+	SecurityGroupID   *string                  `json:"securityGroupID,omitempty"`
 }
 
 // AzurePlatformSpecApplyConfiguration constructs an declarative configuration of the AzurePlatformSpec type for use with
@@ -114,10 +114,10 @@ func (b *AzurePlatformSpecApplyConfiguration) WithMachineIdentityID(value string
 	return b
 }
 
-// WithSecurityGroupName sets the SecurityGroupName field in the declarative configuration to the given value
+// WithSecurityGroupID sets the SecurityGroupID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the SecurityGroupName field is set to the value of the last call.
-func (b *AzurePlatformSpecApplyConfiguration) WithSecurityGroupName(value string) *AzurePlatformSpecApplyConfiguration {
-	b.SecurityGroupName = &value
+// If called multiple times, the SecurityGroupID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithSecurityGroupID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.SecurityGroupID = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
@@ -28,7 +28,6 @@ type AzurePlatformSpecApplyConfiguration struct {
 	Cloud             *string                  `json:"cloud,omitempty"`
 	Location          *string                  `json:"location,omitempty"`
 	ResourceGroupName *string                  `json:"resourceGroup,omitempty"`
-	VnetName          *string                  `json:"vnetName,omitempty"`
 	VnetID            *string                  `json:"vnetID,omitempty"`
 	SubnetID          *string                  `json:"subnetID,omitempty"`
 	SubscriptionID    *string                  `json:"subscriptionID,omitempty"`
@@ -71,14 +70,6 @@ func (b *AzurePlatformSpecApplyConfiguration) WithLocation(value string) *AzureP
 // If called multiple times, the ResourceGroupName field is set to the value of the last call.
 func (b *AzurePlatformSpecApplyConfiguration) WithResourceGroupName(value string) *AzurePlatformSpecApplyConfiguration {
 	b.ResourceGroupName = &value
-	return b
-}
-
-// WithVnetName sets the VnetName field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the VnetName field is set to the value of the last call.
-func (b *AzurePlatformSpecApplyConfiguration) WithVnetName(value string) *AzurePlatformSpecApplyConfiguration {
-	b.VnetName = &value
 	return b
 }
 

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -28,7 +28,6 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	opts.AzurePlatform.Location = "eastus"
 	opts.AzurePlatform.InstanceType = "Standard_D4s_v4"
 	opts.AzurePlatform.DiskSizeGB = 120
-	opts.AzurePlatform.SubnetName = "default"
 
 	cmd.Flags().StringVar(&opts.AzurePlatform.CredentialsFile, "azure-creds", opts.AzurePlatform.CredentialsFile, "Path to an Azure credentials file (required)")
 	cmd.Flags().StringVar(&opts.AzurePlatform.Location, "location", opts.AzurePlatform.Location, "Location for the cluster")
@@ -42,7 +41,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.AzurePlatform.EnableEphemeralOSDisk, "enable-ephemeral-disk", opts.AzurePlatform.EnableEphemeralOSDisk, "If enabled, the Azure VMs in the default NodePool will be setup with ephemeral OS disks")
 	cmd.Flags().StringVar(&opts.AzurePlatform.DiskStorageAccountType, "disk-storage-account-type", opts.AzurePlatform.DiskStorageAccountType, "The disk storage account type for the OS disks for the VMs.")
 	cmd.Flags().StringToStringVarP(&opts.AzurePlatform.ResourceGroupTags, "resource-group-tags", "t", opts.AzurePlatform.ResourceGroupTags, "Additional tags to apply to the resource group created (e.g. 'key1=value1,key2=value2')")
-	cmd.Flags().StringVar(&opts.AzurePlatform.SubnetName, "subnet-name", opts.AzurePlatform.SubnetName, "The subnet name where the VMs will be placed.")
+	cmd.Flags().StringVar(&opts.AzurePlatform.SubnetID, "subnet-id", opts.AzurePlatform.SubnetID, "The subnet ID where the VMs will be placed.")
 
 	_ = cmd.MarkFlagRequired("azure-creds")
 	_ = cmd.MarkPersistentFlagRequired("pull-secret")
@@ -99,6 +98,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			ResourceGroupName:    opts.AzurePlatform.ResourceGroupName,
 			NetworkSecurityGroup: opts.AzurePlatform.NetworkSecurityGroup,
 			ResourceGroupTags:    opts.AzurePlatform.ResourceGroupTags,
+			SubnetID:             opts.AzurePlatform.SubnetID,
 			SubnetName:           opts.AzurePlatform.SubnetName,
 		}).Run(ctx, opts.Log)
 		if err != nil {
@@ -116,6 +116,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		ResourceGroupName:      infra.ResourceGroupName,
 		VnetName:               infra.VnetName,
 		VnetID:                 infra.VNetID,
+		SubnetID:               infra.SubnetID,
 		SubnetName:             infra.SubnetName,
 		BootImageID:            infra.BootImageID,
 		MachineIdentityID:      infra.MachineIdentityID,

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -36,6 +36,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 	cmd.Flags().Int32Var(&opts.AzurePlatform.DiskSizeGB, "root-disk-size", opts.AzurePlatform.DiskSizeGB, "The size of the root disk for machines in the NodePool (minimum 16)")
 	cmd.Flags().StringSliceVar(&opts.AzurePlatform.AvailabilityZones, "availability-zones", opts.AzurePlatform.AvailabilityZones, "The availability zones in which NodePools will be created. Must be left unspecified if the region does not support AZs. If set, one nodepool per zone will be created.")
 	cmd.Flags().StringVar(&opts.AzurePlatform.ResourceGroupName, "resource-group-name", opts.AzurePlatform.ResourceGroupName, "A resource group name to create the HostedCluster infrastructure resources under.")
+	cmd.Flags().StringVar(&opts.AzurePlatform.VnetID, "vnet-id", opts.AzurePlatform.VnetID, "An existing VNET ID.")
 	cmd.Flags().StringVar(&opts.AzurePlatform.DiskEncryptionSetID, "disk-encryption-set-id", opts.AzurePlatform.DiskEncryptionSetID, "The Disk Encryption Set ID to use to encrypt the OS disks for the VMs.")
 	cmd.Flags().StringVar(&opts.AzurePlatform.NetworkSecurityGroup, "network-security-group", opts.AzurePlatform.NetworkSecurityGroup, "The name of the Network Security Group to use in Virtual Network created for HostedCluster.")
 	cmd.Flags().BoolVar(&opts.AzurePlatform.EnableEphemeralOSDisk, "enable-ephemeral-disk", opts.AzurePlatform.EnableEphemeralOSDisk, "If enabled, the Azure VMs in the default NodePool will be setup with ephemeral OS disks")
@@ -95,6 +96,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			CredentialsFile:      opts.AzurePlatform.CredentialsFile,
 			BaseDomain:           opts.BaseDomain,
 			RHCOSImage:           rhcosImage,
+			VnetID:               opts.AzurePlatform.VnetID,
 			ResourceGroupName:    opts.AzurePlatform.ResourceGroupName,
 			NetworkSecurityGroup: opts.AzurePlatform.NetworkSecurityGroup,
 			ResourceGroupTags:    opts.AzurePlatform.ResourceGroupTags,
@@ -113,7 +115,6 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 	exampleOptions.Azure = &apifixtures.ExampleAzureOptions{
 		Location:               infra.Location,
 		ResourceGroupName:      infra.ResourceGroupName,
-		VnetName:               infra.VnetName,
 		VnetID:                 infra.VNetID,
 		SubnetID:               infra.SubnetID,
 		SubnetName:             infra.SubnetName,

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -120,7 +120,7 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		BootImageID:            infra.BootImageID,
 		MachineIdentityID:      infra.MachineIdentityID,
 		InstanceType:           opts.AzurePlatform.InstanceType,
-		SecurityGroupName:      infra.SecurityGroupName,
+		SecurityGroupID:        infra.SecurityGroupID,
 		DiskSizeGB:             opts.AzurePlatform.DiskSizeGB,
 		AvailabilityZones:      opts.AzurePlatform.AvailabilityZones,
 		DiskEncryptionSetID:    opts.AzurePlatform.DiskEncryptionSetID,

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -99,7 +99,6 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 			NetworkSecurityGroup: opts.AzurePlatform.NetworkSecurityGroup,
 			ResourceGroupTags:    opts.AzurePlatform.ResourceGroupTags,
 			SubnetID:             opts.AzurePlatform.SubnetID,
-			SubnetName:           opts.AzurePlatform.SubnetName,
 		}).Run(ctx, opts.Log)
 		if err != nil {
 			return fmt.Errorf("failed to create infra: %w", err)

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -197,6 +197,7 @@ type AzurePlatformOptions struct {
 	DiskSizeGB             int32
 	AvailabilityZones      []string
 	ResourceGroupName      string
+	VnetID                 string
 	DiskEncryptionSetID    string
 	NetworkSecurityGroup   string
 	EnableEphemeralOSDisk  bool

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -202,6 +202,7 @@ type AzurePlatformOptions struct {
 	EnableEphemeralOSDisk  bool
 	DiskStorageAccountType string
 	ResourceGroupTags      map[string]string
+	SubnetID               string
 	SubnetName             string
 }
 

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -203,7 +203,6 @@ type AzurePlatformOptions struct {
 	DiskStorageAccountType string
 	ResourceGroupTags      map[string]string
 	SubnetID               string
-	SubnetName             string
 }
 
 func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures.ExampleOptions, error) {

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -70,7 +70,7 @@ type CreateInfraOutput struct {
 	BootImageID       string `json:"bootImageID"`
 	InfraID           string `json:"infraID"`
 	MachineIdentityID string `json:"machineIdentityID"`
-	SecurityGroupName string `json:"securityGroupName"`
+	SecurityGroupID   string `json:"securityGroupID"`
 }
 
 func NewCreateCommand() *cobra.Command {
@@ -182,12 +182,13 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 
 		// Extract network security group name if one exists
 		if vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup != nil && vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup.ID != nil {
-			result.SecurityGroupName, err = azureutil.GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(*vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup.ID)
+			result.SecurityGroupID = *vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup.ID
+			securityGroupName, err := azureutil.GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(*vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup.ID)
 			if err != nil {
 				return nil, err
 			}
 
-			l.Info("Successfully retrieved existing network security group", "name", result.SecurityGroupName)
+			l.Info("Successfully retrieved existing network security group", "name", securityGroupName)
 		}
 	} else {
 		// Create a network security group
@@ -195,7 +196,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		if err != nil {
 			return nil, err
 		}
-		result.SecurityGroupName = securityGroupName
+		result.SecurityGroupID = nsgID
 		l.Info("Successfully created network security group", "name", securityGroupName)
 
 		// Create a VNET with the network security group

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -54,7 +54,6 @@ type CreateInfraOptions struct {
 	NetworkSecurityGroup string
 	ResourceGroupTags    map[string]string
 	SubnetID             string
-	SubnetName           string
 }
 
 type CreateInfraOutput struct {

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -7547,12 +7547,18 @@ spec:
                         default: default
                         description: |-
                           ResourceGroupName is the name of an existing resource group where all cloud resources created by the Hosted
-                          Cluster are to be placed.
+                          Cluster are to be placed. The resource group is expected to exist under the same subscription as SubscriptionID.
+
+
                           In ARO HCP, this will be the managed resource group where customer cloud resources will be created.
+
+
+                          Resource group naming requirements can be found here: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/.
 
 
                           Example: if your resource group ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>, your
                                    ResourceGroupName is <resourceGroupName>.
+                        pattern: ^[a-zA-Z0-9_()\-\.]{1,89}[a-zA-Z0-9_()\-]$
                         type: string
                         x-kubernetes-validations:
                         - message: ResourceGroupName is immutable
@@ -7560,7 +7566,9 @@ spec:
                       securityGroupID:
                         description: |-
                           SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
-                          configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
+                          configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
+                          expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
+                          in.
                         type: string
                         x-kubernetes-validations:
                         - message: SecurityGroupID is immutable
@@ -7568,8 +7576,11 @@ spec:
                       subnetID:
                         description: |-
                           SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
-                          subnet ID is expected to be a subnet within the VnetID / VnetName.
-                          In ARO HCP, managed services will create the aforementioned load balancer.
+                          subnet is expected to be a subnet within the VNET specified in VnetID. This subnet is expected to exist under the
+                          same subscription as SubscriptionID.
+
+
+                          In ARO HCP, managed services will create the aforementioned load balancer in ResourceGroupName.
                         type: string
                         x-kubernetes-validations:
                         - message: SubnetID is immutable
@@ -7583,7 +7594,11 @@ spec:
                           rule: self == oldSelf
                       vnetID:
                         description: |-
-                          VnetID is the ID of an existing VNET to use in creating VMs.
+                          VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
+                          other than the one specified in ResourceGroupName, but it must exist under the same subscription as
+                          SubscriptionID.
+
+
                           In ARO HCP, this will be the ID of the customer provided VNET.
 
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -3169,8 +3169,6 @@ spec:
                         type: string
                       vnetID:
                         type: string
-                      vnetName:
-                        type: string
                     required:
                     - credentials
                     - location
@@ -3180,7 +3178,6 @@ spec:
                     - subnetID
                     - subscriptionID
                     - vnetID
-                    - vnetName
                     type: object
                   ibmcloud:
                     description: IBMCloud defines IBMCloud specific settings for components
@@ -7595,26 +7592,12 @@ spec:
                         x-kubernetes-validations:
                         - message: VnetID is immutable
                           rule: self == oldSelf
-                      vnetName:
-                        description: |-
-                          VnetName is the resource name of an existing VNET to use in creating VMs. If this field is included, it should
-                          be the resource name matching the VnetID.
-                          In ARO HCP, this will be the name of the customer provided VNET.
-
-
-                          Example: if your VNET ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>,
-                                   your VnetName is <vnetName>
-                        type: string
-                        x-kubernetes-validations:
-                        - message: VnetName is immutable
-                          rule: self == oldSelf
                     required:
                     - credentials
                     - location
                     - resourceGroup
                     - subnetID
                     - subscriptionID
-                    - vnetName
                     type: object
                   ibmcloud:
                     description: IBMCloud defines IBMCloud specific settings for components

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -3163,7 +3163,7 @@ spec:
                         type: string
                       securityGroupName:
                         type: string
-                      subnetName:
+                      subnetID:
                         type: string
                       subscriptionID:
                         type: string
@@ -3177,7 +3177,7 @@ spec:
                     - machineIdentityID
                     - resourceGroup
                     - securityGroupName
-                    - subnetName
+                    - subnetID
                     - subscriptionID
                     - vnetID
                     - vnetName
@@ -7572,16 +7572,15 @@ spec:
                         x-kubernetes-validations:
                         - message: SecurityGroupName is immutable
                           rule: self == oldSelf
-                      subnetName:
-                        default: default
+                      subnetID:
                         description: |-
-                          SubnetName is the name of an existing subnet in VnetName / VnetID where Azure CCM will find an existing load
-                          balancer to be used for node egress.
-
-
-                          Example: if your SubnetID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>,
-                                   your SubnetName is <subnetName>
+                          SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
+                          subnet ID is expected to be a subnet within the VnetID / VnetName.
+                          In ARO HCP, managed services will create the aforementioned load balancer.
                         type: string
+                        x-kubernetes-validations:
+                        - message: SubnetID is immutable
+                          rule: self == oldSelf
                       subscriptionID:
                         description: SubscriptionID is a unique identifier for an
                           Azure subscription used to manage resources.
@@ -7617,7 +7616,7 @@ spec:
                     - credentials
                     - location
                     - resourceGroup
-                    - subnetName
+                    - subnetID
                     - subscriptionID
                     - vnetName
                     type: object

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -3161,7 +3161,7 @@ spec:
                         type: string
                       resourceGroup:
                         type: string
-                      securityGroupName:
+                      securityGroupID:
                         type: string
                       subnetID:
                         type: string
@@ -3176,7 +3176,7 @@ spec:
                     - location
                     - machineIdentityID
                     - resourceGroup
-                    - securityGroupName
+                    - securityGroupID
                     - subnetID
                     - subscriptionID
                     - vnetID
@@ -7560,17 +7560,13 @@ spec:
                         x-kubernetes-validations:
                         - message: ResourceGroupName is immutable
                           rule: self == oldSelf
-                      securityGroupName:
+                      securityGroupID:
                         description: |-
-                          SecurityGroupName is the name of an existing security group on SubnetName. This field is provided as part of the
+                          SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
                           configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
-
-
-                          Example: if your Network Security Group ID is /subscriptions/<subscriptionID>/resourcegroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<securityGroupName>,
-                                   your SecurityGroupName is <securityGroupName>
                         type: string
                         x-kubernetes-validations:
-                        - message: SecurityGroupName is immutable
+                        - message: SecurityGroupID is immutable
                           rule: self == oldSelf
                       subnetID:
                         description: |-

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -7516,12 +7516,18 @@ spec:
                         default: default
                         description: |-
                           ResourceGroupName is the name of an existing resource group where all cloud resources created by the Hosted
-                          Cluster are to be placed.
+                          Cluster are to be placed. The resource group is expected to exist under the same subscription as SubscriptionID.
+
+
                           In ARO HCP, this will be the managed resource group where customer cloud resources will be created.
+
+
+                          Resource group naming requirements can be found here: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/.
 
 
                           Example: if your resource group ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>, your
                                    ResourceGroupName is <resourceGroupName>.
+                        pattern: ^[a-zA-Z0-9_()\-\.]{1,89}[a-zA-Z0-9_()\-]$
                         type: string
                         x-kubernetes-validations:
                         - message: ResourceGroupName is immutable
@@ -7529,7 +7535,9 @@ spec:
                       securityGroupID:
                         description: |-
                           SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
-                          configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
+                          configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
+                          expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
+                          in.
                         type: string
                         x-kubernetes-validations:
                         - message: SecurityGroupID is immutable
@@ -7537,8 +7545,11 @@ spec:
                       subnetID:
                         description: |-
                           SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
-                          subnet ID is expected to be a subnet within the VnetID / VnetName.
-                          In ARO HCP, managed services will create the aforementioned load balancer.
+                          subnet is expected to be a subnet within the VNET specified in VnetID. This subnet is expected to exist under the
+                          same subscription as SubscriptionID.
+
+
+                          In ARO HCP, managed services will create the aforementioned load balancer in ResourceGroupName.
                         type: string
                         x-kubernetes-validations:
                         - message: SubnetID is immutable
@@ -7552,7 +7563,11 @@ spec:
                           rule: self == oldSelf
                       vnetID:
                         description: |-
-                          VnetID is the ID of an existing VNET to use in creating VMs.
+                          VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
+                          other than the one specified in ResourceGroupName, but it must exist under the same subscription as
+                          SubscriptionID.
+
+
                           In ARO HCP, this will be the ID of the customer provided VNET.
 
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -3149,7 +3149,7 @@ spec:
                         type: string
                       securityGroupName:
                         type: string
-                      subnetName:
+                      subnetID:
                         type: string
                       subscriptionID:
                         type: string
@@ -3163,7 +3163,7 @@ spec:
                     - machineIdentityID
                     - resourceGroup
                     - securityGroupName
-                    - subnetName
+                    - subnetID
                     - subscriptionID
                     - vnetID
                     - vnetName
@@ -7541,16 +7541,15 @@ spec:
                         x-kubernetes-validations:
                         - message: SecurityGroupName is immutable
                           rule: self == oldSelf
-                      subnetName:
-                        default: default
+                      subnetID:
                         description: |-
-                          SubnetName is the name of an existing subnet in VnetName / VnetID where Azure CCM will find an existing load
-                          balancer to be used for node egress.
-
-
-                          Example: if your SubnetID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>,
-                                   your SubnetName is <subnetName>
+                          SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
+                          subnet ID is expected to be a subnet within the VnetID / VnetName.
+                          In ARO HCP, managed services will create the aforementioned load balancer.
                         type: string
+                        x-kubernetes-validations:
+                        - message: SubnetID is immutable
+                          rule: self == oldSelf
                       subscriptionID:
                         description: SubscriptionID is a unique identifier for an
                           Azure subscription used to manage resources.
@@ -7586,7 +7585,7 @@ spec:
                     - credentials
                     - location
                     - resourceGroup
-                    - subnetName
+                    - subnetID
                     - subscriptionID
                     - vnetName
                     type: object

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -3155,8 +3155,6 @@ spec:
                         type: string
                       vnetID:
                         type: string
-                      vnetName:
-                        type: string
                     required:
                     - credentials
                     - location
@@ -3166,7 +3164,6 @@ spec:
                     - subnetID
                     - subscriptionID
                     - vnetID
-                    - vnetName
                     type: object
                   ibmcloud:
                     description: IBMCloud defines IBMCloud specific settings for components
@@ -7564,26 +7561,12 @@ spec:
                         x-kubernetes-validations:
                         - message: VnetID is immutable
                           rule: self == oldSelf
-                      vnetName:
-                        description: |-
-                          VnetName is the resource name of an existing VNET to use in creating VMs. If this field is included, it should
-                          be the resource name matching the VnetID.
-                          In ARO HCP, this will be the name of the customer provided VNET.
-
-
-                          Example: if your VNET ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>,
-                                   your VnetName is <vnetName>
-                        type: string
-                        x-kubernetes-validations:
-                        - message: VnetName is immutable
-                          rule: self == oldSelf
                     required:
                     - credentials
                     - location
                     - resourceGroup
                     - subnetID
                     - subscriptionID
-                    - vnetName
                     type: object
                   ibmcloud:
                     description: IBMCloud defines IBMCloud specific settings for components

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -3147,7 +3147,7 @@ spec:
                         type: string
                       resourceGroup:
                         type: string
-                      securityGroupName:
+                      securityGroupID:
                         type: string
                       subnetID:
                         type: string
@@ -3162,7 +3162,7 @@ spec:
                     - location
                     - machineIdentityID
                     - resourceGroup
-                    - securityGroupName
+                    - securityGroupID
                     - subnetID
                     - subscriptionID
                     - vnetID
@@ -7529,17 +7529,13 @@ spec:
                         x-kubernetes-validations:
                         - message: ResourceGroupName is immutable
                           rule: self == oldSelf
-                      securityGroupName:
+                      securityGroupID:
                         description: |-
-                          SecurityGroupName is the name of an existing security group on SubnetName. This field is provided as part of the
+                          SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
                           configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
-
-
-                          Example: if your Network Security Group ID is /subscriptions/<subscriptionID>/resourcegroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<securityGroupName>,
-                                   your SecurityGroupName is <securityGroupName>
                         type: string
                         x-kubernetes-validations:
-                        - message: SecurityGroupName is immutable
+                        - message: SecurityGroupID is immutable
                           rule: self == oldSelf
                       subnetID:
                         description: |-

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -64,6 +64,11 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 		return AzureConfig{}, fmt.Errorf("failed to determine subnet name from SubnetID: %w", err)
 	}
 
+	securityGroupName, err := azureutil.GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(hcp.Spec.Platform.Azure.SecurityGroupID)
+	if err != nil {
+		return AzureConfig{}, fmt.Errorf("failed to determine security group name from SecurityGroupID: %w", err)
+	}
+
 	azureConfig := AzureConfig{
 		Cloud:                        hcp.Spec.Platform.Azure.Cloud,
 		TenantID:                     string(credentialsSecret.Data["AZURE_TENANT_ID"]),
@@ -74,7 +79,7 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 		VnetName:                     hcp.Spec.Platform.Azure.VnetName,
 		VnetResourceGroup:            hcp.Spec.Platform.Azure.ResourceGroupName,
 		SubnetName:                   subnetName,
-		SecurityGroupName:            hcp.Spec.Platform.Azure.SecurityGroupName,
+		SecurityGroupName:            securityGroupName,
 		SecurityGroupResourceGroup:   hcp.Spec.Platform.Azure.ResourceGroupName,
 		LoadBalancerName:             hcp.Spec.InfraID,
 		CloudProviderBackoff:         true,

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -75,12 +75,20 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 		VnetResourceGroup:            hcp.Spec.Platform.Azure.ResourceGroupName,
 		SubnetName:                   subnetName,
 		SecurityGroupName:            hcp.Spec.Platform.Azure.SecurityGroupName,
+		SecurityGroupResourceGroup:   hcp.Spec.Platform.Azure.ResourceGroupName,
 		LoadBalancerName:             hcp.Spec.InfraID,
 		CloudProviderBackoff:         true,
 		CloudProviderBackoffDuration: 6,
 		UseInstanceMetadata:          true,
 		LoadBalancerSku:              "standard",
 		DisableOutboundSNAT:          true,
+	}
+
+	// In ARO HCP, the VNET and NSG will be in the network resource group; it will not be in the resource group
+	// containing all other cloud infrastructure resources.
+	if hcp.Spec.Platform.Azure.VnetResourceGroupName != "" {
+		azureConfig.VnetResourceGroup = hcp.Spec.Platform.Azure.VnetResourceGroupName
+		azureConfig.SecurityGroupResourceGroup = hcp.Spec.Platform.Azure.VnetResourceGroupName
 	}
 
 	return azureConfig, nil
@@ -104,6 +112,7 @@ type AzureConfig struct {
 	VnetResourceGroup            string `json:"vnetResourceGroup"`
 	SubnetName                   string `json:"subnetName"`
 	SecurityGroupName            string `json:"securityGroupName"`
+	SecurityGroupResourceGroup   string `json:"securityGroupResourceGroup"`
 	RouteTableName               string `json:"routeTableName"`
 	CloudProviderBackoff         bool   `json:"cloudProviderBackoff"`
 	CloudProviderBackoffDuration int    `json:"cloudProviderBackoffDuration"`

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2542,16 +2542,15 @@ In ARO HCP, this will be the ID of the customer provided VNET.</p>
 </tr>
 <tr>
 <td>
-<code>subnetName</code></br>
+<code>subnetID</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>SubnetName is the name of an existing subnet in VnetName / VnetID where Azure CCM will find an existing load
-balancer to be used for node egress.</p>
-<p>Example: if your SubnetID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>,
-your SubnetName is <subnetName></p>
+<p>SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
+subnet ID is expected to be a subnet within the VnetID / VnetName.
+In ARO HCP, managed services will create the aforementioned load balancer.</p>
 </td>
 </tr>
 <tr>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2578,17 +2578,14 @@ string
 </tr>
 <tr>
 <td>
-<code>securityGroupName</code></br>
+<code>securityGroupID</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>SecurityGroupName is the name of an existing security group on SubnetName. This field is provided as part of the
+<p>SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
 configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).</p>
-<p>Example: if your Network Security Group ID is /subscriptions/<subscriptionID>/resourcegroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<securityGroupName>,
-your SecurityGroupName is <securityGroupName></p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2513,21 +2513,6 @@ ResourceGroupName is <resourceGroupName>.</p>
 </tr>
 <tr>
 <td>
-<code>vnetName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>VnetName is the resource name of an existing VNET to use in creating VMs. If this field is included, it should
-be the resource name matching the VnetID.
-In ARO HCP, this will be the name of the customer provided VNET.</p>
-<p>Example: if your VNET ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>,
-your VnetName is <vnetName></p>
-</td>
-</tr>
-<tr>
-<td>
 <code>vnetID</code></br>
 <em>
 string

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2448,8 +2448,7 @@ string
 <p>AzurePlatformSpec specifies configuration for clusters running on Azure. Generally, the HyperShift API assumes bring
 your own (BYO) cloud infrastructure resources. For example, resources like a resource group, a subnet, or a vnet
 would be pre-created and then their names would be used respectively in the ResourceGroupName, SubnetName, VnetName
-fields of the Hosted Cluster CR. An existing cloud resource is expected to exist under the same SubscriptionID and
-within the same ResourceGroupName.</p>
+fields of the Hosted Cluster CR. An existing cloud resource is expected to exist under the same SubscriptionID.</p>
 </p>
 <table>
 <thead>
@@ -2505,8 +2504,9 @@ string
 </td>
 <td>
 <p>ResourceGroupName is the name of an existing resource group where all cloud resources created by the Hosted
-Cluster are to be placed.
-In ARO HCP, this will be the managed resource group where customer cloud resources will be created.</p>
+Cluster are to be placed. The resource group is expected to exist under the same subscription as SubscriptionID.</p>
+<p>In ARO HCP, this will be the managed resource group where customer cloud resources will be created.</p>
+<p>Resource group naming requirements can be found here: <a href="https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/">https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/</a>.</p>
 <p>Example: if your resource group ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>, your
 ResourceGroupName is <resourceGroupName>.</p>
 </td>
@@ -2519,9 +2519,10 @@ string
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>VnetID is the ID of an existing VNET to use in creating VMs.
-In ARO HCP, this will be the ID of the customer provided VNET.</p>
+<p>VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
+other than the one specified in ResourceGroupName, but it must exist under the same subscription as
+SubscriptionID.</p>
+<p>In ARO HCP, this will be the ID of the customer provided VNET.</p>
 <p>Example: /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName></p>
 </td>
 </tr>
@@ -2534,8 +2535,9 @@ string
 </td>
 <td>
 <p>SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
-subnet ID is expected to be a subnet within the VnetID / VnetName.
-In ARO HCP, managed services will create the aforementioned load balancer.</p>
+subnet is expected to be a subnet within the VNET specified in VnetID. This subnet is expected to exist under the
+same subscription as SubscriptionID.</p>
+<p>In ARO HCP, managed services will create the aforementioned load balancer in ResourceGroupName.</p>
 </td>
 </tr>
 <tr>
@@ -2570,7 +2572,9 @@ string
 </td>
 <td>
 <p>SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
-configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).</p>
+configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
+expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
+in.</p>
 </td>
 </tr>
 </tbody>

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -389,7 +389,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				ResourceGroupName: o.Azure.ResourceGroupName,
 				VnetName:          o.Azure.VnetName,
 				VnetID:            o.Azure.VnetID,
-				SubnetName:        o.Azure.SubnetName,
+				SubnetID:          o.Azure.SubnetID,
 				SubscriptionID:    o.Azure.Creds.SubscriptionID,
 				MachineIdentityID: o.Azure.MachineIdentityID,
 				SecurityGroupName: o.Azure.SecurityGroupName,

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -384,15 +384,14 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		platformSpec = hyperv1.PlatformSpec{
 			Type: hyperv1.AzurePlatform,
 			Azure: &hyperv1.AzurePlatformSpec{
-				Credentials:       corev1.LocalObjectReference{Name: credentialSecret.Name},
-				Location:          o.Azure.Location,
-				ResourceGroupName: o.Azure.ResourceGroupName,
-				VnetName:          o.Azure.VnetName,
-				VnetID:            o.Azure.VnetID,
-				SubnetID:          o.Azure.SubnetID,
-				SubscriptionID:    o.Azure.Creds.SubscriptionID,
-				MachineIdentityID: o.Azure.MachineIdentityID,
-				SecurityGroupName: o.Azure.SecurityGroupName,
+				Credentials:           corev1.LocalObjectReference{Name: credentialSecret.Name},
+				Location:              o.Azure.Location,
+				ResourceGroupName:     o.Azure.ResourceGroupName,
+				VnetID:                o.Azure.VnetID,
+				SubnetID:              o.Azure.SubnetID,
+				SubscriptionID:        o.Azure.Creds.SubscriptionID,
+				MachineIdentityID:     o.Azure.MachineIdentityID,
+				SecurityGroupID:       o.Azure.SecurityGroupID,
 			},
 		}
 

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -384,14 +384,14 @@ func (o ExampleOptions) Resources() *ExampleResources {
 		platformSpec = hyperv1.PlatformSpec{
 			Type: hyperv1.AzurePlatform,
 			Azure: &hyperv1.AzurePlatformSpec{
-				Credentials:           corev1.LocalObjectReference{Name: credentialSecret.Name},
-				Location:              o.Azure.Location,
-				ResourceGroupName:     o.Azure.ResourceGroupName,
-				VnetID:                o.Azure.VnetID,
-				SubnetID:              o.Azure.SubnetID,
-				SubscriptionID:        o.Azure.Creds.SubscriptionID,
-				MachineIdentityID:     o.Azure.MachineIdentityID,
-				SecurityGroupID:       o.Azure.SecurityGroupID,
+				Credentials:       corev1.LocalObjectReference{Name: credentialSecret.Name},
+				Location:          o.Azure.Location,
+				ResourceGroupName: o.Azure.ResourceGroupName,
+				VnetID:            o.Azure.VnetID,
+				SubnetID:          o.Azure.SubnetID,
+				SubscriptionID:    o.Azure.Creds.SubscriptionID,
+				MachineIdentityID: o.Azure.MachineIdentityID,
+				SecurityGroupID:   o.Azure.SecurityGroupID,
 			},
 		}
 

--- a/examples/fixtures/example_azure.go
+++ b/examples/fixtures/example_azure.go
@@ -13,7 +13,7 @@ type ExampleAzureOptions struct {
 	BootImageID            string
 	MachineIdentityID      string
 	InstanceType           string
-	SecurityGroupName      string
+	SecurityGroupID        string
 	DiskSizeGB             int32
 	AvailabilityZones      []string
 	DiskEncryptionSetID    string

--- a/examples/fixtures/example_azure.go
+++ b/examples/fixtures/example_azure.go
@@ -6,7 +6,6 @@ type ExampleAzureOptions struct {
 	Creds                  util.AzureCreds
 	Location               string
 	ResourceGroupName      string
-	VnetName               string
 	VnetID                 string
 	SubnetID               string
 	SubnetName             string

--- a/examples/fixtures/example_azure.go
+++ b/examples/fixtures/example_azure.go
@@ -8,6 +8,7 @@ type ExampleAzureOptions struct {
 	ResourceGroupName      string
 	VnetName               string
 	VnetID                 string
+	SubnetID               string
 	SubnetName             string
 	BootImageID            string
 	MachineIdentityID      string

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -40832,7 +40832,7 @@ objects:
                           type: string
                         resourceGroup:
                           type: string
-                        securityGroupName:
+                        securityGroupID:
                           type: string
                         subnetID:
                           type: string
@@ -40847,7 +40847,7 @@ objects:
                       - location
                       - machineIdentityID
                       - resourceGroup
-                      - securityGroupName
+                      - securityGroupID
                       - subnetID
                       - subscriptionID
                       - vnetID
@@ -45256,17 +45256,13 @@ objects:
                           x-kubernetes-validations:
                           - message: ResourceGroupName is immutable
                             rule: self == oldSelf
-                        securityGroupName:
+                        securityGroupID:
                           description: |-
-                            SecurityGroupName is the name of an existing security group on SubnetName. This field is provided as part of the
+                            SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
                             configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
-
-
-                            Example: if your Network Security Group ID is /subscriptions/<subscriptionID>/resourcegroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<securityGroupName>,
-                                     your SecurityGroupName is <securityGroupName>
                           type: string
                           x-kubernetes-validations:
-                          - message: SecurityGroupName is immutable
+                          - message: SecurityGroupID is immutable
                             rule: self == oldSelf
                         subnetID:
                           description: |-
@@ -49830,7 +49826,7 @@ objects:
                           type: string
                         resourceGroup:
                           type: string
-                        securityGroupName:
+                        securityGroupID:
                           type: string
                         subnetID:
                           type: string
@@ -49845,7 +49841,7 @@ objects:
                       - location
                       - machineIdentityID
                       - resourceGroup
-                      - securityGroupName
+                      - securityGroupID
                       - subnetID
                       - subscriptionID
                       - vnetID
@@ -54237,17 +54233,13 @@ objects:
                           x-kubernetes-validations:
                           - message: ResourceGroupName is immutable
                             rule: self == oldSelf
-                        securityGroupName:
+                        securityGroupID:
                           description: |-
-                            SecurityGroupName is the name of an existing security group on SubnetName. This field is provided as part of the
+                            SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
                             configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
-
-
-                            Example: if your Network Security Group ID is /subscriptions/<subscriptionID>/resourcegroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<securityGroupName>,
-                                     your SecurityGroupName is <securityGroupName>
                           type: string
                           x-kubernetes-validations:
-                          - message: SecurityGroupName is immutable
+                          - message: SecurityGroupID is immutable
                             rule: self == oldSelf
                         subnetID:
                           description: |-

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -40828,8 +40828,6 @@ objects:
                           type: string
                         machineIdentityID:
                           type: string
-                        networkResourceGroupName:
-                          type: string
                         resourceGroup:
                           type: string
                         securityGroupID:
@@ -40840,8 +40838,6 @@ objects:
                           type: string
                         vnetID:
                           type: string
-                        vnetName:
-                          type: string
                       required:
                       - credentials
                       - location
@@ -40851,7 +40847,6 @@ objects:
                       - subnetID
                       - subscriptionID
                       - vnetID
-                      - vnetName
                       type: object
                     ibmcloud:
                       description: IBMCloud defines IBMCloud specific settings for
@@ -45234,24 +45229,22 @@ objects:
                           description: MachineIdentityID is used as the user-assigned
                             identity to be assigned to the VMs
                           type: string
-                        networkResourceGroupName:
-                          description: |-
-                            NetworkResourceGroupName is the name of an existing resource group provided by a client; it is expected to contain
-                            an existing, pre-setup VNET, Subnet and NSG. This field is only used by ARO HCP.
-                          type: string
-                          x-kubernetes-validations:
-                          - message: NetworkResourceGroupName is immutable
-                            rule: self == oldSelf
                         resourceGroup:
                           default: default
                           description: |-
                             ResourceGroupName is the name of an existing resource group where all cloud resources created by the Hosted
-                            Cluster are to be placed.
+                            Cluster are to be placed. The resource group is expected to exist under the same subscription as SubscriptionID.
+
+
                             In ARO HCP, this will be the managed resource group where customer cloud resources will be created.
+
+
+                            Resource group naming requirements can be found here: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/.
 
 
                             Example: if your resource group ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>, your
                                      ResourceGroupName is <resourceGroupName>.
+                          pattern: ^[a-zA-Z0-9_()\-\.]{1,89}[a-zA-Z0-9_()\-]$
                           type: string
                           x-kubernetes-validations:
                           - message: ResourceGroupName is immutable
@@ -45259,7 +45252,9 @@ objects:
                         securityGroupID:
                           description: |-
                             SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
-                            configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
+                            configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
+                            expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
+                            in.
                           type: string
                           x-kubernetes-validations:
                           - message: SecurityGroupID is immutable
@@ -45267,8 +45262,11 @@ objects:
                         subnetID:
                           description: |-
                             SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
-                            subnet ID is expected to be a subnet within the VnetID / VnetName.
-                            In ARO HCP, managed services will create the aforementioned load balancer.
+                            subnet is expected to be a subnet within the VNET specified in VnetID. This subnet is expected to exist under the
+                            same subscription as SubscriptionID.
+
+
+                            In ARO HCP, managed services will create the aforementioned load balancer in ResourceGroupName.
                           type: string
                           x-kubernetes-validations:
                           - message: SubnetID is immutable
@@ -45282,7 +45280,11 @@ objects:
                             rule: self == oldSelf
                         vnetID:
                           description: |-
-                            VnetID is the ID of an existing VNET to use in creating VMs.
+                            VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
+                            other than the one specified in ResourceGroupName, but it must exist under the same subscription as
+                            SubscriptionID.
+
+
                             In ARO HCP, this will be the ID of the customer provided VNET.
 
 
@@ -45291,26 +45293,12 @@ objects:
                           x-kubernetes-validations:
                           - message: VnetID is immutable
                             rule: self == oldSelf
-                        vnetName:
-                          description: |-
-                            VnetName is the resource name of an existing VNET to use in creating VMs. If this field is included, it should
-                            be the resource name matching the VnetID.
-                            In ARO HCP, this will be the name of the customer provided VNET.
-
-
-                            Example: if your VNET ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>,
-                                     your VnetName is <vnetName>
-                          type: string
-                          x-kubernetes-validations:
-                          - message: VnetName is immutable
-                            rule: self == oldSelf
                       required:
                       - credentials
                       - location
                       - resourceGroup
                       - subnetID
                       - subscriptionID
-                      - vnetName
                       type: object
                     ibmcloud:
                       description: IBMCloud defines IBMCloud specific settings for
@@ -49822,8 +49810,6 @@ objects:
                           type: string
                         machineIdentityID:
                           type: string
-                        networkResourceGroupName:
-                          type: string
                         resourceGroup:
                           type: string
                         securityGroupID:
@@ -49834,8 +49820,6 @@ objects:
                           type: string
                         vnetID:
                           type: string
-                        vnetName:
-                          type: string
                       required:
                       - credentials
                       - location
@@ -49845,7 +49829,6 @@ objects:
                       - subnetID
                       - subscriptionID
                       - vnetID
-                      - vnetName
                       type: object
                     ibmcloud:
                       description: IBMCloud defines IBMCloud specific settings for
@@ -54211,24 +54194,22 @@ objects:
                           description: MachineIdentityID is used as the user-assigned
                             identity to be assigned to the VMs
                           type: string
-                        networkResourceGroupName:
-                          description: |-
-                            NetworkResourceGroupName is the name of an existing resource group provided by a client; it is expected to contain
-                            an existing, pre-setup VNET, Subnet and NSG. This field is only used by ARO HCP.
-                          type: string
-                          x-kubernetes-validations:
-                          - message: NetworkResourceGroupName is immutable
-                            rule: self == oldSelf
                         resourceGroup:
                           default: default
                           description: |-
                             ResourceGroupName is the name of an existing resource group where all cloud resources created by the Hosted
-                            Cluster are to be placed.
+                            Cluster are to be placed. The resource group is expected to exist under the same subscription as SubscriptionID.
+
+
                             In ARO HCP, this will be the managed resource group where customer cloud resources will be created.
+
+
+                            Resource group naming requirements can be found here: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/.
 
 
                             Example: if your resource group ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>, your
                                      ResourceGroupName is <resourceGroupName>.
+                          pattern: ^[a-zA-Z0-9_()\-\.]{1,89}[a-zA-Z0-9_()\-]$
                           type: string
                           x-kubernetes-validations:
                           - message: ResourceGroupName is immutable
@@ -54236,7 +54217,9 @@ objects:
                         securityGroupID:
                           description: |-
                             SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
-                            configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
+                            configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
+                            expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
+                            in.
                           type: string
                           x-kubernetes-validations:
                           - message: SecurityGroupID is immutable
@@ -54244,8 +54227,11 @@ objects:
                         subnetID:
                           description: |-
                             SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
-                            subnet ID is expected to be a subnet within the VnetID / VnetName.
-                            In ARO HCP, managed services will create the aforementioned load balancer.
+                            subnet is expected to be a subnet within the VNET specified in VnetID. This subnet is expected to exist under the
+                            same subscription as SubscriptionID.
+
+
+                            In ARO HCP, managed services will create the aforementioned load balancer in ResourceGroupName.
                           type: string
                           x-kubernetes-validations:
                           - message: SubnetID is immutable
@@ -54259,7 +54245,11 @@ objects:
                             rule: self == oldSelf
                         vnetID:
                           description: |-
-                            VnetID is the ID of an existing VNET to use in creating VMs.
+                            VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
+                            other than the one specified in ResourceGroupName, but it must exist under the same subscription as
+                            SubscriptionID.
+
+
                             In ARO HCP, this will be the ID of the customer provided VNET.
 
 
@@ -54268,26 +54258,12 @@ objects:
                           x-kubernetes-validations:
                           - message: VnetID is immutable
                             rule: self == oldSelf
-                        vnetName:
-                          description: |-
-                            VnetName is the resource name of an existing VNET to use in creating VMs. If this field is included, it should
-                            be the resource name matching the VnetID.
-                            In ARO HCP, this will be the name of the customer provided VNET.
-
-
-                            Example: if your VNET ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>,
-                                     your VnetName is <vnetName>
-                          type: string
-                          x-kubernetes-validations:
-                          - message: VnetName is immutable
-                            rule: self == oldSelf
                       required:
                       - credentials
                       - location
                       - resourceGroup
                       - subnetID
                       - subscriptionID
-                      - vnetName
                       type: object
                     ibmcloud:
                       description: IBMCloud defines IBMCloud specific settings for

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -40828,11 +40828,13 @@ objects:
                           type: string
                         machineIdentityID:
                           type: string
+                        networkResourceGroupName:
+                          type: string
                         resourceGroup:
                           type: string
                         securityGroupName:
                           type: string
-                        subnetName:
+                        subnetID:
                           type: string
                         subscriptionID:
                           type: string
@@ -40846,7 +40848,7 @@ objects:
                       - machineIdentityID
                       - resourceGroup
                       - securityGroupName
-                      - subnetName
+                      - subnetID
                       - subscriptionID
                       - vnetID
                       - vnetName
@@ -45232,6 +45234,14 @@ objects:
                           description: MachineIdentityID is used as the user-assigned
                             identity to be assigned to the VMs
                           type: string
+                        networkResourceGroupName:
+                          description: |-
+                            NetworkResourceGroupName is the name of an existing resource group provided by a client; it is expected to contain
+                            an existing, pre-setup VNET, Subnet and NSG. This field is only used by ARO HCP.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: NetworkResourceGroupName is immutable
+                            rule: self == oldSelf
                         resourceGroup:
                           default: default
                           description: |-
@@ -49816,11 +49826,13 @@ objects:
                           type: string
                         machineIdentityID:
                           type: string
+                        networkResourceGroupName:
+                          type: string
                         resourceGroup:
                           type: string
                         securityGroupName:
                           type: string
-                        subnetName:
+                        subnetID:
                           type: string
                         subscriptionID:
                           type: string
@@ -49834,7 +49846,7 @@ objects:
                       - machineIdentityID
                       - resourceGroup
                       - securityGroupName
-                      - subnetName
+                      - subnetID
                       - subscriptionID
                       - vnetID
                       - vnetName
@@ -54203,6 +54215,14 @@ objects:
                           description: MachineIdentityID is used as the user-assigned
                             identity to be assigned to the VMs
                           type: string
+                        networkResourceGroupName:
+                          description: |-
+                            NetworkResourceGroupName is the name of an existing resource group provided by a client; it is expected to contain
+                            an existing, pre-setup VNET, Subnet and NSG. This field is only used by ARO HCP.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: NetworkResourceGroupName is immutable
+                            rule: self == oldSelf
                         resourceGroup:
                           default: default
                           description: |-

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -45258,15 +45258,6 @@ objects:
                           x-kubernetes-validations:
                           - message: SecurityGroupName is immutable
                             rule: self == oldSelf
-                        subnetName:
-                          default: default
-                          description: |-
-                            SubnetName is the name of an existing subnet in VnetName / VnetID where Azure CCM will find an existing load
-                            balancer to be used for node egress.
-
-
-                            Example: if your SubnetID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>,
-                                     your SubnetName is <subnetName>
                         subnetID:
                           description: |-
                             SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
@@ -45311,7 +45302,6 @@ objects:
                       - credentials
                       - location
                       - resourceGroup
-                      - securityGroupName
                       - subnetID
                       - subscriptionID
                       - vnetName
@@ -54236,6 +54226,9 @@ objects:
                             Example: if your Network Security Group ID is /subscriptions/<subscriptionID>/resourcegroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<securityGroupName>,
                                      your SecurityGroupName is <securityGroupName>
                           type: string
+                          x-kubernetes-validations:
+                          - message: SecurityGroupName is immutable
+                            rule: self == oldSelf
                         subnetID:
                           description: |-
                             SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
@@ -54280,7 +54273,6 @@ objects:
                       - credentials
                       - location
                       - resourceGroup
-                      - securityGroupName
                       - subnetID
                       - subscriptionID
                       - vnetName

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -45267,7 +45267,15 @@ objects:
 
                             Example: if your SubnetID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>,
                                      your SubnetName is <subnetName>
+                        subnetID:
+                          description: |-
+                            SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
+                            subnet ID is expected to be a subnet within the VnetID / VnetName.
+                            In ARO HCP, managed services will create the aforementioned load balancer.
                           type: string
+                          x-kubernetes-validations:
+                          - message: SubnetID is immutable
+                            rule: self == oldSelf
                         subscriptionID:
                           description: SubscriptionID is a unique identifier for an
                             Azure subscription used to manage resources.
@@ -45303,7 +45311,8 @@ objects:
                       - credentials
                       - location
                       - resourceGroup
-                      - subnetName
+                      - securityGroupName
+                      - subnetID
                       - subscriptionID
                       - vnetName
                       type: object
@@ -54227,19 +54236,15 @@ objects:
                             Example: if your Network Security Group ID is /subscriptions/<subscriptionID>/resourcegroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<securityGroupName>,
                                      your SecurityGroupName is <securityGroupName>
                           type: string
-                          x-kubernetes-validations:
-                          - message: SecurityGroupName is immutable
-                            rule: self == oldSelf
-                        subnetName:
-                          default: default
+                        subnetID:
                           description: |-
-                            SubnetName is the name of an existing subnet in VnetName / VnetID where Azure CCM will find an existing load
-                            balancer to be used for node egress.
-
-
-                            Example: if your SubnetID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>,
-                                     your SubnetName is <subnetName>
+                            SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
+                            subnet ID is expected to be a subnet within the VnetID / VnetName.
+                            In ARO HCP, managed services will create the aforementioned load balancer.
                           type: string
+                          x-kubernetes-validations:
+                          - message: SubnetID is immutable
+                            rule: self == oldSelf
                         subscriptionID:
                           description: SubscriptionID is a unique identifier for an
                             Azure subscription used to manage resources.
@@ -54275,7 +54280,8 @@ objects:
                       - credentials
                       - location
                       - resourceGroup
-                      - subnetName
+                      - securityGroupName
+                      - subnetID
                       - subscriptionID
                       - vnetName
                       type: object

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -229,6 +229,11 @@ func reconcileAzureCluster(azureCluster *capiazure.AzureCluster, hcluster *hyper
 	azureCluster.Spec.NetworkSpec.NodeOutboundLB.Name = hcluster.Spec.InfraID
 	azureCluster.Spec.NetworkSpec.NodeOutboundLB.BackendPool.Name = hcluster.Spec.InfraID
 
+	// In ARO HCP, the VNET, subnet, and NSG will be provided by and exist in the vnet resource group.
+	if hcluster.Spec.Platform.Azure.VnetResourceGroupName != "" {
+		azureCluster.Spec.NetworkSpec.Vnet.ResourceGroup = hcluster.Spec.Platform.Azure.VnetResourceGroupName
+	}
+
 	azureCluster.Spec.ControlPlaneEndpoint = capiv1.APIEndpoint{
 		Host: apiEndpoint.Host,
 		Port: apiEndpoint.Port,

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -216,23 +217,22 @@ func reconcileAzureCluster(azureCluster *capiazure.AzureCluster, hcluster *hyper
 	if azureCluster.Annotations == nil {
 		azureCluster.Annotations = map[string]string{}
 	}
-
 	azureCluster.Annotations[capiv1.ManagedByAnnotation] = "external"
+
+	vnetName, vnetResourceGroup, err := azureutil.GetVnetNameAndResourceGroupFromVnetID(hcluster.Spec.Platform.Azure.VnetID)
+	if err != nil {
+		return err
+	}
 
 	azureCluster.Spec.Location = hcluster.Spec.Platform.Azure.Location
 	azureCluster.Spec.ResourceGroup = hcluster.Spec.Platform.Azure.ResourceGroupName
 	azureCluster.Spec.NetworkSpec.Vnet.ID = hcluster.Spec.Platform.Azure.VnetID
-	azureCluster.Spec.NetworkSpec.Vnet.Name = hcluster.Spec.Platform.Azure.VnetName
-	azureCluster.Spec.NetworkSpec.Vnet.ResourceGroup = hcluster.Spec.Platform.Azure.ResourceGroupName
+	azureCluster.Spec.NetworkSpec.Vnet.Name = vnetName
+	azureCluster.Spec.NetworkSpec.Vnet.ResourceGroup = vnetResourceGroup
 	azureCluster.Spec.SubscriptionID = hcluster.Spec.Platform.Azure.SubscriptionID
 	azureCluster.Spec.NetworkSpec.NodeOutboundLB = &capiazure.LoadBalancerSpec{}
 	azureCluster.Spec.NetworkSpec.NodeOutboundLB.Name = hcluster.Spec.InfraID
 	azureCluster.Spec.NetworkSpec.NodeOutboundLB.BackendPool.Name = hcluster.Spec.InfraID
-
-	// In ARO HCP, the VNET, subnet, and NSG will be provided by and exist in the vnet resource group.
-	if hcluster.Spec.Platform.Azure.VnetResourceGroupName != "" {
-		azureCluster.Spec.NetworkSpec.Vnet.ResourceGroup = hcluster.Spec.Platform.Azure.VnetResourceGroupName
-	}
 
 	azureCluster.Spec.ControlPlaneEndpoint = capiv1.APIEndpoint{
 		Host: apiEndpoint.Host,

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -1,9 +1,13 @@
 package azureutil
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 )
 
 // GetSubnetNameFromSubnetID extracts the subnet name from a subnet ID
@@ -12,6 +16,10 @@ func GetSubnetNameFromSubnetID(subnetID string) (string, error) {
 	subnet, err := arm.ParseResourceID(subnetID)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse subnet ID %q: %v", subnetID, err)
+	}
+
+	if !strings.EqualFold(subnet.ResourceType.Type, "virtualnetworks/subnets") {
+		return "", fmt.Errorf("invalid resource type '%s', expected 'virtualNetworks/subnets'", subnet.ResourceType.Type)
 	}
 
 	if subnet.Name == "" {
@@ -29,9 +37,99 @@ func GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(nsgID string) (string
 		return "", fmt.Errorf("failed to parse network security group ID %q: %v", nsgID, err)
 	}
 
+	if !strings.EqualFold(nsg.ResourceType.Type, "networkSecurityGroups") {
+		return "", fmt.Errorf("invalid resource type '%s', expected 'networkSecurityGroups'", nsg.ResourceType.Type)
+	}
+
 	if nsg.Name == "" {
 		return "", fmt.Errorf("failed to parse network security group name from %q", nsgID)
 	}
 
 	return nsg.Name, nil
+}
+
+// GetVnetNameAndResourceGroupFromVnetID extracts the VNET name and its resource group from a VNET ID
+// Example VNET ID: /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>
+func GetVnetNameAndResourceGroupFromVnetID(vnetID string) (string, string, error) {
+	vnet, err := arm.ParseResourceID(vnetID)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse vnet ID %q: %v", vnetID, err)
+	}
+
+	if !strings.EqualFold(vnet.ResourceType.Type, "virtualNetworks") {
+		return "", "", fmt.Errorf("invalid resource type '%s', expected 'virtualNetworks'", vnet.ResourceType.Type)
+	}
+
+	if vnet.Name == "" {
+		return "", "", fmt.Errorf("failed to parse vnet name from %q", vnetID)
+	}
+
+	if vnet.ResourceGroupName == "" {
+		return "", "", fmt.Errorf("failed to parse vnet resource group name from %q", vnetID)
+	}
+
+	return vnet.Name, vnet.ResourceGroupName, nil
+}
+
+// GetVnetInfoFromVnetID extracts the full information on a VNET from a VNET ID by first getting the VNET name and
+// its resource group's name and then using those parameters to query the full information on the VNET using Azure's SDK
+func GetVnetInfoFromVnetID(ctx context.Context, vnetID string, subscriptionID string, azureCreds azcore.TokenCredential) (armnetwork.VirtualNetworksClientGetResponse, error) {
+	partialVnetInfo, err := arm.ParseResourceID(vnetID)
+	if err != nil {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("failed to parse vnet information from vnet ID %q: %v", vnetID, err)
+	}
+
+	if !strings.EqualFold(partialVnetInfo.ResourceType.Type, "virtualNetworks") {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("invalid resource type '%s', expected 'virtualNetworks'", partialVnetInfo.ResourceType.Type)
+	}
+
+	if partialVnetInfo.Name == "" {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("failed to parse vnet name from %q", vnetID)
+	}
+
+	if partialVnetInfo.ResourceGroupName == "" {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("failed to parse vnet resource group name from %q", vnetID)
+	}
+
+	vnet, err := getFullVnetInfo(ctx, subscriptionID, partialVnetInfo.ResourceGroupName, partialVnetInfo.Name, azureCreds)
+	if err != nil {
+		return armnetwork.VirtualNetworksClientGetResponse{}, err
+	}
+
+	return vnet, nil
+}
+
+// getFullVnetInfo gets the full information on a VNET
+func getFullVnetInfo(ctx context.Context, subscriptionID string, vnetResourceGroupName string, clientVnetName string, azureCreds azcore.TokenCredential) (armnetwork.VirtualNetworksClientGetResponse, error) {
+	networksClient, err := armnetwork.NewVirtualNetworksClient(subscriptionID, azureCreds, nil)
+	if err != nil {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("failed to create new virtual networks client: %w", err)
+	}
+
+	vnet, err := networksClient.Get(ctx, vnetResourceGroupName, clientVnetName, nil)
+	if err != nil {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("failed to get virtual network: %w", err)
+	}
+
+	if vnet.ID == nil {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("virtual network has no ID")
+	}
+
+	if vnet.Name == nil {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("virtual network has no name")
+	}
+
+	if vnet.Properties.Subnets == nil || len(vnet.Properties.Subnets) == 0 {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("no subnets found for resource group '%s'", vnetResourceGroupName)
+	}
+
+	if vnet.Properties.Subnets[0].ID == nil {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("no subnet ID found for resource group '%s'", vnetResourceGroupName)
+	}
+
+	if vnet.Properties.Subnets[0].Name == nil {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("no subnet name found for resource group '%s'", vnetResourceGroupName)
+	}
+
+	return vnet, nil
 }

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -1,0 +1,22 @@
+package azureutil
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+)
+
+// GetSubnetNameFromSubnetID extracts the subnet name from a subnet ID
+// Example subnet ID: /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>
+func GetSubnetNameFromSubnetID(subnetID string) (string, error) {
+	subnet, err := arm.ParseResourceID(subnetID)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse subnet ID %q: %v", subnetID, err)
+	}
+
+	if subnet.Name == "" {
+		return "", fmt.Errorf("failed to parse subnet name from %q", subnetID)
+	}
+
+	return subnet.Name, nil
+}

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -20,3 +20,18 @@ func GetSubnetNameFromSubnetID(subnetID string) (string, error) {
 
 	return subnet.Name, nil
 }
+
+// GetNetworkSecurityGroupNameFromNetworkSecurityGroupID extracts the network security group (nsg) name from a nsg ID
+// Example nsg ID: /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<nsgName>
+func GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(nsgID string) (string, error) {
+	nsg, err := arm.ParseResourceID(nsgID)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse network security group ID %q: %v", nsgID, err)
+	}
+
+	if nsg.Name == "" {
+		return "", fmt.Errorf("failed to parse network security group name from %q", nsgID)
+	}
+
+	return nsg.Name, nil
+}

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -46,3 +46,44 @@ func TestGetSubnetNameFromSubnetID(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNetworkSecurityGroupNameFromNetworkSecurityGroupID(t *testing.T) {
+	tests := []struct {
+		testCaseName    string
+		nsgID           string
+		expectedNSGName string
+		expectedErr     bool
+	}{
+		{
+			testCaseName:    "empty NSG ID",
+			nsgID:           "",
+			expectedNSGName: "",
+			expectedErr:     true,
+		},
+		{
+			testCaseName:    "improperly formed nsg ID",
+			nsgID:           "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/networkSecurityGroups",
+			expectedNSGName: "",
+			expectedErr:     true,
+		},
+		{
+			testCaseName:    "properly formed nsg ID",
+			nsgID:           "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/networkSecurityGroups/myNSGName",
+			expectedNSGName: "myNSGName",
+			expectedErr:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.testCaseName, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			subnetID, err := GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(tc.nsgID)
+			if tc.expectedErr {
+				g.Expect(err).To(Not(BeNil()))
+				g.Expect(err).To(HaveOccurred(), "invalid nsg ID format: "+tc.nsgID)
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(subnetID).To(Equal(tc.expectedNSGName))
+			}
+		})
+	}
+}

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -1,0 +1,48 @@
+package azureutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetSubnetNameFromSubnetID(t *testing.T) {
+	tests := []struct {
+		testCaseName       string
+		subnetID           string
+		expectedSubnetName string
+		expectedErr        bool
+	}{
+		{
+			testCaseName:       "empty subnet ID",
+			subnetID:           "",
+			expectedSubnetName: "",
+			expectedErr:        true,
+		},
+		{
+			testCaseName:       "improperly formed subnet ID",
+			subnetID:           "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/virtualNetworks/myVnetName/subnets",
+			expectedSubnetName: "",
+			expectedErr:        true,
+		},
+		{
+			testCaseName:       "properly formed subnet ID",
+			subnetID:           "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/virtualNetworks/myVnetName/subnets/mySubnetName",
+			expectedSubnetName: "mySubnetName",
+			expectedErr:        false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.testCaseName, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			subnetID, err := GetSubnetNameFromSubnetID(tc.subnetID)
+			if tc.expectedErr {
+				g.Expect(err).To(Not(BeNil()))
+				g.Expect(err).To(HaveOccurred(), "invalid subnet ID format: "+tc.subnetID)
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(subnetID).To(Equal(tc.expectedSubnetName))
+			}
+		})
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -464,7 +464,6 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 			CredentialsFile: o.configurableClusterOptions.AzureCredentialsFile,
 			Location:        o.configurableClusterOptions.AzureLocation,
 			InstanceType:    "Standard_D4s_v4",
-			SubnetName:      "default",
 			DiskSizeGB:      120,
 		},
 		PowerVSPlatform: core.PowerVSPlatformOptions{

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1565,7 +1565,6 @@ type AzurePlatformSpec struct {
 	Cloud             string `json:"cloud,omitempty"`
 	Location          string `json:"location"`
 	ResourceGroupName string `json:"resourceGroup"`
-	VnetName          string `json:"vnetName"`
 	VnetID            string `json:"vnetID"`
 	SubnetID          string `json:"subnetID"`
 	SubscriptionID    string `json:"subscriptionID"`

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1570,7 +1570,7 @@ type AzurePlatformSpec struct {
 	SubnetID          string `json:"subnetID"`
 	SubscriptionID    string `json:"subscriptionID"`
 	MachineIdentityID string `json:"machineIdentityID"`
-	SecurityGroupName string `json:"securityGroupName"`
+	SecurityGroupID   string `json:"securityGroupID"`
 }
 
 // Release represents the metadata for an OCP release payload image.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1567,7 +1567,7 @@ type AzurePlatformSpec struct {
 	ResourceGroupName string `json:"resourceGroup"`
 	VnetName          string `json:"vnetName"`
 	VnetID            string `json:"vnetID"`
-	SubnetName        string `json:"subnetName"`
+	SubnetID          string `json:"subnetID"`
 	SubscriptionID    string `json:"subscriptionID"`
 	MachineIdentityID string `json:"machineIdentityID"`
 	SecurityGroupName string `json:"securityGroupName"`

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1779,16 +1779,14 @@ type AzurePlatformSpec struct {
 	// +optional
 	MachineIdentityID string `json:"machineIdentityID,omitempty"`
 
-	// SecurityGroupName is the name of an existing security group on SubnetName. This field is provided as part of the
+	// SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
 	// configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM).
 	//
-	// Example: if your Network Security Group ID is /subscriptions/<subscriptionID>/resourcegroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<securityGroupName>,
-	//          your SecurityGroupName is <securityGroupName>
-	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SecurityGroupName is immutable"
-	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SecurityGroupID is immutable"
+	// +kubebuilder:validation:Required
+	// +required
 	// +immutable
-	SecurityGroupName string `json:"securityGroupName,omitempty"`
+	SecurityGroupID string `json:"securityGroupID,omitempty"`
 }
 
 // Release represents the metadata for an OCP release payload image.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1736,18 +1736,6 @@ type AzurePlatformSpec struct {
 	// +immutable
 	ResourceGroupName string `json:"resourceGroup"`
 
-	// VnetName is the resource name of an existing VNET to use in creating VMs. If this field is included, it should
-	// be the resource name matching the VnetID.
-	// In ARO HCP, this will be the name of the customer provided VNET.
-	//
-	// Example: if your VNET ID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>,
-	//          your VnetName is <vnetName>
-	//
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="VnetName is immutable"
-	// +immutable
-	VnetName string `json:"vnetName"`
-
 	// VnetID is the ID of an existing VNET to use in creating VMs.
 	// In ARO HCP, this will be the ID of the customer provided VNET.
 	//

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1758,15 +1758,14 @@ type AzurePlatformSpec struct {
 	// +immutable
 	VnetID string `json:"vnetID,omitempty"`
 
-	// SubnetName is the name of an existing subnet in VnetName / VnetID where Azure CCM will find an existing load
-	// balancer to be used for node egress.
+	// SubnetID is the subnet ID of an existing subnet where the load balancer for node egress will be created. This
+	// subnet ID is expected to be a subnet within the VnetID / VnetName.
+	// In ARO HCP, managed services will create the aforementioned load balancer.
 	//
-	// Example: if your SubnetID is /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>,
-	//          your SubnetName is <subnetName>
-	//
-	// +kubebuilder:default:=default
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="SubnetID is immutable"
 	// +kubebuilder:validation:Required
-	SubnetName string `json:"subnetName"`
+	// +required
+	SubnetID string `json:"subnetID"`
 
 	// SubscriptionID is a unique identifier for an Azure subscription used to manage resources.
 	//


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR primarily fixes the misunderstand of how a resource group provided by a client will be used in ARO HCP. We originally implemented BYO resource group as a resource group in which to create all cloud infrastructure. That is not correct understanding and not how it will be used in ARO HCP.

The expected setup should be a client brings us a resource group with a existing vnet, subnet, and NSG already setup. ARO HCP would then create a managed resource group with all the cloud infrastructure items in it and use the client's vnet, subnet, and NSG from the provided resource group.

Essentially, this PR:
* removes subnet name from the API in favor of adding the subnet ID in the API instead
* removes the vnet name from the API in favor of using the vnet ID in the API instead
* updates the azure cloud provider config to use the a separate resource group for the vnet and NSG
* updates the HyperShift CLI to use the vnet ID, subnet ID, and NSG ID instead of name
* grabs the resource group the VNET and NSG is in from a VNET ID

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1544](https://issues.redhat.com/browse/HOSTEDCP-1544)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.