### PR TITLE
[release-4.15] OCPBUGS-33207: Remove kube-scheduler readiness probe

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -66,22 +66,6 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			TimeoutSeconds:      5,
 		},
 	}
-	params.ReadinessProbes = config.ReadinessProbes{
-		schedulerContainerMain().Name: {
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/healthz",
-					Port:   intstr.FromInt(schedulerSecurePort),
-					Scheme: corev1.URISchemeHTTPS,
-				},
-			},
-			InitialDelaySeconds: 15,
-			PeriodSeconds:       60,
-			SuccessThreshold:    1,
-			FailureThreshold:    3,
-			TimeoutSeconds:      5,
-		},
-	}
 	params.DeploymentConfig.SetDefaults(hcp, labels, nil)
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.SetDefaultSecurityContext = setDefaultSecurityContext


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/hypershift/pull/3889

/assign jonesbr17