### PR TITLE
OCPBUGS-33101: Fix nil pointer deref when effects not specified in CSC

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -625,7 +625,10 @@ func (r *DedicatedServingComponentSchedulerAndSizer) updateHostedCluster(ctx con
 		hc.Annotations[hyperv1.APICriticalPriorityClass] = *sizeConfig.Effects.APICriticalPriorityClassName
 	}
 
-	resourceRequestAnnotations := resourceRequestsToOverrideAnnotations(sizeConfig.Effects.ResourceRequests)
+	var resourceRequestAnnotations map[string]string
+	if sizeConfig.Effects != nil {
+		resourceRequestAnnotations = resourceRequestsToOverrideAnnotations(sizeConfig.Effects.ResourceRequests)
+	}
 	for k, v := range resourceRequestAnnotations {
 		hc.Annotations[k] = v
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug introduced by #3941 which results in a nil pointer deref when configuration does not contain an 'effects' section.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-33101](https://issues.redhat.com/browse/OCPBUGS-33101)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.