### PR TITLE
OCPBUGS-31398: Recycler-pod image now points to the OCP Payload reference

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2638,7 +2638,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeControllerManager(ctx contex
 
 	recyclerConfig := manifests.RecyclerConfigMap(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, recyclerConfig, func() error {
-		return kcm.ReconcileRecyclerConfig(recyclerConfig, p.OwnerRef)
+		return kcm.ReconcileRecyclerConfig(recyclerConfig, p.OwnerRef, releaseImageProvider)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile kcm recycler config: %w", err)
 	}


### PR DESCRIPTION
Manual cherry-pick from #3901

Which issue(s) this PR fixes:
Original Bug #[OCPBUGS-31398](https://issues.redhat.com/browse/OCPBUGS-31398)