### PR TITLE
CNV-36073: Set time out for external snapshotter on kubevirt csi driver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/controller.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/controller.yaml
@@ -115,6 +115,7 @@ spec:
           - "--v=5"
           - "--csi-address=/csi/csi.sock"
           - "--kubeconfig=/var/run/secrets/tenantcluster/kubeconfig"
+          - "--timeout=3m"
           image: quay.io/openshift/origin-csi-external-snapshotter:latest
           imagePullPolicy: IfNotPresent
           terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
The default timeout is too low in certain cases causing issues. This increases the timeout to 3 minutes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/CNV-36073

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.