### PR TITLE
OCPBUGS-32467: nodepool_controller: add a reconciler for cleanup

### DIFF
--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -42,20 +42,23 @@ func machineHealthCheck(nodePool *hyperv1.NodePool, controlPlaneNamespace string
 	}
 }
 
+const ignitionUserDataPrefix = "user-data"
+
 func IgnitionUserDataSecret(namespace, name, payloadInputHash string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      fmt.Sprintf("user-data-%s-%s", name, payloadInputHash),
-		},
-	}
+	return namedSecret(namespace, fmt.Sprintf("%s-%s-%s", ignitionUserDataPrefix, name, payloadInputHash))
 }
 
+const tokenSecretPrefix = "token"
+
 func TokenSecret(namespace, name, payloadInputHash string) *corev1.Secret {
+	return namedSecret(namespace, fmt.Sprintf("%s-%s-%s", tokenSecretPrefix, name, payloadInputHash))
+}
+
+func namedSecret(namespace, name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      fmt.Sprintf("token-%s-%s", name, payloadInputHash),
+			Name:      name,
 		},
 	}
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -10,19 +10,26 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/api/image/docker10"
 	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/hypershift/support/supportedversion"
+	"github.com/openshift/hypershift/support/testutil"
+	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -37,7 +44,6 @@ import (
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
-	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
@@ -2059,6 +2065,12 @@ func TestGetNodePoolNamespacedName(t *testing.T) {
 }
 
 func TestSetExpirationTimestampOnToken(t *testing.T) {
+	theTime, err := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z")
+	if err != nil {
+		t.Fatalf("could not parse time: %v", err)
+	}
+	fakeClock := testingclock.NewFakeClock(theTime)
+
 	fakeName := "test-token"
 	fakeNamespace := "master-cluster1"
 	fakeCurrentTokenVal := "tokenval1"
@@ -2084,7 +2096,7 @@ func TestSetExpirationTimestampOnToken(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			c := fake.NewClientBuilder().WithObjects(tc.inputSecret).Build()
-			err := setExpirationTimestampOnToken(context.Background(), c, tc.inputSecret)
+			err := setExpirationTimestampOnToken(context.Background(), c, tc.inputSecret, fakeClock.Now)
 			g.Expect(err).To(Not(HaveOccurred()))
 			actualSecretData := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2094,13 +2106,9 @@ func TestSetExpirationTimestampOnToken(t *testing.T) {
 			}
 			err = c.Get(context.Background(), client.ObjectKeyFromObject(actualSecretData), actualSecretData)
 			g.Expect(err).To(Not(HaveOccurred()))
-			rawExpirationTimestamp, ok := actualSecretData.Annotations[hyperv1.IgnitionServerTokenExpirationTimestampAnnotation]
-			g.Expect(ok).To(BeTrue())
-			expirationTimestamp, err := time.Parse(time.RFC3339, rawExpirationTimestamp)
-			g.Expect(err).To(Not(HaveOccurred()))
-			// ensures the 2 hour expiration is active. 119 minutes is one minute less than 2 hours. gives time for
-			// test to run.
-			g.Expect(time.Now().Add(119 * time.Minute).Before(expirationTimestamp)).To(BeTrue())
+			g.Expect(actualSecretData.Annotations).To(testutil.MatchExpected(map[string]string{
+				hyperv1.IgnitionServerTokenExpirationTimestampAnnotation: theTime.Add(2 * time.Hour).Format(time.RFC3339),
+			}))
 		})
 	}
 }
@@ -3306,6 +3314,254 @@ func TestReconcileMachineHealthCheck(t *testing.T) {
 			mhc := &capiv1.MachineHealthCheck{}
 			r.reconcileMachineHealthCheck(context.Background(), mhc, tt.np, tt.hc, "cluster")
 			g.Expect(mhc.Spec).To(testutil.MatchExpected(tt.expected.Spec))
+		})
+	}
+}
+
+func TestSecretJanitor_Reconcile(t *testing.T) {
+	ctx := ctrl.LoggerInto(context.Background(), zapr.NewLogger(zaptest.NewLogger(t)))
+
+	theTime, err := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z")
+	if err != nil {
+		t.Fatalf("could not parse time: %v", err)
+	}
+	fakeClock := testingclock.NewFakeClock(theTime)
+
+	pullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: "myns"},
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: []byte("whatever"),
+		},
+	}
+
+	hostedCluster := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-name", Namespace: "myns"},
+		Spec: hyperv1.HostedClusterSpec{
+			PullSecret: corev1.LocalObjectReference{Name: pullSecret.Name},
+		},
+	}
+
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "nodepool-name", Namespace: "myns"},
+		Spec: hyperv1.NodePoolSpec{
+			ClusterName: hostedCluster.Name,
+			Release:     hyperv1.Release{Image: "fake-release-image"},
+			Config: []corev1.LocalObjectReference{
+				{Name: "machineconfig-1"},
+			},
+		},
+		Status: hyperv1.NodePoolStatus{Version: supportedversion.LatestSupportedVersion.String()},
+	}
+
+	coreMachineConfig := `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: config-1
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+        source: "[Service]\nType=oneshot\nExecStart=/usr/bin/echo Hello World\n\n[Install]\nWantedBy=multi-user.target"
+        filesystem: root
+        mode: 493
+        path: /usr/local/bin/file1.sh
+`
+
+	machineConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machineconfig-1",
+			Namespace: "myns",
+		},
+		Data: map[string]string{
+			TokenSecretConfigKey: coreMachineConfig,
+		},
+	}
+
+	ignitionConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "core-machineconfig",
+			Namespace: "myns-cluster-name",
+			Labels: map[string]string{
+				nodePoolCoreIgnitionConfigLabel: "true",
+			},
+		},
+		Data: map[string]string{
+			TokenSecretConfigKey: coreMachineConfig,
+		},
+	}
+	ignitionConfig2 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "core-machineconfig-2",
+			Namespace: "myns-cluster-name",
+			Labels: map[string]string{
+				nodePoolCoreIgnitionConfigLabel: "true",
+			},
+		},
+		Data: map[string]string{
+			TokenSecretConfigKey: coreMachineConfig,
+		},
+	}
+	ignitionConfig3 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "core-machineconfig-3",
+			Namespace: "myns-cluster-name",
+			Labels: map[string]string{
+				nodePoolCoreIgnitionConfigLabel: "true",
+			},
+		},
+		Data: map[string]string{
+			TokenSecretConfigKey: coreMachineConfig,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(
+		nodePool,
+		hostedCluster,
+		pullSecret,
+		machineConfig,
+		ignitionConfig,
+		ignitionConfig2,
+		ignitionConfig3,
+	).Build()
+	r := secretJanitor{
+		NodePoolReconciler: &NodePoolReconciler{
+			Client:          c,
+			ReleaseProvider: &fakereleaseprovider.FakeReleaseProvider{Version: supportedversion.LatestSupportedVersion.String()},
+			ImageMetadataProvider: &fakeimagemetadataprovider.FakeImageMetadataProvider{Result: &dockerv1client.DockerImageConfig{Config: &docker10.DockerConfig{
+				Labels: map[string]string{},
+			}}},
+		},
+
+		now: fakeClock.Now,
+	}
+
+	for _, testCase := range []struct {
+		name     string
+		input    *corev1.Secret
+		expected *corev1.Secret
+	}{
+		{
+			name: "unrelated secret untouched",
+			input: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "whatever",
+					Namespace: "myns",
+				},
+			},
+			expected: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "whatever",
+					Namespace: "myns",
+				},
+			},
+		},
+		{
+			name: "related but not known secret untouched",
+			input: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "related",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
+					},
+				},
+			},
+			expected: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "related",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
+					},
+				},
+			},
+		},
+		{
+			name: "related known secret with correct hash untouched",
+			input: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "token-nodepool-name-da03707e",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
+					},
+				},
+			},
+			expected: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "token-nodepool-name-da03707e",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
+					},
+				},
+			},
+		},
+		{
+			name: "related token secret with incorrect hash set for expiry",
+			input: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "token-nodepool-name-jsadfkjh23",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
+					},
+				},
+			},
+			expected: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "token-nodepool-name-jsadfkjh23",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
+						"hypershift.openshift.io/ignition-token-expiration-timestamp": "2006-01-02T17:04:05Z",
+					},
+				},
+			},
+		},
+		{
+			name: "related ignition user data secret with incorrect hash deleted",
+			input: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-data-nodepool-name-jsadfkjh23",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := c.Create(ctx, testCase.input); err != nil {
+				t.Errorf("failed to create object: %v", err)
+			}
+
+			key := client.ObjectKeyFromObject(testCase.input)
+			if _, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key}); err != nil {
+				t.Errorf("failed to reconcile object: %v", err)
+			}
+
+			got := &corev1.Secret{}
+			err := c.Get(ctx, client.ObjectKeyFromObject(testCase.input), got)
+			if testCase.expected == nil {
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("expected object to not exist, got error: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("failed to fetch object: %v", err)
+				}
+				if diff := cmp.Diff(got, testCase.expected, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); diff != "" {
+					t.Errorf("got unexpected object after reconcile: %v", diff)
+				}
+			}
 		})
 	}
 }

--- a/hypershift-operator/controllers/scheduler/autoscaler_test.go
+++ b/hypershift-operator/controllers/scheduler/autoscaler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -503,7 +504,7 @@ func TestDetermineRequiredNodes(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			actual := determineRequiredNodes(pendingPods(test.pods), test.pods, test.nodes)
-			g.Expect(actual).To(BeEquivalentTo(test.expected))
+			g.Expect(actual).To(testutil.MatchExpected(test.expected, cmp.AllowUnexported(nodeRequirement{})))
 		})
 	}
 }
@@ -854,7 +855,7 @@ func TestNonRequestServingMachineSetsToScale(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			actual := nonRequestServingMachineSetsToScale(context.Background(), cfg, test.hostedClusters, test.machineSets)
-			g.Expect(actual).To(BeEquivalentTo(test.expect))
+			g.Expect(actual).To(testutil.MatchExpected(test.expect, cmp.AllowUnexported(machineSetReplicas{})))
 		})
 	}
 }


### PR DESCRIPTION
When we change the config for a NodePool or the way in which we hash the values, we leak token and user data secrets. However, since these secrets are annotated with the NodePool they were created for, it's simple to check that the Secret still matches what we expect and clean it up otherwise.

/assign @sjenning 