### PR TITLE
MULTIARCH-4637: Support ppc64le arch for Agent and PowerVS platform

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -176,10 +176,10 @@ type NodePoolSpec struct {
 	// Arch is the preferred processor architecture for the NodePool (currently only supported on AWS)
 	// NOTE: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
 	//	https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
-	// TODO Add ppc64le and s390x to enum validation once the architectures are supported
+	// TODO Add s390x to enum validation once the architecture is supported
 	//
 	// +kubebuilder:default:=amd64
-	// +kubebuilder:validation:Enum=arm64;amd64
+	// +kubebuilder:validation:Enum=arm64;amd64;ppc64le
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Arch is immutable"
 	// +optional
 	Arch string `json:"arch,omitempty"`

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -502,7 +502,8 @@ func Validate(ctx context.Context, opts *CreateOptions) error {
 	}
 
 	// Validate if mgmt cluster and NodePool CPU arches don't match, a multi-arch release image or stream was used
-	if !opts.AWSPlatform.MultiArch && !opts.Render {
+	// Exception for ppc64le arch since management cluster would be in x86 and node pools are going to be in ppc64le arch
+	if !opts.AWSPlatform.MultiArch && !opts.Render && opts.Arch != hyperv1.ArchitecturePPC64LE {
 		mgmtClusterCPUArch, err := hyperutil.GetMgmtClusterCPUArch(ctx)
 		if err != nil {
 			return err
@@ -513,11 +514,12 @@ func Validate(ctx context.Context, opts *CreateOptions) error {
 		}
 	}
 
-	// Validate arch is only amd64 or arm64
+	// Validate arch is only hyperv1.ArchitectureAMD64 or hyperv1.ArchitectureARM64 or hyperv1.ArchitecturePPC64LE
 	arch := strings.ToLower(opts.Arch)
 	switch arch {
-	case "amd64":
-	case "arm64":
+	case hyperv1.ArchitectureAMD64:
+	case hyperv1.ArchitectureARM64:
+	case hyperv1.ArchitecturePPC64LE:
 	default:
 		return fmt.Errorf("specified arch is not supported: %s", opts.Arch)
 	}

--- a/cmd/cluster/powervs/create.go
+++ b/cmd/cluster/powervs/create.go
@@ -26,6 +26,7 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		SilenceUsage: true,
 	}
 
+	opts.Arch = hyperv1.ArchitecturePPC64LE
 	opts.PowerVSPlatform = core.PowerVSPlatformOptions{
 		Region:                 "us-south",
 		Zone:                   "us-south",

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1174,11 +1174,11 @@ spec:
                   NodePool (currently only supported on AWS)\nNOTE: This is set as
                   optional to prevent validation from failing due to a limitation
                   on client side validation with open API machinery:\n\thttps://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215\nTODO
-                  Add ppc64le and s390x to enum validation once the architectures
-                  are supported"
+                  Add s390x to enum validation once the architecture is supported"
                 enum:
                 - arm64
                 - amd64
+                - ppc64le
                 type: string
                 x-kubernetes-validations:
                 - message: Arch is immutable

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -848,7 +848,7 @@ string
 <p>Arch is the preferred processor architecture for the NodePool (currently only supported on AWS)
 NOTE: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
 <a href="https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215">https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215</a>
-TODO Add ppc64le and s390x to enum validation once the architectures are supported</p>
+TODO Add s390x to enum validation once the architecture is supported</p>
 </td>
 </tr>
 </table>
@@ -6901,7 +6901,7 @@ string
 <p>Arch is the preferred processor architecture for the NodePool (currently only supported on AWS)
 NOTE: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
 <a href="https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215">https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215</a>
-TODO Add ppc64le and s390x to enum validation once the architectures are supported</p>
+TODO Add s390x to enum validation once the architecture is supported</p>
 </td>
 </tr>
 </tbody>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -56843,11 +56843,11 @@ objects:
                     NodePool (currently only supported on AWS)\nNOTE: This is set
                     as optional to prevent validation from failing due to a limitation
                     on client side validation with open API machinery:\n\thttps://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215\nTODO
-                    Add ppc64le and s390x to enum validation once the architectures
-                    are supported"
+                    Add s390x to enum validation once the architecture is supported"
                   enum:
                   - arm64
                   - amd64
+                  - ppc64le
                   type: string
                   x-kubernetes-validations:
                   - message: Arch is immutable

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3078,3 +3078,67 @@ func newKVInfraMapMock(objects []client.Object) kvinfra.KubevirtInfraClientMap {
 		"",
 		"")
 }
+
+func TestIsArchAndPlatformSupported(t *testing.T) {
+	testCases := []struct {
+		name     string
+		nodePool *hyperv1.NodePool
+		expect   bool
+	}{
+		{
+			name: "supported arch and platform used",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AWSPlatform,
+					},
+					Arch: hyperv1.ArchitectureAMD64,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "supported platform with multiple arch - amd64",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AgentPlatform,
+					},
+					Arch: hyperv1.ArchitectureAMD64,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "supported platform with multiple arch - ppc64le",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AgentPlatform,
+					},
+					Arch: hyperv1.ArchitecturePPC64LE,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "unsupported arch and platform used",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AWSPlatform,
+					},
+					Arch: hyperv1.ArchitecturePPC64LE,
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isArchAndPlatformSupported(tc.nodePool)).To(Equal(tc.expect))
+		})
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -495,9 +495,11 @@ func (o *options) DefaultClusterOptions(t *testing.T) core.CreateOptions {
 		EtcdStorageClass:          o.configurableClusterOptions.EtcdStorageClass,
 	}
 
-	// Arch is only currently valid for aws platform
-	if o.Platform == hyperv1.AWSPlatform || o.Platform == hyperv1.AzurePlatform {
-		createOption.Arch = "amd64"
+	switch o.Platform {
+	case hyperv1.AWSPlatform, hyperv1.AzurePlatform:
+		createOption.Arch = hyperv1.ArchitectureAMD64
+	case hyperv1.PowerVSPlatform:
+		createOption.Arch = hyperv1.ArchitecturePPC64LE
 	}
 
 	createOption.AWSPlatform.AdditionalTags = append(createOption.AWSPlatform.AdditionalTags, o.additionalTags...)

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -176,10 +176,10 @@ type NodePoolSpec struct {
 	// Arch is the preferred processor architecture for the NodePool (currently only supported on AWS)
 	// NOTE: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
 	//	https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
-	// TODO Add ppc64le and s390x to enum validation once the architectures are supported
+	// TODO Add s390x to enum validation once the architecture is supported
 	//
 	// +kubebuilder:default:=amd64
-	// +kubebuilder:validation:Enum=arm64;amd64
+	// +kubebuilder:validation:Enum=arm64;amd64;ppc64le
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Arch is immutable"
 	// +optional
 	Arch string `json:"arch,omitempty"`


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Want to support ppc64le arch for Agent and PowerVS cloud platform.
Due to recent changes, 4.16 powervs is blocked to use multi arch release image. Trying to fix that as well.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.