### PR TITLE
OCPBUGS-26762: Disable DNS resolving for CNO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -550,9 +550,10 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 	},
 		{
 			// CNO uses konnectivity-proxy to perform proxy readiness checks through the hosted cluster's network
+			// Disable the resolver to ensure that CNO connects to the exact proxy address provided
 			Name:    "konnectivity-proxy",
 			Image:   params.Images.Socks5Proxy,
-			Command: []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy", "--resolve-from-guest-cluster-dns=true"},
+			Command: []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy", "--disable-resolver"},
 			Args:    []string{"run"},
 			Env: []corev1.EnvVar{{
 				Name:  "KUBECONFIG",

--- a/konnectivity-socks5-proxy/main.go
+++ b/konnectivity-socks5-proxy/main.go
@@ -62,7 +62,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&connectDirectlyToCloudAPIs, "connect-directly-to-cloud-apis", false, "If true, traffic destined for AWS or Azure APIs should be sent there directly rather than going through konnectivity. If enabled, proxy env vars from the mgmt cluster must be propagated to this container")
 	cmd.Flags().BoolVar(&resolveFromGuestClusterDNS, "resolve-from-guest-cluster-dns", false, "If DNS resolving should use the guest clusters cluster-dns")
 	cmd.Flags().BoolVar(&resolveFromManagementClusterDNS, "resolve-from-management-cluster-dns", false, "If guest cluster's dns fails, fallback to the management cluster's dns")
-	cmd.Flags().BoolVar(&disableResolver, "disable-resolver", false, "If true, DNS resolving is disabled. Takes precedence over resolve-from-management-cluster-dns and resolve-from-management-cluster-dns")
+	cmd.Flags().BoolVar(&disableResolver, "disable-resolver", false, "If true, DNS resolving is disabled. Takes precedence over resolve-from-guest-cluster-dns and resolve-from-management-cluster-dns")
 
 	cmd.Flags().StringVar(&caCertPath, "ca-cert-path", "/etc/konnectivity/proxy-ca/ca.crt", "The path to the konnectivity client's ca-cert.")
 	cmd.Flags().StringVar(&clientCertPath, "tls-cert-path", "/etc/konnectivity/proxy-client/tls.crt", "The path to the konnectivity client's tls certificate.")


### PR DESCRIPTION
CNO uses the konnectivity-socks5-proxy to perform cluster-wide-proxy readiness checks through the hosted cluster's network.
The cluster-wide-proxy address it uses should not be resolved to avoid double-proxy issues.
