### PR TITLE
OCPBUGS-32186: cmd: report server version, supported OCP

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -97,7 +97,8 @@ const (
 	oidcProviderS3CredsSecretName = "hypershift-operator-oidc-provider-s3-credentials"
 	externaDNSCredsSecretName     = "external-dns-credentials"
 
-	HypershiftOperatorName = "operator"
+	HypershiftOperatorName                = "operator"
+	HyperShiftInstallCLIVersionAnnotation = "hypershift.openshift.io/install-cli-version"
 )
 
 type HyperShiftOperatorCredentialsSecret struct {
@@ -694,7 +695,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 
 	if o.IncludeVersion {
 		deployment.Annotations = map[string]string{
-			"hypershift.openshift.io/install-cli-version": version.String(),
+			HyperShiftInstallCLIVersionAnnotation: version.String(),
 		}
 	}
 

--- a/hypershift-operator/controllers/supportedversion/reconciler_test.go
+++ b/hypershift-operator/controllers/supportedversion/reconciler_test.go
@@ -27,9 +27,9 @@ func TestEnsureSupportedVersionConfigMap(t *testing.T) {
 	cfgMap := manifests.ConfigMap("hypershift")
 	err = c.Get(context.Background(), client.ObjectKeyFromObject(cfgMap), cfgMap)
 	g.Expect(err).To(BeNil())
-	g.Expect(cfgMap.Data[configMapKey]).ToNot(BeEmpty())
-	data := &supportedVersions{}
-	err = json.Unmarshal([]byte(cfgMap.Data[configMapKey]), data)
+	g.Expect(cfgMap.Data[ConfigMapVersionsKey]).ToNot(BeEmpty())
+	data := &SupportedVersions{}
+	err = json.Unmarshal([]byte(cfgMap.Data[ConfigMapVersionsKey]), data)
 	g.Expect(err).To(BeNil())
 	g.Expect(len(data.Versions)).To(Equal(len(supportedversion.Supported())))
 }

--- a/product-cli/main.go
+++ b/product-cli/main.go
@@ -21,9 +21,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	cliversion "github.com/openshift/hypershift/cmd/version"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/hypershift/pkg/version"
 	"github.com/openshift/hypershift/product-cli/cmd/create"
 	"github.com/openshift/hypershift/product-cli/cmd/destroy"
 )
@@ -40,14 +40,13 @@ func main() {
 		},
 	}
 
-	cmd.Version = version.String()
-
 	ctx, cancel := context.WithCancel(context.Background())
 
 	defer cancel()
 
 	cmd.AddCommand(create.NewCommand())
 	cmd.AddCommand(destroy.NewCommand())
+	cmd.AddCommand(cliversion.NewVersionCommand())
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT)


### PR DESCRIPTION
Previously, both hcp and hypershift CLIs would only report their client versions, which was misleading to some users, as the real determination for what versions of OCP are possible to deploy relies on both the client and the server together.

```
$ ./bin/hcp version
Client Version: openshift/hypershift: 0a16c7cad4d056f4cda9a393cfc036e1ceb56d60. Latest supported OCP: 4.16.0
Server Version: openshift/hypershift: 6bb55dffe1bbf25c1086fa4398c8c97b083b57bb. Latest supported OCP: 4.16.0
Server Supports OCP Versions: 4.16, 4.15, 4.14, 4.13
```

/cc @davidvossel 