### PR TITLE
CNF-12792:nto: add configmaps/finalizers under operator `Role`

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -996,6 +996,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Resources: []string{
 					"events",
 					"configmaps",
+					"configmaps/finalizers",
 					"persistentvolumeclaims",
 					"pods",
 					"pods/log",

--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -145,6 +145,7 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef) error {
 			APIGroups: []string{corev1.SchemeGroupVersion.Group},
 			Resources: []string{
 				"configmaps",
+				"configmaps/finalizers",
 				"events",
 			},
 			Verbs: []string{"*"},

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -171,6 +171,7 @@ objects:
     resources:
     - events
     - configmaps
+    - configmaps/finalizers
     - persistentvolumeclaims
     - pods
     - pods/log

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2808,6 +2808,7 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role, enableCVOManagementClu
 			Resources: []string{
 				"events",
 				"configmaps",
+				"configmaps/finalizers",
 				"persistentvolumeclaims",
 				"pods",
 				"pods/log",


### PR DESCRIPTION
**What this PR does / why we need it**:
NTO is watching for the `ConfigMap` that encpasulets the `PerformanceProfile` and creates different components based on the given profile.

We should block the `PerformanceProfile` deletion as long as the dependent components exist.

For that NTO needs access the finalizers of the `ConfigMap`.

We should also update the control plane operator since
it's its responsibility to update NTO's role.

**Which issue(s) this PR fixes**
Fixes # [CNF-11559](https://issues.redhat.com/browse/CNF-11559)