### PR TITLE
OCPBUGS-33060: enable audit log for oauth-openshift

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3246,9 +3246,16 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServer(ctx context.Context,
 		r.Log.V(2).Info("Reconciled oauth pdb", "result", result)
 	}
 
+	auditCfg := manifests.OAuthAuditConfig(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, auditCfg, func() error {
+		return oauth.ReconcileAuditConfig(auditCfg, p.OwnerRef, p.AuditPolicyConfig())
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile oauth openshift audit config: %w", err)
+	}
+
 	deployment := manifests.OAuthServerDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return oauth.ReconcileDeployment(ctx, r, deployment, p.OwnerRef, oauthConfig, p.OAuthServerImage, p.DeploymentConfig, p.IdentityProviders(), p.OauthConfigOverrides, p.AvailabilityProberImage, p.NamedCertificates(), p.Socks5ProxyImage, p.NoProxy, p.ConfigParams(oauthServingCert), hcp.Spec.Platform.Type)
+		return oauth.ReconcileDeployment(ctx, r, deployment, p.AuditWebhookRef, p.OwnerRef, oauthConfig, auditCfg, p.OAuthServerImage, p.DeploymentConfig, p.IdentityProviders(), p.OauthConfigOverrides, p.AvailabilityProberImage, p.NamedCertificates(), p.Socks5ProxyImage, p.NoProxy, p.ConfigParams(oauthServingCert), hcp.Spec.Platform.Type)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile oauth deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/oauth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/oauth.go
@@ -17,6 +17,15 @@ func OAuthServerConfig(ns string) *corev1.ConfigMap {
 	}
 }
 
+func OAuthAuditConfig(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oauth-openshift-audit",
+			Namespace: ns,
+		},
+	}
+}
+
 func OAuthServerPodDisruptionBudget(ns string) *policyv1.PodDisruptionBudget {
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/assets.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/assets.go
@@ -1,0 +1,35 @@
+package oauth
+
+import (
+	"bytes"
+	"embed"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+//go:embed files/*
+var f embed.FS
+
+var (
+	oauthPolicy = mustConfigmapData("audit-policy.yaml", "audit.yaml")
+)
+
+func mustAsset(file string) []byte {
+	data, err := f.ReadFile("files/" + file)
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}
+
+func mustConfigmapData(file string, key string) string {
+	fileBytes := mustAsset(file)
+	cm := &corev1.ConfigMap{}
+	if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(fileBytes), 500).Decode(&cm); err != nil {
+		panic(err)
+	}
+
+	return cm.Data[key]
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/auditcfg.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/auditcfg.go
@@ -1,0 +1,24 @@
+package oauth
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/hypershift/support/config"
+)
+
+const (
+	auditPolicyConfigMapKey  = "policy.yaml"
+	auditPolicyProfileMapKey = "profile"
+)
+
+func ReconcileAuditConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef, auditConfig configv1.Audit) error {
+	ownerRef.ApplyTo(cm)
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+
+	cm.Data[auditPolicyConfigMapKey] = oauthPolicy
+	cm.Data[auditPolicyProfileMapKey] = string(auditConfig.Profile)
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -41,6 +41,12 @@ var (
 			oauthVolumeProvidersTemplate().Name: "/etc/kubernetes/secrets/templates/providers",
 			oauthVolumeWorkLogs().Name:          "/var/run/kubernetes",
 			oauthVolumeMasterCABundle().Name:    "/etc/kubernetes/certs/master-ca",
+			oauthVolumeAuditConfig().Name:       "/etc/kubernetes/audit-config",
+		},
+	}
+	oauthAuditWebhookConfigFileVolumeMount = util.PodVolumeMounts{
+		oauthContainerMain().Name: {
+			oauthAuditWebhookConfigFileVolume().Name: "/etc/kubernetes/auditwebhook",
 		},
 	}
 )
@@ -52,7 +58,7 @@ func oauthLabels() map[string]string {
 	}
 }
 
-func ReconcileDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment, ownerRef config.OwnerRef, config *corev1.ConfigMap, image string, deploymentConfig config.DeploymentConfig, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, availabilityProberImage string, namedCertificates []configv1.APIServerNamedServingCert, socks5ProxyImage string, noProxy []string, params *OAuthConfigParams, platformType hyperv1.PlatformType) error {
+func ReconcileDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment, auditWebhookRef *corev1.LocalObjectReference, ownerRef config.OwnerRef, config *corev1.ConfigMap, auditConfig *corev1.ConfigMap, image string, deploymentConfig config.DeploymentConfig, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, availabilityProberImage string, namedCertificates []configv1.APIServerNamedServingCert, socks5ProxyImage string, noProxy []string, params *OAuthConfigParams, platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main oauth container
@@ -89,7 +95,7 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 	deployment.Spec.Template.Spec = corev1.PodSpec{
 		AutomountServiceAccountToken: utilpointer.Bool(false),
 		Containers: []corev1.Container{
-			util.BuildContainer(oauthContainerMain(), buildOAuthContainerMain(image, noProxy)),
+			util.BuildContainer(oauthContainerMain(), buildOAuthContainerMain(image, auditWebhookRef, noProxy)),
 			socks5ProxyContainer(socks5ProxyImage),
 		},
 		Volumes: []corev1.Volume{
@@ -109,11 +115,40 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 				}),
 			util.BuildVolume(oauthVolumeWorkLogs(), buildOAuthVolumeWorkLogs),
 			util.BuildVolume(oauthVolumeMasterCABundle(), buildOAuthVolumeMasterCABundle),
+			util.BuildVolume(oauthVolumeAuditConfig(), buildOAuthVolumeAuditConfig),
 			{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: utilpointer.Int32(0640)}}},
 			{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: utilpointer.Int32(0640)}}},
 			{Name: "konnectivity-proxy-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: manifests.KonnectivityCAConfigMap("").Name}, DefaultMode: utilpointer.Int32(0640)}}},
 		},
 	}
+
+	if auditConfig.Data[auditPolicyProfileMapKey] != string(configv1.NoneAuditProfileType) {
+		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, corev1.Container{
+			Name:            "audit-logs",
+			Image:           image,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"/bin/bash"},
+			Args: []string{
+				"-c",
+				kas.RenderAuditLogScript(fmt.Sprintf("%s/%s", volumeMounts.Path(oauthContainerMain().Name, oauthVolumeWorkLogs().Name), "audit.log")),
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("5m"),
+					corev1.ResourceMemory: resource.MustParse("10Mi"),
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      oauthVolumeWorkLogs().Name,
+				MountPath: volumeMounts.Path(oauthContainerMain().Name, oauthVolumeWorkLogs().Name),
+			}},
+		})
+	}
+
+	if auditWebhookRef != nil {
+		applyOauthAuditWebhookConfigFileVolume(&deployment.Spec.Template.Spec, auditWebhookRef)
+	}
+
 	deploymentConfig.ApplyTo(deployment)
 	if len(identityProviders) > 0 {
 		_, volumeMountInfo, err := convertIdentityProviders(ctx, identityProviders, providerOverrides, client, deployment.Namespace)
@@ -134,13 +169,24 @@ func oauthContainerMain() *corev1.Container {
 	}
 }
 
-func buildOAuthContainerMain(image string, noProxy []string) func(c *corev1.Container) {
+func buildOAuthContainerMain(image string, auditWebhookRef *corev1.LocalObjectReference, noProxy []string) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.Args = []string{
 			"osinserver",
 			fmt.Sprintf("--config=%s", path.Join(volumeMounts.Path(c.Name, oauthVolumeConfig().Name), OAuthServerConfigKey)),
+			"--audit-log-format=json",
+			"--audit-log-maxbackup=1",
+			"--audit-log-maxsize=10",
+			fmt.Sprintf("--audit-log-path=%s", path.Join(volumeMounts.Path(c.Name, oauthVolumeWorkLogs().Name), "audit.log")),
+			fmt.Sprintf("--audit-policy-file=%s", path.Join(volumeMounts.Path(c.Name, oauthVolumeAuditConfig().Name), auditPolicyConfigMapKey)),
 		}
+
+		if auditWebhookRef != nil {
+			c.Args = append(c.Args, fmt.Sprintf("--audit-webhook-config-file=%s", oauthAuditWebhookConfigFile()))
+			c.Args = append(c.Args, "--audit-webhook-mode=batch")
+		}
+
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 		c.WorkingDir = volumeMounts.Path(c.Name, oauthVolumeWorkLogs().Name)
 		c.Env = []corev1.EnvVar{
@@ -167,6 +213,25 @@ func buildOAuthContainerMain(image string, noProxy []string) func(c *corev1.Cont
 func oauthVolumeConfig() *corev1.Volume {
 	return &corev1.Volume{
 		Name: "oauth-config",
+	}
+}
+
+func oauthVolumeAuditConfig() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "audit-config",
+	}
+}
+
+func oauthAuditWebhookConfigFileVolume() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "oauth-audit-webhook",
+	}
+}
+
+func buildOauthAuditWebhookConfigFileVolume(auditWebhookRef *corev1.LocalObjectReference) func(v *corev1.Volume) {
+	return func(v *corev1.Volume) {
+		v.Secret = &corev1.SecretVolumeSource{}
+		v.Secret.SecretName = auditWebhookRef.Name
 	}
 }
 
@@ -204,6 +269,11 @@ func oauthVolumeServingCert() *corev1.Volume {
 	return &corev1.Volume{
 		Name: "serving-cert",
 	}
+}
+
+func buildOAuthVolumeAuditConfig(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+	v.ConfigMap.Name = manifests.OAuthAuditConfig("").Name
 }
 
 func buildOAuthVolumeServingCert(v *corev1.Volume) {
@@ -315,4 +385,25 @@ func socks5ProxyContainer(socks5ProxyImage string) corev1.Container {
 	}
 
 	return c
+}
+
+func applyOauthAuditWebhookConfigFileVolume(podSpec *corev1.PodSpec, auditWebhookRef *corev1.LocalObjectReference) {
+	podSpec.Volumes = append(podSpec.Volumes, util.BuildVolume(oauthAuditWebhookConfigFileVolume(), buildOauthAuditWebhookConfigFileVolume(auditWebhookRef)))
+	var container *corev1.Container
+	for i, c := range podSpec.Containers {
+		if c.Name == oauthContainerMain().Name {
+			container = &podSpec.Containers[i]
+			break
+		}
+	}
+	if container == nil {
+		panic("main oauth openshift container oauth-server not found in spec")
+	}
+	container.VolumeMounts = append(container.VolumeMounts,
+		oauthAuditWebhookConfigFileVolumeMount.ContainerMounts(oauthContainerMain().Name)...)
+}
+
+func oauthAuditWebhookConfigFile() string {
+	cfgDir := oauthAuditWebhookConfigFileVolumeMount.Path(oauthContainerMain().Name, oauthAuditWebhookConfigFileVolume().Name)
+	return path.Join(cfgDir, hyperv1.AuditWebhookKubeconfigKey)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/files/audit-policy.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/files/audit-policy.yaml
@@ -1,0 +1,18 @@
+# sourced from https://github.com/openshift/cluster-authentication-operator/blob/master/bindata/oauth-openshift/audit-policy.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audit
+  namespace: openshift-authentication
+data:
+  audit.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: None
+      nonResourceURLs:
+      - "/healthz*"
+      - "/logs"
+      - "/metrics"
+      - "/version"
+    - level: Metadata

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -44,6 +44,7 @@ type OAuthServerParams struct {
 	Availability            hyperv1.AvailabilityPolicy
 	Socks5ProxyImage        string
 	NoProxy                 []string
+	AuditWebhookRef         *corev1.LocalObjectReference
 }
 
 type OAuthConfigParams struct {
@@ -95,6 +96,11 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider 
 		p.APIServer = hcp.Spec.Configuration.APIServer
 		p.OAuth = hcp.Spec.Configuration.OAuth
 	}
+
+	if hcp.Spec.AuditWebhook != nil && len(hcp.Spec.AuditWebhook.Name) > 0 {
+		p.AuditWebhookRef = hcp.Spec.AuditWebhook
+	}
+
 	p.Scheduling = config.Scheduling{
 		PriorityClass: config.APICriticalPriorityClass,
 	}
@@ -239,6 +245,16 @@ func (p *OAuthServerParams) ConfigParams(servingCert *corev1.Secret) *OAuthConfi
 		LoginURLOverride:             p.LoginURLOverride,
 		NamedCertificates:            p.NamedCertificates(),
 		OAuthTemplates:               p.OauthTemplates(),
+	}
+}
+
+func (p *OAuthServerParams) AuditPolicyConfig() configv1.Audit {
+	if p.APIServer != nil && p.APIServer.Audit.Profile != "" {
+		return p.APIServer.Audit
+	} else {
+		return configv1.Audit{
+			Profile: configv1.DefaultAuditProfileType,
+		}
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
@@ -1,0 +1,187 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: oauth-openshift
+  namespace: test
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: name
+    uid: ""
+spec:
+  minReadySeconds: 60
+  replicas: 0
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app: oauth-openshift
+      hypershift.openshift.io/control-plane-component: oauth-openshift
+  strategy:
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs
+        oauth.hypershift.openshift.io/config-hash: 24346e1b50066607059af36e3b684b24
+      creationTimestamp: null
+      labels:
+        app: oauth-openshift
+        hypershift.openshift.io/control-plane-component: oauth-openshift
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - osinserver
+        - --config=/etc/kubernetes/config/config.yaml
+        - --audit-log-format=json
+        - --audit-log-maxbackup=1
+        - --audit-log-maxsize=10
+        - --audit-log-path=/var/run/kubernetes/audit.log
+        - --audit-policy-file=/etc/kubernetes/audit-config/policy.yaml
+        - --audit-webhook-config-file=/etc/kubernetes/auditwebhook/webhook-kubeconfig
+        - --audit-webhook-mode=batch
+        env:
+        - name: HTTP_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: HTTPS_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: ALL_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: NO_PROXY
+        image: oauthImage
+        name: oauth-server
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/kubernetes/audit-config
+          name: audit-config
+        - mountPath: /etc/kubernetes/secrets/templates/error
+          name: error-template
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/secrets/templates/login
+          name: login-template
+        - mountPath: /var/run/kubernetes
+          name: logs
+        - mountPath: /etc/kubernetes/certs/master-ca
+          name: master-ca-bundle
+        - mountPath: /etc/kubernetes/config
+          name: oauth-config
+        - mountPath: /etc/kubernetes/secrets/templates/providers
+          name: providers-template
+        - mountPath: /etc/kubernetes/certs/serving-cert
+          name: serving-cert
+        - mountPath: /etc/kubernetes/secrets/session
+          name: session-secret
+        - mountPath: /etc/kubernetes/auditwebhook
+          name: oauth-audit-webhook
+        workingDir: /var/run/kubernetes
+      - args:
+        - run
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-socks5-proxy
+        - --resolve-from-guest-cluster-dns=true
+        - --resolve-from-management-cluster-dns=true
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig
+        image: test-socks-5-proxy-image
+        name: socks-proxy
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: admin-kubeconfig
+        - mountPath: /etc/konnectivity/proxy-client
+          name: konnectivity-proxy-cert
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
+      - args:
+        - -c
+        - "\nset -o errexit\nset -o nounset\nset -o pipefail\n\nfunction cleanup()
+          {\n\tkill -- -$$\n\twait\n}\ntrap cleanup SIGTERM\n\n/usr/bin/tail -c+1
+          -F /var/run/kubernetes/audit.log &\nwait $!\n"
+        command:
+        - /bin/bash
+        image: oauthImage
+        imagePullPolicy: IfNotPresent
+        name: audit-logs
+        resources:
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/run/kubernetes
+          name: logs
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:2040/readyz
+        image: test-availability-image
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      volumes:
+      - configMap:
+          name: oauth-openshift
+        name: oauth-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: oauth-server-crt
+      - name: session-secret
+        secret:
+          defaultMode: 416
+          secretName: oauth-openshift-session
+      - name: error-template
+        secret:
+          defaultMode: 416
+          secretName: oauth-openshift-default-error-template
+      - name: login-template
+        secret:
+          defaultMode: 416
+          secretName: oauth-openshift-default-login-template
+      - name: providers-template
+        secret:
+          defaultMode: 416
+          secretName: oauth-openshift-default-provider-selection-template
+      - emptyDir: {}
+        name: logs
+      - configMap:
+          name: oauth-master-ca-bundle
+        name: master-ca-bundle
+      - configMap:
+          name: oauth-openshift-audit
+        name: audit-config
+      - name: admin-kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - name: konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          defaultMode: 416
+          name: konnectivity-ca-bundle
+        name: konnectivity-proxy-ca
+      - name: oauth-audit-webhook
+        secret:
+          secretName: test-webhook-audit-secret
+status: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
It enables audit logs for `oauth-openshift`.
Currently, hypershift only supports audit logs for `kube-apiserver`, `openshift-apiserver`, and `openshift-oauth-apiserver`. However, `oauth-openshift` also supports audit logs in standalone OCP.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # OCPBUGS-33060


**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ *] This change includes unit tests.