### PR TITLE
HOSTEDCP-1310: use kms images from payload

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms.go
@@ -47,7 +47,7 @@ func GetKMSProvider(kmsSpec *hyperv1.KMSSpec, images KubeAPIServerImages) (kms.I
 	case hyperv1.AWS:
 		return kms.NewAWSKMSProvider(kmsSpec.AWS, images.AWSKMS, images.TokenMinterImage)
 	case hyperv1.AZURE:
-		return kms.NewAzureKMSProvider(kmsSpec.Azure)
+		return kms.NewAzureKMSProvider(kmsSpec.Azure, images.AzureKMS)
 	default:
 		return nil, fmt.Errorf("unrecognized kms provider %s", kmsSpec.Provider)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
@@ -26,10 +26,6 @@ const (
 
 	azureKMSCredsFileKey          = "azure.json"
 	azureProviderConfigNamePrefix = "azure"
-
-	// https://github.com/Azure/kubernetes-kms
-	// TODO: get image from payload
-	azureKMSProviderImage = "mcr.microsoft.com/oss/azure/kms/keyvault:v0.5.0"
 )
 
 var (
@@ -58,14 +54,13 @@ type azureKMSProvider struct {
 	kmsImage string
 }
 
-func NewAzureKMSProvider(kmsSpec *hyperv1.AzureKMSSpec) (*azureKMSProvider, error) {
+func NewAzureKMSProvider(kmsSpec *hyperv1.AzureKMSSpec, image string) (*azureKMSProvider, error) {
 	if kmsSpec == nil {
 		return nil, fmt.Errorf("azure kms metadata not specified")
 	}
 	return &azureKMSProvider{
-		kmsSpec: kmsSpec,
-		// TODO: get image from payload
-		kmsImage: azureKMSProviderImage,
+		kmsSpec:  kmsSpec,
+		kmsImage: image,
 	}, nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -26,6 +26,7 @@ type KubeAPIServerImages struct {
 	HyperKube                  string `json:"hyperKube"`
 	IBMCloudKMS                string `json:"ibmcloudKMS"`
 	AWSKMS                     string `json:"awsKMS"`
+	AzureKMS                   string `json:"azureKMS"`
 	Portieris                  string `json:"portieris"`
 	TokenMinterImage           string
 	AWSPodIdentityWebhookImage string
@@ -103,7 +104,8 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			CLI:                        releaseImageProvider.GetImage("cli"),
 			ClusterConfigOperator:      releaseImageProvider.GetImage("cluster-config-api"),
 			TokenMinterImage:           releaseImageProvider.GetImage("token-minter"),
-			AWSKMS:                     releaseImageProvider.GetImage("aws-kms-provider"),
+			AWSKMS:                     releaseImageProvider.GetImage("aws-kms-encryption-provider"),
+			AzureKMS:                   releaseImageProvider.GetImage("azure-kms-encryption-provider"),
 			AWSPodIdentityWebhookImage: releaseImageProvider.GetImage("aws-pod-identity-webhook"),
 			KonnectivityServer:         releaseImageProvider.GetImage("apiserver-network-proxy"),
 		},

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/events"
-	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/util"
@@ -140,11 +139,6 @@ func defaultCommand() *cobra.Command {
 	return cmd
 
 }
-
-const (
-	// Default AWS KMS provider image. Can be overriden with annotation on HostedCluster
-	defaultAWSKMSProviderImage = "registry.ci.openshift.org/hypershift/aws-encryption-provider:latest"
-)
 
 func NewStartCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -360,17 +354,11 @@ func NewStartCommand() *cobra.Command {
 			os.Exit(1)
 		}
 
-		awsKMSProviderImage := defaultAWSKMSProviderImage
-		if envImage := os.Getenv(images.AWSEncryptionProviderEnvVar); len(envImage) > 0 {
-			awsKMSProviderImage = envImage
-		}
-
 		componentImages := map[string]string{
 			util.AvailabilityProberImageName: availabilityProberImage,
 			"hosted-cluster-config-operator": hostedClusterConfigOperatorImage,
 			"socks5-proxy":                   socks5ProxyImage,
 			"token-minter":                   tokenMinterImage,
-			"aws-kms-provider":               awsKMSProviderImage,
 			util.CPOImageName:                cpoImage,
 			util.CPPKIOImageName:             cpoImage,
 		}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2611,14 +2611,6 @@ func reconcileControlPlaneOperatorDeployment(
 			},
 		)
 	}
-	if envImage := os.Getenv(images.AWSEncryptionProviderEnvVar); len(envImage) > 0 {
-		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
-			corev1.EnvVar{
-				Name:  images.AWSEncryptionProviderEnvVar,
-				Value: envImage,
-			},
-		)
-	}
 	if len(defaultIngressDomain) > 0 {
 		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{

--- a/support/images/envvars.go
+++ b/support/images/envvars.go
@@ -2,14 +2,13 @@ package images
 
 // Image environment variable constants
 const (
-	CAPIEnvVar                  = "IMAGE_CLUSTER_API"
-	AgentCAPIProviderEnvVar     = "IMAGE_AGENT_CAPI_PROVIDER"
-	AWSEncryptionProviderEnvVar = "IMAGE_AWS_ENCRYPTION_PROVIDER"
-	AWSCAPIProviderEnvVar       = "IMAGE_AWS_CAPI_PROVIDER"
-	AzureCAPIProviderEnvVar     = "IMAGE_AZURE_CAPI_PROVIDER"
-	KubevirtCAPIProviderEnvVar  = "IMAGE_KUBEVIRT_CAPI_PROVIDER"
-	PowerVSCAPIProviderEnvVar   = "IMAGE_POWERVS_CAPI_PROVIDER"
-	KonnectivityEnvVar          = "IMAGE_KONNECTIVITY"
+	CAPIEnvVar                 = "IMAGE_CLUSTER_API"
+	AgentCAPIProviderEnvVar    = "IMAGE_AGENT_CAPI_PROVIDER"
+	AWSCAPIProviderEnvVar      = "IMAGE_AWS_CAPI_PROVIDER"
+	AzureCAPIProviderEnvVar    = "IMAGE_AZURE_CAPI_PROVIDER"
+	KubevirtCAPIProviderEnvVar = "IMAGE_KUBEVIRT_CAPI_PROVIDER"
+	PowerVSCAPIProviderEnvVar  = "IMAGE_POWERVS_CAPI_PROVIDER"
+	KonnectivityEnvVar         = "IMAGE_KONNECTIVITY"
 )
 
 // TagMapping returns a mapping between tags in an image-refs ImageStream
@@ -17,7 +16,6 @@ const (
 func TagMapping() map[string]string {
 	return map[string]string{
 		"apiserver-network-proxy":       KonnectivityEnvVar,
-		"aws-encryption-provider":       AWSEncryptionProviderEnvVar,
 		"cluster-api":                   CAPIEnvVar,
 		"cluster-api-provider-agent":    AgentCAPIProviderEnvVar,
 		"cluster-api-provider-aws":      AWSCAPIProviderEnvVar,


### PR DESCRIPTION
Switch to using the `aws-kms-encryption-provider` and `azure-kms-encryption-provider` images from the payload.

This PR also removes the `IMAGE_AWS_ENCRYPTION_PROVIDER` environment variables that could be set on the HO and passed through the CPO to override this image.

`hypershift.openshift.io/aws-kms-provider-image` annotation on the HC is still respected.

Blocked until included in ART payload.