### PR TITLE
HOSTEDCP-1570: remove liveness and readiness probes using metrics endpoint

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -60,38 +59,6 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.Int(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
-	p.DeploymentConfig.ReadinessProbes = config.ReadinessProbes{
-		ingressOperatorContainerName: {
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/metrics",
-					Port:   intstr.FromInt(ingressOperatorMetricsPort),
-					Scheme: corev1.URISchemeHTTP,
-				},
-			},
-			PeriodSeconds:    10,
-			SuccessThreshold: 1,
-			FailureThreshold: 3,
-			TimeoutSeconds:   5,
-		},
-	}
-	p.DeploymentConfig.LivenessProbes = config.LivenessProbes{
-		ingressOperatorContainerName: {
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/metrics",
-					Port:   intstr.FromInt(ingressOperatorMetricsPort),
-					Scheme: corev1.URISchemeHTTP,
-				},
-			},
-			InitialDelaySeconds: 60,
-			PeriodSeconds:       60,
-			SuccessThreshold:    1,
-			FailureThreshold:    5,
-			TimeoutSeconds:      5,
-		},
-	}
-
 	return p
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -113,37 +112,6 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 				PriorityClass: config.DefaultPriorityClass,
 			},
 			SetDefaultSecurityContext: setDefaultSecurityContext,
-			ReadinessProbes: config.ReadinessProbes{
-				containerMain().Name: {
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
-							Port:   intstr.FromInt(metricsPort),
-							Scheme: corev1.URISchemeHTTPS,
-						},
-					},
-					PeriodSeconds:    10,
-					SuccessThreshold: 1,
-					FailureThreshold: 3,
-					TimeoutSeconds:   5,
-				},
-			},
-			LivenessProbes: config.LivenessProbes{
-				containerMain().Name: {
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
-							Port:   intstr.FromInt(metricsPort),
-							Scheme: corev1.URISchemeHTTPS,
-						},
-					},
-					InitialDelaySeconds: 60,
-					PeriodSeconds:       60,
-					SuccessThreshold:    1,
-					FailureThreshold:    5,
-					TimeoutSeconds:      5,
-				},
-			},
 			Resources: config.ResourcesSpec{
 				containerMain().Name: {
 					Requests: corev1.ResourceList{

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -90,29 +90,10 @@ spec:
         - name: AZURE_ENVIRONMENT_FILEPATH
           value: /tmp/azurestackcloud.json
         image: quay.io/openshift/cluster-image-registry-operator:latest
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /metrics
-            port: 60000
-            scheme: HTTPS
-          initialDelaySeconds: 60
-          periodSeconds: 60
-          successThreshold: 1
-          timeoutSeconds: 5
         name: cluster-image-registry-operator
         ports:
         - containerPort: 60000
           name: metrics
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /metrics
-            port: 60000
-            scheme: HTTPS
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes liveness and readiness probes from `cluster-image-registry-operator` and `ingress-operator` This change was discussed in the project-hypershift slack channel. Should probes be desired, upstream operator teams should introduce health endpoints for their respective components. Hypershift should not rely on metrics endpoint as a stop gap for the probes endpoints.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.