### PR TITLE
MULTIARCH-4637: Set arch to ppc64le within PowerVS platform func

### DIFF
--- a/cmd/cluster/powervs/create.go
+++ b/cmd/cluster/powervs/create.go
@@ -26,7 +26,6 @@ func NewCreateCommand(opts *core.CreateOptions) *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	opts.Arch = hyperv1.ArchitecturePPC64LE
 	opts.PowerVSPlatform = core.PowerVSPlatformOptions{
 		Region:                 "us-south",
 		Zone:                   "us-south",
@@ -94,6 +93,9 @@ func CreateCluster(ctx context.Context, opts *core.CreateOptions) error {
 func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtures.ExampleOptions, opts *core.CreateOptions) (err error) {
 	// Load or create infrastructure for the cluster
 	var infra *powervsinfra.Infra
+
+	opts.Arch = hyperv1.ArchitecturePPC64LE
+
 	if len(opts.InfrastructureJSON) > 0 {
 		rawInfra, err := os.ReadFile(opts.InfrastructureJSON)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Set arch to ppc64le within PowerVS applyPlatformSpecificsValues so that the arch is not overridden for other platforms.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.