### PR TITLE
HOSTEDCP-1563: Refine the Azure API in the NodePool Spec

### DIFF
--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -901,7 +901,7 @@ type AzureNodePoolPlatform struct {
 	//
 	// +kubebuilder:default:=default
 	// +kubebuilder:validation:Required
-	SubnetName string `json:"subnetName"`
+	SubnetID string `json:"subnetID"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -872,7 +872,7 @@ type AzureNodePoolPlatform struct {
 	// ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
 	// is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
 	// The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
-	// Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+	// Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
 	// hcluster.Spec.Platform.Azure.ResourceGroupName.
 	//
 	// +optional
@@ -919,11 +919,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
 
-	// SubnetName is the name of the subnet to place the Nodes into
+	// SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
+	// different subnet than the one listed in the HostedCluster, hcluster.Spec.Platform.Azure.SubnetID, but must exist
+	// in the same hcluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
+	// hcluster.Spec.Platform.Azure.SubscriptionID.
 	//
-	// +kubebuilder:default:=default
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="SubnetID is immutable"
 	// +kubebuilder:validation:Required
-	SubnetName string `json:"subnetName"`
+	// +immutable
+	// +required
+	SubnetID string `json:"subnetID"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -863,11 +863,21 @@ type AgentNodePoolPlatform struct {
 }
 
 type AzureNodePoolPlatform struct {
+	// VMSize is the Azure VM instance type to use for the nodes being created in the nodepool.
+	//
+	// +kubebuilder:validation:Required
+	// +required
 	VMSize string `json:"vmsize"`
-	// ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
-	// subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
+
+	// ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
+	// is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
+	// The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
+	// Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+	// hcluster.Spec.Platform.Azure.ResourceGroupName.
+	//
 	// +optional
 	ImageID string `json:"imageID,omitempty"`
+
 	// DiskSizeGB is the size in GB to assign to the OS disk
 	// CAPZ default is 30GB, https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/b3708019a67ff19407b87d63c402af94ca4246f6/api/v1beta1/types.go#L599
 	//
@@ -875,6 +885,7 @@ type AzureNodePoolPlatform struct {
 	// +kubebuilder:validation:Minimum=16
 	// +optional
 	DiskSizeGB int32 `json:"diskSizeGB,omitempty"`
+
 	// DiskStorageAccountType is the disk storage account type to use. Valid values are:
 	// * Standard_LRS: HDD
 	// * StandardSSD_LRS: Standard SSD
@@ -888,16 +899,26 @@ type AzureNodePoolPlatform struct {
 	// +kubebuilder:validation:Enum=Standard_LRS;StandardSSD_LRS;Premium_LRS;UltraSSD_LRS
 	// +optional
 	DiskStorageAccountType string `json:"diskStorageAccountType,omitempty"`
-	// AvailabilityZone of the nodepool. Must not be specified for clusters
-	// in a location that does not support AvailabilityZone.
+
+	// AvailabilityZone is the failure domain identifier where the VM should be attached to. This must not be specified
+	// for clusters in a location that does not support AvailabilityZone.
+	//
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
-	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs.
+
+	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
+	// needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
+	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location
+	// listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.Location.
+	//
 	// +optional
 	DiskEncryptionSetID string `json:"diskEncryptionSetID,omitempty"`
-	// EnableEphemeralOSDisk enables ephemeral OS disk
+
+	// EnableEphemeralOSDisk is a flag when set to true, will enable ephemeral OS disk.
+	//
 	// +optional
 	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
+
 	// SubnetName is the name of the subnet to place the Nodes into
 	//
 	// +kubebuilder:default:=default

--- a/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
@@ -27,7 +27,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	AvailabilityZone       *string `json:"availabilityZone,omitempty"`
 	DiskEncryptionSetID    *string `json:"diskEncryptionSetID,omitempty"`
 	EnableEphemeralOSDisk  *bool   `json:"enableEphemeralOSDisk,omitempty"`
-	SubnetName             *string `json:"subnetName,omitempty"`
+	SubnetID               *string `json:"subnetID,omitempty"`
 }
 
 // AzureNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AzureNodePoolPlatform type for use with
@@ -92,10 +92,10 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithEnableEphemeralOSDisk(valu
 	return b
 }
 
-// WithSubnetName sets the SubnetName field in the declarative configuration to the given value
+// WithSubnetID sets the SubnetID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the SubnetName field is set to the value of the last call.
-func (b *AzureNodePoolPlatformApplyConfiguration) WithSubnetName(value string) *AzureNodePoolPlatformApplyConfiguration {
-	b.SubnetName = &value
+// If called multiple times, the SubnetID field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithSubnetID(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.SubnetID = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
@@ -27,7 +27,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	AvailabilityZone       *string `json:"availabilityZone,omitempty"`
 	DiskEncryptionSetID    *string `json:"diskEncryptionSetID,omitempty"`
 	EnableEphemeralOSDisk  *bool   `json:"enableEphemeralOSDisk,omitempty"`
-	SubnetName             *string `json:"subnetName,omitempty"`
+	SubnetID               *string `json:"subnetID,omitempty"`
 }
 
 // AzureNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AzureNodePoolPlatform type for use with
@@ -92,10 +92,10 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithEnableEphemeralOSDisk(valu
 	return b
 }
 
-// WithSubnetName sets the SubnetName field in the declarative configuration to the given value
+// WithSubnetID sets the SubnetID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the SubnetName field is set to the value of the last call.
-func (b *AzureNodePoolPlatformApplyConfiguration) WithSubnetName(value string) *AzureNodePoolPlatformApplyConfiguration {
-	b.SubnetName = &value
+// If called multiple times, the SubnetID field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithSubnetID(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.SubnetID = &value
 	return b
 }

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -117,7 +117,6 @@ func applyPlatformSpecificsValues(ctx context.Context, exampleOptions *apifixtur
 		ResourceGroupName:      infra.ResourceGroupName,
 		VnetID:                 infra.VNetID,
 		SubnetID:               infra.SubnetID,
-		SubnetName:             infra.SubnetName,
 		BootImageID:            infra.BootImageID,
 		MachineIdentityID:      infra.MachineIdentityID,
 		InstanceType:           opts.AzurePlatform.InstanceType,

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -67,7 +67,6 @@ type CreateInfraOutput struct {
 	VNetID            string `json:"vnetID"`
 	VnetName          string `json:"vnetName"`
 	SubnetID          string `json:"subnetID"`
-	SubnetName        string `json:"subnetName"`
 	BootImageID       string `json:"bootImageID"`
 	InfraID           string `json:"infraID"`
 	MachineIdentityID string `json:"machineIdentityID"`
@@ -176,7 +175,6 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		}
 
 		result.SubnetID = *vnet.Properties.Subnets[0].ID
-		result.SubnetName = *vnet.Properties.Subnets[0].Name
 		result.VNetID = *vnet.ID
 		result.VnetName = *vnet.Name
 		l.Info("Successfully retrieved existing vnet", "name", result.VnetName)
@@ -206,7 +204,6 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 			return nil, err
 		}
 		result.SubnetID = *vnet.Properties.Subnets[0].ID
-		result.SubnetName = *vnet.Properties.Subnets[0].Name
 		result.VNetID = *vnet.ID
 		result.VnetName = *vnet.Name
 		l.Info("Successfully created vnet", "name", result.VnetName)

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1640,12 +1640,15 @@ spec:
                     properties:
                       availabilityZone:
                         description: |-
-                          AvailabilityZone of the nodepool. Must not be specified for clusters
-                          in a location that does not support AvailabilityZone.
+                          AvailabilityZone is the failure domain identifier where the VM should be attached to. This must not be specified
+                          for clusters in a location that does not support AvailabilityZone.
                         type: string
                       diskEncryptionSetID:
-                        description: DiskEncryptionSetID is the ID of the DiskEncryptionSet
-                          resource to use to encrypt the OS disks for the VMs.
+                        description: |-
+                          DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
+                          needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
+                          DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location
+                          listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.Location.
                         type: string
                       diskSizeGB:
                         default: 30
@@ -1674,12 +1677,16 @@ spec:
                         - UltraSSD_LRS
                         type: string
                       enableEphemeralOSDisk:
-                        description: EnableEphemeralOSDisk enables ephemeral OS disk
+                        description: EnableEphemeralOSDisk is a flag when set to true,
+                          will enable ephemeral OS disk.
                         type: boolean
                       imageID:
                         description: |-
-                          ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
-                          subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
+                          ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
+                          is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
+                          The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
+                          Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+                          hcluster.Spec.Platform.Azure.ResourceGroupName.
                         type: string
                       subnetName:
                         default: default
@@ -1687,6 +1694,8 @@ spec:
                           the Nodes into
                         type: string
                       vmsize:
+                        description: VMSize is the Azure VM instance type to use for
+                          the nodes being created in the nodepool.
                         type: string
                     required:
                     - subnetName

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -589,7 +589,7 @@ spec:
                           ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
                           subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
                         type: string
-                      subnetName:
+                      subnetID:
                         default: default
                         description: SubnetName is the name of the subnet to place
                           the Nodes into
@@ -597,7 +597,7 @@ spec:
                       vmsize:
                         type: string
                     required:
-                    - subnetName
+                    - subnetID
                     - vmsize
                     type: object
                   ibmcloud:
@@ -1685,20 +1685,25 @@ spec:
                           ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
                           is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
                           The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
-                          Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+                          Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
                           hcluster.Spec.Platform.Azure.ResourceGroupName.
                         type: string
-                      subnetName:
-                        default: default
-                        description: SubnetName is the name of the subnet to place
-                          the Nodes into
+                      subnetID:
+                        description: |-
+                          SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
+                          different subnet than the one listed in the HostedCluster, hcluster.Spec.Platform.Azure.SubnetID, but must exist
+                          in the same hcluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
+                          hcluster.Spec.Platform.Azure.SubscriptionID.
                         type: string
+                        x-kubernetes-validations:
+                        - message: SubnetID is immutable
+                          rule: self == oldSelf
                       vmsize:
                         description: VMSize is the Azure VM instance type to use for
                           the nodes being created in the nodepool.
                         type: string
                     required:
-                    - subnetName
+                    - subnetID
                     - vmsize
                     type: object
                   ibmcloud:

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -19,14 +19,13 @@ type AzurePlatformCreateOptions struct {
 	DiskEncryptionSetID    string
 	EnableEphemeralOSDisk  bool
 	DiskStorageAccountType string
-	SubnetName             string
+	SubnetID               string
 }
 
 func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	platformOpts := &AzurePlatformCreateOptions{
 		InstanceType: "Standard_D4s_v4",
 		DiskSize:     120,
-		SubnetName:   "default",
 	}
 
 	cmd := &cobra.Command{
@@ -42,7 +41,7 @@ func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
 	cmd.Flags().StringVar(&platformOpts.DiskEncryptionSetID, "disk-encryption-set-id", platformOpts.DiskEncryptionSetID, "The Disk Encryption Set ID to use to encrypt the OS disks for the VMs.")
 	cmd.Flags().BoolVar(&platformOpts.EnableEphemeralOSDisk, "enable-ephemeral-disk", platformOpts.EnableEphemeralOSDisk, "If enabled, the Azure VMs in the NodePool will be setup with ephemeral OS disks")
 	cmd.Flags().StringVar(&platformOpts.DiskStorageAccountType, "disk-storage-account-type", platformOpts.DiskStorageAccountType, "The disk storage account type for the OS disks for the VMs.")
-	cmd.Flags().StringVar(&platformOpts.SubnetName, "subnet-name", platformOpts.SubnetName, "The subnet name where the VMs will be placed.")
+	cmd.Flags().StringVar(&platformOpts.SubnetID, "subnet-id", platformOpts.SubnetID, "The subnet id where the VMs will be placed.")
 
 	cmd.RunE = coreOpts.CreateRunFunc(platformOpts)
 
@@ -63,7 +62,7 @@ func (o *AzurePlatformCreateOptions) UpdateNodePool(_ context.Context, nodePool 
 		DiskEncryptionSetID:    o.DiskEncryptionSetID,
 		EnableEphemeralOSDisk:  o.EnableEphemeralOSDisk,
 		DiskStorageAccountType: o.DiskStorageAccountType,
-		SubnetName:             o.SubnetName,
+		SubnetID:               o.SubnetID,
 	}
 	return nil
 }

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2343,6 +2343,7 @@ string
 </em>
 </td>
 <td>
+<p>VMSize is the Azure VM instance type to use for the nodes being created in the nodepool.</p>
 </td>
 </tr>
 <tr>
@@ -2354,8 +2355,11 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
-subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd</p>
+<p>ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
+is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
+The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
+Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+hcluster.Spec.Platform.Azure.ResourceGroupName.</p>
 </td>
 </tr>
 <tr>
@@ -2398,8 +2402,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>AvailabilityZone of the nodepool. Must not be specified for clusters
-in a location that does not support AvailabilityZone.</p>
+<p>AvailabilityZone is the failure domain identifier where the VM should be attached to. This must not be specified
+for clusters in a location that does not support AvailabilityZone.</p>
 </td>
 </tr>
 <tr>
@@ -2411,7 +2415,10 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs.</p>
+<p>DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
+needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
+DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location
+listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.Location.</p>
 </td>
 </tr>
 <tr>
@@ -2423,7 +2430,7 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>EnableEphemeralOSDisk enables ephemeral OS disk</p>
+<p>EnableEphemeralOSDisk is a flag when set to true, will enable ephemeral OS disk.</p>
 </td>
 </tr>
 <tr>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2358,7 +2358,7 @@ string
 <p>ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
 is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
 The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
-Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
 hcluster.Spec.Platform.Azure.ResourceGroupName.</p>
 </td>
 </tr>
@@ -2435,13 +2435,16 @@ bool
 </tr>
 <tr>
 <td>
-<code>subnetName</code></br>
+<code>subnetID</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>SubnetName is the name of the subnet to place the Nodes into</p>
+<p>SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
+different subnet than the one listed in the HostedCluster, hcluster.Spec.Platform.Azure.SubnetID, but must exist
+in the same hcluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
+hcluster.Spec.Platform.Azure.SubscriptionID.</p>
 </td>
 </tr>
 </tbody>

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -721,7 +721,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 					DiskEncryptionSetID:    o.Azure.DiskEncryptionSetID,
 					EnableEphemeralOSDisk:  o.Azure.EnableEphemeralOSDisk,
 					DiskStorageAccountType: o.Azure.DiskStorageAccountType,
-					SubnetName:             o.Azure.SubnetName,
+					SubnetID:               o.Azure.SubnetID,
 				}
 				nodePools = append(nodePools, nodePool)
 			}
@@ -738,7 +738,7 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				DiskEncryptionSetID:    o.Azure.DiskEncryptionSetID,
 				EnableEphemeralOSDisk:  o.Azure.EnableEphemeralOSDisk,
 				DiskStorageAccountType: o.Azure.DiskStorageAccountType,
-				SubnetName:             o.Azure.SubnetName,
+				SubnetID:               o.Azure.SubnetID,
 			}
 			nodePools = append(nodePools, nodePool)
 		}

--- a/examples/fixtures/example_azure.go
+++ b/examples/fixtures/example_azure.go
@@ -8,7 +8,6 @@ type ExampleAzureOptions struct {
 	ResourceGroupName      string
 	VnetID                 string
 	SubnetID               string
-	SubnetName             string
 	BootImageID            string
 	MachineIdentityID      string
 	InstanceType           string

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -57296,12 +57296,15 @@ objects:
                       properties:
                         availabilityZone:
                           description: |-
-                            AvailabilityZone of the nodepool. Must not be specified for clusters
-                            in a location that does not support AvailabilityZone.
+                            AvailabilityZone is the failure domain identifier where the VM should be attached to. This must not be specified
+                            for clusters in a location that does not support AvailabilityZone.
                           type: string
                         diskEncryptionSetID:
-                          description: DiskEncryptionSetID is the ID of the DiskEncryptionSet
-                            resource to use to encrypt the OS disks for the VMs.
+                          description: |-
+                            DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
+                            needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
+                            DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location
+                            listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.Location.
                           type: string
                         diskSizeGB:
                           default: 30
@@ -57330,13 +57333,16 @@ objects:
                           - UltraSSD_LRS
                           type: string
                         enableEphemeralOSDisk:
-                          description: EnableEphemeralOSDisk enables ephemeral OS
-                            disk
+                          description: EnableEphemeralOSDisk is a flag when set to
+                            true, will enable ephemeral OS disk.
                           type: boolean
                         imageID:
                           description: |-
-                            ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
-                            subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
+                            ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
+                            is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
+                            The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
+                            Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+                            hcluster.Spec.Platform.Azure.ResourceGroupName.
                           type: string
                         subnetName:
                           default: default
@@ -57344,6 +57350,8 @@ objects:
                             the Nodes into
                           type: string
                         vmsize:
+                          description: VMSize is the Azure VM instance type to use
+                            for the nodes being created in the nodepool.
                           type: string
                       required:
                       - subnetName

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -56242,7 +56242,7 @@ objects:
                             ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
                             subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
                           type: string
-                        subnetName:
+                        subnetID:
                           default: default
                           description: SubnetName is the name of the subnet to place
                             the Nodes into
@@ -56250,7 +56250,7 @@ objects:
                         vmsize:
                           type: string
                       required:
-                      - subnetName
+                      - subnetID
                       - vmsize
                       type: object
                     ibmcloud:
@@ -57341,20 +57341,25 @@ objects:
                             ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
                             is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
                             The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
-                            Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+                            Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
                             hcluster.Spec.Platform.Azure.ResourceGroupName.
                           type: string
-                        subnetName:
-                          default: default
-                          description: SubnetName is the name of the subnet to place
-                            the Nodes into
+                        subnetID:
+                          description: |-
+                            SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
+                            different subnet than the one listed in the HostedCluster, hcluster.Spec.Platform.Azure.SubnetID, but must exist
+                            in the same hcluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
+                            hcluster.Spec.Platform.Azure.SubscriptionID.
                           type: string
+                          x-kubernetes-validations:
+                          - message: SubnetID is immutable
+                            rule: self == oldSelf
                         vmsize:
                           description: VMSize is the Azure VM instance type to use
                             for the nodes being created in the nodepool.
                           type: string
                       required:
-                      - subnetName
+                      - subnetID
                       - vmsize
                       type: object
                     ibmcloud:

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
@@ -901,7 +901,7 @@ type AzureNodePoolPlatform struct {
 	//
 	// +kubebuilder:default:=default
 	// +kubebuilder:validation:Required
-	SubnetName string `json:"subnetName"`
+	SubnetID string `json:"subnetID"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -872,7 +872,7 @@ type AzureNodePoolPlatform struct {
 	// ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
 	// is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
 	// The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
-	// Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+	// Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
 	// hcluster.Spec.Platform.Azure.ResourceGroupName.
 	//
 	// +optional
@@ -919,11 +919,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
 
-	// SubnetName is the name of the subnet to place the Nodes into
+	// SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
+	// different subnet than the one listed in the HostedCluster, hcluster.Spec.Platform.Azure.SubnetID, but must exist
+	// in the same hcluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
+	// hcluster.Spec.Platform.Azure.SubscriptionID.
 	//
-	// +kubebuilder:default:=default
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="SubnetID is immutable"
 	// +kubebuilder:validation:Required
-	SubnetName string `json:"subnetName"`
+	// +immutable
+	// +required
+	SubnetID string `json:"subnetID"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -863,11 +863,21 @@ type AgentNodePoolPlatform struct {
 }
 
 type AzureNodePoolPlatform struct {
+	// VMSize is the Azure VM instance type to use for the nodes being created in the nodepool.
+	//
+	// +kubebuilder:validation:Required
+	// +required
 	VMSize string `json:"vmsize"`
-	// ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
-	// subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
+
+	// ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
+	// is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
+	// The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
+	// Hosted Cluster specification respecitvely, hcluster.Spec.Platform.Azure.SubscriptionID and
+	// hcluster.Spec.Platform.Azure.ResourceGroupName.
+	//
 	// +optional
 	ImageID string `json:"imageID,omitempty"`
+
 	// DiskSizeGB is the size in GB to assign to the OS disk
 	// CAPZ default is 30GB, https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/b3708019a67ff19407b87d63c402af94ca4246f6/api/v1beta1/types.go#L599
 	//
@@ -875,6 +885,7 @@ type AzureNodePoolPlatform struct {
 	// +kubebuilder:validation:Minimum=16
 	// +optional
 	DiskSizeGB int32 `json:"diskSizeGB,omitempty"`
+
 	// DiskStorageAccountType is the disk storage account type to use. Valid values are:
 	// * Standard_LRS: HDD
 	// * StandardSSD_LRS: Standard SSD
@@ -888,16 +899,26 @@ type AzureNodePoolPlatform struct {
 	// +kubebuilder:validation:Enum=Standard_LRS;StandardSSD_LRS;Premium_LRS;UltraSSD_LRS
 	// +optional
 	DiskStorageAccountType string `json:"diskStorageAccountType,omitempty"`
-	// AvailabilityZone of the nodepool. Must not be specified for clusters
-	// in a location that does not support AvailabilityZone.
+
+	// AvailabilityZone is the failure domain identifier where the VM should be attached to. This must not be specified
+	// for clusters in a location that does not support AvailabilityZone.
+	//
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
-	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs.
+
+	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
+	// needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
+	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location
+	// listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.Location.
+	//
 	// +optional
 	DiskEncryptionSetID string `json:"diskEncryptionSetID,omitempty"`
-	// EnableEphemeralOSDisk enables ephemeral OS disk
+
+	// EnableEphemeralOSDisk is a flag when set to true, will enable ephemeral OS disk.
+	//
 	// +optional
 	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
+
 	// SubnetName is the name of the subnet to place the Nodes into
 	//
 	// +kubebuilder:default:=default


### PR DESCRIPTION
**What this PR does / why we need it**:
Refine the Azure API in the NodePool Spec:
* add additional details to the NodePool API
* Remove SubnetName in favor of SubnetID in the NodePool API

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1563](https://issues.redhat.com/browse/HOSTEDCP-1563)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.