### PR TITLE
HOSTEDCP-1557: Allow the NSG ID to drive the NSG Resource Group for the Azure Cloud Provider Config

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1783,8 +1783,7 @@ type AzurePlatformSpec struct {
 
 	// SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
 	// configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
-	// expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
-	// in.
+	// expected to exist under the same subscription as SubscriptionID.
 	//
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SecurityGroupID is immutable"
 	// +kubebuilder:validation:Required

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -184,7 +184,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		// Extract network security group name
 		if vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup != nil && vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup.ID != nil {
 			result.SecurityGroupID = *vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup.ID
-			securityGroupName, err := azureutil.GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(*vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup.ID)
+			securityGroupName, _, err := azureutil.GetNameAndResourceGroupFromNetworkSecurityGroupID(*vnet.Properties.Subnets[0].Properties.NetworkSecurityGroup.ID)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -7567,8 +7567,7 @@ spec:
                         description: |-
                           SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
                           configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
-                          expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
-                          in.
+                          expected to exist under the same subscription as SubscriptionID.
                         type: string
                         x-kubernetes-validations:
                         - message: SecurityGroupID is immutable

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -7536,8 +7536,7 @@ spec:
                         description: |-
                           SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
                           configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
-                          expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
-                          in.
+                          expected to exist under the same subscription as SubscriptionID.
                         type: string
                         x-kubernetes-validations:
                         - message: SecurityGroupID is immutable

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -64,7 +64,7 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 		return AzureConfig{}, fmt.Errorf("failed to determine subnet name from SubnetID: %w", err)
 	}
 
-	securityGroupName, err := azureutil.GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(hcp.Spec.Platform.Azure.SecurityGroupID)
+	securityGroupName, securityGroupResourceGroup, err := azureutil.GetNameAndResourceGroupFromNetworkSecurityGroupID(hcp.Spec.Platform.Azure.SecurityGroupID)
 	if err != nil {
 		return AzureConfig{}, fmt.Errorf("failed to determine security group name from SecurityGroupID: %w", err)
 	}
@@ -85,7 +85,7 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 		VnetResourceGroup:            vnetResourceGroup,
 		SubnetName:                   subnetName,
 		SecurityGroupName:            securityGroupName,
-		SecurityGroupResourceGroup:   vnetResourceGroup,
+		SecurityGroupResourceGroup:   securityGroupResourceGroup,
 		LoadBalancerName:             hcp.Spec.InfraID,
 		CloudProviderBackoff:         true,
 		CloudProviderBackoffDuration: 6,

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2573,8 +2573,7 @@ string
 <td>
 <p>SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
 configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
-expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
-in.</p>
+expected to exist under the same subscription as SubscriptionID.</p>
 </td>
 </tr>
 </tbody>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -45253,8 +45253,7 @@ objects:
                           description: |-
                             SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
                             configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
-                            expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
-                            in.
+                            expected to exist under the same subscription as SubscriptionID.
                           type: string
                           x-kubernetes-validations:
                           - message: SecurityGroupID is immutable
@@ -54218,8 +54217,7 @@ objects:
                           description: |-
                             SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
                             configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
-                            expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
-                            in.
+                            expected to exist under the same subscription as SubscriptionID.
                           type: string
                           x-kubernetes-validations:
                           - message: SecurityGroupID is immutable

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -29,23 +29,27 @@ func GetSubnetNameFromSubnetID(subnetID string) (string, error) {
 	return subnet.Name, nil
 }
 
-// GetNetworkSecurityGroupNameFromNetworkSecurityGroupID extracts the network security group (nsg) name from a nsg ID
+// GetNameAndResourceGroupFromNetworkSecurityGroupID extracts the network security group (nsg) name and its resourrce group name from a nsg ID
 // Example nsg ID: /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/networkSecurityGroups/<nsgName>
-func GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(nsgID string) (string, error) {
+func GetNameAndResourceGroupFromNetworkSecurityGroupID(nsgID string) (string, string, error) {
 	nsg, err := arm.ParseResourceID(nsgID)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse network security group ID %q: %v", nsgID, err)
+		return "", "", fmt.Errorf("failed to parse network security group ID %q: %v", nsgID, err)
 	}
 
 	if !strings.EqualFold(nsg.ResourceType.Type, "networkSecurityGroups") {
-		return "", fmt.Errorf("invalid resource type '%s', expected 'networkSecurityGroups'", nsg.ResourceType.Type)
+		return "", "", fmt.Errorf("invalid resource type '%s', expected 'networkSecurityGroups'", nsg.ResourceType.Type)
 	}
 
 	if nsg.Name == "" {
-		return "", fmt.Errorf("failed to parse network security group name from %q", nsgID)
+		return "", "", fmt.Errorf("failed to parse network security group name from %q", nsgID)
 	}
 
-	return nsg.Name, nil
+	if nsg.ResourceGroupName == "" {
+		return "", "", fmt.Errorf("failed to parse resource group name from %q", nsgID)
+	}
+
+	return nsg.Name, nsg.ResourceGroupName, nil
 }
 
 // GetVnetNameAndResourceGroupFromVnetID extracts the VNET name and its resource group from a VNET ID

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -80,14 +80,60 @@ func TestGetNetworkSecurityGroupNameFromNetworkSecurityGroupID(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.testCaseName, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			nsgID, nsgRG, err := GetNameAndResourceGroupFromNetworkSecurityGroupID(tc.nsgID)
+			nsgName, nsgRG, err := GetNameAndResourceGroupFromNetworkSecurityGroupID(tc.nsgID)
 			if tc.expectedErr {
 				g.Expect(err).To(Not(BeNil()))
 				g.Expect(err).To(HaveOccurred(), "invalid nsg ID format: "+tc.nsgID)
 			} else {
 				g.Expect(err).To(BeNil())
-				g.Expect(nsgID).To(Equal(tc.expectedNSGName))
+				g.Expect(nsgName).To(Equal(tc.expectedNSGName))
 				g.Expect(nsgRG).To(Equal(tc.expectedNSGRG))
+			}
+		})
+	}
+}
+
+func TestGetVnetNameAndResourceGroupFromVnetID(t *testing.T) {
+	tests := []struct {
+		testCaseName     string
+		vnetID           string
+		expectedVnetName string
+		expectedVnetRG   string
+		expectedErr      bool
+	}{
+		{
+			testCaseName:     "empty VNET ID",
+			vnetID:           "",
+			expectedVnetName: "",
+			expectedVnetRG:   "",
+			expectedErr:      true,
+		},
+		{
+			testCaseName:     "improperly formed VNET ID",
+			vnetID:           "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/virtualNetworks/",
+			expectedVnetName: "",
+			expectedVnetRG:   "",
+			expectedErr:      true,
+		},
+		{
+			testCaseName:     "properly formed VNET ID",
+			vnetID:           "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/virtualNetworks/myVnetName",
+			expectedVnetName: "myVnetName",
+			expectedVnetRG:   "myResourceGroupName",
+			expectedErr:      false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.testCaseName, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			vnetName, vnetRG, err := GetVnetNameAndResourceGroupFromVnetID(tc.vnetID)
+			if tc.expectedErr {
+				g.Expect(err).To(Not(BeNil()))
+				g.Expect(err).To(HaveOccurred(), "invalid VNET ID format: "+tc.vnetID)
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(vnetName).To(Equal(tc.expectedVnetName))
+				g.Expect(vnetRG).To(Equal(tc.expectedVnetRG))
 			}
 		})
 	}

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -52,37 +52,42 @@ func TestGetNetworkSecurityGroupNameFromNetworkSecurityGroupID(t *testing.T) {
 		testCaseName    string
 		nsgID           string
 		expectedNSGName string
+		expectedNSGRG   string
 		expectedErr     bool
 	}{
 		{
 			testCaseName:    "empty NSG ID",
 			nsgID:           "",
 			expectedNSGName: "",
+			expectedNSGRG:   "",
 			expectedErr:     true,
 		},
 		{
 			testCaseName:    "improperly formed nsg ID",
 			nsgID:           "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/networkSecurityGroups",
 			expectedNSGName: "",
+			expectedNSGRG:   "",
 			expectedErr:     true,
 		},
 		{
 			testCaseName:    "properly formed nsg ID",
 			nsgID:           "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/networkSecurityGroups/myNSGName",
 			expectedNSGName: "myNSGName",
+			expectedNSGRG:   "myResourceGroupName",
 			expectedErr:     false,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.testCaseName, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			subnetID, err := GetNetworkSecurityGroupNameFromNetworkSecurityGroupID(tc.nsgID)
+			nsgID, nsgRG, err := GetNameAndResourceGroupFromNetworkSecurityGroupID(tc.nsgID)
 			if tc.expectedErr {
 				g.Expect(err).To(Not(BeNil()))
 				g.Expect(err).To(HaveOccurred(), "invalid nsg ID format: "+tc.nsgID)
 			} else {
 				g.Expect(err).To(BeNil())
-				g.Expect(subnetID).To(Equal(tc.expectedNSGName))
+				g.Expect(nsgID).To(Equal(tc.expectedNSGName))
+				g.Expect(nsgRG).To(Equal(tc.expectedNSGRG))
 			}
 		})
 	}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1783,8 +1783,7 @@ type AzurePlatformSpec struct {
 
 	// SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
 	// configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
-	// expected to exist under the same subscription as SubscriptionID and in the same resource group VnetID is located
-	// in.
+	// expected to exist under the same subscription as SubscriptionID.
 	//
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SecurityGroupID is immutable"
 	// +kubebuilder:validation:Required


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets the network security group (NSG) resource group based on the resource group in the NSG ID.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1557](https://issues.redhat.com/browse/HOSTEDCP-1557)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.