### PR TITLE
HOSTEDCP-1542: hcco: expose Azure federated token files

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1701,12 +1701,13 @@ type AWSServiceEndpoint struct {
 // would be pre-created and then their names would be used respectively in the ResourceGroupName, SubnetName, VnetName
 // fields of the Hosted Cluster CR. An existing cloud resource is expected to exist under the same SubscriptionID.
 type AzurePlatformSpec struct {
-	// Credentials is the object containing existing Azure credentials needed for creating and managing cloud
-	// infrastructure resources.
+	// TenantID is the id for the Azure tenant in which this Hosted Cluster will be created.
 	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="TenantID is immutable"
+	// +immutable
 	// +required
-	Credentials corev1.LocalObjectReference `json:"credentials"`
+	TenantID string `json:"tenantID,omitempty"`
 
 	// Cloud is the cloud environment identifier, valid values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33
 	//
@@ -1791,6 +1792,70 @@ type AzurePlatformSpec struct {
 	// +immutable
 	// +required
 	SecurityGroupID string `json:"securityGroupID,omitempty"`
+
+	// IngressClientID is the client ID appropriate for the Ingress Operator.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="IngressClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	IngressClientID string `json:"ingressClientID"`
+
+	// ImageRegistryClientID is the client ID appropriate for the Image Registry Operator.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ImageRegistryClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	ImageRegistryClientID string `json:"imageRegistryClientID"`
+
+	// DiskClientID is the client ID appropriate for the Storage Operator. // TODO(skuznets): differentiate file & disk
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="DiskClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	DiskClientID string `json:"diskClientID"`
+
+	// FileClientID is the client ID appropriate for the Storage Operator. // TODO(skuznets): differentiate file & disk
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="FileClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	FileClientID string `json:"fileClientID"`
+
+	// NetworkClientID is the client ID for appropriate for the Network Operator.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="NetworkClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	NetworkClientID string `json:"networkClientID"`
+
+	// KubeCloudControllerClientID is the client ID appropriate for the KCM/KCC.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="KubeCloudControllerClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	KubeCloudControllerClientID string `json:"kubeCloudControllerClientID"`
+
+	// NodePoolManagementClientID is the client ID appropriate for the CAPI Controller.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="NodePoolManagementClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	NodePoolManagementClientID string `json:"nodePoolManagementClientID"`
+
+	// ControlPlaneOperatorClientID is the client ID appropriate for the Control Plane Operator.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ControlPlaneOperatorClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	ControlPlaneOperatorClientID string `json:"controlPlaneOperatorClientID"`
 }
 
 // Release represents the metadata for an OCP release payload image.

--- a/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
@@ -17,22 +17,26 @@ limitations under the License.
 
 package v1beta1
 
-import (
-	v1 "k8s.io/api/core/v1"
-)
-
 // AzurePlatformSpecApplyConfiguration represents an declarative configuration of the AzurePlatformSpec type for use
 // with apply.
 type AzurePlatformSpecApplyConfiguration struct {
-	Credentials       *v1.LocalObjectReference `json:"credentials,omitempty"`
-	Cloud             *string                  `json:"cloud,omitempty"`
-	Location          *string                  `json:"location,omitempty"`
-	ResourceGroupName *string                  `json:"resourceGroup,omitempty"`
-	VnetID            *string                  `json:"vnetID,omitempty"`
-	SubnetID          *string                  `json:"subnetID,omitempty"`
-	SubscriptionID    *string                  `json:"subscriptionID,omitempty"`
-	MachineIdentityID *string                  `json:"machineIdentityID,omitempty"`
-	SecurityGroupID   *string                  `json:"securityGroupID,omitempty"`
+	TenantID                     *string `json:"tenantID,omitempty"`
+	Cloud                        *string `json:"cloud,omitempty"`
+	Location                     *string `json:"location,omitempty"`
+	ResourceGroupName            *string `json:"resourceGroup,omitempty"`
+	VnetID                       *string `json:"vnetID,omitempty"`
+	SubnetID                     *string `json:"subnetID,omitempty"`
+	SubscriptionID               *string `json:"subscriptionID,omitempty"`
+	MachineIdentityID            *string `json:"machineIdentityID,omitempty"`
+	SecurityGroupID              *string `json:"securityGroupID,omitempty"`
+	IngressClientID              *string `json:"ingressClientID,omitempty"`
+	ImageRegistryClientID        *string `json:"imageRegistryClientID,omitempty"`
+	DiskClientID                 *string `json:"diskClientID,omitempty"`
+	FileClientID                 *string `json:"fileClientID,omitempty"`
+	NetworkClientID              *string `json:"networkClientID,omitempty"`
+	KubeCloudControllerClientID  *string `json:"kubeCloudControllerClientID,omitempty"`
+	NodePoolManagementClientID   *string `json:"nodePoolManagementClientID,omitempty"`
+	ControlPlaneOperatorClientID *string `json:"controlPlaneOperatorClientID,omitempty"`
 }
 
 // AzurePlatformSpecApplyConfiguration constructs an declarative configuration of the AzurePlatformSpec type for use with
@@ -41,11 +45,11 @@ func AzurePlatformSpec() *AzurePlatformSpecApplyConfiguration {
 	return &AzurePlatformSpecApplyConfiguration{}
 }
 
-// WithCredentials sets the Credentials field in the declarative configuration to the given value
+// WithTenantID sets the TenantID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Credentials field is set to the value of the last call.
-func (b *AzurePlatformSpecApplyConfiguration) WithCredentials(value v1.LocalObjectReference) *AzurePlatformSpecApplyConfiguration {
-	b.Credentials = &value
+// If called multiple times, the TenantID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithTenantID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.TenantID = &value
 	return b
 }
 
@@ -110,5 +114,69 @@ func (b *AzurePlatformSpecApplyConfiguration) WithMachineIdentityID(value string
 // If called multiple times, the SecurityGroupID field is set to the value of the last call.
 func (b *AzurePlatformSpecApplyConfiguration) WithSecurityGroupID(value string) *AzurePlatformSpecApplyConfiguration {
 	b.SecurityGroupID = &value
+	return b
+}
+
+// WithIngressClientID sets the IngressClientID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the IngressClientID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithIngressClientID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.IngressClientID = &value
+	return b
+}
+
+// WithImageRegistryClientID sets the ImageRegistryClientID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ImageRegistryClientID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithImageRegistryClientID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.ImageRegistryClientID = &value
+	return b
+}
+
+// WithDiskClientID sets the DiskClientID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DiskClientID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithDiskClientID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.DiskClientID = &value
+	return b
+}
+
+// WithFileClientID sets the FileClientID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the FileClientID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithFileClientID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.FileClientID = &value
+	return b
+}
+
+// WithNetworkClientID sets the NetworkClientID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NetworkClientID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithNetworkClientID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.NetworkClientID = &value
+	return b
+}
+
+// WithKubeCloudControllerClientID sets the KubeCloudControllerClientID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the KubeCloudControllerClientID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithKubeCloudControllerClientID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.KubeCloudControllerClientID = &value
+	return b
+}
+
+// WithNodePoolManagementClientID sets the NodePoolManagementClientID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NodePoolManagementClientID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithNodePoolManagementClientID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.NodePoolManagementClientID = &value
+	return b
+}
+
+// WithControlPlaneOperatorClientID sets the ControlPlaneOperatorClientID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ControlPlaneOperatorClientID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithControlPlaneOperatorClientID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.ControlPlaneOperatorClientID = &value
 	return b
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/creds.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/creds.go
@@ -5,7 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func AWSIngressCloudCredsSecret() *corev1.Secret {
+func IngressCloudCredsSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "openshift-ingress-operator",
@@ -14,7 +14,7 @@ func AWSIngressCloudCredsSecret() *corev1.Secret {
 	}
 }
 
-func AWSImageRegistryCloudCredsSecret() *corev1.Secret {
+func ImageRegistryCloudCredsSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "openshift-image-registry",
@@ -23,11 +23,38 @@ func AWSImageRegistryCloudCredsSecret() *corev1.Secret {
 	}
 }
 
-func AWSStorageCloudCredsSecret() *corev1.Secret {
+func EBSStorageCloudCredsSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "openshift-cluster-csi-drivers",
 			Name:      "ebs-cloud-credentials",
+		},
+	}
+}
+
+func ClusterNetworkingCloudCredsSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-cloud-network-config-controller",
+			Name:      "cloud-credentials",
+		},
+	}
+}
+
+func AzureDiskCloudCredsSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-cluster-csi-drivers",
+			Name:      "azure-disk-credentials",
+		},
+	}
+}
+
+func AzureFileCloudCredsSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-cluster-csi-drivers",
+			Name:      "azure-file-credentials",
 		},
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1313,9 +1313,9 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 			return nil
 		}
 		for arn, secret := range map[string]*corev1.Secret{
-			hcp.Spec.Platform.AWS.RolesRef.IngressARN:       manifests.AWSIngressCloudCredsSecret(),
-			hcp.Spec.Platform.AWS.RolesRef.StorageARN:       manifests.AWSStorageCloudCredsSecret(),
-			hcp.Spec.Platform.AWS.RolesRef.ImageRegistryARN: manifests.AWSImageRegistryCloudCredsSecret(),
+			hcp.Spec.Platform.AWS.RolesRef.IngressARN:       manifests.IngressCloudCredsSecret(),
+			hcp.Spec.Platform.AWS.RolesRef.StorageARN:       manifests.EBSStorageCloudCredsSecret(),
+			hcp.Spec.Platform.AWS.RolesRef.ImageRegistryARN: manifests.ImageRegistryCloudCredsSecret(),
 		} {
 			err := syncSecret(secret, arn)
 			if err != nil {
@@ -1323,59 +1323,21 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 			}
 		}
 	case hyperv1.AzurePlatform:
-		referenceCredentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.Azure.Credentials.Name}}
-		if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(referenceCredentialsSecret), referenceCredentialsSecret); err != nil {
-			return []error{fmt.Errorf("failed to get cloud credentials secret in hcp namespace: %w", err)}
-		}
-
-		secretData := map[string][]byte{
-			"azure_client_id":       referenceCredentialsSecret.Data["AZURE_CLIENT_ID"],
-			"azure_client_secret":   referenceCredentialsSecret.Data["AZURE_CLIENT_SECRET"],
-			"azure_region":          []byte(hcp.Spec.Platform.Azure.Location),
-			"azure_resource_prefix": []byte(hcp.Name + "-" + hcp.Spec.InfraID),
-			"azure_resourcegroup":   []byte(hcp.Spec.Platform.Azure.ResourceGroupName),
-			"azure_subscription_id": referenceCredentialsSecret.Data["AZURE_SUBSCRIPTION_ID"],
-			"azure_tenant_id":       referenceCredentialsSecret.Data["AZURE_TENANT_ID"],
-		}
-
-		ingressCredentialSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ingress-operator", Name: "cloud-credentials"}}
-		if _, err := r.CreateOrUpdate(ctx, r.client, ingressCredentialSecret, func() error {
-			ingressCredentialSecret.Data = secretData
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed tom reconcile guest cluster ingress operator secret: %w", err))
-		}
-
-		csiCredentialSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-cluster-csi-drivers", Name: "azure-disk-credentials"}}
-		if _, err := r.CreateOrUpdate(ctx, r.client, csiCredentialSecret, func() error {
-			csiCredentialSecret.Data = secretData
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile guest cluster CSI secret: %w", err))
-		}
-
-		imageRegistrySecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-image-registry", Name: "installer-cloud-credentials"}}
-		if _, err := r.CreateOrUpdate(ctx, r.client, imageRegistrySecret, func() error {
-			imageRegistrySecret.Data = secretData
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile guest cluster image-registry secret: %w", err))
-		}
-
-		cloudNetworkConfigControllerSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-cloud-network-config-controller", Name: "cloud-credentials"}}
-		if _, err := r.CreateOrUpdate(ctx, r.client, cloudNetworkConfigControllerSecret, func() error {
-			cloudNetworkConfigControllerSecret.Data = secretData
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile guest cluster cloud-network-config-controller secret: %w", err))
-		}
-
-		csiDriverSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-cluster-csi-drivers", Name: "azure-file-credentials"}}
-		if _, err := r.CreateOrUpdate(ctx, r.client, csiDriverSecret, func() error {
-			csiDriverSecret.Data = secretData
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile csi driver secret: %w", err))
+		secretData := AzureFederatedTokenCredentialSecretData(hcp.ObjectMeta.Name, hcp.Spec.InfraID, hcp.Spec.Platform.Azure)
+		for clientId, secret := range map[string]*corev1.Secret{
+			hcp.Spec.Platform.Azure.IngressClientID:       manifests.IngressCloudCredsSecret(),
+			hcp.Spec.Platform.Azure.ImageRegistryClientID: manifests.ImageRegistryCloudCredsSecret(),
+			hcp.Spec.Platform.Azure.NetworkClientID:       manifests.ClusterNetworkingCloudCredsSecret(),
+			hcp.Spec.Platform.Azure.DiskClientID:          manifests.AzureDiskCloudCredsSecret(),
+			hcp.Spec.Platform.Azure.FileClientID:          manifests.AzureFileCloudCredsSecret(),
+		} {
+			if _, err := r.CreateOrUpdate(ctx, r.client, secret, func() error {
+				secret.Data = secretData
+				secret.Data["azure_client_id"] = []byte(clientId)
+				return nil
+			}); err != nil {
+				errs = append(errs, fmt.Errorf("failed to reconcile guest cluster secret %s/%s: %w", secret.Namespace, secret.Name, err))
+			}
 		}
 	case hyperv1.PowerVSPlatform:
 		createPowerVSSecret := func(srcSecret, destSecret *corev1.Secret) error {
@@ -1449,6 +1411,17 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 		}
 	}
 	return errs
+}
+
+func AzureFederatedTokenCredentialSecretData(name, infraID string, config *hyperv1.AzurePlatformSpec) map[string][]byte {
+	return map[string][]byte{
+		"azure_region":               []byte(config.Location),
+		"azure_resource_prefix":      []byte(name + "-" + infraID),
+		"azure_resourcegroup":        []byte(config.ResourceGroupName),
+		"azure_subscription_id":      []byte(config.SubscriptionID),
+		"azure_tenant_id":            []byte(config.TenantID),
+		"azure_federated_token_file": []byte("/var/run/secrets/openshift/serviceaccount/token"),
+	}
 }
 
 // reconcileOperatorHub gets the OperatorHubConfig from the HCP, for now the controller only reconcile over the DisableAllDefaultSources field and only once.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -40,6 +40,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
+	platformmanifests "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/manifests"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"gopkg.in/ini.v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -2666,7 +2667,7 @@ func reconcileControlPlaneOperatorDeployment(
 				Name: "provider-creds",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: platformaws.ControlPlaneOperatorCredsSecret("").Name,
+						SecretName: platformmanifests.ControlPlaneOperatorCredsSecret("").Name,
 					},
 				},
 			})

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/manifests"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/blang/semver"
@@ -102,7 +103,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 						Name: "credentials",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: NodePoolManagementCredsSecret("").Name,
+								SecretName: manifests.NodePoolManagementCredsSecret("").Name,
 							},
 						},
 					},
@@ -261,10 +262,10 @@ sts_regional_endpoints = regional
 		return nil
 	}
 	for arn, secret := range map[string]*corev1.Secret{
-		hcluster.Spec.Platform.AWS.RolesRef.KubeCloudControllerARN:  KubeCloudControllerCredsSecret(controlPlaneNamespace),
-		hcluster.Spec.Platform.AWS.RolesRef.NodePoolManagementARN:   NodePoolManagementCredsSecret(controlPlaneNamespace),
-		hcluster.Spec.Platform.AWS.RolesRef.ControlPlaneOperatorARN: ControlPlaneOperatorCredsSecret(controlPlaneNamespace),
-		hcluster.Spec.Platform.AWS.RolesRef.NetworkARN:              CloudNetworkConfigControllerCredsSecret(controlPlaneNamespace),
+		hcluster.Spec.Platform.AWS.RolesRef.KubeCloudControllerARN:  manifests.KubeCloudControllerCredsSecret(controlPlaneNamespace),
+		hcluster.Spec.Platform.AWS.RolesRef.NodePoolManagementARN:   manifests.NodePoolManagementCredsSecret(controlPlaneNamespace),
+		hcluster.Spec.Platform.AWS.RolesRef.ControlPlaneOperatorARN: manifests.ControlPlaneOperatorCredsSecret(controlPlaneNamespace),
+		hcluster.Spec.Platform.AWS.RolesRef.NetworkARN:              manifests.CloudNetworkConfigControllerCredsSecret(controlPlaneNamespace),
 		hcluster.Spec.Platform.AWS.RolesRef.StorageARN:              AWSEBSCSIDriverCredsSecret(controlPlaneNamespace),
 	} {
 		err := syncSecret(secret, arn)
@@ -363,42 +364,6 @@ func (AWS) CAPIProviderPolicyRules() []rbacv1.PolicyRule {
 
 func (AWS) DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error {
 	return nil
-}
-
-func KubeCloudControllerCredsSecret(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      "cloud-controller-creds",
-		},
-	}
-}
-
-func NodePoolManagementCredsSecret(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      "node-management-creds",
-		},
-	}
-}
-
-func ControlPlaneOperatorCredsSecret(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      "control-plane-operator-creds",
-		},
-	}
-}
-
-func CloudNetworkConfigControllerCredsSecret(controlPlaneNamespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controlPlaneNamespace,
-			Name:      "cloud-network-config-controller-creds",
-		},
-	}
 }
 
 func AWSEBSCSIDriverCredsSecret(controlPlaneNamespace string) *corev1.Secret {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/manifests/manifests.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/manifests/manifests.go
@@ -1,0 +1,42 @@
+package manifests
+
+import (
+	"k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func KubeCloudControllerCredsSecret(controlPlaneNamespace string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      "cloud-controller-creds",
+		},
+	}
+}
+
+func NodePoolManagementCredsSecret(controlPlaneNamespace string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      "node-management-creds",
+		},
+	}
+}
+
+func ControlPlaneOperatorCredsSecret(controlPlaneNamespace string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      "control-plane-operator-creds",
+		},
+	}
+}
+
+func CloudNetworkConfigControllerCredsSecret(controlPlaneNamespace string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Namespace: controlPlaneNamespace,
+			Name:      "cloud-network-config-controller-creds",
+		},
+	}
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1701,12 +1701,13 @@ type AWSServiceEndpoint struct {
 // would be pre-created and then their names would be used respectively in the ResourceGroupName, SubnetName, VnetName
 // fields of the Hosted Cluster CR. An existing cloud resource is expected to exist under the same SubscriptionID.
 type AzurePlatformSpec struct {
-	// Credentials is the object containing existing Azure credentials needed for creating and managing cloud
-	// infrastructure resources.
+	// TenantID is the id for the Azure tenant in which this Hosted Cluster will be created.
 	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="TenantID is immutable"
+	// +immutable
 	// +required
-	Credentials corev1.LocalObjectReference `json:"credentials"`
+	TenantID string `json:"tenantID,omitempty"`
 
 	// Cloud is the cloud environment identifier, valid values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33
 	//
@@ -1791,6 +1792,70 @@ type AzurePlatformSpec struct {
 	// +immutable
 	// +required
 	SecurityGroupID string `json:"securityGroupID,omitempty"`
+
+	// IngressClientID is the client ID appropriate for the Ingress Operator.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="IngressClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	IngressClientID string `json:"ingressClientID"`
+
+	// ImageRegistryClientID is the client ID appropriate for the Image Registry Operator.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ImageRegistryClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	ImageRegistryClientID string `json:"imageRegistryClientID"`
+
+	// DiskClientID is the client ID appropriate for the Storage Operator. // TODO(skuznets): differentiate file & disk
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="DiskClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	DiskClientID string `json:"diskClientID"`
+
+	// FileClientID is the client ID appropriate for the Storage Operator. // TODO(skuznets): differentiate file & disk
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="FileClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	FileClientID string `json:"fileClientID"`
+
+	// NetworkClientID is the client ID for appropriate for the Network Operator.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="NetworkClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	NetworkClientID string `json:"networkClientID"`
+
+	// KubeCloudControllerClientID is the client ID appropriate for the KCM/KCC.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="KubeCloudControllerClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	KubeCloudControllerClientID string `json:"kubeCloudControllerClientID"`
+
+	// NodePoolManagementClientID is the client ID appropriate for the CAPI Controller.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="NodePoolManagementClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	NodePoolManagementClientID string `json:"nodePoolManagementClientID"`
+
+	// ControlPlaneOperatorClientID is the client ID appropriate for the Control Plane Operator.
+	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ControlPlaneOperatorClientID is immutable"
+	// +kubebuilder:validation:Required
+	// +immutable
+	// +required
+	ControlPlaneOperatorClientID string `json:"controlPlaneOperatorClientID"`
 }
 
 // Release represents the metadata for an OCP release payload image.


### PR DESCRIPTION
hcco: expose Azure federated token files

Expect components to use Azure workload identity, propagate those
secrets from the HyperShift Operator to each individual HostedCluster
namespace, then to the guest clusters themselves.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

