### PR TITLE
OCPBUGS-33595: Cluster sizing controller: do not error on not found HC

### DIFF
--- a/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller.go
+++ b/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/hypershift/support/releaseinfo"
 	hyperutil "github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -127,6 +128,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	hostedCluster, err := r.getHostedCluster(ctx, request.NamespacedName)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoids an indefinite requeue of hosted clusters that no longer exist

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-33595](https://issues.redhat.com/browse/OCPBUGS-33595)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.