### PR TITLE
HOSTEDCP-1553: Add annotation to customize log verbosity of kube-apiserver

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -300,6 +300,9 @@ const (
 	// ClusterSizeOverrideAnnotation allows overriding the value of the size label regardless of the number
 	// of workers associated with the HostedCluster. The value should be the desired size label.
 	ClusterSizeOverrideAnnotation = "hypershift.openshift.io/cluster-size-override"
+
+	// KubeAPIServerVerbosityLevelAnnotation allows specifing the log verbosity of kube-apiserver.
+	KubeAPIServerVerbosityLevelAnnotation = "hypershift.openshift.io/kube-apiserver-verbosity-level"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -429,21 +429,18 @@ func buildKASContainerMain(image string, port int32, noProxyCIDRs []string, hcp 
 			"hyperkube",
 		}
 
-		// default to level of 2
-		kasVerbosityLevel := "--v=2"
+		kasVerbosityLevel := 2
 		if hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation] != "" {
-			kasAnnotationValue := hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation]
-			_, err := strconv.Atoi(kasAnnotationValue)
-			// ensure integer value in annotation
+			parsedKASVerbosityValue, err := strconv.Atoi(hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation])
 			if err == nil {
-				kasVerbosityLevel = fmt.Sprintf("--v=%s", kasAnnotationValue)
+				kasVerbosityLevel = parsedKASVerbosityValue
 			}
 		}
 
 		c.Args = []string{
 			"kube-apiserver",
 			fmt.Sprintf("--openshift-config=%s", path.Join(volumeMounts.Path(c.Name, kasVolumeConfig().Name), KubeAPIServerConfigKey)),
-			kasVerbosityLevel,
+			fmt.Sprintf("--v=%d", kasVerbosityLevel),
 		}
 
 		c.Env = []corev1.EnvVar{{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -428,10 +428,17 @@ func buildKASContainerMain(image string, port int32, noProxyCIDRs []string, hcp 
 		c.Command = []string{
 			"hyperkube",
 		}
+
+		// default to level of 2
+		kasVerbosityLevel := "-v2"
+		if hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation] != "" {
+			kasVerbosityLevel = fmt.Sprintf("--v=%s", hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation])
+		}
+
 		c.Args = []string{
 			"kube-apiserver",
 			fmt.Sprintf("--openshift-config=%s", path.Join(volumeMounts.Path(c.Name, kasVolumeConfig().Name), KubeAPIServerConfigKey)),
-			"-v2",
+			kasVerbosityLevel,
 		}
 
 		c.Env = []corev1.EnvVar{{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -430,9 +430,14 @@ func buildKASContainerMain(image string, port int32, noProxyCIDRs []string, hcp 
 		}
 
 		// default to level of 2
-		kasVerbosityLevel := "-v2"
+		kasVerbosityLevel := "--v=2"
 		if hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation] != "" {
-			kasVerbosityLevel = fmt.Sprintf("--v=%s", hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation])
+			kasAnnotationValue := hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation]
+			_, err := strconv.Atoi(kasAnnotationValue)
+			// ensure integer value in annotation
+			if err == nil {
+				kasVerbosityLevel = fmt.Sprintf("--v=%s", kasAnnotationValue)
+			}
 		}
 
 		c.Args = []string{

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1808,6 +1808,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.RequestServingNodeAdditionalSelectorAnnotation,
 		hyperv1.AWSLoadBalancerSubnetsAnnotation,
 		hyperv1.ManagementPlatformAnnotation,
+		hyperv1.KubeAPIServerVerbosityLevelAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]


### PR DESCRIPTION

**What this PR does / why we need it**:
Adds annotation to support configuring kube-apiserver log verbosity to a value higher than default of 2. 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-32763

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.