### PR TITLE
OCPBUGS-25758: fix router on 4.14 y-stream upgrade

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3410,6 +3410,21 @@ func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx conte
 		return fmt.Errorf("failed to restart network node identity: %w", err)
 	}
 
+	// Clean up ovnkube-sbdb Route if exists
+	if _, err := util.DeleteIfNeeded(ctx, r.Client, manifests.OVNKubeSBDBRoute(hcp.Namespace)); err != nil {
+		return fmt.Errorf("failed to clean up ovnkube-sbdb route: %w", err)
+	}
+
+	// Clean up ovnkube-master-external Service if exists
+	if _, err := util.DeleteIfNeeded(ctx, r.Client, manifests.MasterExternalService(hcp.Namespace)); err != nil {
+		return fmt.Errorf("failed to clean up ovnkube-master-external service: %w", err)
+	}
+
+	// Clean up ovnkube-master-internal Service if exists
+	if _, err := util.DeleteIfNeeded(ctx, r.Client, manifests.MasterInternalService(hcp.Namespace)); err != nil {
+		return fmt.Errorf("failed to clean up ovnkube-master-internal service: %w", err)
+	}
+
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -111,8 +111,6 @@ func generateRouterConfig(routeList *routev1.RouteList, svcsNameToIP map[string]
 			p.Backends = append(p.Backends, backendDesc{Name: "oauth", HostName: route.Spec.Host, DestinationServiceIP: svcsNameToIP[route.Spec.To.Name], DestinationPort: 6443})
 		case manifests.OauthServerInternalRoute("").Name:
 			p.Backends = append(p.Backends, backendDesc{Name: "oauth_internal", HostName: route.Spec.Host, DestinationServiceIP: svcsNameToIP[route.Spec.To.Name], DestinationPort: 6443})
-		case manifests.OVNKubeSBDBRoute("").Name:
-			p.Backends = append(p.Backends, backendDesc{Name: "ovnkube_sbdb", HostName: route.Spec.Host, DestinationServiceIP: svcsNameToIP[route.Spec.To.Name], DestinationPort: route.Spec.Port.TargetPort.IntVal})
 		case manifests.MetricsForwarderRoute("").Name:
 			p.Backends = append(p.Backends, backendDesc{Name: "metrics_forwarder", HostName: route.Spec.Host, DestinationServiceIP: svcsNameToIP[route.Spec.To.Name], DestinationPort: route.Spec.Port.TargetPort.IntVal})
 		}
@@ -167,6 +165,7 @@ func ReconcileRouterDeployment(deployment *appsv1.Deployment, ownerRef config.Ow
 						},
 					},
 				},
+				ServiceAccountName:           "",
 				AutomountServiceAccountToken: pointer.Bool(false),
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
@@ -53,13 +53,12 @@ func TestGenerateRouterConfig(t *testing.T) {
 	oauthInternal := namedRoute(manifests.OauthServerInternalRoute(testNS), withHost("oauth-internal.example.com"), withSvc("openshift-oauth"))
 	oauthExternalPrivate := namedRoute(manifests.OauthServerExternalPrivateRoute(testNS), withHost("oauth-private.example.com"), withSvc("openshift-oauth"))
 	oauthExternalPublic := namedRoute(manifests.OauthServerExternalPublicRoute(testNS), withHost("oauth-public.example.com"), withSvc("openshift-oauth"))
-	ovnKube := route(manifests.OVNKubeSBDBRoute("").Name, withHost("ovnkube-sbdb.example.com"), withSvc("ovnkube-master-external"), withPort(3000))
 	metricsForwarder := route(manifests.MetricsForwarderRoute("").Name, withHost("metrics-forwarder.example.com"), withSvc("metrics-forwarder"), withPort(4000))
 	kasPublic := namedRoute(manifests.KubeAPIServerExternalPublicRoute(testNS), withHost("kube-apiserver-public.example.com"), withSvc("kube-apiserver"))
 	kasPrivate := namedRoute(manifests.KubeAPIServerExternalPrivateRoute(testNS), withSvc("kube-apiserver-private.example.com"), withSvc("kube-apiserver"))
 
 	routeList := &routev1.RouteList{
-		Items: []routev1.Route{*ignition, *konnectivity, *oauthInternal, *oauthExternalPrivate, *oauthExternalPublic, *ovnKube, *metricsForwarder, *kasPublic, *kasPrivate},
+		Items: []routev1.Route{*ignition, *konnectivity, *oauthInternal, *oauthExternalPrivate, *oauthExternalPublic, *metricsForwarder, *kasPublic, *kasPrivate},
 	}
 
 	svcsNameToIP := make(map[string]string)

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/testdata/zz_fixture_TestGenerateRouterConfig.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/testdata/zz_fixture_TestGenerateRouterConfig.yaml
@@ -25,14 +25,12 @@ frontend main
   acl is_oauth req_ssl_sni -i oauth-public.example.com
   acl is_oauth_internal req_ssl_sni -i oauth-internal.example.com
   acl is_oauth_private req_ssl_sni -i oauth-private.example.com
-  acl is_ovnkube_sbdb req_ssl_sni -i ovnkube-sbdb.example.com
   use_backend ignition if is_ignition
   use_backend konnectivity if is_konnectivity
   use_backend metrics_forwarder if is_metrics_forwarder
   use_backend oauth if is_oauth
   use_backend oauth_internal if is_oauth_internal
   use_backend oauth_private if is_oauth_private
-  use_backend ovnkube_sbdb if is_ovnkube_sbdb
   default_backend kube_api
 
 listen health_check_http_url
@@ -47,7 +45,7 @@ backend konnectivity
   server konnectivity 0.0.0.1:8091
 
 backend metrics_forwarder
-  server metrics_forwarder 0.0.0.6:4000
+  server metrics_forwarder 0.0.0.5:4000
 
 backend oauth
   server oauth 0.0.0.4:6443
@@ -58,8 +56,5 @@ backend oauth_internal
 backend oauth_private
   server oauth_private 0.0.0.4:6443
 
-backend ovnkube_sbdb
-  server ovnkube_sbdb 0.0.0.5:3000
-
 backend kube_api
-  server kube_api 0.0.0.8:6443
+  server kube_api 0.0.0.7:6443

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
@@ -74,3 +74,21 @@ func OVNKubeSBDBRoute(namespace string) *routev1.Route {
 		},
 	}
 }
+
+func MasterExternalService(namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "ovnkube-master-external",
+		},
+	}
+}
+
+func MasterInternalService(namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "ovnkube-master-internal",
+		},
+	}
+}


### PR DESCRIPTION
In 4.13, we used the OCP router for HCP ingress.  The OCP router watches the endpoints of the target service and loads them directly into the haproxy config.  Thus a service with `clusterIP: None` works because the OCP router send traffic directly to pods, bypassing the service network.

In 4.14, we switched away from the OCP router to a simple haproxy pod with a fixed config file that routed to Service clusterIPs.  Because the `ovnkube-master-external` Services have `clusterIP: None`, the string `None` is loaded into the haproxy config template where the `ovnkube-master-external` service IP is expected.  The results in the router pod crash looping.

However, we don't use the `ovnkube-sbdb` Route in 4.14.  The failure is caused by lack of cleanup by the CNO which creates the  internal and external Services and the Route as well.

This PR cleans up those unused resources and explicitly unsets the router `serviceAccountName` as the `router` ServiceAccount is also removed in 4.14.