### PR TITLE
OCPBUGS-33726: Remove service-ca annotation from azure csi & file controller metrics services

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -146,6 +146,24 @@ func OVNKubernetesControlPlaneService(ns string) *corev1.Service {
 	}
 }
 
+func AzureDiskCsiDriverControllerMetricsService(ns string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-disk-csi-driver-controller-metrics",
+			Namespace: ns,
+		},
+	}
+}
+
+func AzureFileCsiDriverControllerMetricsService(ns string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-file-csi-driver-controller-metrics",
+			Namespace: ns,
+		},
+	}
+}
+
 func EtcdSignerSecret(ns string) *corev1.Secret {
 	return secretFor(ns, "etcd-signer")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove service-ca annotation from azure csi & file controller metrics services.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-33726](https://issues.redhat.com/browse/OCPBUGS-33726)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.