### PR TITLE
OCPBUGS-33729: Do not ignore single placeholder pods for a specific hosted cluster

### DIFF
--- a/hypershift-operator/controllers/scheduler/autoscaler_test.go
+++ b/hypershift-operator/controllers/scheduler/autoscaler_test.go
@@ -393,13 +393,13 @@ func TestDetermineRequiredNodes(t *testing.T) {
 		},
 		{
 			name:  "Single pending pod",
-			pods:  pods(4, pending(0), scheduled(1, 2, 3)),
+			pods:  pods(4, pending(0), withPodPairLabel("foo", 0), scheduled(1, 2, 3)),
 			nodes: nodes(4),
 			expected: []nodeRequirement{
 				{
 					sizeLabel: "small",
 					count:     1,
-					pairLabel: "pair-0",
+					pairLabel: "foo",
 				},
 			},
 		},
@@ -454,7 +454,7 @@ func TestDetermineRequiredNodes(t *testing.T) {
 			},
 		},
 		{
-			name:  "ignore unpaired pods",
+			name:  "ignore unpaired pods without pair selector",
 			pods:  pods(3, pending(0, 1, 2)),
 			nodes: nodes(4),
 			expected: []nodeRequirement{


### PR DESCRIPTION
**What this PR does / why we need it**:
The current logic that looks at placeholder pods ignores unpaired pods because in the case of generic placeholders, the pods are likely in the middle of getting rolled out by their respective deployment. However, unpaired pods that correspond to a specific hosted cluster (have a pair node selector) can exist by themselves if there's already an existing node for the cluster. This commit updates the logic to not ignore single placeholder pods for specific hosted clusters.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-33729](https://issues.redhat.com/browse/OCPBUGS-33729)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.