### PR TITLE
OCPBUGS-33724: Fixes update issue with KubeVirt platform

### DIFF
--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -90,6 +90,7 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 		maxUnavailable := intstr.FromInt(1)
 		if deployment.Spec.Strategy.RollingUpdate == nil {
 			deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{}
+			deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 		}
 		deployment.Spec.Strategy.RollingUpdate.MaxSurge = &maxSurge
 		deployment.Spec.Strategy.RollingUpdate.MaxUnavailable = &maxUnavailable


### PR DESCRIPTION
A bug fix (#3382) went in earlier this year that corrected an issue where the kubevirt cloud controller manager (kccm) was not having the deployment config accurately applied. 

This resulted in some deployments having the `replace` update strategy instead of `RollingUpdate` update strategy. 

When we update OCP from one of the older versions which deployed kccm with `replace` strategy, the update fails because we attempt to set `RollingUpdate` update strategy parameters when the update strategy is still `replace`.

To fix this, when we set the inplace update parameters, we need to ensure that the upstate strategy type is set to `RollingUpdate` as well.