### PR TITLE
OCPBUGS-33802: don't delay new cluster creation

### DIFF
--- a/api/scheduling/v1alpha1/clustersizingconfiguration_types.go
+++ b/api/scheduling/v1alpha1/clustersizingconfiguration_types.go
@@ -45,6 +45,7 @@ type ClusterSizingConfigurationSpec struct {
 	// Transitions will require that request-serving pods be re-scheduled between nodes, so each
 	// transition incurs a small user-facing cost as well as a cost to the management cluster. Use
 	// the concurrency configuration options to manage how many transitions can be occurring.
+	// These limits do not apply to new clusters entering the fleet.
 	// If unset, a sensible default will be provided.
 	Concurrency ConcurrencyConfiguration `json:"concurrency,omitempty"`
 

--- a/cmd/install/assets/hypershift-operator/scheduling.hypershift.openshift.io_clustersizingconfigurations.yaml
+++ b/cmd/install/assets/hypershift-operator/scheduling.hypershift.openshift.io_clustersizingconfigurations.yaml
@@ -52,6 +52,7 @@ spec:
                   Transitions will require that request-serving pods be re-scheduled between nodes, so each
                   transition incurs a small user-facing cost as well as a cost to the management cluster. Use
                   the concurrency configuration options to manage how many transitions can be occurring.
+                  These limits do not apply to new clusters entering the fleet.
                   If unset, a sensible default will be provided.
                 properties:
                   limit:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -59255,6 +59255,7 @@ objects:
                     Transitions will require that request-serving pods be re-scheduled between nodes, so each
                     transition incurs a small user-facing cost as well as a cost to the management cluster. Use
                     the concurrency configuration options to manage how many transitions can be occurring.
+                    These limits do not apply to new clusters entering the fleet.
                     If unset, a sensible default will be provided.
                   properties:
                     limit:

--- a/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller.go
+++ b/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller.go
@@ -305,7 +305,11 @@ func (r *reconciler) reconcile(
 	// third, we need to know if we're ready to transition the cluster:
 	// - the hosted cluster has limits to how quickly it can transition up and down, and
 	// - the management plane has limits to how many clusters can be transitioning at any time
-	delayStart := r.now()
+	delayStart := time.Time{}
+	if lastTransitionTime != nil {
+		// if we transitioned in the past, we need to enforce the delay from there
+		delayStart = *lastTransitionTime
+	}
 	lastComputedTime, lastComputedSizeClass := previousComputedSizeFor(hostedCluster)
 	if lastComputedTime != nil && lastComputedSizeClass == sizeClass.Name {
 		// we computed that the cluster should transition already; enforce the delay from that point

--- a/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller_test.go
+++ b/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller_test.go
@@ -205,9 +205,9 @@ func TestSizingController_Reconcile(t *testing.T) {
 			},
 			nodePoolsForHostedCluster: func(_ context.Context, _ *hypershiftv1beta1.HostedCluster) (*hypershiftv1beta1.NodePoolList, error) {
 				return &hypershiftv1beta1.NodePoolList{Items: []hypershiftv1beta1.NodePool{
-					{Status: hypershiftv1beta1.NodePoolStatus{Replicas: 10}},
-					{Status: hypershiftv1beta1.NodePoolStatus{Replicas: 3}},
-					{Status: hypershiftv1beta1.NodePoolStatus{Replicas: 17}},
+					{Spec: hypershiftv1beta1.NodePoolSpec{AutoScaling: &hypershiftv1beta1.NodePoolAutoScaling{Max: 10}}, Status: hypershiftv1beta1.NodePoolStatus{Replicas: 10}},
+					{Spec: hypershiftv1beta1.NodePoolSpec{AutoScaling: &hypershiftv1beta1.NodePoolAutoScaling{Max: 10}}, Status: hypershiftv1beta1.NodePoolStatus{Replicas: 3}},
+					{Spec: hypershiftv1beta1.NodePoolSpec{AutoScaling: &hypershiftv1beta1.NodePoolAutoScaling{Max: 10}}, Status: hypershiftv1beta1.NodePoolStatus{Replicas: 17}},
 				}}, nil
 			},
 			expected: &action{applyCfg: &hypershiftv1beta1applyconfigurations.HostedClusterApplyConfiguration{
@@ -996,7 +996,8 @@ func TestSizingController_Reconcile(t *testing.T) {
 			hostedCluster: &hypershiftv1beta1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns", Name: "hc",
-					Labels: map[string]string{hypershiftv1beta1.HostedClusterSizeLabel: "large"},
+					Labels:      map[string]string{hypershiftv1beta1.HostedClusterSizeLabel: "large"},
+					Annotations: map[string]string{hypershiftv1beta1.HostedClusterScheduledAnnotation: "true"},
 				},
 				Status: hypershiftv1beta1.HostedClusterStatus{Conditions: []metav1.Condition{{
 					Type:               hypershiftv1beta1.ClusterSizeComputed,
@@ -1062,12 +1063,61 @@ func TestSizingController_Reconcile(t *testing.T) {
 			}, requeueAfter: 5 * time.Minute},
 		},
 		{
+			name:   "delay existing scheduled cluster without size for concurrency",
+			config: validCommonConfig,
+			hostedCluster: &hypershiftv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "hc",
+					Annotations: map[string]string{hypershiftv1beta1.HostedClusterScheduledAnnotation: "true"},
+				},
+			},
+			listHostedClusters: func(_ context.Context) (*hypershiftv1beta1.HostedClusterList, error) {
+				return &hypershiftv1beta1.HostedClusterList{Items: []hypershiftv1beta1.HostedCluster{
+					hostedClusterWithTransition("first", fakeClock.Now().Add(-1*time.Minute)),
+					hostedClusterWithTransition("second", fakeClock.Now().Add(-2*time.Minute)),
+					hostedClusterWithTransition("third", fakeClock.Now().Add(-3*time.Minute)),
+					hostedClusterWithTransition("fourth", fakeClock.Now().Add(-4*time.Minute)),
+					hostedClusterWithTransition("fifth", fakeClock.Now().Add(-5*time.Minute)),
+				}}, nil
+			},
+			hccoReportsNodeCount: func(_ context.Context, _ *hypershiftv1beta1.HostedCluster) (bool, error) {
+				return true, nil
+			},
+			hostedControlPlaneForHostedCluster: func(_ context.Context, _ *hypershiftv1beta1.HostedCluster) (*hypershiftv1beta1.HostedControlPlane, error) {
+				return &hypershiftv1beta1.HostedControlPlane{
+					Status: hypershiftv1beta1.HostedControlPlaneStatus{NodeCount: ptr.To(3)},
+				}, nil
+			},
+			expected: &action{applyCfg: &hypershiftv1beta1applyconfigurations.HostedClusterApplyConfiguration{
+				ObjectMetaApplyConfiguration: &metav1applyconfigurations.ObjectMetaApplyConfiguration{Namespace: ptr.To("ns"), Name: ptr.To("hc")},
+				Status: &hypershiftv1beta1applyconfigurations.HostedClusterStatusApplyConfiguration{
+					Conditions: []metav1applyconfigurations.ConditionApplyConfiguration{
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeTransitionPending),
+							Status:             ptr.To(metav1.ConditionTrue),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To("ConcurrencyLimitReached"),
+							Message:            ptr.To("5 HostedClusters have already transitioned sizes in the last 10m0s, more time must elapse before the next transition."),
+						},
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeTransitionRequired),
+							Status:             ptr.To(metav1.ConditionTrue),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To("small"),
+							Message:            ptr.To("The HostedCluster will transition to a new t-shirt size."),
+						},
+					},
+				},
+			}, requeueAfter: 5 * time.Minute},
+		},
+		{
 			name:   "delay for concurrency, no-op since condition already present",
 			config: validCommonConfig,
 			hostedCluster: &hypershiftv1beta1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns", Name: "hc",
-					Labels: map[string]string{hypershiftv1beta1.HostedClusterSizeLabel: "large"},
+					Labels:      map[string]string{hypershiftv1beta1.HostedClusterSizeLabel: "large"},
+					Annotations: map[string]string{hypershiftv1beta1.HostedClusterScheduledAnnotation: "true"},
 				},
 				Status: hypershiftv1beta1.HostedClusterStatus{Conditions: []metav1.Condition{{
 					Type:               hypershiftv1beta1.ClusterSizeComputed,
@@ -1116,7 +1166,8 @@ func TestSizingController_Reconcile(t *testing.T) {
 			hostedCluster: &hypershiftv1beta1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns", Name: "hc",
-					Labels: map[string]string{hypershiftv1beta1.HostedClusterSizeLabel: "large"},
+					Labels:      map[string]string{hypershiftv1beta1.HostedClusterSizeLabel: "large"},
+					Annotations: map[string]string{hypershiftv1beta1.HostedClusterScheduledAnnotation: "true"},
 				},
 				Status: hypershiftv1beta1.HostedClusterStatus{Conditions: []metav1.Condition{{
 					Type:               hypershiftv1beta1.ClusterSizeComputed,
@@ -1187,7 +1238,8 @@ func TestSizingController_Reconcile(t *testing.T) {
 			hostedCluster: &hypershiftv1beta1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns", Name: "hc",
-					Labels: map[string]string{hypershiftv1beta1.HostedClusterSizeLabel: "small"},
+					Labels:      map[string]string{hypershiftv1beta1.HostedClusterSizeLabel: "small"},
+					Annotations: map[string]string{hypershiftv1beta1.HostedClusterScheduledAnnotation: "true"},
 				},
 				Status: hypershiftv1beta1.HostedClusterStatus{Conditions: []metav1.Condition{{
 					Type:               hypershiftv1beta1.ClusterSizeComputed,
@@ -1231,6 +1283,128 @@ func TestSizingController_Reconcile(t *testing.T) {
 							Status:             ptr.To(metav1.ConditionTrue),
 							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
 							Reason:             ptr.To("large"),
+							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
+						},
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeTransitionPending),
+							Status:             ptr.To(metav1.ConditionFalse),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To("ClusterSizeTransitioned"),
+							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
+						},
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeTransitionRequired),
+							Status:             ptr.To(metav1.ConditionFalse),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To(hypershiftv1beta1.AsExpectedReason),
+							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
+						},
+					},
+				},
+			}},
+		},
+		{
+			name:   "transition, don't delay unscheduled cluster for concurrency",
+			config: validCommonConfig,
+			hostedCluster: &hypershiftv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "hc",
+					Labels: map[string]string{hypershiftv1beta1.HostedClusterSizeLabel: "large"},
+				},
+				Status: hypershiftv1beta1.HostedClusterStatus{Conditions: []metav1.Condition{{
+					Type:               hypershiftv1beta1.ClusterSizeComputed,
+					Status:             metav1.ConditionTrue,
+					Reason:             "large",
+					Message:            "The HostedCluster has transitioned to a new t-shirt size.",
+					LastTransitionTime: metav1.NewTime(fakeClock.Now().Add(-20 * time.Minute)),
+				}, {
+					Type:               hypershiftv1beta1.ClusterSizeTransitionRequired,
+					Status:             metav1.ConditionTrue,
+					Reason:             "small",
+					Message:            "The HostedCluster will transition to a new t-shirt size.",
+					LastTransitionTime: metav1.NewTime(fakeClock.Now().Add(-15 * time.Minute)),
+				}}},
+			},
+			listHostedClusters: func(_ context.Context) (*hypershiftv1beta1.HostedClusterList, error) {
+				return &hypershiftv1beta1.HostedClusterList{Items: []hypershiftv1beta1.HostedCluster{
+					hostedClusterWithTransition("first", fakeClock.Now().Add(-1*time.Minute)),
+					hostedClusterWithTransition("second", fakeClock.Now().Add(-2*time.Minute)),
+					hostedClusterWithTransition("third", fakeClock.Now().Add(-3*time.Minute)),
+					hostedClusterWithTransition("fourth", fakeClock.Now().Add(-4*time.Minute)),
+					hostedClusterWithTransition("fifth", fakeClock.Now().Add(-5*time.Minute)),
+				}}, nil
+			},
+			hccoReportsNodeCount: func(_ context.Context, _ *hypershiftv1beta1.HostedCluster) (bool, error) {
+				return true, nil
+			},
+			hostedControlPlaneForHostedCluster: func(_ context.Context, _ *hypershiftv1beta1.HostedCluster) (*hypershiftv1beta1.HostedControlPlane, error) {
+				return &hypershiftv1beta1.HostedControlPlane{
+					Status: hypershiftv1beta1.HostedControlPlaneStatus{NodeCount: ptr.To(3)},
+				}, nil
+			},
+			expected: &action{applyCfg: &hypershiftv1beta1applyconfigurations.HostedClusterApplyConfiguration{
+				ObjectMetaApplyConfiguration: &metav1applyconfigurations.ObjectMetaApplyConfiguration{Namespace: ptr.To("ns"), Name: ptr.To("hc")},
+				Status: &hypershiftv1beta1applyconfigurations.HostedClusterStatusApplyConfiguration{
+					Conditions: []metav1applyconfigurations.ConditionApplyConfiguration{
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeComputed),
+							Status:             ptr.To(metav1.ConditionTrue),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To("small"),
+							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
+						},
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeTransitionPending),
+							Status:             ptr.To(metav1.ConditionFalse),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To("ClusterSizeTransitioned"),
+							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
+						},
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeTransitionRequired),
+							Status:             ptr.To(metav1.ConditionFalse),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To(hypershiftv1beta1.AsExpectedReason),
+							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
+						},
+					},
+				},
+			}},
+		},
+		{
+			name:   "transition, don't delay brand new cluster for concurrency",
+			config: validCommonConfig,
+			hostedCluster: &hypershiftv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "hc",
+				},
+			},
+			listHostedClusters: func(_ context.Context) (*hypershiftv1beta1.HostedClusterList, error) {
+				return &hypershiftv1beta1.HostedClusterList{Items: []hypershiftv1beta1.HostedCluster{
+					hostedClusterWithTransition("first", fakeClock.Now().Add(-1*time.Minute)),
+					hostedClusterWithTransition("second", fakeClock.Now().Add(-2*time.Minute)),
+					hostedClusterWithTransition("third", fakeClock.Now().Add(-3*time.Minute)),
+					hostedClusterWithTransition("fourth", fakeClock.Now().Add(-4*time.Minute)),
+					hostedClusterWithTransition("fifth", fakeClock.Now().Add(-5*time.Minute)),
+				}}, nil
+			},
+			hccoReportsNodeCount: func(_ context.Context, _ *hypershiftv1beta1.HostedCluster) (bool, error) {
+				return true, nil
+			},
+			hostedControlPlaneForHostedCluster: func(_ context.Context, _ *hypershiftv1beta1.HostedCluster) (*hypershiftv1beta1.HostedControlPlane, error) {
+				return &hypershiftv1beta1.HostedControlPlane{
+					Status: hypershiftv1beta1.HostedControlPlaneStatus{NodeCount: ptr.To(3)},
+				}, nil
+			},
+			expected: &action{applyCfg: &hypershiftv1beta1applyconfigurations.HostedClusterApplyConfiguration{
+				ObjectMetaApplyConfiguration: &metav1applyconfigurations.ObjectMetaApplyConfiguration{Namespace: ptr.To("ns"), Name: ptr.To("hc")},
+				Status: &hypershiftv1beta1applyconfigurations.HostedClusterStatusApplyConfiguration{
+					Conditions: []metav1applyconfigurations.ConditionApplyConfiguration{
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeComputed),
+							Status:             ptr.To(metav1.ConditionTrue),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To("small"),
 							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
 						},
 						{

--- a/vendor/github.com/openshift/hypershift/api/scheduling/v1alpha1/clustersizingconfiguration_types.go
+++ b/vendor/github.com/openshift/hypershift/api/scheduling/v1alpha1/clustersizingconfiguration_types.go
@@ -45,6 +45,7 @@ type ClusterSizingConfigurationSpec struct {
 	// Transitions will require that request-serving pods be re-scheduled between nodes, so each
 	// transition incurs a small user-facing cost as well as a cost to the management cluster. Use
 	// the concurrency configuration options to manage how many transitions can be occurring.
+	// These limits do not apply to new clusters entering the fleet.
 	// If unset, a sensible default will be provided.
 	Concurrency ConcurrencyConfiguration `json:"concurrency,omitempty"`
 


### PR DESCRIPTION
hostedclustersizing: don't enforce delays on brand-new clusters

Before, we would make brand-new clusters sit through the transition
delays erroneously. Now, we allow them to take on their first size
without any delay.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

hostedclustersizing: don't enforce concurrency on new clusters

Before, we would enforce global concurrency limits on brand new clusters
joining the fleet and being given a size. This is not tenable with an
SLA for cluster bringup, so we no longer do that.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

