### PR TITLE
OCPBUGS-33742: setting higher priority class for external-dns pods

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -209,6 +209,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 					},
 				},
 				Spec: corev1.PodSpec{
+					PriorityClassName:  HypershiftOperatorPriortyClass,
 					ServiceAccountName: o.ServiceAccount.Name,
 					Containers: []corev1.Container{
 						{

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -489,6 +489,7 @@ objects:
             name: credentials
         imagePullSecrets:
         - name: pull-secret
+        priorityClassName: hypershift-operator
         serviceAccountName: external-dns
         volumes:
         - name: credentials


### PR DESCRIPTION
**What this PR does / why we need it**:
Hypershift operator pods are created with higher `PriorityClass` but `external-dns`, to create a successful HCP we need both of them to up and available. Due to `default` priority class on `external-dns`, this pod gets evicted by the scheduler to fit higher priorityClass pods when there is no available space on suitable nodes.

Now setting the same `priorityClassName` used by the `operator` pod for `external-dns` pod as well.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # OCPBUGS-33742

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.