### PR TITLE
OCPBUGS-33377: Modify token secret MCS hash in place 

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1641,6 +1641,11 @@ func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool
 		tokenSecret.Data[TokenSecretPullSecretHashKey] = []byte(supportutil.HashSimple(pullSecret))
 		tokenSecret.Data[TokenSecretHCConfigurationHashKey] = []byte(hcConfigurationHash)
 	}
+	// TODO (alberto): Only apply this on creation and change the hash generation to only use triggering upgrade fields.
+	// We let this change to happen inplace now as the tokenSecret and the mcs config use the whole spec.Config for the comparing hash.
+	// Otherwise if something which does not trigger a new token generation from spec.Config changes, like .IDP, both hashes would missmatch forever.
+	tokenSecret.Data[TokenSecretHCConfigurationHashKey] = []byte(hcConfigurationHash)
+
 	return nil
 }
 


### PR DESCRIPTION
We are relying on .image and .proxy here to trigger upgrades and create a new tokenSecret https://github.com/openshift/hypershift/pull/3714/files#diff-c666a2a9dc48b0d3de33cc8fa3a054f853671f0428f9d56b263750dfc6d26e00R266
    but then we use the whole .config for the hash in the token and mcs secret https://github.com/openshift/hypershift/pull/3795/files#diff-681fe9efe998da46c20a41e51c975bac6a9b14e93b7705f40da204d30a0ddebcR49.
    Say a new NodePool is created or something triggers a rolling upgrade:
    - A new token secret gets created.
    - Before the ignition controllers watches it and can generate the payload, the hc.config changes to e.g. include an IDP.
    - The MCS secret hc-configuration-hash is updated accordingly.
    - The token secret hc-configuration-hash is not updated, because that only happens on token secret creation.
    - The ignition controller tries to generate the payload and it fails perpetually with https://github.com/openshift/hypershift/pull/3795/files#diff-7cc71524ad99a2a526cceabd327a67c2767dc0c49e5c4aa8629ca88b0d205072R131
    This will also be the case if the ignition server gets recreated by any reason (e.g. management cluster dataplane recycling), all the token secrets which e.g. hc.config.idp changed after they were created will fail to re-generate the payload forever.

This PR mitigates the discrepancy by letting the hash to be changed inplace in the token secret.
Follow up: Only set the hash based on the same input that triggers a new token secret creation.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.