### PR TITLE
NO-JIRA: Reinstate wrongly removed fields from cert rotation objects

### DIFF
--- a/control-plane-pki-operator/certrotationcontroller/certrotationcontroller.go
+++ b/control-plane-pki-operator/certrotationcontroller/certrotationcontroller.go
@@ -91,6 +91,10 @@ func NewCertRotationController(
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 			Owner:         ownerRef,
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "HOSTEDCP",
+				Description:   "Root signer for customer break-glass credentials.",
+			},
 		},
 		certrotation.CABundleConfigMap{
 			Namespace:     hostedControlPlane.Namespace,
@@ -100,6 +104,10 @@ func NewCertRotationController(
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 			Owner:         ownerRef,
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "HOSTEDCP",
+				Description:   "Trust bundle for customer break-glass credentials.",
+			},
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
 			Namespace: hostedControlPlane.Namespace,
@@ -118,6 +126,10 @@ func NewCertRotationController(
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 			Owner:         ownerRef,
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "HOSTEDCP",
+				Description:   "Client certificate for customer break-glass credentials.",
+			},
 		},
 		eventRecorder,
 		clienthelpers.NewHostedControlPlaneStatusReporter(hostedControlPlane.Name, hostedControlPlane.Namespace, hypershiftClient),
@@ -137,6 +149,10 @@ func NewCertRotationController(
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 			Owner:         ownerRef,
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "HOSTEDCP",
+				Description:   "Root signer for SRE break-glass credentials.",
+			},
 		},
 		certrotation.CABundleConfigMap{
 			Namespace:     hostedControlPlane.Namespace,
@@ -146,6 +162,10 @@ func NewCertRotationController(
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 			Owner:         ownerRef,
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "HOSTEDCP",
+				Description:   "Trust bundle for SRE break-glass credentials.",
+			},
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
 			Namespace: hostedControlPlane.Namespace,
@@ -164,6 +184,10 @@ func NewCertRotationController(
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 			Owner:         ownerRef,
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "HOSTEDCP",
+				Description:   "Client certificate for SRE break-glass credentials.",
+			},
 		},
 		eventRecorder,
 		clienthelpers.NewHostedControlPlaneStatusReporter(hostedControlPlane.Name, hostedControlPlane.Namespace, hypershiftClient),


### PR DESCRIPTION
in #4044, the `JiraComponent` and `Description` have been removed from the cert rotation objects since the struct have been changed and these fields were no longer exist. Afterwards it has been turned out that these fields were moved to `AdditionalAnnotations`. This PR reinstates the dropped fields.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.