### PR TITLE
HOSTEDCP-1564: Ensure VNET, NSG, & Managed RG locations match

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1383,57 +1383,6 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 			managementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 		},
 		{
-			name: "Azurecluster with incomplete credentials secret, error",
-			hostedCluster: &hyperv1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster",
-				},
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.AzurePlatform,
-						Azure: &hyperv1.AzurePlatformSpec{
-							Credentials: corev1.LocalObjectReference{Name: "creds"},
-						},
-					},
-					Networking: hyperv1.ClusterNetworking{
-						ClusterNetwork: clusterNet,
-					},
-				}},
-			other: []crclient.Object{
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "creds"}},
-			},
-			expectedResult: errors.New(`[credentials secret for cluster doesn't have required key AZURE_CLIENT_ID, credentials secret for cluster doesn't have required key AZURE_CLIENT_SECRET, credentials secret for cluster doesn't have required key AZURE_SUBSCRIPTION_ID, credentials secret for cluster doesn't have required key AZURE_TENANT_ID]`),
-		},
-		{
-			name: "Azurecluster with complete credentials secret, success",
-			hostedCluster: &hyperv1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster",
-				},
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.AzurePlatform,
-						Azure: &hyperv1.AzurePlatformSpec{
-							Credentials: corev1.LocalObjectReference{Name: "creds"},
-						},
-					},
-					Networking: hyperv1.ClusterNetworking{
-						ClusterNetwork: clusterNet,
-					},
-				}},
-			other: []crclient.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "creds"},
-					Data: map[string][]byte{
-						"AZURE_CLIENT_ID":       nil,
-						"AZURE_CLIENT_SECRET":   nil,
-						"AZURE_SUBSCRIPTION_ID": nil,
-						"AZURE_TENANT_ID":       nil,
-					},
-				},
-			},
-		},
-		{
 			name: "invalid cluster uuid",
 			hostedCluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -3,11 +3,18 @@ package azureutil
 import (
 	"context"
 	"fmt"
+	"k8s.io/utils/ptr"
 	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 )
 
 // GetSubnetNameFromSubnetID extracts the subnet name from a subnet ID
@@ -136,4 +143,77 @@ func getFullVnetInfo(ctx context.Context, subscriptionID string, vnetResourceGro
 	}
 
 	return vnet, nil
+}
+
+// getNetworkSecurityGroupInfo gets the full information on a network security group based on its ID
+func getNetworkSecurityGroupInfo(ctx context.Context, nsgID string, subscriptionID string, azureCreds azcore.TokenCredential) (armnetwork.SecurityGroupsClientGetResponse, error) {
+	partialNSGInfo, err := arm.ParseResourceID(nsgID)
+	if err != nil {
+		return armnetwork.SecurityGroupsClientGetResponse{}, fmt.Errorf("failed to parse network security group id %q: %v", nsgID, err)
+	}
+
+	securityGroupClient, err := armnetwork.NewSecurityGroupsClient(subscriptionID, azureCreds, nil)
+	if err != nil {
+		return armnetwork.SecurityGroupsClientGetResponse{}, fmt.Errorf("failed to create security group client: %w", err)
+	}
+
+	nsg, err := securityGroupClient.Get(ctx, partialNSGInfo.ResourceGroupName, partialNSGInfo.Name, nil)
+	if err != nil {
+		return armnetwork.SecurityGroupsClientGetResponse{}, fmt.Errorf("failed to get network security group: %w", err)
+	}
+
+	return nsg, nil
+}
+
+// getResourceGroupInfo gets the full information on a resource group based on its name
+func getResourceGroupInfo(ctx context.Context, rgName string, subscriptionID string, azureCreds azcore.TokenCredential) (armresources.ResourceGroupsClientGetResponse, error) {
+	resourceGroupClient, err := armresources.NewResourceGroupsClient(subscriptionID, azureCreds, nil)
+	if err != nil {
+		return armresources.ResourceGroupsClientGetResponse{}, fmt.Errorf("failed to create new resource groups client: %w", err)
+	}
+
+	rg, err := resourceGroupClient.Get(ctx, rgName, nil)
+	if err != nil {
+		return armresources.ResourceGroupsClientGetResponse{}, fmt.Errorf("failed to get resource group name, '%s': %w", rgName, err)
+	}
+
+	return rg, nil
+}
+
+// VerifyResourceGroupLocationsMatch verifies the locations match for the VNET, network security group, and managed resource groups
+func VerifyResourceGroupLocationsMatch(ctx context.Context, hc *hyperv1.HostedCluster, credentialsSecret *corev1.Secret) error {
+	// Setup azureCreds so we can retrieve the locations of the resource groups
+	tenantID := string(credentialsSecret.Data["AZURE_TENANT_ID"])
+	clientID := string(credentialsSecret.Data["AZURE_CLIENT_ID"])
+	clientSecret := string(credentialsSecret.Data["AZURE_CLIENT_SECRET"])
+
+	creds, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create azure creds to verify resource group locations: %v", err)
+	}
+
+	// Retrieve full vnet information from the VNET ID
+	vnet, err := GetVnetInfoFromVnetID(ctx, hc.Spec.Platform.Azure.VnetID, hc.Spec.Platform.Azure.SubscriptionID, creds)
+	if err != nil {
+		return fmt.Errorf("failed to get vnet info to verify its location: %v", err)
+	}
+
+	// Retrieve full network security group information from the network security group ID
+	nsg, err := getNetworkSecurityGroupInfo(ctx, hc.Spec.Platform.Azure.SecurityGroupID, hc.Spec.Platform.Azure.SubscriptionID, creds)
+	if err != nil {
+		return fmt.Errorf("failed to get network security group info to verify its location: %v", err)
+	}
+
+	// Retrieve full resource group information from the resource group name
+	rg, err := getResourceGroupInfo(ctx, hc.Spec.Platform.Azure.ResourceGroupName, hc.Spec.Platform.Azure.SubscriptionID, creds)
+	if err != nil {
+		return fmt.Errorf("failed to get resource group info to verify its location: %v", err)
+	}
+
+	// Verify the vnet resource group location, network security group resource group location, and the managed resource group location match
+	if ptr.Deref(vnet.Location, "") != ptr.Deref(nsg.Location, "") || ptr.Deref(nsg.Location, "") != ptr.Deref(rg.Location, "") {
+		return fmt.Errorf("the locations of the resource groups do not match - vnet location: %v; network security group location: %v; managed resource group location: %v", ptr.Deref(vnet.Location, ""), ptr.Deref(nsg.Location, ""), ptr.Deref(rg.Location, ""))
+	}
+
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds validation to the HostedCluster controller to ensure the VNET resource group location, the network security resource group location, and the managed resource group location match.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1564](https://issues.redhat.com/browse/HOSTEDCP-1564)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.