### PR TITLE
OCPBUGS-34071: Do not scale down legacy nodes

### DIFF
--- a/hypershift-operator/controllers/scheduler/autoscaler.go
+++ b/hypershift-operator/controllers/scheduler/autoscaler.go
@@ -206,10 +206,12 @@ func nodeMachineSetsToScaleDown(node *corev1.Node, machineSets []machinev1beta1.
 	pairLabel := node.Labels[OSDFleetManagerPairedNodesLabel]
 	if pairLabel != "" {
 		nodesToScaleDown = filterNodes(nodes, func(n *corev1.Node) bool {
-			return n.Labels[OSDFleetManagerPairedNodesLabel] == pairLabel
+			return n.Labels[OSDFleetManagerPairedNodesLabel] == pairLabel && n.Labels[hyperv1.NodeSizeLabel] != ""
 		})
 	} else {
-		nodesToScaleDown = []corev1.Node{*node}
+		if node.Labels[hyperv1.NodeSizeLabel] != "" {
+			nodesToScaleDown = []corev1.Node{*node}
+		}
 	}
 	var result []machinev1beta1.MachineSet
 	for _, n := range nodesToScaleDown {
@@ -246,7 +248,7 @@ func hostedClusterMachineSetsToScaleDown(ctx context.Context, hostedCluster *hyp
 	if len(nodesWithClusterLabel) > 0 {
 		pairLabel := nodesWithClusterLabel[0].Labels[OSDFleetManagerPairedNodesLabel]
 		clusterNodes = filterNodes(nodes, func(n *corev1.Node) bool {
-			return n.Labels[OSDFleetManagerPairedNodesLabel] == pairLabel
+			return n.Labels[OSDFleetManagerPairedNodesLabel] == pairLabel && n.Labels[hyperv1.NodeSizeLabel] != ""
 		})
 	}
 

--- a/hypershift-operator/controllers/scheduler/autoscaler_test.go
+++ b/hypershift-operator/controllers/scheduler/autoscaler_test.go
@@ -70,6 +70,14 @@ func TestHostedClusterMachineSetsToScaleDown(t *testing.T) {
 			machines:      machines(6),
 			expected:      machineSets(6, withReplicas(1))[4:], // machinesets 4, 5
 		},
+		{
+			name:          "Do not scale down nodes without a size label",
+			hostedCluster: hostedCluster(withAdditionalNodeSelector(fmt.Sprintf("%s=small", hyperv1.NodeSizeLabel)), withHCSizeLabel("small")),
+			machineSets:   machineSets(6, withReplicas(1)),
+			nodes:         nodes(6, withHC(hc, 0, 1, 2, 3, 4, 5), withPairLabel("pair1", 0, 1, 2, 3, 4, 5), withSizeLabel("small", 0, 1), withSizeLabel("medium", 2, 3)),
+			machines:      machines(6),
+			expected:      machineSets(6, withReplicas(1))[2:4], //machinesets 2, 3
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -137,6 +145,22 @@ func TestNodeMachineSetsToScaleDown(t *testing.T) {
 			machineSets: machineSets(8, withReplicas(1)),
 			machines:    machines(8),
 			expected:    machineSets(8, withReplicas(1))[3:4], // machineset 3
+		},
+		{
+			name: "Do not scale down nodes without a size label",
+			node: &(nodes(8, withHC(hostedCluster(), 0, 1, 2, 3, 4, 5),
+				withSizeLabel("small", 0, 1, 6, 7),
+				withSizeLabel("medium", 2, 3),
+				withSizeLabel("", 4, 5),
+				withPairLabel("pair1", 0, 1, 2, 3, 4, 5))[3]), // node 3
+			nodes: nodes(8, withHC(hostedCluster(), 0, 1, 2, 3, 4, 5),
+				withSizeLabel("small", 0, 1, 6, 7),
+				withSizeLabel("medium", 2, 3),
+				withSizeLabel("", 4, 5),
+				withPairLabel("pair1", 0, 1, 2, 3, 4, 5)),
+			machineSets: machineSets(8, withReplicas(1)),
+			machines:    machines(8),
+			expected:    machineSets(8, withReplicas(1))[:4], // machinesets 0, 1, 2, 3
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Legacy nodes (nodes without a size label) are managed by fleet manager. Therefore we should not try to scale their respective machinesets down to avoid continuously reverting fleet manager's changes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-34071](https://issues.redhat.com/browse/OCPBUGS-34071)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.