### PR TITLE
HOSTEDCP-1681: Skip konflux when not necessary

### DIFF
--- a/.tekton/hypershift-operator-main-pull-request.yaml
+++ b/.tekton/hypershift-operator-main-pull-request.yaml
@@ -9,6 +9,10 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: '[pull_request]'
     pipelinesascode.tekton.dev/on-target-branch: '[main]'
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "main"
+      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: hypershift-operator

--- a/.tekton/hypershift-operator-main-push.yaml
+++ b/.tekton/hypershift-operator-main-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-event: '[push]'
-    pipelinesascode.tekton.dev/on-target-branch: '[main]'
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "main"
+      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: hypershift-operator


### PR DESCRIPTION
This leverages a CEL expression to skip the konflux builds when changes only touch things like enhancements, docs, etc.

**What this PR does / why we need it**:

It reduces the load on Konflux by skipping builds for PRs that do not need it. It also makes those PRs quicker and easier to merge.

**Which issue(s) this PR fixes**
Fixes #[HOSTEDCP-1681](https://issues.redhat.com//browse/HOSTEDCP-1681)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.