### PR TITLE
HOSTEDCP-1729: Support for on-demand global routing when creating transit gateway

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/openshift/library-go v0.0.0-20240422143640-fad649cbbd63
 	github.com/operator-framework/api v0.22.0
 	github.com/pkg/errors v0.9.1
-	github.com/ppc64le-cloud/powervs-utils v0.0.0-20230306072409-bc42a581099f
+	github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.71.2
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/client_model v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -1266,8 +1266,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/ppc64le-cloud/powervs-utils v0.0.0-20230306072409-bc42a581099f h1:mQElcED9y4aNwuizXDAI/e2G1WgX4312JV+QsbXhXiU=
-github.com/ppc64le-cloud/powervs-utils v0.0.0-20230306072409-bc42a581099f/go.mod h1:KImYgHmvBVtAczNhyDBDSN54PGIdz0+QiPVQMmObEQY=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247 h1:XY7lIZaLKFDyETNfTTiYmaXO+mk9apox4otFel88nUk=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247/go.mod h1:yfr6HHPYyJzVgnivMsobLMbHQqUHrzcIqWM4Nav4kc8=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.71.2 h1:HZdPRm0ApWPg7F4sHgbqWkL+ddWfpTZsopm5HM/2g4o=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.71.2/go.mod h1:3RiUkFmR9kmPZi9r/8a5jw0a9yg+LMmr7qa0wjqvSiI=
 github.com/prometheus/client_golang v1.18.0 h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=

--- a/vendor/github.com/ppc64le-cloud/powervs-utils/README.md
+++ b/vendor/github.com/ppc64le-cloud/powervs-utils/README.md
@@ -1,1 +1,17 @@
 # powervs-utils
+
+## Building
+
+Build it with
+
+```
+$ go build -v ./...
+```
+
+## Testing
+
+And test it with
+
+```
+$ go test -v ./...
+```

--- a/vendor/github.com/ppc64le-cloud/powervs-utils/region.go
+++ b/vendor/github.com/ppc64le-cloud/powervs-utils/region.go
@@ -30,6 +30,12 @@ func GetRegion(zone string) (region string, err error) {
 		region = "osa"
 	case strings.HasPrefix(zone, "mon"):
 		region = "mon"
+	case strings.HasPrefix(zone, "mad"):
+		region = "mad"
+	case strings.HasPrefix(zone, "wdc"):
+		region = "wdc"
+	case strings.HasPrefix(zone, "tor"):
+		region = "tor"
 	default:
 		return "", fmt.Errorf("region not found for the zone, talk to the developer to add the support into the tool: %s", zone)
 	}
@@ -42,6 +48,8 @@ type Region struct {
 	VPCRegion   string
 	COSRegion   string
 	Zones       []string
+	SysTypes    []string
+	VPCZones    []string
 }
 
 // Regions provides a mapping between Power VS and IBM Cloud VPC and IBM COS regions.
@@ -50,7 +58,12 @@ var Regions = map[string]Region{
 		Description: "Dallas, USA",
 		VPCRegion:   "us-south",
 		COSRegion:   "us-south",
-		Zones:       []string{"dal12"},
+		Zones: []string{
+			"dal10",
+			"dal12",
+		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
 	"eu-de": {
 		Description: "Frankfurt, Germany",
@@ -60,6 +73,8 @@ var Regions = map[string]Region{
 			"eu-de-1",
 			"eu-de-2",
 		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"eu-de-1", "eu-de-2", "eu-de-3"},
 	},
 	"lon": {
 		Description: "London, UK.",
@@ -69,18 +84,46 @@ var Regions = map[string]Region{
 			"lon04",
 			"lon06",
 		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"eu-gb-1", "eu-gb-2", "eu-gb-3"},
+	},
+	"mad": {
+		Description: "Madrid, Spain",
+		VPCRegion:   "eu-es",
+		COSRegion:   "eu-de", // @HACK - PowerVS says COS not supported in this region
+		Zones: []string{
+			"mad02",
+			"mad04",
+		},
+		SysTypes: []string{"s1022"},
+		VPCZones: []string{"eu-es-1", "eu-es-2", "eu-es-3"},
 	},
 	"mon": {
 		Description: "Montreal, Canada",
-		VPCRegion:   "ca-tor",
+		VPCRegion:   "",
 		COSRegion:   "ca-tor",
 		Zones:       []string{"mon01"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{},
 	},
 	"osa": {
 		Description: "Osaka, Japan",
 		VPCRegion:   "jp-osa",
 		COSRegion:   "jp-osa",
 		Zones:       []string{"osa21"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"jp-osa-1", "jp-osa-2", "jp-osa-3"},
+	},
+	"sao": {
+		Description: "São Paulo, Brazil",
+		VPCRegion:   "br-sao",
+		COSRegion:   "br-sao",
+		Zones: []string{
+			"sao01",
+			"sao04",
+		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"br-sao-1", "br-sao-2", "br-sao-3"},
 	},
 	"syd": {
 		Description: "Sydney, Australia",
@@ -90,25 +133,65 @@ var Regions = map[string]Region{
 			"syd04",
 			"syd05",
 		},
-	},
-	"sao": {
-		Description: "São Paulo, Brazil",
-		VPCRegion:   "br-sao",
-		COSRegion:   "br-sao",
-		Zones:       []string{"sao01"},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"au-syd-1", "au-syd-2", "au-syd-3"},
 	},
 	"tok": {
 		Description: "Tokyo, Japan",
 		VPCRegion:   "jp-tok",
 		COSRegion:   "jp-tok",
 		Zones:       []string{"tok04"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"jp-tok-1", "jp-tok-2", "jp-tok-3"},
 	},
+	"tor": {
+		Description: "Toronto, Canada",
+		VPCRegion:   "ca-tor",
+		COSRegion:   "ca-tor",
+		Zones:       []string{"tor01"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"ca-tor-1", "ca-tor-2", "ca-tor-3"},
+	}, // Keeping us-east and us-south zones as individual entries to easily map the respective VPC and COS regions by matching the prefix of the zone like in GetRegion()
 	"us-east": {
 		Description: "Washington DC, USA",
 		VPCRegion:   "us-east",
 		COSRegion:   "us-east",
 		Zones:       []string{"us-east"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"us-east-1", "us-east-2", "us-east-3"},
 	},
+	"us-south": {
+		Description: "Dallas, USA",
+		VPCRegion:   "us-south",
+		COSRegion:   "us-south",
+		Zones: []string{
+			"us-south",
+		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
+	},
+	"wdc": {
+		Description: "Washington DC, USA",
+		VPCRegion:   "us-east",
+		COSRegion:   "us-east",
+		Zones: []string{
+			"wdc06",
+			"wdc07",
+		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"us-east-1", "us-east-2", "us-east-3"},
+	},
+}
+
+// COSRegionForVPCRegion returns the corresponding COS region for the given VPC region
+func COSRegionForVPCRegion(vpcRegion string) (string, error) {
+	for r := range Regions {
+		if vpcRegion == Regions[r].VPCRegion {
+			return Regions[r].COSRegion, nil
+		}
+	}
+
+	return "", fmt.Errorf("COS region corresponding to a VPC region %s not found ", vpcRegion)
 }
 
 // VPCRegionForPowerVSRegion returns the VPC region for the specified PowerVS region.
@@ -156,4 +239,66 @@ func RegionShortNames() []string {
 		keys = append(keys, r)
 	}
 	return keys
+}
+
+// ValidateZone validates that the given zone is known/tested.
+func ValidateZone(zone string) bool {
+	for r := range Regions {
+		for z := range Regions[r].Zones {
+			if zone == Regions[r].Zones[z] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ZoneNames returns the list of zone names.
+func ZoneNames() []string {
+	zones := []string{}
+	for r := range Regions {
+		for z := range Regions[r].Zones {
+			zones = append(zones, Regions[r].Zones[z])
+		}
+	}
+	return zones
+}
+
+// RegionFromZone returns the region name for a given zone name.
+func RegionFromZone(zone string) string {
+	for r := range Regions {
+		for z := range Regions[r].Zones {
+			if zone == Regions[r].Zones[z] {
+				return r
+			}
+		}
+	}
+	return ""
+}
+
+// AvailableSysTypes returns the default system type for the zone.
+func AvailableSysTypes(region string) ([]string, error) {
+	knownRegion, ok := Regions[region]
+	if !ok {
+		return nil, fmt.Errorf("unknown region name provided")
+	}
+	return knownRegion.SysTypes, nil
+}
+
+// IsGlobalRoutingRequiredForTG returns true when powervs and vpc regions are different.
+func IsGlobalRoutingRequiredForTG(powerVSRegion string, vpcRegion string) bool {
+	if r, ok := Regions[powerVSRegion]; ok && r.VPCRegion == vpcRegion {
+		return false
+	}
+	return true
+}
+
+// VPCZonesForVPCRegion returns the VPC zones associated with the VPC region.
+func VPCZonesForVPCRegion(region string) ([]string, error) {
+	for _, regionDetails := range Regions {
+		if regionDetails.VPCRegion == region {
+			return regionDetails.VPCZones, nil
+		}
+	}
+	return nil, fmt.Errorf("VPC zones corresponding to the VPC region %s is not found", region)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -883,8 +883,8 @@ github.com/pkg/profile
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/ppc64le-cloud/powervs-utils v0.0.0-20230306072409-bc42a581099f
-## explicit; go 1.15
+# github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247
+## explicit; go 1.21
 github.com/ppc64le-cloud/powervs-utils
 # github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.71.2
 ## explicit; go 1.21


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Currently transit gateway is using global routing by default. With this change, user has to provide flag to enable global routing and default value is set as local routing(if powervs and VPC regions are same).
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1729](https://issues.redhat.com/browse/HOSTEDCP-1729)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.