### PR TITLE
NO-JIRA: Align kv min version to the default min version (now that default is >= 4.14

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1924,65 +1924,6 @@ func TestValidateReleaseImage(t *testing.T) {
 			},
 			expectedResult: nil,
 		},
-		{
-			name: "KubeVirt platform unsupported release, error",
-			other: []crclient.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"},
-					Data: map[string][]byte{
-						corev1.DockerConfigJsonKey: nil,
-					},
-				},
-			},
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Networking: hyperv1.ClusterNetworking{
-						NetworkType: hyperv1.OVNKubernetes,
-					},
-					PullSecret: corev1.LocalObjectReference{
-						Name: "pull-secret",
-					},
-					Release: hyperv1.Release{
-						Image: "image-4.14.0",
-					},
-
-					Platform: hyperv1.PlatformSpec{
-						Type:     hyperv1.KubevirtPlatform,
-						Kubevirt: &hyperv1.KubevirtPlatformSpec{},
-					},
-				},
-			},
-			expectedResult: errors.New(`the minimum version supported for platform KubeVirt is: "4.15.0". Attempting to use: "4.14.0"`),
-		},
-		{
-			name: "KubeVirt platform supported release, success",
-			other: []crclient.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"},
-					Data: map[string][]byte{
-						corev1.DockerConfigJsonKey: nil,
-					},
-				},
-			},
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Networking: hyperv1.ClusterNetworking{
-						NetworkType: hyperv1.OVNKubernetes,
-					},
-					PullSecret: corev1.LocalObjectReference{
-						Name: "pull-secret",
-					},
-					Release: hyperv1.Release{
-						Image: "image-4.16.0",
-					},
-
-					Platform: hyperv1.PlatformSpec{
-						Type:     hyperv1.KubevirtPlatform,
-						Kubevirt: &hyperv1.KubevirtPlatformSpec{},
-					},
-				},
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -27,8 +27,6 @@ func GetMinSupportedVersion(hc *hyperv1.HostedCluster) semver.Version {
 
 	defaultMinVersion := MinSupportedVersion
 	switch hc.Spec.Platform.Type {
-	case hyperv1.KubevirtPlatform:
-		return semver.MustParse("4.15.0")
 	case hyperv1.IBMCloudPlatform:
 		return semver.MustParse("4.9.0")
 	default:


### PR DESCRIPTION
In the past, the KubeVirt platform had a minimum supported OCP version that differed from the default supported version. This is because KubeVirt required OCP version >= 4.14.  Now that the default minimum version is 4.14, we do not need to treat the kubevirt platform any differently. 