### PR TITLE
OCPBUGS-34274: Generate default worker security group rules based on machineCIDR

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -4702,7 +4702,7 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context
 
 	originalHCP := hcp.DeepCopy()
 	var condition *metav1.Condition
-	sgID, creationErr := createAWSDefaultSecurityGroup(ctx, r.ec2Client, hcp.Spec.InfraID, hcp.Spec.Platform.AWS.CloudProviderConfig.VPC, hcp.Spec.Platform.AWS.ResourceTags)
+	sgID, creationErr := createAWSDefaultSecurityGroup(ctx, r.ec2Client, hcp)
 	if creationErr != nil {
 		condition = &metav1.Condition{
 			Type:    string(hyperv1.AWSDefaultSecurityGroupCreated),
@@ -4749,10 +4749,16 @@ func awsSecurityGroupName(infraID string) string {
 	return fmt.Sprintf("%s-default-sg", infraID)
 }
 
-func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2API, infraID, vpcID string, additionalTags []hyperv1.AWSResourceTag) (string, error) {
+func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2API, hcp *hyperv1.HostedControlPlane) (string, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	// Determine VPC cidr
+	var (
+		vpcID          = hcp.Spec.Platform.AWS.CloudProviderConfig.VPC
+		infraID        = hcp.Spec.InfraID
+		additionalTags = hcp.Spec.Platform.AWS.ResourceTags
+	)
+
+	// Validate VPC exists
 	vpcResult, err := ec2Client.DescribeVpcsWithContext(ctx, &ec2.DescribeVpcsInput{
 		VpcIds: []*string{awssdk.String(vpcID)},
 	})
@@ -4763,7 +4769,18 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 	if len(vpcResult.Vpcs) == 0 {
 		return "", fmt.Errorf("vpc %s not found", vpcID)
 	}
-	vpcCIDR := awssdk.StringValue(vpcResult.Vpcs[0].CidrBlock)
+
+	// Validate the hostedcontrolplane defines a machine CIDR
+	if len(hcp.Spec.Networking.MachineNetwork) == 0 {
+		logger.Error(errors.New("hostedcontrolplane.spec.networking.machineNetwork length is 0"), "failed to extract machine CIDR while creating default security group")
+		return "", errors.New("hostedcontrolplane.spec.networking.machineNetwork length is 0")
+	}
+	machineCIDRs := make([]string, len(hcp.Spec.Networking.MachineNetwork))
+	for i, mNet := range hcp.Spec.Networking.MachineNetwork {
+		machineCIDRs[i] = mNet.CIDR.String()
+	}
+
+	// Search for an existing default worker security group and create one if not found
 	describeSGResult, err := ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{Filters: awsSecurityGroupFilters(infraID)})
 	if err != nil {
 		logger.Error(err, "Failed to list security groups")
@@ -4835,7 +4852,7 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 		sg = describeSGResult.SecurityGroups[0]
 		logger.Info("Created security group", "id", sgID)
 	}
-	ingressPermissions := supportawsutil.DefaultWorkerSGIngressRules(vpcCIDR, sgID, awssdk.StringValue(sg.OwnerId))
+	ingressPermissions := supportawsutil.DefaultWorkerSGIngressRules(machineCIDRs, sgID, awssdk.StringValue(sg.OwnerId))
 	_, err = ec2Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId:       awssdk.String(sgID),
 		IpPermissions: ingressPermissions,

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -4770,10 +4770,9 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 		return "", fmt.Errorf("vpc %s not found", vpcID)
 	}
 
-	// Validate the hostedcontrolplane defines a machine CIDR
 	if len(hcp.Spec.Networking.MachineNetwork) == 0 {
-		logger.Error(errors.New("hostedcontrolplane.spec.networking.machineNetwork length is 0"), "failed to extract machine CIDR while creating default security group")
-		return "", errors.New("hostedcontrolplane.spec.networking.machineNetwork length is 0")
+		// Should never happen
+		return "", errors.New("failed to extract machine CIDR while creating default security group: hostedcontrolplane.spec.networking.machineNetwork length is 0")
 	}
 	machineCIDRs := make([]string, len(hcp.Spec.Networking.MachineNetwork))
 	for i, mNet := range hcp.Spec.Networking.MachineNetwork {
@@ -4783,7 +4782,6 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 	// Search for an existing default worker security group and create one if not found
 	describeSGResult, err := ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{Filters: awsSecurityGroupFilters(infraID)})
 	if err != nil {
-		logger.Error(err, "Failed to list security groups")
 		return "", fmt.Errorf("cannot list security groups, code: %s", awsErrorCode(err))
 	}
 	sgID := ""
@@ -4829,7 +4827,6 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 			},
 		})
 		if err != nil {
-			logger.Error(err, "Failed to create security group")
 			return "", fmt.Errorf("failed to create security group, code: %s", awsErrorCode(err))
 		}
 		sgID = awssdk.StringValue(createSGResult.GroupId)
@@ -4839,13 +4836,11 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 			GroupIds: []*string{awssdk.String(sgID)},
 		}
 		if err = ec2Client.WaitUntilSecurityGroupExistsWithContext(ctx, describeSGInput); err != nil {
-			logger.Error(err, "Failed to wait for security group to exist")
 			return "", fmt.Errorf("failed to find created security group (id: %s), code: %s", sgID, awsErrorCode(err))
 		}
 
 		describeSGResult, err = ec2Client.DescribeSecurityGroups(describeSGInput)
 		if err != nil || len(describeSGResult.SecurityGroups) == 0 {
-			logger.Error(err, "Failed to fetch security group", "sgID", sgID)
 			return "", fmt.Errorf("failed to fetch security group (id: %s), code: %s", sgID, awsErrorCode(err))
 		}
 
@@ -4859,7 +4854,6 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 	})
 	if err != nil {
 		if awsErrorCode(err) != "InvalidPermission.Duplicate" {
-			logger.Error(err, "Failed to set security group ingress rules")
 			return "", fmt.Errorf("failed to set security group ingress rules, code: %s", awsErrorCode(err))
 		}
 		logger.Info("WARNING: got duplicate permissions error when setting security group ingress permissions", "sgID", sgID)


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, these rules were generated off of the containing VPC's main CIDR range. However AWS VPCs can have multiple, distinct CIDR ranges, and the main CIDR range may not be the same as the machine CIDR, where the worker nodes are. This results in security group rules being generated that do not allow the worker nodes to communicate with the hosted control plane via the PrivateLink VPC Endpoint.

Ref: https://aws.amazon.com/about-aws/whats-new/2017/08/amazon-virtual-private-cloud-vpc-now-allows-customers-to-expand-their-existing-vpcs/

**Which issue(s) this PR fixes**:
[OCPBUGS-34274](https://issues.redhat.com/browse/OCPBUGS-34274)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.