### PR TITLE
HOSTEDCP-1688: Use operator namespace for openshift-config-managed-trusted-ca-bundle

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -594,7 +594,7 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, []crclient.Ob
 
 	trustedCABundle := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "hypershift",
+			Namespace: operatorNamespace.Name,
 			Name:      "openshift-config-managed-trusted-ca-bundle",
 			Labels: map[string]string{
 				"config.openshift.io/inject-trusted-cabundle": "true",

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -375,7 +375,7 @@ objects:
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
     name: openshift-config-managed-trusted-ca-bundle
-    namespace: hypershift
+    namespace: ${NAMESPACE}
 - apiVersion: v1
   kind: ServiceAccount
   metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the specified operator namespace for `openshift-config-managed-trusted-ca-bundle` configmap rather than hard-coding to `hypershift`.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
https://issues.redhat.com/browse/HOSTEDCP-1688
