### PR TITLE
OCPBUGS-18711: add AWS STS URL to OIDC provider audiences

### DIFF
--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -523,6 +523,7 @@ func (o *CreateIAMOptions) CreateOIDCProvider(iamClient iamiface.IAMAPI) (string
 	oidcOutput, err := iamClient.CreateOpenIDConnectProvider(&iam.CreateOpenIDConnectProviderInput{
 		ClientIDList: []*string{
 			aws.String("openshift"),
+			aws.String("sts.amazonaws.com"),
 		},
 		// The AWS console mentions that this will be ignored for S3 buckets but creation fails if we don't
 		// pass a thumbprint.


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Bug fix - in hosted cluster on AWS STS cluster [secrets store provider](https://github.com/aws/secrets-store-csi-driver-provider-aws) can't mount secrets if `sts.amazonaws.com` is not set as audience for OIDC provider. See linked Jira for details.

There might be some security implications to setting this audience by default - suggestions welcome. I've checked what CCO does when creating infrastructure for STS clusters and it's hardcoded here: https://github.com/openshift/cloud-credential-operator/blob/2f29d9103ce284095aef5f9eb2b7679c134051a0/pkg/cmd/provisioning/aws/create_identity_provider.go#L341

**Which issue(s) this PR fixes**:

fixes https://issues.redhat.com/browse/OCPBUGS-18711

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.