### PR TITLE
OCPBUGS-33987: Use configmaps to track hosted cluster pair labels and set controller concurrency

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -111,7 +111,7 @@ import (
 )
 
 const (
-	finalizer                           = "hypershift.openshift.io/finalizer"
+	HostedClusterFinalizer              = "hypershift.openshift.io/finalizer"
 	HostedClusterAnnotation             = "hypershift.openshift.io/cluster"
 	clusterDeletionRequeueDuration      = 5 * time.Second
 	ReportingGracePeriodRequeueDuration = 25 * time.Second
@@ -524,8 +524,8 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		// Now we can remove the finalizer.
-		if controllerutil.ContainsFinalizer(hcluster, finalizer) {
-			controllerutil.RemoveFinalizer(hcluster, finalizer)
+		if controllerutil.ContainsFinalizer(hcluster, HostedClusterFinalizer) {
+			controllerutil.RemoveFinalizer(hcluster, HostedClusterFinalizer)
 			if err := r.Update(ctx, hcluster); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from hostedcluster: %w", err)
 			}
@@ -1053,8 +1053,8 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	// Part two: reconcile the state of the world
 
 	// Ensure the cluster has a finalizer for cleanup and update right away.
-	if !controllerutil.ContainsFinalizer(hcluster, finalizer) {
-		controllerutil.AddFinalizer(hcluster, finalizer)
+	if !controllerutil.ContainsFinalizer(hcluster, HostedClusterFinalizer) {
+		controllerutil.AddFinalizer(hcluster, HostedClusterFinalizer)
 		if err := r.Update(ctx, hcluster); err != nil {
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil

--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes_test.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes_test.go
@@ -356,6 +356,9 @@ func TestHostedClusterSchedulerAndSizer(t *testing.T) {
 				Annotations: map[string]string{
 					hyperv1.TopologyAnnotation: hyperv1.DedicatedRequestServingComponentsTopology,
 				},
+				Finalizers: []string{
+					schedulerFinalizer,
+				},
 			},
 		}
 		for _, m := range mods {


### PR DESCRIPTION
**What this PR does / why we need it**:

DedicatedServingComponentScheduler* Operate over HCs as the driving resource. With current setup it might be possible for 2..10 reconciliations to happen conccurently resulting in those HC competing for Node pairs. This might result in Node pairs being split between different HCs silenty. Optimistic lock would make this discrepancy visible by making a patch request fail if one/both of the Nodes were changed. MaxConcurrentReconciles 1 would prevent the discrepancy from happening for most scenarios. Only the case where the intended transactional patch fails for one of the Nodes would potentially cause skew.

Adds the use of configmaps as a lease for a particular fleet manager pair label for a given hosted cluster. In order to label nodes with a given fleet manager label, a configmap named with the pair label must exist and contain the hosted cluster's name and namespace.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-33987

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.