### PR TITLE
OCPBUGS-34544: Disable PersistentVolumeLabel admission plugin

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -275,7 +275,6 @@ func admissionPlugins() []string {
 		"NodeRestriction",
 		"OwnerReferencesPermissionEnforcement",
 		"PersistentVolumeClaimResize",
-		"PersistentVolumeLabel",
 		"PodNodeSelector",
 		"PodTolerationRestriction",
 		"Priority",


### PR DESCRIPTION
**What this PR does / why we need it**:
PersistentVolumeLabel admission plugin needs a valid cloud config. kube-apiserver does not get it in HyperShift, and thus it rejects valid Azure Disk PVs.

The admission plugin was deprecated upstream a long time ago, it was removed from Kubernetes 1.31 (OCP 4.18) and it cannot work without a cloud provider in kube-apiserver anyway.

It's also being disabled in standalone OCP, https://github.com/openshift/cluster-kube-apiserver-operator/pull/1693

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes OCPBUGS-34544
Related to OCPBUGS-31371

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

cc @openshift/storage 