### PR TITLE
CNF-12951:hypershift:performanceprofile: associate profile name with user input

### DIFF
--- a/hypershift-operator/controllers/nodepool/manifests.go
+++ b/hypershift-operator/controllers/nodepool/manifests.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -12,6 +13,10 @@ import (
 const (
 	EC2VolumeDefaultSize int64  = 16
 	EC2VolumeDefaultType string = "gp3"
+
+	// QualifiedNameMaxLength is the maximal name length allowed for k8s object
+	// https://github.com/kubernetes/kubernetes/blob/957c9538670b5f7ead2c9ba9ceb9de081d66caa4/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L34
+	QualifiedNameMaxLength = 63
 )
 
 func machineDeployment(nodePool *hyperv1.NodePool, controlPlaneNamespace string) *capiv1.MachineDeployment {
@@ -72,11 +77,11 @@ func TunedConfigMap(namespace, name string) *corev1.ConfigMap {
 	}
 }
 
-func PerformanceProfileConfigMap(namespace, name string) *corev1.ConfigMap {
+func PerformanceProfileConfigMap(namespace, name, nodePoolName string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "perfprofile-" + name,
+			Name:      util.ShortenName(name, nodePoolName, QualifiedNameMaxLength),
 		},
 	}
 }

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -1047,12 +1047,13 @@ status: {}
 
 	namespace := "test"
 	testCases := []struct {
-		name           string
-		nodePool       *hyperv1.NodePool
-		tuningConfig   []client.Object
-		tunedExpect    string
-		perfprofExpect string
-		error          bool
+		name               string
+		nodePool           *hyperv1.NodePool
+		tuningConfig       []client.Object
+		tunedExpect        string
+		perfprofExpect     string
+		perfProfNameExpect string
+		error              bool
 	}{
 		{
 			name: "gets a single valid TunedConfig",
@@ -1175,9 +1176,10 @@ status: {}
 					BinaryData: nil,
 				},
 			},
-			tunedExpect:    "",
-			perfprofExpect: perfprofOneDefaulted,
-			error:          false,
+			tunedExpect:        "",
+			perfprofExpect:     perfprofOneDefaulted,
+			perfProfNameExpect: "perfprofOne",
+			error:              false,
 		},
 		{
 			name: "Should be at most one PerformanceProfileConfig per NodePool",
@@ -1242,7 +1244,7 @@ status: {}
 			error:          true,
 		},
 		{
-			name: "PerformanceProfiles and Tuned Configs could cohexists",
+			name: "PerformanceProfiles and Tuned Configs could coexists",
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
@@ -1291,9 +1293,10 @@ status: {}
 					},
 				},
 			},
-			tunedExpect:    tuned1Defaulted + "\n---\n" + tuned2Defaulted,
-			perfprofExpect: perfprofOneDefaulted,
-			error:          false,
+			tunedExpect:        tuned1Defaulted + "\n---\n" + tuned2Defaulted,
+			perfprofExpect:     perfprofOneDefaulted,
+			perfProfNameExpect: "perfprofOne",
+			error:              false,
 		},
 	}
 
@@ -1305,7 +1308,7 @@ status: {}
 				Client: fake.NewClientBuilder().WithObjects(tc.tuningConfig...).Build(),
 			}
 
-			td, pp, err := r.getTuningConfig(context.Background(), tc.nodePool)
+			td, pp, ppName, err := r.getTuningConfig(context.Background(), tc.nodePool)
 
 			if tc.error {
 				g.Expect(err).To(HaveOccurred())
@@ -1319,6 +1322,10 @@ status: {}
 			if diff := cmp.Diff(pp, tc.perfprofExpect); diff != "" {
 				t.Errorf("actual Performance Profile config differs from expected: %s", diff)
 				t.Logf("got:\n%s\n, expected:\n%s\n", pp, tc.perfprofExpect)
+			}
+			if diff := cmp.Diff(ppName, tc.perfProfNameExpect); diff != "" {
+				t.Errorf("Performance Profile config name differ from expected: %s", diff)
+				t.Logf("got:\n%s\n, expected:\n%s\n", ppName, tc.perfProfNameExpect)
 			}
 		})
 	}

--- a/support/util/route.go
+++ b/support/util/route.go
@@ -26,17 +26,17 @@ func ShortenRouteHostnameIfNeeded(name, namespace string, baseDomain string) str
 	if len(name)+len(namespace)+1 < validation.DNS1123LabelMaxLength {
 		return ""
 	} else {
-		return fmt.Sprintf("%s.%s", strings.TrimSuffix(shortenName(name+"-"+namespace, "", validation.DNS1123LabelMaxLength), "-"), baseDomain)
+		return fmt.Sprintf("%s.%s", strings.TrimSuffix(ShortenName(name+"-"+namespace, "", validation.DNS1123LabelMaxLength), "-"), baseDomain)
 	}
 }
 
-// shortenName returns a name given a base ("deployment-5") and a suffix ("deploy")
+// ShortenName returns a name given a base ("deployment-5") and a suffix ("deploy")
 // It will first attempt to join them with a dash. If the resulting name is longer
 // than maxLength: if the suffix is too long, it will truncate the base name and add
 // an 8-character hash of the [base]-[suffix] string.  If the suffix is not too long,
 // it will truncate the base, add the hash of the base and return [base]-[hash]-[suffix]
 // Source: openshift/origin v3.9.0 pkg/api/apihelpers/namer.go
-func shortenName(base, suffix string, maxLength int) string {
+func ShortenName(base, suffix string, maxLength int) string {
 	if maxLength <= 0 {
 		return ""
 	}

--- a/support/util/route_test.go
+++ b/support/util/route_test.go
@@ -55,7 +55,7 @@ func TestShortenName(t *testing.T) {
 
 		for j, test := range tests {
 			t.Run(fmt.Sprintf("test-%d-%d", i, j), func(t *testing.T) {
-				result := shortenName(test.base, test.suffix, kvalidation.DNS1123SubdomainMaxLength)
+				result := ShortenName(test.base, test.suffix, kvalidation.DNS1123SubdomainMaxLength)
 				if result != test.expected {
 					t.Errorf("Got unexpected result. Expected: %s Got: %s", test.expected, result)
 				}
@@ -66,14 +66,14 @@ func TestShortenName(t *testing.T) {
 
 func TestShortenNameIsDifferent(t *testing.T) {
 	shortName := randSeq(32)
-	deployerName := shortenName(shortName, "deploy", kvalidation.DNS1123SubdomainMaxLength)
-	builderName := shortenName(shortName, "build", kvalidation.DNS1123SubdomainMaxLength)
+	deployerName := ShortenName(shortName, "deploy", kvalidation.DNS1123SubdomainMaxLength)
+	builderName := ShortenName(shortName, "build", kvalidation.DNS1123SubdomainMaxLength)
 	if deployerName == builderName {
 		t.Errorf("Expecting names to be different: %s\n", deployerName)
 	}
 	longName := randSeq(kvalidation.DNS1123SubdomainMaxLength + 10)
-	deployerName = shortenName(longName, "deploy", kvalidation.DNS1123SubdomainMaxLength)
-	builderName = shortenName(longName, "build", kvalidation.DNS1123SubdomainMaxLength)
+	deployerName = ShortenName(longName, "deploy", kvalidation.DNS1123SubdomainMaxLength)
+	builderName = ShortenName(longName, "build", kvalidation.DNS1123SubdomainMaxLength)
 	if deployerName == builderName {
 		t.Errorf("Expecting names to be different: %s\n", deployerName)
 	}
@@ -84,7 +84,7 @@ func TestShortenNameReturnShortNames(t *testing.T) {
 	for maxLength := 0; maxLength < len(base)+2; maxLength++ {
 		for suffixLen := 0; suffixLen <= maxLength+1; suffixLen++ {
 			suffix := randSeq(suffixLen)
-			got := shortenName(base, suffix, maxLength)
+			got := ShortenName(base, suffix, maxLength)
 			if len(got) > maxLength {
 				t.Fatalf("len(GetName(%[1]q, %[2]q, %[3]d)) = len(%[4]q) = %[5]d; want %[3]d", base, suffix, maxLength, got, len(got))
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
When a `PerformanceProfile` should be mirrored into the HCP namespace, its given name which compose from a constant (perfprof) + the node pool name.

In case there are multiple `PerformanceProfiles`, one per hosted cluster, the approach mentioned above makes it hard to understand which `PreformanceProfile` in the clusters namespace is associate with each hostedcluster.

It requires to examine the node pool \`spec.tuningConfig\` to figure out the relation between user profile and the mirrored one.

This commit suggest to embed the configMap (that encapsulates the performanceProfile) name in the mirrored profile, to make the relation clear and observable on first sight.

**Which issue(s) this PR fixes**
Fixes # [CNF-12951](https://issues.redhat.com/browse/CNF-12951)