### PR TITLE
OCPBUGS-34640: Support for multiple name per component in releaseProvider

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/imageprovider/imageprovider.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/imageprovider/imageprovider.go
@@ -24,10 +24,35 @@ func NewFromImages(componentsImages map[string]string) *ReleaseImageProvider {
 	}
 }
 
+// GetImage returns the image for the given key. If the image is not found, it will be added to the missing images list.
 func (p *ReleaseImageProvider) GetImage(key string) string {
 	image, exist := p.componentsImages[key]
 	if !exist || image == "" {
 		p.missingImages = append(p.missingImages, key)
+	}
+
+	return image
+}
+
+// GetImages returns the first image from the given key list. If the image is not found among the list,
+// it will be added to the missing images list.
+// This is useful when a component image has been renamed and we need to support multiple names among different OCP payloads.
+// Sample: cluster-config-operator -> cluster-config-api
+func (p *ReleaseImageProvider) GetImages(keys []string) string {
+	var (
+		exist bool
+		image string
+	)
+
+	for _, imageName := range keys {
+		image, exist = p.componentsImages[imageName]
+		if exist && image != "" {
+			break
+		}
+	}
+
+	if !exist || image == "" {
+		p.missingImages = append(p.missingImages, keys...)
 	}
 
 	return image

--- a/control-plane-operator/controllers/hostedcontrolplane/imageprovider/imageprovider_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/imageprovider/imageprovider_test.go
@@ -1,0 +1,64 @@
+package imageprovider
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetImages(t *testing.T) {
+	testComponents := []string{"component1", "component2"}
+
+	testCases := []struct {
+		name             string
+		componentsImages map[string]string
+		expectedImage    string
+		missingImages    []string
+	}{
+		{
+			name: "image found in the list",
+			componentsImages: map[string]string{
+				"component1": "image1",
+				"component2": "image2",
+				"component3": "image3",
+			},
+			expectedImage: "image1",
+		},
+		{
+			name: "image found in the list with multiple options",
+			componentsImages: map[string]string{
+				"component1": "image1",
+				"component2": "image2",
+				"component3": "image3",
+			},
+			expectedImage: "image1",
+		},
+		{
+			name: "image found in the list with multiple options but the first one is empty",
+			componentsImages: map[string]string{
+				"component2": "image2",
+				"component3": "image3",
+			},
+			expectedImage: "image2",
+		},
+		{
+			name: "image not found in the list",
+			componentsImages: map[string]string{
+				"component3": "image3",
+			},
+			expectedImage: "",
+			missingImages: testComponents,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			releaseProvider := NewFromImages(tc.componentsImages)
+			image := releaseProvider.GetImages(testComponents)
+			g.Expect(image).To(Equal(tc.expectedImage))
+			if tc.expectedImage == "" {
+				g.Expect(releaseProvider.GetMissingImages()).To(ConsistOf(testComponents))
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -99,10 +99,13 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		ConsolePublicURL:     fmt.Sprintf("https://console-openshift-console.%s", dns.Spec.BaseDomain),
 		DisableProfiling:     util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], manifests.KASDeployment("").Name),
 
+		// TODO: Need to refactor the way we get the images to prevent future image name changes broke our
+		// 		 compatbility between multiple OCP Payload releases.
+		//       for future references: https://issues.redhat.com/browse/OCPBUGS-34640
 		Images: KubeAPIServerImages{
 			HyperKube:                  releaseImageProvider.GetImage("hyperkube"),
 			CLI:                        releaseImageProvider.GetImage("cli"),
-			ClusterConfigOperator:      releaseImageProvider.GetImage("cluster-config-api"),
+			ClusterConfigOperator:      releaseImageProvider.GetImages([]string{"cluster-config-api", "cluster-config-operator"}),
 			TokenMinterImage:           releaseImageProvider.GetImage("token-minter"),
 			AWSKMS:                     releaseImageProvider.GetImage("aws-kms-encryption-provider"),
 			AzureKMS:                   releaseImageProvider.GetImage("azure-kms-encryption-provider"),
@@ -110,6 +113,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			KonnectivityServer:         releaseImageProvider.GetImage("apiserver-network-proxy"),
 		},
 	}
+
 	if hcp.Spec.Configuration != nil {
 		params.APIServer = hcp.Spec.Configuration.APIServer
 		params.Authentication = hcp.Spec.Configuration.Authentication


### PR DESCRIPTION
This PR adds support for components in the OCP payload that change their names across different OCP releases. Here's how it works: when you invoke the GetImages method, you should provide a slice of strings with the possible names the component could have in different OCP releases. The method will return the first matching name it finds

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-34640](https://issues.redhat.com/browse/OCPBUGS-34640)