### PR TITLE
OCPBUGS-34678: Add the missing OPERATOR_IMAGE_VERSION parameter

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -253,6 +253,10 @@ func buildMainContainer(image, registryImage, prunerImage, releaseVersion string
 				Name:  "AZURE_ENVIRONMENT_FILEPATH",
 				Value: "/tmp/azurestackcloud.json",
 			},
+			{
+				Name:  "OPERATOR_IMAGE_VERSION",
+				Value: releaseVersion,
+			},
 		}
 		proxy.SetEnvVars(&c.Env)
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -89,6 +89,8 @@ spec:
           value: quay.io/openshift/cli:latest
         - name: AZURE_ENVIRONMENT_FILEPATH
           value: /tmp/azurestackcloud.json
+        - name: OPERATOR_IMAGE_VERSION
+          value: 1.0.0
         image: quay.io/openshift/cluster-image-registry-operator:latest
         name: cluster-image-registry-operator
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
This Pr adds a new parameter OPERATOR_IMAGE_VERSION required by the Featuregates configuration in Image-registry operator

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-34678 

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.