### PR TITLE
HOSTEDCP-1697: Allow overriding hosted cluster size label

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -296,6 +296,10 @@ const (
 	// health check created for a NodePool. The annotation can be set in either the HostedCluster or the NodePool.
 	// If set on both, the one on the NodePool takes precedence. The value can be a number or a percentage value.
 	MachineHealthCheckMaxUnhealthyAnnotation = "hypershift.openshift.io/machine-health-check-max-unhealthy"
+
+	// ClusterSizeOverrideAnnotation allows overriding the value of the size label regardless of the number
+	// of workers associated with the HostedCluster. The value should be the desired size label.
+	ClusterSizeOverrideAnnotation = "hypershift.openshift.io/cluster-size-override"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller_test.go
+++ b/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller_test.go
@@ -1426,6 +1426,63 @@ func TestSizingController_Reconcile(t *testing.T) {
 			}},
 		},
 		{
+			name:   "transition, use override size",
+			config: validCommonConfig,
+			hostedCluster: &hypershiftv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "hc",
+					Annotations: map[string]string{
+						hypershiftv1beta1.ClusterSizeOverrideAnnotation: "large",
+					},
+				},
+			},
+			listHostedClusters: func(_ context.Context) (*hypershiftv1beta1.HostedClusterList, error) {
+				return &hypershiftv1beta1.HostedClusterList{Items: []hypershiftv1beta1.HostedCluster{
+					hostedClusterWithTransition("first", fakeClock.Now().Add(-1*time.Minute)),
+					hostedClusterWithTransition("second", fakeClock.Now().Add(-2*time.Minute)),
+					hostedClusterWithTransition("third", fakeClock.Now().Add(-3*time.Minute)),
+					hostedClusterWithTransition("fourth", fakeClock.Now().Add(-4*time.Minute)),
+					hostedClusterWithTransition("fifth", fakeClock.Now().Add(-5*time.Minute)),
+				}}, nil
+			},
+			hccoReportsNodeCount: func(_ context.Context, _ *hypershiftv1beta1.HostedCluster) (bool, error) {
+				return true, nil
+			},
+			hostedControlPlaneForHostedCluster: func(_ context.Context, _ *hypershiftv1beta1.HostedCluster) (*hypershiftv1beta1.HostedControlPlane, error) {
+				return &hypershiftv1beta1.HostedControlPlane{
+					Status: hypershiftv1beta1.HostedControlPlaneStatus{NodeCount: ptr.To(0)},
+				}, nil
+			},
+			expected: &action{applyCfg: &hypershiftv1beta1applyconfigurations.HostedClusterApplyConfiguration{
+				ObjectMetaApplyConfiguration: &metav1applyconfigurations.ObjectMetaApplyConfiguration{Namespace: ptr.To("ns"), Name: ptr.To("hc")},
+				Status: &hypershiftv1beta1applyconfigurations.HostedClusterStatusApplyConfiguration{
+					Conditions: []metav1applyconfigurations.ConditionApplyConfiguration{
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeComputed),
+							Status:             ptr.To(metav1.ConditionTrue),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To("large"),
+							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
+						},
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeTransitionPending),
+							Status:             ptr.To(metav1.ConditionFalse),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To("ClusterSizeTransitioned"),
+							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
+						},
+						{
+							Type:               ptr.To(hypershiftv1beta1.ClusterSizeTransitionRequired),
+							Status:             ptr.To(metav1.ConditionFalse),
+							LastTransitionTime: ptr.To(metav1.NewTime(fakeClock.Now())),
+							Reason:             ptr.To(hypershiftv1beta1.AsExpectedReason),
+							Message:            ptr.To("The HostedCluster has transitioned to a new t-shirt size."),
+						},
+					},
+				},
+			}},
+		},
+		{
 			name:   "happy case: cluster has not changed size, already has condition and label",
 			config: validCommonConfig,
 			hostedCluster: &hypershiftv1beta1.HostedCluster{


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a hosted cluster annotation
`hypershift.openshift.io/cluster-size-override` that allows setting a cluster size regardless of the number of nodes in the cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1697](https://issues.redhat.com/browse/HOSTEDCP-1697)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.