### PR TITLE
OCPBUGS-34699: Allow access to root-ca configmap in cluster-network-operator role

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -33,6 +33,8 @@ import (
 const (
 	operatorName          = "cluster-network-operator"
 	konnectivityProxyName = "konnectivity-proxy"
+	caConfigMap           = "root-ca"
+	caConfigMapKey        = "ca.crt"
 )
 
 type Images struct {
@@ -115,8 +117,8 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 		TokenAudience:           hcp.Spec.IssuerURL,
 		SbDbPubStrategy:         util.ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.OVNSbDb),
 		DefaultIngressDomain:    defaultIngressDomain,
-		CAConfigMap:             "root-ca",
-		CAConfigMapKey:          "ca.crt",
+		CAConfigMap:             caConfigMap,
+		CAConfigMapKey:          caConfigMapKey,
 	}
 
 	p.DeploymentConfig.AdditionalLabels = map[string]string{
@@ -153,6 +155,7 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef, networkType hype
 				},
 				ResourceNames: []string{
 					"openshift-service-ca.crt",
+					caConfigMap,
 				},
 				Verbs: []string{
 					"get",

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
@@ -212,6 +212,7 @@ func expectedRules(networkType hyperv1.NetworkType) []rbacv1.PolicyRule {
 			},
 			ResourceNames: []string{
 				"openshift-service-ca.crt",
+				caConfigMap,
 			},
 			Verbs: []string{
 				"get",


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `root-ca` to the `resourceNames` in the `cluster-network-operator` role to provide the access required.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

https://issues.redhat.com/browse/OCPBUGS-34699
