### PR TITLE
IR-471:registry operator: Add missing env var, wait for rbac

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -46,6 +46,15 @@ echo "{{ .WorkerNamespace }}" > "{{ .TokenDir }}/namespace"
 cp "{{ .CABundle }}" "{{ .TokenDir }}/ca.crt"
 export KUBERNETES_SERVICE_HOST=kube-apiserver
 export KUBERNETES_SERVICE_PORT=$KUBE_APISERVER_SERVICE_PORT
+
+while true; do
+  if curl --fail --cacert {{ .TokenDir }}/ca.crt -H "Authorization: Bearer $(cat {{ .TokenDir }}/token)" "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/apis/config.openshift.io/v1/featuregates" &> /dev/null; then
+    break
+  fi
+  echo "Waiting for access to featuregates resource"
+  sleep 2
+done
+
 exec /usr/bin/cluster-image-registry-operator \
   --files="{{ .ServingCertDir }}/tls.crt" \
   --files="{{ .ServingCertDir }}/tls.key"

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -253,6 +253,10 @@ func buildMainContainer(image, registryImage, prunerImage, releaseVersion string
 				Name:  "AZURE_ENVIRONMENT_FILEPATH",
 				Value: "/tmp/azurestackcloud.json",
 			},
+			{
+				Name:  "OPERATOR_IMAGE_VERSION",
+				Value: releaseVersion,
+			},
 		}
 		proxy.SetEnvVars(&c.Env)
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -69,6 +69,15 @@ spec:
           cp "/etc/certificate/ca/ca.crt" "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
           export KUBERNETES_SERVICE_HOST=kube-apiserver
           export KUBERNETES_SERVICE_PORT=$KUBE_APISERVER_SERVICE_PORT
+
+          while true; do
+            if curl --fail --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/apis/config.openshift.io/v1/featuregates" &> /dev/null; then
+              break
+            fi
+            echo "Waiting for access to featuregates resource"
+            sleep 2
+          done
+
           exec /usr/bin/cluster-image-registry-operator \
             --files="/etc/secrets/tls.crt" \
             --files="/etc/secrets/tls.key"

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -89,6 +89,8 @@ spec:
           value: quay.io/openshift/cli:latest
         - name: AZURE_ENVIRONMENT_FILEPATH
           value: /tmp/azurestackcloud.json
+        - name: OPERATOR_IMAGE_VERSION
+          value: 1.0.0
         image: quay.io/openshift/cluster-image-registry-operator:latest
         name: cluster-image-registry-operator
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the missing OPERATOR_IMAGE_VERSION required by the new addition of featuregate in the Image-registry operator

In some cases the image registry operator starts (and crashes) before
the CVO has given its service account proper rbac. This commit adds a
wait for access to the infrastructure resource before allowing the
operator to start.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-34678

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.