### PR TITLE
[release-4.15] HOSTEDCP-1708: remove liveness and readiness probes that use the metrics

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -60,39 +59,6 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.Int(1))
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
-	p.DeploymentConfig.ReadinessProbes = config.ReadinessProbes{
-		ingressOperatorContainerName: {
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/metrics",
-					Port:   intstr.FromInt(ingressOperatorMetricsPort),
-					Scheme: corev1.URISchemeHTTP,
-				},
-			},
-			InitialDelaySeconds: 15,
-			PeriodSeconds:       60,
-			SuccessThreshold:    1,
-			FailureThreshold:    3,
-			TimeoutSeconds:      5,
-		},
-	}
-	p.DeploymentConfig.LivenessProbes = config.LivenessProbes{
-		ingressOperatorContainerName: {
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/metrics",
-					Port:   intstr.FromInt(ingressOperatorMetricsPort),
-					Scheme: corev1.URISchemeHTTP,
-				},
-			},
-			InitialDelaySeconds: 60,
-			PeriodSeconds:       60,
-			SuccessThreshold:    1,
-			FailureThreshold:    5,
-			TimeoutSeconds:      5,
-		},
-	}
-
 	return p
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -113,38 +113,6 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 				PriorityClass: config.DefaultPriorityClass,
 			},
 			SetDefaultSecurityContext: setDefaultSecurityContext,
-			ReadinessProbes: config.ReadinessProbes{
-				containerMain().Name: {
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
-							Port:   intstr.FromInt(metricsPort),
-							Scheme: corev1.URISchemeHTTPS,
-						},
-					},
-					InitialDelaySeconds: 15,
-					PeriodSeconds:       60,
-					SuccessThreshold:    1,
-					FailureThreshold:    3,
-					TimeoutSeconds:      5,
-				},
-			},
-			LivenessProbes: config.LivenessProbes{
-				containerMain().Name: {
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
-							Port:   intstr.FromInt(metricsPort),
-							Scheme: corev1.URISchemeHTTPS,
-						},
-					},
-					InitialDelaySeconds: 60,
-					PeriodSeconds:       60,
-					SuccessThreshold:    1,
-					FailureThreshold:    5,
-					TimeoutSeconds:      5,
-				},
-			},
 			Resources: config.ResourcesSpec{
 				containerMain().Name: {
 					Requests: corev1.ResourceList{

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -88,30 +88,10 @@ spec:
         - name: AZURE_ENVIRONMENT_FILEPATH
           value: /tmp/azurestackcloud.json
         image: quay.io/openshift/cluster-image-registry-operator:latest
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /metrics
-            port: 60000
-            scheme: HTTPS
-          initialDelaySeconds: 60
-          periodSeconds: 60
-          successThreshold: 1
-          timeoutSeconds: 5
         name: cluster-image-registry-operator
         ports:
         - containerPort: 60000
           name: metrics
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /metrics
-            port: 60000
-            scheme: HTTPS
-          initialDelaySeconds: 15
-          periodSeconds: 60
-          successThreshold: 1
-          timeoutSeconds: 5
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
Cherry pick of #4001 on release-4.15.

#4001: remove liveness and readiness probes that use the metrics

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```