### PR TITLE
OCPBUGS-34807: Fixed ValidReleaseInfo condition

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -50,8 +50,6 @@ type Images struct {
 	OVN                          string
 	OVNControlPlane              string
 	EgressRouterCNI              string
-	KuryrDaemon                  string
-	KuryrController              string
 	NetworkMetricsDaemon         string
 	NetworkCheckSource           string
 	NetworkCheckTarget           string
@@ -96,8 +94,6 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 			OVN:                          userReleaseImageProvider.GetImage("ovn-kubernetes"),
 			OVNControlPlane:              releaseImageProvider.GetImage("ovn-kubernetes"),
 			EgressRouterCNI:              userReleaseImageProvider.GetImage("egress-router-cni"),
-			KuryrDaemon:                  userReleaseImageProvider.GetImage("kuryr-cni"),
-			KuryrController:              userReleaseImageProvider.GetImage("kuryr-controller"),
 			NetworkMetricsDaemon:         userReleaseImageProvider.GetImage("network-metrics-daemon"),
 			NetworkCheckSource:           userReleaseImageProvider.GetImage("cluster-network-operator"),
 			NetworkCheckTarget:           userReleaseImageProvider.GetImage("cluster-network-operator"),
@@ -541,8 +537,6 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 			{Name: "OVN_IMAGE", Value: params.Images.OVN},
 			{Name: "OVN_CONTROL_PLANE_IMAGE", Value: params.Images.OVNControlPlane},
 			{Name: "EGRESS_ROUTER_CNI_IMAGE", Value: params.Images.EgressRouterCNI},
-			{Name: "KURYR_DAEMON_IMAGE", Value: params.Images.KuryrDaemon},
-			{Name: "KURYR_CONTROLLER_IMAGE", Value: params.Images.KuryrController},
 			{Name: "NETWORK_METRICS_DAEMON_IMAGE", Value: params.Images.NetworkMetricsDaemon},
 			{Name: "NETWORK_CHECK_SOURCE_IMAGE", Value: params.Images.NetworkCheckSource},
 			{Name: "NETWORK_CHECK_TARGET_IMAGE", Value: params.Images.NetworkCheckTarget},

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -78,8 +78,6 @@ spec:
         - name: OVN_IMAGE
         - name: OVN_CONTROL_PLANE_IMAGE
         - name: EGRESS_ROUTER_CNI_IMAGE
-        - name: KURYR_DAEMON_IMAGE
-        - name: KURYR_CONTROLLER_IMAGE
         - name: NETWORK_METRICS_DAEMON_IMAGE
         - name: NETWORK_CHECK_SOURCE_IMAGE
         - name: NETWORK_CHECK_TARGET_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -78,8 +78,6 @@ spec:
         - name: OVN_IMAGE
         - name: OVN_CONTROL_PLANE_IMAGE
         - name: EGRESS_ROUTER_CNI_IMAGE
-        - name: KURYR_DAEMON_IMAGE
-        - name: KURYR_CONTROLLER_IMAGE
         - name: NETWORK_METRICS_DAEMON_IMAGE
         - name: NETWORK_CHECK_SOURCE_IMAGE
         - name: NETWORK_CHECK_TARGET_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -79,8 +79,6 @@ spec:
         - name: OVN_IMAGE
         - name: OVN_CONTROL_PLANE_IMAGE
         - name: EGRESS_ROUTER_CNI_IMAGE
-        - name: KURYR_DAEMON_IMAGE
-        - name: KURYR_CONTROLLER_IMAGE
         - name: NETWORK_METRICS_DAEMON_IMAGE
         - name: NETWORK_CHECK_SOURCE_IMAGE
         - name: NETWORK_CHECK_TARGET_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -24,7 +24,7 @@ type KonnectivityParams struct {
 
 func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, externalAddress string, externalPort int32, setDefaultSecurityContext bool) *KonnectivityParams {
 	p := &KonnectivityParams{
-		KonnectivityAgentImage: releaseImageProvider.GetImage("konnectivity-agent"),
+		KonnectivityAgentImage: releaseImageProvider.GetImage("apiserver-network-proxy"),
 		OwnerRef:               config.OwnerRefFrom(hcp),
 	}
 
@@ -90,10 +90,6 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider
 	// non root security context if scc capability is missing
 	p.AgentDeamonSetConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	p.AgentDeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
-	// check apiserver-network-proxy image in ocp payload and use it
-	if image, exist := releaseImageProvider.ImageExist("apiserver-network-proxy"); exist {
-		p.KonnectivityAgentImage = image
-	}
 
 	if _, ok := hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]; ok {
 		p.KonnectivityAgentImage = hcp.Annotations[hyperv1.KonnectivityAgentImageAnnotation]


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously the condition was reconciled immediately before accessing any image in the playload. which means the condition will always be `True`

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.