### PR TITLE
OCPBUGS-34734: Fix disconnected metadata inspection for nodepool

### DIFF
--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -374,8 +374,10 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		ReleaseProvider:         releaseProviderWithOpenShiftImageRegistryOverrides,
 		CreateOrUpdateProvider:  createOrUpdate,
 		HypershiftOperatorImage: operatorImage,
-		ImageMetadataProvider:   &hyperutil.RegistryClientImageMetadataProvider{},
-		KubevirtInfraClients:    kvinfra.NewKubevirtInfraClientMap(),
+		ImageMetadataProvider: &hyperutil.RegistryClientImageMetadataProvider{
+			OpenShiftImageRegistryOverrides: imageRegistryOverrides,
+		},
+		KubevirtInfraClients: kvinfra.NewKubevirtInfraClientMap(),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}


### PR DESCRIPTION
Fix disconnected metadata inspection for nodepool

**Which issue(s) this PR fixes:**
Fixes #[OCPBUGS-34734](https://issues.redhat.com/browse/OCPBUGS-34734)