### PR TITLE
[release-4.15] OCPBUGS-33627: Restrict image registry overrides to control plane components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -163,6 +163,7 @@ type HostedControlPlaneReconciler struct {
 
 	Log                                     logr.Logger
 	ReleaseProvider                         releaseinfo.ProviderWithOpenShiftImageRegistryOverrides
+	UserReleaseProvider                     releaseinfo.Provider
 	createOrUpdate                          func(hcp *hyperv1.HostedControlPlane) upsert.CreateOrUpdateFN
 	EnableCIDebugOutput                     bool
 	OperateOnReleaseImage                   string
@@ -915,7 +916,8 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
 		return err
 	}
-	userReleaseImage, err := r.ReleaseProvider.Lookup(ctx, hostedControlPlane.Spec.ReleaseImage, pullSecret.Data[corev1.DockerConfigJsonKey])
+	// UserReleaseProvider doesn't include registry overrides as they should not get propagated to the data plane.
+	userReleaseImage, err := r.UserReleaseProvider.Lookup(ctx, hostedControlPlane.Spec.ReleaseImage, pullSecret.Data[corev1.DockerConfigJsonKey])
 	if err != nil {
 		return fmt.Errorf("failed to get lookup release image: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -984,6 +984,7 @@ func TestEventHandling(t *testing.T) {
 		Client:                        c,
 		ManagementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 		ReleaseProvider:               &fakereleaseprovider.FakeReleaseProvider{},
+		UserReleaseProvider:           &fakereleaseprovider.FakeReleaseProvider{},
 		reconcileInfrastructureStatus: func(context.Context, *hyperv1.HostedControlPlane) (InfrastructureStatus, error) {
 			return readyInfraStatus, nil
 		},
@@ -1318,6 +1319,7 @@ func TestNonReadyInfraTriggersRequeueAfter(t *testing.T) {
 		Client:                        c,
 		ManagementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 		ReleaseProvider:               &fakereleaseprovider.FakeReleaseProvider{},
+		UserReleaseProvider:           &fakereleaseprovider.FakeReleaseProvider{},
 		reconcileInfrastructureStatus: func(context.Context, *hyperv1.HostedControlPlane) (InfrastructureStatus, error) {
 			return InfrastructureStatus{}, nil
 		},

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -394,6 +394,14 @@ func NewStartCommand() *cobra.Command {
 			ComponentImages: componentImages,
 		}
 
+		userReleaseProvider := &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
+			Delegate: &releaseinfo.RegistryMirrorProviderDecorator{
+				Delegate:          coreReleaseProvider,
+				RegistryOverrides: nil, // UserReleaseProvider shouldn't include registry overrides as they should not get propagated to the data plane.
+			},
+			OpenShiftImageRegistryOverrides: imageRegistryOverrides,
+		}
+
 		cpReleaseProvider := &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
 			Delegate: &releaseinfo.RegistryMirrorProviderDecorator{
 				Delegate:          coreReleaseProvider,
@@ -417,7 +425,7 @@ func NewStartCommand() *cobra.Command {
 			Client:                                  mgr.GetClient(),
 			ManagementClusterCapabilities:           mgmtClusterCaps,
 			ReleaseProvider:                         cpReleaseProvider,
-			UserReleaseProvider:                     coreReleaseProvider,
+			UserReleaseProvider:                     userReleaseProvider,
 			EnableCIDebugOutput:                     enableCIDebugOutput,
 			OperateOnReleaseImage:                   os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
 			DefaultIngressDomain:                    defaultIngressDomain,

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -386,15 +386,17 @@ func NewStartCommand() *cobra.Command {
 			imageRegistryOverrides = util.ConvertImageRegistryOverrideStringToMap(openShiftImgOverrides)
 		}
 
-		releaseProvider := &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
+		coreReleaseProvider := &releaseinfo.StaticProviderDecorator{
+			Delegate: &releaseinfo.CachedProvider{
+				Inner: &releaseinfo.RegistryClientProvider{},
+				Cache: map[string]*releaseinfo.ReleaseImage{},
+			},
+			ComponentImages: componentImages,
+		}
+
+		cpReleaseProvider := &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
 			Delegate: &releaseinfo.RegistryMirrorProviderDecorator{
-				Delegate: &releaseinfo.StaticProviderDecorator{
-					Delegate: &releaseinfo.CachedProvider{
-						Inner: &releaseinfo.RegistryClientProvider{},
-						Cache: map[string]*releaseinfo.ReleaseImage{},
-					},
-					ComponentImages: componentImages,
-				},
+				Delegate:          coreReleaseProvider,
 				RegistryOverrides: registryOverrides,
 			},
 			OpenShiftImageRegistryOverrides: imageRegistryOverrides,
@@ -414,7 +416,8 @@ func NewStartCommand() *cobra.Command {
 		if err := (&hostedcontrolplane.HostedControlPlaneReconciler{
 			Client:                                  mgr.GetClient(),
 			ManagementClusterCapabilities:           mgmtClusterCaps,
-			ReleaseProvider:                         releaseProvider,
+			ReleaseProvider:                         cpReleaseProvider,
+			UserReleaseProvider:                     coreReleaseProvider,
 			EnableCIDebugOutput:                     enableCIDebugOutput,
 			OperateOnReleaseImage:                   os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
 			DefaultIngressDomain:                    defaultIngressDomain,

--- a/support/releaseinfo/registry_mirror_provider.go
+++ b/support/releaseinfo/registry_mirror_provider.go
@@ -31,12 +31,18 @@ func (p *RegistryMirrorProviderDecorator) Lookup(ctx context.Context, image stri
 	if err != nil {
 		return nil, err
 	}
-	for i := range releaseImage.ImageStream.Spec.Tags {
+
+	imageStream := releaseImage.ImageStream.DeepCopy() // deepCopy so the cache is not overriden.
+	for i := range imageStream.Spec.Tags {
 		for registrySource, registryDest := range p.RegistryOverrides {
-			releaseImage.ImageStream.Spec.Tags[i].From.Name = strings.Replace(releaseImage.ImageStream.Spec.Tags[i].From.Name, registrySource, registryDest, 1)
+			imageStream.Spec.Tags[i].From.Name = strings.Replace(imageStream.Spec.Tags[i].From.Name, registrySource, registryDest, 1)
 		}
 	}
-	return releaseImage, nil
+
+	return &ReleaseImage{
+		ImageStream:    imageStream,
+		StreamMetadata: releaseImage.StreamMetadata,
+	}, nil
 }
 
 func (p *RegistryMirrorProviderDecorator) GetRegistryOverrides() map[string]string {


### PR DESCRIPTION
**What this PR does / why we need it**:
manual-backport of https://github.com/openshift/hypershift/pull/3952 and https://github.com/openshift/hypershift/pull/4114

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.