### PR TITLE
OCPBUGS-34741: Fix fleet manager pair label check

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -594,7 +594,7 @@ func (r *DedicatedServingComponentSchedulerAndSizer) Reconcile(ctx context.Conte
 		pairLabel = ""
 		if len(nodes) > 0 {
 			pairLabel = nodes[0].Labels[OSDFleetManagerPairedNodesLabel]
-			if pairLabel != "" {
+			if pairLabel == "" {
 				return ctrl.Result{}, fmt.Errorf("node %s has no fleetmanager pair label", nodes[0].Name)
 			}
 		}

--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes_test.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes_test.go
@@ -382,13 +382,6 @@ func TestHostedClusterSchedulerAndSizer(t *testing.T) {
 			}
 		}
 	}
-	_ = scheduledHC
-	hcName := func(name string) func(*hyperv1.HostedCluster) {
-		return func(hc *hyperv1.HostedCluster) {
-			hc.Name = name
-		}
-	}
-	_ = hcName
 
 	node := func(name, zone, sizeLabel, OSDFleetManagerPairedNodesID string, mods ...func(*corev1.Node)) *corev1.Node {
 		n := &corev1.Node{}
@@ -463,6 +456,49 @@ func TestHostedClusterSchedulerAndSizer(t *testing.T) {
 		}
 	}
 
+	provisionedDeployment := func(d *appsv1.Deployment, size string, nodes []corev1.Node) []client.Object {
+		labels := map[string]string{
+			PlaceholderLabel:               d.Name,
+			hyperv1.HostedClusterSizeLabel: size,
+		}
+		var result []client.Object
+		d.Labels = labels
+		d.Generation = 1
+		d.Spec = appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(2)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+			},
+		}
+		d.Status = appsv1.DeploymentStatus{
+			AvailableReplicas:  2,
+			ReadyReplicas:      2,
+			UpdatedReplicas:    2,
+			Replicas:           2,
+			ObservedGeneration: 1,
+		}
+		result = append(result, d)
+		for _, n := range nodes {
+			result = append(result, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-" + n.Name,
+					Namespace: placeholderNamespace,
+					Labels:    labels,
+				},
+				Spec: corev1.PodSpec{
+					NodeName: n.Name,
+				},
+			})
+		}
+
+		return result
+	}
+
 	placeHolderPod := func(depName, name string) *corev1.Pod {
 		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -502,6 +538,7 @@ func TestHostedClusterSchedulerAndSizer(t *testing.T) {
 		expectError           bool
 		expectPlaceholder     bool
 	}{
+
 		{
 			name: "scheduled hosted cluster with 2 existing Nodes",
 			hc:   hostedcluster(scheduledHC),
@@ -558,6 +595,19 @@ func TestHostedClusterSchedulerAndSizer(t *testing.T) {
 				node("n2", "zone-b", "small", "id1", withCluster(hostedcluster())),
 			),
 			expectPlaceholder: true,
+		},
+		{
+			name: "label nodes when placeholder deployment is ready",
+			hc:   hostedcluster(withSize("medium")),
+			additionalObjects: provisionedDeployment(placeholderDeployment(hostedcluster()), "medium", []corev1.Node{
+				*(node("n1", "zone-a", "medium", "pair1")),
+				*(node("n2", "zone-b", "medium", "pair1")),
+			}),
+			nodes: nodes(
+				node("n1", "zone-a", "medium", "pair1"),
+				node("n2", "zone-b", "medium", "pair1"),
+			),
+			checkScheduledNodes: true,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
We should error when there is an empty fleet manager label. However, we were checking for a non-empty fleet manager label.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-34741](https://issues.redhat.com/browse/OCPBUGS-34741)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.