### PR TITLE
OCPBUGS-34650: Allow specifying the volume detach timeout for machines via NodePools

### DIFF
--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -168,6 +168,11 @@ type NodePoolSpec struct {
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
+	// NodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volume from a node.
+	// After the timeout, volumes that haven't been detached are skipped.
+	// +optional
+	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
+
 	// NodeLabels propagates a list of labels to Nodes, only once on creation.
 	// Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 	// +optional

--- a/api/hypershift/v1alpha1/zz_generated.deepcopy.go
+++ b/api/hypershift/v1alpha1/zz_generated.deepcopy.go
@@ -2069,6 +2069,11 @@ func (in *NodePoolSpec) DeepCopyInto(out *NodePoolSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.NodeVolumeDetachTimeout != nil {
+		in, out := &in.NodeVolumeDetachTimeout, &out.NodeVolumeDetachTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.NodeLabels != nil {
 		in, out := &in.NodeLabels, &out.NodeLabels
 		*out = make(map[string]string, len(*in))

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -134,14 +134,24 @@ type NodePoolSpec struct {
 	// +kubebuilder:validation:Optional
 	Config []corev1.LocalObjectReference `json:"config,omitempty"`
 
-	// NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+	// NodeDrainTimeout is the maximum amount of time that the controller will spend on draining a node.
 	// The default value is 0, meaning that the node can be drained without any time limitations.
 	// NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
 	// TODO (alberto): Today changing this field will trigger a recreate rolling update, which kind of defeats
 	// the purpose of the change. In future we plan to propagate this field in-place.
-	// https://github.com/kubernetes-sigs/cluster-api/issues/5880
+	// https://github.com/kubernetes-sigs/cluster-api/issues/5880 / https://github.com/kubernetes-sigs/cluster-api/pull/10589
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
+
+	// NodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
+	// The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+	// After the timeout, the detachment of volumes that haven't been detached yet is skipped.
+	// TODO (cbusse): Same comment as Alberto's for `NodeDrainTimeout`:
+	// Today changing this field will trigger a recreate rolling update, which kind of defeats
+	// the purpose of the change. In future we plan to propagate this field in-place.
+	// https://github.com/kubernetes-sigs/cluster-api/issues/5880 / https://github.com/kubernetes-sigs/cluster-api/pull/10589
+	// +optional
+	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// NodeLabels propagates a list of labels to Nodes, only once on creation.
 	// Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

--- a/api/hypershift/v1beta1/zz_generated.deepcopy.go
+++ b/api/hypershift/v1beta1/zz_generated.deepcopy.go
@@ -2112,6 +2112,11 @@ func (in *NodePoolSpec) DeepCopyInto(out *NodePoolSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.NodeVolumeDetachTimeout != nil {
+		in, out := &in.NodeVolumeDetachTimeout, &out.NodeVolumeDetachTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.NodeLabels != nil {
 		in, out := &in.NodeLabels, &out.NodeLabels
 		*out = make(map[string]string, len(*in))

--- a/client/applyconfiguration/hypershift/v1alpha1/nodepoolspec.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/nodepoolspec.go
@@ -25,20 +25,21 @@ import (
 // NodePoolSpecApplyConfiguration represents an declarative configuration of the NodePoolSpec type for use
 // with apply.
 type NodePoolSpecApplyConfiguration struct {
-	ClusterName      *string                                `json:"clusterName,omitempty"`
-	Release          *ReleaseApplyConfiguration             `json:"release,omitempty"`
-	Platform         *NodePoolPlatformApplyConfiguration    `json:"platform,omitempty"`
-	NodeCount        *int32                                 `json:"nodeCount,omitempty"`
-	Replicas         *int32                                 `json:"replicas,omitempty"`
-	Management       *NodePoolManagementApplyConfiguration  `json:"management,omitempty"`
-	AutoScaling      *NodePoolAutoScalingApplyConfiguration `json:"autoScaling,omitempty"`
-	Config           []v1.LocalObjectReference              `json:"config,omitempty"`
-	NodeDrainTimeout *metav1.Duration                       `json:"nodeDrainTimeout,omitempty"`
-	NodeLabels       map[string]string                      `json:"nodeLabels,omitempty"`
-	Taints           []TaintApplyConfiguration              `json:"taints,omitempty"`
-	PausedUntil      *string                                `json:"pausedUntil,omitempty"`
-	TuningConfig     []v1.LocalObjectReference              `json:"tuningConfig,omitempty"`
-	Arch             *string                                `json:"arch,omitempty"`
+	ClusterName             *string                                `json:"clusterName,omitempty"`
+	Release                 *ReleaseApplyConfiguration             `json:"release,omitempty"`
+	Platform                *NodePoolPlatformApplyConfiguration    `json:"platform,omitempty"`
+	NodeCount               *int32                                 `json:"nodeCount,omitempty"`
+	Replicas                *int32                                 `json:"replicas,omitempty"`
+	Management              *NodePoolManagementApplyConfiguration  `json:"management,omitempty"`
+	AutoScaling             *NodePoolAutoScalingApplyConfiguration `json:"autoScaling,omitempty"`
+	Config                  []v1.LocalObjectReference              `json:"config,omitempty"`
+	NodeDrainTimeout        *metav1.Duration                       `json:"nodeDrainTimeout,omitempty"`
+	NodeVolumeDetachTimeout *metav1.Duration                       `json:"nodeVolumeDetachTimeout,omitempty"`
+	NodeLabels              map[string]string                      `json:"nodeLabels,omitempty"`
+	Taints                  []TaintApplyConfiguration              `json:"taints,omitempty"`
+	PausedUntil             *string                                `json:"pausedUntil,omitempty"`
+	TuningConfig            []v1.LocalObjectReference              `json:"tuningConfig,omitempty"`
+	Arch                    *string                                `json:"arch,omitempty"`
 }
 
 // NodePoolSpecApplyConfiguration constructs an declarative configuration of the NodePoolSpec type for use with
@@ -118,6 +119,14 @@ func (b *NodePoolSpecApplyConfiguration) WithConfig(values ...v1.LocalObjectRefe
 // If called multiple times, the NodeDrainTimeout field is set to the value of the last call.
 func (b *NodePoolSpecApplyConfiguration) WithNodeDrainTimeout(value metav1.Duration) *NodePoolSpecApplyConfiguration {
 	b.NodeDrainTimeout = &value
+	return b
+}
+
+// WithNodeVolumeDetachTimeout sets the NodeVolumeDetachTimeout field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NodeVolumeDetachTimeout field is set to the value of the last call.
+func (b *NodePoolSpecApplyConfiguration) WithNodeVolumeDetachTimeout(value metav1.Duration) *NodePoolSpecApplyConfiguration {
+	b.NodeVolumeDetachTimeout = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/nodepoolspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/nodepoolspec.go
@@ -25,19 +25,20 @@ import (
 // NodePoolSpecApplyConfiguration represents an declarative configuration of the NodePoolSpec type for use
 // with apply.
 type NodePoolSpecApplyConfiguration struct {
-	ClusterName      *string                                `json:"clusterName,omitempty"`
-	Release          *ReleaseApplyConfiguration             `json:"release,omitempty"`
-	Platform         *NodePoolPlatformApplyConfiguration    `json:"platform,omitempty"`
-	Replicas         *int32                                 `json:"replicas,omitempty"`
-	Management       *NodePoolManagementApplyConfiguration  `json:"management,omitempty"`
-	AutoScaling      *NodePoolAutoScalingApplyConfiguration `json:"autoScaling,omitempty"`
-	Config           []v1.LocalObjectReference              `json:"config,omitempty"`
-	NodeDrainTimeout *metav1.Duration                       `json:"nodeDrainTimeout,omitempty"`
-	NodeLabels       map[string]string                      `json:"nodeLabels,omitempty"`
-	Taints           []TaintApplyConfiguration              `json:"taints,omitempty"`
-	PausedUntil      *string                                `json:"pausedUntil,omitempty"`
-	TuningConfig     []v1.LocalObjectReference              `json:"tuningConfig,omitempty"`
-	Arch             *string                                `json:"arch,omitempty"`
+	ClusterName             *string                                `json:"clusterName,omitempty"`
+	Release                 *ReleaseApplyConfiguration             `json:"release,omitempty"`
+	Platform                *NodePoolPlatformApplyConfiguration    `json:"platform,omitempty"`
+	Replicas                *int32                                 `json:"replicas,omitempty"`
+	Management              *NodePoolManagementApplyConfiguration  `json:"management,omitempty"`
+	AutoScaling             *NodePoolAutoScalingApplyConfiguration `json:"autoScaling,omitempty"`
+	Config                  []v1.LocalObjectReference              `json:"config,omitempty"`
+	NodeDrainTimeout        *metav1.Duration                       `json:"nodeDrainTimeout,omitempty"`
+	NodeVolumeDetachTimeout *metav1.Duration                       `json:"nodeVolumeDetachTimeout,omitempty"`
+	NodeLabels              map[string]string                      `json:"nodeLabels,omitempty"`
+	Taints                  []TaintApplyConfiguration              `json:"taints,omitempty"`
+	PausedUntil             *string                                `json:"pausedUntil,omitempty"`
+	TuningConfig            []v1.LocalObjectReference              `json:"tuningConfig,omitempty"`
+	Arch                    *string                                `json:"arch,omitempty"`
 }
 
 // NodePoolSpecApplyConfiguration constructs an declarative configuration of the NodePoolSpec type for use with
@@ -109,6 +110,14 @@ func (b *NodePoolSpecApplyConfiguration) WithConfig(values ...v1.LocalObjectRefe
 // If called multiple times, the NodeDrainTimeout field is set to the value of the last call.
 func (b *NodePoolSpecApplyConfiguration) WithNodeDrainTimeout(value metav1.Duration) *NodePoolSpecApplyConfiguration {
 	b.NodeDrainTimeout = &value
+	return b
+}
+
+// WithNodeVolumeDetachTimeout sets the NodeVolumeDetachTimeout field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NodeVolumeDetachTimeout field is set to the value of the last call.
+func (b *NodePoolSpecApplyConfiguration) WithNodeVolumeDetachTimeout(value metav1.Duration) *NodePoolSpecApplyConfiguration {
+	b.NodeVolumeDetachTimeout = &value
 	return b
 }
 

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -40,6 +40,7 @@ func NewCreateCommands() *cobra.Command {
 		NodeSelector:                   nil,
 		Log:                            log.Log,
 		NodeDrainTimeout:               0,
+		NodeVolumeDetachTimeout:        0,
 		NodeUpgradeType:                "",
 		Arch:                           "amd64",
 		OLMCatalogPlacement:            v1beta1.ManagementOLMCatalogPlacement,
@@ -69,6 +70,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ImageContentSources, "image-content-sources", opts.ImageContentSources, "Path to a file with image content sources")
 	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If 0 or greater, creates a nodepool with that many replicas; else if less than 0, does not create a nodepool.")
 	cmd.PersistentFlags().DurationVar(&opts.NodeDrainTimeout, "node-drain-timeout", opts.NodeDrainTimeout, "The NodeDrainTimeout on any created NodePools")
+	cmd.PersistentFlags().DurationVar(&opts.NodeVolumeDetachTimeout, "node-volume-detach-timeout", opts.NodeVolumeDetachTimeout, "The NodeVolumeDetachTimeout on any created NodePools")
 	cmd.PersistentFlags().StringArrayVar(&opts.Annotations, "annotations", opts.Annotations, "Annotations to apply to the hostedcluster (key=value). Can be specified multiple times.")
 	cmd.PersistentFlags().BoolVar(&opts.FIPS, "fips", opts.FIPS, "Enables FIPS mode for nodes in the cluster")
 	cmd.PersistentFlags().BoolVar(&opts.AutoRepair, "auto-repair", opts.AutoRepair, "Enables machine autorepair with machine health checks")

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -58,6 +58,7 @@ type CreateOptions struct {
 	NetworkType                      string
 	NodePoolReplicas                 int32
 	NodeDrainTimeout                 time.Duration
+	NodeVolumeDetachTimeout          time.Duration
 	PullSecretFile                   string
 	ReleaseImage                     string
 	ReleaseStream                    string
@@ -343,6 +344,7 @@ func createCommonFixture(ctx context.Context, opts *CreateOptions) (*apifixtures
 		NetworkType:                      hyperv1.NetworkType(opts.NetworkType),
 		NodePoolReplicas:                 opts.NodePoolReplicas,
 		NodeDrainTimeout:                 opts.NodeDrainTimeout,
+		NodeVolumeDetachTimeout:          opts.NodeVolumeDetachTimeout,
 		PullSecret:                       pullSecret,
 		ReleaseImage:                     opts.ReleaseImage,
 		SSHPrivateKey:                    sshPrivateKey,

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -309,6 +309,11 @@ spec:
                   NodeLabels propagates a list of labels to Nodes, only once on creation.
                   Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                 type: object
+              nodeVolumeDetachTimeout:
+                description: |-
+                  NodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volume from a node.
+                  After the timeout, volumes that haven't been detached are skipped.
+                type: string
               pausedUntil:
                 description: |-
                   PausedUntil is a field that can be used to pause reconciliation on a resource.
@@ -1398,12 +1403,12 @@ spec:
                 type: object
               nodeDrainTimeout:
                 description: |-
-                  NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                  NodeDrainTimeout is the maximum amount of time that the controller will spend on draining a node.
                   The default value is 0, meaning that the node can be drained without any time limitations.
                   NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
                   TODO (alberto): Today changing this field will trigger a recreate rolling update, which kind of defeats
                   the purpose of the change. In future we plan to propagate this field in-place.
-                  https://github.com/kubernetes-sigs/cluster-api/issues/5880
+                  https://github.com/kubernetes-sigs/cluster-api/issues/5880 / https://github.com/kubernetes-sigs/cluster-api/pull/10589
                 type: string
               nodeLabels:
                 additionalProperties:
@@ -1412,6 +1417,16 @@ spec:
                   NodeLabels propagates a list of labels to Nodes, only once on creation.
                   Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                 type: object
+              nodeVolumeDetachTimeout:
+                description: |-
+                  NodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
+                  The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+                  After the timeout, the detachment of volumes that haven't been detached yet is skipped.
+                  TODO (cbusse): Same comment as Alberto's for `NodeDrainTimeout`:
+                  Today changing this field will trigger a recreate rolling update, which kind of defeats
+                  the purpose of the change. In future we plan to propagate this field in-place.
+                  https://github.com/kubernetes-sigs/cluster-api/issues/5880 / https://github.com/kubernetes-sigs/cluster-api/pull/10589
+                type: string
               pausedUntil:
                 description: |-
                   PausedUntil is a field that can be used to pause reconciliation on a resource.

--- a/docs/content/how-to/agent/create-heterogeneous-nodepools.md
+++ b/docs/content/how-to/agent/create-heterogeneous-nodepools.md
@@ -102,6 +102,7 @@ spec:
     autoRepair: false
     upgradeType: InPlace
   nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
   platform:
     agent:
       agentLabelSelector:

--- a/docs/content/how-to/automated-machine-management/configure-machines.md
+++ b/docs/content/how-to/automated-machine-management/configure-machines.md
@@ -79,6 +79,7 @@ spec:
       strategy: RollingUpdate
     upgradeType: Replace
   nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
   platform:
     aws:
       instanceProfile: example-profile

--- a/docs/content/how-to/automated-machine-management/nodepool-lifecycle.md
+++ b/docs/content/how-to/automated-machine-management/nodepool-lifecycle.md
@@ -99,9 +99,9 @@ Several conditions can prevent Node(s) from being drained successfully:
 
 #### Prevention
 
-To prevent Nodes from becoming stuck when scaling down, set the `.spec.nodeDrainTimeout` in the NodePool CR to a value greater than `0s`. 
+To prevent Nodes from becoming stuck when scaling down, set the `.spec.nodeDrainTimeout` and `.spec.nodeVolumeDetachTimeout` in the NodePool CR to a value greater than `0s`. 
 
-This forces Nodes to be removed once the timeout specified in the field has been reached even if the Node cannot be drained successfully.
+This forces Nodes to be removed once the timeout specified in the field has been reached, regardless of whether the node can be drained or the volumes can be detached successfully.
 
 !!! note
     See the [Hypershift API reference page](../../reference/api.md) for more details.

--- a/docs/content/how-to/aws/create-aws-hosted-cluster-arm-workers.md
+++ b/docs/content/how-to/aws/create-aws-hosted-cluster-arm-workers.md
@@ -41,6 +41,7 @@ spec:
     autoRepair: false
     upgradeType: Replace
   nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
   platform:
     aws:
       instanceProfile: hypershift-arm-2m289-worker

--- a/docs/content/labs/Dual/hostedcluster/nodepool.md
+++ b/docs/content/labs/Dual/hostedcluster/nodepool.md
@@ -24,6 +24,7 @@ spec:
     autoRepair: false
     upgradeType: InPlace
   nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
   platform:
     type: Agent
   release:

--- a/docs/content/labs/IPv4/hostedcluster/nodepool.md
+++ b/docs/content/labs/IPv4/hostedcluster/nodepool.md
@@ -24,6 +24,7 @@ spec:
     autoRepair: false
     upgradeType: InPlace
   nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
   platform:
     type: Agent
   release:

--- a/docs/content/labs/IPv6/hostedcluster/nodepool.md
+++ b/docs/content/labs/IPv6/hostedcluster/nodepool.md
@@ -24,6 +24,7 @@ spec:
     autoRepair: false
     upgradeType: InPlace
   nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
   platform:
     type: Agent
   release:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -766,12 +766,32 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+<p>NodeDrainTimeout is the maximum amount of time that the controller will spend on draining a node.
 The default value is 0, meaning that the node can be drained without any time limitations.
 NOTE: NodeDrainTimeout is different from <code>kubectl drain --timeout</code>
 TODO (alberto): Today changing this field will trigger a recreate rolling update, which kind of defeats
 the purpose of the change. In future we plan to propagate this field in-place.
-<a href="https://github.com/kubernetes-sigs/cluster-api/issues/5880">https://github.com/kubernetes-sigs/cluster-api/issues/5880</a></p>
+<a href="https://github.com/kubernetes-sigs/cluster-api/issues/5880">https://github.com/kubernetes-sigs/cluster-api/issues/5880</a> / <a href="https://github.com/kubernetes-sigs/cluster-api/pull/10589">https://github.com/kubernetes-sigs/cluster-api/pull/10589</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeVolumeDetachTimeout</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
+The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+After the timeout, the detachment of volumes that haven&rsquo;t been detached yet is skipped.
+TODO (cbusse): Same comment as Alberto&rsquo;s for <code>NodeDrainTimeout</code>:
+Today changing this field will trigger a recreate rolling update, which kind of defeats
+the purpose of the change. In future we plan to propagate this field in-place.
+<a href="https://github.com/kubernetes-sigs/cluster-api/issues/5880">https://github.com/kubernetes-sigs/cluster-api/issues/5880</a> / <a href="https://github.com/kubernetes-sigs/cluster-api/pull/10589">https://github.com/kubernetes-sigs/cluster-api/pull/10589</a></p>
 </td>
 </tr>
 <tr>
@@ -6813,12 +6833,32 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+<p>NodeDrainTimeout is the maximum amount of time that the controller will spend on draining a node.
 The default value is 0, meaning that the node can be drained without any time limitations.
 NOTE: NodeDrainTimeout is different from <code>kubectl drain --timeout</code>
 TODO (alberto): Today changing this field will trigger a recreate rolling update, which kind of defeats
 the purpose of the change. In future we plan to propagate this field in-place.
-<a href="https://github.com/kubernetes-sigs/cluster-api/issues/5880">https://github.com/kubernetes-sigs/cluster-api/issues/5880</a></p>
+<a href="https://github.com/kubernetes-sigs/cluster-api/issues/5880">https://github.com/kubernetes-sigs/cluster-api/issues/5880</a> / <a href="https://github.com/kubernetes-sigs/cluster-api/pull/10589">https://github.com/kubernetes-sigs/cluster-api/pull/10589</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeVolumeDetachTimeout</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
+The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+After the timeout, the detachment of volumes that haven&rsquo;t been detached yet is skipped.
+TODO (cbusse): Same comment as Alberto&rsquo;s for <code>NodeDrainTimeout</code>:
+Today changing this field will trigger a recreate rolling update, which kind of defeats
+the purpose of the change. In future we plan to propagate this field in-place.
+<a href="https://github.com/kubernetes-sigs/cluster-api/issues/5880">https://github.com/kubernetes-sigs/cluster-api/issues/5880</a> / <a href="https://github.com/kubernetes-sigs/cluster-api/pull/10589">https://github.com/kubernetes-sigs/cluster-api/pull/10589</a></p>
 </td>
 </tr>
 <tr>

--- a/examples/fixtures/example.go
+++ b/examples/fixtures/example.go
@@ -62,6 +62,7 @@ type ExampleOptions struct {
 	SSHPrivateKey                    []byte
 	NodePoolReplicas                 int32
 	NodeDrainTimeout                 time.Duration
+	NodeVolumeDetachTimeout          time.Duration
 	ImageContentSources              []hyperv1.ImageContentSource
 	InfraID                          string
 	MachineCIDR                      string
@@ -643,8 +644,9 @@ func (o ExampleOptions) Resources() *ExampleResources {
 				Platform: hyperv1.NodePoolPlatform{
 					Type: cluster.Spec.Platform.Type,
 				},
-				Arch:             o.Arch,
-				NodeDrainTimeout: &metav1.Duration{Duration: o.NodeDrainTimeout},
+				Arch:                    o.Arch,
+				NodeDrainTimeout:        &metav1.Duration{Duration: o.NodeDrainTimeout},
+				NodeVolumeDetachTimeout: &metav1.Duration{Duration: o.NodeVolumeDetachTimeout},
 			},
 		}
 	}

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -58967,6 +58967,11 @@ objects:
                     NodeLabels propagates a list of labels to Nodes, only once on creation.
                     Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                   type: object
+                nodeVolumeDetachTimeout:
+                  description: |-
+                    NodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volume from a node.
+                    After the timeout, volumes that haven't been detached are skipped.
+                  type: string
                 pausedUntil:
                   description: |-
                     PausedUntil is a field that can be used to pause reconciliation on a resource.
@@ -60060,12 +60065,12 @@ objects:
                   type: object
                 nodeDrainTimeout:
                   description: |-
-                    NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                    NodeDrainTimeout is the maximum amount of time that the controller will spend on draining a node.
                     The default value is 0, meaning that the node can be drained without any time limitations.
                     NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
                     TODO (alberto): Today changing this field will trigger a recreate rolling update, which kind of defeats
                     the purpose of the change. In future we plan to propagate this field in-place.
-                    https://github.com/kubernetes-sigs/cluster-api/issues/5880
+                    https://github.com/kubernetes-sigs/cluster-api/issues/5880 / https://github.com/kubernetes-sigs/cluster-api/pull/10589
                   type: string
                 nodeLabels:
                   additionalProperties:
@@ -60074,6 +60079,16 @@ objects:
                     NodeLabels propagates a list of labels to Nodes, only once on creation.
                     Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                   type: object
+                nodeVolumeDetachTimeout:
+                  description: |-
+                    NodeVolumeDetachTimeout is the maximum amount of time that the controller will spend on detaching volumes from a node.
+                    The default value is 0, meaning that the volumes will be detached from the node without any time limitations.
+                    After the timeout, the detachment of volumes that haven't been detached yet is skipped.
+                    TODO (cbusse): Same comment as Alberto's for `NodeDrainTimeout`:
+                    Today changing this field will trigger a recreate rolling update, which kind of defeats
+                    the purpose of the change. In future we plan to propagate this field in-place.
+                    https://github.com/kubernetes-sigs/cluster-api/issues/5880 / https://github.com/kubernetes-sigs/cluster-api/pull/10589
+                  type: string
                 pausedUntil:
                   description: |-
                     PausedUntil is a field that can be used to pause reconciliation on a resource.

--- a/hypershift-operator/controllers/nodepool/inplace.go
+++ b/hypershift-operator/controllers/nodepool/inplace.go
@@ -86,8 +86,9 @@ func (r *NodePoolReconciler) reconcileMachineSet(ctx context.Context,
 				Name: machineSet.Spec.Template.Spec.InfrastructureRef.Name,
 			},
 			// Keep current version for later check.
-			Version:          machineSet.Spec.Template.Spec.Version,
-			NodeDrainTimeout: nodePool.Spec.NodeDrainTimeout,
+			Version:                 machineSet.Spec.Template.Spec.Version,
+			NodeDrainTimeout:        nodePool.Spec.NodeDrainTimeout,
+			NodeVolumeDetachTimeout: nodePool.Spec.NodeVolumeDetachTimeout,
 		},
 	}
 

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1718,8 +1718,9 @@ func (r *NodePoolReconciler) reconcileMachineDeployment(log logr.Logger,
 				Name: machineDeployment.Spec.Template.Spec.InfrastructureRef.Name,
 			},
 			// Keep current version for later check.
-			Version:          machineDeployment.Spec.Template.Spec.Version,
-			NodeDrainTimeout: nodePool.Spec.NodeDrainTimeout,
+			Version:                 machineDeployment.Spec.Template.Spec.Version,
+			NodeDrainTimeout:        nodePool.Spec.NodeDrainTimeout,
+			NodeVolumeDetachTimeout: nodePool.Spec.NodeVolumeDetachTimeout,
 		},
 	}
 

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -26,6 +26,7 @@ func NewCreateCommands() *cobra.Command {
 		Name:                           "example",
 		Namespace:                      "clusters",
 		NodeDrainTimeout:               0,
+		NodeVolumeDetachTimeout:        0,
 		NodeSelector:                   nil,
 		NodeUpgradeType:                "",
 		PullSecretFile:                 "",
@@ -62,6 +63,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The HostedCluster's name.")
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The HostedCluster's namespace name.")
 	cmd.PersistentFlags().DurationVar(&opts.NodeDrainTimeout, "node-drain-timeout", opts.NodeDrainTimeout, "The NodeDrainTimeout for any created NodePools.")
+	cmd.PersistentFlags().DurationVar(&opts.NodeVolumeDetachTimeout, "node-volume-detach-timeout", opts.NodeVolumeDetachTimeout, "The NodeVolumeDetachTimeout for any created NodePools.")
 	cmd.PersistentFlags().Int32Var(&opts.NodePoolReplicas, "node-pool-replicas", opts.NodePoolReplicas, "If set to 0 or greater, NodePools will be created with that many replicas. If set to less than 0, no NodePools will be created.")
 	cmd.PersistentFlags().StringToStringVar(&opts.NodeSelector, "node-selector", opts.NodeSelector, "A comma separated list of key=value pairs to use as the node selector for the Hosted Control Plane pods to stick to. (e.g. role=cp,disk=fast)")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, volume detachments unhandled by CAPI block the deletion of machines. Prominent examples are daemonset pods with an attached volume ([see this issue](https://github.com/kubernetes-sigs/cluster-api/issues/6158)) as well as unresponsive nodes with pods attached.

This PR allows passing the NodeVolumeDetachTimeout through NodePools to created CAPI machines, which will allow us to skip volume detachment if it doesn't happen on the CAPI side. 

Enables us to provide short term fixes for the following OCPBUGs by specifying the timeout in NodePools we create:
- https://issues.redhat.com/browse/OCPBUGS-34650 until https://github.com/kubernetes-sigs/cluster-api/issues/6158 is fixed
- https://issues.redhat.com/browse/OCPBUGS-29698 until https://github.com/kubernetes-sigs/cluster-api/issues/10661 is fixed

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.