### PR TITLE
HOSTEDCP-1709: test/e2e: constrain actions to context, timeout

### DIFF
--- a/test/e2e/nodepool_kv_advanced_multinet_test.go
+++ b/test/e2e/nodepool_kv_advanced_multinet_test.go
@@ -256,7 +256,7 @@ iptables -t nat -A PREROUTING -p tcp -d %[1]s -j DNAT --to-destination %[2]s
 	if err != nil {
 		return "", err
 	}
-	return e2eutil.RunCommandInPod(k.infra.Ctx(), infraClient, dnsmasqPod.Name, dnsmasqPod.Namespace, []string{"/bin/sh", "-c", command}, dnsmasqPod.Spec.Containers[0].Name)
+	return e2eutil.RunCommandInPod(k.infra.Ctx(), infraClient, dnsmasqPod.Name, dnsmasqPod.Namespace, []string{"/bin/sh", "-c", command}, dnsmasqPod.Spec.Containers[0].Name, 20*time.Minute)
 }
 
 func (k KubeVirtAdvancedMultinetTest) firstMachineAddress() (string, error) {

--- a/test/e2e/util/client.go
+++ b/test/e2e/util/client.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"time"
 
 	"k8s.io/client-go/rest"
 	cr "sigs.k8s.io/controller-runtime"
@@ -16,6 +17,7 @@ func GetConfig() (*rest.Config, error) {
 	}
 	cfg.QPS = 100
 	cfg.Burst = 100
+	cfg.Timeout = 5 * time.Minute
 	return cfg, nil
 }
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -951,7 +951,7 @@ func RunCommandInPod(ctx context.Context, c crclient.Client, component, namespac
 		ContainerName: containerName,
 	}
 
-	err = podExecuter.Run()
+	err = podExecuter.Run(ctx)
 	return stdOut.String(), err
 }
 
@@ -1082,7 +1082,7 @@ func EnsureSecretEncryptedUsingKMS(t *testing.T, ctx context.Context, hostedClus
 			Config:        restConfig,
 		}
 
-		if err := podExecuter.Run(); err != nil {
+		if err := podExecuter.Run(ctx); err != nil {
 			t.Errorf("failed to execute etcdctl command; %v", err)
 		}
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -847,7 +847,7 @@ func EnsureNetworkPolicies(t *testing.T, ctx context.Context, c crclient.Client,
 			}
 
 			// Validate cluster-version-operator is not allowed to access management KAS.
-			_, err = RunCommandInPod(ctx, c, "cluster-version-operator", hcpNamespace, command, "cluster-version-operator")
+			_, err = RunCommandInPod(ctx, c, "cluster-version-operator", hcpNamespace, command, "cluster-version-operator", 0)
 			g.Expect(err).To(HaveOccurred())
 
 			// Validate private router is not allowed to access management KAS.
@@ -857,13 +857,13 @@ func EnsureNetworkPolicies(t *testing.T, ctx context.Context, c crclient.Client,
 					// === CONT  TestCreateClusterPrivate/EnsureHostedCluster/EnsureNetworkPolicies/EnsureLimitedEgressTrafficToManagementKAS
 					//    util.go:851: private router pod was unexpectedly allowed to reach the management KAS. stdOut: . stdErr: Internal error occurred: error executing command in container: container is not created or running
 					// Should be solve with https://issues.redhat.com/browse/HOSTEDCP-1200
-					_, err := RunCommandInPod(ctx, c, "private-router", hcpNamespace, command, "private-router")
+					_, err := RunCommandInPod(ctx, c, "private-router", hcpNamespace, command, "private-router", 0)
 					g.Expect(err).To(HaveOccurred())
 				}
 			}
 
 			// Validate cluster api is allowed to access management KAS.
-			stdOut, err := RunCommandInPod(ctx, c, "cluster-api", hcpNamespace, command, "manager")
+			stdOut, err := RunCommandInPod(ctx, c, "cluster-api", hcpNamespace, command, "manager", 0)
 			// Expect curl return a 403 from the KAS.
 			if !strings.Contains(stdOut, "HTTP/2 403") || err != nil {
 				t.Errorf("cluster api pod was unexpectedly not allowed to reach the management KAS. stdOut: %s. stdErr: %s", stdOut, err.Error())
@@ -920,7 +920,7 @@ func checkPodsHaveLabel(ctx context.Context, c crclient.Client, allowedComponent
 	return nil
 }
 
-func RunCommandInPod(ctx context.Context, c crclient.Client, component, namespace string, command []string, containerName string) (string, error) {
+func RunCommandInPod(ctx context.Context, c crclient.Client, component, namespace string, command []string, containerName string, timeout time.Duration) (string, error) {
 	podList := &corev1.PodList{}
 	if err := c.List(ctx, podList,
 		client.InNamespace(namespace),
@@ -949,6 +949,7 @@ func RunCommandInPod(ctx context.Context, c crclient.Client, component, namespac
 		PodName:       podList.Items[0].Name,
 		Config:        restConfig,
 		ContainerName: containerName,
+		Timeout:       timeout,
 	}
 
 	err = podExecuter.Run(ctx)


### PR DESCRIPTION
test/e2e: constrain actions to context, timeout

Asynchronous actions that serve to make test assertions, etc, must be
constrained by the test context and/or a timeout - otherwise, even tests
that get interrupted will hang forever on these cases.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

test/e2e: explicitly constrain pod streams

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @sjenning 