### PR TITLE
NO-JIRA: test/e2e: don't validate metrics after failure

### DIFF
--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -287,7 +287,7 @@ func teardownHostedCluster(t *testing.T, ctx context.Context, hc *hyperv1.Hosted
 	// Save off any error so that we can continue with the teardown
 	dumpErr := dumpCluster(ctx, t, true)
 
-	if !cleanupPhase {
+	if !cleanupPhase && !t.Failed() {
 		ValidateMetrics(t, ctx, hc, []string{
 			hcmetrics.SilenceAlertsMetricName,
 			hcmetrics.LimitedSupportEnabledMetricName,


### PR DESCRIPTION
When we fail to bring up the hosted cluster, there's no reason to try to validate anything.

/assign @sjenning 