### PR TITLE
HOSTEDCP-1689: add PodMonitor for external-dns

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -98,6 +98,7 @@ const (
 	externaDNSCredsSecretName     = "external-dns-credentials"
 
 	HypershiftOperatorName                = "operator"
+	ExternalDNSDeploymentName             = "external-dns"
 	HyperShiftInstallCLIVersionAnnotation = "hypershift.openshift.io/install-cli-version"
 )
 
@@ -191,22 +192,22 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "external-dns",
+			Name:      ExternalDNSDeploymentName,
 			Namespace: o.Namespace.Name,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"name": "external-dns",
+					"name": ExternalDNSDeploymentName,
 				},
 			},
 			Replicas: &replicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"name":                    "external-dns",
-						"app":                     "external-dns",
-						hyperv1.OperatorComponent: "external-dns",
+						"name":                    ExternalDNSDeploymentName,
+						"app":                     ExternalDNSDeploymentName,
+						hyperv1.OperatorComponent: ExternalDNSDeploymentName,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -862,6 +863,36 @@ func (o ExternalDNSClusterRoleBinding) Build() *rbacv1.ClusterRoleBinding {
 		},
 	}
 	return binding
+}
+
+type ExternalDNSPodMonitor struct {
+	Namespace *corev1.Namespace
+}
+
+func (o ExternalDNSPodMonitor) Build() *prometheusoperatorv1.PodMonitor {
+	return &prometheusoperatorv1.PodMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PodMonitor",
+			APIVersion: prometheusoperatorv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace.Name,
+			Name:      ExternalDNSDeploymentName,
+		},
+		Spec: prometheusoperatorv1.PodMonitorSpec{
+			JobLabel: "component",
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": ExternalDNSDeploymentName,
+				},
+			},
+			PodMetricsEndpoints: []prometheusoperatorv1.PodMetricsEndpoint{{
+				Port:     "metrics",
+				Interval: "30s",
+			},
+			},
+		},
+	}
 }
 
 type HyperShiftOperatorServiceAccount struct {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -649,6 +649,11 @@ func hyperShiftOperatorManifests(opts Options) ([]crclient.Object, []crclient.Ob
 			TxtOwnerId:        opts.ExternalDNSTxtOwnerId,
 		}.Build()
 		objects = append(objects, externalDNSDeployment)
+
+		podMonitor := assets.ExternalDNSPodMonitor{
+			Namespace: operatorNamespace,
+		}.Build()
+		objects = append(objects, podMonitor)
 	}
 
 	if opts.MonitoringDashboards {

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -497,6 +497,23 @@ objects:
           secret:
             secretName: ${EXTERNAL_DNS_CREDS_SECRET}
   status: {}
+- apiVersion: monitoring.coreos.com/v1
+  kind: PodMonitor
+  metadata:
+    creationTimestamp: null
+    name: external-dns
+    namespace: ${NAMESPACE}
+  spec:
+    jobLabel: component
+    namespaceSelector: {}
+    podMetricsEndpoints:
+    - bearerTokenSecret:
+        key: ""
+      interval: 30s
+      port: metrics
+    selector:
+      matchLabels:
+        name: external-dns
 - apiVersion: apps/v1
   kind: Deployment
   metadata:


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

This PR adds a `PodMonitor` for `external-dns`, enabling SRE to better observe issues with dns creation that could block cluster installations.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1689](https://issues.redhat.com//browse/HOSTEDCP-1689)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.