### PR TITLE
CNF-11845: nodepoolcontroller: mirror containerruntimeconfig to HCP NS

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -56,6 +56,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	k8sutilspointer "k8s.io/utils/pointer"
+	"k8s.io/utils/set"
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capipowervs "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
@@ -102,16 +103,19 @@ const (
 	TokenSecretIgnitionReachedAnnotation      = "hypershift.openshift.io/ignition-reached"
 	TokenSecretNodePoolUpgradeType            = "hypershift.openshift.io/node-pool-upgrade-type"
 
-	tuningConfigKey                  = "tuning"
-	tunedConfigMapLabel              = "hypershift.openshift.io/tuned-config"
-	nodeTuningGeneratedConfigLabel   = "hypershift.openshift.io/nto-generated-machine-config"
-	PerformanceProfileConfigMapLabel = "hypershift.openshift.io/performanceprofile-config"
+	tuningConfigKey                      = "tuning"
+	tunedConfigMapLabel                  = "hypershift.openshift.io/tuned-config"
+	nodeTuningGeneratedConfigLabel       = "hypershift.openshift.io/nto-generated-machine-config"
+	PerformanceProfileConfigMapLabel     = "hypershift.openshift.io/performanceprofile-config"
+	ContainerRuntimeConfigConfigMapLabel = "hypershift.openshift.io/containerruntimeconfig-config"
 
 	controlPlaneOperatorManagesDecompressAndDecodeConfig = "io.openshift.hypershift.control-plane-operator-manages.decompress-decode-config"
 
 	controlPlaneOperatorCreatesDefaultAWSSecurityGroup = "io.openshift.hypershift.control-plane-operator-creates-aws-sg"
 
 	labelManagedPrefix = "managed.hypershift.openshift.io"
+	// mirroredConfigLabel added to objects that were mirrored from the node pool namespace into the HCP namespace
+	mirroredConfigLabel = "hypershift.openshift.io/mirrored-config"
 )
 
 type NodePoolReconciler struct {
@@ -131,6 +135,12 @@ type NotReadyError struct {
 type CPOCapabilities struct {
 	DecompressAndDecodeConfig     bool
 	CreateDefaultAWSSecurityGroup bool
+}
+
+// MirrorConfig holds the information needed to mirror a config object to HCP namespace
+type MirrorConfig struct {
+	*corev1.ConfigMap
+	Labels map[string]string
 }
 
 var (
@@ -577,7 +587,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 	// TODO (alberto): consider moving the expectedCoreConfigResources check
 	// into the token Secret controller so we don't block Machine infra creation on this.
 	expectedCoreConfigResources := expectedCoreConfigResourcesForHostedCluster(hcluster)
-	config, missingConfigs, err := r.getConfig(ctx, nodePool, expectedCoreConfigResources, controlPlaneNamespace, releaseImage, hcluster)
+	config, mirroredConfigs, missingConfigs, err := r.getConfig(ctx, nodePool, expectedCoreConfigResources, controlPlaneNamespace, releaseImage, hcluster)
 	if err != nil {
 		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolValidMachineConfigConditionType,
@@ -598,6 +608,9 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		})
 		// We watch configmaps so we will get an event when these get created
 		return ctrl.Result{}, nil
+	}
+	if err := r.reconcileMirroredConfigs(ctx, log, mirroredConfigs, controlPlaneNamespace, nodePool); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to mirror configs: %w", err)
 	}
 	SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 		Type:               hyperv1.NodePoolValidMachineConfigConditionType,
@@ -1654,6 +1667,22 @@ func reconcilePerformanceProfileConfigMap(performanceProfileConfigMap *corev1.Co
 	return nil
 }
 
+func mutateMirroredConfig(cm *corev1.ConfigMap, mirroredConfig *MirrorConfig, nodePool *hyperv1.NodePool) error {
+	cm.Immutable = k8sutilspointer.Bool(true)
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	if cm.Labels == nil {
+		cm.Labels = make(map[string]string)
+	}
+	cm.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
+	cm.Labels[nodePoolAnnotation] = nodePool.GetName()
+	cm.Labels[mirroredConfigLabel] = ""
+	cm.Labels = labels.Merge(cm.Labels, mirroredConfig.Labels)
+	cm.Data = mirroredConfig.Data
+	return nil
+}
+
 func reconcileTokenSecret(tokenSecret *corev1.Secret, nodePool *hyperv1.NodePool, compressedConfig []byte, pullSecret []byte, hcConfigurationHash string) error {
 	// The token secret controller updates expired token IDs for token Secrets.
 	// When that happens the NodePool controller reconciles the userData Secret with the new token ID.
@@ -2080,14 +2109,14 @@ func (r *NodePoolReconciler) getConfig(ctx context.Context,
 	controlPlaneResource string,
 	releaseImage *releaseinfo.ReleaseImage,
 	hcluster *hyperv1.HostedCluster,
-) (configsRaw string, missingConfigs bool, err error) {
+) (configsRaw string, mirroredConfigs []*MirrorConfig, missingConfigs bool, err error) {
 	var configs []corev1.ConfigMap
 	var allConfigPlainText []string
 	var errors []error
 
 	isHAProxyIgnitionConfigManaged, cpoImage, err := r.isHAProxyIgnitionConfigManaged(ctx, hcluster)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to check if we manage haproxy ignition config: %w", err)
+		return "", nil, false, fmt.Errorf("failed to check if we manage haproxy ignition config: %w", err)
 	}
 	if isHAProxyIgnitionConfigManaged {
 		oldHAProxyIgnitionConfig := &corev1.ConfigMap{
@@ -2095,18 +2124,18 @@ func (r *NodePoolReconciler) getConfig(ctx context.Context,
 		}
 		err := r.Client.Get(ctx, client.ObjectKeyFromObject(oldHAProxyIgnitionConfig), oldHAProxyIgnitionConfig)
 		if err != nil && !apierrors.IsNotFound(err) {
-			return "", false, fmt.Errorf("failed to get CPO-managed haproxy ignition config: %w", err)
+			return "", nil, false, fmt.Errorf("failed to get CPO-managed haproxy ignition config: %w", err)
 		}
 		if err == nil {
 			if err := r.Client.Delete(ctx, oldHAProxyIgnitionConfig); err != nil && !apierrors.IsNotFound(err) {
-				return "", false, fmt.Errorf("failed to delete the CPO-managed haproxy ignition config: %w", err)
+				return "", nil, false, fmt.Errorf("failed to delete the CPO-managed haproxy ignition config: %w", err)
 			}
 		}
 		expectedCoreConfigResources--
 
 		haproxyIgnitionConfig, missing, err := r.reconcileHAProxyIgnitionConfig(ctx, releaseImage.ComponentImages(), hcluster, cpoImage)
 		if err != nil {
-			return "", false, fmt.Errorf("failed to generate haproxy ignition config: %w", err)
+			return "", nil, false, fmt.Errorf("failed to generate haproxy ignition config: %w", err)
 		}
 		if missing {
 			missingConfigs = true
@@ -2152,22 +2181,25 @@ func (r *NodePoolReconciler) getConfig(ctx context.Context,
 
 	configs = append(configs, nodeTuningGeneratedConfigs.Items...)
 
-	for _, config := range configs {
+	for i, config := range configs {
 		manifestRaw := config.Data[TokenSecretConfigKey]
-		manifest, err := defaultAndValidateConfigManifest([]byte(manifestRaw))
+		manifest, mirrorConfig, err := defaultAndValidateConfigManifest([]byte(manifestRaw))
 		if err != nil {
 			errors = append(errors, fmt.Errorf("configmap %q failed validation: %w", config.Name, err))
 			continue
 		}
-
 		allConfigPlainText = append(allConfigPlainText, string(manifest))
+		if mirrorConfig != nil && config.Namespace == nodePool.Namespace {
+			mirrorConfig.ConfigMap = &configs[i]
+			mirroredConfigs = append(mirroredConfigs, mirrorConfig)
+		}
 	}
 
 	// These configs are the input to a hash func whose output is used as part of the name of the user-data secret,
 	// so our output must be deterministic.
 	sort.Strings(allConfigPlainText)
 
-	return strings.Join(allConfigPlainText, "\n---\n"), missingConfigs, utilerrors.NewAggregate(errors)
+	return strings.Join(allConfigPlainText, "\n---\n"), mirroredConfigs, missingConfigs, utilerrors.NewAggregate(errors)
 }
 
 func (r *NodePoolReconciler) getTuningConfig(ctx context.Context,
@@ -2299,7 +2331,7 @@ func validateManagement(nodePool *hyperv1.NodePool) error {
 	return nil
 }
 
-func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
+func defaultAndValidateConfigManifest(manifest []byte) ([]byte, *MirrorConfig, error) {
 	scheme := runtime.NewScheme()
 	_ = mcfgv1.Install(scheme)
 	_ = v1alpha1.Install(scheme)
@@ -2310,10 +2342,12 @@ func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
 		serializer.DefaultMetaFactory, scheme, scheme,
 		serializer.SerializerOptions{Yaml: true, Pretty: true, Strict: false},
 	)
+	// for manifests that should be mirrored into hosted control plane namespace
+	var mirrorConfig *MirrorConfig
 
 	cr, _, err := yamlSerializer.Decode(manifest, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding config: %w", err)
+		return nil, nil, fmt.Errorf("error decoding config: %w", err)
 	}
 
 	switch obj := cr.(type) {
@@ -2321,7 +2355,7 @@ func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
 		addWorkerLabel(&obj.ObjectMeta)
 		manifest, err = encode(cr, yamlSerializer)
 		if err != nil {
-			return nil, fmt.Errorf("failed to encode machine config after defaulting it: %w", err)
+			return nil, nil, fmt.Errorf("failed to encode machine config after defaulting it: %w", err)
 		}
 	case *v1alpha1.ImageContentSourcePolicy:
 	case *configv1.ImageDigestMirrorSet:
@@ -2334,7 +2368,7 @@ func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
 		}
 		manifest, err = encode(cr, yamlSerializer)
 		if err != nil {
-			return nil, fmt.Errorf("failed to encode kubelet config after setting built-in MCP selector: %w", err)
+			return nil, nil, fmt.Errorf("failed to encode kubelet config after setting built-in MCP selector: %w", err)
 		}
 	case *mcfgv1.ContainerRuntimeConfig:
 		obj.Spec.MachineConfigPoolSelector = &metav1.LabelSelector{
@@ -2344,13 +2378,13 @@ func defaultAndValidateConfigManifest(manifest []byte) ([]byte, error) {
 		}
 		manifest, err = encode(cr, yamlSerializer)
 		if err != nil {
-			return nil, fmt.Errorf("failed to encode container runtime config after setting built-in MCP selector: %w", err)
+			return nil, nil, fmt.Errorf("failed to encode container runtime config after setting built-in MCP selector: %w", err)
 		}
+		mirrorConfig = &MirrorConfig{Labels: map[string]string{ContainerRuntimeConfigConfigMapLabel: ""}}
 	default:
-		return nil, fmt.Errorf("unsupported config type: %T", obj)
+		return nil, nil, fmt.Errorf("unsupported config type: %T", obj)
 	}
-
-	return manifest, err
+	return manifest, mirrorConfig, err
 }
 
 func addWorkerLabel(obj *metav1.ObjectMeta) {
@@ -3102,7 +3136,7 @@ func (r *secretJanitor) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return ctrl.Result{}, err
 	}
 
-	config, missingConfigs, err := r.getConfig(ctx, nodePool, expectedCoreConfigResources, controlPlaneNamespace, releaseImage, hcluster)
+	config, _, missingConfigs, err := r.getConfig(ctx, nodePool, expectedCoreConfigResources, controlPlaneNamespace, releaseImage, hcluster)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -3243,6 +3277,64 @@ func deleteConfigByLabel(ctx context.Context, c client.Client, lbl map[string]st
 		cm := &cmList.Items[i]
 		if _, err := supportutil.DeleteIfNeeded(ctx, c, cm); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// reconcileMirroredConfigs mirrors configs into
+// the HCP namespace, that are needed as an input for certain operators (such as NTO)
+func (r *NodePoolReconciler) reconcileMirroredConfigs(ctx context.Context, logr logr.Logger, mirroredConfigs []*MirrorConfig, controlPlaneNamespace string, nodePool *hyperv1.NodePool) error {
+	// get configs which already mirrored to the HCP namespace
+	existingConfigsList := &corev1.ConfigMapList{}
+	if err := r.List(ctx, existingConfigsList, &client.ListOptions{
+		Namespace:     controlPlaneNamespace,
+		LabelSelector: labels.SelectorFromValidatedSet(labels.Set{mirroredConfigLabel: ""}),
+	}); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	want := set.Set[string]{}
+	for _, mirrorConfig := range mirroredConfigs {
+		want.Insert(supportutil.ShortenName(mirrorConfig.Name, nodePool.Name, validation.LabelValueMaxLength))
+	}
+	have := set.Set[string]{}
+	for _, configMap := range existingConfigsList.Items {
+		have.Insert(configMap.Name)
+	}
+	toCreate, toDelete := want.Difference(have), have.Difference(want)
+	if len(toCreate) > 0 {
+		logr = logr.WithValues("toCreate", toCreate.UnsortedList())
+	}
+	if len(toDelete) > 0 {
+		logr = logr.WithValues("toDelete", toDelete.UnsortedList())
+	}
+	if len(toCreate) > 0 || len(toDelete) > 0 {
+		logr.Info("updating mirrored configs")
+	}
+	// delete the redundant configs that are no longer part of the nodepool spec
+	for i := 0; i < len(existingConfigsList.Items); i++ {
+		existingConfig := &existingConfigsList.Items[i]
+		if toDelete.Has(existingConfig.Name) {
+			_, err := supportutil.DeleteIfNeeded(ctx, r.Client, existingConfig)
+			if err != nil {
+				return fmt.Errorf("failed to delete ConfigMap %s/%s: %w", existingConfig.Namespace, existingConfig.Name, err)
+			}
+		}
+	}
+	// update or create the configs that need to be mirrored into the HCP NS
+	for _, mirroredConfig := range mirroredConfigs {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      supportutil.ShortenName(mirroredConfig.Name, nodePool.Name, validation.LabelValueMaxLength),
+				Namespace: controlPlaneNamespace},
+		}
+		if result, err := r.CreateOrUpdate(ctx, r.Client, cm, func() error {
+			return mutateMirroredConfig(cm, mirroredConfig, nodePool)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile mirrored %s/%s ConfigMap: %w", cm.Namespace, cm.Name, err)
+		} else {
+			logr.Info("Reconciled ConfigMap", "result", result)
 		}
 	}
 	return nil

--- a/vendor/k8s.io/utils/set/OWNERS
+++ b/vendor/k8s.io/utils/set/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - logicalhan
+  - thockin
+approvers:
+  - logicalhan
+  - thockin

--- a/vendor/k8s.io/utils/set/ordered.go
+++ b/vendor/k8s.io/utils/set/ordered.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+// ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+// If future releases of Go add new ordered types,
+// this constraint will be modified to include them.
+type ordered interface {
+	integer | float | ~string
+}
+
+// integer is a constraint that permits any integer type.
+// If future releases of Go add new predeclared integer types,
+// this constraint will be modified to include them.
+type integer interface {
+	signed | unsigned
+}
+
+// float is a constraint that permits any floating-point type.
+// If future releases of Go add new predeclared floating-point types,
+// this constraint will be modified to include them.
+type float interface {
+	~float32 | ~float64
+}
+
+// signed is a constraint that permits any signed integer type.
+// If future releases of Go add new predeclared signed integer types,
+// this constraint will be modified to include them.
+type signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// unsigned is a constraint that permits any unsigned integer type.
+// If future releases of Go add new predeclared unsigned integer types,
+// this constraint will be modified to include them.
+type unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}

--- a/vendor/k8s.io/utils/set/set.go
+++ b/vendor/k8s.io/utils/set/set.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+import (
+	"sort"
+)
+
+// Empty is public since it is used by some internal API objects for conversions between external
+// string arrays and internal sets, and conversion logic requires public types today.
+type Empty struct{}
+
+// Set is a set of the same type elements, implemented via map[ordered]struct{} for minimal memory consumption.
+type Set[E ordered] map[E]Empty
+
+// New creates a new set.
+func New[E ordered](items ...E) Set[E] {
+	ss := Set[E]{}
+	ss.Insert(items...)
+	return ss
+}
+
+// KeySet creates a Set[E] from a keys of a map[E](? extends interface{}).
+func KeySet[E ordered, A any](theMap map[E]A) Set[E] {
+	ret := Set[E]{}
+	for key := range theMap {
+		ret.Insert(key)
+	}
+	return ret
+}
+
+// Insert adds items to the set.
+func (s Set[E]) Insert(items ...E) Set[E] {
+	for _, item := range items {
+		s[item] = Empty{}
+	}
+	return s
+}
+
+// Delete removes all items from the set.
+func (s Set[E]) Delete(items ...E) Set[E] {
+	for _, item := range items {
+		delete(s, item)
+	}
+	return s
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Set[E]) Has(item E) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Set[E]) HasAll(items ...E) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Set[E]) HasAny(items ...E) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s Set[E]) Union(s2 Set[E]) Set[E] {
+	result := Set[E]{}
+	result.Insert(s.UnsortedList()...)
+	result.Insert(s2.UnsortedList()...)
+	return result
+}
+
+// Len returns the number of elements in the set.
+func (s Set[E]) Len() int {
+	return len(s)
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s Set[E]) Intersection(s2 Set[E]) Set[E] {
+	var walk, other Set[E]
+	result := Set[E]{}
+	if s.Len() < s2.Len() {
+		walk = s
+		other = s2
+	} else {
+		walk = s2
+		other = s
+	}
+	for key := range walk {
+		if other.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s Set[E]) IsSuperset(s2 Set[E]) bool {
+	for item := range s2 {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s Set[E]) Difference(s2 Set[E]) Set[E] {
+	result := Set[E]{}
+	for key := range s {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+func (s Set[E]) Equal(s2 Set[E]) bool {
+	return s.Len() == s2.Len() && s.IsSuperset(s2)
+}
+
+type sortableSlice[E ordered] []E
+
+func (s sortableSlice[E]) Len() int {
+	return len(s)
+}
+func (s sortableSlice[E]) Less(i, j int) bool { return s[i] < s[j] }
+func (s sortableSlice[E]) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// SortedList returns the contents as a sorted slice.
+func (s Set[E]) SortedList() []E {
+	res := make(sortableSlice[E], 0, s.Len())
+	for key := range s {
+		res = append(res, key)
+	}
+	sort.Sort(res)
+	return res
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Set[E]) UnsortedList() []E {
+	res := make([]E, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
+// PopAny returns a single element from the set.
+func (s Set[E]) PopAny() (E, bool) {
+	for key := range s {
+		s.Delete(key)
+		return key, true
+	}
+	var zeroValue E
+	return zeroValue, false
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Set[T]) Clone() Set[T] {
+	result := make(Set[T], len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s Set[T]) SymmetricDifference(s2 Set[T]) Set[T] {
+	return s.Difference(s2).Union(s2.Difference(s))
+}

--- a/vendor/k8s.io/utils/set/set_go_1.20.go
+++ b/vendor/k8s.io/utils/set/set_go_1.20.go
@@ -1,0 +1,33 @@
+//go:build !go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+// Clear empties the set.
+// It is preferable to replace the set with a newly constructed set,
+// but not all callers can do that (when there are other references to the map).
+// In some cases the set *won't* be fully cleared, e.g. a Set[float32] containing NaN
+// can't be cleared because NaN can't be removed.
+// For sets containing items of a type that is reflexive for ==,
+// this is optimized to a single call to runtime.mapclear().
+func (s Set[T]) Clear() Set[T] {
+	for key := range s {
+		delete(s, key)
+	}
+	return s
+}

--- a/vendor/k8s.io/utils/set/set_go_1.21.go
+++ b/vendor/k8s.io/utils/set/set_go_1.21.go
@@ -1,0 +1,27 @@
+//go:build go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+// Clear empties the set.
+// It is preferable to replace the set with a newly constructed set,
+// but not all callers can do that (when there are other references to the map).
+func (s Set[T]) Clear() Set[T] {
+	clear(s)
+	return s
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2147,6 +2147,7 @@ k8s.io/utils/net
 k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/ptr
+k8s.io/utils/set
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
 # kubevirt.io/api v1.1.1


### PR DESCRIPTION
**What this PR does / why we need it**:

NTO is one of core OCP operator and it's running as a pod in the HCP namespace.

The operartor requires containerruntime (if exists)
in order to perform certain tuning decisions.

Here, we support mirroring of this object into the HCP namespace,
so the operator will be able to access and get the information it's
needed.

Fixes # 
[CNF-11845](https://issues.redhat.com/browse/CNF-11845)

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [X] This change includes unit tests.