### PR TITLE
OCPBUGS-24400: Recover the ETCD member on HostedCluster boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ build: hypershift-operator control-plane-operator control-plane-pki-operator hyp
 
 .PHONY: sync
 sync:
-	$(GO) work sync 
+	$(GO) work sync
 
 .PHONY: update
 update: sync api-deps api api-docs deps clients app-sre-saas-template


### PR DESCRIPTION
Eventually, the ETCD deployment encountered issues booting when many HostedControlPlanes were being created. This caused one or more members to get stuck while trying to join the cluster but unable to do so. Once a pod is stuck in CrashLoopBackOff, the script will now create a snapshot and then remove the member folder, allowing the member to be properly formed and added to the cluster on the next attempt.

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-24400](https://issues.redhat.com/browse/OCPBUGS-24400)