### PR TITLE
HOSTEDCP-1712: Initialize infra id for e2e-azure tests

### DIFF
--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -39,6 +39,8 @@ func createClusterOpts(ctx context.Context, client crclient.Client, hc *hyperv1.
 	switch hc.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
 		opts.InfraID = hc.Name
+	case hyperv1.AzurePlatform:
+		opts.InfraID = hc.Name
 	case hyperv1.PowerVSPlatform:
 		opts.InfraID = fmt.Sprintf("%s-infra", hc.Name)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Initialize infra id for e2e-azure tests

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [HOSTEDCP-1712](https://issues.redhat.com/browse/HOSTEDCP-1712)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.