### PR TITLE
NO-JIRA: Delete references to the openshift-sdn image in CNO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -39,7 +39,6 @@ const (
 
 type Images struct {
 	NetworkOperator              string
-	SDN                          string
 	KubeProxy                    string
 	KubeRBACProxy                string
 	Multus                       string
@@ -85,7 +84,6 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	p := Params{
 		Images: Images{
 			NetworkOperator:              releaseImageProvider.GetImage("cluster-network-operator"),
-			SDN:                          userReleaseImageProvider.GetImage("sdn"),
 			KubeProxy:                    userReleaseImageProvider.GetImage("kube-proxy"),
 			KubeRBACProxy:                userReleaseImageProvider.GetImage("kube-rbac-proxy"),
 			Multus:                       userReleaseImageProvider.GetImage("multus-cni"),
@@ -531,7 +529,6 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 				},
 			}},
 
-			{Name: "SDN_IMAGE", Value: params.Images.SDN},
 			{Name: "KUBE_PROXY_IMAGE", Value: params.Images.KubeProxy},
 			{Name: "KUBE_RBAC_PROXY_IMAGE", Value: params.Images.KubeRBACProxy},
 			{Name: "MULTUS_IMAGE", Value: params.Images.Multus},

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -65,7 +65,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: SDN_IMAGE
         - name: KUBE_PROXY_IMAGE
         - name: KUBE_RBAC_PROXY_IMAGE
         - name: MULTUS_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -65,7 +65,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: SDN_IMAGE
         - name: KUBE_PROXY_IMAGE
         - name: KUBE_RBAC_PROXY_IMAGE
         - name: MULTUS_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -66,7 +66,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: SDN_IMAGE
         - name: KUBE_PROXY_IMAGE
         - name: KUBE_RBAC_PROXY_IMAGE
         - name: MULTUS_IMAGE


### PR DESCRIPTION
**What this PR does / why we need it**:
openshift-sdn is gone in 4.17. There are still a bunch of references to it that need to be cleaned up, but for now, at least stop trying to resolve the image, since that would cause errors even in clusters that aren't trying to use openshift-sdn.

I am not sure that this is correct... it seems like maybe a given version of hypershift supports multiple target versions of openshift? In which case it would need to be able to refer to the 4.16 and earlier sdn images, but not the 4.17 and later sdn images?

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Related to SDN-4896; there was no epic for hypershift because I didn't realize that hypershift also referred to the image directly until someone pointed it out...

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.