### PR TITLE
HOSTEDCP-1709: hack/test: remove timeouts

### DIFF
--- a/hack/ci-test-e2e-azure.sh
+++ b/hack/ci-test-e2e-azure.sh
@@ -25,7 +25,6 @@ trap generate_junit EXIT
 
 bin/test-e2e \
   -test.v \
-  -test.timeout=2h10m \
   -test.run='^TestCreateCluster.*|^TestNodePool.*' \
   -test.parallel=20 \
   --e2e.platform=Azure \

--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -43,7 +43,6 @@ fi
 
 bin/test-e2e \
   -test.v \
-  -test.timeout=2h10m \
   -test.run=${CI_TESTS_RUN} \
   -test.parallel=20 \
   --e2e.aws-credentials-file=/etc/hypershift-pool-aws-credentials/credentials \


### PR DESCRIPTION
The top-level `go test` timeout does nothing beneficial for us - we need to be well-formed in the face of SIGTERM from the test platform anyway, and we need to time out within our tests, not from the top-level, as this will give us sensible test failure output (e.g. a specific assertion failed) versus the current panic output which makes it impossible to generate jUnit.

/assign @sjenning 