### PR TITLE
HOSTEDCP-1446: hack: make the e2e script generic

### DIFF
--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -41,9 +41,9 @@ if [[ -n "${REQUEST_SERVING_COMPONENT_TEST}" ]]; then
   --e2e.management-cluster-name=$(cat "${SHARED_DIR}/management_cluster_name")"
 fi
 
-bin/test-e2e \
-  -test.v \
-  -test.run=${CI_TESTS_RUN} \
+declare -a default_args=(
+  -test.v
+  -test.run=${CI_TESTS_RUN}
   -test.parallel=20 \
   --e2e.aws-credentials-file=/etc/hypershift-pool-aws-credentials/credentials \
   --e2e.aws-zones=us-east-1a,us-east-1b,us-east-1c \
@@ -57,6 +57,20 @@ bin/test-e2e \
   --e2e.additional-tags="expirationDate=$(date -d '4 hours' --iso=minutes --utc)" \
   --e2e.aws-endpoint-access=PublicAndPrivate \
   --e2e.external-dns-domain=service.ci.hypershift.devcluster.openshift.com \
-  ${REQUEST_SERVING_COMPONENT_PARAMS} | tee /tmp/test_out &
+  ${REQUEST_SERVING_COMPONENT_PARAMS}
+)
+
+# We would like all end-to-end testing for HyperShift to use this script, so we can set flags centrally
+# and provide the jUnit results, etc, for everyone in the same way. In order to do that, we need to allow
+# each consumer to pass disjoint sets of flags to the end-to-end binary. We already accept one argument,
+# the set of tests to run, so we will continue to honor the previous calling convention unless the caller
+# is passing more flags. That allows us to default to the current behavior and let callers opt into the
+# new paradigm over time. Once that migration is done, default_args will be removed.
+declare -a args="$@"
+if [[ "$#" -lt 2 ]]; then
+  args="${default_args[@]}"
+fi
+
+bin/test-e2e ${args} | tee /tmp/test_out &
 
 wait $!


### PR DESCRIPTION
Today, we duplicate the ci-test-e2e.sh script for Azure, and the KubeVirt tests don't even use it. This has a bunch of downsides, most notably that we don't even have jUnit for KubeVirt tests. We should aim to have only the generic, required, static flags in this script and allow each caller to simply pass their own as necessary.
