### PR TITLE
[release-4.15] HOSTEDCP-1714: Kubernetes API Server Log Verbosity Annotation cherry pick to 4.15

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -259,6 +259,9 @@ const (
 	// This annotation is only set by the hypershift-operator on HosterControlPlanes.
 	// It is not set by the end-user.
 	DisableClusterAutoscalerAnnotation = "hypershift.openshift.io/disable-cluster-autoscaler"
+
+	// KubeAPIServerVerbosityLevelAnnotation allows specifing the log verbosity of kube-apiserver.
+	KubeAPIServerVerbosityLevelAnnotation = "hypershift.openshift.io/kube-apiserver-verbosity-level"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -429,21 +429,18 @@ func buildKASContainerMain(image string, port int32, noProxyCIDRs []string, hcp 
 			"hyperkube",
 		}
 
-		// default to level of 2
-		kasVerbosityLevel := "--v=2"
+		kasVerbosityLevel := 2
 		if hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation] != "" {
-			kasAnnotationValue := hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation]
-			_, err := strconv.Atoi(kasAnnotationValue)
-			// ensure integer value in annotation
+			parsedKASVerbosityValue, err := strconv.Atoi(hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation])
 			if err == nil {
-				kasVerbosityLevel = fmt.Sprintf("--v=%s", kasAnnotationValue)
+				kasVerbosityLevel = parsedKASVerbosityValue
 			}
 		}
 
 		c.Args = []string{
 			"kube-apiserver",
 			fmt.Sprintf("--openshift-config=%s", path.Join(volumeMounts.Path(c.Name, kasVolumeConfig().Name), KubeAPIServerConfigKey)),
-			kasVerbosityLevel,
+			fmt.Sprintf("--v=%d", kasVerbosityLevel),
 		}
 
 		c.Env = []corev1.EnvVar{{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -428,10 +428,17 @@ func buildKASContainerMain(image string, port int32, noProxyCIDRs []string, hcp 
 		c.Command = []string{
 			"hyperkube",
 		}
+
+		// default to level of 2
+		kasVerbosityLevel := "-v2"
+		if hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation] != "" {
+			kasVerbosityLevel = fmt.Sprintf("--v=%s", hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation])
+		}
+
 		c.Args = []string{
 			"kube-apiserver",
 			fmt.Sprintf("--openshift-config=%s", path.Join(volumeMounts.Path(c.Name, kasVolumeConfig().Name), KubeAPIServerConfigKey)),
-			"-v2",
+			kasVerbosityLevel,
 		}
 
 		c.Env = []corev1.EnvVar{{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -430,9 +430,14 @@ func buildKASContainerMain(image string, port int32, noProxyCIDRs []string, hcp 
 		}
 
 		// default to level of 2
-		kasVerbosityLevel := "-v2"
+		kasVerbosityLevel := "--v=2"
 		if hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation] != "" {
-			kasVerbosityLevel = fmt.Sprintf("--v=%s", hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation])
+			kasAnnotationValue := hcp.Annotations[hyperv1.KubeAPIServerVerbosityLevelAnnotation]
+			_, err := strconv.Atoi(kasAnnotationValue)
+			// ensure integer value in annotation
+			if err == nil {
+				kasVerbosityLevel = fmt.Sprintf("--v=%s", kasAnnotationValue)
+			}
 		}
 
 		c.Args = []string{

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1806,6 +1806,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.KubeAPIServerGOGCAnnotation,
 		hyperv1.KubeAPIServerGOMemoryLimitAnnotation,
 		hyperv1.RequestServingNodeAdditionalSelectorAnnotation,
+		hyperv1.KubeAPIServerVerbosityLevelAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]


### PR DESCRIPTION
Cherry pick of #4026 on release-4.15.

#4026: rebase + merge conflicts

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Parent issue https://issues.redhat.com/browse/HOSTEDCP-1553
4.15 cherry pick issue https://issues.redhat.com/browse/HOSTEDCP-1714
4.16 cherry pick issue https://issues.redhat.com/browse/HOSTEDCP-1715

```release-note

```