### PR TITLE
OCPBUGS-33951: Documentation for disconnected MGMT Cluster

### DIFF
--- a/docs/content/how-to/disconnected/idms-icsp-for-management-clusters.md
+++ b/docs/content/how-to/disconnected/idms-icsp-for-management-clusters.md
@@ -12,6 +12,93 @@ For the Control Plane, ICSP/IDMS objects are managed in the Management Cluster. 
 
 In summary, to work with disconnected registries in the HostedControlPlane, you first need to create the appropriate ICSP/IDMS in the Management Cluster. Then, to deploy disconnected workloads in the Data Plane, you need to add the desired entries into the ImageContentSources field inside the HostedCluster manifest.
 
+### Mirroring Prerequisites for the Management Cluster
+
+Deploying HostedControlPlanes in a disconnected environment involves a mirroring process that is straightforward, provided you have the necessary prerequisites:
+
+1. **Private Registry**: Ensure a private registry is deployed and operational.
+2. **Credentials**: Have a credentials file to pull from a public registry and push to your private registry.
+3. **oc-mirror Tool**: Install the `oc-mirror` tool.
+
+#### Setting Up the Private Registry
+
+For the private registry, robust platforms typically use large-scale solutions like Quay or Artifactory. However, for testing or development environments, you can set up a smaller registry by following these [steps](../../labs/IPv4/registry.md).
+
+#### Preparing the Credentials File
+
+Your credentials file, typically located at `${HOME}/.docker/config.json`, must include login credentials for at least two registries:
+
+- The public registry from which you pull images (e.g., `quay.io`).
+- Your private registry to which you push the images.
+
+Refer to the official OpenShift documentation for detailed instructions on setting up the registry pull secret [here](https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-installation-images.html#installation-adding-registry-pull-secret_installing-mirroring-installation-images).
+
+#### Installing the oc-mirror Tool
+
+Download the `oc-mirror` plugin for the `oc` CLI and place it in the correct directory. Follow the instructions in the OpenShift documentation [here](https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-disconnected.html#installation-oc-mirror-installing-plugin_installing-mirroring-disconnected).
+
+### Preparing the ImageSetConfiguration file
+
+With the prerequisites in place, you need to prepare the `ImageSetConfiguration` file. This file specifies the OpenShift Container Platform (OCP) releases, Operator Lifecycle Manager (OLM) catalogs, and additional images you wish to mirror.
+
+Here is a sample `ImageSetConfiguration`:
+
+```yaml
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+storageConfig:
+  registry:
+    imageURL: registry.sample.lab:5000/openshift/release/metadata:latest
+mirror:
+  platform:
+    channels:
+    - name: stable-4.14
+      minVersion: 4.14.26
+      maxVersion: 4.14.28
+      type: ocp
+    - name: stable-4.15
+      minVersion: 4.15.13
+      maxVersion: 4.15.17
+      type: ocp
+    - name: candidate-4.16
+      minVersion: 4.16.0-rc.2
+      maxVersion: 4.16.0-rc.4
+      type: ocp
+  additionalImages:
+  - name: quay.io/karmab/origin-keepalived-ipfailover:latest
+  - name: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10
+  operators:
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.15
+    packages:
+    - name: lvms-operator
+    - name: local-storage-operator
+    - name: odf-csi-addons-operator
+    - name: odf-operator
+    - name: mcg-operator
+    - name: ocs-operator
+    - name: metallb-operator
+```
+
+For a detailed explanation of each field in the `ImageSetConfiguration`, consult the [official documentation](https://docs.openshift.com/container-platform/4.15/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-creating-image-set-config_installing-mirroring-disconnected).
+
+### Running the Mirroring Process
+
+To start the mirroring process, execute the following command:
+
+```bash
+oc-mirror --config imagesetconfig.yaml docker://${PRIVATE_REGISTRY_ADDRESS}
+```
+
+!!! Note
+    If your private registry uses a self-signed CA or a CA not recognized by the system running the `oc-mirror` command, you can use the `--source-skip-tls` flag to bypass certificate verification.
+
+After several minutes, the process will complete, generating output files in the current directory. The key files are `ImageContentSourcePolicies` and `CatalogSource`, which must be applied to the management cluster to enable a disconnected deployment of the HostedControlPlanes.
+
+!!! Important
+    If you have a `Registry-root-url/Namespace` or `Registry-root-url` (E.G: ) IDMS/ICSP entry into the Management cluster for the OCP Metadata and Release images, the Hypershift operator cannot assume where the destination will be, so you need to explicitly create a IDMS/ICSP object with both entries. More info [here](./known-issues.md#idmsicsp-with-only-root-registry-are-not-propagated-to-the-registry-override-flag-under-ignition-server)
+
+    You must run the `oc-mirror` command twice. The first run generates a complete `ImageContentSourcePolicy` file, while the second run provides the differences between the two runs. Always maintain a backup of these files to merge them into a comprehensive `ImageContentSourcePolicy` file if needed. This backup ensures you have a complete policy file.
+
 ### Debugging IDMS/ICSP Propagation
 
 You can check if the entries created in the ICSP/IDMS are being propagated properly checking the deployments in the HostedControlPlane. For instance, if you check the ignition-server deployment you can see the command the pod will execute, you need to check if the `--registry-overrides` flag is followed by a serie of tuples separated by comma:

--- a/docs/content/how-to/disconnected/known-issues.md
+++ b/docs/content/how-to/disconnected/known-issues.md
@@ -202,7 +202,9 @@ failed to lookup release image: failed to extract release metadata: failed to ge
 ```
 
 **Root Cause**:
-Once the ICSP/IDMS are created in the Management cluster and they are only using in the "sources" side a root registry instead of pointing a registry namespace, the image-overrides are not properly propagated through all the deployments in the HostedControlPlane namespace. This is how looks like:
+Once the ICSP/IDMS are created in the Management cluster and they are only using in the "sources" side a root registry instead of pointing a registry namespace, the image-overrides are not filled with the explicit destination OCP Metadata and Release images, so the Hypeshift operator cannot infer the extact location of the images in the private registry.
+
+This is a sample:
 
 ```yaml
 apiVersion: config.openshift.io/v1
@@ -225,7 +227,7 @@ spec:
     source: docker.io
 ```
 
-**Workaround:**
+**Solution:**
 In order to solve the issue and perform a successful HostedControlPlane disconnected deployment you need at least to create the OCP namespaced reference in a IDMS/ICSP. A sample will look like this:
 
 ```yaml


### PR DESCRIPTION
On the OCP Standalone product documentation, we explicitly says how to imageContentSources should be configured for IPI deployments, I'm following the same approach. Once you perform the oc-mirror stage, the output file with the ImageContentSources, should be pasted as IDMS/ICSP into the Management cluster, making possible to perform a disconnected deployment and explicitly matching the Metadata and Images OCP container images with the mirrored ones in the private registry

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-33951](https://issues.redhat.com/browse/OCPBUGS-33951)