### PR TITLE
NO-JIRA: Update ci image of capk to 4.17

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	hostedClusterAnnotation = "hypershift.openshift.io/cluster"
-	imageCAPK               = "registry.ci.openshift.org/ocp/4.16:cluster-api-provider-kubevirt"
+	imageCAPK               = "registry.ci.openshift.org/ocp/4.17:cluster-api-provider-kubevirt"
 )
 
 type Kubevirt struct{}


### PR DESCRIPTION
This updates the capk image used for testing in main to 4.17