### PR TITLE
kubevirt, e2e: Skip advanced multinet for CI

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -117,6 +118,11 @@ func TestNodePool(t *testing.T) {
 			setup: func(t *testing.T) {
 				if globalOpts.Platform != hyperv1.KubevirtPlatform {
 					t.Skip("tests only supported on platform KubeVirt")
+				}
+				//FIXME: Un-quarentine the kubevirt multinet advanced test when CI has enough
+				//       resources to run it without issues.
+				if os.Getenv("CI") == "true" {
+					t.Skip("Quarentined test 'kubevirt advanced multinet' cannot run at CI")
 				}
 			},
 			build: func(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts core.CreateOptions) []NodePoolTestCase {


### PR DESCRIPTION
**What this PR does / why we need it**:
CI do not have enough resources to run the kubevirt advanced multinet test, this change skip that test if CI is detected.