### PR TITLE
OCPBUGS-35369: OCPBUGS-35252: Enforce Privileged Instead of Restricted PSA in 4.16

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"path"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,5 +68,24 @@ func reconcileConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, minTLS
 			CipherSuites:  cipherSuites,
 		},
 	}
+
+	// disables automatically setting the `pod-security.kubernetes.io/enforce` label on namespaces by the pod-security-admission-label-synchronization-controller
+	// see https://github.com/openshift/cluster-policy-controller/blob/50c2a8337f08856bbae4cd419bb8ffcbdf92567c/pkg/cmd/controller/psalabelsyncer.go#L19
+	index := -1
+	for i := range cfg.FeatureGates {
+		fg := cfg.FeatureGates[i]
+		if strings.HasPrefix(fg, "OpenShiftPodSecurityAdmission") {
+			index = i
+			break
+		}
+	}
+
+	if index != -1 {
+		// overwrite
+		cfg.FeatureGates[index] = "OpenShiftPodSecurityAdmission=false"
+	} else {
+		cfg.FeatureGates = append(cfg.FeatureGates, "OpenShiftPodSecurityAdmission=false")
+	}
+
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -90,7 +90,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 									Kind:       "PodSecurityConfiguration",
 								},
 								Defaults: podsecurityadmissionv1beta1.PodSecurityDefaults{
-									Enforce:        "restricted",
+									Enforce:        "privileged",
 									EnforceVersion: "latest",
 									Audit:          "restricted",
 									AuditVersion:   "latest",

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -100,7 +100,6 @@ func TestCreateClusterRequestServingIsolation(t *testing.T) {
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		guestClient := e2eutil.WaitForGuestClient(t, testContext, mgtClient, hostedCluster)
-		e2eutil.EnsurePSANotPrivileged(t, ctx, guestClient)
 		e2eutil.EnsureAllReqServingPodsLandOnReqServingNodes(t, ctx, guestClient)
 		e2eutil.EnsureOnlyRequestServingPodsOnRequestServingNodes(t, ctx, guestClient)
 		e2eutil.EnsureNoHCPPodsLandOnDefaultNode(t, ctx, guestClient, hostedCluster)


### PR DESCRIPTION
**What this PR does / why we need it**:
Align HyperShift with OpenShift's expectation that PSA is going back to enforcing privileged by default instead of restricted.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
- https://issues.redhat.com/browse/OCPBUGS-35252

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.