### PR TITLE
HOSTEDCP-1709: test/e2e: add a harness for asynchronous assertions

### DIFF
--- a/test/e2e/nodepool_kv_cache_image_test.go
+++ b/test/e2e/nodepool_kv_cache_image_test.go
@@ -5,9 +5,10 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
-	"time"
 
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/gomega"
@@ -49,12 +50,19 @@ func (k KubeVirtCacheTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []core
 	g := NewWithT(t)
 
 	np := &hyperv1.NodePool{}
-	g.Eventually(func(gg Gomega) {
-		gg.Expect(k.client.Get(k.ctx, util.ObjectKey(&nodePool), np)).Should(Succeed())
-		gg.Expect(np.Status.Platform).ToNot(BeNil())
-		gg.Expect(np.Status.Platform.KubeVirt).ToNot(BeNil())
-		gg.Expect(np.Status.Platform.KubeVirt.CacheName).ToNot(BeEmpty(), "cache DataVolume name should be populated")
-	}).WithContext(k.ctx).Within(5 * time.Minute).WithPolling(time.Second).Should(Succeed())
+	e2eutil.EventuallyObject(
+		t, k.ctx, fmt.Sprintf("waiting for NodePool %s/%s to have a cache data volume", nodePool.Namespace, nodePool.Name),
+		func(ctx context.Context) (*hyperv1.NodePool, error) {
+			err := k.client.Get(k.ctx, util.ObjectKey(&nodePool), np)
+			return np, err
+		},
+		func(pool *hyperv1.NodePool) (done bool, reasons []string, err error) {
+			if np.Status.Platform != nil && np.Status.Platform.KubeVirt != nil && np.Status.Platform.KubeVirt.CacheName != "" {
+				return true, nil, nil
+			}
+			return false, []string{"no cache data volume set"}, nil
+		},
+	)
 
 	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
 	var guestNamespace string

--- a/test/e2e/nodepool_kv_jsonpatch_test.go
+++ b/test/e2e/nodepool_kv_jsonpatch_test.go
@@ -5,10 +5,11 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -49,12 +50,19 @@ func (k KubeVirtJsonPatchTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []
 	g := NewWithT(t)
 
 	np := &hyperv1.NodePool{}
-	g.Eventually(func(gg Gomega) {
-		gg.Expect(k.client.Get(k.ctx, util.ObjectKey(&nodePool), np)).Should(Succeed())
-		gg.Expect(np.Spec.Platform).ToNot(BeNil())
-		gg.Expect(np.Spec.Platform.Type).To(Equal(hyperv1.KubevirtPlatform))
-		gg.Expect(np.Spec.Platform.Kubevirt).ToNot(BeNil())
-	}).WithContext(k.ctx).Within(5 * time.Minute).WithPolling(time.Second).Should(Succeed())
+	e2eutil.EventuallyObject(
+		t, k.ctx, fmt.Sprintf("waiting for NodePool %s/%s to have a kubevirt platform", nodePool.Namespace, nodePool.Name),
+		func(ctx context.Context) (*hyperv1.NodePool, error) {
+			err := k.client.Get(k.ctx, util.ObjectKey(&nodePool), np)
+			return np, err
+		},
+		func(pool *hyperv1.NodePool) (done bool, reasons []string, err error) {
+			if np.Spec.Platform.Kubevirt != nil && np.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+				return true, nil, nil
+			}
+			return false, []string{fmt.Sprintf("invalid platform type, wanted %s, got %s", hyperv1.KubevirtPlatform, np.Spec.Platform.Type)}, nil
+		},
+	)
 
 	localInfraNS := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
 	var guestNamespace string
@@ -78,19 +86,26 @@ func (k KubeVirtJsonPatchTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []
 	infraClient, err := cm.DiscoverKubevirtClusterClient(k.ctx, k.client, k.hostedCluster.Spec.InfraID, creds, localInfraNS, np.GetNamespace())
 	g.Expect(err).ShouldNot(HaveOccurred())
 
-	vmis := &kubevirtv1.VirtualMachineInstanceList{}
 	labelSelector := labels.SelectorFromValidatedSet(labels.Set{hyperv1.NodePoolNameLabel: np.Name})
-	g.Eventually(func(gg Gomega) {
-		gg.Expect(
-			infraClient.GetInfraClient().List(k.ctx, vmis, &crclient.ListOptions{Namespace: guestNamespace, LabelSelector: labelSelector}),
-		).To(Succeed())
-
-		gg.Expect(vmis.Items).To(HaveLen(1))
-		vmi := vmis.Items[0]
-
-		gg.Expect(vmi.Spec.Domain.CPU).ToNot(BeNil())
-		gg.Expect(vmi.Spec.Domain.CPU.Cores).To(Equal(uint32(3)))
-	}).WithContext(k.ctx).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+	e2eutil.EventuallyObjects(
+		t, k.ctx, fmt.Sprintf("waiting for one VirtualMachineInstance with 3 CPU cores"),
+		func(ctx context.Context) ([]*kubevirtv1.VirtualMachineInstance, error) {
+			vmis := &kubevirtv1.VirtualMachineInstanceList{}
+			err := infraClient.GetInfraClient().List(k.ctx, vmis, &crclient.ListOptions{Namespace: guestNamespace, LabelSelector: labelSelector})
+			var ptrs []*kubevirtv1.VirtualMachineInstance
+			for i := range vmis.Items {
+				ptrs = append(ptrs, &vmis.Items[i])
+			}
+			return ptrs, err
+		},
+		func(items []*kubevirtv1.VirtualMachineInstance) (done bool, reasons []string, err error) {
+			return len(items) == 1, []string{fmt.Sprintf("wanted one VirtualMachineInstance, got %d", len(items))}, nil
+		},
+		func(instance *kubevirtv1.VirtualMachineInstance) (done bool, reasons []string, err error) {
+			cores := ptr.Deref(instance.Spec.Domain.CPU, kubevirtv1.CPU{}).Cores
+			return cores == uint32(3), []string{fmt.Sprintf("wanted 3 CPU cores, got %d", cores)}, nil
+		},
+	)
 }
 
 func (k KubeVirtJsonPatchTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {

--- a/test/e2e/util/eventually.go
+++ b/test/e2e/util/eventually.go
@@ -1,0 +1,396 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	certificatesv1alpha1 "github.com/openshift/hypershift/api/certificates/v1alpha1"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func defaultOptions() *EventuallyOptions {
+	return &EventuallyOptions{
+		interval:       1 * time.Second,
+		timeout:        10 * time.Minute,
+		immediate:      true,
+		dumpConditions: true,
+	}
+}
+
+// EventuallyOptions configure asynchronous assertion behavior.
+type EventuallyOptions struct {
+	interval  time.Duration
+	timeout   time.Duration
+	immediate bool
+
+	dumpConditions      bool
+	filterConditionDump []Condition
+}
+
+// EventuallyOption configures a
+type EventuallyOption func(*EventuallyOptions)
+
+// WithInterval sets the polling interval.
+func WithInterval(interval time.Duration) EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.interval = interval
+	}
+}
+
+// WithTimeout sets the polling timeout.
+func WithTimeout(timeout time.Duration) EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.timeout = timeout
+	}
+}
+
+// WithDelayedStart configures the asynchronous assertion to start immediately.
+func WithDelayedStart() EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.immediate = false
+	}
+}
+
+// WithoutConditionDump configures the asynchronous assertion to dump conditions on failure.
+func WithoutConditionDump() EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.dumpConditions = false
+	}
+}
+
+// WithFilteredConditionDump configures the asynchronous assertion to only dump the specified conditions.
+func WithFilteredConditionDump(matchers ...Condition) EventuallyOption {
+	return func(o *EventuallyOptions) {
+		o.filterConditionDump = append(o.filterConditionDump, matchers...)
+	}
+}
+
+// EventuallyObject polls until the predicate is fulfilled on the object.
+func EventuallyObject[T client.Object](t *testing.T, ctx context.Context, objective string, getter func(context.Context) (T, error), predicate Predicate[T], options ...EventuallyOption) {
+	t.Helper()
+	opts := defaultOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
+	t.Logf("waiting for %s", objective)
+	start := time.Now()
+	lastTimestamp := time.Now()
+	var previousError string
+	var previousReasons []string
+	var object T
+	err := wait.PollUntilContextTimeout(ctx, opts.interval, opts.timeout, opts.immediate, func(ctx context.Context) (bool, error) {
+		var getErr error
+		object, getErr = getter(ctx)
+		if getErr != nil {
+			if getErr.Error() != previousError {
+				previousError = getErr.Error()
+				t.Logf("failed to get %T: %v", object, getErr)
+			}
+			return false, nil
+		}
+
+		done, reasons, err := predicate(object)
+		if err != nil {
+			return false, err
+		}
+		if !done && len(reasons) == 0 {
+			return false, fmt.Errorf("programmer error: predicate returned false with no message")
+		}
+		if diff := cmp.Diff(previousReasons, reasons); diff != "" {
+			prefix := ""
+			if !done {
+				prefix = "in"
+			}
+			t.Logf("observed %T %s/%s %svalid at RV %s after %s:", object, object.GetNamespace(), object.GetName(), prefix, object.GetResourceVersion(), time.Since(lastTimestamp))
+			for _, message := range reasons {
+				t.Log(" - " + message)
+			}
+			previousReasons = reasons
+		}
+
+		lastTimestamp = time.Now()
+		return done, nil
+	})
+	duration := time.Since(start).Round(time.Second)
+
+	if err != nil {
+		if opts.dumpConditions && !reflect.ValueOf(object).Elem().IsZero() { // can't use != nil here
+			conditions, err := Conditions(object)
+			if err != nil {
+				t.Fatalf("failed to extract conditions from %T %s/%s: %v", object, object.GetNamespace(), object.GetName(), err)
+			}
+			t.Logf("%T %s/%s conditions:", object, object.GetNamespace(), object.GetName())
+			for _, condition := range conditions {
+				for _, matcher := range opts.filterConditionDump {
+					if matcher.Matches(condition) {
+						t.Logf(condition.String())
+					}
+				}
+			}
+		}
+		t.Fatalf("Failed to wait for %s in %s: %v", objective, duration, err)
+	}
+	t.Logf("Successfully waited for %s in %s", objective, duration)
+}
+
+type predicateResult struct {
+	done    bool
+	reasons []string
+}
+
+// EventuallyObjects polls until the predicate is fulfilled on each of a set of objects.
+func EventuallyObjects[T client.Object](t *testing.T, ctx context.Context, objective string, getter func(context.Context) ([]T, error), groupPredicate Predicate[[]T], predicate Predicate[T], options ...EventuallyOption) {
+	t.Helper()
+	opts := defaultOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
+	t.Logf("waiting for %s", objective)
+	start := time.Now()
+	lastTimestamp := time.Now()
+	var previousError string
+	previousResults := map[types.NamespacedName]predicateResult{}
+	var invalidObjects []T
+	err := wait.PollUntilContextTimeout(ctx, opts.interval, opts.timeout, opts.immediate, func(ctx context.Context) (bool, error) {
+		objects, getErr := getter(ctx)
+		if getErr != nil {
+			if getErr.Error() != previousError {
+				previousError = getErr.Error()
+				t.Logf("failed to get %T: %v", new(T), getErr)
+			}
+			return false, nil
+		}
+
+		currentResults := map[types.NamespacedName]predicateResult{}
+		done, reasons, err := groupPredicate(objects)
+		if err != nil {
+			return false, err
+		}
+		if !done && len(reasons) == 0 {
+			return false, fmt.Errorf("programmer error: predicate returned false with no message")
+		}
+		currentResults[types.NamespacedName{ /* empty sentinel */ }] = predicateResult{
+			done:    done,
+			reasons: reasons,
+		}
+
+		for _, object := range objects {
+			objectDone, objectReasons, objectError := predicate(object)
+			if objectError != nil {
+				return false, objectError
+			}
+			if !objectDone && len(objectReasons) == 0 {
+				return false, fmt.Errorf("programmer error: predicate returned false with no message")
+			}
+			currentResults[types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()}] = predicateResult{
+				done:    objectDone,
+				reasons: objectReasons,
+			}
+			if !objectDone {
+				invalidObjects = append(invalidObjects, object)
+			}
+			done = done && objectDone
+		}
+		if diff := cmp.Diff(previousResults, currentResults, cmp.AllowUnexported(predicateResult{})); diff != "" {
+			prefix := ""
+			if !done {
+				prefix = "in"
+			}
+			t.Logf("observed %svalid %T state after %s", prefix, new(T), time.Since(lastTimestamp))
+			for key, result := range currentResults {
+				previous, seen := previousResults[key]
+				if diff := cmp.Diff(previous.reasons, result.reasons); !seen || diff != "" {
+					prefix := ""
+					if !result.done {
+						prefix = "in"
+					}
+					identifier := "collection"
+					if diff := cmp.Diff(key, types.NamespacedName{}); diff != "" {
+						identifier = fmt.Sprintf("%s/%s", key.Namespace, key.Name)
+					}
+					t.Logf(" - observed %T %s %svalid:", new(T), identifier, prefix)
+					for _, message := range result.reasons {
+						t.Log("    - " + message)
+					}
+				}
+			}
+			previousResults = currentResults
+		}
+
+		lastTimestamp = time.Now()
+		return done, nil
+	})
+	duration := time.Since(start).Round(time.Second)
+
+	if err != nil {
+		if opts.dumpConditions {
+			for _, object := range invalidObjects {
+				if !reflect.ValueOf(object).Elem().IsZero() { // can't use != nil here
+					conditions, err := Conditions(object)
+					if err != nil {
+						t.Errorf("failed to extract conditions from %T %s/%s: %v", object, object.GetNamespace(), object.GetName(), err)
+						continue
+					}
+					t.Logf("%T %s/%s conditions:", object, object.GetNamespace(), object.GetName())
+					for _, condition := range conditions {
+						for _, matcher := range opts.filterConditionDump {
+							if matcher.Matches(condition) {
+								t.Logf(condition.String())
+							}
+						}
+					}
+				}
+			}
+		}
+		t.Fatalf("Failed to wait for %s in %s: %v", objective, duration, err)
+	}
+	t.Logf("Successfully waited for %s in %s", objective, duration)
+}
+
+// Predicate evaluates an object. Return whether the object in question matches your predicate, the reasons
+// why or why not, and whether an error occurred. If determining that an object does not match a predicate,
+// a message is required. Returning an error is fatal to the asynchronous assertion using this predicate.
+type Predicate[T any] func(T) (done bool, reasons []string, err error)
+
+// AggregatePredicates closes over a logical AND for all the child predicates.
+func AggregatePredicates[T any](predicates ...Predicate[T]) Predicate[T] {
+	return func(item T) (bool, []string, error) {
+		var allReasons []string
+		allDone := true
+		for _, predicate := range predicates {
+			done, reasons, err := predicate(item)
+			if err != nil {
+				return false, nil, err
+			}
+			allReasons = append(allReasons, reasons...)
+			allDone = allDone && done
+		}
+		return allDone, allReasons, nil
+	}
+}
+
+// Condition is a generic structure required to adapt all the different concrete condition types into one.
+type Condition struct {
+	Type    string
+	Status  metav1.ConditionStatus
+	Reason  string
+	Message string
+}
+
+// String formats a condition in the canonical way.
+func (c Condition) String() string {
+	msg := fmt.Sprintf("%s=%s", c.Type, c.Status)
+	if c.Reason != "" {
+		msg += ": " + c.Reason
+	}
+	if c.Message != "" {
+		msg += "(" + c.Message + ")"
+	}
+	return msg
+}
+
+// Conditions extracts conditions from the item and adapts them to the generic wrapper.
+func Conditions(item client.Object) ([]Condition, error) {
+	switch obj := item.(type) {
+	case *corev1.Node:
+		conditions := make([]Condition, len(obj.Status.Conditions))
+		for _, condition := range obj.Status.Conditions {
+			conditions = append(conditions, Condition{
+				Type:    string(condition.Type),
+				Status:  metav1.ConditionStatus(condition.Status),
+				Reason:  condition.Reason,
+				Message: condition.Message,
+			})
+		}
+		return conditions, nil
+	case *hyperv1.NodePool:
+		conditions := make([]Condition, len(obj.Status.Conditions))
+		for _, condition := range obj.Status.Conditions {
+			conditions = append(conditions, Condition{
+				Type:    condition.Type,
+				Status:  metav1.ConditionStatus(condition.Status),
+				Reason:  condition.Reason,
+				Message: condition.Message,
+			})
+		}
+		return conditions, nil
+	case *hyperv1.HostedCluster:
+		return adaptConditions(obj.Status.Conditions), nil
+	case *hyperv1.HostedControlPlane:
+		return adaptConditions(obj.Status.Conditions), nil
+	case *certificatesv1alpha1.CertificateRevocationRequest:
+		return adaptConditions(obj.Status.Conditions), nil
+	case *certificatesv1.CertificateSigningRequest:
+		conditions := make([]Condition, len(obj.Status.Conditions))
+		for _, condition := range obj.Status.Conditions {
+			conditions = append(conditions, Condition{
+				Type:    string(condition.Type),
+				Status:  metav1.ConditionStatus(condition.Status),
+				Reason:  condition.Reason,
+				Message: condition.Message,
+			})
+		}
+		return conditions, nil
+	default:
+		return nil, fmt.Errorf("object %T unknown", item)
+	}
+}
+
+func adaptConditions(in []metav1.Condition) []Condition {
+	conditions := make([]Condition, len(in))
+	for _, condition := range in {
+		conditions = append(conditions, Condition{
+			Type:    condition.Type,
+			Status:  condition.Status,
+			Reason:  condition.Reason,
+			Message: condition.Message,
+		})
+	}
+	return conditions
+}
+
+func (needle Condition) Matches(condition Condition) bool {
+	return (needle.Status == "" || needle.Status == condition.Status) &&
+		(needle.Reason == "" || needle.Reason == condition.Reason) &&
+		(needle.Message == "" || needle.Message == condition.Message)
+}
+
+// ConditionPredicate returns a predicate that validates that a particular condition type exists and has the requisite status, reason and/or message.
+func ConditionPredicate[T client.Object](needle Condition) Predicate[T] {
+	return func(item T) (bool, []string, error) {
+		haystack, err := Conditions(item)
+		if err != nil {
+			return false, nil, err
+		}
+		for _, condition := range haystack {
+			if needle.Type == condition.Type {
+				valid := needle.Matches(condition)
+				prefix := ""
+				if !valid {
+					prefix = "in"
+				}
+				return valid, []string{fmt.Sprintf("%scorrect condition: wanted %s, got %s", prefix, needle.String(), condition.String())}, nil
+			}
+		}
+
+		return false, []string{fmt.Sprintf("missing condition: wanted %s, did not find condition of this type", needle.String())}, nil
+	}
+}
+
+func NoOpPredicate[T any]() Predicate[T] {
+	return func(item T) (bool, []string, error) {
+		return true, nil, nil
+	}
+}

--- a/test/integration/framework/hosted-cluster.go
+++ b/test/integration/framework/hosted-cluster.go
@@ -28,6 +28,7 @@ func InterruptableContext(parent context.Context) context.Context {
 	signal.Notify(sigs, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigs
+		fmt.Println("Received an interrupt, cancelling test context...")
 		cancel()
 	}()
 	return ctx

--- a/test/integration/hosted_cluster_sizing_test.go
+++ b/test/integration/hosted_cluster_sizing_test.go
@@ -14,11 +14,9 @@ import (
 	schedulingv1alpha1applyconfigurations "github.com/openshift/hypershift/client/applyconfiguration/scheduling/v1alpha1"
 	hypershiftclient "github.com/openshift/hypershift/client/clientset/clientset"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/integration/framework"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func noop(in *schedulingv1alpha1applyconfigurations.SizeConfigurationApplyConfiguration) *schedulingv1alpha1applyconfigurations.SizeConfigurationApplyConfiguration {
@@ -130,9 +128,9 @@ func TestHostedSizingController(t *testing.T) {
 		t.Logf("expecting hosted cluster %s/%s to delay transition", testCtx.HostedCluster.Namespace, testCtx.HostedCluster.Name)
 		waitForHostedClusterCondition(t, testContext, testCtx.MgmtCluster.HyperShiftClient,
 			testCtx.HostedCluster.Namespace, testCtx.HostedCluster.Name,
-			[]condition{
-				{conditionType: hypershiftv1beta1.ClusterSizeTransitionPending, status: metav1.ConditionTrue, reason: "TransitionDelayNotElapsed"},
-				{conditionType: hypershiftv1beta1.ClusterSizeTransitionRequired, status: metav1.ConditionTrue, reason: "medium"},
+			[]util.Condition{
+				{Type: hypershiftv1beta1.ClusterSizeTransitionPending, Status: metav1.ConditionTrue, Reason: "TransitionDelayNotElapsed"},
+				{Type: hypershiftv1beta1.ClusterSizeTransitionRequired, Status: metav1.ConditionTrue, Reason: "medium"},
 			}, nil,
 		)
 
@@ -178,9 +176,9 @@ func TestHostedSizingController(t *testing.T) {
 		t.Logf("expecting hosted cluster %s/%s to delay transition for concurrency", testCtx.HostedCluster.Namespace, testCtx.HostedCluster.Name)
 		waitForHostedClusterCondition(t, testContext, testCtx.MgmtCluster.HyperShiftClient,
 			testCtx.HostedCluster.Namespace, testCtx.HostedCluster.Name,
-			[]condition{
-				{conditionType: hypershiftv1beta1.ClusterSizeTransitionPending, status: metav1.ConditionTrue, reason: "ConcurrencyLimitReached"},
-				{conditionType: hypershiftv1beta1.ClusterSizeTransitionRequired, status: metav1.ConditionTrue, reason: "large"},
+			[]util.Condition{
+				{Type: hypershiftv1beta1.ClusterSizeTransitionPending, Status: metav1.ConditionTrue, Reason: "ConcurrencyLimitReached"},
+				{Type: hypershiftv1beta1.ClusterSizeTransitionRequired, Status: metav1.ConditionTrue, Reason: "large"},
 			}, nil,
 		)
 
@@ -229,103 +227,52 @@ func waitForHostedClusterToHaveSize(t *testing.T, ctx context.Context, client hy
 	t.Logf("expecting hosted cluster %s/%s to transition to %s size", namespace, name, size)
 	waitForHostedClusterCondition(t, ctx, client,
 		namespace, name,
-		[]condition{
-			{conditionType: hypershiftv1beta1.ClusterSizeComputed, status: metav1.ConditionTrue, reason: size},
-			{conditionType: hypershiftv1beta1.ClusterSizeTransitionPending, status: metav1.ConditionFalse, reason: "ClusterSizeTransitioned"},
-			{conditionType: hypershiftv1beta1.ClusterSizeTransitionRequired, status: metav1.ConditionFalse, reason: hypershiftv1beta1.AsExpectedReason},
+		[]util.Condition{
+			{Type: hypershiftv1beta1.ClusterSizeComputed, Status: metav1.ConditionTrue, Reason: size},
+			{Type: hypershiftv1beta1.ClusterSizeTransitionPending, Status: metav1.ConditionFalse, Reason: "ClusterSizeTransitioned"},
+			{Type: hypershiftv1beta1.ClusterSizeTransitionRequired, Status: metav1.ConditionFalse, Reason: hypershiftv1beta1.AsExpectedReason},
 		},
-		func(hostedCluster *hypershiftv1beta1.HostedCluster) (done bool, reason string, err error) {
+		func(hostedCluster *hypershiftv1beta1.HostedCluster) (done bool, reason []string, err error) {
 			label, present := hostedCluster.ObjectMeta.Labels[hypershiftv1beta1.HostedClusterSizeLabel]
 			if !present {
-				return false, fmt.Sprintf("hostedCluster.metadata.labels[%s] missing", hypershiftv1beta1.HostedClusterSizeLabel), nil
+				return false, []string{fmt.Sprintf("hostedCluster.metadata.labels[%s] missing", hypershiftv1beta1.HostedClusterSizeLabel)}, nil
 			}
 			if label != size {
-				return false, fmt.Sprintf("hostedCluster.metadata.labels[%s]=%s, wanted %s", hypershiftv1beta1.HostedClusterSizeLabel, label, size), nil
+				return false, []string{fmt.Sprintf("hostedCluster.metadata.labels[%s]=%s, wanted %s", hypershiftv1beta1.HostedClusterSizeLabel, label, size)}, nil
 			}
-			return true, fmt.Sprintf("hostedCluster.metadata.labels[%s]=%s", hypershiftv1beta1.HostedClusterSizeLabel, label), nil
+			return true, []string{fmt.Sprintf("hostedCluster.metadata.labels[%s]=%s", hypershiftv1beta1.HostedClusterSizeLabel, label)}, nil
 		},
 	)
 }
 
-var relevantConditions = sets.New[string](hypershiftv1beta1.ClusterSizeTransitionPending, hypershiftv1beta1.ClusterSizeComputed, hypershiftv1beta1.ClusterSizeTransitionRequired)
-
-type validationFunc func(*hypershiftv1beta1.HostedCluster) (done bool, reason string, err error)
-
-type condition struct {
-	conditionType string
-	status        metav1.ConditionStatus
-	reason        string
-}
-
-func waitForHostedClusterCondition(t *testing.T, ctx context.Context, client hypershiftclient.Interface, namespace, name string, conditions []condition, validate validationFunc) {
+func waitForHostedClusterCondition(t *testing.T, ctx context.Context, client hypershiftclient.Interface, namespace, name string, conditions []util.Condition, validate util.Predicate[*hypershiftv1beta1.HostedCluster]) {
 	var display []string
 	for _, condition := range conditions {
-		display = append(display, fmt.Sprintf("%s=%s: %s", condition.conditionType, condition.status, condition.reason))
+		display = append(display, condition.String())
 	}
 	intent := fmt.Sprintf("hosted cluster %s/%s to have status conditions %s", namespace, name, strings.Join(display, ", "))
 	if validate != nil {
 		intent += " and match validation func"
 	}
-	t.Logf("waiting for %s", intent)
-	var lastResourceVersion string
-	lastTimestamp := time.Now()
-	var lastReason string
-	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
-		hostedCluster, err := client.HypershiftV1beta1().HostedClusters(namespace).Get(ctx, name, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			t.Logf("hosted cluster %s/%s does not exist yet", namespace, name)
-			return false, nil
-		}
-		if err != nil && !apierrors.IsNotFound(err) {
-			return true, err
-		}
-		if hostedCluster.ObjectMeta.ResourceVersion != lastResourceVersion {
-			t.Logf("hosted cluster %s/%s observed at RV %s after %s", namespace, name, hostedCluster.ObjectMeta.ResourceVersion, time.Since(lastTimestamp))
-			for _, condition := range hostedCluster.Status.Conditions {
-				if !relevantConditions.Has(condition.Type) {
-					continue
-				}
-				msg := fmt.Sprintf("%s=%s", condition.Type, condition.Status)
-				if condition.Reason != "" {
-					msg += ": " + condition.Reason
-				}
-				if condition.Message != "" {
-					msg += " (" + condition.Message + ")"
-				}
-				t.Logf("hosted cluster %s/%s status: %s", namespace, name, msg)
-			}
-			lastResourceVersion = hostedCluster.ObjectMeta.ResourceVersion
-			lastTimestamp = time.Now()
-		}
 
-		conditionsMet := true
-		for _, expected := range conditions {
-			var conditionMet bool
-			for _, actual := range hostedCluster.Status.Conditions {
-				if actual.Type == expected.conditionType &&
-					actual.Status == expected.status &&
-					actual.Reason == expected.reason {
-					conditionMet = true
-					break
-				}
-			}
-			conditionsMet = conditionsMet && conditionMet
-		}
-		if conditionsMet {
-			if validate != nil {
-				done, validationReason, err := validate(hostedCluster)
-				if validationReason != lastReason {
-					t.Logf("hosted cluster %s/%s validation: %s", namespace, name, validationReason)
-					lastReason = validationReason
-				}
-				return done, err
-			} else {
-				return true, nil
-			}
-		}
-
-		return false, nil
-	}); err != nil {
-		t.Fatalf("never saw %s: %v", intent, err)
+	var predicates []util.Predicate[*hypershiftv1beta1.HostedCluster]
+	for _, condition := range conditions {
+		predicates = append(predicates, util.ConditionPredicate[*hypershiftv1beta1.HostedCluster](condition))
 	}
+	if validate != nil {
+		predicates = append(predicates, validate)
+	}
+
+	util.EventuallyObject(
+		t, ctx, intent,
+		func(ctx context.Context) (*hypershiftv1beta1.HostedCluster, error) {
+			return client.HypershiftV1beta1().HostedClusters(namespace).Get(ctx, name, metav1.GetOptions{})
+		},
+		util.AggregatePredicates(predicates...),
+		util.WithFilteredConditionDump(
+			util.Condition{Type: hypershiftv1beta1.ClusterSizeTransitionPending},
+			util.Condition{Type: hypershiftv1beta1.ClusterSizeComputed},
+			util.Condition{Type: hypershiftv1beta1.ClusterSizeTransitionRequired},
+		),
+	)
 }

--- a/test/integration/placeholder_test.go
+++ b/test/integration/placeholder_test.go
@@ -4,18 +4,19 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	schedulingv1alpha1applyconfigurations "github.com/openshift/hypershift/client/applyconfiguration/scheduling/v1alpha1"
+	"github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/integration/framework"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/util/wait"
 	corev1applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -85,7 +86,7 @@ func TestPlaceholders(t *testing.T) {
 		}), metav1.ApplyOptions{FieldManager: "e2e-test"}); err != nil {
 			t.Fatalf("failed to apply labels to node: %v", err)
 		}
-		
+
 		waitForPlaceholders(testContext, t, testCtx.MgmtCluster.KubeClient, config, []string{"first"})
 
 		t.Log("setting the cluster sizing configuration to have 3 small placeholders, to cause scale up")
@@ -147,33 +148,25 @@ func waitForPlaceholders(ctx context.Context, t *testing.T, kubeClient kubernete
 	}
 
 	for size, count := range placeholders {
-		t.Logf("waiting for %d %s placeholders", count, size)
-		var lastResourceVersion string
-		lastTimestamp := time.Now()
-		lastCount := -1
-		if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
-			deployments, err := kubeClient.AppsV1().Deployments("request-serving-node-placeholders").List(ctx, metav1.ListOptions{
-				LabelSelector: labels.SelectorFromSet(labels.Set{"hypershift.openshift.io/hosted-cluster-size": size}).Add(*placeholderPresent).String(),
-			})
-			if err != nil {
-				return false, err
-			}
-			if deployments.ResourceVersion != lastResourceVersion {
-				if len(deployments.Items) != lastCount {
-					t.Logf("observed %d %s placeholders at RV %s after %s", len(deployments.Items), size, deployments.ResourceVersion, time.Since(lastTimestamp))
-					lastCount = len(deployments.Items)
+		util.EventuallyObjects(
+			t, ctx, fmt.Sprintf("%d %s placeholders", count, size),
+			func(ctx context.Context) ([]*appsv1.Deployment, error) {
+				deployments, err := kubeClient.AppsV1().Deployments("request-serving-node-placeholders").List(ctx, metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(labels.Set{"hypershift.openshift.io/hosted-cluster-size": size}).Add(*placeholderPresent).String(),
+				})
+				var ptrs []*appsv1.Deployment
+				for _, d := range deployments.Items {
+					ptrs = append(ptrs, &d)
 				}
-				lastResourceVersion = deployments.ResourceVersion
-				lastTimestamp = time.Now()
-			}
-			if len(deployments.Items) != count {
-				return false, nil
-			}
-			for _, deployment := range deployments.Items {
+				return ptrs, err
+			},
+			func(deployments []*appsv1.Deployment) (done bool, reasons []string, err error) {
+				return len(deployments) == count, []string{fmt.Sprintf("expected %d %s placeholders, found %d", count, size, len(deployments))}, nil
+			},
+			func(deployment *appsv1.Deployment) (done bool, reasons []string, err error) {
 				var expectedAffinity *corev1.NodeAffinity
 				if len(pairedNodes) == 0 {
 					expectedAffinity = nil
-
 				} else {
 					expectedAffinity = &corev1.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
@@ -188,13 +181,11 @@ func waitForPlaceholders(ctx context.Context, t *testing.T, kubeClient kubernete
 					}
 				}
 				if diff := cmp.Diff(deployment.Spec.Template.Spec.Affinity.NodeAffinity, expectedAffinity); diff != "" {
-					t.Logf("placeholder %q had invalid node affinity: %v", deployment.Name, diff)
-					return false, nil
+					return false, []string{fmt.Sprintf("invalid node affinity: %v", diff)}, nil
 				}
-			}
-			return true, nil
-		}); err != nil {
-			t.Fatalf("never saw placeholders: %v", err)
-		}
+				return true, []string{"valid node affinity"}, nil
+			},
+			util.WithoutConditionDump(),
+		)
 	}
 }


### PR DESCRIPTION
test/e2e: add a harness for asynchronous assertions

We have a lot of functional requirements on asynchronus assertions on
top of the need that they assert correctly. Closing over these
requiredments in a helper seems prudent given how common they are in the
test codebase.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @sjenning 

