### PR TITLE
OCPBUGS-35450: Remove KMS V1 provider support for IBM Cloud

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -170,10 +170,6 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 							totalProviderInstances++
 						}
 					}
-				case hyperv1.IBMCloud:
-					if hcp.Spec.SecretEncryption.KMS.IBMCloud != nil {
-						totalProviderInstances = len(hcp.Spec.SecretEncryption.KMS.IBMCloud.KeyList)
-					}
 				}
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove KMS V1 provider support for IBM Cloud

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/projects/OCPBUGS/issues/OCPBUGS-35450

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.