### PR TITLE
OCPBUGS-35513: cluster/core: fix nodepool naming

### DIFF
--- a/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_default_creation_flags_for_cesar.yaml
+++ b/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_default_creation_flags_for_cesar.yaml
@@ -119,7 +119,7 @@ apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool
 metadata:
   creationTimestamp: null
-  name: cesarfakeName
+  name: cesar-fakeName
   namespace: clusters
 spec:
   arch: amd64

--- a/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -116,7 +116,7 @@ apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool
 metadata:
   creationTimestamp: null
-  name: examplefakeName
+  name: example-fakeName
   namespace: clusters
 spec:
   arch: amd64

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -713,6 +713,10 @@ type DefaultNodePoolConstructor func(platformType hyperv1.PlatformType, suffix s
 
 func defaultNodePool(opts *CreateOptions) func(platformType hyperv1.PlatformType, suffix string) *hyperv1.NodePool {
 	return func(platformType hyperv1.PlatformType, suffix string) *hyperv1.NodePool {
+		name := opts.Name
+		if suffix != "" {
+			name = fmt.Sprintf("%s-%s", opts.Name, suffix)
+		}
 		return &hyperv1.NodePool{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "NodePool",
@@ -720,7 +724,7 @@ func defaultNodePool(opts *CreateOptions) func(platformType hyperv1.PlatformType
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: opts.Namespace,
-				Name:      opts.Name + suffix,
+				Name:      name,
 			},
 			Spec: hyperv1.NodePoolSpec{
 				Management: hyperv1.NodePoolManagement{


### PR DESCRIPTION
cluster/core: fix nodepool naming

The dash was accidentally omitted.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Based on https://github.com/openshift/hypershift/pull/4212