### PR TITLE
CNV-30445: KubeVirt: Enable multiqueue by default

### DIFF
--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -725,6 +725,7 @@ type KubevirtNodePoolPlatform struct {
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=Enable;Disable
+	// +kubebuilder:default=Enable
 	NetworkInterfaceMultiQueue *MultiQueueSetting `json:"networkInterfaceMultiqueue,omitempty"`
 
 	// AdditionalNetworks specify the extra networks attached to the nodes

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift/hypershift/api/ibmcapi"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/openshift/hypershift/api/ibmcapi"
 )
 
 const (
@@ -730,6 +731,7 @@ type KubevirtNodePoolPlatform struct {
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=Enable;Disable
+	// +kubebuilder:default=Enable
 	NetworkInterfaceMultiQueue *MultiQueueSetting `json:"networkInterfaceMultiqueue,omitempty"`
 
 	// AdditionalNetworks specify the extra networks attached to the nodes

--- a/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -112,6 +112,7 @@ spec:
       compute:
         cores: 2
         memory: 4Gi
+      networkInterfaceMultiqueue: Enable
       rootVolume:
         persistent:
           size: 32Gi

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -720,6 +720,7 @@ spec:
                             type: string
                         type: object
                       networkInterfaceMultiqueue:
+                        default: Enable
                         description: |-
                           NetworkInterfaceMultiQueue If set to "Enable", virtual network interfaces configured with a virtio bus will also
                           enable the vhost multiqueue feature for network devices. The number of queues created depends on additional
@@ -1880,6 +1881,7 @@ spec:
                             type: string
                         type: object
                       networkInterfaceMultiqueue:
+                        default: Enable
                         description: |-
                           NetworkInterfaceMultiQueue If set to "Enable", virtual network interfaces configured with a virtio bus will also
                           enable the vhost multiqueue feature for network devices. The number of queues created depends on additional

--- a/cmd/nodepool/kubevirt/create.go
+++ b/cmd/nodepool/kubevirt/create.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift/hypershift/cmd/cluster/kubevirt/params"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/hypershift/cmd/cluster/kubevirt/params"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/nodepool/core"
@@ -26,7 +27,8 @@ func DefaultOptions() *RawKubevirtPlatformCreateOptions {
 			RootVolumeSize:       32,
 			AttachDefaultNetwork: pointer.Bool(true),
 		},
-		QoSClass: "Burstable",
+		QoSClass:                   "Burstable",
+		NetworkInterfaceMultiQueue: string(hyperv1.MultiQueueEnable),
 	}
 }
 
@@ -42,7 +44,7 @@ func bindCoreOptions(opts *RawKubevirtPlatformCreateOptions, flags *pflag.FlagSe
 	flags.StringVar(&opts.RootVolumeAccessModes, "root-volume-access-modes", opts.RootVolumeAccessModes, "The access modes of the root volume to use for machines in the NodePool (comma-delimited list)")
 	flags.StringVar(&opts.RootVolumeVolumeMode, "root-volume-volume-mode", opts.RootVolumeVolumeMode, "The volume mode of the root volume to use for machines in the NodePool. Supported values are \"Block\", \"Filesystem\"")
 	flags.StringVar(&opts.CacheStrategyType, "root-volume-cache-strategy", opts.CacheStrategyType, "Set the boot image caching strategy; Supported values:\n- \"None\": no caching (default).\n- \"PVC\": Cache into a PVC; only for QCOW image; ignored for container images")
-	flags.StringVar(&opts.NetworkInterfaceMultiQueue, "network-multiqueue", opts.NetworkInterfaceMultiQueue, `If "Enable", virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. supported values are "Enable" and "Disable"; default = "Disable"`)
+	flags.StringVar(&opts.NetworkInterfaceMultiQueue, "network-multiqueue", opts.NetworkInterfaceMultiQueue, `If "Enable", virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. supported values are "Enable" and "Disable"; default = "Enable"`)
 	flags.StringVar(&opts.QoSClass, "qos-class", opts.QoSClass, `If "Guaranteed", set the limit cpu and memory of the VirtualMachineInstance, to be the same as the requested cpu and memory; supported values: "Burstable" and "Guaranteed"`)
 	flags.StringArrayVar(&opts.AdditionalNetworks, "additional-network", opts.AdditionalNetworks, fmt.Sprintf(`Specify additional network that should be attached to the nodes, the "name" field should point to a multus network attachment definition with the format "[namespace]/[name]", it can be specified multiple times to attach to multiple networks. Supported parameters: %s, example: "name:ns1/nad-foo`, params.Supported(NetworkOpts{})))
 	flags.BoolVar(opts.AttachDefaultNetwork, "attach-default-network", *opts.AttachDefaultNetwork, `Specify if the default pod network should be attached to the nodes. This can only be set if --additional-network is configured`)

--- a/cmd/nodepool/kubevirt/create_test.go
+++ b/cmd/nodepool/kubevirt/create_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"k8s.io/utils/ptr"
+
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 )
 
 func TestRawKubevirtPlatformCreateOptions_Validate(t *testing.T) {
@@ -78,6 +79,68 @@ func TestValidatedKubevirtPlatformCreateOptions_Complete(t *testing.T) {
 				},
 			},
 			expectedError: `failed to parse "--additional-network" flag: unknown param(s): badfield:ns2/nad2`,
+		},
+		{
+			name: "should succeed configuring NetworkInterfaceMultiQueue=Enable",
+			input: RawKubevirtPlatformCreateOptions{
+				KubevirtPlatformOptions: &KubevirtPlatformOptions{
+					Cores:                1,
+					RootVolumeSize:       16,
+					AttachDefaultNetwork: ptr.To(true),
+				},
+				AdditionalNetworks: []string{
+					"name:ns1/nad1",
+					"name:ns2/nad2",
+				},
+				NetworkInterfaceMultiQueue: "Enable",
+			},
+			output: []hypershiftv1beta1.KubevirtNetwork{
+				{
+					Name: "ns1/nad1",
+				},
+				{
+					Name: "ns2/nad2",
+				},
+			},
+		},
+		{
+			name: "should succeed configuring NetworkInterfaceMultiQueue=Disable",
+			input: RawKubevirtPlatformCreateOptions{
+				KubevirtPlatformOptions: &KubevirtPlatformOptions{
+					Cores:                1,
+					RootVolumeSize:       16,
+					AttachDefaultNetwork: ptr.To(true),
+				},
+				AdditionalNetworks: []string{
+					"name:ns1/nad1",
+					"name:ns2/nad2",
+				},
+				NetworkInterfaceMultiQueue: "Disable",
+			},
+			output: []hypershiftv1beta1.KubevirtNetwork{
+				{
+					Name: "ns1/nad1",
+				},
+				{
+					Name: "ns2/nad2",
+				},
+			},
+		},
+		{
+			name: "should fail configuring NetworkInterfaceMultiQueue",
+			input: RawKubevirtPlatformCreateOptions{
+				KubevirtPlatformOptions: &KubevirtPlatformOptions{
+					Cores:                1,
+					RootVolumeSize:       16,
+					AttachDefaultNetwork: ptr.To(true),
+				},
+				AdditionalNetworks: []string{
+					"name:ns1/nad1",
+					"name:ns2/nad2",
+				},
+				NetworkInterfaceMultiQueue: "wrong",
+			},
+			expectedError: `wrong value for the --network-multiqueue parameter. Supported values are "Enable" or "Disable"`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -59397,6 +59397,7 @@ objects:
                               type: string
                           type: object
                         networkInterfaceMultiqueue:
+                          default: Enable
                           description: |-
                             NetworkInterfaceMultiQueue If set to "Enable", virtual network interfaces configured with a virtio bus will also
                             enable the vhost multiqueue feature for network devices. The number of queues created depends on additional
@@ -60560,6 +60561,7 @@ objects:
                               type: string
                           type: object
                         networkInterfaceMultiqueue:
+                          default: Enable
                           description: |-
                             NetworkInterfaceMultiQueue If set to "Enable", virtual network interfaces configured with a virtio bus will also
                             enable the vhost multiqueue feature for network devices. The number of queues created depends on additional


### PR DESCRIPTION
## What this PR does / why we need it
After the performance issue [RHEL-1334](https://issues.redhat.com/browse/RHEL-1334) had solved, multiqueue should be enabled.

## Which issue(s) this PR fixes
Fixes #[CNV-30445](https://issues.redhat.com//browse/CNV-30445)

## Checklist
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.