### PR TITLE
NO-JIRA: remove CI_TESTS_RUNS from e2e script as we now directly pass…

### DIFF
--- a/hack/ci-test-e2e.sh
+++ b/hack/ci-test-e2e.sh
@@ -1,20 +1,11 @@
 #!/usr/bin/env bash
-#
-# This script takes the first argument and use it as the input for -test.run.
+
 
 set -euo pipefail
 
 set -o monitor
 
 set -x
-
-CI_TESTS_RUN=${1:-}
-if [ -z  ${CI_TESTS_RUN} ]
-then
-      echo "Running all tests"
-else
-      echo "Running tests matching ${CI_TESTS_RUN}"
-fi
 
 generate_junit() {
   # propagate SIGTERM to the `test-e2e` process


### PR DESCRIPTION
remove CI_TESTS_RUNS from e2e script as it is now directly passed in test.run flag . 
PR causing this change  -> https://github.com/openshift/release/pull/53047/files

this causes a confusing log like shown below 
```
hack/ci-test-e2e.sh -test.v '-test.run=^TestNodePool.*' ...........
+ CI_TESTS_RUN=-test.v
+ '[' -z -test.v ']'
+ echo 'Running tests matching -test.v'
Running tests matching -test.v
```

this will log out that were running tests matching test.v (currently we use the first argument passed into the script) when in actual fact the test are now running whatever was set in the tests.run flag

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.