### PR TITLE
HOSTEDCP-1684: remove CLI requirement for RG flag when NSG ID is supp…

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -76,16 +76,6 @@ func NewCreateCommand() *cobra.Command {
 		Use:          "azure",
 		Short:        "Creates Azure infrastructure resources for a cluster",
 		SilenceUsage: true,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			// Check if the network security group is set and the resource group is not
-			nsg, _ := cmd.Flags().GetString("network-security-group-id")
-			rg, _ := cmd.Flags().GetString("resource-group-name")
-
-			if nsg != "" && rg == "" {
-				fmt.Println("Error: Flag --resource-group-name is required when using --network-security-group-id")
-				os.Exit(1)
-			}
-		},
 	}
 
 	opts := CreateInfraOptions{


### PR DESCRIPTION


**What this PR does / why we need it**: removes CLI requirement for RG flag when NSG ID is supplied

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1684](https://issues.redhat.com/browse/HOSTEDCP-1684)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.