### PR TITLE
NO-JIRA: test/e2e: reduce logging for ssh and oc adm inspect

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -480,10 +480,8 @@ func (i *OCAdmInspect) Run(ctx context.Context, cmdArgs ...string) {
 	}
 	allArgs = append(allArgs, cmdArgs...)
 	cmd := exec.CommandContext(ctx, i.oc, allArgs...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		i.log.Info("oc adm inspect returned an error", "args", allArgs, "error", err.Error(), "output", string(out))
-	}
+	// oc adm inspect command always returns an error so ignore
+	cmd.CombinedOutput()
 }
 
 type OCAdmNodeLogs struct {

--- a/test/e2e/util/dump/copy-machine-journals.sh
+++ b/test/e2e/util/dump/copy-machine-journals.sh
@@ -49,7 +49,7 @@ fi
 
 function retryonfailure {
   for i in $(seq 1 10); do
-    echo "Attempt #${i}: $@"
+    #echo "Attempt #${i}: $@"
     if ! "$@"; then
       sleep 1
     else 
@@ -60,9 +60,9 @@ function retryonfailure {
 }
 
 function dump_config {
-  echo "Failed to ssh to AWS instance, dumping ssh configuration"
   machine_ip="${1:-}"
   config_file="${2:-}"
+  echo "Failed to ssh to AWS instance ${machine_ip}, dumping ssh configuration"
   cat "${config_file}" > "${DEST_DIR}/ssh-config-${machine_ip}.txt"
   return 1
 }
@@ -80,6 +80,7 @@ Host bastion
     StrictHostKeyChecking  no
     PasswordAuthentication no
     UserKnownHostsFile     /dev/null
+    LogLevel               ERROR
 Host machine
     User                   core
     Hostname               ${machine_ip}
@@ -87,6 +88,7 @@ Host machine
     PasswordAuthentication no
     UserKnownHostsFile     /dev/null
     ProxyJump              bastion
+    LogLevel               ERROR
 EOF
 
   if retryonfailure ssh -F "${config_file}" -n machine "sudo journalctl > /tmp/journal.log && gzip -f /tmp/journal.log" || dump_config "${machine_ip}" "${config_file}"; then


### PR DESCRIPTION
Removes logging like
```
Attempt #2: ssh -F /tmp/tmp.rws1F4Y6V1 -n machine sudo journalctl > /tmp/journal.log && gzip -f /tmp/journal.log
Warning: Permanently added '3.89.9.23' (ED25519) to the list of known hosts.
Warning: Permanently added '10.0.136.42' (ED25519) to the list of known hosts.
```
and
```
    logger.go:146: 2024-06-18T12:36:13.241Z	INFO	oc adm inspect returned an error	{"args": ["adm", "inspect", "--dest-dir", "/logs/artifacts/TestCreateClusterCustomConfig_Teardown/hostedcluster-example-d8np5", "--kubeconfig", "/tmp/kubeconfig-2522436477", "daemonset.apps,deployment.apps,replicaset.apps,statefulset.apps,job.batch,configmap,endpoints,event,persistentvolumeclaim,pod,replicationcontroller,service,customresourcedefinition.apiextensions.k8s.io,controllerrevision.apps,clusteroperator.config.openshift.io,namespace,node,persistentvolume,clusterrole.rbac.authorization.k8s.io,clusterrolebinding.rbac.authorization.k8s.io,role.rbac.authorization.k8s.io,rolebinding.rbac.authorization.k8s.io,securitycontextconstraints.security.openshift.io,csidriver.storage.k8s.io,csinode.storage.k8s.io,storageclass.storage.k8s.io,volumeattachment.storage.k8s.io,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontent.snapshot.storage.k8s.io"], "error": "exit status 1", "output": "Gathering data for ns/openshift-monitoring...\nWarning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+\nGathering data for ns/openshift-console-operator...\nGathering data for ns/openshift-console...\nGathering data for ns/openshift-cluster-storage-operator...\nGathering data for ns/openshift-dns-operator...\nGathering data for ns/openshift-dns...\nGathering data for ns/openshift-image-registry...\nGathering data for ns/openshift-ingress-operator...\nGathering data for ns/openshift-ingress...\nGathering data for ns/openshift-ingress-canary...\nGathering data for ns/openshift-insights...\nGathering data for ns/openshift-config...\nGathering data for ns/openshift-config-managed...\nGathering data for ns/openshift-kube-apiserver-operator...\nGathering data for ns/openshift-kube-apiserver...\nGathering data for ns/openshift-kube-controller-manager...\nGathering data for ns/openshift-kube-controller-manager-operator...\nGathering data for ns/openshift-kube-scheduler...\nGathering data for ns/openshift-kube-scheduler-operator...\nGathering data for ns/openshift-kube-storage-version-migrator...\nGathering data for ns/openshift-kube-storage-version-migrator-operator...\nGathering data for ns/openshift-user-workload-monitoring...\nGathering data for ns/openshift-multus...\nGathering data for ns/openshift-ovn-kubernetes...\nGathering data for ns/openshift-host-network...\nGathering data for ns/openshift-network-diagnostics...\nGathering data for ns/openshift-network-node-identity...\nGathering data for ns/openshift-network-operator...\nGathering data for ns/openshift-cloud-network-config-controller...\nGathering data for ns/openshift-cluster-node-tuning-operator...\nGathering data for ns/openshift-apiserver-operator...\nGathering data for ns/openshift-apiserver...\nGathering data for ns/openshift-controller-manager-operator...\nGathering data for ns/openshift-controller-manager...\nGathering data for ns/openshift-cluster-samples-operator...\nGathering data for ns/openshift-operator-lifecycle-manager...\nGathering data for ns/openshift-service-ca-operator...\nGathering data for ns/openshift-service-ca...\nGathering data for ns/openshift-cluster-csi-drivers...\nGathering data for ns/default...\nGathering data for ns/kube-node-lease...\nGathering data for ns/kube-public...\nGathering data for ns/kube-system...\nGathering data for ns/openshift...\nGathering data for ns/openshift-authentication...\nGathering data for ns/openshift-authentication-operator...\nGathering data for ns/openshift-cloud-controller-manager...\nGathering data for ns/openshift-cloud-credential-operator...\nGathering data for ns/openshift-cluster-machine-approver...\nGathering data for ns/openshift-cluster-version...\nGathering data for ns/openshift-config-operator...\nGathering data for ns/openshift-console-user-settings...\nGathering data for ns/openshift-etcd...\nGathering data for ns/openshift-infra...\nGathering data for ns/openshift-machine-api...\nGathering data for ns/openshift-machine-config-operator...\nGathering data for ns/openshift-marketplace...\nGathering data for ns/openshift-node...\nGathering data for ns/openshift-operators...\nGathering data for ns/openshift-route-controller-manager...\nWrote inspect data to /logs/artifacts/TestCreateClusterCustomConfig_Teardown/hostedcluster-example-d8np5.\nerror: inspection completed with the errors occurred while gathering data:\n    [skipping gathering secrets/support due to error: secrets \"support\" not found, skipping gathering sharedconfigmaps.sharedresource.openshift.io due to error: the server doesn't have a resource type \"sharedconfigmaps\", skipping gathering sharedsecrets.sharedresource.openshift.io due to error: the server doesn't have a resource type \"sharedsecrets\"]\n"}
```