### PR TITLE
[release-4.15] OCPBUGS-35815: Add hypershift-cluster-version-operator image to release providers

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -28,11 +28,17 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imagepr
 		CLIImage:                releaseImageProvider.GetImage("cli"),
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
 		ControlPlaneImage:       util.HCPControlPlaneReleaseImage(hcp),
-		Image:                   hcp.Spec.ReleaseImage,
+		Image:                   releaseImageProvider.GetImage("cluster-version-operator"),
 		OwnerRef:                config.OwnerRefFrom(hcp),
 		ClusterID:               hcp.Spec.ClusterID,
 		PlatformType:            hcp.Spec.Platform.Type,
 	}
+	// fallback to hcp.Spec.ReleaseImage if "cluster-version-operator" image is not available.
+	// This could happen for example in local dev enviroments if the "OPERATE_ON_RELEASE_IMAGE" env variable is not set.
+	if p.Image == "" {
+		p.Image = hcp.Spec.ReleaseImage
+	}
+
 	if enableCVOManagementClusterMetricsAccess {
 		p.DeploymentConfig.AdditionalLabels = map[string]string{
 			config.NeedMetricsServerAccessLabel: "true",

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -378,6 +378,7 @@ func NewStartCommand() *cobra.Command {
 			"aws-kms-provider":               awsKMSProviderImage,
 			util.CPOImageName:                cpoImage,
 			util.CPPKIOImageName:             cpoImage,
+			"cluster-version-operator":       os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
 		}
 		for name, image := range imageOverrides {
 			componentImages[name] = image


### PR DESCRIPTION
**What this PR does / why we need it**:
cherry-pick of https://github.com/openshift/hypershift/pull/4185

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.