### PR TITLE
HOSTEDCP-1709: test/e2e: updates to the eventually construct

### DIFF
--- a/test/e2e/nodepool_kv_cache_image_test.go
+++ b/test/e2e/nodepool_kv_cache_image_test.go
@@ -56,11 +56,13 @@ func (k KubeVirtCacheTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []core
 			err := k.client.Get(k.ctx, util.ObjectKey(&nodePool), np)
 			return np, err
 		},
-		func(pool *hyperv1.NodePool) (done bool, reasons []string, err error) {
-			if np.Status.Platform != nil && np.Status.Platform.KubeVirt != nil && np.Status.Platform.KubeVirt.CacheName != "" {
-				return true, nil, nil
-			}
-			return false, []string{"no cache data volume set"}, nil
+		[]e2eutil.Predicate[*hyperv1.NodePool]{
+			func(pool *hyperv1.NodePool) (done bool, reasons string, err error) {
+				if np.Status.Platform != nil && np.Status.Platform.KubeVirt != nil && np.Status.Platform.KubeVirt.CacheName != "" {
+					return true, "", nil
+				}
+				return false, "no cache data volume set", nil
+			},
 		},
 	)
 

--- a/test/integration/hosted_cluster_sizing_test.go
+++ b/test/integration/hosted_cluster_sizing_test.go
@@ -232,15 +232,15 @@ func waitForHostedClusterToHaveSize(t *testing.T, ctx context.Context, client hy
 			{Type: hypershiftv1beta1.ClusterSizeTransitionPending, Status: metav1.ConditionFalse, Reason: "ClusterSizeTransitioned"},
 			{Type: hypershiftv1beta1.ClusterSizeTransitionRequired, Status: metav1.ConditionFalse, Reason: hypershiftv1beta1.AsExpectedReason},
 		},
-		func(hostedCluster *hypershiftv1beta1.HostedCluster) (done bool, reason []string, err error) {
+		func(hostedCluster *hypershiftv1beta1.HostedCluster) (done bool, reason string, err error) {
 			label, present := hostedCluster.ObjectMeta.Labels[hypershiftv1beta1.HostedClusterSizeLabel]
 			if !present {
-				return false, []string{fmt.Sprintf("hostedCluster.metadata.labels[%s] missing", hypershiftv1beta1.HostedClusterSizeLabel)}, nil
+				return false, fmt.Sprintf("hostedCluster.metadata.labels[%s] missing", hypershiftv1beta1.HostedClusterSizeLabel), nil
 			}
 			if label != size {
-				return false, []string{fmt.Sprintf("hostedCluster.metadata.labels[%s]=%s, wanted %s", hypershiftv1beta1.HostedClusterSizeLabel, label, size)}, nil
+				return false, fmt.Sprintf("hostedCluster.metadata.labels[%s]=%s, wanted %s", hypershiftv1beta1.HostedClusterSizeLabel, label, size), nil
 			}
-			return true, []string{fmt.Sprintf("hostedCluster.metadata.labels[%s]=%s", hypershiftv1beta1.HostedClusterSizeLabel, label)}, nil
+			return true, fmt.Sprintf("hostedCluster.metadata.labels[%s]=%s", hypershiftv1beta1.HostedClusterSizeLabel, label), nil
 		},
 	)
 }
@@ -268,7 +268,7 @@ func waitForHostedClusterCondition(t *testing.T, ctx context.Context, client hyp
 		func(ctx context.Context) (*hypershiftv1beta1.HostedCluster, error) {
 			return client.HypershiftV1beta1().HostedClusters(namespace).Get(ctx, name, metav1.GetOptions{})
 		},
-		util.AggregatePredicates(predicates...),
+		predicates,
 		util.WithFilteredConditionDump(
 			util.Condition{Type: hypershiftv1beta1.ClusterSizeTransitionPending},
 			util.Condition{Type: hypershiftv1beta1.ClusterSizeComputed},

--- a/test/integration/hosted_cluster_sizing_test.go
+++ b/test/integration/hosted_cluster_sizing_test.go
@@ -269,10 +269,6 @@ func waitForHostedClusterCondition(t *testing.T, ctx context.Context, client hyp
 			return client.HypershiftV1beta1().HostedClusters(namespace).Get(ctx, name, metav1.GetOptions{})
 		},
 		predicates,
-		util.WithFilteredConditionDump(
-			util.Condition{Type: hypershiftv1beta1.ClusterSizeTransitionPending},
-			util.Condition{Type: hypershiftv1beta1.ClusterSizeComputed},
-			util.Condition{Type: hypershiftv1beta1.ClusterSizeTransitionRequired},
-		),
+		util.WithoutConditionDump(),
 	)
 }


### PR DESCRIPTION
test/e2e: add post-summary, verbosity toggle to eventually

We now summarize *only* the failing predicates when we fail to achieve
our target. Also, the mid-stream summarization is toggled with an
environment variable, which we can default to verbose but turn down in
CI.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

test/e2e: round durations for brevity

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @sjenning 