### PR TITLE
HOSTEDCP-1716: When running the HO locally it should no required a running pod

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,7 +9,7 @@
 
 2. Build HyperShift.
 
-        # requires go v1.16+
+        # requires go v1.22+
         $ make build
 
 3. Install HyperShift in development mode which causes the operator deployment

--- a/docs/content/contribute/run-hypershift-operator-locally.md
+++ b/docs/content/contribute/run-hypershift-operator-locally.md
@@ -17,7 +17,9 @@ To run the HyperShift Operator locally, follow these steps:
 
 2. Build HyperShift.
 
-    make build
+        # requires go v1.16+
+        $ make build
+
 
 3. Install HyperShift in development mode which causes the operator deployment to be deployment scaled to zero so that it doesn't conflict with your local operator process (see [Prerequisites](../getting-started.md#prerequisites)):
 

--- a/docs/content/contribute/run-hypershift-operator-locally.md
+++ b/docs/content/contribute/run-hypershift-operator-locally.md
@@ -9,7 +9,7 @@ To run the HyperShift Operator locally, follow these steps:
 1. Ensure that the `KUBECONFIG` environment variable is set to a management cluster where HyperShift has not been installed yet.
 
   ```shell linenums="1"
-   export KUBECONFIG=kubeconfig
+   export KUBECONFIG="/path/to/your/kubeconfig"
   ```
 
 2. Build HyperShift.
@@ -26,7 +26,7 @@ hypershift install render | oc delete -f -
 4. Install HyperShift in development mode which causes the operator deployment to be deployment scaled to zero so that it doesn't conflict with your local operator process (see [Prerequisites](../getting-started.md#prerequisites)):
 
 ```shell linenums="1"
-REGION=us-east-1
+REGION=your-region
 BUCKET_NAME=your-bucket-name
 AWS_CREDS="$HOME/.aws/credentials"
 

--- a/docs/content/contribute/run-hypershift-operator-locally.md
+++ b/docs/content/contribute/run-hypershift-operator-locally.md
@@ -17,8 +17,13 @@ To run the HyperShift Operator locally, follow these steps:
         # requires go v1.22+
         $ make build
 
+3. Remove previous artifacts (if any). The command below ensures any existing artifacts are cleared before proceeding with installation:
 
-3. Install HyperShift in development mode which causes the operator deployment to be deployment scaled to zero so that it doesn't conflict with your local operator process (see [Prerequisites](../getting-started.md#prerequisites)):
+```shell linenums="1"
+hypershift install render | oc delete -f -
+```
+
+4. Install HyperShift in development mode which causes the operator deployment to be deployment scaled to zero so that it doesn't conflict with your local operator process (see [Prerequisites](../getting-started.md#prerequisites)):
 
 ```shell linenums="1"
 REGION=us-east-1
@@ -29,13 +34,13 @@ AWS_CREDS="$HOME/.aws/credentials"
   --oidc-storage-provider-s3-bucket-name $BUCKET_NAME \
   --oidc-storage-provider-s3-credentials $AWS_CREDS \
   --oidc-storage-provider-s3-region $REGION \
-  --enable-defaulting-webhook=false
-  --enable-conversion-webhook=false
-  --enable-validating-webhook=false
+  --enable-defaulting-webhook=false \
+  --enable-conversion-webhook=false \
+  --enable-validating-webhook=false \
   --development=true
 ```
 
-4. Run the HyperShift operator locally.
+5. Run the HyperShift operator locally.
 
 ```shell linenums="1"
 set -euo pipefail

--- a/docs/content/contribute/run-hypershift-operator-locally.md
+++ b/docs/content/contribute/run-hypershift-operator-locally.md
@@ -2,9 +2,6 @@
 title: Run the hypershift-operator locally
 ---
 
-# Overview
-The Hypershift operator contains a set of controllers that manage the control plane components of a hosted control plane cluster created with the Hypershift Installer.
-
 ## Run the HyperShift Operator locally
 
 To run the HyperShift Operator locally, follow these steps:
@@ -17,7 +14,7 @@ To run the HyperShift Operator locally, follow these steps:
 
 2. Build HyperShift.
 
-        # requires go v1.16+
+        # requires go v1.22+
         $ make build
 
 
@@ -28,7 +25,7 @@ REGION=us-east-1
 BUCKET_NAME=your-bucket-name
 AWS_CREDS="$HOME/.aws/credentials"
 
-hypershift install \
+./bin/hypershift install \
   --oidc-storage-provider-s3-bucket-name $BUCKET_NAME \
   --oidc-storage-provider-s3-credentials $AWS_CREDS \
   --oidc-storage-provider-s3-region $REGION \

--- a/docs/content/contribute/run-locally.md
+++ b/docs/content/contribute/run-locally.md
@@ -1,22 +1,59 @@
 ---
-title: Run operators locally
+title: Run the hypershift-operator locally
 ---
 
-# How to run the HyperShift Operator in a local process
+# Overview
+The Hypershift operator contains a set of controllers that manage the control plane components of a hosted control plane cluster created with the Hypershift Installer.
 
-1. Ensure the `KUBECONFIG` environment variable points to a management cluster
-   with no HyperShift installed yet.
+## Run the HyperShift Operator locally
+
+To run the HyperShift Operator locally, follow these steps:
+
+1. Ensure that the `KUBECONFIG` environment variable is set to a management cluster where HyperShift has not been installed yet.
+
+  ```shell linenums="1"
+   export KUBECONFIG=kubeconfig
+  ```
 
 2. Build HyperShift.
 
-        make build
+    make build
 
-3. Install HyperShift in development mode which causes the operator deployment
-   to be deployment scaled to zero so that it doesn't conflict with your local
-   operator process.
+3. Install HyperShift in development mode which causes the operator deployment to be deployment scaled to zero so that it doesn't conflict with your local operator process (see [Prerequisites](../getting-started.md#prerequisites)):
 
-        bin/hypershift install --development
+```shell linenums="1"
+REGION=us-east-1
+BUCKET_NAME=your-bucket-name
+AWS_CREDS="$HOME/.aws/credentials"
+
+hypershift install \
+  --oidc-storage-provider-s3-bucket-name $BUCKET_NAME \
+  --oidc-storage-provider-s3-credentials $AWS_CREDS \
+  --oidc-storage-provider-s3-region $REGION \
+  --enable-defaulting-webhook=false
+  --enable-conversion-webhook=false
+  --enable-validating-webhook=false
+  --development=true
+```
 
 4. Run the HyperShift operator locally.
 
-        bin/hypershift-operator run
+```shell linenums="1"
+set -euo pipefail
+export METRICS_SET="Telemetry"
+
+export MY_NAMESPACE=hypershift
+export MY_NAME=operator
+
+./bin/hypershift-operator \
+  run \
+  --metrics-addr=0 \
+  --enable-ocp-cluster-monitoring=false \
+  --enable-ci-debug-output=true \
+  --private-platform=AWS \
+  --enable-ci-debug-output=true \
+  --oidc-storage-provider-s3-bucket-name=${BUCKET_NAME} \
+  --oidc-storage-provider-s3-region=${REGION} \
+  --oidc-storage-provider-s3-credentials=$HOME/.aws/credentials \
+  --control-plane-operator-image=quay.io/hypershift/hypershift:latest
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -263,4 +263,5 @@ nav:
   - 'Onboard a Platform': contribute/onboard-a-platform.md
   - 'Run Tests': contribute/run-tests.md
   - 'Develop in Cluster': contribute/develop_in_cluster.md
+  - 'Run hypershift-operator locally': contribute/run-locally.md
   - 'Conotribute to docs': contribute/contribute-docs.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -263,5 +263,5 @@ nav:
   - 'Onboard a Platform': contribute/onboard-a-platform.md
   - 'Run Tests': contribute/run-tests.md
   - 'Develop in Cluster': contribute/develop_in_cluster.md
-  - 'Run hypershift-operator locally': contribute/run-locally.md
-  - 'Conotribute to docs': contribute/contribute-docs.md
+  - 'Run hypershift-operator locally': contribute/run-hypershift-operator-locally.md
+  - 'Contribute to docs': contribute/contribute-docs.md


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR covers the steps to run the HyperShift Operator locally without needing access to a full production environment.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-1716](https://issues.redhat.com//browse/HOSTEDCP-1716)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.