### PR TITLE
OCPBUGS-36188: kubevirt-csi-driver: Pass infra kubeconfig in case of external infra

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -324,7 +324,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, image, hcpName, openShif
 	if openShiftTrustedCABundleConfigMapForCPOExists {
 		util.DeploymentAddOpenShiftTrustedCABundleConfigMap(deployment)
 	}
-	if isExternalInfraKv(hcp) {
+	if IsExternalInfraKv(hcp) {
 		// injects the kubevirt credentials secret volume, volume mount path, and appends cli arg.
 		util.DeploymentAddKubevirtInfraCredentials(deployment)
 	}
@@ -461,7 +461,7 @@ func buildHCCClusterSignerCA(v *corev1.Volume) {
 	}
 }
 
-func isExternalInfraKv(hcp *hyperv1.HostedControlPlane) bool {
+func IsExternalInfraKv(hcp *hyperv1.HostedControlPlane) bool {
 	if hcp.Spec.Platform.Kubevirt != nil &&
 		hcp.Spec.Platform.Kubevirt.Credentials != nil &&
 		hcp.Spec.Platform.Kubevirt.Credentials.InfraKubeConfigSecret != nil &&


### PR DESCRIPTION
When an external infra cluster topology is being used with the kubevirt provider, In which the guest nodes are being created on a different cluster than the mgmt cluster, the `kubevirt-csi-driver` container should be provided with an additional argument of `--infra-cluster-kubeconfig`, which should be mount on the container from the `kubevirt-infra-credentials` secret in the HCP namespace. Also, in the 'driver-config' ConfigMap, the key of `infraClusterNamespace` should be set to be the namespace of the VMs on the external infra cluster, not the HCP namespace.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.