### PR TITLE
HOSTEDCP-1778: Enable MultiArch flag by default

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -44,6 +44,7 @@ type RawCreateOptions struct {
 	EnableProxy             bool
 	SingleNATGateway        bool
 	MultiArch               bool
+	SkipMultiArchImageCheck bool
 }
 
 // validatedCreateOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -359,6 +360,7 @@ func DefaultOptions() *RawCreateOptions {
 		RootVolumeType: "gp3",
 		RootVolumeSize: 120,
 		EndpointAccess: string(hyperv1.Public),
+		MultiArch:      true,
 	}
 }
 
@@ -388,6 +390,7 @@ func BindDeveloperOptions(opts *RawCreateOptions, flags *flag.FlagSet) {
 	bindCoreOptions(opts, flags)
 	flags.StringVar(&opts.IAMJSON, "iam-json", opts.IAMJSON, "Path to file containing IAM information for the cluster. If not specified, IAM will be created")
 	flags.BoolVar(&opts.SingleNATGateway, "single-nat-gateway", opts.SingleNATGateway, "If enabled, only a single NAT gateway is created, even if multiple zones are specified")
+	flags.BoolVar(&opts.SkipMultiArchImageCheck, "skip-multi-arch-image-check", opts.SkipMultiArchImageCheck, "If enabled, skips checking if the release image is multi-arch for multi-arch HCs; this should only be used for unit testing.")
 	opts.Credentials.BindFlags(flags)
 }
 
@@ -467,6 +470,11 @@ func ValidateCreateCredentialInfo(opts awsutil.AWSCredentialsOptions, credential
 
 // validateMultiArchRelease validates a release image or release stream is multi-arch if the multi-arch flag is set
 func validateMultiArchRelease(ctx context.Context, releaseImage, releaseStream, pullSecretFile string, awsOpts *RawCreateOptions) error {
+	// Skip checking if the release image is multi-arch in unit testing
+	if awsOpts.SkipMultiArchImageCheck {
+		return nil
+	}
+
 	// Validate the release image is multi-arch when the multi-arch flag is set and a release image is provided
 	if awsOpts.MultiArch && len(releaseImage) > 0 {
 		pullSecret, err := os.ReadFile(pullSecretFile)

--- a/cmd/cluster/aws/create_test.go
+++ b/cmd/cluster/aws/create_test.go
@@ -231,6 +231,7 @@ func TestCreateCluster(t *testing.T) {
 				"--control-plane-operator-image=fakeCPOImage",
 				"--release-image=fakeReleaseImage",
 				"--annotations=hypershift.openshift.io/cleanup-cloud-resources=true",
+				"--skip-multi-arch-image-check=true",
 			},
 		},
 	} {

--- a/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_default_creation_flags_for_cesar.yaml
+++ b/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_default_creation_flags_for_cesar.yaml
@@ -68,7 +68,7 @@ spec:
         vpc: fakeVPCID
         zone: fakeName
       endpointAccess: Public
-      multiArch: false
+      multiArch: true
       region: us-east-2
       rolesRef:
         controlPlaneOperatorARN: fakeControlPlaneOperatorARN

--- a/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -65,7 +65,7 @@ spec:
         vpc: fakeVPCID
         zone: fakeName
       endpointAccess: Public
-      multiArch: false
+      multiArch: true
       region: us-east-1
       rolesRef:
         controlPlaneOperatorARN: fakeControlPlaneOperatorARN


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable MultiArch flag by default

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1778](https://issues.redhat.com//browse/HOSTEDCP-1778)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.