### PR TITLE
WIP: HOSTEDCP-1737: Use a fixed static IP for dataplane remote-kas HAProxy in shared-ingress mode

### DIFF
--- a/hypershift-operator/controllers/sharedingress/manifests.go
+++ b/hypershift-operator/controllers/sharedingress/manifests.go
@@ -26,6 +26,15 @@ func RouterConfigurationConfigMap() *corev1.ConfigMap {
 	}
 }
 
+func RouterStaticIPsMappingConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "static-ips-mapping",
+			Namespace: RouterNamespace,
+		},
+	}
+}
+
 func RouterPublicService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/hypershift-operator/controllers/sharedingress/router_config.template
+++ b/hypershift-operator/controllers/sharedingress/router_config.template
@@ -22,7 +22,7 @@ frontend dataplane-kas-svc
   tcp-request content accept if { req_ssl_hello_type 1 }
 
   {{- range .Backends }}
-  acl is_{{ .Name }} dst {{ .SVCIP }}
+  acl is_{{ .Name }} dst {{ .DataPlaneStaticIP }}
   {{- end }}
   {{- range .Backends }}
   use_backend {{ .Name }} if is_{{ .Name }}

--- a/hypershift-operator/controllers/sharedingress/router_test.go
+++ b/hypershift-operator/controllers/sharedingress/router_test.go
@@ -145,6 +145,11 @@ func TestGenerateConfig(t *testing.T) {
 		return []string{svc.Name}
 	}
 
+	ipsMapping := map[string]string{
+		testNamespace1: "172.0.0.1",
+		testNamespace2: "172.0.0.2",
+	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
@@ -163,9 +168,9 @@ func TestGenerateConfig(t *testing.T) {
 				Client:         fakeClient,
 				createOrUpdate: upsert.New(false).CreateOrUpdate,
 			}
-			config, _, err := r.generateConfig(ctx.Background())
+			config, _, err := r.generateConfig(ctx.Background(), ipsMapping)
 			g.Expect(err).ToNot(HaveOccurred())
-			testutil.CompareWithFixture(t, config)
+			testutil.CompareWithFixture(t, config, testutil.WithExtension(".cfg"))
 		})
 	}
 }

--- a/hypershift-operator/controllers/sharedingress/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.cfg
+++ b/hypershift-operator/controllers/sharedingress/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.cfg
@@ -20,8 +20,8 @@ frontend dataplane-kas-svc
   bind :::6443 v4v6 accept-proxy
   tcp-request inspect-delay 5s
   tcp-request content accept if { req_ssl_hello_type 1 }
-  acl is_test-hc1-kube-apiserver dst 4.4.4.4
-  acl is_test-hc2-kube-apiserver dst 4.4.4.4
+  acl is_test-hc1-kube-apiserver dst 172.0.0.1
+  acl is_test-hc2-kube-apiserver dst 172.0.0.2
   use_backend test-hc1-kube-apiserver if is_test-hc1-kube-apiserver
   use_backend test-hc2-kube-apiserver if is_test-hc2-kube-apiserver
 

--- a/support/testutil/testutil.go
+++ b/support/testutil/testutil.go
@@ -74,6 +74,12 @@ type options struct {
 
 type option func(*options)
 
+func WithExtension(extension string) option {
+	return func(opts *options) {
+		opts.Extension = extension
+	}
+}
+
 // golden determines the golden file to use
 func golden(t *testing.T, opts *options) (string, error) {
 	if opts.Extension == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

The shared ingress controller now assigns a fixed static IP for each Hosted Cluster. This IP is used as the destination IP for requests sent from the data-plane through the HAproxy using the proxy protocol. This is then caught by the shared ingress router and used to discriminate which HostedCluster's KAS the request should be routed to.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.