### PR TITLE
NO-JIRA: cmd: add support to configure machine networts via CLI

### DIFF
--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -100,6 +100,7 @@ func TestCreateCluster(t *testing.T) {
 				"--release-image=fakeReleaseImage",
 				"--annotations=hypershift.openshift.io/cleanup-cloud-resources=true",
 				"--render-sensitive",
+				"--machine-cidr=192.168.25.0/24",
 			},
 		},
 	} {

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
@@ -44,6 +44,8 @@ spec:
   networking:
     clusterNetwork:
     - cidr: 10.132.0.0/14
+    machineNetwork:
+    - cidr: 192.168.25.0/24
     networkType: OVNKubernetes
     serviceNetwork:
     - cidr: 172.31.0.0/16


### PR DESCRIPTION
**What this PR does / why we need it**:

Empty by default for backward compatibility, we can now configure the
Machine networks via the CLI.

This will become handy for the OpenStack platform, where when we let the
CAPI provider (namely CAPO) to handle the networks, we still need to
provide a machine network CIDR and using the CLI seems a consistent way
to do so.
