### PR TITLE
NO-JIRA: skip multiarch test before HC creation

### DIFF
--- a/test/e2e/nodepool_arm64_create_test.go
+++ b/test/e2e/nodepool_arm64_create_test.go
@@ -22,12 +22,6 @@ func NewNodePoolArm64CreateTest(hostedCluster *hyperv1.HostedCluster) *NodePoolA
 }
 
 func (arm64np *NodePoolArm64CreateTest) Setup(t *testing.T) {
-	if globalOpts.Platform != hyperv1.AWSPlatform {
-		t.Skip("test only supported on platform AWS")
-	}
-	if arm64np.hostedCluster.Spec.Platform.AWS.MultiArch != true {
-		t.Skip("test only supported on multi-arch clusters")
-	}
 	t.Log("Starting NodePoolArm64CreateTest.")
 }
 

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -135,6 +135,15 @@ func TestNodePoolMultiArch(t *testing.T) {
 	t.Parallel()
 	nodePoolTestCasesPerHostedCluster := []HostedClusterNodePoolTestCases{
 		{
+			setup: func(t *testing.T) {
+				if !globalOpts.configurableClusterOptions.AWSMultiArch {
+					t.Skip("test only supported on multi-arch clusters")
+				}
+				if globalOpts.Platform != hyperv1.AWSPlatform {
+					t.Skip("test only supported on platform AWS")
+				}
+				t.Log("Starting NodePoolArm64CreateTest.")
+			},
 			build: func(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts e2eutil.PlatformAgnosticOptions) []NodePoolTestCase {
 				return []NodePoolTestCase{
 					{


### PR DESCRIPTION
**What this PR does / why we need it**: skips multiarch test before HC creation. Now we skip the testcase which is called after setting up the hc for it. With this change we will avoid creating an unnecessary HC during our e2e.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.