### PR TITLE
HOSTEDCP-1790: Expose the KAS services through port 443

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -8,7 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	cmdutil "github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/pkg/version"
-	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
@@ -451,7 +451,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 
 	if o.EnableCVOManagementClusterMetricsAccess {
 		envVars = append(envVars, corev1.EnvVar{
-			Name:  config.EnableCVOManagementClusterMetricsAccessEnvVar,
+			Name:  constants.EnableCVOManagementClusterMetricsAccessEnvVar,
 			Value: "1",
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/autoscaler/reconcile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,9 +55,9 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 		// we might end up locked with three nodes.
 		"--skip-nodes-with-local-storage=false",
 		"--alsologtostderr",
-		fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),
-		fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
-		fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
+		fmt.Sprintf("--leader-elect-lease-duration=%s", constants.RecommendedLeaseDuration),
+		fmt.Sprintf("--leader-elect-retry-period=%s", constants.RecommendedRetryPeriod),
+		fmt.Sprintf("--leader-elect-renew-deadline=%s", constants.RecommendedRenewDeadline),
 		"--balance-similar-node-groups=true",
 		"--v=4",
 	}
@@ -195,10 +196,10 @@ func ReconcileAutoscalerDeployment(deployment *appsv1.Deployment, hcp *hyperv1.H
 
 	deploymentConfig := config.DeploymentConfig{
 		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
+			constants.NeedManagementKASAccessLabel: "true",
 		},
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/cco/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cco/reconcile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
 )
@@ -63,7 +64,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 		apiPort:                 pointer.Int32(util.KASPodPort(hcp)),
 		deploymentConfig: config.DeploymentConfig{
 			Scheduling: config.Scheduling{
-				PriorityClass: config.DefaultPriorityClass,
+				PriorityClass: constants.DefaultPriorityClass,
 			},
 			SetDefaultSecurityContext: setDefaultSecurityContext,
 			Resources: config.ResourcesSpec{

--- a/control-plane-operator/controllers/hostedcontrolplane/cco/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cco/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -89,7 +89,7 @@ spec:
         - /usr/bin/control-plane-operator
         - availability-prober
         - --target
-        - https://kube-apiserver:6443/readyz
+        - https://kube-apiserver:443/readyz
         - --kubeconfig=/var/kubeconfig/kubeconfig
         - --required-api=operator.openshift.io,v1,CloudCredential
         - --wait-for-infrastructure-resource

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/params.go
@@ -8,6 +8,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 )
 
 type AWSParams struct {
@@ -45,7 +46,7 @@ func NewAWSParams(hcp *hyperv1.HostedControlPlane) *AWSParams {
 		},
 	}
 	p.DeploymentConfig.AdditionalLabels = additionalLabels()
-	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -92,9 +93,9 @@ func buildCCMContainer(controllerManagerImage string) func(c *corev1.Container) 
 			"--cloud-config=/etc/cloud/aws.conf",
 			"--configure-cloud-routes=false",
 			"--leader-elect=true",
-			fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),
-			fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
-			fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
+			fmt.Sprintf("--leader-elect-lease-duration=%s", constants.RecommendedLeaseDuration),
+			fmt.Sprintf("--leader-elect-renew-deadline=%s", constants.RecommendedRenewDeadline),
+			fmt.Sprintf("--leader-elect-retry-period=%s", constants.RecommendedRetryPeriod),
 			"--leader-elect-resource-namespace=openshift-cloud-controller-manager",
 			"--authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
 			"--authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/params.go
@@ -3,6 +3,7 @@ package azure
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -37,7 +38,7 @@ func NewAzureParams(hcp *hyperv1.HostedControlPlane) *AzureParams {
 		},
 	}
 	p.DeploymentConfig.AdditionalLabels = additionalLabels()
-	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -86,9 +87,9 @@ func buildCCMContainer(p *AzureParams, controllerManagerImage, namespace string)
 			"--leader-elect=true",
 			"--route-reconciliation-period=10s",
 			"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
-			fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),
-			fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
-			fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
+			fmt.Sprintf("--leader-elect-lease-duration=%s", constants.RecommendedLeaseDuration),
+			fmt.Sprintf("--leader-elect-renew-deadline=%s", constants.RecommendedRenewDeadline),
+			fmt.Sprintf("--leader-elect-retry-period=%s", constants.RecommendedRetryPeriod),
 			"--leader-elect-resource-namespace=openshift-cloud-controller-manager",
 			"--v=4",
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -215,7 +216,7 @@ func newDeploymentConfig() config.DeploymentConfig {
 		},
 	}
 	result.AdditionalLabels = additionalLabels()
-	result.Scheduling.PriorityClass = config.DefaultPriorityClass
+	result.Scheduling.PriorityClass = constants.DefaultPriorityClass
 
 	result.Replicas = 1
 
@@ -230,7 +231,7 @@ func ccmLabels() map[string]string {
 
 func additionalLabels() map[string]string {
 	return map[string]string{
-		hyperv1.ControlPlaneComponent:       "cloud-controller-manager",
-		config.NeedManagementKASAccessLabel: "true",
+		hyperv1.ControlPlaneComponent:          "cloud-controller-manager",
+		constants.NeedManagementKASAccessLabel: "true",
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/powervs/powervs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/powervs/powervs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	supportconfig "github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 )
 
 const (
@@ -207,7 +208,7 @@ func ReconcileCCMDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedCo
 
 	deploymentConfig := supportconfig.DeploymentConfig{
 		Scheduling: supportconfig.Scheduling{
-			PriorityClass: supportconfig.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -8,6 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -30,7 +31,7 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, releaseIm
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		Resources: map[string]corev1.ResourceRequirements{
 			cpcContainerMain().Name: {

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -116,9 +117,9 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	}
 
 	p.DeploymentConfig.AdditionalLabels = map[string]string{
-		config.NeedManagementKASAccessLabel: "true",
+		constants.NeedManagementKASAccessLabel: "true",
 	}
-	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	// No support for multus-admission-controller at the moment. TODO: add support after https://issues.redhat.com/browse/OCPBUGS-7942 is resolved.
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
@@ -410,7 +411,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 	// If CP is running on kube cluster, pass user ID for CNO to run its managed services with
 	if params.DeploymentConfig.SetDefaultSecurityContext {
 		cnoEnv = append(cnoEnv, corev1.EnvVar{
-			Name: "RUN_AS_USER", Value: strconv.Itoa(config.DefaultSecurityContextUser),
+			Name: "RUN_AS_USER", Value: strconv.Itoa(constants.DefaultSecurityContextUser),
 		})
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -123,7 +123,7 @@ spec:
         - /usr/bin/control-plane-operator
         - availability-prober
         - --target
-        - https://kube-apiserver:6443/readyz
+        - https://kube-apiserver:443/readyz
         - --kubeconfig=/var/kubeconfig/kubeconfig
         - --required-api=operator.openshift.io,v1,Network
         - --required-api=network.operator.openshift.io,v1,EgressRouter

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -126,7 +126,7 @@ spec:
         - /usr/bin/control-plane-operator
         - availability-prober
         - --target
-        - https://kube-apiserver:6443/readyz
+        - https://kube-apiserver:443/readyz
         - --kubeconfig=/var/kubeconfig/kubeconfig
         - --required-api=operator.openshift.io,v1,Network
         - --required-api=network.operator.openshift.io,v1,EgressRouter

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -124,7 +124,7 @@ spec:
         - /usr/bin/control-plane-operator
         - availability-prober
         - --target
-        - https://kube-apiserver:6443/readyz
+        - https://kube-apiserver:443/readyz
         - --kubeconfig=/var/kubeconfig/kubeconfig
         - --required-api=operator.openshift.io,v1,Network
         - --required-api=network.operator.openshift.io,v1,EgressRouter

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
@@ -12,6 +12,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -35,7 +36,7 @@ func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.Host
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
 	}
 	params.Scheduling = config.Scheduling{
-		PriorityClass: config.DefaultPriorityClass,
+		PriorityClass: constants.DefaultPriorityClass,
 	}
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		params.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
@@ -82,7 +83,7 @@ func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.Host
 	}
 
 	params.DeploymentConfig.AdditionalLabels = map[string]string{
-		config.NeedManagementKASAccessLabel: "true",
+		constants.NeedManagementKASAccessLabel: "true",
 	}
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	params.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.Int(1))

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -604,7 +605,7 @@ func ReconcileInfra(client crclient.Client, hcp *hyperv1.HostedControlPlane, ctx
 	}
 
 	deploymentConfig := &config.DeploymentConfig{}
-	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	deploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	deploymentConfig.SetDefaults(hcp, nil, utilpointer.Int(1))
 

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -41,7 +42,7 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imagepr
 
 	if enableCVOManagementClusterMetricsAccess {
 		p.DeploymentConfig.AdditionalLabels = map[string]string{
-			config.NeedMetricsServerAccessLabel: "true",
+			constants.NeedMetricsServerAccessLabel: "true",
 		}
 	}
 	p.DeploymentConfig.Resources = config.ResourcesSpec{
@@ -58,7 +59,7 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imagepr
 			},
 		},
 	}
-	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -66,7 +67,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 		"app":                         "dns-operator",
 		hyperv1.ControlPlaneComponent: "dns-operator",
 	}
-	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -9,6 +9,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
+	"github.com/openshift/hypershift/support/constants"
 
 	"github.com/openshift/hypershift/support/config"
 	hyputils "github.com/openshift/hypershift/support/util"
@@ -65,7 +66,7 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imagep
 		p.DeploymentConfig.AdditionalLabels = make(map[string]string)
 	}
 	p.DeploymentConfig.AdditionalLabels[hyperv1.ControlPlaneComponent] = "etcd"
-	p.DeploymentConfig.Scheduling.PriorityClass = config.EtcdPriorityClass
+	p.DeploymentConfig.Scheduling.PriorityClass = constants.EtcdPriorityClass
 	if hcp.Annotations[hyperv1.EtcdPriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.EtcdPriorityClass]
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/util"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -114,7 +115,7 @@ func ReconcileStatefulSet(ss *appsv1.StatefulSet, p *EtcdParams) error {
 		if p.DeploymentConfig.AdditionalLabels == nil {
 			p.DeploymentConfig.AdditionalLabels = make(map[string]string)
 		}
-		p.DeploymentConfig.AdditionalLabels[config.NeedManagementKASAccessLabel] = "true"
+		p.DeploymentConfig.AdditionalLabels[constants.NeedManagementKASAccessLabel] = "true"
 	}
 
 	ss.Spec.Template.Spec.InitContainers = []corev1.Container{

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -785,7 +785,7 @@ func (r *HostedControlPlaneReconciler) healthCheckKASLoadBalancers(ctx context.C
 		}
 
 		endpoint := externalRoute.Status.Ingress[0].RouterCanonicalHostname
-		port := 443
+		port := config.RouterSVCPort
 		if sharedingress.UseSharedIngress() {
 			endpoint = externalRoute.Spec.Host
 			port = sharedingress.ExternalDNSLBPort

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/hypershift/support/api"
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	"github.com/openshift/hypershift/support/testutil"
@@ -215,7 +216,7 @@ func TestBuildOAuthVolumeTemplates(t *testing.T) {
 
 func TestReconcileAPIServerService(t *testing.T) {
 	targetNamespace := "test"
-	apiPort := int32(config.KASSVCPort)
+	apiPort := int32(constants.KASSVCPort)
 	kasPort := "client"
 	hostname := "test.example.com"
 	allowCIDR := []hyperv1.CIDRBlock{"1.2.3.4/24"}

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/upsert"
@@ -724,16 +725,16 @@ func reconcileDeployment(deployment *appsv1.Deployment,
 	// set security context
 	if !managementClusterHasCapabilitySecurityContextConstraint {
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser: utilpointer.Int64(config.DefaultSecurityContextUser),
+			RunAsUser: utilpointer.Int64(constants.DefaultSecurityContextUser),
 		}
 	}
 
 	deploymentConfig := config.DeploymentConfig{
 		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
+			constants.NeedManagementKASAccessLabel: "true",
 		},
 	}
-	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	deploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		deploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}
@@ -856,12 +857,12 @@ haproxy -f /tmp/haproxy.conf
 	// set security context
 	if !managementClusterHasCapabilitySecurityContextConstraint {
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser: utilpointer.Int64(config.DefaultSecurityContextUser),
+			RunAsUser: utilpointer.Int64(constants.DefaultSecurityContextUser),
 		}
 	}
 
 	deploymentConfig := config.DeploymentConfig{}
-	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	deploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		deploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -46,7 +47,7 @@ func HCPRouterConfig(hcp *hyperv1.HostedControlPlane, setDefaultSecurityContext 
 		},
 	}
 
-	cfg.Scheduling.PriorityClass = config.APICriticalPriorityClass
+	cfg.Scheduling.PriorityClass = constants.APICriticalPriorityClass
 	cfg.SetRequestServingDefaults(hcp, hcpRouterLabels(), nil)
 	cfg.SetRestartAnnotation(hcp.ObjectMeta)
 	cfg.SetDefaultSecurityContext = setDefaultSecurityContext
@@ -116,7 +117,7 @@ func generateRouterConfig(routeList *routev1.RouteList, svcsNameToIP map[string]
 		}
 	}
 	if p.HasKubeAPI {
-		p.KASSVCPort = config.KASSVCPort
+		p.KASSVCPort = constants.KASSVCPort
 	}
 	out := &bytes.Buffer{}
 	if err := routerConfigTemplate.Execute(out, p); err != nil {
@@ -251,7 +252,7 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 	for i, port := range svc.Spec.Ports {
 		switch port.Name {
 		case "https":
-			svc.Spec.Ports[i].Port = config.RouterSVCPort
+			svc.Spec.Ports[i].Port = constants.RouterSVCPort
 			svc.Spec.Ports[i].TargetPort = intstr.FromString("https")
 			svc.Spec.Ports[i].Protocol = corev1.ProtocolTCP
 			foundHTTPS = true
@@ -260,7 +261,7 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 	if !foundHTTPS {
 		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
 			Name:       "https",
-			Port:       config.RouterSVCPort,
+			Port:       constants.RouterSVCPort,
 			TargetPort: intstr.FromString("https"),
 			Protocol:   corev1.ProtocolTCP,
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -251,7 +251,7 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 	for i, port := range svc.Spec.Ports {
 		switch port.Name {
 		case "https":
-			svc.Spec.Ports[i].Port = 443
+			svc.Spec.Ports[i].Port = config.RouterSVCPort
 			svc.Spec.Ports[i].TargetPort = intstr.FromString("https")
 			svc.Spec.Ports[i].Protocol = corev1.ProtocolTCP
 			foundHTTPS = true
@@ -260,7 +260,7 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 	if !foundHTTPS {
 		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
 			Name:       "https",
-			Port:       443,
+			Port:       config.RouterSVCPort,
 			TargetPort: intstr.FromString("https"),
 			Protocol:   corev1.ProtocolTCP,
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/testdata/zz_fixture_TestGenerateRouterConfig.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/testdata/zz_fixture_TestGenerateRouterConfig.yaml
@@ -57,4 +57,4 @@ backend oauth_private
   server oauth_private 0.0.0.4:6443
 
 backend kube_api
-  server kube_api 0.0.0.7:6443
+  server kube_api 0.0.0.7:443

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
@@ -52,7 +53,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
 		Platform:                platform,
 	}
-	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -37,9 +38,9 @@ func ReconcileServiceCAPIKubeconfigSecret(secret, cert *corev1.Secret, ca *corev
 
 func InClusterKASURL(platformType hyperv1.PlatformType) string {
 	if platformType == hyperv1.IBMCloudPlatform {
-		return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, config.KASSVCIBMCloudPort)
+		return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, constants.KASSVCIBMCloudPort)
 	}
-	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, config.KASSVCPort)
+	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, constants.KASSVCPort)
 }
 
 func InClusterKASReadyURL(platformType hyperv1.PlatformType) string {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -43,8 +43,19 @@ func InClusterKASURL(platformType hyperv1.PlatformType) string {
 	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, constants.KASSVCPort)
 }
 
+func InClusterKASURLOld(platformType hyperv1.PlatformType) string {
+	if platformType == hyperv1.IBMCloudPlatform {
+		return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, constants.KASSVCIBMCloudPort)
+	}
+	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, constants.KASSVCPortOld)
+}
+
 func InClusterKASReadyURL(platformType hyperv1.PlatformType) string {
 	return InClusterKASURL(platformType) + "/readyz"
+}
+
+func InClusterKASReadyURLOld(platformType hyperv1.PlatformType) string {
+	return InClusterKASURLOld(platformType) + "/readyz"
 }
 
 func ReconcileLocalhostKubeconfigSecret(secret, cert *corev1.Secret, ca *corev1.ConfigMap, ownerRef config.OwnerRef, apiServerPort int32) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
@@ -119,7 +120,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		params.Scheduler = hcp.Spec.Configuration.Scheduler
 	}
 
-	params.AdvertiseAddress = util.GetAdvertiseAddress(hcp, config.DefaultAdvertiseIPv4Address, config.DefaultAdvertiseIPv6Address)
+	params.AdvertiseAddress = util.GetAdvertiseAddress(hcp, constants.DefaultAdvertiseIPv4Address, constants.DefaultAdvertiseIPv6Address)
 
 	params.KASPodPort = util.KASPodPort(hcp)
 	if _, ok := hcp.Annotations[hyperv1.PortierisImageAnnotation]; ok {
@@ -132,10 +133,10 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	case hyperv1.Managed:
 		params.EtcdURL = fmt.Sprintf("https://etcd-client.%s.svc:2379", hcp.Namespace)
 	default:
-		params.EtcdURL = config.DefaultEtcdURL
+		params.EtcdURL = constants.DefaultEtcdURL
 	}
 	params.Scheduling = config.Scheduling{
-		PriorityClass: config.APICriticalPriorityClass,
+		PriorityClass: constants.APICriticalPriorityClass,
 	}
 	if hcp.Annotations[hyperv1.APICriticalPriorityClass] != "" {
 		params.Scheduling.PriorityClass = hcp.Annotations[hyperv1.APICriticalPriorityClass]
@@ -420,7 +421,7 @@ func (p *KubeAPIServerParams) AdditionalCORSAllowedOrigins() []string {
 }
 
 func (p *KubeAPIServerParams) InternalRegistryHostName() string {
-	return config.DefaultImageRegistryHostname
+	return constants.DefaultImageRegistryHostname
 }
 
 func (p *KubeAPIServerParams) ExternalRegistryHostNames() []string {
@@ -443,7 +444,7 @@ func (p *KubeAPIServerParams) ServiceAccountIssuerURL() string {
 	if p.ServiceAccountIssuer != "" {
 		return p.ServiceAccountIssuer
 	} else {
-		return config.DefaultServiceAccountIssuer
+		return constants.DefaultServiceAccountIssuer
 	}
 }
 
@@ -468,7 +469,7 @@ func (p *KubeAPIServerParams) ServiceNodePortRange() string {
 	if p.Network != nil && len(p.Network.ServiceNodePortRange) > 0 {
 		return p.Network.ServiceNodePortRange
 	} else {
-		return config.DefaultServiceNodePortRange
+		return constants.DefaultServiceNodePortRange
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
@@ -11,7 +11,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/api/util/ipnet"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
-	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 )
 
 // TODO (cewong): Add tests for other params
@@ -27,22 +27,22 @@ func TestNewAPIServerParamsAPIAdvertiseAddressAndPort(t *testing.T) {
 	}{
 		{
 			name:               "not specified",
-			expectedAddress:    config.DefaultAdvertiseIPv4Address,
+			expectedAddress:    constants.DefaultAdvertiseIPv4Address,
 			serviceNetworkCIDR: "10.0.0.0/24",
-			expectedPort:       config.KASPodDefaultPort,
+			expectedPort:       constants.KASPodDefaultPort,
 		},
 		{
 			name:               "address specified",
 			advertiseAddress:   "1.2.3.4",
 			serviceNetworkCIDR: "10.0.0.0/24",
 			expectedAddress:    "1.2.3.4",
-			expectedPort:       config.KASPodDefaultPort,
+			expectedPort:       constants.KASPodDefaultPort,
 		},
 		{
 			name:               "port set for default service publishing strategies",
 			port:               pointer.Int32(6789),
 			serviceNetworkCIDR: "10.0.0.0/24",
-			expectedAddress:    config.DefaultAdvertiseIPv4Address,
+			expectedAddress:    constants.DefaultAdvertiseIPv4Address,
 			expectedPort:       6789,
 		},
 		{
@@ -55,7 +55,7 @@ func TestNewAPIServerParamsAPIAdvertiseAddressAndPort(t *testing.T) {
 			},
 			port:               pointer.Int32(6789),
 			serviceNetworkCIDR: "10.0.0.0/24",
-			expectedAddress:    config.DefaultAdvertiseIPv4Address,
+			expectedAddress:    constants.DefaultAdvertiseIPv4Address,
 			expectedPort:       6789,
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -14,6 +14,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/util"
 )
@@ -109,7 +110,7 @@ func ReconcileServiceClusterIP(svc *corev1.Service, owner *metav1.OwnerReference
 		svc.Spec.Ports = []corev1.ServicePort{portSpec}
 	}
 
-	portSpec.Port = int32(config.KASSVCPort)
+	portSpec.Port = int32(constants.KASSVCPort)
 	portSpec.Protocol = corev1.ProtocolTCP
 	portSpec.TargetPort = intstr.FromString("client")
 	if svc.Annotations == nil {
@@ -153,7 +154,7 @@ func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublis
 			return host, port, message, err
 		}
 		host = strategy.Route.Hostname
-		port = config.RouterSVCPort
+		port = constants.RouterSVCPort
 	}
 	return
 }
@@ -173,9 +174,9 @@ func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlan
 		svc.Spec.Ports = []corev1.ServicePort{portSpec}
 	}
 
-	portSpec.Port = int32(config.KASSVCPort)
+	portSpec.Port = int32(constants.KASSVCPort)
 	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-		portSpec.Port = int32(config.KASSVCIBMCloudPort)
+		portSpec.Port = int32(constants.KASSVCIBMCloudPort)
 	}
 	portSpec.Protocol = corev1.ProtocolTCP
 	portSpec.TargetPort = intstr.FromString("client")
@@ -353,13 +354,13 @@ func ReconcileKonnectivityServerServiceStatus(svc *corev1.Service, route *routev
 	case hyperv1.Route:
 		if strategy.Route != nil && strategy.Route.Hostname != "" {
 			host = strategy.Route.Hostname
-			port = config.RouterSVCPort
+			port = constants.RouterSVCPort
 			return
 		}
 		if route.Spec.Host == "" {
 			return
 		}
-		port = config.RouterSVCPort
+		port = constants.RouterSVCPort
 		host = route.Spec.Host
 	}
 	return

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -153,7 +153,7 @@ func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublis
 			return host, port, message, err
 		}
 		host = strategy.Route.Hostname
-		port = 443
+		port = config.RouterSVCPort
 	}
 	return
 }
@@ -353,13 +353,13 @@ func ReconcileKonnectivityServerServiceStatus(svc *corev1.Service, route *routev
 	case hyperv1.Route:
 		if strategy.Route != nil && strategy.Route.Hostname != "" {
 			host = strategy.Route.Hostname
-			port = 443
+			port = config.RouterSVCPort
 			return
 		}
 		if route.Spec.Host == "" {
 			return
 		}
-		port = 443
+		port = config.RouterSVCPort
 		host = route.Spec.Host
 	}
 	return

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
@@ -13,8 +13,8 @@ import (
 	kcpv1 "github.com/openshift/api/kubecontrolplane/v1"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
-
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 )
 
 const (
@@ -48,8 +48,8 @@ func generateConfig(serviceServingCA *corev1.ConfigMap) (string, error) {
 		},
 		ExtendedArguments: map[string]kcpv1.Arguments{
 			"leader-elect":                []string{"true"},
-			"leader-elect-renew-deadline": []string{config.KCMRecommendedRenewDeadline},
-			"leader-elect-retry-period":   []string{config.KCMRecommendedRetryPeriod},
+			"leader-elect-renew-deadline": []string{constants.KCMRecommendedRenewDeadline},
+			"leader-elect-retry-period":   []string{constants.KCMRecommendedRetryPeriod},
 		},
 		ServiceServingCert: kcpv1.ServiceServingCert{
 			CertFile: serviceServingCAPath,

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -18,10 +18,9 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
 	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
-
-	"github.com/openshift/hypershift/support/config"
 )
 
 const (
@@ -351,8 +350,8 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 		"--kube-api-qps=150",
 		"--leader-elect-resource-lock=leases",
 		"--leader-elect=true",
-		fmt.Sprintf("--leader-elect-renew-deadline=%s", config.KCMRecommendedRenewDeadline),
-		fmt.Sprintf("--leader-elect-retry-period=%s", config.KCMRecommendedRetryPeriod),
+		fmt.Sprintf("--leader-elect-renew-deadline=%s", constants.KCMRecommendedRenewDeadline),
+		fmt.Sprintf("--leader-elect-retry-period=%s", constants.KCMRecommendedRetryPeriod),
 		fmt.Sprintf("--root-ca-file=%s", cpath(kcmVolumeRootCA().Name, certs.CASignerCertMapKey)),
 		fmt.Sprintf("--secure-port=%d", DefaultPort),
 		fmt.Sprintf("--service-account-private-key-file=%s", cpath(kcmVolumeServiceSigner().Name, pki.ServiceSignerPrivateKey)),

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -61,7 +62,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	}
 
 	params.Scheduling = config.Scheduling{
-		PriorityClass: config.DefaultPriorityClass,
+		PriorityClass: constants.DefaultPriorityClass,
 	}
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		params.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -8,6 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 )
 
 const (
@@ -36,7 +37,7 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider
 			},
 		},
 	}
-	p.AgentDeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.AgentDeploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		p.AgentDeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/machineapprover/reconcile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 	"gopkg.in/yaml.v2"
@@ -187,11 +188,11 @@ func ReconcileMachineApproverDeployment(deployment *appsv1.Deployment, hcp *hype
 
 	deploymentConfig := config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
+			constants.NeedManagementKASAccessLabel: "true",
 		},
 	}
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {

--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/util"
 
@@ -50,9 +51,9 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	}
 
 	p.DeploymentConfig.AdditionalLabels = map[string]string{
-		config.NeedManagementKASAccessLabel: "true",
+		constants.NeedManagementKASAccessLabel: "true",
 	}
-	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	p.DeploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	p.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.Int(1))
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
@@ -8,6 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,7 +59,7 @@ func TestReconcileOpenshiftAPIServerDeploymentNoChanges(t *testing.T) {
 		oapiDeployment.Spec.MinReadySeconds = 60
 		expectedMinReadySeconds := oapiDeployment.Spec.MinReadySeconds
 		tc.auditConfig.Data = map[string]string{"policy.yaml": "test-data"}
-		err := ReconcileDeployment(oapiDeployment, nil, ownerRef, &tc.cm, tc.auditConfig, serviceServingCA, tc.deploymentConfig, imageName, "socks5ProxyImage", config.DefaultEtcdURL, util.AvailabilityProberImageName, false, hyperv1.IBMCloudPlatform, tc.additionalTrustBundle, tc.clusterConf)
+		err := ReconcileDeployment(oapiDeployment, nil, ownerRef, &tc.cm, tc.auditConfig, serviceServingCA, tc.deploymentConfig, imageName, "socks5ProxyImage", constants.DefaultEtcdURL, util.AvailabilityProberImageName, false, hyperv1.IBMCloudPlatform, tc.additionalTrustBundle, tc.clusterConf)
 		g.Expect(err).To(BeNil())
 		g.Expect(expectedTermGraceSeconds).To(Equal(oapiDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds))
 		g.Expect(expectedMinReadySeconds).To(Equal(oapiDeployment.Spec.MinReadySeconds))
@@ -155,7 +156,7 @@ func TestReconcileOpenshiftAPIServerDeploymentTrustBundle(t *testing.T) {
 			oapiDeployment := manifests.OpenShiftAPIServerDeployment(targetNamespace)
 			ownerRef := config.OwnerRefFrom(hcp)
 			tc.auditConfig.Data = map[string]string{"policy.yaml": "test-data"}
-			err := ReconcileDeployment(oapiDeployment, nil, ownerRef, testOapiCM, tc.auditConfig, nil, tc.deploymentConfig, imageName, "socks5ProxyImage", config.DefaultEtcdURL, util.AvailabilityProberImageName, false, hyperv1.AgentPlatform, tc.additionalTrustBundle, tc.clusterConf)
+			err := ReconcileDeployment(oapiDeployment, nil, ownerRef, testOapiCM, tc.auditConfig, nil, tc.deploymentConfig, imageName, "socks5ProxyImage", constants.DefaultEtcdURL, util.AvailabilityProberImageName, false, hyperv1.AgentPlatform, tc.additionalTrustBundle, tc.clusterConf)
 			g.Expect(err).To(BeNil())
 			if tc.expectProjectedVolumeMounted {
 				g.Expect(oapiDeployment.Spec.Template.Spec.Volumes).To(ContainElement(*tc.expectedVolume))

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -10,6 +10,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/util"
 )
@@ -74,7 +75,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig
 
 	params.OpenShiftAPIServerDeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.APICriticalPriorityClass,
+			PriorityClass: constants.APICriticalPriorityClass,
 		},
 		LivenessProbes: config.LivenessProbes{
 			oasContainerMain().Name: {
@@ -124,7 +125,7 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig
 
 	params.OpenShiftOAuthAPIServerDeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.APICriticalPriorityClass,
+			PriorityClass: constants.APICriticalPriorityClass,
 		},
 		LivenessProbes: config.LivenessProbes{
 			oauthContainerMain().Name: {
@@ -178,9 +179,9 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig
 	case hyperv1.Unmanaged:
 		params.EtcdURL = hcp.Spec.Etcd.Unmanaged.Endpoint
 	case hyperv1.Managed:
-		params.EtcdURL = config.DefaultEtcdURL
+		params.EtcdURL = constants.DefaultEtcdURL
 	default:
-		params.EtcdURL = config.DefaultEtcdURL
+		params.EtcdURL = constants.DefaultEtcdURL
 	}
 
 	params.OwnerRef = config.OwnerRefFrom(hcp)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -96,7 +97,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider 
 		p.OAuth = hcp.Spec.Configuration.OAuth
 	}
 	p.Scheduling = config.Scheduling{
-		PriorityClass: config.APICriticalPriorityClass,
+		PriorityClass: constants.APICriticalPriorityClass,
 	}
 	if hcp.Annotations[hyperv1.APICriticalPriorityClass] != "" {
 		p.Scheduling.PriorityClass = hcp.Annotations[hyperv1.APICriticalPriorityClass]

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	OAuthServerPort   = 6443
-	RouteExternalPort = 443
+	OAuthServerPort = 6443
 )
 
 var (
@@ -64,14 +63,14 @@ func ReconcileServiceStatus(svc *corev1.Service, route *routev1.Route, strategy 
 	case hyperv1.Route:
 		if strategy.Route != nil && strategy.Route.Hostname != "" {
 			host = strategy.Route.Hostname
-			port = RouteExternalPort
+			port = config.RouterSVCPort
 			return
 		}
 		if route.Spec.Host == "" {
 			message = fmt.Sprintf("OAuth service route does not contain valid host; %v since creation", duration.ShortHumanDuration(time.Since(route.ObjectMeta.CreationTimestamp.Time)))
 			return
 		}
-		port = RouteExternalPort
+		port = config.RouterSVCPort
 		host = route.Spec.Host
 	case hyperv1.NodePort:
 		if strategy.NodePort == nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -11,6 +11,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 )
 
 const (
@@ -63,14 +64,14 @@ func ReconcileServiceStatus(svc *corev1.Service, route *routev1.Route, strategy 
 	case hyperv1.Route:
 		if strategy.Route != nil && strategy.Route.Hostname != "" {
 			host = strategy.Route.Hostname
-			port = config.RouterSVCPort
+			port = constants.RouterSVCPort
 			return
 		}
 		if route.Spec.Host == "" {
 			message = fmt.Sprintf("OAuth service route does not contain valid host; %v since creation", duration.ShortHumanDuration(time.Since(route.ObjectMeta.CreationTimestamp.Time)))
 			return
 		}
-		port = config.RouterSVCPort
+		port = constants.RouterSVCPort
 		host = route.Spec.Host
 	case hyperv1.NodePort:
 		if strategy.NodePort == nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -65,7 +66,7 @@ func reconcileConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, deploy
 	cfg.Deployer.ImageTemplateFormat.Format = deployerImage
 
 	// registry config
-	cfg.DockerPullSecret.InternalRegistryHostname = config.DefaultImageRegistryHostname
+	cfg.DockerPullSecret.InternalRegistryHostname = constants.DefaultImageRegistryHostname
 	if imageConfig != nil {
 		cfg.DockerPullSecret.RegistryURLs = imageConfig.ExternalRegistryHostnames
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -9,6 +9,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/globalconfig"
 )
 
@@ -40,7 +41,7 @@ func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, observ
 
 	params.DeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		Resources: map[string]corev1.ResourceRequirements{
 			ocmContainerMain().Name: {

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/olm-collect-profiles.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/olm-collect-profiles.go
@@ -5,6 +5,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/support/assets"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,7 +27,7 @@ func ReconcileCollectProfilesCronJob(cronJob *batchv1.CronJob, ownerRef config.O
 	ownerRef.ApplyTo(cronJob)
 	cronJob.Spec = olmCollectProfilesCronJob.DeepCopy().Spec
 	cronJob.Spec.JobTemplate.Spec.Template.ObjectMeta.Labels = map[string]string{
-		config.NeedManagementKASAccessLabel: "true",
+		constants.NeedManagementKASAccessLabel: "true",
 	}
 	cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image = olmImage
 	for i, arg := range cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args {

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
@@ -4,6 +4,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	"k8s.io/utils/pointer"
 )
@@ -44,7 +45,7 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, releaseI
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 	}
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
@@ -56,7 +57,7 @@ func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, releaseI
 
 	params.PackageServerConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.APICriticalPriorityClass,
+			PriorityClass: constants.APICriticalPriorityClass,
 		},
 	}
 	if hcp.Annotations[hyperv1.APICriticalPriorityClass] != "" {

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileCatalogOperatorDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileCatalogOperatorDeployment_Preserve_existing_resources.yaml
@@ -116,7 +116,7 @@ spec:
         - /usr/bin/control-plane-operator
         - availability-prober
         - --target
-        - https://kube-apiserver:6443/readyz
+        - https://kube-apiserver:443/readyz
         - --kubeconfig=/var/kubeconfig/kubeconfig
         - --required-api=operators.coreos.com,v1alpha1,CatalogSource
         imagePullPolicy: IfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileOLMOperatorDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileOLMOperatorDeployment_Preserve_existing_resources.yaml
@@ -113,7 +113,7 @@ spec:
         - /usr/bin/control-plane-operator
         - availability-prober
         - --target
-        - https://kube-apiserver:6443/readyz
+        - https://kube-apiserver:443/readyz
         - --kubeconfig=/var/kubeconfig/kubeconfig
         - --required-api=operators.coreos.com,v1alpha1,CatalogSource
         - --required-api=operators.coreos.com,v1alpha1,Subscription

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	utilsnet "k8s.io/utils/net"
 )
@@ -155,9 +156,9 @@ func generateKubeConfig(url string, crtBytes, keyBytes, caBytes []byte) ([]byte,
 
 func inClusterKASURL(platformType hyperv1.PlatformType) string {
 	if platformType == hyperv1.IBMCloudPlatform {
-		return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, config.KASSVCIBMCloudPort)
+		return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, constants.KASSVCIBMCloudPort)
 	}
-	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, config.KASSVCPort)
+	return fmt.Sprintf("https://%s:%d", manifests.KubeAPIServerServiceName, constants.KASSVCPort)
 }
 
 // AddBracketsIfIPv6 function is needed to build the serverAPI url for every kubeconfig created.

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
@@ -6,6 +6,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/util"
 )
@@ -86,9 +87,9 @@ func NewPKIParams(hcp *hyperv1.HostedControlPlane,
 	// Check this for more info: https://github.com/kubernetes/enhancements/issues/2438
 	ipv4, err := util.IsIPv4(p.ServiceCIDR[0])
 	if err != nil || ipv4 {
-		p.NodeInternalAPIServerIP = util.AdvertiseAddressWithDefault(hcp, config.DefaultAdvertiseIPv4Address)
+		p.NodeInternalAPIServerIP = util.AdvertiseAddressWithDefault(hcp, constants.DefaultAdvertiseIPv4Address)
 	} else {
-		p.NodeInternalAPIServerIP = util.AdvertiseAddressWithDefault(hcp, config.DefaultAdvertiseIPv6Address)
+		p.NodeInternalAPIServerIP = util.AdvertiseAddressWithDefault(hcp, constants.DefaultAdvertiseIPv6Address)
 	}
 
 	return p

--- a/control-plane-operator/controllers/hostedcontrolplane/pkioperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pkioperator/reconcile.go
@@ -5,6 +5,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/proxy"
 	hyperutil "github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -102,11 +103,11 @@ func ReconcileDeployment(
 
 	deploymentConfig := config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
+			constants.NeedManagementKASAccessLabel: "true",
 		},
 		Resources: map[string]corev1.ResourceRequirements{
 			"control-plane-pki-operator": {

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
@@ -118,7 +119,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 		prunerImage:      userReleaseImageProvider.GetImage("cli"),
 		deploymentConfig: config.DeploymentConfig{
 			Scheduling: config.Scheduling{
-				PriorityClass: config.DefaultPriorityClass,
+				PriorityClass: constants.DefaultPriorityClass,
 			},
 			SetDefaultSecurityContext: setDefaultSecurityContext,
 			Resources: config.ResourcesSpec{

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
@@ -9,6 +9,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 )
 
 type OpenShiftRouteControllerManagerParams struct {
@@ -31,7 +32,7 @@ func NewOpenShiftRouteControllerManagerParams(hcp *hyperv1.HostedControlPlane, r
 
 	params.DeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		Resources: map[string]corev1.ResourceRequirements{
 			routeOCMContainerMain().Name: {

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/config.go
@@ -16,6 +16,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 )
 
 const (
@@ -36,15 +37,15 @@ func ReconcileConfig(config *corev1.ConfigMap, ownerRef config.OwnerRef, profile
 }
 
 func generateConfig(profile configv1.SchedulerProfile) (string, error) {
-	leaseDuration, err := time.ParseDuration(config.RecommendedLeaseDuration)
+	leaseDuration, err := time.ParseDuration(constants.RecommendedLeaseDuration)
 	if err != nil {
 		return "", err
 	}
-	renewDeadline, err := time.ParseDuration(config.RecommendedRenewDeadline)
+	renewDeadline, err := time.ParseDuration(constants.RecommendedRenewDeadline)
 	if err != nil {
 		return "", err
 	}
-	retryPeriod, err := time.ParseDuration(config.RecommendedRetryPeriod)
+	retryPeriod, err := time.ParseDuration(constants.RecommendedRetryPeriod)
 	if err != nil {
 		return "", err
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/config_test.go
@@ -8,20 +8,21 @@ import (
 
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/hypershift/support/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbasev1 "k8s.io/component-base/config/v1alpha1"
 	schedulerv1 "k8s.io/kube-scheduler/config/v1"
 	"k8s.io/utils/pointer"
+
+	"github.com/openshift/hypershift/support/constants"
 )
 
 func TestGenerateConfig(t *testing.T) {
 	g := NewWithT(t)
-	leaseDuration, err := time.ParseDuration(config.RecommendedLeaseDuration)
+	leaseDuration, err := time.ParseDuration(constants.RecommendedLeaseDuration)
 	g.Expect(err).ShouldNot(HaveOccurred())
-	renewDeadline, err := time.ParseDuration(config.RecommendedRenewDeadline)
+	renewDeadline, err := time.ParseDuration(constants.RecommendedRenewDeadline)
 	g.Expect(err).ShouldNot(HaveOccurred())
-	retryPeriod, err := time.ParseDuration(config.RecommendedRetryPeriod)
+	retryPeriod, err := time.ParseDuration(constants.RecommendedRetryPeriod)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	leaderElectionConfig := componentbasev1.LeaderElectionConfiguration{

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -37,7 +38,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		params.APIServer = hcp.Spec.Configuration.APIServer
 	}
 	params.Scheduling = config.Scheduling{
-		PriorityClass: config.DefaultPriorityClass,
+		PriorityClass: constants.DefaultPriorityClass,
 	}
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		params.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/params.go
@@ -4,6 +4,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -42,10 +43,10 @@ func NewParams(
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	// Run only one replica of the operator
 	params.DeploymentConfig.Scheduling = config.Scheduling{
-		PriorityClass: config.DefaultPriorityClass,
+		PriorityClass: constants.DefaultPriorityClass,
 	}
 	params.DeploymentConfig.AdditionalLabels = map[string]string{
-		config.NeedManagementKASAccessLabel: "true",
+		constants.NeedManagementKASAccessLabel: "true",
 	}
 	params.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.Int(1))
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
@@ -97,7 +97,7 @@ spec:
         - /usr/bin/control-plane-operator
         - availability-prober
         - --target
-        - https://kube-apiserver:6443/readyz
+        - https://kube-apiserver:443/readyz
         - --kubeconfig=/var/kubeconfig/kubeconfig
         - --required-api=operator.openshift.io,v1,CSISnapshotController
         imagePullPolicy: IfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
@@ -4,6 +4,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -40,13 +41,13 @@ func NewParams(
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
 		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
+			constants.NeedManagementKASAccessLabel: "true",
 		},
 	}
 	params.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	// Run only one replica of the operator
 	params.DeploymentConfig.Scheduling = config.Scheduling{
-		PriorityClass: config.DefaultPriorityClass,
+		PriorityClass: constants.DefaultPriorityClass,
 	}
 	params.DeploymentConfig.SetDefaults(hcp, nil, utilpointer.Int(1))
 	params.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -68,6 +68,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/storage"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
@@ -1160,7 +1161,7 @@ func (r *reconciler) reconcileOpenshiftOAuthAPIServerAPIServices(ctx context.Con
 func (r *reconciler) reconcileKASEndpoints(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	var errs []error
 
-	kasAdvertiseAddress := util.GetAdvertiseAddress(hcp, config.DefaultAdvertiseIPv4Address, config.DefaultAdvertiseIPv6Address)
+	kasAdvertiseAddress := util.GetAdvertiseAddress(hcp, constants.DefaultAdvertiseIPv4Address, constants.DefaultAdvertiseIPv6Address)
 	kasEndpointsPort := util.KASPodPort(hcp)
 	kasEndpointSlicePort := kasEndpointsPort
 

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -20,7 +20,7 @@ import (
 	kubernetesdefaultproxy "github.com/openshift/hypershift/kubernetes-default-proxy"
 	"github.com/openshift/hypershift/pkg/version"
 	"github.com/openshift/hypershift/support/capabilities"
-	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
@@ -398,7 +398,7 @@ func NewStartCommand() *cobra.Command {
 			OpenShiftImageRegistryOverrides: imageRegistryOverrides,
 		}
 
-		defaultIngressDomain := os.Getenv(config.DefaultIngressDomainEnvVar)
+		defaultIngressDomain := os.Getenv(constants.DefaultIngressDomainEnvVar)
 
 		metricsSet, err := metrics.MetricsSetFromEnv()
 		if err != nil {
@@ -407,7 +407,7 @@ func NewStartCommand() *cobra.Command {
 		}
 		setupLog.Info("Using metrics set", "set", metricsSet.String())
 
-		enableCVOManagementClusterMetricsAccess := (os.Getenv(config.EnableCVOManagementClusterMetricsAccessEnvVar) == "1")
+		enableCVOManagementClusterMetricsAccess := (os.Getenv(constants.EnableCVOManagementClusterMetricsAccessEnvVar) == "1")
 
 		if err := (&hostedcontrolplane.HostedControlPlaneReconciler{
 			Client:                                  mgr.GetClient(),

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -97,6 +97,7 @@ import (
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/infraid"
@@ -932,7 +933,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			// TODO: (cewong) Remove this hack when we no longer need to support HostedControlPlanes that report
 			// the wrong port for the route strategy.
 			if isAPIServerRoute(hcluster) {
-				hcluster.Status.ControlPlaneEndpoint.Port = config.RouterSVCPort
+				hcluster.Status.ControlPlaneEndpoint.Port = constants.RouterSVCPort
 			}
 			hcluster.Status.OAuthCallbackURLTemplate = hcp.Status.OAuthCallbackURLTemplate
 		}
@@ -2616,7 +2617,7 @@ func reconcileControlPlaneOperatorDeployment(
 	if len(defaultIngressDomain) > 0 {
 		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
-				Name:  config.DefaultIngressDomainEnvVar,
+				Name:  constants.DefaultIngressDomainEnvVar,
 				Value: defaultIngressDomain,
 			},
 		)
@@ -2625,7 +2626,7 @@ func reconcileControlPlaneOperatorDeployment(
 	if enableCVOManagementClusterMetricsAccess {
 		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
-				Name:  config.EnableCVOManagementClusterMetricsAccessEnvVar,
+				Name:  constants.EnableCVOManagementClusterMetricsAccessEnvVar,
 				Value: "1",
 			},
 		)
@@ -2722,17 +2723,17 @@ func reconcileControlPlaneOperatorDeployment(
 	// set security context
 	if setDefaultSecurityContext {
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser: k8sutilspointer.Int64(config.DefaultSecurityContextUser),
+			RunAsUser: k8sutilspointer.Int64(constants.DefaultSecurityContextUser),
 		}
 	}
 
 	deploymentConfig := config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
+			constants.NeedManagementKASAccessLabel: "true",
 		},
 	}
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
@@ -3084,11 +3085,11 @@ func reconcileCAPIProviderDeployment(deployment *appsv1.Deployment, capiProvider
 
 	deploymentConfig := config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
+			constants.NeedManagementKASAccessLabel: "true",
 		},
 	}
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
@@ -3167,9 +3168,9 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 						Args: []string{"--namespace", "$(MY_NAMESPACE)",
 							"--v=4",
 							"--leader-elect=true",
-							fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),
-							fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
-							fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
+							fmt.Sprintf("--leader-elect-lease-duration=%s", constants.RecommendedLeaseDuration),
+							fmt.Sprintf("--leader-elect-retry-period=%s", constants.RecommendedRetryPeriod),
+							fmt.Sprintf("--leader-elect-renew-deadline=%s", constants.RecommendedRenewDeadline),
 						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
@@ -3219,17 +3220,17 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 	// set security context
 	if setDefaultSecurityContext {
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser: k8sutilspointer.Int64(config.DefaultSecurityContextUser),
+			RunAsUser: k8sutilspointer.Int64(constants.DefaultSecurityContextUser),
 		}
 	}
 
 	deploymentConfig := config.DeploymentConfig{
 		Scheduling: config.Scheduling{
-			PriorityClass: config.DefaultPriorityClass,
+			PriorityClass: constants.DefaultPriorityClass,
 		},
 		SetDefaultSecurityContext: setDefaultSecurityContext,
 		AdditionalLabels: map[string]string{
-			config.NeedManagementKASAccessLabel: "true",
+			constants.NeedManagementKASAccessLabel: "true",
 		},
 	}
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
@@ -4335,11 +4336,11 @@ func findAdvertiseAddress(hc *hyperv1.HostedCluster) (net.IP, *field.Error) {
 	}
 
 	if strings.Contains(hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String(), ".") {
-		advertiseAddress = net.ParseIP(config.DefaultAdvertiseIPv4Address)
+		advertiseAddress = net.ParseIP(constants.DefaultAdvertiseIPv4Address)
 	}
 
 	if strings.Contains(hc.Spec.Networking.ClusterNetwork[0].CIDR.IP.String(), ":") {
-		advertiseAddress = net.ParseIP(config.DefaultAdvertiseIPv6Address)
+		advertiseAddress = net.ParseIP(constants.DefaultAdvertiseIPv6Address)
 	}
 
 	return advertiseAddress, nil

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -932,7 +932,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			// TODO: (cewong) Remove this hack when we no longer need to support HostedControlPlanes that report
 			// the wrong port for the route strategy.
 			if isAPIServerRoute(hcluster) {
-				hcluster.Status.ControlPlaneEndpoint.Port = 443
+				hcluster.Status.ControlPlaneEndpoint.Port = config.RouterSVCPort
 			}
 			hcluster.Status.OAuthCallbackURLTemplate = hcp.Status.OAuthCallbackURLTemplate
 		}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/hypershift/support/capabilities"
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
@@ -2912,7 +2913,7 @@ func TestFindAdvertiseAddress(t *testing.T) {
 		{
 			name:             "given a hc without AdvertiseAddress, it should return the default IPv4 address",
 			cn:               []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.16.1.0/24")}},
-			resultAdvAddress: config.DefaultAdvertiseIPv4Address,
+			resultAdvAddress: constants.DefaultAdvertiseIPv4Address,
 		},
 		{
 			name:             "given an IPv6 hc with defined AdvertiseAddress, it should return that address",
@@ -2923,7 +2924,7 @@ func TestFindAdvertiseAddress(t *testing.T) {
 		{
 			name:             "given an IPv6 hc wihtout AdvertiseAddress, it return IPv6 default address",
 			cn:               []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("fd01::/64")}},
-			resultAdvAddress: config.DefaultAdvertiseIPv6Address,
+			resultAdvAddress: constants.DefaultAdvertiseIPv6Address,
 		},
 		{
 			name:    "given an invalid IPv4 AdvertiseAddress, it should fail",

--- a/hypershift-operator/controllers/hostedcluster/ignitionserver/ignitionserver.go
+++ b/hypershift-operator/controllers/hostedcluster/ignitionserver/ignitionserver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
@@ -610,12 +611,12 @@ func reconcileDeployment(deployment *appsv1.Deployment,
 	// set security context
 	if !managementClusterHasCapabilitySecurityContextConstraint {
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser: utilpointer.Int64(config.DefaultSecurityContextUser),
+			RunAsUser: utilpointer.Int64(constants.DefaultSecurityContextUser),
 		}
 	}
 
 	deploymentConfig := config.DeploymentConfig{}
-	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	deploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	deploymentConfig.SetDefaults(hcp, ignitionServerLabels, nil)
 	deploymentConfig.ApplyTo(deployment)
@@ -728,12 +729,12 @@ haproxy -f /tmp/haproxy.conf
 	// set security context
 	if !managementClusterHasCapabilitySecurityContextConstraint {
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser: utilpointer.Int64(config.DefaultSecurityContextUser),
+			RunAsUser: utilpointer.Int64(constants.DefaultSecurityContextUser),
 		}
 	}
 
 	deploymentConfig := config.DeploymentConfig{}
-	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	deploymentConfig.Scheduling.PriorityClass = constants.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		deploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -230,7 +230,12 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 			},
 		},
 	}
-	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Spec.Platform.Type), p.utilitiesImage, &deploymentSpec.Template.Spec)
+
+	inClusterKASReadyURL := kas.InClusterKASReadyURL(hcp.Spec.Platform.Type)
+	if p.payloadVersion != nil && p.payloadVersion.Major == 4 && p.payloadVersion.Minor < 17 {
+		inClusterKASReadyURL = kas.InClusterKASReadyURLOld(hcp.Spec.Platform.Type)
+	}
+	util.AvailabilityProber(inClusterKASReadyURL, p.utilitiesImage, &deploymentSpec.Template.Spec)
 	return deploymentSpec, nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/networkpolicy"
 	"github.com/openshift/hypershift/support/capabilities"
-	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/upsert"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -157,9 +157,9 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 }
 
 func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster, isOpenShiftDNS bool, managementClusterNetwork *configv1.Network) error {
-	port := intstr.FromInt32(config.KASSVCPort)
+	port := intstr.FromInt32(constants.KASSVCPort)
 	if hcluster.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-		port = intstr.FromInt32(config.KASSVCIBMCloudPort)
+		port = intstr.FromInt32(constants.KASSVCIBMCloudPort)
 	}
 	protocol := corev1.ProtocolTCP
 	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -157,7 +157,7 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 }
 
 func reconcileKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster, isOpenShiftDNS bool, managementClusterNetwork *configv1.Network) error {
-	port := intstr.FromInt32(constants.KASSVCPort)
+	port := intstr.FromInt32(constants.KASPodDefaultPort)
 	if hcluster.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
 		port = intstr.FromInt32(constants.KASSVCIBMCloudPort)
 	}

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	sharedingress "github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	api "github.com/openshift/hypershift/support/api"
-	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
@@ -110,9 +110,9 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 
 	// Set the default
 	if ipv4 {
-		apiServerInternalAddress = config.DefaultAdvertiseIPv4Address
+		apiServerInternalAddress = constants.DefaultAdvertiseIPv4Address
 	} else {
-		apiServerInternalAddress = config.DefaultAdvertiseIPv6Address
+		apiServerInternalAddress = constants.DefaultAdvertiseIPv6Address
 	}
 
 	// TODO (alberto): Technically this should call util.BindAPIPortWithDefaultFromHostedCluster and let 443 be an invalid value.
@@ -197,7 +197,7 @@ func haproxyFrontendListenAddress(hc *hyperv1.HostedCluster) int32 {
 	if hc.Spec.Networking.APIServer != nil && hc.Spec.Networking.APIServer.Port != nil {
 		return *hc.Spec.Networking.APIServer.Port
 	}
-	return config.KASPodDefaultPort
+	return constants.KASPodDefaultPort
 }
 
 func urlPort(u *url.URL) (int32, error) {
@@ -419,7 +419,7 @@ func generateHAProxyStaticPod(name, image, internalAPIAddress, configPath string
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser: pointer.Int64(config.DefaultSecurityContextUser),
+					RunAsUser: pointer.Int64(constants.DefaultSecurityContextUser),
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -487,7 +487,7 @@ func generateKubernetesDefaultProxyPod(image string, listenAddr string, proxyAdd
 						"--apiserver-addr=" + apiserverAddr,
 					},
 					SecurityContext: &corev1.SecurityContext{
-						RunAsUser: pointer.Int64(config.DefaultSecurityContextUser),
+						RunAsUser: pointer.Int64(constants.DefaultSecurityContextUser),
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{

--- a/hypershift-operator/controllers/nodepool/haproxy_test.go
+++ b/hypershift-operator/controllers/nodepool/haproxy_test.go
@@ -161,7 +161,7 @@ kind: Config`
 					},
 				}
 			}),
-			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:6443"},
+			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:443"},
 		},
 		{
 			name: "public and private cluster uses .local address",
@@ -196,7 +196,7 @@ kind: Config`
 					},
 				}
 			}),
-			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:6443"},
+			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:443"},
 		},
 		{
 			name: "public cluster uses address from kubeconfig",

--- a/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_private_cluster_uses_.local_address_and_LB_kas.yaml
+++ b/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_private_cluster_uses_.local_address_and_LB_kas.yaml
@@ -26,4 +26,4 @@ backend remote_apiserver
   option httpchk GET /version
   option log-health-checks
   default-server inter 10s fall 3 rise 3
-  server controlplane api.hc.hypershift.local:6443
+  server controlplane api.hc.hypershift.local:443

--- a/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_public_and_private_cluster_uses_.local_address_and_LB_kas.yaml
+++ b/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_public_and_private_cluster_uses_.local_address_and_LB_kas.yaml
@@ -26,4 +26,4 @@ backend remote_apiserver
   option httpchk GET /version
   option log-health-checks
   default-server inter 10s fall 3 rise 3
-  server controlplane api.hc.hypershift.local:6443
+  server controlplane api.hc.hypershift.local:443

--- a/hypershift-operator/controllers/sharedingress/router.go
+++ b/hypershift-operator/controllers/sharedingress/router.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -99,7 +100,7 @@ func generateRouterConfig(svcList *corev1.ServiceList, routes []routev1.Route, s
 		}
 		switch route.Name {
 		case manifests.KubeAPIServerExternalPublicRoute("").Name:
-			p.ExternalDNSBackends = append(p.ExternalDNSBackends, ExternalDNSBackendDesc{Name: route.Namespace + "-apiserver", HostName: route.Spec.Host, DestinationServiceIP: svcsNameToIP[route.Namespace+route.Spec.To.Name], DestinationPort: config.KASSVCPort})
+			p.ExternalDNSBackends = append(p.ExternalDNSBackends, ExternalDNSBackendDesc{Name: route.Namespace + "-apiserver", HostName: route.Spec.Host, DestinationServiceIP: svcsNameToIP[route.Namespace+route.Spec.To.Name], DestinationPort: constants.KASSVCPort})
 		case ignitionserver.Route("").Name:
 			p.ExternalDNSBackends = append(p.ExternalDNSBackends, ExternalDNSBackendDesc{Name: route.Namespace + "-ignition", HostName: route.Spec.Host, DestinationServiceIP: svcsNameToIP[route.Namespace+route.Spec.To.Name], DestinationPort: 443})
 		case manifests.KonnectivityServerRoute("").Name:

--- a/hypershift-operator/controllers/sharedingress/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.yaml
+++ b/hypershift-operator/controllers/sharedingress/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.yaml
@@ -64,7 +64,7 @@ backend test-hc1-ignition
 backend test-hc1-konnectivity
   server test-hc1-konnectivity 2.2.2.2:8091
 backend test-hc1-apiserver
-  server test-hc1-apiserver 4.4.4.4:6443
+  server test-hc1-apiserver 4.4.4.4:443
 backend test-hc1-oauth
   server test-hc1-oauth 3.3.3.3:6443
 backend test-hc2-ignition
@@ -72,6 +72,6 @@ backend test-hc2-ignition
 backend test-hc2-konnectivity
   server test-hc2-konnectivity 2.2.2.2:8091
 backend test-hc2-apiserver
-  server test-hc2-apiserver 4.4.4.4:6443
+  server test-hc2-apiserver 4.4.4.4:443
 backend test-hc2-oauth
   server test-hc2-oauth 3.3.3.3:6443

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -44,7 +44,7 @@ import (
 	"github.com/openshift/hypershift/pkg/version"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/capabilities"
-	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/releaseinfo"
@@ -308,7 +308,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	}
 
 	monitoringDashboards := (os.Getenv("MONITORING_DASHBOARDS") == "1")
-	enableCVOManagementClusterMetricsAccess := (os.Getenv(config.EnableCVOManagementClusterMetricsAccessEnvVar) == "1")
+	enableCVOManagementClusterMetricsAccess := (os.Getenv(constants.EnableCVOManagementClusterMetricsAccessEnvVar) == "1")
 
 	certRotationScale, err := pkiconfig.GetCertRotationScale()
 	if err != nil {

--- a/support/awsutil/sg.go
+++ b/support/awsutil/sg.go
@@ -156,30 +156,8 @@ func DefaultWorkerSGIngressRules(machineCIDRs []string, sgGroupID, sgUserID stri
 						CidrIp: aws.String(cidr),
 					},
 				},
-				FromPort: aws.Int64(6443),
-				ToPort:   aws.Int64(6443),
-			},
-			{
-				// This is for the private link endpoint.
-				IpProtocol: aws.String("tcp"),
-				IpRanges: []*ec2.IpRange{
-					{
-						CidrIp: aws.String(cidr),
-					},
-				},
 				FromPort: aws.Int64(443),
 				ToPort:   aws.Int64(443),
-			},
-			{
-				// This is for the private link endpoint.
-				IpProtocol: aws.String("udp"),
-				IpRanges: []*ec2.IpRange{
-					{
-						CidrIp: aws.String(cidr),
-					},
-				},
-				FromPort: aws.Int64(6443),
-				ToPort:   aws.Int64(6443),
 			},
 			{
 				// This is for the private link endpoint.

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -30,9 +30,10 @@ const (
 	// https://bugzilla.redhat.com/show_bug.cgi?id=2060650
 	// TODO(alberto): explore exposing multiple Azure frontend IPs on the load balancer.
 	KASSVCLBAzurePort           = 7443
-	KASSVCPort                  = 6443
+	KASSVCPort                  = 443
 	KASPodDefaultPort           = 6443
 	KASSVCIBMCloudPort          = 2040
+	RouterSVCPort               = 443
 	DefaultServiceNodePortRange = "30000-32767"
 	DefaultSecurityContextUser  = 1001
 	RecommendedLeaseDuration    = "137s"

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -102,7 +103,7 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 	// set default security context for pod
 	if c.SetDefaultSecurityContext {
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser: pointer.Int64(DefaultSecurityContextUser),
+			RunAsUser: pointer.Int64(constants.DefaultSecurityContextUser),
 		}
 	}
 

--- a/support/constants/constants.go
+++ b/support/constants/constants.go
@@ -32,6 +32,7 @@ const (
 	KASSVCLBAzurePort           = 7443
 	KASSVCIBMCloudPort          = 2040
 	KASSVCPort                  = 443
+	KASSVCPortOld               = 6443
 	KASPodDefaultPort           = 6443
 	RouterSVCPort               = 443
 	DefaultServiceNodePortRange = "30000-32767"

--- a/support/constants/constants.go
+++ b/support/constants/constants.go
@@ -1,4 +1,4 @@
-package config
+package constants
 
 const (
 	// NeedManagementKASAccessLabel is used by network policies
@@ -30,9 +30,9 @@ const (
 	// https://bugzilla.redhat.com/show_bug.cgi?id=2060650
 	// TODO(alberto): explore exposing multiple Azure frontend IPs on the load balancer.
 	KASSVCLBAzurePort           = 7443
+	KASSVCIBMCloudPort          = 2040
 	KASSVCPort                  = 443
 	KASPodDefaultPort           = 6443
-	KASSVCIBMCloudPort          = 2040
 	RouterSVCPort               = 443
 	DefaultServiceNodePortRange = "30000-32767"
 	DefaultSecurityContextUser  = 1001

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 )
 
 func MachineCIDRs(machineNetwork []hyperv1.MachineNetworkEntry) []string {
@@ -74,9 +75,9 @@ func KASPodPortFromHostedCluster(hc *hyperv1.HostedCluster) int32 {
 // to communicate with the KAS via the api.<hc-name>.hypershift.local host.
 func APIPortForLocalZone(isLBKAS bool) int32 {
 	if isLBKAS {
-		return 6443
+		return config.KASSVCPort
 	}
-	return 443
+	return config.RouterSVCPort
 }
 
 func AdvertiseAddress(hcp *hyperv1.HostedControlPlane) *string {

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -2,7 +2,7 @@ package util
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 )
 
 func MachineCIDRs(machineNetwork []hyperv1.MachineNetworkEntry) []string {
@@ -75,9 +75,9 @@ func KASPodPortFromHostedCluster(hc *hyperv1.HostedCluster) int32 {
 // to communicate with the KAS via the api.<hc-name>.hypershift.local host.
 func APIPortForLocalZone(isLBKAS bool) int32 {
 	if isLBKAS {
-		return config.KASSVCPort
+		return constants.KASSVCPort
 	}
-	return config.RouterSVCPort
+	return constants.RouterSVCPort
 }
 
 func AdvertiseAddress(hcp *hyperv1.HostedControlPlane) *string {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/support/conditions"
 	suppconfig "github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/constants"
 	"github.com/openshift/hypershift/support/util"
 	"github.com/openshift/library-go/test/library/metrics"
 	promapi "github.com/prometheus/client_golang/api"
@@ -785,7 +786,7 @@ func EnsureNetworkPolicies(t *testing.T, ctx context.Context, c crclient.Client,
 		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		t.Run("EnsureComponentsHaveNeedManagementKASAccessLabel", func(t *testing.T) {
 			g := NewWithT(t)
-			err := checkPodsHaveLabel(ctx, c, expectedKasManagementComponents, hcpNamespace, client.MatchingLabels{suppconfig.NeedManagementKASAccessLabel: "true"})
+			err := checkPodsHaveLabel(ctx, c, expectedKasManagementComponents, hcpNamespace, client.MatchingLabels{constants.NeedManagementKASAccessLabel: "true"})
 			g.Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -866,7 +867,7 @@ func checkPodsHaveLabel(ctx context.Context, c crclient.Client, allowedComponent
 
 	// Get the component name for each labelled pod and ensure it exists in the components slice
 	for _, pod := range podList.Items {
-		if pod.Labels[suppconfig.NeedManagementKASAccessLabel] == "" {
+		if pod.Labels[constants.NeedManagementKASAccessLabel] == "" {
 			continue
 		}
 		componentName := getComponentName(&pod)

--- a/test/integration/framework/client.go
+++ b/test/integration/framework/client.go
@@ -17,6 +17,7 @@ import (
 	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hcpmanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	homanifests "github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/support/constants"
 	v1 "k8s.io/api/authentication/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,7 +116,7 @@ func WaitForGuestRestConfig(ctx context.Context, logger logr.Logger, opts *Optio
 		logPath := "apiserver-port-forward.log"
 		cmd := exec.CommandContext(portForwardCtx, opts.OCPath,
 			"port-forward", "service/kube-apiserver", "--namespace", hostedControlPlaneNamespace,
-			fmt.Sprintf("%s:6443", forwardedLocalPort),
+			fmt.Sprintf("%s:%d", forwardedLocalPort, constants.KASSVCPort),
 			"--kubeconfig", opts.Kubeconfig,
 		)
 		if err := StartCommand(logger, opts, logPath, cmd); err != nil {


### PR DESCRIPTION
Follows up https://github.com/openshift/hypershift/pull/3849. 

Expose the KAS services through port 443 instead of 6443 by default, regardless of whether Route KAS or LB KAS is used. 

Also, refer to the constants defined in constants.go instead of hardcoding them whenever possible. 