### PR TITLE
OCPBUGS-34816: Block data plane HC configuration requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build: hypershift-operator control-plane-operator control-plane-pki-operator hyp
 
 .PHONY: sync
 sync:
-	$(GO) work sync 
+	$(GO) work sync
 
 .PHONY: update
 update: sync api-deps api api-docs deps clients app-sre-saas-template

--- a/cmd/infra/aws/delegating_client.go
+++ b/cmd/infra/aws/delegating_client.go
@@ -21,7 +21,7 @@ import (
 )
 
 // NewDelegatingClient creates a new set of AWS service clients that delegate individual calls to the right credentials.
-func NewDelegatingClient(
+func NewDelegatingClient (
 	awsEbsCsiDriverControllerCredentialsFile string,
 	cloudControllerCredentialsFile string,
 	cloudNetworkConfigControllerCredentialsFile string,
@@ -50,8 +50,8 @@ func NewDelegatingClient(
 		Fn:   request.MakeAddToUserAgentHandler("openshift.io hypershift", "cloud-controller"),
 	})
 	cloudController := &cloudControllerClientDelegate{
-		ec2Client:   ec2.New(cloudControllerSession, awsConfig),
-		elbClient:   elb.New(cloudControllerSession, awsConfig),
+		ec2Client: ec2.New(cloudControllerSession, awsConfig),
+		elbClient: elb.New(cloudControllerSession, awsConfig),
 		elbv2Client: elbv2.New(cloudControllerSession, awsConfig),
 	}
 	cloudNetworkConfigControllerSession, err := session.NewSessionWithOptions(session.Options{SharedConfigFiles: []string{cloudNetworkConfigControllerCredentialsFile}})
@@ -74,7 +74,7 @@ func NewDelegatingClient(
 		Fn:   request.MakeAddToUserAgentHandler("openshift.io hypershift", "control-plane-operator"),
 	})
 	controlPlaneOperator := &controlPlaneOperatorClientDelegate{
-		ec2Client:     ec2.New(controlPlaneOperatorSession, awsConfig),
+		ec2Client: ec2.New(controlPlaneOperatorSession, awsConfig),
 		route53Client: route53.New(controlPlaneOperatorSession, awsConfig),
 	}
 	nodePoolSession, err := session.NewSessionWithOptions(session.Options{SharedConfigFiles: []string{nodePoolCredentialsFile}})
@@ -101,39 +101,38 @@ func NewDelegatingClient(
 	}
 	return &DelegatingClient{
 		EC2API: &ec2Client{
-			EC2API:                       nil,
-			awsEbsCsiDriverController:    awsEbsCsiDriverController,
-			cloudController:              cloudController,
+			EC2API: nil,
+			awsEbsCsiDriverController: awsEbsCsiDriverController,
+			cloudController: cloudController,
 			cloudNetworkConfigController: cloudNetworkConfigController,
-			controlPlaneOperator:         controlPlaneOperator,
-			nodePool:                     nodePool,
+			controlPlaneOperator: controlPlaneOperator,
+			nodePool: nodePool,
 		},
 		ELBAPI: &elbClient{
-			ELBAPI:          nil,
+			ELBAPI: nil,
 			cloudController: cloudController,
 		},
 		ELBV2API: &elbv2Client{
-			ELBV2API:        nil,
+			ELBV2API: nil,
 			cloudController: cloudController,
 		},
 		Route53API: &route53Client{
-			Route53API:           nil,
+			Route53API: nil,
 			controlPlaneOperator: controlPlaneOperator,
 		},
 		S3API: &s3Client{
-			S3API:                  nil,
+			S3API: nil,
 			openshiftImageRegistry: openshiftImageRegistry,
 		},
 	}, nil
 }
-
 type awsEbsCsiDriverControllerClientDelegate struct {
 	ec2Client ec2iface.EC2API
 }
 
 type cloudControllerClientDelegate struct {
-	ec2Client   ec2iface.EC2API
-	elbClient   elbiface.ELBAPI
+	ec2Client ec2iface.EC2API
+	elbClient elbiface.ELBAPI
 	elbv2Client elbv2iface.ELBV2API
 }
 
@@ -142,7 +141,7 @@ type cloudNetworkConfigControllerClientDelegate struct {
 }
 
 type controlPlaneOperatorClientDelegate struct {
-	ec2Client     ec2iface.EC2API
+	ec2Client ec2iface.EC2API
 	route53Client route53iface.Route53API
 }
 
@@ -154,6 +153,7 @@ type openshiftImageRegistryClientDelegate struct {
 	s3Client s3iface.S3API
 }
 
+
 // DelegatingClient embeds clients for AWS services we have privileges to use with guest cluster component roles.
 type DelegatingClient struct {
 	ec2iface.EC2API
@@ -163,16 +163,17 @@ type DelegatingClient struct {
 	s3iface.S3API
 }
 
+
 // ec2Client delegates to individual component clients for API calls we know those components will have privileges to make.
 type ec2Client struct {
 	// embedding this fulfills the interface and falls back to a panic for APIs we don't have privileges for
 	ec2iface.EC2API
 
-	awsEbsCsiDriverController    *awsEbsCsiDriverControllerClientDelegate
-	cloudController              *cloudControllerClientDelegate
+	awsEbsCsiDriverController *awsEbsCsiDriverControllerClientDelegate
+	cloudController *cloudControllerClientDelegate
 	cloudNetworkConfigController *cloudNetworkConfigControllerClientDelegate
-	controlPlaneOperator         *controlPlaneOperatorClientDelegate
-	nodePool                     *nodePoolClientDelegate
+	controlPlaneOperator *controlPlaneOperatorClientDelegate
+	nodePool *nodePoolClientDelegate
 }
 
 func (c *ec2Client) AttachVolumeWithContext(ctx aws.Context, input *ec2.AttachVolumeInput, opts ...request.Option) (*ec2.VolumeAttachment, error) {
@@ -593,3 +594,5 @@ func (c *s3Client) PutObjectWithContext(ctx aws.Context, input *s3.PutObjectInpu
 func (c *s3Client) PutPublicAccessBlockWithContext(ctx aws.Context, input *s3.PutPublicAccessBlockInput, opts ...request.Option) (*s3.PutPublicAccessBlockOutput, error) {
 	return c.openshiftImageRegistry.s3Client.PutPublicAccessBlockWithContext(ctx, input, opts...)
 }
+
+	

--- a/cmd/infra/aws/delegating_client.go
+++ b/cmd/infra/aws/delegating_client.go
@@ -21,7 +21,7 @@ import (
 )
 
 // NewDelegatingClient creates a new set of AWS service clients that delegate individual calls to the right credentials.
-func NewDelegatingClient (
+func NewDelegatingClient(
 	awsEbsCsiDriverControllerCredentialsFile string,
 	cloudControllerCredentialsFile string,
 	cloudNetworkConfigControllerCredentialsFile string,
@@ -50,8 +50,8 @@ func NewDelegatingClient (
 		Fn:   request.MakeAddToUserAgentHandler("openshift.io hypershift", "cloud-controller"),
 	})
 	cloudController := &cloudControllerClientDelegate{
-		ec2Client: ec2.New(cloudControllerSession, awsConfig),
-		elbClient: elb.New(cloudControllerSession, awsConfig),
+		ec2Client:   ec2.New(cloudControllerSession, awsConfig),
+		elbClient:   elb.New(cloudControllerSession, awsConfig),
 		elbv2Client: elbv2.New(cloudControllerSession, awsConfig),
 	}
 	cloudNetworkConfigControllerSession, err := session.NewSessionWithOptions(session.Options{SharedConfigFiles: []string{cloudNetworkConfigControllerCredentialsFile}})
@@ -74,7 +74,7 @@ func NewDelegatingClient (
 		Fn:   request.MakeAddToUserAgentHandler("openshift.io hypershift", "control-plane-operator"),
 	})
 	controlPlaneOperator := &controlPlaneOperatorClientDelegate{
-		ec2Client: ec2.New(controlPlaneOperatorSession, awsConfig),
+		ec2Client:     ec2.New(controlPlaneOperatorSession, awsConfig),
 		route53Client: route53.New(controlPlaneOperatorSession, awsConfig),
 	}
 	nodePoolSession, err := session.NewSessionWithOptions(session.Options{SharedConfigFiles: []string{nodePoolCredentialsFile}})
@@ -101,38 +101,39 @@ func NewDelegatingClient (
 	}
 	return &DelegatingClient{
 		EC2API: &ec2Client{
-			EC2API: nil,
-			awsEbsCsiDriverController: awsEbsCsiDriverController,
-			cloudController: cloudController,
+			EC2API:                       nil,
+			awsEbsCsiDriverController:    awsEbsCsiDriverController,
+			cloudController:              cloudController,
 			cloudNetworkConfigController: cloudNetworkConfigController,
-			controlPlaneOperator: controlPlaneOperator,
-			nodePool: nodePool,
+			controlPlaneOperator:         controlPlaneOperator,
+			nodePool:                     nodePool,
 		},
 		ELBAPI: &elbClient{
-			ELBAPI: nil,
+			ELBAPI:          nil,
 			cloudController: cloudController,
 		},
 		ELBV2API: &elbv2Client{
-			ELBV2API: nil,
+			ELBV2API:        nil,
 			cloudController: cloudController,
 		},
 		Route53API: &route53Client{
-			Route53API: nil,
+			Route53API:           nil,
 			controlPlaneOperator: controlPlaneOperator,
 		},
 		S3API: &s3Client{
-			S3API: nil,
+			S3API:                  nil,
 			openshiftImageRegistry: openshiftImageRegistry,
 		},
 	}, nil
 }
+
 type awsEbsCsiDriverControllerClientDelegate struct {
 	ec2Client ec2iface.EC2API
 }
 
 type cloudControllerClientDelegate struct {
-	ec2Client ec2iface.EC2API
-	elbClient elbiface.ELBAPI
+	ec2Client   ec2iface.EC2API
+	elbClient   elbiface.ELBAPI
 	elbv2Client elbv2iface.ELBV2API
 }
 
@@ -141,7 +142,7 @@ type cloudNetworkConfigControllerClientDelegate struct {
 }
 
 type controlPlaneOperatorClientDelegate struct {
-	ec2Client ec2iface.EC2API
+	ec2Client     ec2iface.EC2API
 	route53Client route53iface.Route53API
 }
 
@@ -153,7 +154,6 @@ type openshiftImageRegistryClientDelegate struct {
 	s3Client s3iface.S3API
 }
 
-
 // DelegatingClient embeds clients for AWS services we have privileges to use with guest cluster component roles.
 type DelegatingClient struct {
 	ec2iface.EC2API
@@ -163,17 +163,16 @@ type DelegatingClient struct {
 	s3iface.S3API
 }
 
-
 // ec2Client delegates to individual component clients for API calls we know those components will have privileges to make.
 type ec2Client struct {
 	// embedding this fulfills the interface and falls back to a panic for APIs we don't have privileges for
 	ec2iface.EC2API
 
-	awsEbsCsiDriverController *awsEbsCsiDriverControllerClientDelegate
-	cloudController *cloudControllerClientDelegate
+	awsEbsCsiDriverController    *awsEbsCsiDriverControllerClientDelegate
+	cloudController              *cloudControllerClientDelegate
 	cloudNetworkConfigController *cloudNetworkConfigControllerClientDelegate
-	controlPlaneOperator *controlPlaneOperatorClientDelegate
-	nodePool *nodePoolClientDelegate
+	controlPlaneOperator         *controlPlaneOperatorClientDelegate
+	nodePool                     *nodePoolClientDelegate
 }
 
 func (c *ec2Client) AttachVolumeWithContext(ctx aws.Context, input *ec2.AttachVolumeInput, opts ...request.Option) (*ec2.VolumeAttachment, error) {
@@ -594,5 +593,3 @@ func (c *s3Client) PutObjectWithContext(ctx aws.Context, input *s3.PutObjectInpu
 func (c *s3Client) PutPublicAccessBlockWithContext(ctx aws.Context, input *s3.PutPublicAccessBlockInput, opts ...request.Option) (*s3.PutPublicAccessBlockOutput, error) {
 	return c.openshiftImageRegistry.s3Client.PutPublicAccessBlockWithContext(ctx, input, opts...)
 }
-
-	

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -232,6 +232,7 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef, platform hyperv1
 			},
 		}...)
 	}
+	// TODO (jparrill): Add RBAC specific needs for Agent platform
 	return nil
 }
 
@@ -443,7 +444,7 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 
 func buildHCCVolumeKubeconfig(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName:  manifests.KASServiceKubeconfigSecret("").Name,
+		SecretName:  manifests.HCCOKubeconfigSecret("").Name,
 		DefaultMode: pointer.Int32(0640),
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2832,6 +2832,10 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 	if err := r.Get(ctx, client.ObjectKeyFromObject(bootstrapClientCertSecret), bootstrapClientCertSecret); err != nil {
 		return fmt.Errorf("failed to get bootstrap client cert secret: %w", err)
 	}
+	hccoClientCertSecret := manifests.HCCOClientCertSecret(hcp.Namespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(hccoClientCertSecret), hccoClientCertSecret); err != nil {
+		return fmt.Errorf("failed to get HCCO client cert secret: %w", err)
+	}
 
 	serviceKubeconfigSecret := manifests.KASServiceKubeconfigSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, serviceKubeconfigSecret, func() error {
@@ -2849,6 +2853,13 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 		return kas.ReconcileServiceCAPIKubeconfigSecret(capiKubeconfigSecret, clientCertSecret, rootCA, p.OwnerRef, hcp.Spec.InfraID, hcp.Spec.Platform.Type)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile CAPI service admin kubeconfig secret: %w", err)
+	}
+
+	hccoKubeconfigSecret := manifests.HCCOKubeconfigSecret(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, hccoKubeconfigSecret, func() error {
+		return kas.ReconcileHCCOKubeconfigSecret(hccoKubeconfigSecret, hccoClientCertSecret, rootCA, p.OwnerRef, hcp.Spec.Platform.Type)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile HCCO kubeconfig secret: %w", err)
 	}
 
 	localhostKubeconfigSecret := manifests.KASLocalhostKubeconfigSecret(hcp.Namespace)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -181,6 +181,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 	// TODO remove in 4.16 once we're able to have different featuregates for hypershift
 	featureGates := append([]string{}, p.FeatureGates...)
 	featureGates = append(featureGates, "StructuredAuthenticationConfiguration=true")
+	featureGates = append(featureGates, "ValidatingAdmissionPolicy=true")
 	args.Set("feature-gates", featureGates...)
 	args.Set("goaway-chance", "0")
 	args.Set("http2-max-streams-per-connection", "2000")

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -756,6 +756,22 @@ cat <<EOF >/tmp/manifests/99_feature-gate.yaml
 %[3]s
 EOF
 
+touch /tmp/manifests/hcco-rolebinding.yaml
+cat <<EOF >/tmp/manifests/hcco-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hcco-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:hosted-cluster-config-operator
+EOF
+
 /usr/bin/render \
    --asset-output-dir /tmp/output \
    --rendered-manifest-dir=/tmp/manifests \

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -769,7 +769,7 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: system:hosted-cluster-config-operator
+  name: system:hosted-cluster-config
 EOF
 
 /usr/bin/render \

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -58,3 +58,8 @@ func ReconcileExternalKubeconfigSecret(secret, cert *corev1.Secret, ca *corev1.C
 func ReconcileBootstrapKubeconfigSecret(secret, cert *corev1.Secret, ca *corev1.ConfigMap, ownerRef config.OwnerRef, externalURL string) error {
 	return pki.ReconcileKubeConfig(secret, cert, ca, externalURL, "", manifests.KubeconfigScopeBootstrap, ownerRef)
 }
+
+func ReconcileHCCOKubeconfigSecret(secret, cert *corev1.Secret, ca *corev1.ConfigMap, ownerRef config.OwnerRef, platformType hyperv1.PlatformType) error {
+	svcURL := InClusterKASURL(platformType)
+	return pki.ReconcileKubeConfig(secret, cert, ca, svcURL, "", "service", ownerRef)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas_pki_setup.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas_pki_setup.go
@@ -173,7 +173,7 @@ func (r *HostedControlPlaneReconciler) setupKASClientSigners(
 	}
 	totalClientCABundle = append(totalClientCABundle, hccoKubeconfigSigner)
 
-	// system:hosted-cluster-config-operator client cert
+	// system:hosted-cluster-config client cert
 	if _, err := reconcileSub(
 		manifests.HCCOClientCertSecret(hcp.Namespace),
 		hccoKubeconfigSigner,

--- a/control-plane-operator/controllers/hostedcontrolplane/kas_pki_setup.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas_pki_setup.go
@@ -160,6 +160,29 @@ func (r *HostedControlPlaneReconciler) setupKASClientSigners(
 	}
 
 	// ----------
+	//	HCCO signer
+	// ----------
+
+	hccoKubeconfigSigner, err := reconcileSigner(
+		manifests.HCCOSigner(hcp.Namespace),
+		pki.ReconcileHCCOSigner,
+	)
+
+	if err != nil {
+		return err
+	}
+	totalClientCABundle = append(totalClientCABundle, hccoKubeconfigSigner)
+
+	// system:hosted-cluster-config-operator client cert
+	if _, err := reconcileSub(
+		manifests.HCCOClientCertSecret(hcp.Namespace),
+		hccoKubeconfigSigner,
+		pki.ReconcileHCCOClientCertSecret,
+	); err != nil {
+		return err
+	}
+
+	// ----------
 	//	CSR signer
 	// ----------
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/configoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/configoperator.go
@@ -18,21 +18,21 @@ func ConfigOperatorDeployment(ns string) *appsv1.Deployment {
 
 func ConfigOperatorRole(ns string) *rbacv1.Role {
 	r := &rbacv1.Role{}
-	r.Name = "hosted-cluster-config-operator"
+	r.Name = "hosted-cluster-config"
 	r.Namespace = ns
 	return r
 }
 
 func ConfigOperatorRoleBinding(ns string) *rbacv1.RoleBinding {
 	rb := &rbacv1.RoleBinding{}
-	rb.Name = "hosted-cluster-config-operator"
+	rb.Name = "hosted-cluster-config"
 	rb.Namespace = ns
 	return rb
 }
 
 func ConfigOperatorServiceAccount(ns string) *corev1.ServiceAccount {
 	sa := &corev1.ServiceAccount{}
-	sa.Name = "hosted-cluster-config-operator"
+	sa.Name = "hosted-cluster-config"
 	sa.Namespace = ns
 	return sa
 }
@@ -40,6 +40,6 @@ func ConfigOperatorServiceAccount(ns string) *corev1.ServiceAccount {
 func ConfigOperatorPodMonitor(ns string) *prometheusoperatorv1.PodMonitor {
 	return &prometheusoperatorv1.PodMonitor{ObjectMeta: metav1.ObjectMeta{
 		Namespace: ns,
-		Name:      "hosted-cluster-config-operator",
+		Name:      "hosted-cluster-config",
 	}}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -63,6 +63,15 @@ func KASServiceCAPIKubeconfigSecret(controlPlaneNamespace, infraID string) *core
 	}
 }
 
+func HCCOKubeconfigSecret(controlPlaneNamespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcco-kubeconfig",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+}
+
 func KASExternalKubeconfigSecret(controlPlaneNamespace string, ref *hyperv1.KubeconfigSecretRef) *corev1.Secret {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -224,6 +224,14 @@ func SystemAdminClientCertSecret(ns string) *corev1.Secret {
 	return secretFor(ns, "system-admin-client")
 }
 
+func HCCOSigner(ns string) *corev1.Secret {
+	return secretFor(ns, "hcco-signer")
+}
+
+func HCCOClientCertSecret(ns string) *corev1.Secret {
+	return secretFor(ns, "hcco-client")
+}
+
 func KASMachineBootstrapClientCertSecret(ns string) *corev1.Secret {
 	return secretFor(ns, "kas-bootstrap-client")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -49,6 +49,10 @@ func ReconcileAdminKubeconfigSigner(secret *corev1.Secret, ownerRef config.Owner
 	return reconcileSelfSignedCA(secret, ownerRef, "admin-kubeconfig-signer", "openshift")
 }
 
+func ReconcileHCCOSigner(secret *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSelfSignedCA(secret, ownerRef, "hcco-signer", "openshift")
+}
+
 func ReconcileKubeCSRSigner(secret *corev1.Secret, ownerRef config.OwnerRef) error {
 	return reconcileSelfSignedCA(secret, ownerRef, "kube-csr-signer", "openshift")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -90,6 +90,10 @@ func ReconcileSystemAdminClientCertSecret(secret, ca *corev1.Secret, ownerRef co
 	return reconcileSignedCert(secret, ca, ownerRef, "system:admin", []string{"system:masters"}, X509UsageClientAuth)
 }
 
+func ReconcileHCCOClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	return reconcileSignedCert(secret, ca, ownerRef, fmt.Sprintf("system:%s", config.HCCOUser), []string{"kubernetes"}, X509UsageClientAuth)
+}
+
 func ReconcileServiceAccountKubeconfig(secret, csrSigner *corev1.Secret, ca *corev1.ConfigMap, hcp *hyperv1.HostedControlPlane, serviceAccountNamespace, serviceAccountName string) error {
 	cn := serviceaccount.MakeUsername(serviceAccountNamespace, serviceAccountName)
 	if err := reconcileSignedCert(secret, csrSigner, config.OwnerRef{}, cn, serviceaccount.MakeGroupNames(serviceAccountNamespace), X509UsageClientAuth); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
@@ -1,0 +1,170 @@
+package kas
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/upsert"
+	k8sadmissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type AdmissionPolicy struct {
+	Name             string
+	MatchConstraints *k8sadmissionv1beta1.MatchResources
+	Validations      []k8sadmissionv1beta1.Validation
+}
+
+const (
+	AdmissionPolicyNameConfig = "config"
+	AdmissionPolicyNameMirror = "mirror"
+	AdmissionPolicyNameICSP   = "icsp"
+)
+
+var (
+	allAdmissionPoliciesOperations = []k8sadmissionv1beta1.OperationType{"*"}
+	defaultMatchResourcesScope     = k8sadmissionv1beta1.ScopeType("*")
+	defaultMatchPolicyType         = k8sadmissionv1beta1.Equivalent
+	HCCOUserValidation             = k8sadmissionv1beta1.Validation{
+		Expression: fmt.Sprintf("request.userInfo.username == 'system:%s' || (has(object.spec) && has(oldObject.spec) && object.spec == oldObject.spec)", config.HCCOUser),
+		Message:    "This resource cannot be created, updated, or deleted. Please ask your administrator to modify the resource in the HostedCluster object.",
+		Reason:     ptr.To(metav1.StatusReasonInvalid),
+	}
+)
+
+// ReconcileKASValidatingAdmissionPolicies will create ValidatingAdmissionPolicies which block certain resources
+// from being updated/deleted from the DataPlane side.
+func ReconcileKASValidatingAdmissionPolicies(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("reconciling validating admission policies")
+
+	if err := reconcileConfigValidatingAdmissionPolicy(ctx, hcp, client, createOrUpdate); err != nil {
+		return fmt.Errorf("failed to reconcile Config Validating Admission Policy: %v", err)
+	}
+
+	if err := reconcileMirrorValidatingAdmissionPolicy(ctx, hcp, client, createOrUpdate); err != nil {
+		return fmt.Errorf("failed to reconcile Mirror Validating Admission Policies: %v", err)
+	}
+
+	return nil
+}
+
+func reconcileConfigValidatingAdmissionPolicy(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	// Config AdmissionPolicy
+	configAdmissionPolicy := AdmissionPolicy{Name: AdmissionPolicyNameConfig}
+	configAPIVersion := []string{configv1.GroupVersion.Version}
+	configAPIGroup := []string{configv1.GroupVersion.Group}
+	configResources := []string{
+		"apiservers",
+		"authentications",
+		"featuregates",
+		"images",
+		"imagecontentpolicies",
+		"infrastructures",
+		"ingresses",
+		"proxies",
+		"schedulers",
+		"networks",
+		"oauths",
+	}
+
+	if hcp.Spec.OLMCatalogPlacement == hyperv1.ManagementOLMCatalogPlacement {
+		configResources = append(configResources, "operatorhubs")
+	}
+	configAdmissionPolicy.Validations = []k8sadmissionv1beta1.Validation{HCCOUserValidation}
+	configAdmissionPolicy.MatchConstraints = constructPolicyMatchConstraints(configResources, configAPIVersion, configAPIGroup, []k8sadmissionv1beta1.OperationType{"UPDATE", "DELETE"})
+	if err := configAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
+		return fmt.Errorf("error reconciling Config Validating Admission Policy: %v", err)
+	}
+
+	return nil
+}
+
+func reconcileMirrorValidatingAdmissionPolicy(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	// Mirroring AdmissionPolicies
+	mirrorAdmissionPolicy := AdmissionPolicy{Name: AdmissionPolicyNameMirror}
+	mirrorAPIVersion := []string{configv1.GroupVersion.Version}
+	mirrorAPIGroup := []string{configv1.GroupVersion.Group}
+	mirrorResources := []string{
+		"imagedigestmirrorsets",
+		"imagetagmirrorsets",
+	}
+
+	if hcp.Spec.OLMCatalogPlacement == hyperv1.ManagementOLMCatalogPlacement {
+		mirrorResources = append(mirrorResources, "operatorhubs")
+	}
+	mirrorAdmissionPolicy.Validations = []k8sadmissionv1beta1.Validation{HCCOUserValidation}
+	mirrorAdmissionPolicy.MatchConstraints = constructPolicyMatchConstraints(mirrorResources, mirrorAPIVersion, mirrorAPIGroup, allAdmissionPoliciesOperations)
+	if err := mirrorAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
+		return fmt.Errorf("error reconciling Mirror Validating Admission Policy: %v", err)
+	}
+
+	// ICSP lives in other API, this is why we need to create another vap and vap-binding
+	icspAdmissionPolicy := AdmissionPolicy{Name: AdmissionPolicyNameICSP}
+	icspAPIVersion := []string{operatorv1alpha1.GroupVersion.Version}
+	icspAPIGroup := []string{operatorv1alpha1.GroupVersion.Group}
+	icspResources := []string{"imagecontentsourcepolicies"}
+
+	icspAdmissionPolicy.Validations = []k8sadmissionv1beta1.Validation{HCCOUserValidation}
+	icspAdmissionPolicy.MatchConstraints = constructPolicyMatchConstraints(icspResources, icspAPIVersion, icspAPIGroup, allAdmissionPoliciesOperations)
+	if err := icspAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
+		return fmt.Errorf("error reconciling ICSP Validating Admission Policy: %v", err)
+	}
+
+	return nil
+}
+
+func (ap *AdmissionPolicy) reconcileAdmissionPolicy(ctx context.Context, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	vap := manifests.ValidatingAdmissionPolicy(ap.Name)
+	if _, err := createOrUpdate(ctx, client, vap, func() error {
+		if vap.Spec.MatchConstraints != nil {
+			vap.Spec.MatchConstraints.ResourceRules = ap.MatchConstraints.ResourceRules
+			vap.Spec.MatchConstraints.MatchPolicy = ap.MatchConstraints.MatchPolicy
+		} else {
+			vap.Spec.MatchConstraints = ap.MatchConstraints
+		}
+		vap.Spec.Validations = ap.Validations
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to create/update Validating Admission Policy with name %s: %v", ap.Name, err)
+	}
+
+	policyBinding := manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", ap.Name))
+	if _, err := createOrUpdate(ctx, client, policyBinding, func() error {
+		policyBinding.Spec.PolicyName = ap.Name
+		policyBinding.Spec.ValidationActions = []k8sadmissionv1beta1.ValidationAction{k8sadmissionv1beta1.Deny}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to create/update Validating Admission Policy Binding with name %s: %v", ap.Name, err)
+	}
+
+	return nil
+}
+
+func constructPolicyMatchConstraints(resources, apiVersion, apiGroup []string, operations []k8sadmissionv1beta1.OperationType) *k8sadmissionv1beta1.MatchResources {
+	return &k8sadmissionv1beta1.MatchResources{
+		ResourceRules: []k8sadmissionv1beta1.NamedRuleWithOperations{
+			{
+				RuleWithOperations: k8sadmissionv1beta1.RuleWithOperations{
+					Operations: operations,
+					Rule: k8sadmissionv1beta1.Rule{
+						APIGroups:   apiGroup,
+						APIVersions: apiVersion,
+						Resources:   resources,
+						Scope:       &defaultMatchResourcesScope,
+					},
+				},
+			},
+		},
+		MatchPolicy: &defaultMatchPolicyType,
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/admissionpolicies.go
@@ -1,0 +1,22 @@
+package manifests
+
+import (
+	k8sadmissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ValidatingAdmissionPolicy(name string) *k8sadmissionv1beta1.ValidatingAdmissionPolicy {
+	return &k8sadmissionv1beta1.ValidatingAdmissionPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: k8sadmissionv1beta1.SchemeGroupVersion.String(),
+			Kind:       "ValidatingAdmissionPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+func ValidatingAdmissionPolicyBinding(bindingName string) *k8sadmissionv1beta1.ValidatingAdmissionPolicyBinding {
+	return &k8sadmissionv1beta1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: bindingName},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -42,6 +42,7 @@ import (
 	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/blang/semver"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
@@ -275,6 +276,20 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 	log.Info("reconciling kubernetes.default endpoints and endpointslice")
 	if err := r.reconcileKASEndpoints(ctx, hcp); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile kubernetes.default endpoints and endpointslice: %w", err))
+	}
+
+	releaseImageVersion, err := semver.Parse(releaseImage.Version())
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to parse release image version: %w", err)
+	}
+
+	// The exception for IBMCloudPlatform is due to the fact that the IBM will include new certificates for HCCO from 4.17 version
+	if !(hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform && (releaseImageVersion.Major == 4 && releaseImageVersion.Minor < 17)) {
+		// Apply new ValidatingAdmissionPolicy to restrict the modification/deletion of certain
+		// objects from the DataPlane which are managed by the HCCO.
+		if err := kas.ReconcileKASValidatingAdmissionPolicies(ctx, hcp, r.client, r.CreateOrUpdate); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile validating admission policies: %w", err))
+		}
 	}
 
 	log.Info("reconciling install configmap")

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -21,6 +21,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 	"github.com/openshift/hypershift/support/globalconfig"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
@@ -61,6 +62,13 @@ var initialObjects = []client.Object{
 	manifests.NodeTuningClusterOperator(),
 	manifests.NamespaceKubeSystem(),
 	&configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}},
+	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameConfig),
+	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameMirror),
+	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameICSP),
+	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameConfig)),
+	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameMirror)),
+	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameICSP)),
+
 	fakeOperatorHub(),
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -25,6 +25,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
@@ -75,7 +76,7 @@ type HostedClusterConfigOperatorConfig struct {
 }
 
 func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
-	cfg.UserAgent = "hosted-cluster-config-operator-manager"
+	cfg.UserAgent = config.HCCOUserAgent
 	allSelector := cache.ByObject{
 		Label: labels.Everything(),
 	}

--- a/go.mod
+++ b/go.mod
@@ -254,9 +254,9 @@ replace github.com/google/cel-go => github.com/google/cel-go v0.17.7
 
 // These are because of github.com/openshift/cluster-node-tuning-operator@v0.0.0-20240131125539-0e319439e65a
 replace (
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.3
-	k8s.io/kubernetes => k8s.io/kubernetes v0.29.3
-	k8s.io/mount-utils => k8s.io/mount-utils v0.29.3
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.30.2
+	k8s.io/kubernetes => k8s.io/kubernetes v0.30.2
+	k8s.io/mount-utils => k8s.io/mount-utils v0.30.2
 )
 
 // There is an error with newer versions of prometheus

--- a/go.work.sum
+++ b/go.work.sum
@@ -698,6 +698,7 @@ k8s.io/component-helpers v0.30.1/go.mod h1:b1Xk27UJ3p/AmPqDx7khrnSxrdwQy9gTP7O1y
 k8s.io/controller-manager v0.27.4/go.mod h1:5+Fo0k+t3MDyuNLjmXzU/dJcD2c34ii8Wef+OmqhkVg=
 k8s.io/cri-api v0.28.4/go.mod h1:QaLIWi4Ejw0uHZlGRUIDmc2IlNlwc9Wp4gb6tEjeQCs=
 k8s.io/csi-translation-lib v0.29.3/go.mod h1:snAzieA58/oiQXQZr27b0+b6/3+ZzitwI+57cUsMKKQ=
+k8s.io/csi-translation-lib v0.30.2/go.mod h1:jFT8vquP6eSDUwDHk0mKT6uKFWlZp60ecUEUhmlGsOY=
 k8s.io/dynamic-resource-allocation v0.26.2/go.mod h1:LvsFr+Mp6LvEYypFPkB/xq0u+W368qVldQckybgQTgM=
 k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 h1:pWEwq4Asjm4vjW7vcsmijwBhOr1/shsbSYiWXmNGlks=
 k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
@@ -708,7 +709,7 @@ k8s.io/klog/v2 v2.90.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=
 k8s.io/metrics v0.30.1/go.mod h1:gVAhTTgfNKsn9D1kB7Nmb1T31relBuXzzGUE7klyOkM=
-k8s.io/mount-utils v0.29.3/go.mod h1:9IWJTMe8tG0MYMLEp60xK9GYVeCdA3g4LowmnVi+t9Y=
+k8s.io/mount-utils v0.30.2/go.mod h1:9sCVmwGLcV1MPvbZ+rToMDnl1QcGozy+jBPd0MsQLIo=
 k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20230505201702-9f6742963106/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/support/config/types.go
+++ b/support/config/types.go
@@ -6,7 +6,7 @@ const (
 	PodSafeToEvictLocalVolumesKey = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
 
 	// HCCOUser references the user used by the HostedClusterConfigOperator
-	HCCOUser = "hosted-cluster-config-operator"
+	HCCOUser = "hosted-cluster-config"
 	// HCCOUserAgent references the userAgent used by the HostedClusterConfigOperator
 	HCCOUserAgent = "hosted-cluster-config-operator-manager"
 )

--- a/support/config/types.go
+++ b/support/config/types.go
@@ -4,4 +4,9 @@ const (
 	// PodSafeToEvictLocalVolumesKey is an annotation used by the CA operator which makes sure
 	// all the pods annotated with it and the picking the desired local volumes that are safe to evict, could be drained properly.
 	PodSafeToEvictLocalVolumesKey = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
+
+	// HCCOUser references the user used by the HostedClusterConfigOperator
+	HCCOUser = "hosted-cluster-config-operator"
+	// HCCOUserAgent references the userAgent used by the HostedClusterConfigOperator
+	HCCOUserAgent = "hosted-cluster-config-operator-manager"
 )

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -147,6 +147,7 @@ func (h *hypershiftTest) after(hostedCluster *hyperv1.HostedCluster, platform hy
 			EnsureHCPPodsAffinitiesAndTolerations(t, context.Background(), h.client, hostedCluster)
 		}
 		EnsureSATokenNotMountedUnlessNecessary(t, context.Background(), h.client, hostedCluster)
+		EnsureAdmissionPolicies(t, context.Background(), h.client, hostedCluster)
 	})
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2367,8 +2367,8 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
 # github.com/google/cel-go => github.com/google/cel-go v0.17.7
-# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.3
-# k8s.io/kubernetes => k8s.io/kubernetes v0.29.3
-# k8s.io/mount-utils => k8s.io/mount-utils v0.29.3
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.30.2
+# k8s.io/kubernetes => k8s.io/kubernetes v0.30.2
+# k8s.io/mount-utils => k8s.io/mount-utils v0.30.2
 # github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.18.0
 # github.com/prometheus/common => github.com/prometheus/common v0.45.0


### PR DESCRIPTION
Added ValidatingAdmissionPolicies to the KAS's HostedCluster to block all configuration requests managed in the management cluster via the HostedCluster object.

Enabling the ValidatingAdmissionPolicy feature gate in the KAS allows us to block certain requests from the Data Plane side without using a webhook. To achieve this, we created the necessary resources (Certificate, RBAC, etc.) that allow HCCO to be identified with a specific user. This designated user will be the only one authorized to execute the required requests. All other users, including those using the admin-kubeconfig, will be blocked by the VAPs validation

Pull Request Content:

- Enabled ValidatingAdmissionPolicies (VAP) FeatureGate on the KAS
- Added a new user (via certificates) to HCCO
- Implemented a new reconciler on HCCO for VAPs managed by Hypershift
- Updated Kubernetes dependency to v0.30.2
- Added E2E test for VAPs configured by HCCO

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-34816](https://issues.redhat.com/browse/OCPBUGS-34816)
