### PR TITLE
NodePoolTest: set initial nodepool replicas to 1

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -157,9 +157,7 @@ func executeNodePoolTests(t *testing.T, nodePoolTestCasesPerHostedCluster []Host
 			}
 			t.Parallel()
 			clusterOpts := globalOpts.DefaultClusterOptions(t)
-			// We set replicas to 0 in order to allow the inner tests to
-			// create their own NodePools with the proper replicas
-			clusterOpts.NodePoolReplicas = 0
+			clusterOpts.NodePoolReplicas = 1
 
 			ctx, cancel := context.WithCancel(testContext)
 			defer cancel()


### PR DESCRIPTION
If set to 0, there are conditions that can't be retrieved due to lack of worker nodes, resulting in a timeout waiting for the condition to appear.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.