### PR TITLE
NO-JIRA: Default azure to run as managed-service=aro

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -275,9 +275,6 @@ const (
 	// AroHCP represents the ARO HCP managed service offering
 	AroHCP = "ARO-HCP"
 
-	// RosaHCP represents the ROSA HCP managed service offering
-	RosaHCP = "ROSA-HCP"
-
 	// HostedClusterSizeLabel is a label on HostedClusters indicating a size based on the number of nodes.
 	HostedClusterSizeLabel = "hypershift.openshift.io/hosted-cluster-size"
 

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -170,11 +170,18 @@ func (o ExternalDNSCredsSecret) Build() *corev1.Secret {
 	return secret
 }
 
+type ExternalDNSProvider string
+
+const (
+	AWSExternalDNSProvider   ExternalDNSProvider = "aws"
+	AzureExternalDNSProvider ExternalDNSProvider = "azure"
+)
+
 type ExternalDNSDeployment struct {
 	Namespace         *corev1.Namespace
 	Image             string
 	ServiceAccount    *corev1.ServiceAccount
-	Provider          string
+	Provider          ExternalDNSProvider
 	DomainFilter      string
 	CredentialsSecret *corev1.Secret
 	TxtOwnerId        string
@@ -286,7 +293,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 
 	// Add platform specific settings
 	switch o.Provider {
-	case "aws":
+	case AWSExternalDNSProvider:
 		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
 				Name:  "AWS_SHARED_CREDENTIALS_FILE",
@@ -303,7 +310,7 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 			"--aws-batch-change-interval=10s",
 			"--aws-zones-cache-duration=1h",
 		)
-	case "azure":
+	case AzureExternalDNSProvider:
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
 			"--azure-config-file=/etc/provider/credentials",
 		)


### PR DESCRIPTION
**What this PR does / why we need it**:
There's a single valid known use case for azure atm. Let's default to it.
Also this drops rosa variable since there's no usage nor valid semantic for it atm.

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.