### PR TITLE
HOSTEDCP-1795: Customize the self-generated cert validity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build: hypershift-operator control-plane-operator control-plane-pki-operator hyp
 
 .PHONY: sync
 sync:
-	$(GO) work sync 
+	$(GO) work sync
 
 .PHONY: update
 update: sync api-deps api api-docs deps clients app-sre-saas-template

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -317,6 +317,9 @@ const (
 	// This annotation signals to the NodePool controller that it is safe to use TopologySpreadConstraints on a NodePool
 	// without triggering an unexpected update of KubeVirt VMs.
 	NodePoolSupportsKubevirtTopologySpreadConstraintsAnnotation = "hypershift.openshift.io/nodepool-supports-kubevirt-topology-spread-constraints"
+
+	// SelfSignedCertificateValidityAnnotation allows specifying the validity of the self-signed certificate generated for HCP components. The format of the annotation is a go duration string with a numeric component and unit.
+	SelfSignedCertificateValidityAnnotation = "hypershift.openshift.io/certificate-validity"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -139,11 +141,20 @@ func ReconcileIgnitionServer(ctx context.Context,
 			log.Info("reconciled ignition CA cert secret", "result", result)
 		}
 
+		var (
+			validity *time.Duration
+			err      error
+		)
+
+		if validity, err = certs.GenerateCertValidity(ptr.To(hcp.Annotations[hyperv1.SelfSignedCertificateValidityAnnotation])); err != nil {
+			return fmt.Errorf("failed to parse ignition server cert validity: %w", err)
+		}
+
 		// Reconcile an ignition serving certificate issued by the generated root CA.
 		// We only create this and don't update it for now.
 		servingCertSecret := ignitionserver.IgnitionServingCertSecret(controlPlaneNamespace)
 		if result, err := createOrUpdate(ctx, c, servingCertSecret, func() error {
-			return reconcileServingCertSecret(servingCertSecret, caCertSecret, ignitionServerAddress)
+			return reconcileServingCertSecret(servingCertSecret, caCertSecret, ignitionServerAddress, *validity)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile ignition serving cert: %w", err)
 		} else {
@@ -369,7 +380,7 @@ func reconcileCACertSecret(caCertSecret *corev1.Secret) error {
 	})
 }
 
-func reconcileServingCertSecret(servingCertSecret *corev1.Secret, caCertSecret *corev1.Secret, ignitionServerAddress string) error {
+func reconcileServingCertSecret(servingCertSecret *corev1.Secret, caCertSecret *corev1.Secret, ignitionServerAddress string, validity time.Duration) error {
 	servingCertSecret.Type = corev1.SecretTypeTLS
 
 	var dnsNames, ipAddresses []string
@@ -391,6 +402,7 @@ func reconcileServingCertSecret(servingCertSecret *corev1.Secret, caCertSecret *
 		"",
 		dnsNames,
 		ipAddresses,
+		validity,
 		func(o *certs.CAOpts) {
 			o.CASignerCertMapKey = corev1.TLSCertKey
 			o.CASignerKeyMapKey = corev1.TLSPrivateKeyKey

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/aws_pod_identity_webhook.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/aws_pod_identity_webhook.go
@@ -1,10 +1,12 @@
 package pki
 
 import (
+	"time"
+
 	"github.com/openshift/hypershift/support/config"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func ReconcileAWSPodIdentityWebhookServingCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "127.0.0.1", nil, X509UsageClientServerAuth, nil, []string{"127.0.0.1"})
+func ReconcileAWSPodIdentityWebhookServingCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "127.0.0.1", nil, X509UsageClientServerAuth, nil, []string{"127.0.0.1"}, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/azure_disk_csi_driver_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/azure_disk_csi_driver_controller.go
@@ -2,18 +2,19 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileAzureDiskCsiDriverControllerMetricsServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileAzureDiskCsiDriverControllerMetricsServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		fmt.Sprintf("azure-disk-csi-driver-controller.%s.svc", secret.Namespace),
 		fmt.Sprintf("azure-disk-csi-driver-controller.%s.svc.cluster.local", secret.Namespace),
 		"azure-disk-csi-driver-controller",
 		"localhost",
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "azure-disk-csi-driver-controller", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "azure-disk-csi-driver-controller", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/azure_file_csi_driver_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/azure_file_csi_driver_controller.go
@@ -2,18 +2,19 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileAzureFileCsiDriverControllerMetricsServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileAzureFileCsiDriverControllerMetricsServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		fmt.Sprintf("azure-file-csi-driver-controller.%s.svc", secret.Namespace),
 		fmt.Sprintf("azure-file-csi-driver-controller.%s.svc.cluster.local", secret.Namespace),
 		"azure-file-csi-driver-controller",
 		"localhost",
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "azure-file-csi-driver-controller", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "azure-file-csi-driver-controller", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/cert.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/cert.go
@@ -2,6 +2,7 @@ package pki
 
 import (
 	"crypto/x509"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -18,27 +19,27 @@ var (
 	X509SignerUsage  = X509DefaultUsage | x509.KeyUsageCertSign
 )
 
-func reconcileSignedCert(secret *corev1.Secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage) error {
-	return reconcileSignedCertWithKeys(secret, ca, ownerRef, cn, org, extUsages, corev1.TLSCertKey, corev1.TLSPrivateKeyKey, certs.CASignerCertMapKey)
+func reconcileSignedCert(secret *corev1.Secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage, validity time.Duration) error {
+	return reconcileSignedCertWithKeys(secret, ca, ownerRef, cn, org, extUsages, corev1.TLSCertKey, corev1.TLSPrivateKeyKey, certs.CASignerCertMapKey, validity)
 }
 
-func reconcileSignedCertWithKeys(secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage, crtKey, keyKey, caKey string) error {
-	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, cn, org, extUsages, crtKey, keyKey, caKey, nil, nil, "")
+func reconcileSignedCertWithKeys(secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage, crtKey, keyKey, caKey string, validity time.Duration) error {
+	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, cn, org, extUsages, crtKey, keyKey, caKey, nil, nil, "", validity)
 }
 
-func reconcileSignedCertWithAddresses(secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage, dnsNames []string, ips []string) error {
-	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, cn, org, extUsages, corev1.TLSCertKey, corev1.TLSPrivateKeyKey, certs.CASignerCertMapKey, dnsNames, ips, "")
+func reconcileSignedCertWithAddresses(secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage, dnsNames []string, ips []string, validity time.Duration) error {
+	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, cn, org, extUsages, corev1.TLSCertKey, corev1.TLSPrivateKeyKey, certs.CASignerCertMapKey, dnsNames, ips, "", validity)
 }
 
-func reconcileSignedCertWithAddressesAndSecretType(secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage, dnsNames []string, ips []string, secretType corev1.SecretType) error {
-	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, cn, org, extUsages, corev1.TLSCertKey, corev1.TLSPrivateKeyKey, certs.CASignerCertMapKey, dnsNames, ips, secretType)
+func reconcileSignedCertWithAddressesAndSecretType(secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage, dnsNames []string, ips []string, secretType corev1.SecretType, validity time.Duration) error {
+	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, cn, org, extUsages, corev1.TLSCertKey, corev1.TLSPrivateKeyKey, certs.CASignerCertMapKey, dnsNames, ips, secretType, validity)
 }
 
-func reconcileSignedCertWithKeysAndAddresses(secret *corev1.Secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage, crtKey string, keyKey string, caKey string, dnsNames []string, ips []string, secretType corev1.SecretType) error {
+func reconcileSignedCertWithKeysAndAddresses(secret *corev1.Secret, ca *corev1.Secret, ownerRef config.OwnerRef, cn string, org []string, extUsages []x509.ExtKeyUsage, crtKey string, keyKey string, caKey string, dnsNames []string, ips []string, secretType corev1.SecretType, validity time.Duration) error {
 	ownerRef.ApplyTo(secret)
 	secret.Type = corev1.SecretTypeOpaque
 	if secretType != "" {
 		secret.Type = secretType
 	}
-	return certs.ReconcileSignedCert(secret, ca, cn, org, extUsages, crtKey, keyKey, caKey, dnsNames, ips)
+	return certs.ReconcileSignedCert(secret, ca, cn, org, extUsages, crtKey, keyKey, caKey, dnsNames, ips, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/cert_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/cert_test.go
@@ -21,6 +21,7 @@ func TestReconcileSignedCertWithKeysAndAddresses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed go generate CA: %v", err)
 	}
+	validity := certs.DefaultSelfSignedCertValidity
 
 	caSecret := &corev1.Secret{
 		Data: map[string][]byte{
@@ -112,7 +113,7 @@ func TestReconcileSignedCertWithKeysAndAddresses(t *testing.T) {
 			}
 			initialKey, initalCert := secret.Data[corev1.TLSPrivateKeyKey], secret.Data[corev1.TLSCertKey]
 
-			if err := reconcileSignedCertWithKeysAndAddresses(secret, caSecret, config.OwnerRef{}, "foo", []string{"org"}, X509UsageServerAuth, corev1.TLSCertKey, corev1.TLSPrivateKeyKey, certs.CASignerCertMapKey, []string{"foo.svc.local"}, []string{"127.0.0.1"}, ""); err != nil {
+			if err := reconcileSignedCertWithKeysAndAddresses(secret, caSecret, config.OwnerRef{}, "foo", []string{"org"}, X509UsageServerAuth, corev1.TLSCertKey, corev1.TLSPrivateKeyKey, certs.CASignerCertMapKey, []string{"foo.svc.local"}, []string{"127.0.0.1"}, "", validity); err != nil {
 				t.Fatalf("reconcileSignedCertWithKeysAndAddresses failed: %v", err)
 			}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/csisnapshotcontroller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/csisnapshotcontroller.go
@@ -2,6 +2,7 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/openshift/hypershift/support/config"
 	corev1 "k8s.io/api/core/v1"
@@ -11,11 +12,11 @@ import (
 // In standalone OCP it's created automatically when csi-snapshot-controller-operator creates Service for
 // the webhook with annotation `service.openshift.io/serving-cert-secret-name`, in HyperShift
 // it must be done by control-plane-operator.
-func ReconcileCSISnapshotWebhookTLS(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileCSISnapshotWebhookTLS(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"csi-snapshot-webhook",
 		fmt.Sprintf("csi-snapshot-webhook.%s.svc", secret.Namespace),
 		fmt.Sprintf("csi-snapshot-webhook.%s.svc.cluster.local", secret.Namespace),
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "packageserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "packageserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/cvo.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/cvo.go
@@ -2,18 +2,19 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileCVOServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileCVOServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		fmt.Sprintf("cluster-version-operator.%s.svc", secret.Namespace),
 		fmt.Sprintf("cluster-version-operator.%s.svc.cluster.local", secret.Namespace),
 		"cluster-version-operator",
 		"localhost",
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "cluster-version-operator", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "cluster-version-operator", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
@@ -2,6 +2,7 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -20,15 +21,15 @@ const (
 	EtcdPeerKeyKey = "peer.key"
 )
 
-func ReconcileEtcdClientSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCertWithKeys(secret, ca, ownerRef, "etcd-client", []string{"kubernetes"}, X509UsageClientAuth, EtcdClientCrtKey, EtcdClientKeyKey, "")
+func ReconcileEtcdClientSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
+	return reconcileSignedCertWithKeys(secret, ca, ownerRef, "etcd-client", []string{"kubernetes"}, X509UsageClientAuth, EtcdClientCrtKey, EtcdClientKeyKey, "", validity)
 }
 
-func ReconcileEtcdMetricsClientSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCertWithKeys(secret, ca, ownerRef, "etcd-metrics-client", []string{"kubernetes"}, X509UsageClientAuth, EtcdClientCrtKey, EtcdClientKeyKey, "")
+func ReconcileEtcdMetricsClientSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
+	return reconcileSignedCertWithKeys(secret, ca, ownerRef, "etcd-metrics-client", []string{"kubernetes"}, X509UsageClientAuth, EtcdClientCrtKey, EtcdClientKeyKey, "", validity)
 }
 
-func ReconcileEtcdServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileEtcdServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		fmt.Sprintf("etcd-client.%s.svc", secret.Namespace),
 		fmt.Sprintf("etcd-client.%s.svc.cluster.local", secret.Namespace),
@@ -38,10 +39,10 @@ func ReconcileEtcdServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerR
 		"localhost",
 	}
 
-	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-server", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdServerCrtKey, EtcdServerKeyKey, "", dnsNames, nil, "")
+	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-server", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdServerCrtKey, EtcdServerKeyKey, "", dnsNames, nil, "", validity)
 }
 
-func ReconcileEtcdPeerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileEtcdPeerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		fmt.Sprintf("*.etcd-discovery.%s.svc", secret.Namespace),
 		fmt.Sprintf("*.etcd-discovery.%s.svc.cluster.local", secret.Namespace),
@@ -49,5 +50,5 @@ func ReconcileEtcdPeerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef
 		"::1",
 	}
 
-	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-discovery", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdPeerCrtKey, EtcdPeerKeyKey, "", dnsNames, nil, "")
+	return reconcileSignedCertWithKeysAndAddresses(secret, ca, ownerRef, "etcd-discovery", []string{"kubernetes"}, X509UsageClientServerAuth, EtcdPeerCrtKey, EtcdPeerKeyKey, "", dnsNames, nil, "", validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ignitionserver.go
@@ -2,17 +2,18 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileIgnitionServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileIgnitionServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"ignition-server",
 		fmt.Sprintf("ignition-server.%s.svc", secret.Namespace),
 		fmt.Sprintf("ignition-server.%s.svc.cluster.local", secret.Namespace),
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "ignition-server", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "ignition-server", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ingress.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ingress.go
@@ -2,13 +2,14 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileIngressCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef, ingressSubdomain string) error {
+func ReconcileIngressCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef, ingressSubdomain string, validity time.Duration) error {
 	ingressHostNames := []string{fmt.Sprintf("*.%s", ingressSubdomain)}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-ingress", []string{"openshift"}, X509UsageClientServerAuth, ingressHostNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-ingress", []string{"openshift"}, X509UsageClientServerAuth, ingressHostNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kcm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kcm.go
@@ -2,17 +2,18 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/openshift/hypershift/support/config"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func ReconcileKCMServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileKCMServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		fmt.Sprintf("kube-controller-manager.%s.svc", secret.Namespace),
 		fmt.Sprintf("kube-controller-manager.%s.svc.cluster.local", secret.Namespace),
 		"kube-controller-manager",
 		"localhost",
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "kube-controller-manager", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "kube-controller-manager", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/konnectivity.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/konnectivity.go
@@ -2,6 +2,7 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/openshift/hypershift/support/config"
 	corev1 "k8s.io/api/core/v1"
@@ -11,7 +12,7 @@ func ReconcileKonnectivitySignerSecret(secret *corev1.Secret, ownerRef config.Ow
 	return reconcileSelfSignedCA(secret, ownerRef, "konnectivity-signer", "kubernetes")
 }
 
-func ReconcileKonnectivityServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileKonnectivityServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"localhost",
 		"konnectivity-server-local",
@@ -21,10 +22,10 @@ func ReconcileKonnectivityServerSecret(secret, ca *corev1.Secret, ownerRef confi
 	ips := []string{
 		"127.0.0.1",
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "konnectivity-server-local", []string{"kubernetes"}, X509UsageServerAuth, dnsNames, ips)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "konnectivity-server-local", []string{"kubernetes"}, X509UsageServerAuth, dnsNames, ips, validity)
 }
 
-func ReconcileKonnectivityClusterSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalKconnectivityAddress string) error {
+func ReconcileKonnectivityClusterSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalKconnectivityAddress string, validity time.Duration) error {
 	dnsNames := []string{
 		"konnectivity-server",
 		fmt.Sprintf("konnectivity-server.%s.svc", secret.Namespace),
@@ -36,13 +37,13 @@ func ReconcileKonnectivityClusterSecret(secret, ca *corev1.Secret, ownerRef conf
 	} else {
 		dnsNames = append(dnsNames, externalKconnectivityAddress)
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "konnectivity-server", []string{"kubernetes"}, X509UsageServerAuth, dnsNames, ips)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "konnectivity-server", []string{"kubernetes"}, X509UsageServerAuth, dnsNames, ips, validity)
 }
 
-func ReconcileKonnectivityClientSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCert(secret, ca, ownerRef, "konnectivity-client", []string{"kubernetes"}, X509UsageClientAuth)
+func ReconcileKonnectivityClientSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
+	return reconcileSignedCert(secret, ca, ownerRef, "konnectivity-client", []string{"kubernetes"}, X509UsageClientAuth, validity)
 }
 
-func ReconcileKonnectivityAgentSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCert(secret, ca, ownerRef, "konnectivity-agent", []string{"kubernetes"}, X509UsageClientAuth)
+func ReconcileKonnectivityAgentSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
+	return reconcileSignedCert(secret, ca, ownerRef, "konnectivity-agent", []string{"kubernetes"}, X509UsageClientAuth, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/mcs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/mcs.go
@@ -2,15 +2,16 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileMachineConfigServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileMachineConfigServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	hostNames := []string{
 		fmt.Sprintf("*.machine-config-server.%s.svc.cluster.local", secret.Namespace),
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "machine-config-server", []string{"openshift"}, X509UsageServerAuth, hostNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "machine-config-server", []string{"openshift"}, X509UsageServerAuth, hostNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/multus_admission_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/multus_admission_controller.go
@@ -2,18 +2,19 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileMultusAdmissionControllerServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileMultusAdmissionControllerServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		fmt.Sprintf("multus-admission-controller.%s.svc", secret.Namespace),
 		fmt.Sprintf("multus-admission-controller.%s.svc.cluster.local", secret.Namespace),
 		"multus-admission-controller",
 		"localhost",
 	}
-	return reconcileSignedCertWithAddressesAndSecretType(secret, ca, ownerRef, "multus-admission-controller", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, corev1.SecretTypeTLS)
+	return reconcileSignedCertWithAddressesAndSecretType(secret, ca, ownerRef, "multus-admission-controller", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, corev1.SecretTypeTLS, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/network_node_identity.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/network_node_identity.go
@@ -2,18 +2,19 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileNetworkNodeIdentityServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileNetworkNodeIdentityServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		fmt.Sprintf("network-node-identity.%s.svc", secret.Namespace),
 		fmt.Sprintf("network-node-identity.%s.svc.cluster.local", secret.Namespace),
 		"network-node-identity",
 		"localhost",
 	}
-	return reconcileSignedCertWithAddressesAndSecretType(secret, ca, ownerRef, "network-node-identity", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, corev1.SecretTypeTLS)
+	return reconcileSignedCertWithAddressesAndSecretType(secret, ca, ownerRef, "network-node-identity", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, corev1.SecretTypeTLS, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/nto.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/nto.go
@@ -2,17 +2,18 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileNodeTuningOperatorServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileNodeTuningOperatorServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"node-tuning-operator",
 		fmt.Sprintf("node-tuning-operator.%s.svc", secret.Namespace),
 		fmt.Sprintf("node-tuning-operator.%s.svc.cluster.local", secret.Namespace),
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "node-tuning-operator", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "node-tuning-operator", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/oauth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/oauth.go
@@ -2,13 +2,14 @@ package pki
 
 import (
 	"net"
+	"time"
 
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func ReconcileOAuthServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalOAuthAddress string) error {
+func ReconcileOAuthServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef, externalOAuthAddress string, validity time.Duration) error {
 	var dnsNames, ips []string
 	oauthIP := net.ParseIP(externalOAuthAddress)
 	if oauthIP != nil {
@@ -16,7 +17,7 @@ func ReconcileOAuthServerCert(secret, ca *corev1.Secret, ownerRef config.OwnerRe
 	} else {
 		dnsNames = append(dnsNames, externalOAuthAddress)
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-oauth", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, ips)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-oauth", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, ips, validity)
 }
 
 func ReconcileOAuthMasterCABundle(caBundle *corev1.ConfigMap, ownerRef config.OwnerRef, sourceCerts []*corev1.Secret) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/oauth_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/oauth_test.go
@@ -54,7 +54,7 @@ func TestReconcileOAuthServerCert(t *testing.T) {
 			secret := &corev1.Secret{}
 			secret.Name = "cert"
 			secret.Namespace = "dummy"
-			err = ReconcileOAuthServerCert(secret, ca, ownerRef, test.address)
+			err = ReconcileOAuthServerCert(secret, ca, ownerRef, test.address, certs.DefaultSelfSignedCertValidity)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/olm.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/olm.go
@@ -2,13 +2,14 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileOLMPackageServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileOLMPackageServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"packageserver",
 		fmt.Sprintf("packageserver.%s.svc", secret.Namespace),
@@ -16,23 +17,23 @@ func ReconcileOLMPackageServerCertSecret(secret, ca *corev1.Secret, ownerRef con
 		"packageserver.default.svc",
 		"packageserver.default.svc.cluster.local",
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "packageserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "packageserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }
 
-func ReconcileOLMCatalogOperatorServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileOLMCatalogOperatorServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"catalog-operator-metrics",
 		fmt.Sprintf("catalog-operator-metrics.%s.svc", secret.Namespace),
 		fmt.Sprintf("catalog-operator-metrics.%s.svc.cluster.local", secret.Namespace),
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "catalog-operator-metrics", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "catalog-operator-metrics", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }
 
-func ReconcileOLMOperatorServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileOLMOperatorServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"olm-operator-metrics",
 		fmt.Sprintf("olm-operator-metrics.%s.svc", secret.Namespace),
 		fmt.Sprintf("olm-operator-metrics.%s.svc.cluster.local", secret.Namespace),
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "olm-operator-metrics", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "olm-operator-metrics", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/openshift.go
@@ -2,13 +2,14 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileOpenShiftAPIServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileOpenShiftAPIServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"openshift-apiserver",
 		fmt.Sprintf("openshift-apiserver.%s.svc", secret.Namespace),
@@ -16,10 +17,10 @@ func ReconcileOpenShiftAPIServerCertSecret(secret, ca *corev1.Secret, ownerRef c
 		"openshift-apiserver.default.svc",
 		"openshift-apiserver.default.svc.cluster.local",
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-apiserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-apiserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }
 
-func ReconcileOpenShiftOAuthAPIServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileOpenShiftOAuthAPIServerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"openshift-oauth-apiserver",
 		fmt.Sprintf("openshift-oauth-apiserver.%s.svc", secret.Namespace),
@@ -27,18 +28,18 @@ func ReconcileOpenShiftOAuthAPIServerCertSecret(secret, ca *corev1.Secret, owner
 		"openshift-oauth-apiserver.default.svc",
 		"openshift-oauth-apiserver.default.svc.cluster.local",
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-oauth-apiserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-oauth-apiserver", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }
 
-func ReconcileOpenShiftAuthenticatorCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator", []string{"openshift"}, X509UsageClientAuth, nil, nil)
+func ReconcileOpenShiftAuthenticatorCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator", []string{"openshift"}, X509UsageClientAuth, nil, nil, validity)
 }
 
-func ReconcileOpenShiftControllerManagerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileOpenShiftControllerManagerCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		"openshift-controller-manager",
 		fmt.Sprintf("openshift-controller-manager.%s.svc", secret.Namespace),
 		fmt.Sprintf("openshift-controller-manager.%s.svc.cluster.local", secret.Namespace),
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-controller-manager", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "openshift-controller-manager", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ovn_control_plane_metrics.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ovn_control_plane_metrics.go
@@ -2,18 +2,19 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
 )
 
-func ReconcileOVNControlPlaneMetricsServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileOVNControlPlaneMetricsServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		fmt.Sprintf("ovnkube-control-plane.%s.svc", secret.Namespace),
 		fmt.Sprintf("ovnkube-control-plane.%s.svc.cluster.local", secret.Namespace),
 		"ovnkube-control-plane",
 		"localhost",
 	}
-	return reconcileSignedCertWithAddressesAndSecretType(secret, ca, ownerRef, "ovnkube-control-plane", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, corev1.SecretTypeTLS)
+	return reconcileSignedCertWithAddressesAndSecretType(secret, ca, ownerRef, "ovnkube-control-plane", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, corev1.SecretTypeTLS, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/registryoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/registryoperator.go
@@ -1,6 +1,8 @@
 package pki
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/hypershift/support/config"
@@ -8,10 +10,10 @@ import (
 
 const metricsHostname = "cluster-image-registry-operator"
 
-func ReconcileRegistryOperatorServingCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+func ReconcileRegistryOperatorServingCert(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
 	dnsNames := []string{
 		metricsHostname,
 		"localhost",
 	}
-	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, metricsHostname, []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, metricsHostname, []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, validity)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/sa.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/sa.go
@@ -2,6 +2,7 @@ package pki
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -32,8 +33,8 @@ func ReconcileServiceAccountSigningKeySecret(secret *corev1.Secret, ownerRef con
 	return nil
 }
 
-func ReconcileMetricsSAClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCert(secret, ca, ownerRef, "system:serviceaccount:hypershift:prometheus", []string{"kubernetes"}, X509UsageClientAuth)
+func ReconcileMetricsSAClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef, validity time.Duration) error {
+	return reconcileSignedCert(secret, ca, ownerRef, "system:serviceaccount:hypershift:prometheus", []string{"kubernetes"}, X509UsageClientAuth, validity)
 }
 
 func hasKeys(secret *corev1.Secret, keys ...string) bool {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1810,6 +1810,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.AWSLoadBalancerSubnetsAnnotation,
 		hyperv1.ManagementPlatformAnnotation,
 		hyperv1.KubeAPIServerVerbosityLevelAnnotation,
+		hyperv1.SelfSignedCertificateValidityAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/support/certs/tls_test.go
+++ b/support/certs/tls_test.go
@@ -180,6 +180,7 @@ func abs(i int) int {
 
 func TestReconcileSignedCertWithCustomCAKeys(t *testing.T) {
 	t.Parallel()
+	validity := certs.DefaultSelfSignedCertValidity
 	ca := &corev1.Secret{Type: corev1.SecretTypeTLS}
 	if err := certs.ReconcileSelfSignedCA(ca, "some-cn", "some-ou", func(o *certs.CAOpts) {
 		o.CASignerCertMapKey = "ca-signer-cert"
@@ -204,6 +205,7 @@ func TestReconcileSignedCertWithCustomCAKeys(t *testing.T) {
 		"",
 		nil,
 		nil,
+		validity,
 		func(o *certs.CAOpts) {
 			o.CASignerCertMapKey = "ca-signer-cert"
 			o.CASignerKeyMapKey = "ca-signer-key"


### PR DESCRIPTION
Now via annotation the self-generated certificates validity could be customized. This will help to test the certificates regeneration

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-1795](https://issues.redhat.com/browse/HOSTEDCP-1779)
