### PR TITLE
NO-JIRA: KubeVirtJsonPatchTest: fix vmi slice assignment

### DIFF
--- a/test/e2e/nodepool_kv_jsonpatch_test.go
+++ b/test/e2e/nodepool_kv_jsonpatch_test.go
@@ -30,7 +30,7 @@ type KubeVirtJsonPatchTest struct {
 	hostedCluster *hyperv1.HostedCluster
 }
 
-func NewKubeKubeVirtJsonPatchTest(ctx context.Context, cl crclient.Client, hc *hyperv1.HostedCluster) *KubeVirtJsonPatchTest {
+func NewKubeVirtJsonPatchTest(ctx context.Context, cl crclient.Client, hc *hyperv1.HostedCluster) *KubeVirtJsonPatchTest {
 	return &KubeVirtJsonPatchTest{
 		ctx:           ctx,
 		client:        cl,
@@ -43,7 +43,7 @@ func (k KubeVirtJsonPatchTest) Setup(t *testing.T) {
 		t.Skip("test only supported on platform KubeVirt")
 	}
 
-	t.Log("Starting test KubeKubeVirtJsonPatchTest")
+	t.Log("Starting test KubeVirtJsonPatchTest")
 }
 
 func (k KubeVirtJsonPatchTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []corev1.Node) {
@@ -96,7 +96,7 @@ func (k KubeVirtJsonPatchTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []
 			err := infraClient.GetInfraClient().List(k.ctx, vmis, &crclient.ListOptions{Namespace: guestNamespace, LabelSelector: labelSelector})
 			var ptrs []*kubevirtv1.VirtualMachineInstance
 			for i := range vmis.Items {
-				ptrs[i] = &vmis.Items[i]
+				ptrs = append(ptrs, &vmis.Items[i])
 			}
 			return ptrs, err
 		},

--- a/test/e2e/nodepool_kv_nodeselector_test.go
+++ b/test/e2e/nodepool_kv_nodeselector_test.go
@@ -33,7 +33,7 @@ type KubeVirtNodeSelectorTest struct {
 	nodeSelector  map[string]string
 }
 
-func NewKubeKubeVirtNodeSelectorTest(ctx context.Context, cl crclient.Client, hc *hyperv1.HostedCluster) *KubeVirtNodeSelectorTest {
+func NewKubeVirtNodeSelectorTest(ctx context.Context, cl crclient.Client, hc *hyperv1.HostedCluster) *KubeVirtNodeSelectorTest {
 	return &KubeVirtNodeSelectorTest{
 		ctx:           ctx,
 		client:        cl,

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -94,12 +94,12 @@ func TestNodePool(t *testing.T) {
 						test: NewKubeVirtQoSClassGuaranteedTest(ctx, mgtClient, hostedCluster),
 					},
 					{
-						name: "KubeKubeVirtJsonPatchTest",
-						test: NewKubeKubeVirtJsonPatchTest(ctx, mgtClient, hostedCluster),
+						name: "KubeVirtJsonPatchTest",
+						test: NewKubeVirtJsonPatchTest(ctx, mgtClient, hostedCluster),
 					},
 					{
 						name: "KubeVirtNodeSelectorTest",
-						test: NewKubeKubeVirtNodeSelectorTest(ctx, mgtClient, hostedCluster),
+						test: NewKubeVirtNodeSelectorTest(ctx, mgtClient, hostedCluster),
 					},
 					{
 						name: "KubeVirtNodeMultinetTest",


### PR DESCRIPTION
the following change broke the kubevirt e2e test suite:
https://github.com/openshift/hypershift/commit/6f6a78b7ff2932087b47609c5a16436bad5aeb1c#diff-fad16312cbcaea633c33fbabe940966d9d936a14dd67a239d1b6c6250fc8679aR99 as it is trying to access an empty slice by index.

This fix is required on order to fix the [4.17-periodics-e2e-kubevirt-aws-ovn](https://prow.ci.openshift.org/?job=periodic-ci-openshift-hypershift-release-4.17-periodics-e2e-kubevirt-aws-ovn) periodic job

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [4.17-periodics-e2e-kubevirt-aws-ovn](https://prow.ci.openshift.org/?job=periodic-ci-openshift-hypershift-release-4.17-periodics-e2e-kubevirt-aws-ovn)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.