### PR TITLE
HOSTEDCP-1808: Update Mkdocs, dependencies and dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,2 +1,2 @@
-FROM squidfunk/mkdocs-material:8.5.11
+FROM squidfunk/mkdocs-material:9
 RUN pip install mkdocs-mermaid2-plugin mkdocs-glightbox

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,3 +16,7 @@ serve-containerized:
 .PHONY: image
 image:
 	$(RUNTIME) build -t $(IMG) .
+
+.PHONY: push
+push:
+	$(RUNTIME) push $(IMG)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -43,6 +43,13 @@ markdown_extensions:
 - pymdownx.details
 - pymdownx.tabbed:
     alternate_style: true
+validation:
+  omitted_files: warn
+  absolute_links: ignore  # Or 'relative_to_docs' - new in MkDocs 1.6
+  unrecognized_links: ignore
+  anchors: ignore
+  nav:
+    omitted_files: ignore
 nav:
 - Home: index.md
 - 'Getting started': getting-started.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.3.0
-mkdocs-material==8.2.8
-mkdocs-mermaid2-plugin==0.5.2
-mkdocs-glightbox==0.3.0
+mkdocs==1.6.0
+mkdocs-material==9.5.28
+mkdocs-mermaid2-plugin==1.1.1
+mkdocs-glightbox==0.4.0


### PR DESCRIPTION
This PR contains several updates:

This PR contains several updates:

- The main one addresses a security flaw identified by SNYK, as mentioned in the header. To address this, all Mkdocs dependencies have been updated, and ultimately, urllib3 is used in the mkdocs-mermaid2-plugin.
- The Dockerfile has been updated to include the latest version of Mkdocs Material.
- The mkdocs.yml file has been updated to ignore non-relevant messages.
- The Makefile has been updated to include a push target for sending the created container image to the destination repository.

**Which issue(s) this PR fixes**:
- [HOSTEDCP-1810](https://issues.redhat.com/browse/HOSTEDCP-1810)
- [HOSTEDCP-1809](https://issues.redhat.com/browse/HOSTEDCP-1809)