### PR TITLE
OCPBUGS-36680: ensure additionalTrustBundle propogates to workers

### DIFF
--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -103,7 +103,7 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 		FeatureGateManifest: o.FeatureGateManifest,
 	}
 
-	payload, err := p.GetPayload(ctx, o.Image, config.String(), "", "")
+	payload, err := p.GetPayload(ctx, o.Image, config.String(), "", "", "")
 	if err != nil {
 		return err
 	}

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"io"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"os"
 	"os/exec"
@@ -78,8 +79,9 @@ type LocalIgnitionProvider struct {
 var _ IgnitionProvider = (*LocalIgnitionProvider)(nil)
 
 const pullSecretName = "pull-secret"
+const additionalTrustBundleName = "user-ca-bundle"
 
-func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage string, customConfig string, pullSecretHash string, hcConfigurationHash string) ([]byte, error) {
+func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, customConfig, pullSecretHash, additionalTrustBundleHash, hcConfigurationHash string) ([]byte, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -104,6 +106,29 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 	// Verify the pullSecret hash matches the passed-in parameter pullSecretHash to ensure the correct pull secret gets loaded into the payload
 	if pullSecretHash != "" && util.HashSimple(pullSecret) != pullSecretHash {
 		return nil, fmt.Errorf("pull secret does not match hash")
+	}
+
+	additionalTrustBundle := ""
+	atbCM := &corev1.ConfigMap{}
+
+	cmExists := true
+	if err = p.Client.Get(ctx, client.ObjectKey{Namespace: p.Namespace, Name: additionalTrustBundleName}, atbCM); err != nil {
+		if errors.IsNotFound(err) {
+			cmExists = false
+		} else {
+			return nil, fmt.Errorf("failed to get additionalTrustBundle configmap: %w", err)
+		}
+	}
+
+	if cmExists {
+		data, exists := atbCM.Data["ca-bundle.crt"]
+		if !exists {
+			return nil, fmt.Errorf("additionalTrustBundle configmap missing %q key", "ca-bundle.crt")
+		}
+		additionalTrustBundle = data
+	}
+	if additionalTrustBundleHash != "" && util.HashSimple(additionalTrustBundle) != additionalTrustBundleHash {
+		return nil, fmt.Errorf("additionalTrustBundle does not match hash")
 	}
 
 	// Fetch the bootstrap kubeconfig contents
@@ -131,6 +156,20 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 	// Verify the MCS configmap is up-to-date
 	if hcConfigurationHash != "" && mcsConfig.Data["configuration-hash"] != hcConfigurationHash {
 		return nil, fmt.Errorf("machine-config-server configmap is out of date, waiting for update %s != %s", mcsConfig.Data["configuration-hash"], hcConfigurationHash)
+	}
+
+	userCaBundleConfigCM := &corev1.ConfigMap{}
+	if err := yaml.Unmarshal([]byte(mcsConfig.Data["user-ca-bundle-config.yaml"]), &userCaBundleConfigCM); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal user-ca-bundle-config.yaml: %w", err)
+	}
+
+	// Verify that all the keys and values from additionalTrustBundle are in the user-ca-bundle-config.yaml
+	if atbCM.Data != nil {
+		for key, value := range atbCM.Data {
+			if userCaBundleConfigCM.Data[key] != value {
+				return nil, fmt.Errorf("user-ca-bundle-config.yaml in machine-config-server configmap does not contain all additionalTrustBundles")
+			}
+		}
 	}
 
 	// Look up the release image metadata

--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -23,19 +23,20 @@ import (
 )
 
 const (
-	TokenSecretReleaseKey             = "release"
-	TokenSecretConfigKey              = "config"
-	TokenSecretTokenKey               = "token"
-	TokenSecretOldTokenKey            = "old_token"
-	TokenSecretPayloadKey             = "payload"
-	TokenSecretMessageKey             = "message"
-	TokenSecretPullSecretHashKey      = "pull-secret-hash"
-	TokenSecretHCConfigurationHashKey = "hc-configuration-hash"
-	InvalidConfigReason               = "InvalidConfig"
-	TokenSecretReasonKey              = "reason"
-	TokenSecretAnnotation             = "hypershift.openshift.io/ignition-config"
-	TokenSecretNodePoolUpgradeType    = "hypershift.openshift.io/node-pool-upgrade-type"
-	TokenSecretTokenGenerationTime    = "hypershift.openshift.io/last-token-generation-time"
+	TokenSecretReleaseKey                   = "release"
+	TokenSecretConfigKey                    = "config"
+	TokenSecretTokenKey                     = "token"
+	TokenSecretOldTokenKey                  = "old_token"
+	TokenSecretPayloadKey                   = "payload"
+	TokenSecretMessageKey                   = "message"
+	TokenSecretPullSecretHashKey            = "pull-secret-hash"
+	TokenSecretHCConfigurationHashKey       = "hc-configuration-hash"
+	TokenSecretAdditionalTrustBundleHashKey = "additional-trust-bundle-hash"
+	InvalidConfigReason                     = "InvalidConfig"
+	TokenSecretReasonKey                    = "reason"
+	TokenSecretAnnotation                   = "hypershift.openshift.io/ignition-config"
+	TokenSecretNodePoolUpgradeType          = "hypershift.openshift.io/node-pool-upgrade-type"
+	TokenSecretTokenGenerationTime          = "hypershift.openshift.io/last-token-generation-time"
 	// Set the ttl 1h above the reconcile resync period so every existing
 	// token Secret has the chance to rotate their token ID during a reconciliation cycle
 	// while the expired ones get eventually garbageCollected.
@@ -79,7 +80,7 @@ func NewPayloadStore() *ExpiringCache {
 type IgnitionProvider interface {
 	// GetPayload returns the ignition payload content for
 	// the provided release image and a config string containing 0..N MachineConfig yaml definitions.
-	GetPayload(ctx context.Context, payloadImage, config string, pullSecretHash string, hcConfigurationHash string) ([]byte, error)
+	GetPayload(ctx context.Context, payloadImage, config, pullSecretHash, additionalTrustBundleHash, hcConfigurationHash string) ([]byte, error)
 }
 
 // TokenSecretReconciler watches token Secrets
@@ -260,9 +261,10 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	PayloadCacheMissTotal.Inc()
 	pullSecretHash := string(tokenSecret.Data[TokenSecretPullSecretHashKey])
 	hcConfigurationHash := string(tokenSecret.Data[TokenSecretHCConfigurationHashKey])
+	additionalTrustBundleHash := string(tokenSecret.Data[TokenSecretAdditionalTrustBundleHashKey])
 	payload, err := func() ([]byte, error) {
 		start := time.Now()
-		payload, err := r.IgnitionProvider.GetPayload(ctx, releaseImage, config.String(), pullSecretHash, hcConfigurationHash)
+		payload, err := r.IgnitionProvider.GetPayload(ctx, releaseImage, config.String(), pullSecretHash, additionalTrustBundleHash, hcConfigurationHash)
 		if err != nil {
 			return nil, fmt.Errorf("error getting ignition payload: %v", err)
 		}

--- a/ignition-server/controllers/tokensecret_controller_test.go
+++ b/ignition-server/controllers/tokensecret_controller_test.go
@@ -25,7 +25,7 @@ var (
 
 type fakeIgnitionProvider struct{}
 
-func (p *fakeIgnitionProvider) GetPayload(ctx context.Context, releaseImage string, config string, pullSecretHash string, hcConfigurationHash string) (payload []byte, err error) {
+func (p *fakeIgnitionProvider) GetPayload(ctx context.Context, releaseImage, config, pullSecretHash, additionalTrustBundleHash, hcConfigurationHash string) (payload []byte, err error) {
 	return []byte(fakePayload), nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a has for the additionalTrustBundle CM specified in the HC to the token secret, this will regenerate the payload and re rollout the nodes with the up to date additionalTrustBundle

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-36680

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.