### PR TITLE
OCPBUGS-36681: Set Azure VM identity if user assigned identity set

### DIFF
--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -45,11 +45,16 @@ func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1
 		NetworkInterfaces: []capiazure.NetworkInterface{{
 			SubnetName: subnetName,
 		}},
-		Identity:               capiazure.VMIdentityUserAssigned,
-		UserAssignedIdentities: []capiazure.UserAssignedIdentity{{ProviderID: hcluster.Spec.Platform.Azure.MachineIdentityID}},
-		SSHPublicKey:           sshKey,
-		FailureDomain:          failureDomain(nodePool),
+		SSHPublicKey:  sshKey,
+		FailureDomain: failureDomain(nodePool),
 	}}}
+
+	if hcluster.Spec.Platform.Azure.MachineIdentityID != "" {
+		azureMachineTemplate.Template.Spec.Identity = capiazure.VMIdentityUserAssigned
+		azureMachineTemplate.Template.Spec.UserAssignedIdentities = []capiazure.UserAssignedIdentity{{
+			ProviderID: hcluster.Spec.Platform.Azure.MachineIdentityID,
+		}}
+	}
 
 	if nodePool.Spec.Platform.Azure.DiskEncryptionSetID != "" {
 		azureMachineTemplate.Template.Spec.OSDisk.ManagedDisk.DiskEncryptionSet = &capiazure.DiskEncryptionSetParameters{


### PR DESCRIPTION
**What this PR does / why we need it**:
Only set the Azure VM identity if a user assigned identity was provided.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-36681](https://issues.redhat.com/browse/OCPBUGS-36681)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.