### PR TITLE
HOSTEDCP-1795,HOSTEDCP-1796: Customize the self-generated cert validity and rotation

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2583,6 +2583,16 @@ func reconcileControlPlaneOperatorDeployment(
 		},
 	}
 
+	if hc.Annotations[certs.CertificateValidityAnnotation] != "" {
+		certValidity := hc.Annotations[certs.CertificateValidityAnnotation]
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  certs.CertificateValidityEnvVar,
+				Value: certValidity,
+			},
+		)
+	}
+
 	if openShiftTrustedCABundleConfigMapExists {
 		hyperutil.DeploymentAddOpenShiftTrustedCABundleConfigMap(deployment)
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2593,6 +2593,16 @@ func reconcileControlPlaneOperatorDeployment(
 		)
 	}
 
+	if hc.Annotations[certs.CertificateRenewalAnnotation] != "" {
+		certRenewalPercentage := hc.Annotations[certs.CertificateRenewalAnnotation]
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  certs.CertificateRenewalEnvVar,
+				Value: certRenewalPercentage,
+			},
+		)
+	}
+
 	if openShiftTrustedCABundleConfigMapExists {
 		hyperutil.DeploymentAddOpenShiftTrustedCABundleConfigMap(deployment)
 	}

--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"math/big"
 	"net"
+	"os"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -45,6 +46,11 @@ const (
 	TLSSignerKeyMapKey = "tls.key"
 	// UserCABundleMapKeyis the key value in a user-provided CA configMap.
 	UserCABundleMapKey = "ca-bundle.crt"
+	// Custom certificate validity. The format of the annotation is a go duration string with a numeric component and unit.
+	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+	CertificateValidityAnnotation = "hypershift.openshift.io/certificate-validity"
+	CertificateValidityEnvVar     = "CERTIFICATE_VALIDITY"
+	CertificateValidityDefault    = ValidityOneYear
 )
 
 // CertCfg contains all needed fields to configure a new certificate
@@ -117,12 +123,14 @@ func SelfSignedCertificate(cfg *CertCfg, key *rsa.PrivateKey) (*x509.Certificate
 	if err != nil {
 		return nil, err
 	}
+
+	now := time.Now()
 	cert := x509.Certificate{
 		BasicConstraintsValid: true,
 		IsCA:                  cfg.IsCA,
 		KeyUsage:              cfg.KeyUsages,
-		NotAfter:              time.Now().Add(cfg.Validity),
-		NotBefore:             time.Now(),
+		NotAfter:              now.Add(cfg.Validity),
+		NotBefore:             now,
 		SerialNumber:          serial,
 		Subject:               cfg.Subject,
 	}
@@ -156,13 +164,14 @@ func signedCertificate(
 		return nil, err
 	}
 
+	now := time.Now()
 	certTmpl := x509.Certificate{
 		DNSNames:              csr.DNSNames,
 		ExtKeyUsage:           cfg.ExtKeyUsages,
 		IPAddresses:           csr.IPAddresses,
 		KeyUsage:              cfg.KeyUsages,
-		NotAfter:              time.Now().Add(cfg.Validity),
-		NotBefore:             caCert.NotBefore,
+		NotAfter:              now.Add(cfg.Validity),
+		NotBefore:             now,
 		SerialNumber:          serial,
 		Subject:               csr.Subject,
 		IsCA:                  cfg.IsCA,
@@ -286,6 +295,11 @@ func ValidateKeyPair(pemKey, pemCertificate []byte, cfg *CertCfg, minimumRemaini
 		errs = append(errs, fmt.Errorf("actual dns names differ from expected: %s", dnsNamesDiff))
 	}
 
+	certValidity := cert.NotAfter.Sub(cert.NotBefore)
+	if certValidity.Truncate(time.Minute) != cfg.Validity.Truncate(time.Minute) {
+		errs = append(errs, fmt.Errorf("actual validity %v differs from expected %v", (certValidity.Hours())/24, (cfg.Validity.Hours())/24))
+	}
+
 	extUsageDiff := cmp.Diff(cert.ExtKeyUsage, cfg.ExtKeyUsages, cmpopts.SortSlices(func(a, b x509.ExtKeyUsage) bool { return a < b }))
 	if extUsageDiff != "" {
 		errs = append(errs, fmt.Errorf("actual extended key usages differ from expected: %s", extUsageDiff))
@@ -356,11 +370,21 @@ func ReconcileSignedCert(
 		secret.Data[caKey] = append([]byte(nil), ca.Data[opts.CASignerCertMapKey]...)
 	}
 
+	certValidity := CertificateValidityDefault
+
+	if value := os.Getenv(CertificateValidityEnvVar); value != "" {
+		customCertValidityEnvVar, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("failed to parse custom certificate validity from env var %s: %w", CertificateValidityEnvVar, err)
+		}
+		certValidity = customCertValidityEnvVar
+	}
+
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: cn, Organization: org},
 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsages: extUsages,
-		Validity:     ValidityOneYear,
+		Validity:     certValidity,
 		DNSNames:     dnsNames,
 		IPAddresses:  ipAddresses,
 	}

--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -50,7 +51,12 @@ const (
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
 	CertificateValidityAnnotation = "hypershift.openshift.io/certificate-validity"
 	CertificateValidityEnvVar     = "CERTIFICATE_VALIDITY"
-	CertificateValidityDefault    = ValidityOneYear
+	// Custom certificate renewal percentage. The format of the annotation is a float64 value between 0 and 1.
+	// The certificate will renew when less than CertificateRenewalEnvVar of its validity period remains.
+	// For example, if you set the validity period to 100 days and the renewal percentage to 0.30,
+	// the certificate will renew when there are fewer than 30 days remaining (100 days * 0.30 = 30 days) before it expires.
+	CertificateRenewalAnnotation = "hypershift.openshift.io/certificate-renewal"
+	CertificateRenewalEnvVar     = "CERTIFICATE_RENEWAL_PERCENTAGE"
 )
 
 // CertCfg contains all needed fields to configure a new certificate
@@ -370,7 +376,7 @@ func ReconcileSignedCert(
 		secret.Data[caKey] = append([]byte(nil), ca.Data[opts.CASignerCertMapKey]...)
 	}
 
-	certValidity := CertificateValidityDefault
+	certValidity := ValidityOneYear
 
 	if value := os.Getenv(CertificateValidityEnvVar); value != "" {
 		customCertValidityEnvVar, err := time.ParseDuration(value)
@@ -388,7 +394,18 @@ func ReconcileSignedCert(
 		DNSNames:     dnsNames,
 		IPAddresses:  ipAddresses,
 	}
-	if err := ValidateKeyPair(secret.Data[keyKey], secret.Data[crtKey], cfg, 30*ValidityOneDay); err == nil {
+
+	minimumRemainingValidity := 30 * ValidityOneDay
+
+	if value := os.Getenv(CertificateRenewalEnvVar); value != "" {
+		renewalPercentage, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("failed to parse custom certificate renewal percentage from env var %s: %w", CertificateRenewalEnvVar, err)
+		}
+		minimumRemainingValidity = time.Duration(float64(certValidity) * renewalPercentage)
+	}
+
+	if err := ValidateKeyPair(secret.Data[keyKey], secret.Data[crtKey], cfg, minimumRemainingValidity); err == nil {
 		return nil
 	}
 	certBytes, keyBytes, _, err := signCertificate(cfg, ca, opts)


### PR DESCRIPTION
Now via annotation the self-generated certificates validity and rotation could be customised. This will help to test the certificates regeneration

**Which issue(s) this PR fixes** :
Fixes #[HOSTEDCP-1779](https://issues.redhat.com/browse/HOSTEDCP-1779)

- https://issues.redhat.com/browse/HOSTEDCP-1795
- https://issues.redhat.com/browse/HOSTEDCP-1796

Another more complete approach is implemented here: https://github.com/openshift/hypershift/pull/4318 for [HOSTEDCP-1795](https://issues.redhat.com/browse/HOSTEDCP-1795)

We decided to go with a much smaller version and not exposed to the API.