### PR TITLE
OCPBUGS-33934: Add newline after TLS certs referenced by image.config

### DIFF
--- a/hypershift-operator/init.go
+++ b/hypershift-operator/init.go
@@ -130,7 +130,9 @@ func getImageRegistryCABundle(ctx context.Context, client crclient.Client) (*byt
 	if configmap.Data != nil {
 		var buf bytes.Buffer
 		for _, crt := range configmap.Data {
-			buf.WriteString(crt)
+			// Added a newline character to the end of each certificate to avoid bad concatenation
+			// of certificates in the buffer using the UI.
+			buf.WriteString(fmt.Sprintf("%s\n", crt))
 		}
 		if buf.Len() > 0 {
 			return &buf, nil


### PR DESCRIPTION
Once you add more than one certificate to the ConfigMap referenced in the image.config.openshift.io spec field, the getImageRegistryCABundle processes the certificates properly. However, if you add these through the UI console, the user might not include the newline character, which results in overlapping certificates. This PR ensures a newline is always added after each certificate processed.

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-33934](https://issues.redhat.com/browse/OCPBUGS-33934)