### PR TITLE
OCPBUGS-35899: Doubled machineHealthCheck timeout on Agent and None

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1931,7 +1931,14 @@ func (r *NodePoolReconciler) reconcileMachineHealthCheck(ctx context.Context,
 	// https://github.com/openshift/managed-cluster-config/blob/14d4255ec75dc263ffd3d897dfccc725cb2b7072/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
 	// TODO (alberto): possibly expose this config at the nodePool API.
 	maxUnhealthy := intstr.FromInt(2)
-	timeOut := 8 * time.Minute
+	var timeOut time.Duration
+
+	switch hc.Spec.Platform.Type {
+	case hyperv1.AgentPlatform, hyperv1.NonePlatform:
+		timeOut = 16 * time.Minute
+	default:
+		timeOut = 8 * time.Minute
+	}
 
 	maxUnhealthyOverride := nodePool.Annotations[hyperv1.MachineHealthCheckMaxUnhealthyAnnotation]
 	if maxUnhealthyOverride == "" {


### PR DESCRIPTION
Duplicated the MachineHealthCheck timeout in both Agent and None platforms to better align with real-world scenarios

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-35899](https://issues.redhat.com/browse/OCPBUGS-35899)