### PR TITLE
OCPBUGS-36689: Omit the unused 0000_50_olm_06-psm-operator.service.ya…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -56,6 +56,8 @@ var (
 		"0000_50_olm_02-services.yaml",
 		"0000_50_olm_06-psm-operator.deployment.yaml",
 		"0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml",
+		"0000_50_olm_06-psm-operator.service.yaml",
+		"0000_50_olm_06-psm-operator.servicemonitor.yaml",
 		"0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml",
 		"0000_50_olm_07-olm-operator.deployment.yaml",
 		"0000_50_olm_07-collect-profiles.cronjob.yaml",


### PR DESCRIPTION
…ml and 0000_50_olm_06-psm-operator.servicemonitor.yaml manifests as they're breaking Prometheus discovery


I took the initiative as this is blocking https://github.com/openshift/cluster-monitoring-operator/pull/2403.

I don't know if this is the best approach.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.