### PR TITLE
OCPBUGS-34865: Fix name resolution for HTTPS konnectivity proxy

### DIFF
--- a/support/konnectivityproxy/dialer.go
+++ b/support/konnectivityproxy/dialer.go
@@ -177,6 +177,7 @@ func NewKonnectivityDialer(opts Options) (ProxyDialer, error) {
 		disableResolver:              opts.DisableResolver,
 		resolveFromGuestCluster:      opts.ResolveFromGuestClusterDNS,
 		resolveFromManagementCluster: opts.ResolveFromManagementClusterDNS,
+		mustResolve:                  opts.ResolveBeforeDial,
 		dnsFallback:                  &proxy.fallbackToMCDNS,
 		log:                          opts.Log,
 	}


### PR DESCRIPTION

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
The new HTTPS konnectivity proxy requires that DNS names be resolved before generating a proper CONNECT string for the Konnectivity server. However the dialer was returning a nil IP if it didn't think it needed to resolve a name through the hosted cluster. This fix is to always resolve a name if using the HTTPS konnectivity proxy.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-34865](https://issues.redhat.com/browse/OCPBUGS-34865)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.