### PR TITLE
OCPBUGS-34816: Fix the resource from is checking the MHC platform

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1933,7 +1933,7 @@ func (r *NodePoolReconciler) reconcileMachineHealthCheck(ctx context.Context,
 	maxUnhealthy := intstr.FromInt(2)
 	var timeOut time.Duration
 
-	switch hc.Spec.Platform.Type {
+	switch nodePool.Spec.Platform.Type {
 	case hyperv1.AgentPlatform, hyperv1.NonePlatform:
 		timeOut = 16 * time.Minute
 	default:


### PR DESCRIPTION
Fixing the resource used to evaluate the platform to set the MachineHealthCheckTimeout

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-35899](https://issues.redhat.com/browse/OCPBUGS-35899)