### PR TITLE
OCPBUGS-37060: OCPBUGS-35905: E2E test to verify openshift-apiserver TLS certificates

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
@@ -92,16 +92,18 @@ func TestReconcileOpenshiftAPIServerDeploymentTrustBundle(t *testing.T) {
 	hcp.Namespace = "namespace"
 	ownerRef := config.OwnerRefFrom(hcp)
 	testCases := []struct {
-		name                         string
-		cm                           corev1.ConfigMap
-		expectedVolume               *corev1.Volume
-		auditConfig                  *corev1.ConfigMap
-		expectedVolumeProjection     []corev1.VolumeProjection
-		deploymentConfig             config.DeploymentConfig
-		additionalTrustBundle        *corev1.LocalObjectReference
-		clusterConf                  *hyperv1.ClusterConfiguration
-		imageRegistryAdditionalCAs   *corev1.ConfigMap
-		expectProjectedVolumeMounted bool
+		name                              string
+		cm                                corev1.ConfigMap
+		expectedVolume                    *corev1.Volume
+		expectedProxyVolume               *corev1.Volume
+		auditConfig                       *corev1.ConfigMap
+		expectedVolumeProjection          []corev1.VolumeProjection
+		deploymentConfig                  config.DeploymentConfig
+		additionalTrustBundle             *corev1.LocalObjectReference
+		clusterConf                       *hyperv1.ClusterConfiguration
+		imageRegistryAdditionalCAs        *corev1.ConfigMap
+		expectProjectedVolumeMounted      bool
+		expectProjectedProxyVolumeMounted bool
 	}{
 		{
 			name:             "Trust bundle provided",
@@ -119,15 +121,17 @@ func TestReconcileOpenshiftAPIServerDeploymentTrustBundle(t *testing.T) {
 					},
 				},
 			},
-			expectProjectedVolumeMounted: true,
+			expectProjectedVolumeMounted:      true,
+			expectProjectedProxyVolumeMounted: false,
 		},
 		{
-			name:                         "Trust bundle not provided",
-			auditConfig:                  manifests.OpenShiftAPIServerAuditConfig(targetNamespace),
-			deploymentConfig:             config.DeploymentConfig{},
-			expectedVolume:               nil,
-			additionalTrustBundle:        nil,
-			expectProjectedVolumeMounted: false,
+			name:                              "Trust bundle not provided",
+			auditConfig:                       manifests.OpenShiftAPIServerAuditConfig(targetNamespace),
+			deploymentConfig:                  config.DeploymentConfig{},
+			expectedVolume:                    nil,
+			additionalTrustBundle:             nil,
+			expectProjectedVolumeMounted:      false,
+			expectProjectedProxyVolumeMounted: false,
 		},
 		{
 			name:             "Trust bundle and image registry additional CAs provided",
@@ -158,7 +162,36 @@ func TestReconcileOpenshiftAPIServerDeploymentTrustBundle(t *testing.T) {
 					},
 				},
 			},
-			expectProjectedVolumeMounted: true,
+			expectProjectedVolumeMounted:      true,
+			expectProjectedProxyVolumeMounted: false,
+		},
+		{
+			name:             "Trust bundle and proxy trust bundle provided",
+			auditConfig:      manifests.OpenShiftAPIServerAuditConfig(targetNamespace),
+			deploymentConfig: config.DeploymentConfig{},
+			additionalTrustBundle: &corev1.LocalObjectReference{
+				Name: "user-ca-bundle",
+			},
+			expectedVolume: &corev1.Volume{
+				Name: "additional-trust-bundle",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources:     []corev1.VolumeProjection{getFakeVolumeProjectionCABundle()},
+						DefaultMode: ptr.To[int32](420),
+					},
+				},
+			},
+			expectedProxyVolume: &corev1.Volume{
+				Name: "proxy-additional-trust-bundle",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources:     []corev1.VolumeProjection{getFakeVolumeProjectionCABundle()},
+						DefaultMode: ptr.To[int32](420),
+					},
+				},
+			},
+			expectProjectedVolumeMounted:      true,
+			expectProjectedProxyVolumeMounted: true,
 		},
 	}
 	for _, tc := range testCases {
@@ -171,6 +204,11 @@ func TestReconcileOpenshiftAPIServerDeploymentTrustBundle(t *testing.T) {
 				g.Expect(oapiDeployment.Spec.Template.Spec.Volumes).To(ContainElement(*tc.expectedVolume))
 			} else {
 				g.Expect(oapiDeployment.Spec.Template.Spec.Volumes).NotTo(ContainElement(&corev1.Volume{Name: "additional-trust-bundle"}))
+			}
+			if tc.expectProjectedProxyVolumeMounted {
+				g.Expect(oapiDeployment.Spec.Template.Spec.Volumes).To(ContainElement(*tc.expectedProxyVolume))
+			} else {
+				g.Expect(oapiDeployment.Spec.Template.Spec.Volumes).NotTo(ContainElement(&corev1.Volume{Name: "proxy-additional-trust-bundle"}))
 			}
 		})
 	}


### PR DESCRIPTION
manual backport of [OCPBUGS-35905](https://issues.redhat.com/browse/OCPBUGS-35905)

- Depending on https://github.com/openshift/hypershift/pull/4357
