### PR TITLE
OCPBUGS-37065: OCPBUGS-35899: Doubled machineHealthCheck timeout on Agent and None

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1883,6 +1883,15 @@ func (r *NodePoolReconciler) reconcileMachineHealthCheck(mhc *capiv1.MachineHeal
 	// https://github.com/openshift/managed-cluster-config/blob/14d4255ec75dc263ffd3d897dfccc725cb2b7072/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
 	// TODO (alberto): possibly expose this config at the nodePool API.
 	maxUnhealthy := intstr.FromInt(2)
+	var timeOut time.Duration
+
+	switch hc.Spec.Platform.Type {
+	case hyperv1.AgentPlatform, hyperv1.NonePlatform:
+		timeOut = 16 * time.Minute
+	default:
+		timeOut = 8 * time.Minute
+	}
+
 	resourcesName := generateName(CAPIClusterName, nodePool.Spec.ClusterName, nodePool.GetName())
 	mhc.Spec = capiv1.MachineHealthCheckSpec{
 		ClusterName: CAPIClusterName,

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1885,7 +1885,7 @@ func (r *NodePoolReconciler) reconcileMachineHealthCheck(mhc *capiv1.MachineHeal
 	maxUnhealthy := intstr.FromInt(2)
 	var timeOut time.Duration
 
-	switch hc.Spec.Platform.Type {
+	switch nodePool.Spec.Platform.Type {
 	case hyperv1.AgentPlatform, hyperv1.NonePlatform:
 		timeOut = 16 * time.Minute
 	default:
@@ -1905,14 +1905,14 @@ func (r *NodePoolReconciler) reconcileMachineHealthCheck(mhc *capiv1.MachineHeal
 				Type:   corev1.NodeReady,
 				Status: corev1.ConditionFalse,
 				Timeout: metav1.Duration{
-					Duration: 8 * time.Minute,
+					Duration: timeOut,
 				},
 			},
 			{
 				Type:   corev1.NodeReady,
 				Status: corev1.ConditionUnknown,
 				Timeout: metav1.Duration{
-					Duration: 8 * time.Minute,
+					Duration: timeOut,
 				},
 			},
 		},


### PR DESCRIPTION
Manual Cherrypick of:

- https://github.com/openshift/hypershift/pull/4345
- https://github.com/openshift/hypershift/pull/4365