### PR TITLE
OCPBUGS-37102: Separate ibmcloud kms encryption configuration types

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/ibmcloud.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/ibmcloud.go
@@ -68,6 +68,8 @@ func (p *ibmCloudKMSProvider) GenerateKMSEncryptionConfig() (*v1.EncryptionConfi
 				Endpoint:   ibmCloudKMSUnixSocket,
 				Timeout:    &metav1.Duration{Duration: 35 * time.Second},
 			},
+		},
+		{
 			Identity: &v1.IdentityConfiguration{},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Separate ibmcloud kms encryption configuration types to allow enablement of KMS

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-37102

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.