### PR TITLE
OSASINFRA-3538: openstack: cluster CLI

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/cluster/none"
+	"github.com/openshift/hypershift/cmd/cluster/openstack"
 	"github.com/openshift/hypershift/cmd/cluster/powervs"
 	"github.com/openshift/hypershift/cmd/log"
 )
@@ -34,6 +35,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
 	cmd.AddCommand(azure.NewCreateCommand(opts))
 	cmd.AddCommand(powervs.NewCreateCommand(opts))
+	cmd.AddCommand(openstack.NewCreateCommand(opts))
 
 	return cmd
 }
@@ -67,6 +69,7 @@ func NewDestroyCommands() *cobra.Command {
 	cmd.AddCommand(kubevirt.NewDestroyCommand(opts))
 	cmd.AddCommand(azure.NewDestroyCommand(opts))
 	cmd.AddCommand(powervs.NewDestroyCommand(opts))
+	cmd.AddCommand(openstack.NewDestroyCommand(opts))
 
 	return cmd
 }

--- a/cmd/cluster/openstack/create.go
+++ b/cmd/cluster/openstack/create.go
@@ -1,0 +1,249 @@
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/openshift/hypershift/cmd/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func DefaultOptions() *RawCreateOptions {
+	return &RawCreateOptions{}
+}
+
+func BindOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
+	bindCoreOptions(opts, flags)
+}
+
+func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
+	flags.StringVar(&opts.OpenStackCredentialsFile, "openstack-credentials-file", opts.OpenStackCredentialsFile, "Path to the OpenStack credentials file (required)")
+	flags.StringVar(&opts.OpenStackCACertFile, "openstack-ca-cert-file", opts.OpenStackCACertFile, "Path to the OpenStack CA certificate file (optional)")
+	flags.StringVar(&opts.OpenStackExternalNetworkName, "openstack-external-network-name", opts.OpenStackExternalNetworkName, "Name of the OpenStack external network (optional)")
+	flags.StringVar(&opts.OpenStackNodeFlavor, "openstack-node-flavor", opts.OpenStackNodeFlavor, "The flavor to use for OpenStack nodes")
+}
+
+type RawCreateOptions struct {
+	OpenStackCredentialsFile     string
+	OpenStackCACertFile          string
+	OpenStackExternalNetworkName string
+	OpenStackNodeFlavor          string
+
+	externalDNSDomain string
+}
+
+// validatedCreateOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
+type validatedCreateOptions struct {
+	*RawCreateOptions
+}
+
+type ValidatedCreateOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*validatedCreateOptions
+}
+
+// completedCreateOptions is a private wrapper that enforces a call of Complete() before cluster creation can be invoked.
+type completedCreateOptions struct {
+	*ValidatedCreateOptions
+
+	externalDNSDomain string
+	name, namespace   string
+}
+
+type CreateOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*completedCreateOptions
+}
+
+func (o *RawCreateOptions) Validate(ctx context.Context, opts *core.CreateOptions) (core.PlatformCompleter, error) {
+	// Check that the OpenStack credentials file arg is set and that the file exists with the "openstack" cloud
+	if err := validateOpenStackCredentialsFile(o.OpenStackCredentialsFile); err != nil {
+		return nil, err
+	}
+
+	if err := util.ValidateRequiredOption("pull-secret", opts.PullSecretFile); err != nil {
+		return nil, err
+	}
+
+	return &ValidatedCreateOptions{
+		validatedCreateOptions: &validatedCreateOptions{
+			RawCreateOptions: o,
+		},
+	}, nil
+}
+
+func (o *ValidatedCreateOptions) Complete(ctx context.Context, opts *core.CreateOptions) (core.Platform, error) {
+	output := &CreateOptions{
+		completedCreateOptions: &completedCreateOptions{
+			ValidatedCreateOptions: o,
+			name:                   opts.Name,
+			namespace:              opts.Namespace,
+			externalDNSDomain:      opts.ExternalDNSDomain,
+		},
+	}
+
+	return output, nil
+}
+
+func (o *RawCreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) error {
+	cluster.Spec.Platform = hyperv1.PlatformSpec{
+		Type:      hyperv1.OpenStackPlatform,
+		OpenStack: &hyperv1.OpenStackPlatformSpec{},
+	}
+
+	cluster.Spec.Platform.OpenStack.IdentityRef = hyperv1.OpenStackIdentityReference{
+		Name:      credentialsSecret(cluster.Namespace, cluster.Name).Name,
+		CloudName: "openstack", // TODO: make this configurable or at least check the clouds.yaml file
+	}
+
+	if o.OpenStackExternalNetworkName != "" {
+		cluster.Spec.Platform.OpenStack.ExternalNetwork = &hyperv1.NetworkParam{
+			Filter: &hyperv1.NetworkFilter{
+				Name: o.OpenStackExternalNetworkName,
+			},
+		}
+	}
+
+	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "")
+	if o.externalDNSDomain != "" {
+		for i, svc := range cluster.Spec.Services {
+			switch svc.Service {
+			case hyperv1.APIServer:
+				cluster.Spec.Services[i].Route = &hyperv1.RoutePublishingStrategy{
+					Hostname: fmt.Sprintf("api-%s.%s", cluster.Name, o.externalDNSDomain),
+				}
+
+			case hyperv1.OAuthServer:
+				cluster.Spec.Services[i].Route = &hyperv1.RoutePublishingStrategy{
+					Hostname: fmt.Sprintf("oauth-%s.%s", cluster.Name, o.externalDNSDomain),
+				}
+
+			case hyperv1.Konnectivity:
+				cluster.Spec.Services[i].Route = &hyperv1.RoutePublishingStrategy{
+					Hostname: fmt.Sprintf("konnectivity-%s.%s", cluster.Name, o.externalDNSDomain),
+				}
+			case hyperv1.Ignition:
+				cluster.Spec.Services[i].Route = &hyperv1.RoutePublishingStrategy{
+					Hostname: fmt.Sprintf("ignition-%s.%s", cluster.Name, o.externalDNSDomain),
+				}
+			case hyperv1.OVNSbDb:
+				cluster.Spec.Services[i].Route = &hyperv1.RoutePublishingStrategy{
+					Hostname: fmt.Sprintf("ovn-sbdb-%s.%s", cluster.Name, o.externalDNSDomain),
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (o *RawCreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstructor) []*hyperv1.NodePool {
+	return nil
+}
+
+func (o *CreateOptions) GenerateResources() ([]client.Object, error) {
+	credentialsContents, err := os.ReadFile(o.OpenStackCredentialsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read OpenStack credentials file: %w", err)
+	}
+	credentialsSecret := credentialsSecret(o.namespace, o.name)
+	credentialsSecret.Data = map[string][]byte{
+		"clouds.yaml": credentialsContents,
+	}
+
+	if o.OpenStackCACertFile != "" {
+		caCertContents, err := os.ReadFile(o.OpenStackCACertFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read OpenStack CA certificate file: %w", err)
+		}
+		credentialsSecret.Data["cacert"] = caCertContents
+	}
+
+	return []client.Object{credentialsSecret}, nil
+}
+
+func credentialsSecret(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-cloud-credentials",
+			Namespace: namespace,
+			Labels:    map[string]string{util.DeleteWithClusterLabelName: "true"},
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+}
+
+var _ core.Platform = (*CreateOptions)(nil)
+
+func NewCreateCommand(opts *core.RawCreateOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "openstack",
+		Short:        "Creates basic functional HostedCluster resources on OpenStack platform",
+		SilenceUsage: true,
+	}
+
+	openstackOpts := DefaultOptions()
+	BindOptions(openstackOpts, cmd.Flags())
+	cmd.MarkPersistentFlagRequired("pull-secret")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if opts.Timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
+		}
+
+		if err := core.CreateCluster(ctx, opts, openstackOpts); err != nil {
+			opts.Log.Error(err, "Failed to create cluster")
+			return err
+		}
+		return nil
+	}
+
+	return cmd
+}
+
+// validateOpenStackCredentialsFile checks that the OpenStack credentials file exists
+// and that the cloud name is "openstack" which we hardcode for now.
+func validateOpenStackCredentialsFile(credentialsFile string) error {
+	if credentialsFile == "" {
+		return fmt.Errorf("OpenStack credentials file is required")
+	}
+
+	if _, err := os.Stat(credentialsFile); err != nil {
+		return fmt.Errorf("OpenStack credentials file does not exist: %w", err)
+	}
+
+	cloudsFile, err := os.ReadFile(credentialsFile)
+	if err != nil {
+		return fmt.Errorf("failed to read OpenStack credentials file: %w", err)
+	}
+	clouds := make(map[string]interface{})
+	if err := yaml.Unmarshal(cloudsFile, &clouds); err != nil {
+		return fmt.Errorf("failed to parse OpenStack credentials file: %w", err)
+	}
+	_, ok := clouds["clouds"]
+	if !ok {
+		return fmt.Errorf("'clouds' key not found in credentials file")
+	}
+	clouds = clouds["clouds"].(map[string]interface{})
+	if _, ok := clouds["openstack"]; !ok {
+		return fmt.Errorf("'openstack' cloud not found in credentials file")
+	}
+	return nil
+}

--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -1,0 +1,125 @@
+package openstack
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/test/integration/framework"
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+)
+
+func TestCreateOptions_Validate(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		input         RawCreateOptions
+		expectedError string
+	}{
+		{
+			name:          "missing OpenStack credentials file",
+			input:         RawCreateOptions{},
+			expectedError: "OpenStack credentials file is required",
+		},
+	} {
+		var errString string
+		if _, err := test.input.Validate(context.Background(), nil); err != nil {
+			errString = err.Error()
+		}
+		if diff := cmp.Diff(test.expectedError, errString); diff != "" {
+			t.Errorf("got incorrect error: %v", diff)
+		}
+	}
+}
+
+func TestCreateCluster(t *testing.T) {
+	utilrand.Seed(1234567890)
+	certs.UnsafeSeed(1234567890)
+	ctx := framework.InterruptableContext(context.Background())
+	tempDir := t.TempDir()
+	t.Setenv("FAKE_CLIENT", "true")
+
+	cloudsYAML := map[string]interface{}{
+		"clouds": map[string]interface{}{
+			"openstack": map[string]interface{}{
+				"auth": map[string]interface{}{
+					"auth_url": "fakeAuthURL",
+				},
+			},
+		},
+	}
+	cloudsData, err := yaml.Marshal(cloudsYAML)
+	if err != nil {
+		t.Fatalf("failed to marshal clouds.yaml: %v", err)
+	}
+	credentialsFile := filepath.Join(tempDir, "clouds.yaml")
+	if err := os.WriteFile(credentialsFile, cloudsData, 0600); err != nil {
+		t.Fatalf("failed to write creds: %v", err)
+	}
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "minimal flags necessary to render",
+			args: []string{
+				"--openstack-credentials-file=" + credentialsFile,
+				"--pull-secret=" + pullSecretFile,
+			},
+		},
+		{
+			name: "default creation flags",
+			args: []string{
+				"--openstack-credentials-file=" + credentialsFile,
+				"--openstack-external-network-name=fakeExternalNetwork",
+				"--openstack-node-flavor=fakeFlavor",
+				"--pull-secret=" + pullSecretFile,
+				"--auto-repair",
+				"--name=test",
+				"--node-pool-replicas=2",
+				"--base-domain=test.hypershift.devcluster.openshift.com",
+				"--control-plane-operator-image=fakeCPOImage",
+				"--release-image=fakeReleaseImage",
+				"--annotations=hypershift.openshift.io/cleanup-cloud-resources=true",
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := core.DefaultOptions()
+			core.BindDeveloperOptions(coreOpts, flags)
+			openstackOpts := DefaultOptions()
+			BindOptions(openstackOpts, flags)
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			tempDir := t.TempDir()
+			manifestsFile := filepath.Join(tempDir, "manifests.yaml")
+			coreOpts.Render = true
+			coreOpts.RenderInto = manifestsFile
+
+			if err := core.CreateCluster(ctx, coreOpts, openstackOpts); err != nil {
+				t.Fatalf("failed to create cluster: %v", err)
+			}
+
+			manifests, err := os.ReadFile(manifestsFile)
+			if err != nil {
+				t.Fatalf("failed to read manifests file: %v", err)
+			}
+			testutil.CompareWithFixture(t, manifests)
+		})
+	}
+}

--- a/cmd/cluster/openstack/destroy.go
+++ b/cmd/cluster/openstack/destroy.go
@@ -1,0 +1,67 @@
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/log"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/errors"
+)
+
+func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "openstack",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on OpenStack",
+		SilenceUsage: true,
+	}
+
+	logger := log.Log
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		if err := DestroyCluster(ctx, opts); err != nil {
+			logger.Error(err, "Failed to destroy cluster")
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}
+func DestroyCluster(ctx context.Context, o *core.DestroyOptions) error {
+	hostedCluster, err := core.GetCluster(ctx, o)
+	if err != nil {
+		return err
+	}
+
+	if hostedCluster != nil {
+		o.InfraID = hostedCluster.Spec.InfraID
+	}
+
+	var inputErrors []error
+	if o.InfraID == "" {
+		inputErrors = append(inputErrors, fmt.Errorf("infrastructure ID is required"))
+	}
+	if err := errors.NewAggregate(inputErrors); err != nil {
+		return fmt.Errorf("required inputs are missing: %w", err)
+	}
+
+	return core.DestroyCluster(ctx, hostedCluster, o, destroyPlatformSpecifics)
+}
+
+func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error {
+	return nil
+}

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
@@ -1,0 +1,114 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: ZmFrZQ==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: test-pull-secret
+  namespace: clusters
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  annotations:
+    hypershift.openshift.io/cleanup-cloud-resources: "true"
+    hypershift.openshift.io/control-plane-operator-image: fakeCPOImage
+  creationTimestamp: null
+  name: test
+  namespace: clusters
+spec:
+  autoscaling: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: test.hypershift.devcluster.openshift.com
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: test-f9nvz
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    openstack:
+      externalNetwork:
+        filter:
+          name: fakeExternalNetwork
+      identityRef:
+        cloudName: openstack
+        name: test-cloud-credentials
+    type: OpenStack
+  pullSecret:
+    name: test-pull-secret
+  release:
+    image: fakeReleaseImage
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: test-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  - service: OVNSbDb
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: v1
+data:
+  clouds.yaml: Y2xvdWRzOgogICAgb3BlbnN0YWNrOgogICAgICAgIGF1dGg6CiAgICAgICAgICAgIGF1dGhfdXJsOiBmYWtlQXV0aFVSTAo=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: test-cloud-credentials
+  namespace: clusters
+type: Opaque
+---
+apiVersion: v1
+data:
+  key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: test-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: ZmFrZQ==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-pull-secret
+  namespace: clusters
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  creationTimestamp: null
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: ""
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: example-sffhb
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    openstack:
+      identityRef:
+        cloudName: openstack
+        name: example-cloud-credentials
+    type: OpenStack
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: example-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  - service: OVNSbDb
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: v1
+data:
+  clouds.yaml: Y2xvdWRzOgogICAgb3BlbnN0YWNrOgogICAgICAgIGF1dGg6CiAgICAgICAgICAgIGF1dGhfdXJsOiBmYWtlQXV0aFVSTAo=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-cloud-credentials
+  namespace: clusters
+type: Opaque
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	google.golang.org/grpc v1.64.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.1
 	k8s.io/apiextensions-apiserver v0.30.1
 	k8s.io/apimachinery v0.30.1
@@ -237,7 +238,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/cluster-bootstrap v0.30.1 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kms v0.30.1 // indirect

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/hypershift/product-cli/cmd/cluster/agent"
 	"github.com/openshift/hypershift/product-cli/cmd/cluster/aws"
 	"github.com/openshift/hypershift/product-cli/cmd/cluster/kubevirt"
+	"github.com/openshift/hypershift/product-cli/cmd/cluster/openstack"
 )
 
 func NewCreateCommands() *cobra.Command {
@@ -30,6 +31,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.AddCommand(agent.NewCreateCommand(opts))
 	cmd.AddCommand(aws.NewCreateCommand(opts))
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
+	cmd.AddCommand(openstack.NewCreateCommand(opts))
 
 	return cmd
 }
@@ -61,6 +63,7 @@ func NewDestroyCommands() *cobra.Command {
 	cmd.AddCommand(agent.NewDestroyCommand(opts))
 	cmd.AddCommand(aws.NewDestroyCommand(opts))
 	cmd.AddCommand(kubevirt.NewDestroyCommand(opts))
+	cmd.AddCommand(openstack.NewDestroyCommand(opts))
 
 	return cmd
 }

--- a/product-cli/cmd/cluster/openstack/create.go
+++ b/product-cli/cmd/cluster/openstack/create.go
@@ -1,0 +1,37 @@
+package openstack
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/cluster/openstack"
+)
+
+func NewCreateCommand(opts *core.RawCreateOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "openstack",
+		Short:        "Creates basic functional HostedCluster resources on OpenStack platform",
+		SilenceUsage: true,
+	}
+
+	openstackOpts := openstack.DefaultOptions()
+	openstack.BindOptions(openstackOpts, cmd.Flags())
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if opts.Timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
+		}
+
+		if err := core.CreateCluster(ctx, opts, openstackOpts); err != nil {
+			opts.Log.Error(err, "Failed to create cluster")
+			return err
+		}
+		return nil
+	}
+
+	return cmd
+}

--- a/product-cli/cmd/cluster/openstack/destroy.go
+++ b/product-cli/cmd/cluster/openstack/destroy.go
@@ -1,0 +1,42 @@
+package openstack
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/cluster/openstack"
+	"github.com/openshift/hypershift/cmd/log"
+)
+
+func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "openstack",
+		Short:        "Destroys a HostedCluster and its associated infrastructure on OpenStack platform",
+		SilenceUsage: true,
+	}
+
+	logger := log.Log
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		if err := openstack.DestroyCluster(ctx, opts); err != nil {
+			logger.Error(err, "Failed to destroy cluster")
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/cluster/none"
+	hypershiftopenstack "github.com/openshift/hypershift/cmd/cluster/openstack"
 	"github.com/openshift/hypershift/cmd/cluster/powervs"
 	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
 	awscmdutil "github.com/openshift/hypershift/cmd/infra/aws/util"
@@ -98,6 +99,10 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.BaseDomain, "e2e.base-domain", "", "The ingress base domain for the cluster")
 	flag.StringVar(&globalOpts.configurableClusterOptions.ControlPlaneOperatorImage, "e2e.control-plane-operator-image", "", "The image to use for the control plane operator. If none specified, the default is used.")
 	flag.Var(&globalOpts.additionalTags, "e2e.additional-tags", "Additional tags to set on AWS resources")
+	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackCredentialsFile, "e2e.openstack-credentials-file", "", "Path to the OpenStack credentials file")
+	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackCACertFile, "e2e.openstack-ca-cert-file", "", "Path to the OpenStack CA certificate file")
+	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackExternalNetworkName, "e2e.openstack-external-network-name", "", "Name of the OpenStack external network")
+	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeFlavor, "e2e.openstack-node-flavor", "", "The flavor to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureCredentialsFile, "e2e.azure-credentials-file", "", "Path to an Azure credentials file")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureLocation, "e2e.azure-location", "eastus", "The location to use for Azure")
 	flag.StringVar(&globalOpts.configurableClusterOptions.SSHKeyFile, "e2e.ssh-key-file", "", "Path to a ssh public key")
@@ -412,6 +417,8 @@ type configurableClusterOptions struct {
 	AWSCredentialsFile            string
 	AWSMultiArch                  bool
 	AzureCredentialsFile          string
+	OpenStackCredentialsFile      string
+	OpenStackCACertFile           string
 	AzureLocation                 string
 	Region                        string
 	Zone                          stringSliceVar
@@ -432,6 +439,8 @@ type configurableClusterOptions struct {
 	NodePoolReplicas              int
 	SSHKeyFile                    string
 	NetworkType                   string
+	OpenStackExternalNetworkName  string
+	OpenStackNodeFlavor           string
 	PowerVSResourceGroup          string
 	PowerVSRegion                 string
 	PowerVSZone                   string
@@ -475,15 +484,16 @@ func (o *options) DefaultClusterOptions(t *testing.T) e2eutil.PlatformAgnosticOp
 			},
 			EtcdStorageClass: o.configurableClusterOptions.EtcdStorageClass,
 		},
-		NonePlatform:     o.DefaultNoneOptions(),
-		AWSPlatform:      o.DefaultAWSOptions(),
-		KubevirtPlatform: o.DefaultKubeVirtOptions(),
-		AzurePlatform:    o.DefaultAzureOptions(),
-		PowerVSPlatform:  o.DefaultPowerVSOptions(),
+		NonePlatform:      o.DefaultNoneOptions(),
+		AWSPlatform:       o.DefaultAWSOptions(),
+		KubevirtPlatform:  o.DefaultKubeVirtOptions(),
+		AzurePlatform:     o.DefaultAzureOptions(),
+		PowerVSPlatform:   o.DefaultPowerVSOptions(),
+		OpenStackPlatform: o.DefaultOpenStackOptions(),
 	}
 
 	switch o.Platform {
-	case hyperv1.AWSPlatform, hyperv1.AzurePlatform, hyperv1.NonePlatform, hyperv1.KubevirtPlatform:
+	case hyperv1.AWSPlatform, hyperv1.AzurePlatform, hyperv1.NonePlatform, hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform:
 		createOption.Arch = hyperv1.ArchitectureAMD64
 	case hyperv1.PowerVSPlatform:
 		createOption.Arch = hyperv1.ArchitecturePPC64LE
@@ -509,6 +519,17 @@ func (o *options) DefaultNoneOptions() none.RawCreateOptions {
 		APIServerAddress:          "",
 		ExposeThroughLoadBalancer: true,
 	}
+}
+
+func (p *options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions {
+	opts := hypershiftopenstack.RawCreateOptions{
+		OpenStackCredentialsFile:     p.configurableClusterOptions.OpenStackCredentialsFile,
+		OpenStackCACertFile:          p.configurableClusterOptions.OpenStackCACertFile,
+		OpenStackExternalNetworkName: p.configurableClusterOptions.OpenStackExternalNetworkName,
+		OpenStackNodeFlavor:          p.configurableClusterOptions.OpenStackNodeFlavor,
+	}
+
+	return opts
 }
 
 func (o *options) DefaultAWSOptions() hypershiftaws.RawCreateOptions {

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -164,6 +164,9 @@ func createCluster(ctx context.Context, hc *hyperv1.HostedCluster, opts *Platfor
 
 		opts.InfrastructureJSON = infraFile
 		return renderCreate(ctx, &opts.RawCreateOptions, &opts.PowerVSPlatform, manifestsFile, renderLogFile, createLogFile)
+	case hyperv1.OpenStackPlatform:
+		return renderCreate(ctx, &opts.RawCreateOptions, &opts.OpenStackPlatform, manifestsFile, renderLogFile, createLogFile)
+
 	default:
 		return fmt.Errorf("unsupported platform %s", hc.Spec.Platform.Type)
 	}

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/cluster/none"
+	"github.com/openshift/hypershift/cmd/cluster/openstack"
 	"github.com/openshift/hypershift/cmd/cluster/powervs"
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -35,11 +36,12 @@ import (
 type PlatformAgnosticOptions struct {
 	core.RawCreateOptions
 
-	NonePlatform     none.RawCreateOptions
-	AWSPlatform      aws.RawCreateOptions
-	KubevirtPlatform kubevirt.RawCreateOptions
-	AzurePlatform    azure.RawCreateOptions
-	PowerVSPlatform  powervs.RawCreateOptions
+	NonePlatform      none.RawCreateOptions
+	AWSPlatform       aws.RawCreateOptions
+	KubevirtPlatform  kubevirt.RawCreateOptions
+	AzurePlatform     azure.RawCreateOptions
+	PowerVSPlatform   powervs.RawCreateOptions
+	OpenStackPlatform openstack.RawCreateOptions
 }
 
 type hypershiftTestFunc func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster)


### PR DESCRIPTION
**What this PR does / why we need it**:

* Basic CLI options for cluster create & destroy. More options
  will come with Node pools and in the future with more usecases.
* Set a default Machine Network when creating the cluster with the CLI.
* Add the CLI options to e2e.
