### PR TITLE
[release-4.16] OCPBUGS-30282: Multiple MachineConfigs in one CM

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -121,8 +121,8 @@ type NodePoolSpec struct {
 	//
 	// https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
 	//
-	// Each ConfigMap must have a single key named "config" whose value is the
-	// JSON or YAML of a serialized Resource for machineconfiguration.openshift.io:
+	// Each ConfigMap must have a single key named "config" whose value is the YML
+	// with one or more serialized machineconfiguration.openshift.io resources:
 	// KubeletConfig
 	// ContainerRuntimeConfig
 	// MachineConfig

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1225,8 +1225,8 @@ spec:
                   https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
 
 
-                  Each ConfigMap must have a single key named "config" whose value is the
-                  JSON or YAML of a serialized Resource for machineconfiguration.openshift.io:
+                  Each ConfigMap must have a single key named "config" whose value is the YML
+                  with one or more serialized machineconfiguration.openshift.io resources:
                   KubeletConfig
                   ContainerRuntimeConfig
                   MachineConfig

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -744,8 +744,8 @@ NodePoolAutoScaling
 MachineConfig resources to be injected into the ignition configurations of
 nodes in the NodePool. The MachineConfig API schema is defined here:</p>
 <p><a href="https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185">https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185</a></p>
-<p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the
-JSON or YAML of a serialized Resource for machineconfiguration.openshift.io:
+<p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the YML
+with one or more serialized machineconfiguration.openshift.io resources:
 KubeletConfig
 ContainerRuntimeConfig
 MachineConfig
@@ -6791,8 +6791,8 @@ NodePoolAutoScaling
 MachineConfig resources to be injected into the ignition configurations of
 nodes in the NodePool. The MachineConfig API schema is defined here:</p>
 <p><a href="https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185">https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185</a></p>
-<p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the
-JSON or YAML of a serialized Resource for machineconfiguration.openshift.io:
+<p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the YML
+with one or more serialized machineconfiguration.openshift.io resources:
 KubeletConfig
 ContainerRuntimeConfig
 MachineConfig

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -58200,8 +58200,8 @@ objects:
                     https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
 
 
-                    Each ConfigMap must have a single key named "config" whose value is the
-                    JSON or YAML of a serialized Resource for machineconfiguration.openshift.io:
+                    Each ConfigMap must have a single key named "config" whose value is the YML
+                    with one or more serialized machineconfiguration.openshift.io resources:
                     KubeletConfig
                     ContainerRuntimeConfig
                     MachineConfig

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -269,7 +269,7 @@ spec:
   kernelType: ""
   osImageURL: ""
 `
-	machineConfig2 := `
+	machineConfig23 := `
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -287,8 +287,28 @@ spec:
         filesystem: root
         mode: 493
         path: /usr/local/bin/file2.sh
+--- # empty yamls should be ignored
+
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: config-3
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+        source: "[Service]\nType=oneshot\nExecStart=/usr/bin/echo Hello World 3\n\n[Install]\nWantedBy=multi-user.target"
+        filesystem: root
+        mode: 493
+        path: /usr/local/bin/file3.sh
 `
-	machineConfig2Defaulted := `apiVersion: machineconfiguration.openshift.io/v1
+	machineConfig23Defaulted := `apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   creationTimestamp: null
@@ -318,7 +338,40 @@ spec:
   kernelArguments: null
   kernelType: ""
   osImageURL: ""
+
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: config-3
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents: null
+        filesystem: root
+        mode: 493
+        path: /usr/local/bin/file3.sh
+        source: |-
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/bin/echo Hello World 3
+
+          [Install]
+          WantedBy=multi-user.target
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: ""
+  osImageURL: ""
 `
+
 	kubeletConfig1 := `
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
@@ -492,7 +545,7 @@ status:
 			error:  false,
 		},
 		{
-			name: "gets two valid MachineConfig",
+			name: "gets three valid MachineConfig, two of them in a single config-map",
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
@@ -525,11 +578,11 @@ status:
 						Namespace: namespace,
 					},
 					Data: map[string]string{
-						TokenSecretConfigKey: machineConfig2,
+						TokenSecretConfigKey: machineConfig23,
 					},
 				},
 			},
-			expect: machineConfig1Defaulted + "\n---\n" + machineConfig2Defaulted,
+			expect: machineConfig1Defaulted + "\n---\n" + machineConfig23Defaulted,
 			error:  false,
 		},
 		{
@@ -717,7 +770,7 @@ status:
 						},
 					},
 					Data: map[string]string{
-						TokenSecretConfigKey: machineConfig2Defaulted,
+						TokenSecretConfigKey: machineConfig1Defaulted,
 					},
 				},
 				&corev1.ConfigMap{

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -121,8 +121,8 @@ type NodePoolSpec struct {
 	//
 	// https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
 	//
-	// Each ConfigMap must have a single key named "config" whose value is the
-	// JSON or YAML of a serialized Resource for machineconfiguration.openshift.io:
+	// Each ConfigMap must have a single key named "config" whose value is the YML
+	// with one or more serialized machineconfiguration.openshift.io resources:
 	// KubeletConfig
 	// ContainerRuntimeConfig
 	// MachineConfig


### PR DESCRIPTION
This PR is a manual cherry-pick of  https://github.com/openshift/hypershift/pull/3695 into branch `release-4.16` because automatic `/cherry-pick` failed due to a code conflict.