### PR TITLE
HOSTEDCP-1813: Moves MachineIdentity from the HostedCluster API to the NodePool API

### DIFF
--- a/api/hypershift/v1alpha1/hostedcluster_types.go
+++ b/api/hypershift/v1alpha1/hostedcluster_types.go
@@ -1573,7 +1573,6 @@ type AzurePlatformSpec struct {
 	VnetID            string `json:"vnetID"`
 	SubnetID          string `json:"subnetID"`
 	SubscriptionID    string `json:"subscriptionID"`
-	MachineIdentityID string `json:"machineIdentityID"`
 	SecurityGroupID   string `json:"securityGroupID"`
 }
 

--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -934,7 +934,8 @@ type AzureNodePoolPlatform struct {
 	// Diagnostics specifies the diagnostics settings for a virtual machine.
 	// If not specified then Boot diagnostics will be disabled.
 	// +optional
-	Diagnostics *Diagnostics `json:"diagnostics,omitempty"`
+	Diagnostics       *Diagnostics `json:"diagnostics,omitempty"`
+	MachineIdentityID string       `json:"machineIdentityID"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1823,11 +1823,6 @@ type AzurePlatformSpec struct {
 	// +required
 	SubscriptionID string `json:"subscriptionID"`
 
-	// MachineIdentityID is used as the user-assigned identity to be assigned to the VMs
-	//
-	// +optional
-	MachineIdentityID string `json:"machineIdentityID,omitempty"`
-
 	// SecurityGroupID is the ID of an existing security group on the SubnetID. This field is provided as part of the
 	// configuration for the Azure cloud provider, aka Azure cloud controller manager (CCM). This security group is
 	// expected to exist under the same subscription as SubscriptionID.

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -902,8 +902,8 @@ type AzureNodePoolPlatform struct {
 	// ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
 	// is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
 	// The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
-	// Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
-	// hcluster.Spec.Platform.Azure.ResourceGroupName.
+	// Hosted Cluster specification respectively, HostedCluster.Spec.Platform.Azure.SubscriptionID and
+	// HostedCluster.Spec.Platform.Azure.ResourceGroupName.
 	//
 	// +optional
 	ImageID string `json:"imageID,omitempty"`
@@ -937,9 +937,9 @@ type AzureNodePoolPlatform struct {
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
-	// needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
+	// needs to exist in the same subscription id listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.SubscriptionID.
 	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location
-	// listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.Location.
+	// listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.Location.
 	//
 	// +optional
 	DiskEncryptionSetID string `json:"diskEncryptionSetID,omitempty"`
@@ -950,9 +950,9 @@ type AzureNodePoolPlatform struct {
 	EnableEphemeralOSDisk bool `json:"enableEphemeralOSDisk,omitempty"`
 
 	// SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
-	// different subnet than the one listed in the HostedCluster, hcluster.Spec.Platform.Azure.SubnetID, but must exist
-	// in the same hcluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
-	// hcluster.Spec.Platform.Azure.SubscriptionID.
+	// different subnet than the one listed in the HostedCluster, HostedCluster.Spec.Platform.Azure.SubnetID, but must
+	// exist in the same HostedCluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
+	// HostedCluster.Spec.Platform.Azure.SubscriptionID.
 	//
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="SubnetID is immutable"
 	// +kubebuilder:validation:Required
@@ -961,9 +961,21 @@ type AzureNodePoolPlatform struct {
 	SubnetID string `json:"subnetID"`
 
 	// Diagnostics specifies the diagnostics settings for a virtual machine.
-	// If not specified then Boot diagnostics will be disabled.
+	// If not specified, then Boot diagnostics will be disabled.
 	// +optional
 	Diagnostics *Diagnostics `json:"diagnostics,omitempty"`
+
+	// MachineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. This
+	// field is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
+	// user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
+	// under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
+	//
+	// If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
+	// in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
+	// HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
+	//
+	// +optional
+	MachineIdentityID string `json:"machineIdentityID,omitempty"`
 }
 
 // We define our own condition type since metav1.Condition has validation

--- a/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
@@ -29,6 +29,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	EnableEphemeralOSDisk  *bool                          `json:"enableEphemeralOSDisk,omitempty"`
 	SubnetID               *string                        `json:"subnetID,omitempty"`
 	Diagnostics            *DiagnosticsApplyConfiguration `json:"diagnostics,omitempty"`
+	MachineIdentityID      *string                        `json:"machineIdentityID,omitempty"`
 }
 
 // AzureNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AzureNodePoolPlatform type for use with
@@ -106,5 +107,13 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithSubnetID(value string) *Az
 // If called multiple times, the Diagnostics field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithDiagnostics(value *DiagnosticsApplyConfiguration) *AzureNodePoolPlatformApplyConfiguration {
 	b.Diagnostics = value
+	return b
+}
+
+// WithMachineIdentityID sets the MachineIdentityID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the MachineIdentityID field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithMachineIdentityID(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.MachineIdentityID = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1alpha1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azureplatformspec.go
@@ -31,7 +31,6 @@ type AzurePlatformSpecApplyConfiguration struct {
 	VnetID            *string                  `json:"vnetID,omitempty"`
 	SubnetID          *string                  `json:"subnetID,omitempty"`
 	SubscriptionID    *string                  `json:"subscriptionID,omitempty"`
-	MachineIdentityID *string                  `json:"machineIdentityID,omitempty"`
 	SecurityGroupID   *string                  `json:"securityGroupID,omitempty"`
 }
 
@@ -94,14 +93,6 @@ func (b *AzurePlatformSpecApplyConfiguration) WithSubnetID(value string) *AzureP
 // If called multiple times, the SubscriptionID field is set to the value of the last call.
 func (b *AzurePlatformSpecApplyConfiguration) WithSubscriptionID(value string) *AzurePlatformSpecApplyConfiguration {
 	b.SubscriptionID = &value
-	return b
-}
-
-// WithMachineIdentityID sets the MachineIdentityID field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the MachineIdentityID field is set to the value of the last call.
-func (b *AzurePlatformSpecApplyConfiguration) WithMachineIdentityID(value string) *AzurePlatformSpecApplyConfiguration {
-	b.MachineIdentityID = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
@@ -29,6 +29,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	EnableEphemeralOSDisk  *bool                          `json:"enableEphemeralOSDisk,omitempty"`
 	SubnetID               *string                        `json:"subnetID,omitempty"`
 	Diagnostics            *DiagnosticsApplyConfiguration `json:"diagnostics,omitempty"`
+	MachineIdentityID      *string                        `json:"machineIdentityID,omitempty"`
 }
 
 // AzureNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AzureNodePoolPlatform type for use with
@@ -106,5 +107,13 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithSubnetID(value string) *Az
 // If called multiple times, the Diagnostics field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithDiagnostics(value *DiagnosticsApplyConfiguration) *AzureNodePoolPlatformApplyConfiguration {
 	b.Diagnostics = value
+	return b
+}
+
+// WithMachineIdentityID sets the MachineIdentityID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the MachineIdentityID field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithMachineIdentityID(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.MachineIdentityID = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
@@ -31,7 +31,6 @@ type AzurePlatformSpecApplyConfiguration struct {
 	VnetID            *string                  `json:"vnetID,omitempty"`
 	SubnetID          *string                  `json:"subnetID,omitempty"`
 	SubscriptionID    *string                  `json:"subscriptionID,omitempty"`
-	MachineIdentityID *string                  `json:"machineIdentityID,omitempty"`
 	SecurityGroupID   *string                  `json:"securityGroupID,omitempty"`
 }
 
@@ -94,14 +93,6 @@ func (b *AzurePlatformSpecApplyConfiguration) WithSubnetID(value string) *AzureP
 // If called multiple times, the SubscriptionID field is set to the value of the last call.
 func (b *AzurePlatformSpecApplyConfiguration) WithSubscriptionID(value string) *AzurePlatformSpecApplyConfiguration {
 	b.SubscriptionID = &value
-	return b
-}
-
-// WithMachineIdentityID sets the MachineIdentityID field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the MachineIdentityID field is set to the value of the last call.
-func (b *AzurePlatformSpecApplyConfiguration) WithMachineIdentityID(value string) *AzurePlatformSpecApplyConfiguration {
-	b.MachineIdentityID = &value
 	return b
 }
 

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -198,7 +198,6 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 			ResourceGroupName: o.infra.ResourceGroupName,
 			VnetID:            o.infra.VNetID,
 			SubnetID:          o.infra.SubnetID,
-			MachineIdentityID: o.infra.MachineIdentityID,
 			SecurityGroupID:   o.infra.SecurityGroupID,
 		},
 	}
@@ -281,6 +280,7 @@ func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstr
 				EnableEphemeralOSDisk:  o.EnableEphemeralOSDisk,
 				DiskStorageAccountType: o.DiskStorageAccountType,
 				SubnetID:               o.infra.SubnetID,
+				MachineIdentityID:      o.infra.MachineIdentityID,
 			}
 			nodePools = append(nodePools, nodePool)
 		}
@@ -298,6 +298,7 @@ func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstr
 		EnableEphemeralOSDisk:  o.EnableEphemeralOSDisk,
 		DiskStorageAccountType: o.DiskStorageAccountType,
 		SubnetID:               o.infra.SubnetID,
+		MachineIdentityID:      o.infra.MachineIdentityID,
 	}
 	return []*hyperv1.NodePool{nodePool}
 }

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -52,7 +52,6 @@ spec:
       credentials:
         name: bryans-cluster-cloud-credentials
       location: fakeLocation
-      machineIdentityID: fakeMachineIdentityID
       resourceGroup: fakeResourceGroupName
       securityGroupID: fakeSecurityGroupID
       subnetID: fakeSubnetID
@@ -134,6 +133,7 @@ spec:
       diskStorageAccountType: Standard_LRS
       enableEphemeralOSDisk: true
       imageID: fakeBootImageID
+      machineIdentityID: fakeMachineIdentityID
       subnetID: fakeSubnetID
       vmsize: Standard_DS2_v2
     type: Azure

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -52,7 +52,6 @@ spec:
       credentials:
         name: example-cloud-credentials
       location: fakeLocation
-      machineIdentityID: fakeMachineIdentityID
       resourceGroup: fakeResourceGroupName
       securityGroupID: fakeSecurityGroupID
       subnetID: fakeSubnetID
@@ -132,6 +131,7 @@ spec:
     azure:
       diskSizeGB: 120
       imageID: fakeBootImageID
+      machineIdentityID: fakeMachineIdentityID
       subnetID: fakeSubnetID
       vmsize: Standard_D4s_v4
     type: Azure

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -3472,8 +3472,6 @@ spec:
                         x-kubernetes-map-type: atomic
                       location:
                         type: string
-                      machineIdentityID:
-                        type: string
                       resourceGroup:
                         type: string
                       securityGroupID:
@@ -3487,7 +3485,6 @@ spec:
                     required:
                     - credentials
                     - location
-                    - machineIdentityID
                     - resourceGroup
                     - securityGroupID
                     - subnetID
@@ -8254,10 +8251,6 @@ spec:
                         x-kubernetes-validations:
                         - message: Location is immutable
                           rule: self == oldSelf
-                      machineIdentityID:
-                        description: MachineIdentityID is used as the user-assigned
-                          identity to be assigned to the VMs
-                        type: string
                       resourceGroup:
                         default: default
                         description: |-

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -3458,8 +3458,6 @@ spec:
                         x-kubernetes-map-type: atomic
                       location:
                         type: string
-                      machineIdentityID:
-                        type: string
                       resourceGroup:
                         type: string
                       securityGroupID:
@@ -3473,7 +3471,6 @@ spec:
                     required:
                     - credentials
                     - location
-                    - machineIdentityID
                     - resourceGroup
                     - securityGroupID
                     - subnetID
@@ -8218,10 +8215,6 @@ spec:
                         x-kubernetes-validations:
                         - message: Location is immutable
                           rule: self == oldSelf
-                      machineIdentityID:
-                        description: MachineIdentityID is used as the user-assigned
-                          identity to be assigned to the VMs
-                        type: string
                       resourceGroup:
                         default: default
                         description: |-

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -633,6 +633,8 @@ spec:
                           ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
                           subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
                         type: string
+                      machineIdentityID:
+                        type: string
                       subnetID:
                         description: |-
                           SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
@@ -646,6 +648,7 @@ spec:
                       vmsize:
                         type: string
                     required:
+                    - machineIdentityID
                     - subnetID
                     - vmsize
                     type: object
@@ -1740,7 +1743,7 @@ spec:
                       diagnostics:
                         description: |-
                           Diagnostics specifies the diagnostics settings for a virtual machine.
-                          If not specified then Boot diagnostics will be disabled.
+                          If not specified, then Boot diagnostics will be disabled.
                         properties:
                           storageAccountType:
                             default: Disabled
@@ -1772,9 +1775,9 @@ spec:
                       diskEncryptionSetID:
                         description: |-
                           DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
-                          needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
+                          needs to exist in the same subscription id listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.SubscriptionID.
                           DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location
-                          listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.Location.
+                          listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.Location.
                         type: string
                       diskSizeGB:
                         default: 30
@@ -1811,15 +1814,27 @@ spec:
                           ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
                           is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
                           The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
-                          Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
-                          hcluster.Spec.Platform.Azure.ResourceGroupName.
+                          Hosted Cluster specification respectively, HostedCluster.Spec.Platform.Azure.SubscriptionID and
+                          HostedCluster.Spec.Platform.Azure.ResourceGroupName.
+                        type: string
+                      machineIdentityID:
+                        description: |-
+                          MachineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. This
+                          field is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
+                          user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
+                          under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
+
+
+                          If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
+                          in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
+                          HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
                         type: string
                       subnetID:
                         description: |-
                           SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
-                          different subnet than the one listed in the HostedCluster, hcluster.Spec.Platform.Azure.SubnetID, but must exist
-                          in the same hcluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
-                          hcluster.Spec.Platform.Azure.SubscriptionID.
+                          different subnet than the one listed in the HostedCluster, HostedCluster.Spec.Platform.Azure.SubnetID, but must
+                          exist in the same HostedCluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
+                          HostedCluster.Spec.Platform.Azure.SubscriptionID.
                         type: string
                         x-kubernetes-validations:
                         - message: SubnetID is immutable

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2431,8 +2431,8 @@ string
 <p>ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
 is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
 The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
-Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
-hcluster.Spec.Platform.Azure.ResourceGroupName.</p>
+Hosted Cluster specification respectively, HostedCluster.Spec.Platform.Azure.SubscriptionID and
+HostedCluster.Spec.Platform.Azure.ResourceGroupName.</p>
 </td>
 </tr>
 <tr>
@@ -2489,9 +2489,9 @@ string
 <td>
 <em>(Optional)</em>
 <p>DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
-needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
+needs to exist in the same subscription id listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.SubscriptionID.
 DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location
-listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.Location.</p>
+listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.Location.</p>
 </td>
 </tr>
 <tr>
@@ -2515,9 +2515,9 @@ string
 </td>
 <td>
 <p>SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
-different subnet than the one listed in the HostedCluster, hcluster.Spec.Platform.Azure.SubnetID, but must exist
-in the same hcluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
-hcluster.Spec.Platform.Azure.SubscriptionID.</p>
+different subnet than the one listed in the HostedCluster, HostedCluster.Spec.Platform.Azure.SubnetID, but must
+exist in the same HostedCluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
+HostedCluster.Spec.Platform.Azure.SubscriptionID.</p>
 </td>
 </tr>
 <tr>
@@ -2532,7 +2532,25 @@ Diagnostics
 <td>
 <em>(Optional)</em>
 <p>Diagnostics specifies the diagnostics settings for a virtual machine.
-If not specified then Boot diagnostics will be disabled.</p>
+If not specified, then Boot diagnostics will be disabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>machineIdentityID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MachineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. This
+field is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
+user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
+under HostedCluster.Spec.Platform.Azure.ResourceGroupName.</p>
+<p>If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
+in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
+HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.</p>
 </td>
 </tr>
 </tbody>
@@ -2647,18 +2665,6 @@ string
 </td>
 <td>
 <p>SubscriptionID is a unique identifier for an Azure subscription used to manage resources.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>machineIdentityID</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MachineIdentityID is used as the user-assigned identity to be assigned to the VMs</p>
 </td>
 </tr>
 <tr>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -49131,8 +49131,6 @@ objects:
                           x-kubernetes-map-type: atomic
                         location:
                           type: string
-                        machineIdentityID:
-                          type: string
                         resourceGroup:
                           type: string
                         securityGroupID:
@@ -49146,7 +49144,6 @@ objects:
                       required:
                       - credentials
                       - location
-                      - machineIdentityID
                       - resourceGroup
                       - securityGroupID
                       - subnetID
@@ -59397,8 +59394,6 @@ objects:
                           x-kubernetes-map-type: atomic
                         location:
                           type: string
-                        machineIdentityID:
-                          type: string
                         resourceGroup:
                           type: string
                         securityGroupID:
@@ -59412,7 +59407,6 @@ objects:
                       required:
                       - credentials
                       - location
-                      - machineIdentityID
                       - resourceGroup
                       - securityGroupID
                       - subnetID
@@ -66834,6 +66828,8 @@ objects:
                             ImageID is the id of the image to boot from. If unset, the default image at the location below will be used:
                             subscription/$subscriptionID/resourceGroups/$resourceGroupName/providers/Microsoft.Compute/images/rhcos.x86_64.vhd
                           type: string
+                        machineIdentityID:
+                          type: string
                         subnetID:
                           description: |-
                             SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
@@ -66847,6 +66843,7 @@ objects:
                         vmsize:
                           type: string
                       required:
+                      - machineIdentityID
                       - subnetID
                       - vmsize
                       type: object
@@ -67944,7 +67941,7 @@ objects:
                         diagnostics:
                           description: |-
                             Diagnostics specifies the diagnostics settings for a virtual machine.
-                            If not specified then Boot diagnostics will be disabled.
+                            If not specified, then Boot diagnostics will be disabled.
                           properties:
                             storageAccountType:
                               default: Disabled
@@ -67976,9 +67973,9 @@ objects:
                         diskEncryptionSetID:
                           description: |-
                             DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
-                            needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
+                            needs to exist in the same subscription id listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.SubscriptionID.
                             DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location
-                            listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.Location.
+                            listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.Location.
                           type: string
                         diskSizeGB:
                           default: 30
@@ -68015,19 +68012,27 @@ objects:
                             ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and
                             is expected to exist: subscription/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Compute/images/rhcos.x86_64.vhd.
                             The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
-                            Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
-                            hcluster.Spec.Platform.Azure.ResourceGroupName.
+                            Hosted Cluster specification respectively, HostedCluster.Spec.Platform.Azure.SubscriptionID and
+                            HostedCluster.Spec.Platform.Azure.ResourceGroupName.
                           type: string
                         machineIdentityID:
-                          description: MachineIdentityID is used as the user-assigned
-                            identity to be assigned to the VMs
+                          description: |-
+                            MachineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. This
+                            field is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
+                            user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
+                            under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
+
+
+                            If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
+                            in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
+                            HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
                           type: string
                         subnetID:
                           description: |-
                             SubnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a
-                            different subnet than the one listed in the HostedCluster, hcluster.Spec.Platform.Azure.SubnetID, but must exist
-                            in the same hcluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
-                            hcluster.Spec.Platform.Azure.SubscriptionID.
+                            different subnet than the one listed in the HostedCluster, HostedCluster.Spec.Platform.Azure.SubnetID, but must
+                            exist in the same HostedCluster.Spec.Platform.Azure.VnetID and must exist under the same subscription ID,
+                            HostedCluster.Spec.Platform.Azure.SubscriptionID.
                           type: string
                           x-kubernetes-validations:
                           - message: SubnetID is immutable

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -53930,10 +53930,6 @@ objects:
                           x-kubernetes-validations:
                           - message: Location is immutable
                             rule: self == oldSelf
-                        machineIdentityID:
-                          description: MachineIdentityID is used as the user-assigned
-                            identity to be assigned to the VMs
-                          type: string
                         resourceGroup:
                           default: default
                           description: |-
@@ -64178,10 +64174,6 @@ objects:
                           x-kubernetes-validations:
                           - message: Location is immutable
                             rule: self == oldSelf
-                        machineIdentityID:
-                          description: MachineIdentityID is used as the user-assigned
-                            identity to be assigned to the VMs
-                          type: string
                         resourceGroup:
                           default: default
                           description: |-
@@ -68025,6 +68017,10 @@ objects:
                             The <subscriptionID> and the <resourceGroupName> are expected to be the same resource group documented in the
                             Hosted Cluster specification respectively, hcluster.Spec.Platform.Azure.SubscriptionID and
                             hcluster.Spec.Platform.Azure.ResourceGroupName.
+                          type: string
+                        machineIdentityID:
+                          description: MachineIdentityID is used as the user-assigned
+                            identity to be assigned to the VMs
                           type: string
                         subnetID:
                           description: |-

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -49,10 +49,10 @@ func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1
 		FailureDomain: failureDomain(nodePool),
 	}}}
 
-	if hcluster.Spec.Platform.Azure.MachineIdentityID != "" {
+	if nodePool.Spec.Platform.Azure.MachineIdentityID != "" {
 		azureMachineTemplate.Template.Spec.Identity = capiazure.VMIdentityUserAssigned
 		azureMachineTemplate.Template.Spec.UserAssignedIdentities = []capiazure.UserAssignedIdentity{{
-			ProviderID: hcluster.Spec.Platform.Azure.MachineIdentityID,
+			ProviderID: nodePool.Spec.Platform.Azure.MachineIdentityID,
 		}}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves `MachineIdentity` from the Azure section in the HostedCluster API to the Azure section in the NodePool API

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1813](https://issues.redhat.com/browse/HOSTEDCP-1813)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.