### PR TITLE
OCPBUGS-34820: Keep in sync the HC and HCP ICS field

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -2306,12 +2306,6 @@ func (r *reconciler) reconcileImageContentPolicyType(ctx context.Context, hcp *h
 		return fmt.Errorf("failed to reconcile image digest mirror set: %w", err)
 	}
 
-	if (idms.Spec.ImageDigestMirrors != nil && len(idms.Spec.ImageDigestMirrors) <= 0) || idms.Spec.ImageDigestMirrors == nil {
-		if _, err := util.DeleteIfNeeded(ctx, r.client, idms); err != nil {
-			return fmt.Errorf("failed to delete image digest mirror set: %w", err)
-		}
-	}
-
 	return nil
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -395,39 +395,6 @@ func withICS(hcp *hyperv1.HostedControlPlane) *hyperv1.HostedControlPlane {
 	return hcpOriginal
 }
 
-func fakeIDMS() *configv1.ImageDigestMirrorSet {
-	return &configv1.ImageDigestMirrorSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster",
-		},
-		Spec: configv1.ImageDigestMirrorSetSpec{
-			ImageDigestMirrors: []configv1.ImageDigestMirrors{
-				{
-					Source: "example.com/test",
-					Mirrors: []configv1.ImageMirror{
-						"mirror1.example.com/test1",
-						"mirror2.example.com/test2",
-					},
-				},
-				{
-					Source: "sample.com/test",
-					Mirrors: []configv1.ImageMirror{
-						"mirror1.sample.com/test1",
-						"mirror2.sample.com/test2",
-					},
-				},
-				{
-					Source: "quay.io/test",
-					Mirrors: []configv1.ImageMirror{
-						"mirror1.quay.io/test1",
-						"mirror2.quay.io/test2",
-					},
-				},
-			},
-		},
-	}
-}
-
 func TestReconcileKubeadminPasswordHashSecret(t *testing.T) {
 	testNamespace := "master-cluster1"
 	testHCPName := "cluster1"
@@ -987,25 +954,19 @@ func TestReconcileImageContentPolicyType(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		hcp                   *hyperv1.HostedControlPlane
-		expectedIDMS          *configv1.ImageDigestMirrorSet
-		expectedToFail        bool
 		removeICSAndReconcile bool
 	}{
 		{
-			name:         "ICS with content, it should return an IDMS with the same content",
-			hcp:          withICS(fakeHCP()),
-			expectedIDMS: fakeIDMS(),
+			name: "ICS with content, it should return an IDMS with the same content",
+			hcp:  withICS(fakeHCP()),
 		},
 		{
-			name:           "ICS empty, is should return a not found error",
-			hcp:            fakeHCP(),
-			expectedToFail: true,
+			name: "ICS empty, is should return an empty IDMS",
+			hcp:  fakeHCP(),
 		},
 		{
-			name:                  "ICS with content and updated the HCP deleting the ICS, it should return a not found error",
+			name:                  "ICS And IDMS should be in sync always",
 			hcp:                   withICS(fakeHCP()),
-			expectedIDMS:          nil,
-			expectedToFail:        true,
 			removeICSAndReconcile: true,
 		},
 	}
@@ -1024,14 +985,14 @@ func TestReconcileImageContentPolicyType(t *testing.T) {
 
 			idms := globalconfig.ImageDigestMirrorSet()
 			err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(idms), idms)
-			if tc.hcp.Spec.ImageContentSources == nil && tc.expectedToFail {
-				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "expecting a not-found error, received: %v", err)
-			}
+			g.Expect(err).ToNot(HaveOccurred(), "error getting IDMS")
 
-			if !tc.removeICSAndReconcile && !tc.expectedToFail {
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(len(tc.hcp.Spec.ImageContentSources)).To(Equal(len(idms.Spec.ImageDigestMirrors)))
-				g.Expect(tc.expectedIDMS.Spec).To(BeEquivalentTo(idms.Spec))
+			// Same number of ICS and IDMS
+			g.Expect(len(tc.hcp.Spec.ImageContentSources)).To(Equal(len(idms.Spec.ImageDigestMirrors)), "expecting equal values between IDMS and ICS")
+
+			if tc.hcp.Spec.ImageContentSources != nil {
+				// Check if the ICS and IDMS have the same values
+				compareICSAndIDMS(g, tc.hcp.Spec.ImageContentSources, idms)
 			}
 
 			if tc.removeICSAndReconcile {
@@ -1043,9 +1004,21 @@ func TestReconcileImageContentPolicyType(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 				idms := globalconfig.ImageDigestMirrorSet()
 				err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(idms), idms)
-				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "expecting a not-found error, received: %v", err)
+				g.Expect(err).ToNot(HaveOccurred(), "error getting IDMS")
+				g.Expect(len(origHCP.Spec.ImageContentSources)).To(Equal(len(idms.Spec.ImageDigestMirrors)), "expecting equal values between IDMS and ICS")
+				compareICSAndIDMS(g, origHCP.Spec.ImageContentSources, idms)
 			}
 		})
 	}
+}
 
+func compareICSAndIDMS(g *WithT, ics []hyperv1.ImageContentSource, idms *configv1.ImageDigestMirrorSet) {
+	g.Expect(len(ics)).To(Equal(len(idms.Spec.ImageDigestMirrors)), "expecting equal values between IDMS and ICS")
+	// Check if the ICS and IDMS have the same values
+	for i, ics := range ics {
+		g.Expect(ics.Source).To(Equal(idms.Spec.ImageDigestMirrors[i].Source))
+		for j, mirrorics := range ics.Mirrors {
+			g.Expect(mirrorics).To(Equal(string(idms.Spec.ImageDigestMirrors[i].Mirrors[j])))
+		}
+	}
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1893,6 +1893,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	hcp.Spec.Autoscaling = hcluster.Spec.Autoscaling
 	hcp.Spec.NodeSelector = hcluster.Spec.NodeSelector
 	hcp.Spec.Tolerations = hcluster.Spec.Tolerations
+	hcp.Spec.ImageContentSources = hcluster.Spec.ImageContentSources
 
 	// Pass through Platform spec.
 	hcp.Spec.Platform = *hcluster.Spec.Platform.DeepCopy()


### PR DESCRIPTION
The issue happens because the ImageContentSource field from the HostedCluster object in not in sync with the HostedControlPlane ImageContentSource field.

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-34820](https://issues.redhat.com/browse/OCPBUGS-34820)