### PR TITLE
HOSTEDCP-1815: feat(ignition): Add option to disable ignition server reconciliation

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -334,6 +334,9 @@ const (
 	// SkipControlPlaneNamespaceDeletionAnnotation tells the the hosted cluster controller not to delete the hosted control plane
 	// namespace during hosted cluster deletion when this annotation is set to the value "true".
 	SkipControlPlaneNamespaceDeletionAnnotation = "hypershift.openshift.io/skip-delete-hosted-controlplane-namespace"
+
+	// DisableIgnitionServerAnnotation controls skipping of the ignition server deployment.
+	DisableIgnitionServerAnnotation = "hypershift.openshift.io/disable-ignition-server"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -334,6 +334,9 @@ const (
 	// SkipControlPlaneNamespaceDeletionAnnotation tells the the hosted cluster controller not to delete the hosted control plane
 	// namespace during hosted cluster deletion when this annotation is set to the value "true".
 	SkipControlPlaneNamespaceDeletionAnnotation = "hypershift.openshift.io/skip-delete-hosted-controlplane-namespace"
+
+	// DisableIgnitionServerAnnotation controls skipping of the ignition server deployment.
+	DisableIgnitionServerAnnotation = "hypershift.openshift.io/disable-ignition-server"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.


### PR DESCRIPTION
**What this PR does / why we need it**: Adds support to disable ignition server reconcilement 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/HOSTEDCP-1815

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.