### PR TITLE
HOSTEDCP-1791: dont render any secrets in manifest file

### DIFF
--- a/cmd/cluster/agent/create_test.go
+++ b/cmd/cluster/agent/create_test.go
@@ -27,6 +27,7 @@ func TestCreateCluster(t *testing.T) {
 			name: "minimal flags necessary to render",
 			args: []string{
 				"--api-server-address=fakeAddress", // if we don't set it, the machine's IP is looked up, which isn't portable
+				"--render-sensitive",
 			},
 		},
 	} {

--- a/cmd/cluster/aws/create_test.go
+++ b/cmd/cluster/aws/create_test.go
@@ -213,6 +213,7 @@ func TestCreateCluster(t *testing.T) {
 				"--iam-json=" + iamFile,
 				"--role-arn=fakeRoleARN",
 				"--pull-secret=" + pullSecretFile,
+				"--render-sensitive",
 			},
 		},
 		{
@@ -233,6 +234,7 @@ func TestCreateCluster(t *testing.T) {
 				"--control-plane-operator-image=fakeCPOImage",
 				"--release-image=fakeReleaseImage",
 				"--annotations=hypershift.openshift.io/cleanup-cloud-resources=true",
+				"--render-sensitive",
 			},
 		},
 	} {

--- a/cmd/cluster/azure/create_test.go
+++ b/cmd/cluster/azure/create_test.go
@@ -70,6 +70,7 @@ func TestCreateCluster(t *testing.T) {
 				"--azure-creds=" + credentialsFile,
 				"--infra-json=" + infraFile,
 				"--rhcos-image=whatever",
+				"--render-sensitive",
 			},
 		},
 		{

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -91,6 +91,18 @@ status:
 ---
 apiVersion: v1
 data:
+  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
+  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
+  AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
+  AZURE_TENANT_ID: ZmFrZVRlbmFudElE
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: example-cloud-credentials
+  namespace: clusters
+---
+apiVersion: v1
+data:
   key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
 kind: Secret
 metadata:

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -712,7 +712,7 @@ func CreateCluster(ctx context.Context, rawOpts *RawCreateOptions, rawPlatform P
 		}
 		for _, object := range resources.asObjects() {
 			if !opts.RenderSensitive {
-				if secret, ok := object.(*corev1.Secret); ok && strings.Contains(secret.Name, "cloud-credentials") {
+				if _, ok := object.(*corev1.Secret); ok {
 					continue
 				}
 			}

--- a/cmd/cluster/kubevirt/create_test.go
+++ b/cmd/cluster/kubevirt/create_test.go
@@ -126,7 +126,9 @@ func TestCreateCluster(t *testing.T) {
 	}{
 		{
 			name: "minimal flags necessary to render",
-			args: []string{},
+			args: []string{
+				"--render-sensitive",
+			},
 		},
 		{
 			name: "test from dvossel",
@@ -150,6 +152,7 @@ func TestCreateCluster(t *testing.T) {
 				"--infra-volumesnapshot-class-mapping=ocs-storagecluster-rbd-snap/rdb-snap",
 				"--toleration", "key=key1,value=value1,effect=noSchedule",
 				"--toleration", "key=key2,value=value2,effect=noSchedule",
+				"--render-sensitive",
 			},
 		},
 	} {

--- a/cmd/cluster/none/create_test.go
+++ b/cmd/cluster/none/create_test.go
@@ -27,6 +27,7 @@ func TestCreateCluster(t *testing.T) {
 			name: "minimal flags necessary to render",
 			args: []string{
 				"--external-api-server-address=fakeAddress", // if we don't set it, the machine's IP is looked up, which isn't portable
+				"--render-sensitive",
 			},
 		},
 	} {

--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -97,6 +97,7 @@ func TestCreateCluster(t *testing.T) {
 				"--control-plane-operator-image=fakeCPOImage",
 				"--release-image=fakeReleaseImage",
 				"--annotations=hypershift.openshift.io/cleanup-cloud-resources=true",
+				"--render-sensitive",
 			},
 		},
 	} {

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
@@ -90,6 +90,18 @@ status:
 ---
 apiVersion: v1
 data:
+  clouds.yaml: Y2xvdWRzOgogICAgb3BlbnN0YWNrOgogICAgICAgIGF1dGg6CiAgICAgICAgICAgIGF1dGhfdXJsOiBmYWtlQXV0aFVSTAo=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: test-cloud-credentials
+  namespace: clusters
+type: Opaque
+---
+apiVersion: v1
+data:
   key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
 kind: Secret
 metadata:

--- a/cmd/cluster/powervs/create_test.go
+++ b/cmd/cluster/powervs/create_test.go
@@ -92,6 +92,7 @@ func TestCreateCluster(t *testing.T) {
 			name: "minimal flags necessary to render",
 			args: []string{
 				"--infra-json=" + infraFile,
+				"--render-sensitive",
 			},
 		},
 	} {


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent all secrets from being rendered in manifest by default.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.