### PR TITLE
OCPBUGS-37486: Set right endpointSlice port

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1169,7 +1169,6 @@ func (r *reconciler) reconcileKASEndpoints(ctx context.Context, hcp *hyperv1.Hos
 
 	kasAdvertiseAddress := util.GetAdvertiseAddress(hcp, config.DefaultAdvertiseIPv4Address, config.DefaultAdvertiseIPv6Address)
 	kasEndpointsPort := util.KASPodPort(hcp)
-	kasEndpointSlicePort := kasEndpointsPort
 
 	// We only keep reconciling the endpoint for existing clusters that are relying on this for nodes haproxy to work.
 	// Otherwise, changing the haproxy config to !=443 would result in a NodePool rollout which want to avoid for existing clusters.
@@ -1189,7 +1188,7 @@ func (r *reconciler) reconcileKASEndpoints(ctx context.Context, hcp *hyperv1.Hos
 	}
 	kasEndpointSlice := manifests.KASEndpointSlice()
 	if _, err := r.CreateOrUpdate(ctx, r.client, kasEndpointSlice, func() error {
-		kas.ReconcileKASEndpointSlice(kasEndpointSlice, kasAdvertiseAddress, kasEndpointSlicePort)
+		kas.ReconcileKASEndpointSlice(kasEndpointSlice, kasAdvertiseAddress, kasEndpointsPort)
 		return nil
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile kubernetes.default endpoint slice: %w", err))


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This https://github.com/openshift/hypershift/pull/4228 introduced an inconsistency between the endpoint and endpointSlice ports. Resulting in old HCs having hcp.Spec.Networking.APIServer.Port=443 failing to talk to the CP via kubernetes.svc.
This PR fixes that.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.