### PR TITLE
OSASINFRA-3550: openstack: configure nodepool ports for Ingress

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
@@ -32,7 +32,9 @@ func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Se
 	globalconfig.ReconcileDNSConfig(dns, hcp)
 
 	infra := globalconfig.InfrastructureConfig()
-	globalconfig.ReconcileInfrastructure(infra, hcp)
+	if err := globalconfig.ReconcileInfrastructure(infra, hcp); err != nil {
+		return &MCSParams{}, fmt.Errorf("failed on infrastructure reconciliation config: %w", err)
+	}
 
 	network := globalconfig.NetworkConfig()
 	if err := globalconfig.ReconcileNetworkConfig(network, hcp); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/IBM/networking-go-sdk v0.45.0
 	github.com/IBM/platform-services-go-sdk v0.60.0
 	github.com/IBM/vpc-go-sdk v0.50.0
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/aws/aws-sdk-go v1.52.6
 	github.com/blang/semver v3.5.1+incompatible

--- a/hypershift-operator/controllers/nodepool/openstack/openstack.go
+++ b/hypershift-operator/controllers/nodepool/openstack/openstack.go
@@ -2,9 +2,13 @@ package openstack
 
 import (
 	"fmt"
+	"net"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/api/util/ipnet"
 
+	"github.com/apparentlymart/go-cidr/cidr"
+	openstackutil "github.com/openshift/hypershift/support/openstackutil"
 	utilpointer "k8s.io/utils/pointer"
 	capiopenstack "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 )
@@ -27,5 +31,41 @@ func MachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.Node
 		return nil, fmt.Errorf("image name is required")
 	}
 
+	port := capiopenstack.PortOpts{}
+
+	var machineNetworks []hyperv1.MachineNetworkEntry
+	if hcluster.Spec.Networking.MachineNetwork == nil || len(hcluster.Spec.Networking.MachineNetwork) == 0 {
+		machineNetworks = []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR(openstackutil.DefaultCIDRBlock)}}
+	} else {
+		machineNetworks = hcluster.Spec.Networking.MachineNetwork
+	}
+	ingressIP, err := getIngressIP(machineNetworks[0])
+	if err != nil {
+		return nil, err
+	}
+	port.AllowedAddressPairs = []capiopenstack.AddressPair{
+		{
+			// Allows Ingress VIP traffic on that port
+			IPAddress: ingressIP,
+		},
+	}
+	openStackMachineTemplate.Template.Spec.Ports = []capiopenstack.PortOpts{port}
+
 	return openStackMachineTemplate, nil
+}
+
+// getIngressIP returns the IP address to be used for the Ingress VIP.
+// We take the seventh IP from the CIDR range like we do in the installer.
+// https://github.com/openshift/installer/blob/8e548c31b0431419350edd1fabd4dcb06263440f/pkg/types/openstack/defaults/platform.go#L48
+func getIngressIP(machineNetwork hyperv1.MachineNetworkEntry) (string, error) {
+	// go-cidr expects a net.IPNet, so we need to convert the hypershift type of CIDR to net.IPNet
+	machineNetworkIPNet := &net.IPNet{
+		IP:   machineNetwork.CIDR.IP,
+		Mask: machineNetwork.CIDR.Mask,
+	}
+	ip, err := cidr.Host(machineNetworkIPNet, 7)
+	if err != nil {
+		return "", err
+	}
+	return ip.String(), nil
 }

--- a/hypershift-operator/controllers/nodepool/openstack/openstack.go
+++ b/hypershift-operator/controllers/nodepool/openstack/openstack.go
@@ -2,12 +2,10 @@ package openstack
 
 import (
 	"fmt"
-	"net"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/api/util/ipnet"
 
-	"github.com/apparentlymart/go-cidr/cidr"
 	openstackutil "github.com/openshift/hypershift/support/openstackutil"
 	utilpointer "k8s.io/utils/pointer"
 	capiopenstack "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
@@ -39,7 +37,7 @@ func MachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.Node
 	} else {
 		machineNetworks = hcluster.Spec.Networking.MachineNetwork
 	}
-	ingressIP, err := getIngressIP(machineNetworks[0])
+	ingressIP, err := openstackutil.GetIngressIP(machineNetworks[0])
 	if err != nil {
 		return nil, err
 	}
@@ -52,20 +50,4 @@ func MachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.Node
 	openStackMachineTemplate.Template.Spec.Ports = []capiopenstack.PortOpts{port}
 
 	return openStackMachineTemplate, nil
-}
-
-// getIngressIP returns the IP address to be used for the Ingress VIP.
-// We take the seventh IP from the CIDR range like we do in the installer.
-// https://github.com/openshift/installer/blob/8e548c31b0431419350edd1fabd4dcb06263440f/pkg/types/openstack/defaults/platform.go#L48
-func getIngressIP(machineNetwork hyperv1.MachineNetworkEntry) (string, error) {
-	// go-cidr expects a net.IPNet, so we need to convert the hypershift type of CIDR to net.IPNet
-	machineNetworkIPNet := &net.IPNet{
-		IP:   machineNetwork.CIDR.IP,
-		Mask: machineNetwork.CIDR.Mask,
-	}
-	ip, err := cidr.Host(machineNetworkIPNet, 7)
-	if err != nil {
-		return "", err
-	}
-	return ip.String(), nil
 }

--- a/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
+++ b/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
@@ -120,18 +120,3 @@ func TestOpenStackMachineTemplate(t *testing.T) {
 		})
 	}
 }
-
-func TestGetIngressIP(t *testing.T) {
-	machineNetwork := hyperv1.MachineNetworkEntry{
-		CIDR: *ipnet.MustParseCIDR("10.0.0.0/16"),
-	}
-
-	expectedIP := "10.0.0.7"
-	ip, err := getIngressIP(machineNetwork)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if ip != expectedIP {
-		t.Errorf("expected IP: %s, got: %s", expectedIP, ip)
-	}
-}

--- a/support/openstackutil/constants.go
+++ b/support/openstackutil/constants.go
@@ -1,0 +1,5 @@
+package openstackutil
+
+const (
+	DefaultCIDRBlock = "10.0.0.0/16"
+)

--- a/support/openstackutil/constants.go
+++ b/support/openstackutil/constants.go
@@ -1,5 +1,0 @@
-package openstackutil
-
-const (
-	DefaultCIDRBlock = "10.0.0.0/16"
-)

--- a/support/openstackutil/machinenetworking.go
+++ b/support/openstackutil/machinenetworking.go
@@ -1,0 +1,28 @@
+package openstackutil
+
+import (
+	"net"
+
+	"github.com/apparentlymart/go-cidr/cidr"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+const (
+	DefaultCIDRBlock = "10.0.0.0/16"
+)
+
+// GetIngressIP returns the IP address to be used for the Ingress VIP.
+// We take the seventh IP from the CIDR range like we do in the installer.
+// https://github.com/openshift/installer/blob/8e548c31b0431419350edd1fabd4dcb06263440f/pkg/types/openstack/defaults/platform.go#L48
+func GetIngressIP(machineNetwork hyperv1.MachineNetworkEntry) (string, error) {
+	// go-cidr expects a net.IPNet, so we need to convert the hypershift type of CIDR to net.IPNet
+	machineNetworkIPNet := &net.IPNet{
+		IP:   machineNetwork.CIDR.IP,
+		Mask: machineNetwork.CIDR.Mask,
+	}
+	ip, err := cidr.Host(machineNetworkIPNet, 7)
+	if err != nil {
+		return "", err
+	}
+	return ip.String(), nil
+}

--- a/support/openstackutil/machinenetworking_test.go
+++ b/support/openstackutil/machinenetworking_test.go
@@ -1,0 +1,25 @@
+package openstackutil
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/api/util/ipnet"
+)
+
+func TestGetIngressIP(t *testing.T) {
+	machineNetwork := hyperv1.MachineNetworkEntry{
+		CIDR: *ipnet.MustParseCIDR("10.0.0.0/16"),
+	}
+
+	expectedIP := "10.0.0.7" // Seventh IP from the CIDR range
+
+	ip, err := GetIngressIP(machineNetwork)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ip != expectedIP {
+		t.Errorf("expected IP: %s, got: %s", expectedIP, ip)
+	}
+}

--- a/vendor/github.com/apparentlymart/go-cidr/LICENSE
+++ b/vendor/github.com/apparentlymart/go-cidr/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Martin Atkins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
@@ -1,0 +1,236 @@
+// Package cidr is a collection of assorted utilities for computing
+// network and host addresses within network ranges.
+//
+// It expects a CIDR-type address structure where addresses are divided into
+// some number of prefix bits representing the network and then the remaining
+// suffix bits represent the host.
+//
+// For example, it can help to calculate addresses for sub-networks of a
+// parent network, or to calculate host addresses within a particular prefix.
+//
+// At present this package is prioritizing simplicity of implementation and
+// de-prioritizing speed and memory usage. Thus caution is advised before
+// using this package in performance-critical applications or hot codepaths.
+// Patches to improve the speed and memory usage may be accepted as long as
+// they do not result in a significant increase in code complexity.
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+// Subnet takes a parent CIDR range and creates a subnet within it
+// with the given number of additional prefix bits and the given
+// network number.
+//
+// For example, 10.3.0.0/16, extended by 8 bits, with a network number
+// of 5, becomes 10.3.5.0/24 .
+func Subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
+	return SubnetBig(base, newBits, big.NewInt(int64(num)))
+}
+
+// SubnetBig takes a parent CIDR range and creates a subnet within it with the
+// given number of additional prefix bits and the given network number. It
+// differs from Subnet in that it takes a *big.Int for the num, instead of an int.
+//
+// For example, 10.3.0.0/16, extended by 8 bits, with a network number of 5,
+// becomes 10.3.5.0/24 .
+func SubnetBig(base *net.IPNet, newBits int, num *big.Int) (*net.IPNet, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	newPrefixLen := parentLen + newBits
+
+	if newPrefixLen > addrLen {
+		return nil, fmt.Errorf("insufficient address space to extend prefix of %d by %d", parentLen, newBits)
+	}
+
+	maxNetNum := uint64(1<<uint64(newBits)) - 1
+	if num.Uint64() > maxNetNum {
+		return nil, fmt.Errorf("prefix extension of %d does not accommodate a subnet numbered %d", newBits, num)
+	}
+
+	return &net.IPNet{
+		IP:   insertNumIntoIP(ip, num, newPrefixLen),
+		Mask: net.CIDRMask(newPrefixLen, addrLen),
+	}, nil
+}
+
+// Host takes a parent CIDR range and turns it into a host IP address with the
+// given host number.
+//
+// For example, 10.3.0.0/16 with a host number of 2 gives 10.3.0.2.
+func Host(base *net.IPNet, num int) (net.IP, error) {
+	return HostBig(base, big.NewInt(int64(num)))
+}
+
+// HostBig takes a parent CIDR range and turns it into a host IP address with
+// the given host number. It differs from Host in that it takes a *big.Int for
+// the num, instead of an int.
+//
+// For example, 10.3.0.0/16 with a host number of 2 gives 10.3.0.2.
+func HostBig(base *net.IPNet, num *big.Int) (net.IP, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	hostLen := addrLen - parentLen
+
+	maxHostNum := big.NewInt(int64(1))
+	maxHostNum.Lsh(maxHostNum, uint(hostLen))
+	maxHostNum.Sub(maxHostNum, big.NewInt(1))
+
+	numUint64 := big.NewInt(int64(num.Uint64()))
+	if num.Cmp(big.NewInt(0)) == -1 {
+		numUint64.Neg(num)
+		numUint64.Sub(numUint64, big.NewInt(int64(1)))
+		num.Sub(maxHostNum, numUint64)
+	}
+
+	if numUint64.Cmp(maxHostNum) == 1 {
+		return nil, fmt.Errorf("prefix of %d does not accommodate a host numbered %d", parentLen, num)
+	}
+	var bitlength int
+	if ip.To4() != nil {
+		bitlength = 32
+	} else {
+		bitlength = 128
+	}
+	return insertNumIntoIP(ip, num, bitlength), nil
+}
+
+// AddressRange returns the first and last addresses in the given CIDR range.
+func AddressRange(network *net.IPNet) (net.IP, net.IP) {
+	// the first IP is easy
+	firstIP := network.IP
+
+	// the last IP is the network address OR NOT the mask address
+	prefixLen, bits := network.Mask.Size()
+	if prefixLen == bits {
+		// Easy!
+		// But make sure that our two slices are distinct, since they
+		// would be in all other cases.
+		lastIP := make([]byte, len(firstIP))
+		copy(lastIP, firstIP)
+		return firstIP, lastIP
+	}
+
+	firstIPInt, bits := ipToInt(firstIP)
+	hostLen := uint(bits) - uint(prefixLen)
+	lastIPInt := big.NewInt(1)
+	lastIPInt.Lsh(lastIPInt, hostLen)
+	lastIPInt.Sub(lastIPInt, big.NewInt(1))
+	lastIPInt.Or(lastIPInt, firstIPInt)
+
+	return firstIP, intToIP(lastIPInt, bits)
+}
+
+// AddressCount returns the number of distinct host addresses within the given
+// CIDR range.
+//
+// Since the result is a uint64, this function returns meaningful information
+// only for IPv4 ranges and IPv6 ranges with a prefix size of at least 65.
+func AddressCount(network *net.IPNet) uint64 {
+	prefixLen, bits := network.Mask.Size()
+	return 1 << (uint64(bits) - uint64(prefixLen))
+}
+
+//VerifyNoOverlap takes a list subnets and supernet (CIDRBlock) and verifies
+//none of the subnets overlap and all subnets are in the supernet
+//it returns an error if any of those conditions are not satisfied
+func VerifyNoOverlap(subnets []*net.IPNet, CIDRBlock *net.IPNet) error {
+	firstLastIP := make([][]net.IP, len(subnets))
+	for i, s := range subnets {
+		first, last := AddressRange(s)
+		firstLastIP[i] = []net.IP{first, last}
+	}
+	for i, s := range subnets {
+		if !CIDRBlock.Contains(firstLastIP[i][0]) || !CIDRBlock.Contains(firstLastIP[i][1]) {
+			return fmt.Errorf("%s does not fully contain %s", CIDRBlock.String(), s.String())
+		}
+		for j := 0; j < len(subnets); j++ {
+			if i == j {
+				continue
+			}
+
+			first := firstLastIP[j][0]
+			last := firstLastIP[j][1]
+			if s.Contains(first) || s.Contains(last) {
+				return fmt.Errorf("%s overlaps with %s", subnets[j].String(), s.String())
+			}
+		}
+	}
+	return nil
+}
+
+// PreviousSubnet returns the subnet of the desired mask in the IP space
+// just lower than the start of IPNet provided. If the IP space rolls over
+// then the second return value is true
+func PreviousSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	startIP := checkIPv4(network.IP)
+	previousIP := make(net.IP, len(startIP))
+	copy(previousIP, startIP)
+	cMask := net.CIDRMask(prefixLen, 8*len(previousIP))
+	previousIP = Dec(previousIP)
+	previous := &net.IPNet{IP: previousIP.Mask(cMask), Mask: cMask}
+	if startIP.Equal(net.IPv4zero) || startIP.Equal(net.IPv6zero) {
+		return previous, true
+	}
+	return previous, false
+}
+
+// NextSubnet returns the next available subnet of the desired mask size
+// starting for the maximum IP of the offset subnet
+// If the IP exceeds the maxium IP then the second return value is true
+func NextSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	_, currentLast := AddressRange(network)
+	mask := net.CIDRMask(prefixLen, 8*len(currentLast))
+	currentSubnet := &net.IPNet{IP: currentLast.Mask(mask), Mask: mask}
+	_, last := AddressRange(currentSubnet)
+	last = Inc(last)
+	next := &net.IPNet{IP: last.Mask(mask), Mask: mask}
+	if last.Equal(net.IPv4zero) || last.Equal(net.IPv6zero) {
+		return next, true
+	}
+	return next, false
+}
+
+//Inc increases the IP by one this returns a new []byte for the IP
+func Inc(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	incIP := make([]byte, len(IP))
+	copy(incIP, IP)
+	for j := len(incIP) - 1; j >= 0; j-- {
+		incIP[j]++
+		if incIP[j] > 0 {
+			break
+		}
+	}
+	return incIP
+}
+
+//Dec decreases the IP by one this returns a new []byte for the IP
+func Dec(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	decIP := make([]byte, len(IP))
+	copy(decIP, IP)
+	decIP = checkIPv4(decIP)
+	for j := len(decIP) - 1; j >= 0; j-- {
+		decIP[j]--
+		if decIP[j] < 255 {
+			break
+		}
+	}
+	return decIP
+}
+
+func checkIPv4(ip net.IP) net.IP {
+	// Go for some reason allocs IPv6len for IPv4 so we have to correct it
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
+}

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
@@ -1,0 +1,37 @@
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+func ipToInt(ip net.IP) (*big.Int, int) {
+	val := &big.Int{}
+	val.SetBytes([]byte(ip))
+	if len(ip) == net.IPv4len {
+		return val, 32
+	} else if len(ip) == net.IPv6len {
+		return val, 128
+	} else {
+		panic(fmt.Errorf("Unsupported address length %d", len(ip)))
+	}
+}
+
+func intToIP(ipInt *big.Int, bits int) net.IP {
+	ipBytes := ipInt.Bytes()
+	ret := make([]byte, bits/8)
+	// Pack our IP bytes into the end of the return array,
+	// since big.Int.Bytes() removes front zero padding.
+	for i := 1; i <= len(ipBytes); i++ {
+		ret[len(ret)-i] = ipBytes[len(ipBytes)-i]
+	}
+	return net.IP(ret)
+}
+
+func insertNumIntoIP(ip net.IP, bigNum *big.Int, prefixLen int) net.IP {
+	ipInt, totalBits := ipToInt(ip)
+	bigNum.Lsh(bigNum, uint(totalBits-prefixLen))
+	ipInt.Or(ipInt, bigNum)
+	return intToIP(ipInt, totalBits)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,6 +249,9 @@ github.com/NYTimes/gziphandler
 # github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230321174746-8dcc6526cfb1
 ## explicit; go 1.18
 github.com/antlr/antlr4/runtime/Go/antlr/v4
+# github.com/apparentlymart/go-cidr v1.1.0
+## explicit
+github.com/apparentlymart/go-cidr/cidr
 # github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 ## explicit
 github.com/armon/go-socks5


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add `CIDR` to `SubnetSpec` so when a user asks for CAPO to manage a subnet, they can provide the CIDR (they couldn't before, they could only provide the DNS nameserver and the DHCP allocation pool)
* Configure the OpenStackMachineTemplate with ports that allow Ingress traffic via allowed address pairs, where the IP of Ingress will be the 7th available IP in the subnet, like it's done in the Installer already.
* Add a few validations when managed subnets are in use