### PR TITLE
OCPBUGS-37625: DedicatedRequestServing scheduler: make taken labels list consistent

### DIFF
--- a/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/dedicated_request_serving_nodes.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	corev1applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
@@ -813,12 +814,12 @@ func (r *DedicatedServingComponentSchedulerAndSizer) takenNodePairLabels(ctx con
 	if err := r.List(ctx, nodes, client.HasLabels{hyperv1.HostedClusterLabel, OSDFleetManagerPairedNodesLabel}); err != nil {
 		return nil, fmt.Errorf("failed to list nodes: %w", err)
 	}
-	var result []string
+	result := sets.New[string]()
 	for _, node := range nodes.Items {
 		labelValue := node.Labels[OSDFleetManagerPairedNodesLabel]
-		result = append(result, labelValue)
+		result.Insert(labelValue)
 	}
-	return result, nil
+	return sets.List(result), nil
 }
 
 func (r *DedicatedServingComponentSchedulerAndSizer) ensurePlaceholderDeployment(ctx context.Context, hc *hyperv1.HostedCluster, size, pairLabel string, nodesNeeded int) (*appsv1.Deployment, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The list of fleet manager labels to use in building the node selector for placeholder pods was not consistent across calls. This resulted in potentially different variations of a given placeholder deployment in every reconcile, resulting in churn of placeholders that would prevent certain hosted clusters from getting scheduled. This commit makes the list of taken labels consistent across calls to get them by putting them in a set and sorting them.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-37625](https://issues.redhat.com/browse/OCPBUGS-37625)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.