### PR TITLE
HOSTEDCP-1569: test: e2e: skip unknown conditions instead of erroring

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -266,7 +266,9 @@ func validateNodePoolConditions(t *testing.T, ctx context.Context, client crclie
 		for i, condition := range nodePool.Status.Conditions {
 			expectedStatus, known := expectedConditions[condition.Type]
 			if !known {
-				return false, fmt.Errorf("unknown condition %s", condition.Type)
+				// We don't know what this condition is, so we can't validate it
+				// Newer HOs may have additional conditions that we don't know about
+				continue
 			}
 			conditionsValid = conditionsValid && (condition.Status == expectedStatus)
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1463,7 +1463,9 @@ func validateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 
 			expectedStatus, known := expectedConditions[hyperv1.ConditionType(condition.Type)]
 			if !known {
-				return false, fmt.Errorf("unknown condition %s", condition.Type)
+				// We don't know what this condition is, so we can't validate it
+				// Newer HOs may have additional conditions that we don't know about
+				continue
 			}
 
 			conditionsValid = conditionsValid && (condition.Status == expectedStatus)


### PR DESCRIPTION
Rehearsal failure trying to use `main` HO with 4.16 release
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/52306/rehearse-52306-periodic-ci-openshift-hypershift-release-4.16-periodics-e2e-aws-ovn/1818008709683482624
```
    nodepool_test.go:289: correct condition: wanted ValidReleaseImage=True, got ValidReleaseImage=True: AsExpected(Using release image: registry.build01.ci.openshift.org/ci-op-0vx638ni/release@sha256:6f727aeaa9a820058419e293027d0d1c006d5776b32dbebd23d9180cc4b7e245)
    nodepool_test.go:298: Failed to validate NodePool conditions in 0s: unknown condition ValidArchPlatform
        --- FAIL: TestNodePool/Main/TestNodepoolMachineconfigGetsRolledout (1380.22s)
```

HO in `main` adds a condition that is not in the set of known conditions in 4.16 `ValidArchPlatform`.  The condition does, in fact, exist in 4.16, so we could add it to the set of known/validated conditions.  However, we do have the potential of the HO adding HC or NP conditions in the future that do not exist in 4.16 and we should just skip over the unknown condition instead of erroring on it.

cc @muraee 