### PR TITLE
OSASINFRA-3487: e2e/openstack: skip cluster operator validations

### DIFF
--- a/docs/content/how-to/openstack/create-openstack-cluster.md
+++ b/docs/content/how-to/openstack/create-openstack-cluster.md
@@ -163,6 +163,9 @@ NAME            VERSION   KUBECONFIG                       PROGRESS   AVAILABLE 
 example         4.17.0    example-admin-kubeconfig         Completed  True        False         The hosted control plane is available
 ```
 
+Because Ingress is not yet supported on this platform, the Console operator won't report Ready.
+Once the user deploys Ingress on day 2 (e.g. via Metal LB), the console becomes available.
+
 ## Accessing the HostedCluster
 
 CLI access to the guest cluster is gained by retrieving the guest cluster's

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -69,6 +69,12 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 			// thus the PVC is RWO and VMs are expected to be non-live-migratable
 			conditions[hyperv1.KubeVirtNodesLiveMigratable] = metav1.ConditionFalse
 		}
+	case hyperv1.OpenStackPlatform:
+		// Ingress isn't yet implemented for HCP on OpenStack platform so the
+		// console operator won't be Ready from CVO's perspective
+		conditions[hyperv1.ClusterVersionAvailable] = metav1.ConditionFalse
+		conditions[hyperv1.ClusterVersionProgressing] = metav1.ConditionFalse
+		conditions[hyperv1.ClusterVersionSucceeding] = metav1.ConditionFalse
 	}
 
 	if hostedCluster.Spec.Etcd.ManagementType == hyperv1.Unmanaged {

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/azure"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/none"
+	"github.com/openshift/hypershift/cmd/cluster/openstack"
 	"github.com/openshift/hypershift/cmd/cluster/powervs"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/cmd/util"
@@ -248,6 +249,8 @@ func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster
 			Location:        createOpts.AzurePlatform.Location,
 		}
 		return azure.DestroyCluster(ctx, opts)
+	case hyperv1.OpenStackPlatform:
+		return openstack.DestroyCluster(ctx, opts)
 	case hyperv1.PowerVSPlatform:
 		opts.PowerVSPlatform = core.PowerVSPlatformDestroyOptions{
 			BaseDomain:             createOpts.BaseDomain,


### PR DESCRIPTION
**What this PR does / why we need it**:

Ingress isn't yet implemented for HCP on OpenStack platform so the
console operator won't be Ready from CVO perspective, which makes an e2e
validation failing.
We skip it for now and we'll add it later.
