### PR TITLE
HOSTEDCP-1778: Default multi-arch flag to true and default release stream for HCP CLI

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -96,6 +96,8 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.BoolVar(&opts.OLMDisableDefaultSources, "olm-disable-default-sources", opts.OLMDisableDefaultSources, "Disables the OLM default catalog sources for the HostedCluster.")
 	flags.StringVar(&opts.Arch, "arch", opts.Arch, "The default processor architecture for the NodePool (e.g. arm64, amd64)")
 	flags.StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
+	flags.StringVar(&opts.ReleaseStream, "release-stream", opts.ReleaseStream, "The OCP release stream for the cluster (e.g. 4-stable-multi), this flag is ignored if release-image is set")
+
 }
 
 // BindDeveloperOptions binds options that should only be exposed to developers in the `hypershift` CLI
@@ -103,7 +105,6 @@ func BindDeveloperOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	bindCoreOptions(opts, flags)
 
 	flags.StringVar(&opts.ControlPlaneOperatorImage, "control-plane-operator-image", opts.ControlPlaneOperatorImage, "Override the default image used to deploy the control plane operator")
-	flags.StringVar(&opts.ReleaseStream, "release-stream", opts.ReleaseStream, "The OCP release stream for the cluster (e.g. 4.15.0-0.nightly), this flag is ignored if release-image is set")
 
 	flags.StringVar(&opts.InfrastructureJSON, "infra-json", opts.InfrastructureJSON, "Path to file containing infrastructure information for the cluster. If not specified, infrastructure will be created")
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -23,7 +23,7 @@ var (
 
 // https://docs.ci.openshift.org/docs/getting-started/useful-links/#services
 const (
-	defaultReleaseStream = "4-stable-multi"
+	DefaultReleaseStream = "4-stable-multi"
 
 	multiArchReleaseURLTemplate = "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/latest"
 	releaseURLTemplate          = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/latest"
@@ -37,7 +37,7 @@ type OCPVersion struct {
 
 func LookupDefaultOCPVersion(releaseStream string) (OCPVersion, error) {
 	if len(releaseStream) == 0 {
-		releaseStream = defaultReleaseStream
+		releaseStream = DefaultReleaseStream
 	}
 
 	var releaseURL string

--- a/product-cli/cmd/cluster/aws/create.go
+++ b/product-cli/cmd/cluster/aws/create.go
@@ -7,6 +7,7 @@ import (
 
 	hypershiftaws "github.com/openshift/hypershift/cmd/cluster/aws"
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/version"
 )
 
 func NewCreateCommand(opts *core.RawCreateOptions) *cobra.Command {
@@ -15,6 +16,8 @@ func NewCreateCommand(opts *core.RawCreateOptions) *cobra.Command {
 		Short:        "Creates basic functional HostedCluster resources on AWS",
 		SilenceUsage: true,
 	}
+
+	opts.ReleaseStream = version.DefaultReleaseStream
 
 	awsOpts := hypershiftaws.DefaultOptions()
 	awsOpts.MultiArch = true

--- a/product-cli/cmd/cluster/aws/create.go
+++ b/product-cli/cmd/cluster/aws/create.go
@@ -17,6 +17,8 @@ func NewCreateCommand(opts *core.RawCreateOptions) *cobra.Command {
 	}
 
 	awsOpts := hypershiftaws.DefaultOptions()
+	awsOpts.MultiArch = true
+
 	hypershiftaws.BindOptions(awsOpts, cmd.Flags())
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()


### PR DESCRIPTION
**What this PR does / why we need it**:
- Default multi-arch flag to true for HCP CLI
- Default release stream to multi-arch HCP CLI

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1778](https://issues.redhat.com/browse/HOSTEDCP-1778)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.