### PR TITLE
HOSTEDCP-1669: Make hostedcluster.spec.services immutable for non IBM platforms

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -321,6 +321,7 @@ const (
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.
+// +kubebuilder:validation:XValidation:rule="self.platform.type != 'IBMCloud' ? self.services == oldSelf.services : true", message="Services is immutable. Changes might result in unpredictable and disruptive behavior."
 type HostedClusterSpec struct {
 	// Release specifies the desired OCP release payload for the hosted cluster.
 	//

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -9679,6 +9679,11 @@ spec:
             - services
             - sshKey
             type: object
+            x-kubernetes-validations:
+            - message: Services is immutable. Changes might result in unpredictable
+                and disruptive behavior.
+              rule: 'self.platform.type != ''IBMCloud'' ? self.services == oldSelf.services
+                : true'
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -55606,6 +55606,11 @@ objects:
               - services
               - sshKey
               type: object
+              x-kubernetes-validations:
+              - message: Services is immutable. Changes might result in unpredictable
+                  and disruptive behavior.
+                rule: 'self.platform.type != ''IBMCloud'' ? self.services == oldSelf.services
+                  : true'
             status:
               description: Status is the latest observed status of the HostedCluster.
               properties:

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -61,6 +61,7 @@ func TestCreateCluster(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred(), "couldn't create guest clients")
 
 		integration.RunTestControlPlanePKIOperatorBreakGlassCredentials(t, testContext, hostedCluster, mgmtClients, guestClients)
+		e2eutil.EnsureAPIUX(t, ctx, mgtClient, hostedCluster)
 	}).
 		Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -896,6 +896,22 @@ func EnsureHCPContainersHaveResourceRequests(t *testing.T, ctx context.Context, 
 	})
 }
 
+func EnsureAPIUX(t *testing.T, ctx context.Context, hostClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	t.Run("EnsureHostedClusterImmutability", func(t *testing.T) {
+		g := NewWithT(t)
+
+		for i, svc := range hostedCluster.Spec.Services {
+			if svc.Service == hyperv1.APIServer {
+				svc.Type = hyperv1.NodePort
+				hostedCluster.Spec.Services[i] = svc
+			}
+		}
+		err := hostClient.Update(ctx, hostedCluster)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("Services is immutable"))
+	})
+}
+
 func EnsureSecretEncryptedUsingKMS(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, guestClient crclient.Client) {
 	t.Run("EnsureSecretEncryptedUsingKMS", func(t *testing.T) {
 		// create secret in guest cluster


### PR DESCRIPTION
There's many non supported input/day 2 changes we need to validate on the API for better UX. This is one of them. Any upcoming change needs to include a validation to the introducingwq check

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.