### PR TITLE
HOSTEDCP-1764: retrieve registryOverrides when ImageStream is not ava…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3760,12 +3760,12 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 					}
 				}
 			} else {
-				for name, catalog := range olm.CatalogToImage {
-					pullSecret := common.PullSecret(hcp.Namespace)
-					if err := r.Get(ctx, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
-						return fmt.Errorf("failed to get pull secret for namespace %s: %w", hcp.Namespace, err)
-					}
+				pullSecret := common.PullSecret(hcp.Namespace)
+				if err := r.Get(ctx, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
+					return fmt.Errorf("failed to get pull secret for namespace %s: %w", hcp.Namespace, err)
+				}
 
+				for name, catalog := range olm.CatalogToImage {
 					parts := strings.Split(catalog, ":")
 					if len(parts) != 2 {
 						return fmt.Errorf("invalid catalog format %s, expected 'registry:tag'", catalog)
@@ -3802,7 +3802,7 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 							*override = imageOverride
 						}
 					} else {
-						return fmt.Errorf("unknown catalog %s", name)
+						return fmt.Errorf("unknown catalog for catalog image override %s", name)
 					}
 				}
 			}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -76,6 +76,7 @@ import (
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -3760,49 +3761,49 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 					}
 				}
 			} else {
-				pullSecret := common.PullSecret(hcp.Namespace)
-				if err := r.Get(ctx, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
-					return fmt.Errorf("failed to get pull secret for namespace %s: %w", hcp.Namespace, err)
-				}
-
-				for name, catalog := range olm.CatalogToImage {
-					parts := strings.Split(catalog, ":")
-					if len(parts) != 2 {
-						return fmt.Errorf("invalid catalog format %s, expected 'registry:tag'", catalog)
+				if !overrideImages {
+					pullSecret := common.PullSecret(hcp.Namespace)
+					if err := r.Get(ctx, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
+						return fmt.Errorf("failed to get pull secret for namespace %s: %w", hcp.Namespace, err)
 					}
-					catalogImage, tag := parts[0], parts[1]
 
-					catalogImageParts := strings.Split(catalogImage, "/")
-					catalogRepo := catalogImageParts[len(catalogImageParts)-1]
-					catalogRegistry := strings.Join(catalogImageParts[:len(catalogImageParts)-1], "/")
-
-					if isImageRegistryOverrides != nil {
-						if mirror, exists := isImageRegistryOverrides[catalogRegistry]; exists && len(mirror) > 0 {
-							catalogRegistry = mirror[0]
+					for name, catalog := range olm.CatalogToImage {
+						imageRef, err := reference.Parse(catalog)
+						if err != nil {
+							return fmt.Errorf("failed to parse catalog image %s: %w", catalog, err)
 						}
-					}
 
-					catalogImageWithRegistryOverride := fmt.Sprintf("%s/%s:%s", catalogRegistry, catalogRepo, tag)
-					listDigest, err := registryclient.GetListDigest(ctx, catalogImageWithRegistryOverride, pullSecret.Data[corev1.DockerConfigJsonKey])
-					if err != nil {
-						return fmt.Errorf("failed to get manifest for image %s: %v", catalogImageWithRegistryOverride, err)
-					}
-
-					imageOverride := fmt.Sprintf("%s/%s@%s", catalogRegistry, catalogRepo, listDigest.String())
-
-					catalogOverrides := map[string]*string{
-						"redhat-operators":    &p.RedHatOperatorsCatalogImageOverride,
-						"certified-operators": &p.CertifiedOperatorsCatalogImageOverride,
-						"community-operators": &p.CommunityOperatorsCatalogImageOverride,
-						"redhat-marketplace":  &p.RedHatMarketplaceCatalogImageOverride,
-					}
-
-					if override, exists := catalogOverrides[name]; exists {
-						if ptr.Deref(override, "") == "" {
-							*override = imageOverride
+						if len(isImageRegistryOverrides) > 0 {
+							for registrySource, registryDest := range isImageRegistryOverrides {
+								if strings.Contains(imageRef.Exact(), registrySource) {
+									imageRef, err = reference.Parse(strings.Replace(imageRef.Exact(), registrySource, registryDest[0], 1))
+									if err != nil {
+										return fmt.Errorf("failed to parse registry override image %s: %w", registryDest[0], err)
+									}
+								}
+							}
 						}
-					} else {
-						return fmt.Errorf("unknown catalog for catalog image override %s", name)
+
+						listDigest, err := registryclient.GetListDigest(ctx, imageRef.Exact(), pullSecret.Data[corev1.DockerConfigJsonKey])
+						if err != nil {
+							return fmt.Errorf("failed to get manifest for image %s: %v", imageRef.Exact(), err)
+						}
+						imageRef.ID = listDigest.String()
+
+						catalogOverrides := map[string]*string{
+							"redhat-operators":    &p.RedHatOperatorsCatalogImageOverride,
+							"certified-operators": &p.CertifiedOperatorsCatalogImageOverride,
+							"community-operators": &p.CommunityOperatorsCatalogImageOverride,
+							"redhat-marketplace":  &p.RedHatMarketplaceCatalogImageOverride,
+						}
+
+						if override, exists := catalogOverrides[name]; exists {
+							if ptr.Deref(override, "") == "" {
+								*override = imageRef.Exact()
+							}
+						} else {
+							return fmt.Errorf("unknown catalog for catalog image override %s", name)
+						}
 					}
 				}
 			}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -75,6 +75,7 @@ import (
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -3743,17 +3744,66 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 				return fmt.Errorf("failed to reconcile catalogs: %w", err)
 			}
 
-			catalogsImageStream := manifests.CatalogsImageStream(hcp.Namespace)
-			if !overrideImages {
-				isImageRegistryOverrides := util.ConvertImageRegistryOverrideStringToMap(p.OLMCatalogsISRegistryOverridesAnnotation)
-				if _, err := createOrUpdate(ctx, r, catalogsImageStream, func() error {
-					return olm.ReconcileCatalogsImageStream(catalogsImageStream, p.OwnerRef, isImageRegistryOverrides)
-				}); err != nil {
-					return fmt.Errorf("failed to reconcile catalogs image stream: %w", err)
+			isImageRegistryOverrides := util.ConvertImageRegistryOverrideStringToMap(p.OLMCatalogsISRegistryOverridesAnnotation)
+
+			if r.ManagementClusterCapabilities.Has(capabilities.CapabilityImageStream) {
+				catalogsImageStream := manifests.CatalogsImageStream(hcp.Namespace)
+				if !overrideImages {
+					if _, err := createOrUpdate(ctx, r, catalogsImageStream, func() error {
+						return olm.ReconcileCatalogsImageStream(catalogsImageStream, p.OwnerRef, isImageRegistryOverrides)
+					}); err != nil {
+						return fmt.Errorf("failed to reconcile catalogs image stream: %w", err)
+					}
+				} else {
+					if _, err := util.DeleteIfNeeded(ctx, r, catalogsImageStream); err != nil {
+						return fmt.Errorf("failed to remove OLM Catalog ImageStream: %w", err)
+					}
 				}
-			} else if r.ManagementClusterCapabilities.Has(capabilities.CapabilityImageStream) {
-				if _, err := util.DeleteIfNeeded(ctx, r, catalogsImageStream); err != nil {
-					return fmt.Errorf("failed to remove OLM Catalog ImageStream: %w", err)
+			} else {
+				for name, catalog := range olm.CatalogToImage {
+					pullSecret := common.PullSecret(hcp.Namespace)
+					if err := r.Get(ctx, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
+						return fmt.Errorf("failed to get pull secret for namespace %s: %w", hcp.Namespace, err)
+					}
+
+					parts := strings.Split(catalog, ":")
+					if len(parts) != 2 {
+						return fmt.Errorf("invalid catalog format %s, expected 'registry:tag'", catalog)
+					}
+					catalogImage, tag := parts[0], parts[1]
+
+					catalogImageParts := strings.Split(catalogImage, "/")
+					catalogRepo := catalogImageParts[len(catalogImageParts)-1]
+					catalogRegistry := strings.Join(catalogImageParts[:len(catalogImageParts)-1], "/")
+
+					if isImageRegistryOverrides != nil {
+						if mirror, exists := isImageRegistryOverrides[catalogRegistry]; exists && len(mirror) > 0 {
+							catalogRegistry = mirror[0]
+						}
+					}
+
+					catalogImageWithRegistryOverride := fmt.Sprintf("%s/%s:%s", catalogRegistry, catalogRepo, tag)
+					listDigest, err := registryclient.GetListDigest(ctx, catalogImageWithRegistryOverride, pullSecret.Data[corev1.DockerConfigJsonKey])
+					if err != nil {
+						return fmt.Errorf("failed to get manifest for image %s: %v", catalogImageWithRegistryOverride, err)
+					}
+
+					imageOverride := fmt.Sprintf("%s/%s@%s", catalogRegistry, catalogRepo, listDigest.String())
+
+					catalogOverrides := map[string]*string{
+						"redhat-operators":    &p.RedHatOperatorsCatalogImageOverride,
+						"certified-operators": &p.CertifiedOperatorsCatalogImageOverride,
+						"community-operators": &p.CommunityOperatorsCatalogImageOverride,
+						"redhat-marketplace":  &p.RedHatMarketplaceCatalogImageOverride,
+					}
+
+					if override, exists := catalogOverrides[name]; exists {
+						if ptr.Deref(override, "") == "" {
+							*override = imageOverride
+						}
+					} else {
+						return fmt.Errorf("unknown catalog %s", name)
+					}
 				}
 			}
 

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -445,3 +445,24 @@ func GetCorrectArchImage(ctx context.Context, component string, imageRef string,
 
 	return imageRef, nil
 }
+
+func GetListDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, error) {
+	repo, dockerImageRef, err := GetRepoSetup(ctx, imageRef, pullSecret)
+	if err != nil {
+		return "", fmt.Errorf("failed to get repo setup: %v", err)
+	}
+
+	var srcDigest digest.Digest
+	if len(dockerImageRef.ID) > 0 {
+		srcDigest = digest.Digest(dockerImageRef.ID)
+	} else if len(dockerImageRef.Tag) > 0 {
+		desc, err := repo.Tags(ctx).Get(ctx, dockerImageRef.Tag)
+		if err != nil {
+			return "", err
+		}
+		srcDigest = desc.Digest
+	} else {
+		return "", fmt.Errorf("no tag or digest specified")
+	}
+	return srcDigest, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Remove need for annotating images on create command when we are in aks

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1764](https://issues.redhat.com/browse/HOSTEDCP-1764)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.