### PR TITLE
HOSTEDCP-1669: Add first azure services validation

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -321,7 +321,12 @@ const (
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.
+
 // +kubebuilder:validation:XValidation:rule="self.platform.type != 'IBMCloud' ? self.services == oldSelf.services : true", message="Services is immutable. Changes might result in unpredictable and disruptive behavior."
+// +kubebuilder:validation:XValidation:rule="self.platform.type == 'Azure' ? self.services.exists(s, s.service == 'APIServer' && s.servicePublishingStrategy.type == 'Route' && s.servicePublishingStrategy.route.hostname != '') : true",message="Azure platform requires APIServer Route service with a hostname to be defined"
+// +kubebuilder:validation:XValidation:rule="self.platform.type == 'Azure' ? self.services.exists(s, s.service == 'OAuthServer' && s.servicePublishingStrategy.type == 'Route' && s.servicePublishingStrategy.route.hostname != '') : true",message="Azure platform requires OAuthServer Route service with a hostname to be defined"
+// +kubebuilder:validation:XValidation:rule="self.platform.type == 'Azure' ? self.services.exists(s, s.service == 'Konnectivity' && s.servicePublishingStrategy.type == 'Route' && s.servicePublishingStrategy.route.hostname != '') : true",message="Azure platform requires Konnectivity Route service with a hostname to be defined"
+// +kubebuilder:validation:XValidation:rule="self.platform.type == 'Azure' ? self.services.exists(s, s.service == 'Ignition' && s.servicePublishingStrategy.type == 'Route' && s.servicePublishingStrategy.route.hostname != '') : true",message="Azure platform requires Ignition Route service with a hostname to be defined"
 type HostedClusterSpec struct {
 	// Release specifies the desired OCP release payload for the hosted cluster.
 	//

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -9684,6 +9684,26 @@ spec:
                 and disruptive behavior.
               rule: 'self.platform.type != ''IBMCloud'' ? self.services == oldSelf.services
                 : true'
+            - message: Azure platform requires APIServer Route service with a hostname
+                to be defined
+              rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
+                == ''APIServer'' && s.servicePublishingStrategy.type == ''Route''
+                && s.servicePublishingStrategy.route.hostname != '''') : true'
+            - message: Azure platform requires OAuthServer Route service with a hostname
+                to be defined
+              rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
+                == ''OAuthServer'' && s.servicePublishingStrategy.type == ''Route''
+                && s.servicePublishingStrategy.route.hostname != '''') : true'
+            - message: Azure platform requires Konnectivity Route service with a hostname
+                to be defined
+              rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
+                == ''Konnectivity'' && s.servicePublishingStrategy.type == ''Route''
+                && s.servicePublishingStrategy.route.hostname != '''') : true'
+            - message: Azure platform requires Ignition Route service with a hostname
+                to be defined
+              rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
+                == ''Ignition'' && s.servicePublishingStrategy.type == ''Route'' &&
+                s.servicePublishingStrategy.route.hostname != '''') : true'
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3764,7 +3764,6 @@ which contain any of the given tags will be excluded from the result.</p>
 <a href="#hypershift.openshift.io/v1beta1.HostedCluster">HostedCluster</a>)
 </p>
 <p>
-<p>HostedClusterSpec is the desired behavior of a HostedCluster.</p>
 </p>
 <table>
 <thead>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -55611,6 +55611,26 @@ objects:
                   and disruptive behavior.
                 rule: 'self.platform.type != ''IBMCloud'' ? self.services == oldSelf.services
                   : true'
+              - message: Azure platform requires APIServer Route service with a hostname
+                  to be defined
+                rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
+                  == ''APIServer'' && s.servicePublishingStrategy.type == ''Route''
+                  && s.servicePublishingStrategy.route.hostname != '''') : true'
+              - message: Azure platform requires OAuthServer Route service with a
+                  hostname to be defined
+                rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
+                  == ''OAuthServer'' && s.servicePublishingStrategy.type == ''Route''
+                  && s.servicePublishingStrategy.route.hostname != '''') : true'
+              - message: Azure platform requires Konnectivity Route service with a
+                  hostname to be defined
+                rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
+                  == ''Konnectivity'' && s.servicePublishingStrategy.type == ''Route''
+                  && s.servicePublishingStrategy.route.hostname != '''') : true'
+              - message: Azure platform requires Ignition Route service with a hostname
+                  to be defined
+                rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
+                  == ''Ignition'' && s.servicePublishingStrategy.type == ''Route''
+                  && s.servicePublishingStrategy.route.hostname != '''') : true'
             status:
               description: Status is the latest observed status of the HostedCluster.
               properties:

--- a/support/assets/readasset.go
+++ b/support/assets/readasset.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/hypershift/support/api"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -68,6 +69,12 @@ func MustRoleBinding(reader AssetReader, fileName string) *rbacv1.RoleBinding {
 	roleBinding := &rbacv1.RoleBinding{}
 	deserializeResource(reader, fileName, roleBinding)
 	return roleBinding
+}
+
+func MustHostedCluster(reader AssetReader, fileName string) *hyperv1.HostedCluster {
+	hostedCluster := &hyperv1.HostedCluster{}
+	deserializeResource(reader, fileName, hostedCluster)
+	return hostedCluster
 }
 
 func deserializeResource(reader AssetReader, fileName string, obj runtime.Object) {

--- a/test/e2e/assets.go
+++ b/test/e2e/assets.go
@@ -1,0 +1,11 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"embed"
+)
+
+//go:embed assets/*
+var content embed.FS

--- a/test/e2e/assets/azure-services-ignition-route-not-hostname.yaml
+++ b/test/e2e/assets/azure-services-ignition-route-not-hostname.yaml
@@ -1,0 +1,67 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: azure-services-ignition-route-not-hostname
+  namespace: default
+spec:
+  autoscaling: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: agarcial.hypershift.devcluster.openshift.com
+    privateZoneID: ID
+    publicZoneID: ID
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+          storageClassName: gp3-csi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: infraID
+  infrastructureAvailabilityPolicy: SingleReplica
+  issuerURL: https://issuerURL.com
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    machineNetwork:
+    - cidr: 10.0.0.0/16
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    type: Azure
+  pullSecret:
+    name: secret
+  release:
+    image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: key-management-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: Route
+      route:
+        hostname: api.agarcial.hypershift.devcluster.openshift.com
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+      route:
+        hostname: OAuthServer.agarcial.hypershift.devcluster.openshift.com
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+      route:
+        hostname: Konnectivity.agarcial.hypershift.devcluster.openshift.com
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+      # we don't set hostname here to make validation fail.
+  sshKey:
+    name: sshKey


### PR DESCRIPTION
This enforce all azure services to be route and have a hostname. This satisfies shared ingress expectation

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This enforce all azure services to be route and have a hostname. This satisfies shared ingress expectation
This is the first of a series of PRs to improve API UX validation 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.