### PR TITLE
set proxy envvars on aws and azure CCMs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -100,6 +101,7 @@ func buildCCMContainer(controllerManagerImage string) func(c *corev1.Container) 
 			"--authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
 		}
 		c.VolumeMounts = podVolumeMounts().ContainerMounts(c.Name)
+		proxy.SetEnvVars(&c.Env)
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -93,6 +94,7 @@ func buildCCMContainer(p *AzureParams, controllerManagerImage, namespace string)
 			"--v=4",
 		}
 		c.VolumeMounts = podVolumeMounts().ContainerMounts(c.Name)
+		proxy.SetEnvVars(&c.Env)
 	}
 }
 


### PR DESCRIPTION
Currently results is CCMs attempting direct access to cloud endpoints only reachable via the proxy for proxied management clusters.