### PR TITLE
OSASINFRA-3550: openstack: ingress API & octavia ingress provider

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1918,6 +1918,48 @@ type OpenStackPlatformSpec struct {
 	// +listType=set
 	// +optional
 	Tags []string `json:"tags,omitempty"`
+
+	// IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+	// be associated with the OpenShift ingress port.
+	//
+	// +optional
+	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
+
+	// IngressProvider specifies the ingress provider to use for the cluster.
+	// Valid values are None and Octavia.
+	// The default value is None which means Ingress is not enabled.
+	// Octavia provider is experimental and might be replaced in the future.
+	// When Octavia is selected, a floating IP has to be provided in IngressFloatingIP.
+	//
+	// +default=None
+	// +kubebuilder:default=None
+	// +kubebuilder:validation:Enum=None;Octavia
+	// +optional
+	IngressProvider OpenStackIngressProvider `json:"ingressProvider,omitempty"`
+}
+
+// OpenStackIngressProvider specifies the ingress provider to use for the cluster.
+type OpenStackIngressProvider string
+
+const (
+	// OpenStackIngressProviderNone is the default value and means no ingress provider is used.
+	OpenStackIngressProviderNone OpenStackIngressProvider = OpenStackIngressProvider("None")
+
+	// OpenStackIngressProviderOctavia is the value to use when using Octavia as the ingress provider.
+	OpenStackIngressProviderOctavia OpenStackIngressProvider = OpenStackIngressProvider("Octavia")
+)
+
+func (p *OpenStackIngressProvider) String() string {
+	return string(*p)
+}
+
+func (p *OpenStackIngressProvider) Set(s string) error {
+	*p = OpenStackIngressProvider(s)
+	return nil
+}
+
+func (p *OpenStackIngressProvider) Type() string {
+	return "OpenStackIngressProvider"
 }
 
 // OpenStackIdentityReference is a reference to an infrastructure

--- a/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
@@ -17,6 +17,10 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
 // OpenStackPlatformSpecApplyConfiguration represents an declarative configuration of the OpenStackPlatformSpec type for use
 // with apply.
 type OpenStackPlatformSpecApplyConfiguration struct {
@@ -29,6 +33,8 @@ type OpenStackPlatformSpecApplyConfiguration struct {
 	ExternalNetwork        *NetworkParamApplyConfiguration               `json:"externalNetwork,omitempty"`
 	DisableExternalNetwork *bool                                         `json:"disableExternalNetwork,omitempty"`
 	Tags                   []string                                      `json:"tags,omitempty"`
+	IngressFloatingIP      *string                                       `json:"ingressFloatingIP,omitempty"`
+	IngressProvider        *hypershiftv1beta1.OpenStackIngressProvider   `json:"ingressProvider,omitempty"`
 }
 
 // OpenStackPlatformSpecApplyConfiguration constructs an declarative configuration of the OpenStackPlatformSpec type for use with
@@ -118,5 +124,21 @@ func (b *OpenStackPlatformSpecApplyConfiguration) WithTags(values ...string) *Op
 	for i := range values {
 		b.Tags = append(b.Tags, values[i])
 	}
+	return b
+}
+
+// WithIngressFloatingIP sets the IngressFloatingIP field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the IngressFloatingIP field is set to the value of the last call.
+func (b *OpenStackPlatformSpecApplyConfiguration) WithIngressFloatingIP(value string) *OpenStackPlatformSpecApplyConfiguration {
+	b.IngressFloatingIP = &value
+	return b
+}
+
+// WithIngressProvider sets the IngressProvider field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the IngressProvider field is set to the value of the last call.
+func (b *OpenStackPlatformSpecApplyConfiguration) WithIngressProvider(value hypershiftv1beta1.OpenStackIngressProvider) *OpenStackPlatformSpecApplyConfiguration {
+	b.IngressProvider = &value
 	return b
 }

--- a/cmd/cluster/openstack/create.go
+++ b/cmd/cluster/openstack/create.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/support/openstackutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,8 @@ func BindOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 }
 
 func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
+	flags.StringVar(&opts.OpenStackIngressFloatingIP, "openstack-ingress-floating-ip", opts.OpenStackIngressFloatingIP, "An available floating IP in your OpenStack cluster that will be associated with the OpenShift ingress port (optional)")
+	flags.Var(&opts.OpenStackIngressProvider, "openstack-ingress-provider", "The provider for the ingress controller (can be 'none' which is the default or 'octavia') (optional)")
 	flags.StringVar(&opts.OpenStackCredentialsFile, "openstack-credentials-file", opts.OpenStackCredentialsFile, "Path to the OpenStack credentials file (required)")
 	flags.StringVar(&opts.OpenStackCACertFile, "openstack-ca-cert-file", opts.OpenStackCACertFile, "Path to the OpenStack CA certificate file (optional)")
 	flags.StringVar(&opts.OpenStackExternalNetworkID, "openstack-external-network-id", opts.OpenStackExternalNetworkID, "ID of the OpenStack external network (optional)")
@@ -38,6 +41,8 @@ type RawCreateOptions struct {
 	OpenStackCredentialsFile   string
 	OpenStackCACertFile        string
 	OpenStackExternalNetworkID string
+	OpenStackIngressFloatingIP string
+	OpenStackIngressProvider   hyperv1.OpenStackIngressProvider
 
 	externalDNSDomain string
 
@@ -96,6 +101,10 @@ func (o *RawCreateOptions) Validate(ctx context.Context, opts *core.CreateOption
 		return nil, err
 	}
 
+	if err := openstackutil.ValidateIngressOptions(o.OpenStackIngressProvider, o.OpenStackIngressFloatingIP); err != nil {
+		return nil, err
+	}
+
 	validOpts := &ValidatedCreateOptions{
 		validatedCreateOptions: &validatedCreateOptions{
 			RawCreateOptions: o,
@@ -123,6 +132,14 @@ func (o *RawCreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster
 		cluster.Spec.Platform.OpenStack.ExternalNetwork = &hyperv1.NetworkParam{
 			ID: &o.OpenStackExternalNetworkID,
 		}
+	}
+
+	if o.OpenStackIngressFloatingIP != "" {
+		cluster.Spec.Platform.OpenStack.IngressFloatingIP = o.OpenStackIngressFloatingIP
+	}
+
+	if o.OpenStackIngressProvider != "" {
+		cluster.Spec.Platform.OpenStack.IngressProvider = hyperv1.OpenStackIngressProvider(o.OpenStackIngressProvider)
 	}
 
 	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, o.externalDNSDomain != "")

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -8629,6 +8629,23 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      ingressFloatingIP:
+                        description: |-
+                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                          be associated with the OpenShift ingress port.
+                        type: string
+                      ingressProvider:
+                        default: None
+                        description: |-
+                          IngressProvider specifies the ingress provider to use for the cluster.
+                          Valid values are None and Octavia.
+                          The default value is None which means Ingress is not enabled.
+                          Octavia provider is experimental and might be replaced in the future.
+                          When Octavia is selected, a floating IP has to be provided in IngressFloatingIP.
+                        enum:
+                        - None
+                        - Octavia
+                        type: string
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -8593,6 +8593,23 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      ingressFloatingIP:
+                        description: |-
+                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                          be associated with the OpenShift ingress port.
+                        type: string
+                      ingressProvider:
+                        default: None
+                        description: |-
+                          IngressProvider specifies the ingress provider to use for the cluster.
+                          Valid values are None and Octavia.
+                          The default value is None which means Ingress is not enabled.
+                          Octavia provider is experimental and might be replaced in the future.
+                          When Octavia is selected, a floating IP has to be provided in IngressFloatingIP.
+                        enum:
+                        - None
+                        - Octavia
+                        type: string
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -164,3 +164,57 @@ func ReconcileDefaultIngressPassthroughRoute(route *routev1.Route, cpService *co
 
 	return nil
 }
+
+// ReconcileDefaultIngressOctaviaService reconciles the default Ingress Service.
+func ReconcileDefaultIngressOctaviaService(ingressService *corev1.Service, ingressFloatingIP string) error {
+	if ingressFloatingIP == "" {
+		return fmt.Errorf("ingress floating IP is empty")
+	}
+
+	ingressService.Spec.Type = corev1.ServiceTypeLoadBalancer
+	ingressService.Spec.LoadBalancerIP = ingressFloatingIP
+
+	// Reconcile ports for http and https.
+	// We don't want to override the whole ServicePort, because
+	// after a reconcile loop, the spec will be updated with more fields.
+	var httpPortFound, httpsPortFound bool
+	for i := range ingressService.Spec.Ports {
+		switch ingressService.Spec.Ports[i].Name {
+		case "http":
+			ingressService.Spec.Ports[i].Protocol = corev1.ProtocolTCP
+			ingressService.Spec.Ports[i].Port = 80
+			ingressService.Spec.Ports[i].TargetPort = intstr.FromInt(80)
+			httpPortFound = true
+		case "https":
+			ingressService.Spec.Ports[i].Protocol = corev1.ProtocolTCP
+			ingressService.Spec.Ports[i].Port = 443
+			ingressService.Spec.Ports[i].TargetPort = intstr.FromInt(443)
+			httpsPortFound = true
+		}
+	}
+
+	if !httpPortFound {
+		ingressService.Spec.Ports = append(ingressService.Spec.Ports, corev1.ServicePort{
+			Name:       "http",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       80,
+			TargetPort: intstr.FromInt(80),
+		})
+	}
+
+	if !httpsPortFound {
+		ingressService.Spec.Ports = append(ingressService.Spec.Ports, corev1.ServicePort{
+			Name:       "https",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       443,
+			TargetPort: intstr.FromInt(443),
+		})
+	}
+
+	if ingressService.Spec.Selector == nil {
+		ingressService.Spec.Selector = map[string]string{}
+	}
+	ingressService.Spec.Selector["ingresscontroller.operator.openshift.io/deployment-ingresscontroller"] = "default"
+
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
@@ -35,6 +35,15 @@ func IngressDefaultIngressNodePortService() *corev1.Service {
 	}
 }
 
+func IngressDefaultIngressOctaviaService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "octavia-ingress",
+			Namespace: "openshift-ingress",
+		},
+	}
+}
+
 const IngressDefaultIngressPassthroughServiceName = "default-ingress-passthrough-service"
 
 func IngressDefaultIngressPassthroughService(namespace string) *corev1.Service {

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -7692,6 +7692,29 @@ string
 </tr>
 </tbody>
 </table>
+###OpenStackIngressProvider { #hypershift.openshift.io/v1beta1.OpenStackIngressProvider }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.OpenStackPlatformSpec">OpenStackPlatformSpec</a>)
+</p>
+<p>
+<p>OpenStackIngressProvider specifies the ingress provider to use for the cluster.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;None&#34;</p></td>
+<td><p>OpenStackIngressProviderNone is the default value and means no ingress provider is used.</p>
+</td>
+</tr><tr><td><p>&#34;Octavia&#34;</p></td>
+<td><p>OpenStackIngressProviderOctavia is the value to use when using Octavia as the ingress provider.</p>
+</td>
+</tr></tbody>
+</table>
 ###OpenStackNodePoolPlatform { #hypershift.openshift.io/v1beta1.OpenStackNodePoolPlatform }
 <p>
 (<em>Appears on:</em>
@@ -7889,6 +7912,37 @@ to an external network is not possible or desirable, e.g. if using a provider ne
 <td>
 <em>(Optional)</em>
 <p>Tags to set on all resources in cluster which support tags</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingressFloatingIP</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+be associated with the OpenShift ingress port.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingressProvider</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.OpenStackIngressProvider">
+OpenStackIngressProvider
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IngressProvider specifies the ingress provider to use for the cluster.
+Valid values are None and Octavia.
+The default value is None which means Ingress is not enabled.
+Octavia provider is experimental and might be replaced in the future.
+When Octavia is selected, a floating IP has to be provided in IngressFloatingIP.</p>
 </td>
 </tr>
 </tbody>

--- a/hack/app-sre/saas_template.yaml
+++ b/hack/app-sre/saas_template.yaml
@@ -54554,6 +54554,23 @@ objects:
                           - cloudName
                           - name
                           type: object
+                        ingressFloatingIP:
+                          description: |-
+                            IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                            be associated with the OpenShift ingress port.
+                          type: string
+                        ingressProvider:
+                          default: None
+                          description: |-
+                            IngressProvider specifies the ingress provider to use for the cluster.
+                            Valid values are None and Octavia.
+                            The default value is None which means Ingress is not enabled.
+                            Octavia provider is experimental and might be replaced in the future.
+                            When Octavia is selected, a floating IP has to be provided in IngressFloatingIP.
+                          enum:
+                          - None
+                          - Octavia
+                          type: string
                         managedSubnets:
                           description: |-
                             ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,
@@ -64820,6 +64837,23 @@ objects:
                           - cloudName
                           - name
                           type: object
+                        ingressFloatingIP:
+                          description: |-
+                            IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                            be associated with the OpenShift ingress port.
+                          type: string
+                        ingressProvider:
+                          default: None
+                          description: |-
+                            IngressProvider specifies the ingress provider to use for the cluster.
+                            Valid values are None and Octavia.
+                            The default value is None which means Ingress is not enabled.
+                            Octavia provider is experimental and might be replaced in the future.
+                            When Octavia is selected, a floating IP has to be provided in IngressFloatingIP.
+                          enum:
+                          - None
+                          - Octavia
+                          type: string
                         managedSubnets:
                           description: |-
                             ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/support/openstackutil/ingress.go
+++ b/support/openstackutil/ingress.go
@@ -1,0 +1,26 @@
+package openstackutil
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+// ValidateIngressOptions checks that the OpenStack ingress provider is valid and that the floating IP is set if the provider is "octavia".
+func ValidateIngressOptions(ingressProvider hyperv1.OpenStackIngressProvider, ingressFloatingIP string) error {
+	if ingressFloatingIP == "" && ingressProvider == "" {
+		return nil
+	}
+	if ingressFloatingIP != "" && ingressProvider == "" {
+		return fmt.Errorf("cannot set floating IP without specifying ingress provider")
+	}
+	if ingressProvider != "" && ingressFloatingIP == "" {
+		return fmt.Errorf("cannot set ingress provider without specifying floating IP")
+	}
+	// For now, the floating IP can only be set when the ingress provider is "Octavia".
+	// This is because the floating IP is only used for the Octavia ingress provider.
+	if ingressProvider != "" && ingressProvider != hyperv1.OpenStackIngressProviderOctavia {
+		return fmt.Errorf("invalid ingress provider %s", ingressProvider.String())
+	}
+	return nil
+}

--- a/support/openstackutil/ingress_test.go
+++ b/support/openstackutil/ingress_test.go
@@ -1,0 +1,68 @@
+package openstackutil
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestValidateIngressOptions(t *testing.T) {
+	tests := []struct {
+		name              string
+		ingressProvider   string
+		ingressFloatingIP string
+		expectedError     string
+	}{
+		{
+			name:              "valid options",
+			ingressProvider:   "Octavia",
+			ingressFloatingIP: "1.2.3.4",
+			expectedError:     "",
+		},
+		{
+			name:              "missing floating IP",
+			ingressProvider:   "Octavia",
+			ingressFloatingIP: "",
+			expectedError:     "cannot set ingress provider without specifying floating IP",
+		},
+		{
+			name:              "missing provider",
+			ingressProvider:   "",
+			ingressFloatingIP: "1.2.3.4",
+			expectedError:     "cannot set floating IP without specifying ingress provider",
+		},
+		{
+			name:              "None provider with floating IP",
+			ingressProvider:   "None",
+			ingressFloatingIP: "1.2.3.4",
+			expectedError:     "invalid ingress provider None",
+		},
+		{
+			name:              "invalid provider with floating IP",
+			ingressProvider:   "invalid",
+			ingressFloatingIP: "1.2.3.4",
+			expectedError:     "invalid ingress provider invalid",
+		},
+		{
+			name:              "empty options",
+			ingressProvider:   "",
+			ingressFloatingIP: "",
+			expectedError:     "",
+		},
+	}
+
+	for _, test := range tests {
+		err := ValidateIngressOptions(hyperv1.OpenStackIngressProvider(test.ingressProvider), test.ingressFloatingIP)
+		if test.expectedError != "" {
+			if err == nil {
+				t.Errorf("%s: expected error '%s', got no error", test.name, test.expectedError)
+			} else if err.Error() != test.expectedError {
+				t.Errorf("%s: expected error '%s', got '%s'", test.name, test.expectedError, err.Error())
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s: expected no error, got '%s'", test.name, err.Error())
+			}
+		}
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -106,6 +106,8 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackExternalNetworkID, "e2e.openstack-external-network-id", "", "ID of the OpenStack external network")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeFlavor, "e2e.openstack-node-flavor", "", "The flavor to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
+	flag.Var(&globalOpts.configurableClusterOptions.OpenStackIngressProvider, "e2e.openstack-ingress-provider", "The provider for the ingress controller (can be 'none' which is the default or 'octavia') (optional)")
+	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackIngressFloatingIP, "e2e.openstack-ingress-floating-ip", "", "The floating IP to use for the ingress controller (optional)")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureCredentialsFile, "e2e.azure-credentials-file", "", "Path to an Azure credentials file")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureLocation, "e2e.azure-location", "eastus", "The location to use for Azure")
 	flag.StringVar(&globalOpts.configurableClusterOptions.SSHKeyFile, "e2e.ssh-key-file", "", "Path to a ssh public key")
@@ -422,6 +424,8 @@ type configurableClusterOptions struct {
 	AzureCredentialsFile          string
 	OpenStackCredentialsFile      string
 	OpenStackCACertFile           string
+	OpenStackIngressFloatingIP    string
+	OpenStackIngressProvider      hyperv1.OpenStackIngressProvider
 	AzureLocation                 string
 	Region                        string
 	Zone                          stringSliceVar
@@ -530,6 +534,8 @@ func (p *options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 		OpenStackCredentialsFile:   p.configurableClusterOptions.OpenStackCredentialsFile,
 		OpenStackCACertFile:        p.configurableClusterOptions.OpenStackCACertFile,
 		OpenStackExternalNetworkID: p.configurableClusterOptions.OpenStackExternalNetworkID,
+		OpenStackIngressFloatingIP: p.configurableClusterOptions.OpenStackIngressFloatingIP,
+		OpenStackIngressProvider:   p.configurableClusterOptions.OpenStackIngressProvider,
 		NodePoolOpts: &openstacknodepool.RawOpenStackPlatformCreateOptions{
 			OpenStackPlatformOptions: &openstacknodepool.OpenStackPlatformOptions{
 				Flavor:    p.configurableClusterOptions.OpenStackNodeFlavor,


### PR DESCRIPTION
**What this PR does / why we need it**:

Until now, we didn't have a working Ingress on an initial deployment, and we thought we would just rely on day 2 operations to setup Ingress with e.g. MetalLB.
It turns out that we could use OpenStack Octavia (Load Balancer as a service) as an optional provider for Ingress, at least for now in dev-preview.

With this PR, we don't expect the OpenStack cloud to have Octavia enabled which is why we disable the provider by default, which means Ingress won't be working on day 1 and it's up to the user to deploy something (e.g. MetalLB).

If Octavia is used, the floating IP and the DNS record for Ingress would have to be pre-created before deploying the hosted cluster.
The new CLI would be:
```bash
hypershift create cluster openstack --openstack-ingress-provider Octavia --openstack-ingress-floating-ip <-ingress-floating-IP> (...)
```

We have some validation that check that if a FIP is provided, it's only accepted with the Octavia provider for now.
The HCP.Spec has been updated as well to allow the Ingress FIP to be stored and the Ingress provider (default to `None` now).

In the future, we might change the default and even remove the Octavia provider if we find a better way (e.g. re-using on-prem LB, based on Keepalived).
But by keeping it "disabled" by default ensure some sort of backward compatibility even if OpenStack is dev-preview now.