### PR TITLE
OCPBUGS-37934: Reverting ETCD cluster rebuild

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -24,8 +24,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var ETCDHasBeenReadyAnnotation = "hypershift.openshift.io/etcd-has-been-ready"
-
 func etcdContainer() *corev1.Container {
 	return &corev1.Container{
 		Name: "etcd",
@@ -183,14 +181,6 @@ func ReconcileStatefulSet(ss *appsv1.StatefulSet, p *EtcdParams) error {
 	}
 
 	p.DeploymentConfig.ApplyToStatefulSet(ss)
-
-	// If the StatefulSet is ever ready, set the annotation.
-	if util.IsStatefulSetReady(ss) {
-		if ss.Annotations == nil {
-			ss.Annotations = make(map[string]string)
-		}
-		ss.Annotations[ETCDHasBeenReadyAnnotation] = "true"
-	}
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -116,9 +116,6 @@ const (
 
 	hcpReadyRequeueInterval    = 1 * time.Minute
 	hcpNotReadyRequeueInterval = 15 * time.Second
-
-	etcdRecoveryPeriod  = 5 * time.Minute
-	etcdRecoveryTimeout = 10 * time.Minute
 )
 
 type InfrastructureStatus struct {
@@ -987,8 +984,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 			return fmt.Errorf("failed to reconcile etcd: %w", err)
 		}
 		// Block until etcd is fully rolled out at the desired generation
-		ready := util.IsStatefulSetReady(ctx, statefulSet)
-		if !ready {
+		if ready := util.IsStatefulSetReady(ctx, statefulSet); !ready {
 			r.Log.Info("Waiting for etcd statefulset to become ready")
 			return nil
 		}
@@ -2721,19 +2717,6 @@ func (r *HostedControlPlaneReconciler) reconcileManagedEtcd(ctx context.Context,
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile etcd-defrag-operator role binding: %w", err)
 		}
-	}
-
-	// Block to recover the ETCD cluster if it is not ready after etcdRecoveryPeriod
-	timePassed := time.Since(statefulSet.ObjectMeta.CreationTimestamp.Time)
-	ready := util.IsStatefulSetReady(ctx, statefulSet)
-	// If the etcd cluster is not ready after etcdRecoveryPeriod, we will attempt to recover it
-	// but we will stop trying it after etcdRecoveryTimeout to avoid loss of data in other scenarios.
-	if !ready && (timePassed > etcdRecoveryPeriod && timePassed <= etcdRecoveryTimeout) {
-		r.Log.Info("Forcing ETCD cluster recreation")
-		// This will force the recreation of the ETCD pod
-		statefulSet.Spec.Template.Labels = map[string]string{"forcedRecreation": "true"}
-		// This will force the recreation of the ETCD PVC
-		statefulSet.Spec.VolumeClaimTemplates[0].SetLabels(map[string]string{"forcedRecreation": "true"})
 	}
 
 	if result, err := createOrUpdate(ctx, r, statefulSet, func() error {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -18,7 +18,6 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/autoscaler"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/etcd"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ingress"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -1570,49 +1569,6 @@ func TestReconcileRouterServiceStatus(t *testing.T) {
 					t.Errorf("got unexpected event message")
 				}
 			}
-		})
-	}
-}
-
-func TestShouldRecreateEtcd(t *testing.T) {
-	creationTimestamp := metav1.Time{Time: metav1.Now().Add(-etcdRecoveryPeriod)}
-	testCases := []struct {
-		name     string
-		sts      appsv1.StatefulSet
-		expected bool
-	}{
-		{
-			name: "when no annotations and within timeframe, should recreate",
-			sts: appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "etcd",
-					Namespace:         "test",
-					CreationTimestamp: creationTimestamp,
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "When annotations present, should NOT recreate",
-			sts: appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "etcd",
-					Namespace:         "test",
-					CreationTimestamp: creationTimestamp,
-					Annotations: map[string]string{
-						etcd.ETCDHasBeenReadyAnnotation: "true",
-					},
-				},
-			},
-			expected: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
-			result := shouldRecreateEtcd(&tc.sts)
-			g.Expect(result).To(Equal(tc.expected))
 		})
 	}
 }

--- a/support/util/deployment.go
+++ b/support/util/deployment.go
@@ -25,7 +25,7 @@ func IsDeploymentReady(ctx context.Context, deployment *appsv1.Deployment) bool 
 	return true
 }
 
-func IsStatefulSetReady(statefulSet *appsv1.StatefulSet) bool {
+func IsStatefulSetReady(ctx context.Context, statefulSet *appsv1.StatefulSet) bool {
 	if ptr.Deref(statefulSet.Spec.Replicas, 0) != statefulSet.Status.AvailableReplicas ||
 		ptr.Deref(statefulSet.Spec.Replicas, 0) != statefulSet.Status.ReadyReplicas ||
 		ptr.Deref(statefulSet.Spec.Replicas, 0) != statefulSet.Status.UpdatedReplicas ||

--- a/support/util/deployment_test.go
+++ b/support/util/deployment_test.go
@@ -212,7 +212,7 @@ func TestIsStatefulSetReady(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ready := IsStatefulSetReady(tt.statefulSet)
+		ready := IsStatefulSetReady(context.TODO(), tt.statefulSet)
 		if ready != tt.ready {
 			t.Errorf("IsStatefulSetReady() statefulset %s got ready %t, expected %t", tt.statefulSet.Name, ready, tt.ready)
 			return


### PR DESCRIPTION
This PR reverts:

- https://github.com/openshift/hypershift/pull/4354
- https://github.com/openshift/hypershift/pull/4419

This is quite destructive and automatic approach, and could have side-effects in clusters already existent.
We are working in another approach which is less destructive, meanwhile we look for the root cause of the issue.