### PR TITLE
OSASINFRA-3554: OpenStack: Use external network ID in favor of Name

### DIFF
--- a/cmd/cluster/openstack/create.go
+++ b/cmd/cluster/openstack/create.go
@@ -31,13 +31,13 @@ func BindOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.OpenStackCredentialsFile, "openstack-credentials-file", opts.OpenStackCredentialsFile, "Path to the OpenStack credentials file (required)")
 	flags.StringVar(&opts.OpenStackCACertFile, "openstack-ca-cert-file", opts.OpenStackCACertFile, "Path to the OpenStack CA certificate file (optional)")
-	flags.StringVar(&opts.OpenStackExternalNetworkName, "openstack-external-network-name", opts.OpenStackExternalNetworkName, "Name of the OpenStack external network (optional)")
+	flags.StringVar(&opts.OpenStackExternalNetworkID, "openstack-external-network-id", opts.OpenStackExternalNetworkID, "ID of the OpenStack external network (optional)")
 }
 
 type RawCreateOptions struct {
-	OpenStackCredentialsFile     string
-	OpenStackCACertFile          string
-	OpenStackExternalNetworkName string
+	OpenStackCredentialsFile   string
+	OpenStackCACertFile        string
+	OpenStackExternalNetworkID string
 
 	externalDNSDomain string
 
@@ -119,11 +119,9 @@ func (o *RawCreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster
 		CloudName: "openstack", // TODO: make this configurable or at least check the clouds.yaml file
 	}
 
-	if o.OpenStackExternalNetworkName != "" {
+	if o.OpenStackExternalNetworkID != "" {
 		cluster.Spec.Platform.OpenStack.ExternalNetwork = &hyperv1.NetworkParam{
-			Filter: &hyperv1.NetworkFilter{
-				Name: o.OpenStackExternalNetworkName,
-			},
+			ID: &o.OpenStackExternalNetworkID,
 		}
 	}
 

--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -86,7 +86,7 @@ func TestCreateCluster(t *testing.T) {
 			name: "default creation flags",
 			args: []string{
 				"--openstack-credentials-file=" + credentialsFile,
-				"--openstack-external-network-name=fakeExternalNetwork",
+				"--openstack-external-network-id=5387f86a-a10e-47fe-91c6-41ac131f9f30",
 				"--openstack-node-image-name=rhcos",
 				"--openstack-node-flavor=fakeFlavor",
 				"--pull-secret=" + pullSecretFile,

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
@@ -51,8 +51,7 @@ spec:
   platform:
     openstack:
       externalNetwork:
-        filter:
-          name: fakeExternalNetwork
+        id: 5387f86a-a10e-47fe-91c6-41ac131f9f30
       identityRef:
         cloudName: openstack
         name: test-cloud-credentials

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2630,14 +2630,14 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 
 		cfg := manifests.OpenStackProviderConfig(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, cfg, func() error {
-			return openstack.ReconcileCloudConfigConfigMap(cfg, hcp.Spec.Platform.OpenStack.IdentityRef.CloudName, credentialsSecret, caCertData)
+			return openstack.ReconcileCloudConfigConfigMap(hcp.Spec.Platform.OpenStack.ExternalNetwork.ID, cfg, hcp.Spec.Platform.OpenStack.IdentityRef.CloudName, credentialsSecret, caCertData)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile OpenStack cloud config: %w", err)
 		}
 
 		withSecrets := manifests.OpenStackProviderConfigWithCredentials(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, withSecrets, func() error {
-			return openstack.ReconcileCloudConfigSecret(withSecrets, hcp.Spec.Platform.OpenStack.IdentityRef.CloudName, credentialsSecret, caCertData)
+			return openstack.ReconcileCloudConfigSecret(hcp.Spec.Platform.OpenStack.ExternalNetwork.ID, withSecrets, hcp.Spec.Platform.OpenStack.IdentityRef.CloudName, credentialsSecret, caCertData)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile OpenStack cloud config with credentials: %w", err)
 		}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1421,12 +1421,13 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 		}
 		caCertData := openstack.GetCACertFromCredentialsSecret(credentialsSecret)
 		cloudName := hcp.Spec.Platform.OpenStack.IdentityRef.CloudName
+		externalNetworkID := hcp.Spec.Platform.OpenStack.ExternalNetwork.ID
 
 		errs = append(errs,
-			r.reconcileOpenStackCredentialsSecret(ctx, "openshift-cluster-csi-drivers", "openstack-cloud-credentials", credentialsSecret, cloudName, caCertData),
-			r.reconcileOpenStackCredentialsSecret(ctx, "openshift-image-registry", "installer-cloud-credentials", credentialsSecret, cloudName, caCertData),
-			r.reconcileOpenStackCredentialsSecret(ctx, "openshift-cloud-network-config-controller", "cloud-credentials", credentialsSecret, cloudName, caCertData),
-			r.reconcileOpenStackCredentialsSecret(ctx, "openshift-cluster-csi-drivers", "manila-cloud-credentials", credentialsSecret, cloudName, caCertData),
+			r.reconcileOpenStackCredentialsSecret(ctx, externalNetworkID, "openshift-cluster-csi-drivers", "openstack-cloud-credentials", credentialsSecret, cloudName, caCertData),
+			r.reconcileOpenStackCredentialsSecret(ctx, externalNetworkID, "openshift-image-registry", "installer-cloud-credentials", credentialsSecret, cloudName, caCertData),
+			r.reconcileOpenStackCredentialsSecret(ctx, externalNetworkID, "openshift-cloud-network-config-controller", "cloud-credentials", credentialsSecret, cloudName, caCertData),
+			r.reconcileOpenStackCredentialsSecret(ctx, externalNetworkID, "openshift-cluster-csi-drivers", "manila-cloud-credentials", credentialsSecret, cloudName, caCertData),
 		)
 	case hyperv1.PowerVSPlatform:
 		createPowerVSSecret := func(srcSecret, destSecret *corev1.Secret) error {
@@ -1503,7 +1504,7 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 }
 
 // reconcileOpenStackCredentialsSecret is a wrapper used to reconcile the OpenStack cloud config secrets.
-func (r *reconciler) reconcileOpenStackCredentialsSecret(ctx context.Context, namespace, name string, credentialsSecret *corev1.Secret, cloudName string, caCertData []byte) error {
+func (r *reconciler) reconcileOpenStackCredentialsSecret(ctx context.Context, externalNetworkID *string, namespace, name string, credentialsSecret *corev1.Secret, cloudName string, caCertData []byte) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -1512,7 +1513,7 @@ func (r *reconciler) reconcileOpenStackCredentialsSecret(ctx context.Context, na
 		Data: credentialsSecret.Data,
 	}
 	if _, err := r.CreateOrUpdate(ctx, r.client, secret, func() error {
-		return openstack.ReconcileCloudConfigSecret(secret, cloudName, credentialsSecret, caCertData)
+		return openstack.ReconcileCloudConfigSecret(externalNetworkID, secret, cloudName, credentialsSecret, caCertData)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile secret %s/%s: %w", secret.Namespace, secret.Name, err)
 	}

--- a/docs/content/how-to/openstack/create-openstack-cluster.md
+++ b/docs/content/how-to/openstack/create-openstack-cluster.md
@@ -110,7 +110,7 @@ export FLAVOR="m1.large"
 
 # Optional flags:
 # External network to use for the API and Ingress endpoints.
-export EXTERNAL_NETWORK="public"
+export EXTERNAL_ID="5387f86a-a10e-47fe-91c6-41ac131f9f30"
 
 # CA certificate path to use for the OpenStack API if using self-signed certificates.
 export CA_CERT_PATH="$HOME/ca.crt"
@@ -125,7 +125,7 @@ hcp create cluster openstack \
 --ssh-key $SSH_KEY \
 --openstack-ca-cert-file $CA_CERT_PATH \
 --openstack-credentials-file $CLOUDS_YAML \
---openstack-external-network-name $EXTERNAL_NETWORK \
+--openstack-external-network-id $EXTERNAL_ID \
 --openstack-node-image-name $IMAGE_NAME \
 --openstack-node-flavor $FLAVOR
 ```

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -283,7 +283,7 @@ func (a OpenStack) ReconcileCredentials(ctx context.Context, c client.Client, cr
 	}
 
 	if _, err := createOrUpdate(ctx, c, cloudNetworkConfigCreds, func() error {
-		return openstack.ReconcileCloudConfigSecret(cloudNetworkConfigCreds, hcluster.Spec.Platform.OpenStack.IdentityRef.CloudName, credentialsSecret, caCertData)
+		return openstack.ReconcileCloudConfigSecret(hcluster.Spec.Platform.OpenStack.ExternalNetwork.ID, cloudNetworkConfigCreds, hcluster.Spec.Platform.OpenStack.IdentityRef.CloudName, credentialsSecret, caCertData)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile OpenStack cloud config: %w", err)
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -102,7 +102,7 @@ func TestMain(m *testing.M) {
 	flag.Var(&globalOpts.additionalTags, "e2e.additional-tags", "Additional tags to set on AWS resources")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackCredentialsFile, "e2e.openstack-credentials-file", "", "Path to the OpenStack credentials file")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackCACertFile, "e2e.openstack-ca-cert-file", "", "Path to the OpenStack CA certificate file")
-	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackExternalNetworkName, "e2e.openstack-external-network-name", "", "Name of the OpenStack external network")
+	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackExternalNetworkID, "e2e.openstack-external-network-id", "", "ID of the OpenStack external network")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeFlavor, "e2e.openstack-node-flavor", "", "The flavor to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureCredentialsFile, "e2e.azure-credentials-file", "", "Path to an Azure credentials file")
@@ -441,7 +441,7 @@ type configurableClusterOptions struct {
 	NodePoolReplicas              int
 	SSHKeyFile                    string
 	NetworkType                   string
-	OpenStackExternalNetworkName  string
+	OpenStackExternalNetworkID    string
 	OpenStackNodeFlavor           string
 	OpenStackNodeImageName        string
 	PowerVSResourceGroup          string
@@ -526,9 +526,9 @@ func (o *options) DefaultNoneOptions() none.RawCreateOptions {
 
 func (p *options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions {
 	opts := hypershiftopenstack.RawCreateOptions{
-		OpenStackCredentialsFile:     p.configurableClusterOptions.OpenStackCredentialsFile,
-		OpenStackCACertFile:          p.configurableClusterOptions.OpenStackCACertFile,
-		OpenStackExternalNetworkName: p.configurableClusterOptions.OpenStackExternalNetworkName,
+		OpenStackCredentialsFile:   p.configurableClusterOptions.OpenStackCredentialsFile,
+		OpenStackCACertFile:        p.configurableClusterOptions.OpenStackCACertFile,
+		OpenStackExternalNetworkID: p.configurableClusterOptions.OpenStackExternalNetworkID,
 		NodePoolOpts: &openstacknodepool.RawOpenStackPlatformCreateOptions{
 			OpenStackPlatformOptions: &openstacknodepool.OpenStackPlatformOptions{
 				Flavor:    p.configurableClusterOptions.OpenStackNodeFlavor,


### PR DESCRIPTION
When the user provides an external network to hypershift that must be used by CCM to ensure that network is used when creating Floating IPs for the Load Balancers. CCM expects an external Network ID, right now we accept a Name from the user. This commit changes this behavior to consume an ID instead.