### PR TITLE
OCPBUGS-37488: CSO: add environment variable for tools image

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
@@ -108,6 +108,8 @@ spec:
           value: quay.io/openshift/origin-aws-ebs-csi-driver:latest
         - name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
           value: quay.io/openshift/origin-csi-livenessprobe:latest
+        - name: TOOLS_IMAGE
+          value: quay.io/openshift/origin-tools:latest
         image: quay.io/openshift/origin-cluster-storage-operator:latest
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
@@ -49,6 +49,7 @@ var (
 		"HYPERSHIFT_IMAGE":                                "token-minter",
 		"AWS_EBS_DRIVER_CONTROL_PLANE_IMAGE":              "aws-ebs-csi-driver",
 		"LIVENESS_PROBE_CONTROL_PLANE_IMAGE":              "csi-livenessprobe",
+		"TOOLS_IMAGE":                                     "tools",
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the environment variable for the `tools` image, used by some CSI operators to start an init container and create a credentials file.

This requirement was caught here: https://github.com/openshift/csi-operator/pull/248#issuecomment-2268533539

**Which issue(s) this PR fixes**
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
  - IIUC we don't need docs for this.
- [ ] This change includes unit tests.
  - IIUC this is covered by the existing unit tests (`envreplacer_test.go`)