### PR TITLE
OSASINFRA-3555: openstack: e2e adjustments

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/reconcile.go
@@ -3,6 +3,8 @@ package openstack
 import (
 	"fmt"
 
+	k8sutilspointer "k8s.io/utils/pointer"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -41,8 +43,9 @@ func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedContr
 				Containers: []corev1.Container{
 					util.BuildContainer(ccmContainer(), buildCCMContainer(releaseImageProvider.GetImage("openstack-cloud-controller-manager"), hcp.Spec.InfraID)),
 				},
-				Volumes:            []corev1.Volume{},
-				ServiceAccountName: serviceAccountName,
+				Volumes:                      []corev1.Volume{},
+				ServiceAccountName:           serviceAccountName,
+				AutomountServiceAccountToken: k8sutilspointer.Bool(false),
 			},
 		},
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/api/util/ipnet"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -217,6 +218,12 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _
 						"--leader-elect",
 						"--metrics-bind-addr=127.0.0.1:8080",
 						"--v=2",
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("10Mi"),
+						},
 					},
 					Ports: []corev1.ContainerPort{
 						{

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/azure"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/cluster/none"
+	"github.com/openshift/hypershift/cmd/cluster/openstack"
 	"github.com/openshift/hypershift/cmd/cluster/powervs"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/cmd/util"
@@ -263,6 +264,8 @@ func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster
 			TransitGateway:         createOpts.PowerVSPlatform.TransitGateway,
 		}
 		return powervs.DestroyCluster(ctx, opts)
+	case hyperv1.OpenStackPlatform:
+		return openstack.DestroyCluster(ctx, opts)
 
 	default:
 		return fmt.Errorf("unsupported cluster platform %s", hc.Spec.Platform.Type)

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -256,11 +256,25 @@ func (h *hypershiftTest) createHostedCluster(opts *PlatformAgnosticOptions, plat
 		}
 	}
 
+	// case platform specific options
+	var clusterName string
+	switch platform {
+	case hyperv1.OpenStackPlatform:
+		// On some platforms (OpenStack), the cluster name can be pre-set in the environment
+		// so the DNS record for Ingress can be created with the correct name prior to cluster creation.
+		clusterName = os.Getenv("CLUSTER_NAME")
+		if clusterName == "" {
+			clusterName = SimpleNameGenerator.GenerateName("example-")
+		}
+	default:
+		clusterName = SimpleNameGenerator.GenerateName("example-")
+	}
+
 	// Build the skeletal HostedCluster based on the provided platform.
 	hc := &hyperv1.HostedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace.Name,
-			Name:      SimpleNameGenerator.GenerateName("example-"),
+			Name:      clusterName,
 		},
 		Spec: hyperv1.HostedClusterSpec{
 			Platform: hyperv1.PlatformSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

* Allow e2e to destroy a cluster that runs on the OpenStack platform.
* Override HostedCluster name if CLUSTER_NAME env is set on OpenStack platform.
* openstack: add missing resources fields to CAPO
* openstack: add missing AutomountServiceAccountToken to CCM