### PR TITLE
OCPBUGS-38041: test: e2e: handle 409 conflict in EnsureHostedClusterImmutability

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -900,13 +900,14 @@ func EnsureAPIUX(t *testing.T, ctx context.Context, hostClient crclient.Client, 
 	t.Run("EnsureHostedClusterImmutability", func(t *testing.T) {
 		g := NewWithT(t)
 
-		for i, svc := range hostedCluster.Spec.Services {
-			if svc.Service == hyperv1.APIServer {
-				svc.Type = hyperv1.NodePort
-				hostedCluster.Spec.Services[i] = svc
+		err := UpdateObject(t, ctx, hostClient, hostedCluster, func(obj *hyperv1.HostedCluster) {
+			for i, svc := range obj.Spec.Services {
+				if svc.Service == hyperv1.APIServer {
+					svc.Type = hyperv1.NodePort
+					obj.Spec.Services[i] = svc
+				}
 			}
-		}
-		err := hostClient.Update(ctx, hostedCluster)
+		})
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("Services is immutable"))
 	})


### PR DESCRIPTION
Prevents

```
{Failed  === RUN   TestCreateCluster/Main/EnsureHostedClusterImmutability
    util.go:911: 
        Expected
            <string>: Operation cannot be fulfilled on hostedclusters.hypershift.openshift.io "example-c88md": the object has been modified; please apply your changes to the latest version and try again
        to contain substring
            <string>: Services is immutable
        --- FAIL: TestCreateCluster/Main/EnsureHostedClusterImmutability (0.05s)
}
```

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.17-periodics-e2e-aws-ovn/1820792184916414464