### PR TITLE
NO-JIRA: [kubevirt] Fix KubeVirtNodesLiveMigratable condition for NodePools with 0 replicas

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -1209,6 +1209,11 @@ func (r *NodePoolReconciler) setAllMachinesLMCondition(ctx context.Context, node
 		return fmt.Errorf("failed to list KubeVirt Machines: %w", err)
 	}
 
+	if len(kubevirtMachines.Items) == 0 {
+		// not setting the condition if there are no kubevirt machines present
+		return nil
+	}
+
 	numNotLiveMigratable := 0
 	messageMap := make(map[string][]string)
 	var mapReason, mapMessage string

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -65,7 +65,7 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 			}
 		}
 		if hostedCluster.Annotations[hyperv1.ManagementPlatformAnnotation] == string(hyperv1.AWSPlatform) {
-			// in the e2e presubmit we're using gp3-csi as a storage class for the HostedCluster,
+			// in the e2e we're using a filesystem VolumeMode by default for the VMs,
 			// thus the PVC is RWO and VMs are expected to be non-live-migratable
 			conditions[hyperv1.KubeVirtNodesLiveMigratable] = metav1.ConditionFalse
 		}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1466,6 +1466,7 @@ func validateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		expectedConditions[hyperv1.ClusterVersionSucceeding] = metav1.ConditionFalse
 		expectedConditions[hyperv1.ClusterVersionProgressing] = metav1.ConditionTrue
 		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
+		delete(expectedConditions, hyperv1.KubeVirtNodesLiveMigratable)
 	}
 
 	var predicates []Predicate[*hyperv1.HostedCluster]


### PR DESCRIPTION
In cases where the NodePool has 0 replicas and there are no KubevirtMachines registered with the nodepool, the condition of KubeVirtNodesLiveMigratable should not be set at all (whether true or false).
This is done in order to fix the failure in the TestNodePool e2e, in which the HostedCluster conditions are being verified on a 0-replicas NodePool.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.