### PR TITLE
[release-4.14] OCPBUGS-38060: Add HTTP konnectivity proxy to OAuth server

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2830,8 +2830,9 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServer(ctx context.Context,
 	}
 
 	deployment := manifests.OAuthServerDeployment(hcp.Namespace)
+	clusterNoProxy := proxy.DefaultNoProxy(hcp)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return oauth.ReconcileDeployment(ctx, r, deployment, p.OwnerRef, oauthConfig, p.OAuthServerImage, p.DeploymentConfig, p.IdentityProviders(), p.OauthConfigOverrides, p.AvailabilityProberImage, p.NamedCertificates(), p.Socks5ProxyImage, p.NoProxy, hcp.Spec.Platform.Type)
+		return oauth.ReconcileDeployment(ctx, r, deployment, p.OwnerRef, oauthConfig, p.OAuthServerImage, p.DeploymentConfig, p.IdentityProviders(), p.OauthConfigOverrides, p.AvailabilityProberImage, p.NamedCertificates(), p.ProxyImage, p.ProxyConfig, clusterNoProxy, p.OAuthNoProxy, p.ConfigParams(oauthServingCert), hcp.Spec.Platform.Type)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile oauth deployment: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The socks5 konnectivity proxy does not honor user-configured HTTP/S proxies when sending traffic through the dataplane. Most identity providers handled by the OAuth server do use HTTP/S for external communication and should honor any user configured proxy. This commit adds an additional container to the oauth server deployment with the HTTP konnectivity proxy. This proxy does honor the user-configured HTTP/S proxy for the HostedCluster when sending traffic through the data plane. The socks5 proxy is still used for the LDAP identity provider which does not use the proxy for its traffic. On the OAuth server, the HTTP_PROXY and HTTPS_PROXY environment variables point to the HTTP proxy while the ALL_PROXY variable still points to the socks5 proxy.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.