### PR TITLE
OCPBUGS-25937: Support KMS v2 on AWS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas/kms"
 	"github.com/openshift/hypershift/support/api"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 )
 
 func applyKMSConfig(podSpec *corev1.PodSpec, secretEncryptionData *hyperv1.SecretEncryptionSpec, images KubeAPIServerImages) error {
@@ -21,13 +22,44 @@ func applyKMSConfig(podSpec *corev1.PodSpec, secretEncryptionData *hyperv1.Secre
 	return provider.ApplyKMSConfig(podSpec)
 }
 
-func generateKMSEncryptionConfig(kmsSpec *hyperv1.KMSSpec) ([]byte, error) {
+// getKMSAPIVersion returns the KMS API version from the given EncryptionConfig
+// secret.  If the current state is using the IdentityProvider, the function
+// returns v2 as the default version to start with.
+func getKMSAPIVersion(config *corev1.Secret) (string, error) {
+	apiVersion := "v2"
+	encryptionConfigBytes := config.Data[secretEncryptionConfigurationKey]
+	if len(encryptionConfigBytes) > 0 {
+		currentConfig := v1.EncryptionConfiguration{}
+		gvks, _, err := api.Scheme.ObjectKinds(&currentConfig)
+		if err != nil || len(gvks) == 0 {
+			return "", fmt.Errorf("cannot determine gvk of resource: %v", err)
+		}
+		if _, _, err = api.YamlSerializer.Decode(encryptionConfigBytes, &gvks[0], &currentConfig); err != nil {
+			return "", fmt.Errorf("cannot decode resource: %v", err)
+		}
+
+		// Only look at write keys to return the APIVersion currently used.
+		for _, r := range currentConfig.Resources {
+			if len(r.Providers) > 0 && r.Providers[0].KMS != nil {
+				return r.Providers[0].KMS.APIVersion, nil
+			}
+		}
+	}
+	return apiVersion, nil
+}
+
+func generateKMSEncryptionConfig(config *corev1.Secret, kmsSpec *hyperv1.KMSSpec) ([]byte, error) {
 	provider, err := GetKMSProvider(kmsSpec, KubeAPIServerImages{})
 	if err != nil {
 		return nil, err
 	}
 
-	encryptionConfig, err := provider.GenerateKMSEncryptionConfig()
+	apiVersion, err := getKMSAPIVersion(config)
+	if err != nil {
+		return nil, err
+	}
+
+	encryptionConfig, err := provider.GenerateKMSEncryptionConfig(apiVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/aws.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/aws.go
@@ -166,6 +166,9 @@ func (p *awsKMSProvider) ApplyKMSConfig(podSpec *corev1.PodSpec) error {
 	}
 	container.VolumeMounts = append(container.VolumeMounts,
 		awsKMSVolumeMounts.ContainerMounts(KasMainContainerName)...)
+
+	container.Args = append(container.Args, "--encryption-provider-config-automatic-reload=false")
+
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
@@ -66,7 +66,7 @@ func NewAzureKMSProvider(kmsSpec *hyperv1.AzureKMSSpec, image string) (*azureKMS
 	}, nil
 }
 
-func (p *azureKMSProvider) GenerateKMSEncryptionConfig() (*v1.EncryptionConfiguration, error) {
+func (p *azureKMSProvider) GenerateKMSEncryptionConfig(_ string) (*v1.EncryptionConfiguration, error) {
 	var providerConfiguration []v1.ProviderConfiguration
 
 	activeKeyHash, err := util.HashStruct(p.kmsSpec.ActiveKey)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/ibmcloud.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/ibmcloud.go
@@ -58,7 +58,7 @@ func NewIBMCloudKMSProvider(ibmCloud *hyperv1.IBMCloudKMSSpec, kmsImage string) 
 	}, nil
 }
 
-func (p *ibmCloudKMSProvider) GenerateKMSEncryptionConfig() (*v1.EncryptionConfiguration, error) {
+func (p *ibmCloudKMSProvider) GenerateKMSEncryptionConfig(_ string) (*v1.EncryptionConfiguration, error) {
 
 	providerConfiguration := []v1.ProviderConfiguration{
 		{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/kms.go
@@ -6,7 +6,7 @@ import (
 )
 
 type IKMSProvider interface {
-	GenerateKMSEncryptionConfig() (*v1.EncryptionConfiguration, error)
+	GenerateKMSEncryptionConfig(apiVersion string) (*v1.EncryptionConfiguration, error)
 
 	ApplyKMSConfig(podSpec *corev1.PodSpec) error
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/secretencryption.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/secretencryption.go
@@ -21,7 +21,7 @@ func ReconcileKMSEncryptionConfig(config *corev1.Secret,
 		config.Data = map[string][]byte{}
 	}
 
-	encryptionConfigurationBytes, err := generateKMSEncryptionConfig(encryptionSpec)
+	encryptionConfigurationBytes, err := generateKMSEncryptionConfig(config, encryptionSpec)
 	if err != nil {
 		return err
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/secretencryption_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/secretencryption_test.go
@@ -1,0 +1,162 @@
+package kas
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	kmsAPIVersionV1 = "v1"
+	kmsAPIVersionV2 = "v2"
+)
+
+func TestReconcileKMSEncryptionConfigAWS(t *testing.T) {
+	encryptionSpec := hyperv1.KMSSpec{Provider: hyperv1.AWS, AWS: &hyperv1.AWSKMSSpec{
+		ActiveKey: hyperv1.AWSKMSKeyEntry{ARN: "test"},
+	}}
+
+	testCases := []struct {
+		name           string
+		config         *v1.EncryptionConfiguration
+		expectedConfig *v1.EncryptionConfiguration
+	}{
+		{
+			name:           "No encryption config",
+			expectedConfig: generateExpectedEncryptionConfig(kmsAPIVersionV2),
+		},
+		{
+			name: "Encryption config with Identity provider",
+			config: &v1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
+				Resources: []v1.ResourceConfiguration{
+					{
+						Resources: config.KMSEncryptedObjects(),
+						Providers: []v1.ProviderConfiguration{
+							{
+								Identity: &v1.IdentityConfiguration{},
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: generateExpectedEncryptionConfig(kmsAPIVersionV2),
+		},
+		{
+			name: "KMS v1 encryption config",
+			config: &v1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
+				Resources: []v1.ResourceConfiguration{
+					{
+						Resources: config.KMSEncryptedObjects(),
+						Providers: []v1.ProviderConfiguration{
+							{
+								KMS: &v1.KMSConfiguration{
+									APIVersion: "v1",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: generateExpectedEncryptionConfig(kmsAPIVersionV1),
+		},
+		{
+			name: "KMS v2 encryption config",
+			config: &v1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
+				Resources: []v1.ResourceConfiguration{
+					{
+						Resources: config.KMSEncryptedObjects(),
+						Providers: []v1.ProviderConfiguration{
+							{
+								KMS: &v1.KMSConfiguration{
+									APIVersion: "v2",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: generateExpectedEncryptionConfig(kmsAPIVersionV2),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encryptionConfigFile := manifests.KASSecretEncryptionConfigFile("test-namespace")
+			encryptionConfigFile.Data = map[string][]byte{}
+			if tc.config != nil {
+				buff := bytes.NewBuffer([]byte{})
+				err := api.YamlSerializer.Encode(tc.config, buff)
+				if err != nil {
+					t.Errorf("failed to encode encryption config: %v", err)
+				}
+				encryptionConfigFile.Data[secretEncryptionConfigurationKey] = buff.Bytes()
+			}
+
+			err := ReconcileKMSEncryptionConfig(encryptionConfigFile, config.OwnerRef{}, &encryptionSpec)
+			if err != nil {
+				t.Errorf("failed to reconcile KMS encryption config: %v", err)
+			}
+
+			encryptionConfigBytes := encryptionConfigFile.Data[secretEncryptionConfigurationKey]
+			if len(encryptionConfigBytes) == 0 {
+				t.Error("reconciled empty encryption config")
+			}
+			config := v1.EncryptionConfiguration{}
+			gvks, _, err := api.Scheme.ObjectKinds(&config)
+			if err != nil || len(gvks) == 0 {
+				t.Errorf("cannot determine gvk of resource: %v", err)
+			}
+			if _, _, err = api.YamlSerializer.Decode(encryptionConfigBytes, &gvks[0], &config); err != nil {
+				t.Errorf("cannot decode resource: %v", err)
+			}
+
+			if diff := cmp.Diff(config, *tc.expectedConfig); diff != "" {
+				t.Errorf("reconciled encrytion config differs from expected: %s", diff)
+			}
+		})
+	}
+}
+
+func generateExpectedEncryptionConfig(apiVersion string) *v1.EncryptionConfiguration {
+	config := &v1.EncryptionConfiguration{
+		TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
+		Resources: []v1.ResourceConfiguration{
+			{
+				Resources: config.KMSEncryptedObjects(),
+				Providers: []v1.ProviderConfiguration{
+					{
+						KMS: &v1.KMSConfiguration{
+							APIVersion: apiVersion,
+							Name:       "awskmskey-3157003241",
+							Endpoint:   "unix:///var/run/awskmsactive.sock",
+							Timeout:    &metav1.Duration{Duration: 35 * time.Second},
+						},
+					},
+					{
+						Identity: &v1.IdentityConfiguration{},
+					},
+				},
+			},
+		},
+	}
+
+	if apiVersion == kmsAPIVersionV1 {
+		config.Resources[0].Providers[0].KMS.CacheSize = ptr.To[int32](100)
+	}
+
+	return config
+}

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -161,7 +161,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 		g.Expect(hostedCluster.Spec.SecretEncryption.KMS.AWS.Auth.AWSKMSRoleARN).ToNot(BeEmpty())
 
 		guestClient := e2eutil.WaitForGuestClient(t, testContext, mgtClient, hostedCluster)
-		e2eutil.EnsureSecretEncryptedUsingKMS(t, ctx, hostedCluster, guestClient)
+		e2eutil.EnsureSecretEncryptedUsingKMSV2(t, ctx, hostedCluster, guestClient)
 		// test oauth with identity provider
 		e2eutil.EnsureOAuthWithIdentityProvider(t, ctx, mgtClient, hostedCluster)
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -914,62 +914,78 @@ func EnsureAPIUX(t *testing.T, ctx context.Context, hostClient crclient.Client, 
 
 func EnsureSecretEncryptedUsingKMS(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, guestClient crclient.Client) {
 	t.Run("EnsureSecretEncryptedUsingKMS", func(t *testing.T) {
-		// create secret in guest cluster
-		testSecret := corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-secret",
-				Namespace: "default",
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				"myKey": []byte("myData"),
-			},
-		}
-		if err := guestClient.Create(ctx, &testSecret); err != nil {
-			t.Errorf("failed to create a secret in guest cluster; %v", err)
-		}
-
-		restConfig, err := GetConfig()
-		if err != nil {
-			t.Errorf("failed to get restConfig; %v", err)
-		}
-
-		secretEtcdKey := fmt.Sprintf("/kubernetes.io/secrets/%s/%s", testSecret.Namespace, testSecret.Name)
-		command := []string{
-			"/usr/bin/etcdctl",
-			"--endpoints=localhost:2379",
-			"--cacert=/etc/etcd/tls/etcd-ca/ca.crt",
-			"--cert=/etc/etcd/tls/client/etcd-client.crt",
-			"--key=/etc/etcd/tls/client/etcd-client.key",
-			"get",
-			secretEtcdKey,
-		}
-
-		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
-		out := new(bytes.Buffer)
-
-		podExecuter := PodExecOptions{
-			StreamOptions: StreamOptions{
-				IOStreams: genericclioptions.IOStreams{
-					Out:    out,
-					ErrOut: os.Stderr,
-				},
-			},
-			Command:       command,
-			Namespace:     hcpNamespace,
-			PodName:       "etcd-0",
-			ContainerName: "etcd",
-			Config:        restConfig,
-		}
-
-		if err := podExecuter.Run(ctx); err != nil {
-			t.Errorf("failed to execute etcdctl command; %v", err)
-		}
-
-		if !strings.Contains(out.String(), "k8s:enc:kms:") {
-			t.Errorf("secret is not encrypted using kms")
-		}
+		ensureSecretEncryptedUsingKMS(t, ctx, hostedCluster, guestClient, "k8s:enc:kms:")
 	})
+}
+
+func EnsureSecretEncryptedUsingKMSV1(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, guestClient crclient.Client) {
+	t.Run("EnsureSecretEncryptedUsingKMSV1", func(t *testing.T) {
+		ensureSecretEncryptedUsingKMS(t, ctx, hostedCluster, guestClient, "k8s:enc:kms:v1")
+	})
+}
+
+func EnsureSecretEncryptedUsingKMSV2(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, guestClient crclient.Client) {
+	t.Run("EnsureSecretEncryptedUsingKMSV2", func(t *testing.T) {
+		ensureSecretEncryptedUsingKMS(t, ctx, hostedCluster, guestClient, "k8s:enc:kms:v2")
+	})
+}
+
+func ensureSecretEncryptedUsingKMS(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, guestClient crclient.Client, expectedPrefix string) {
+	// create secret in guest cluster
+	testSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"myKey": []byte("myData"),
+		},
+	}
+	if err := guestClient.Create(ctx, &testSecret); err != nil {
+		t.Errorf("failed to create a secret in guest cluster; %v", err)
+	}
+
+	restConfig, err := GetConfig()
+	if err != nil {
+		t.Errorf("failed to get restConfig; %v", err)
+	}
+
+	secretEtcdKey := fmt.Sprintf("/kubernetes.io/secrets/%s/%s", testSecret.Namespace, testSecret.Name)
+	command := []string{
+		"/usr/bin/etcdctl",
+		"--endpoints=localhost:2379",
+		"--cacert=/etc/etcd/tls/etcd-ca/ca.crt",
+		"--cert=/etc/etcd/tls/client/etcd-client.crt",
+		"--key=/etc/etcd/tls/client/etcd-client.key",
+		"get",
+		secretEtcdKey,
+	}
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	out := new(bytes.Buffer)
+
+	podExecuter := PodExecOptions{
+		StreamOptions: StreamOptions{
+			IOStreams: genericclioptions.IOStreams{
+				Out:    out,
+				ErrOut: os.Stderr,
+			},
+		},
+		Command:       command,
+		Namespace:     hcpNamespace,
+		PodName:       "etcd-0",
+		ContainerName: "etcd",
+		Config:        restConfig,
+	}
+
+	if err := podExecuter.Run(ctx); err != nil {
+		t.Errorf("failed to execute etcdctl command; %v", err)
+	}
+
+	if !strings.Contains(out.String(), expectedPrefix) {
+		t.Errorf("secret is not encrypted using kms")
+	}
 }
 
 func createK8sClient() (*k8s.Clientset, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add support for KMS v2 on AWS. New AWS clusters will only be able to use the new KMS v2 API whilst existing clusters that are already using the v1 API will not be migrated to v2 and stay on v1.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-25937

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.