### PR TITLE
OCPBUGS-37179: OCPBUGS-38165: E2E test to verify openshift-apiserver TLS certificates

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
@@ -38,16 +38,18 @@ func TestReconcileOpenshiftAPIServerDeploymentTrustBundle(t *testing.T) {
 	hcp.Namespace = "namespace"
 	ownerRef := config.OwnerRefFrom(hcp)
 	testCases := []struct {
-		name                         string
-		cm                           corev1.ConfigMap
-		expectedVolume               *corev1.Volume
-		auditConfig                  *corev1.ConfigMap
-		expectedVolumeProjection     []corev1.VolumeProjection
-		deploymentConfig             config.DeploymentConfig
-		additionalTrustBundle        *corev1.LocalObjectReference
-		clusterConf                  *hyperv1.ClusterConfiguration
-		imageRegistryAdditionalCAs   *corev1.ConfigMap
-		expectProjectedVolumeMounted bool
+		name                              string
+		cm                                corev1.ConfigMap
+		expectedVolume                    *corev1.Volume
+		expectedProxyVolume               *corev1.Volume
+		auditConfig                       *corev1.ConfigMap
+		expectedVolumeProjection          []corev1.VolumeProjection
+		deploymentConfig                  config.DeploymentConfig
+		additionalTrustBundle             *corev1.LocalObjectReference
+		clusterConf                       *hyperv1.ClusterConfiguration
+		imageRegistryAdditionalCAs        *corev1.ConfigMap
+		expectProjectedVolumeMounted      bool
+		expectProjectedProxyVolumeMounted bool
 	}{
 		{
 			name:             "Trust bundle provided",
@@ -65,15 +67,17 @@ func TestReconcileOpenshiftAPIServerDeploymentTrustBundle(t *testing.T) {
 					},
 				},
 			},
-			expectProjectedVolumeMounted: true,
+			expectProjectedVolumeMounted:      true,
+			expectProjectedProxyVolumeMounted: false,
 		},
 		{
-			name:                         "Trust bundle not provided",
-			auditConfig:                  manifests.OpenShiftAPIServerAuditConfig(targetNamespace),
-			deploymentConfig:             config.DeploymentConfig{},
-			expectedVolume:               nil,
-			additionalTrustBundle:        nil,
-			expectProjectedVolumeMounted: false,
+			name:                              "Trust bundle not provided",
+			auditConfig:                       manifests.OpenShiftAPIServerAuditConfig(targetNamespace),
+			deploymentConfig:                  config.DeploymentConfig{},
+			expectedVolume:                    nil,
+			additionalTrustBundle:             nil,
+			expectProjectedVolumeMounted:      false,
+			expectProjectedProxyVolumeMounted: false,
 		},
 		{
 			name:             "Trust bundle and image registry additional CAs provided",
@@ -104,7 +108,36 @@ func TestReconcileOpenshiftAPIServerDeploymentTrustBundle(t *testing.T) {
 					},
 				},
 			},
-			expectProjectedVolumeMounted: true,
+			expectProjectedVolumeMounted:      true,
+			expectProjectedProxyVolumeMounted: false,
+		},
+		{
+			name:             "Trust bundle and proxy trust bundle provided",
+			auditConfig:      manifests.OpenShiftAPIServerAuditConfig(targetNamespace),
+			deploymentConfig: config.DeploymentConfig{},
+			additionalTrustBundle: &corev1.LocalObjectReference{
+				Name: "user-ca-bundle",
+			},
+			expectedVolume: &corev1.Volume{
+				Name: "additional-trust-bundle",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources:     []corev1.VolumeProjection{getFakeVolumeProjectionCABundle()},
+						DefaultMode: ptr.To[int32](420),
+					},
+				},
+			},
+			expectedProxyVolume: &corev1.Volume{
+				Name: "proxy-additional-trust-bundle",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources:     []corev1.VolumeProjection{getFakeVolumeProjectionCABundle()},
+						DefaultMode: ptr.To[int32](420),
+					},
+				},
+			},
+			expectProjectedVolumeMounted:      true,
+			expectProjectedProxyVolumeMounted: true,
 		},
 	}
 	for _, tc := range testCases {
@@ -117,6 +150,11 @@ func TestReconcileOpenshiftAPIServerDeploymentTrustBundle(t *testing.T) {
 				g.Expect(oapiDeployment.Spec.Template.Spec.Volumes).To(ContainElement(*tc.expectedVolume))
 			} else {
 				g.Expect(oapiDeployment.Spec.Template.Spec.Volumes).NotTo(ContainElement(&corev1.Volume{Name: "additional-trust-bundle"}))
+			}
+			if tc.expectProjectedProxyVolumeMounted {
+				g.Expect(oapiDeployment.Spec.Template.Spec.Volumes).To(ContainElement(*tc.expectedProxyVolume))
+			} else {
+				g.Expect(oapiDeployment.Spec.Template.Spec.Volumes).NotTo(ContainElement(&corev1.Volume{Name: "proxy-additional-trust-bundle"}))
 			}
 		})
 	}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -508,6 +508,51 @@ func EnsureNoPodsWithTooHighPriority(t *testing.T, ctx context.Context, client c
 	})
 }
 
+func EnsureOAPIMountsTrustBundle(t *testing.T, ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	t.Run("EnsureOAPIMountsTrustBundle", func(t *testing.T) {
+		g := NewWithT(t)
+		var (
+			podList corev1.PodList
+			oapiPod corev1.Pod
+			command = []string{
+				"test",
+				"-f",
+				"/etc/pki/tls/certs/ca-bundle.crt",
+			}
+			hcpNs = manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+		)
+
+		err := mgmtClient.List(ctx, &podList, crclient.InNamespace(hcpNs.Name), crclient.MatchingLabels{"app": "openshift-apiserver"})
+		g.Expect(err).ToNot(HaveOccurred(), "failed to get pods in namespace %s: %v", hcpNs, err)
+
+		for _, pod := range podList.Items {
+			if strings.HasPrefix(pod.Name, "openshift-apiserver") {
+				oapiPod = *pod.DeepCopy()
+			}
+		}
+		g.Expect(oapiPod.ObjectMeta).ToNot(BeNil(), "no openshift-apiserver pod found")
+		g.Expect(oapiPod.ObjectMeta.Name).ToNot(BeEmpty(), "no openshift-apiserver pod found")
+
+		// Check additionalTrustBundle volume and volumeMount
+		if hostedCluster.Spec.AdditionalTrustBundle != nil && hostedCluster.Spec.AdditionalTrustBundle.Name != "" {
+			g.Expect(oapiPod.Spec.Volumes).To(ContainElement(corev1.Volume{
+				Name: "additional-trust-bundle",
+			}), "no volume named additional-trust-bundle found in openshift-apiserver pod")
+		}
+
+		// Check Proxy TLS Certificates
+		if hostedCluster.Spec.Configuration != nil && hostedCluster.Spec.Configuration.Proxy != nil && hostedCluster.Spec.Configuration.Proxy.TrustedCA.Name != "" {
+			g.Expect(oapiPod.Spec.Volumes).To(ContainElement(corev1.Volume{
+				Name: "proxy-additional-trust-bundle",
+			}), "no volume named proxy-additional-trust-bundle found in openshift-apiserver pod")
+		}
+
+		_, err = RunCommandInPod(ctx, mgmtClient, "openshift-apiserver", hcpNs.Name, command, "openshift-apiserver")
+		g.Expect(err).ToNot(HaveOccurred(), "failed to run command in pod: %v", err)
+	})
+
+}
+
 func EnsureAllContainersHavePullPolicyIfNotPresent(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureAllContainersHavePullPolicyIfNotPresent", func(t *testing.T) {
 		namespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name).Name
@@ -1257,6 +1302,7 @@ func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 
 	EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Namespace)
 	EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+	EnsureOAPIMountsTrustBundle(t, context.Background(), client, hostedCluster)
 	EnsureGuestWebhooksValidated(t, ctx, guestClient)
 
 	if numNodes > 0 {
@@ -1298,6 +1344,11 @@ func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 	validateHostedClusterConditions(t, ctx, client, hostedCluster, numNodes > 0)
 
 	EnsureNoCrashingPods(t, ctx, client, hostedCluster)
+
+	if hostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform {
+		g.Expect(hostedCluster.Spec.Configuration.Ingress.LoadBalancer.Platform.AWS.Type).To(Equal(configv1.NLB))
+	}
+
 }
 
 func validateHostedClusterConditions(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, hasWorkerNodes bool) {


### PR DESCRIPTION
Manual backport of [OCPBUGS-35905](https://issues.redhat.com/browse/OCPBUGS-35905)

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-37179](https://issues.redhat.com/browse/OCPBUGS-37179)

