### PR TITLE
CNV-42532: KubeVirt: add label to DataVolume

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -326,6 +326,9 @@ const (
 	// This annotation signals to the NodePool controller that it is safe to use TopologySpreadConstraints on a NodePool
 	// without triggering an unexpected update of KubeVirt VMs.
 	NodePoolSupportsKubevirtTopologySpreadConstraintsAnnotation = "hypershift.openshift.io/nodepool-supports-kubevirt-topology-spread-constraints"
+
+	// IsKubeVirtRHCOSVolumeLabelName labels rhcos DataVolumes and PVCs, to be able to filter them, e.g. for backup
+	IsKubeVirtRHCOSVolumeLabelName = "hypershift.openshift.io/is-kubevirt-rhcos"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/hypershift-operator/controllers/nodepool/kubevirt/imagecacher.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/imagecacher.go
@@ -222,8 +222,9 @@ func (qi *cachedBootImage) buildDVForCache(nodePool *hyperv1.NodePool, uid strin
 			GenerateName: bootImageNamePrefix,
 			Namespace:    qi.namespace,
 			Labels: map[string]string{
-				bootImageDVLabelRoleName: bootImageDVLabelRoleValue,
-				bootImageDVLabelUID:      uid,
+				bootImageDVLabelRoleName:               bootImageDVLabelRoleValue,
+				bootImageDVLabelUID:                    uid,
+				hyperv1.IsKubeVirtRHCOSVolumeLabelName: "true",
 			},
 			Annotations: map[string]string{
 				bootImageDVAnnotationHash:          qi.hash,

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -236,6 +236,9 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: rootVolumeName,
+			Labels: map[string]string{
+				hyperv1.IsKubeVirtRHCOSVolumeLabelName: "true",
+			},
 		},
 		Spec: v1beta1.DataVolumeSpec{
 			Source: dvSource,

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
-	suppconfig "github.com/openshift/hypershift/support/config"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
@@ -24,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	suppconfig "github.com/openshift/hypershift/support/config"
 )
 
 const (
@@ -1328,6 +1328,9 @@ func generateNodeTemplate(options ...nodeTemplateOption) *capikubevirt.VirtualMa
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rhcos",
+						Labels: map[string]string{
+							hyperv1.IsKubeVirtRHCOSVolumeLabelName: "true",
+						},
 					},
 					Spec: v1beta1.DataVolumeSpec{
 						Source: &v1beta1.DataVolumeSource{


### PR DESCRIPTION
Added the `hypershift.openshift.io/nodepool-name` label to the rhcos datavolume, to allow easy access to these datavolumes, e.g. for backup.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.