### PR TITLE
NO-JIRA: Fix CEL rules in the CRD

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -333,11 +333,11 @@ const (
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.
 
-// +kubebuilder:validation:XValidation:rule="self.platform.type != 'IBMCloud' ? self.services == oldSelf.services : true", message="Services is immutable. Changes might result in unpredictable and disruptive behavior."
-// +kubebuilder:validation:XValidation:rule="self.platform.type == 'Azure' ? self.services.exists(s, s.service == 'APIServer' && s.servicePublishingStrategy.type == 'Route' && s.servicePublishingStrategy.route.hostname != '') : true",message="Azure platform requires APIServer Route service with a hostname to be defined"
-// +kubebuilder:validation:XValidation:rule="self.platform.type == 'Azure' ? self.services.exists(s, s.service == 'OAuthServer' && s.servicePublishingStrategy.type == 'Route' && s.servicePublishingStrategy.route.hostname != '') : true",message="Azure platform requires OAuthServer Route service with a hostname to be defined"
-// +kubebuilder:validation:XValidation:rule="self.platform.type == 'Azure' ? self.services.exists(s, s.service == 'Konnectivity' && s.servicePublishingStrategy.type == 'Route' && s.servicePublishingStrategy.route.hostname != '') : true",message="Azure platform requires Konnectivity Route service with a hostname to be defined"
-// +kubebuilder:validation:XValidation:rule="self.platform.type == 'Azure' ? self.services.exists(s, s.service == 'Ignition' && s.servicePublishingStrategy.type == 'Route' && s.servicePublishingStrategy.route.hostname != '') : true",message="Azure platform requires Ignition Route service with a hostname to be defined"
+// +kubebuilder:validation:XValidation:rule=`self.platform.type != "IBMCloud" ? self.services == oldSelf.services : true`, message="Services is immutable. Changes might result in unpredictable and disruptive behavior."
+// +kubebuilder:validation:XValidation:rule=`self.platform.type == "Azure" ? self.services.exists(s, s.service == "APIServer" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname != "") : true`,message="Azure platform requires APIServer Route service with a hostname to be defined"
+// +kubebuilder:validation:XValidation:rule=`self.platform.type == "Azure" ? self.services.exists(s, s.service == "OAuthServer" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname != "") : true`,message="Azure platform requires OAuthServer Route service with a hostname to be defined"
+// +kubebuilder:validation:XValidation:rule=`self.platform.type == "Azure" ? self.services.exists(s, s.service == "Konnectivity" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname != "") : true`,message="Azure platform requires Konnectivity Route service with a hostname to be defined"
+// +kubebuilder:validation:XValidation:rule=`self.platform.type == "Azure" ? self.services.exists(s, s.service == "Ignition" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname != "") : true`,message="Azure platform requires Ignition Route service with a hostname to be defined"
 type HostedClusterSpec struct {
 	// Release specifies the desired OCP release payload for the hosted cluster.
 	//

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -9699,28 +9699,28 @@ spec:
             x-kubernetes-validations:
             - message: Services is immutable. Changes might result in unpredictable
                 and disruptive behavior.
-              rule: 'self.platform.type != ''IBMCloud'' ? self.services == oldSelf.services
+              rule: 'self.platform.type != "IBMCloud" ? self.services == oldSelf.services
                 : true'
             - message: Azure platform requires APIServer Route service with a hostname
                 to be defined
-              rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
-                == ''APIServer'' && s.servicePublishingStrategy.type == ''Route''
-                && s.servicePublishingStrategy.route.hostname != '''') : true'
+              rule: 'self.platform.type == "Azure" ? self.services.exists(s, s.service
+                == "APIServer" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname
+                != "") : true'
             - message: Azure platform requires OAuthServer Route service with a hostname
                 to be defined
-              rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
-                == ''OAuthServer'' && s.servicePublishingStrategy.type == ''Route''
-                && s.servicePublishingStrategy.route.hostname != '''') : true'
+              rule: 'self.platform.type == "Azure" ? self.services.exists(s, s.service
+                == "OAuthServer" && s.servicePublishingStrategy.type == "Route" &&
+                s.servicePublishingStrategy.route.hostname != "") : true'
             - message: Azure platform requires Konnectivity Route service with a hostname
                 to be defined
-              rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
-                == ''Konnectivity'' && s.servicePublishingStrategy.type == ''Route''
-                && s.servicePublishingStrategy.route.hostname != '''') : true'
+              rule: 'self.platform.type == "Azure" ? self.services.exists(s, s.service
+                == "Konnectivity" && s.servicePublishingStrategy.type == "Route" &&
+                s.servicePublishingStrategy.route.hostname != "") : true'
             - message: Azure platform requires Ignition Route service with a hostname
                 to be defined
-              rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
-                == ''Ignition'' && s.servicePublishingStrategy.type == ''Route'' &&
-                s.servicePublishingStrategy.route.hostname != '''') : true'
+              rule: 'self.platform.type == "Azure" ? self.services.exists(s, s.service
+                == "Ignition" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname
+                != "") : true'
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:


### PR DESCRIPTION
Some CEL rules seems to be wrong, using double single-quotes instead of double quotes.

e.g.

```yaml
rule: 'self.platform.type == ''Azure'' ? self.services.exists(s, s.service
  == ''APIServer'' && s.servicePublishingStrategy.type == ''Route''
  && s.servicePublishingStrategy.route.hostname != '''') : true'
```

This PR change this strings to use real double quotes:

```yaml
rule: 'self.platform.type == "Azure" ? self.services.exists(s, s.service
  == "APIServer" && s.servicePublishingStrategy.type == "Route" 
  && s.servicePublishingStrategy.route.hostname  != "") : true'
```

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.