### PR TITLE
OCPBUGS-38183: make use of azure-disk-driver-control-plane-image

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
@@ -48,6 +48,8 @@ var (
 		"POWERVS_BLOCK_CSI_DRIVER_IMAGE":                  "powervs-block-csi-driver",
 		"HYPERSHIFT_IMAGE":                                "token-minter",
 		"AWS_EBS_DRIVER_CONTROL_PLANE_IMAGE":              "aws-ebs-csi-driver",
+		"AZURE_DISK_DRIVER_CONTROL_PLANE_IMAGE":           "azure-disk-csi-driver",
+		"AZURE_FILE_DRIVER_CONTROL_PLANE_IMAGE":           "azure-file-csi-driver",
 		"LIVENESS_PROBE_CONTROL_PLANE_IMAGE":              "csi-livenessprobe",
 		"TOOLS_IMAGE":                                     "tools",
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Allows azure-disk-csi-driver-controller to use registryOverride images, without affecting azure-disk-csi-driver dataplane images 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-38183](https://issues.redhat.com/browse/OCPBUGS-38183)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.