### PR TITLE
OCPBUGS-38357: openstack: add option to configure nodepool AZ

### DIFF
--- a/api/hypershift/v1beta1/openstack.go
+++ b/api/hypershift/v1beta1/openstack.go
@@ -12,6 +12,19 @@ type OpenStackNodePoolPlatform struct {
 	//
 	// +optional
 	ImageName string `json:"imageName,omitempty"`
+
+	// availabilityZone is the nova availability zone in which the provider will create the VM.
+	// If not specified, the VM will be created in the default availability zone specified in the nova configuration.
+	// Availability zone names must NOT contain : since it is used by admin users to specify hosts where instances
+	// are launched in server creation. Also, it must not contain spaces otherwise it will lead to node that belongs
+	// to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for further information.
+	// The maximum length of availability zone name is 63 as per labels limits.
+	//
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[^: ]*$`
+	// +kubebuilder:validation:MaxLength=63
+	// +optional
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 }
 
 // OpenStackPlatformSpec specifies configuration for clusters running on OpenStack.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -930,6 +930,18 @@ spec:
                     description: OpenStack specifies the configuration used when using
                       OpenStack platform.
                     properties:
+                      availabilityZone:
+                        description: |-
+                          availabilityZone is the nova availability zone in which the provider will create the VM.
+                          If not specified, the VM will be created in the default availability zone specified in the nova configuration.
+                          Availability zone names must NOT contain : since it is used by admin users to specify hosts where instances
+                          are launched in server creation. Also, it must not contain spaces otherwise it will lead to node that belongs
+                          to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for further information.
+                          The maximum length of availability zone name is 63 as per labels limits.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: '^[^: ]*$'
+                        type: string
                       flavor:
                         description: Flavor is the OpenStack flavor to use for the
                           node instances.

--- a/client/applyconfiguration/hypershift/v1beta1/openstacknodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/openstacknodepoolplatform.go
@@ -20,8 +20,9 @@ package v1beta1
 // OpenStackNodePoolPlatformApplyConfiguration represents an declarative configuration of the OpenStackNodePoolPlatform type for use
 // with apply.
 type OpenStackNodePoolPlatformApplyConfiguration struct {
-	Flavor    *string `json:"flavor,omitempty"`
-	ImageName *string `json:"imageName,omitempty"`
+	Flavor           *string `json:"flavor,omitempty"`
+	ImageName        *string `json:"imageName,omitempty"`
+	AvailabilityZone *string `json:"availabilityZone,omitempty"`
 }
 
 // OpenStackNodePoolPlatformApplyConfiguration constructs an declarative configuration of the OpenStackNodePoolPlatform type for use with
@@ -43,5 +44,13 @@ func (b *OpenStackNodePoolPlatformApplyConfiguration) WithFlavor(value string) *
 // If called multiple times, the ImageName field is set to the value of the last call.
 func (b *OpenStackNodePoolPlatformApplyConfiguration) WithImageName(value string) *OpenStackNodePoolPlatformApplyConfiguration {
 	b.ImageName = &value
+	return b
+}
+
+// WithAvailabilityZone sets the AvailabilityZone field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AvailabilityZone field is set to the value of the last call.
+func (b *OpenStackNodePoolPlatformApplyConfiguration) WithAvailabilityZone(value string) *OpenStackNodePoolPlatformApplyConfiguration {
+	b.AvailabilityZone = &value
 	return b
 }

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -934,6 +934,18 @@ spec:
                     description: OpenStack specifies the configuration used when using
                       OpenStack platform.
                     properties:
+                      availabilityZone:
+                        description: |-
+                          availabilityZone is the nova availability zone in which the provider will create the VM.
+                          If not specified, the VM will be created in the default availability zone specified in the nova configuration.
+                          Availability zone names must NOT contain : since it is used by admin users to specify hosts where instances
+                          are launched in server creation. Also, it must not contain spaces otherwise it will lead to node that belongs
+                          to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for further information.
+                          The maximum length of availability zone name is 63 as per labels limits.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: '^[^: ]*$'
+                        type: string
                       flavor:
                         description: Flavor is the OpenStack flavor to use for the
                           node instances.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -934,6 +934,18 @@ spec:
                     description: OpenStack specifies the configuration used when using
                       OpenStack platform.
                     properties:
+                      availabilityZone:
+                        description: |-
+                          availabilityZone is the nova availability zone in which the provider will create the VM.
+                          If not specified, the VM will be created in the default availability zone specified in the nova configuration.
+                          Availability zone names must NOT contain : since it is used by admin users to specify hosts where instances
+                          are launched in server creation. Also, it must not contain spaces otherwise it will lead to node that belongs
+                          to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for further information.
+                          The maximum length of availability zone name is 63 as per labels limits.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: '^[^: ]*$'
+                        type: string
                       flavor:
                         description: Flavor is the OpenStack flavor to use for the
                           node instances.

--- a/cmd/nodepool/openstack/create.go
+++ b/cmd/nodepool/openstack/create.go
@@ -17,8 +17,9 @@ func DefaultOptions() *RawOpenStackPlatformCreateOptions {
 }
 
 type OpenStackPlatformOptions struct {
-	Flavor    string
-	ImageName string
+	Flavor         string
+	ImageName      string
+	AvailabityZone string
 }
 
 // completedCreateOptions is a private wrapper that enforces a call of Complete() before nodepool creation can be invoked.
@@ -79,6 +80,7 @@ func BindOptions(opts *RawOpenStackPlatformCreateOptions, flags *pflag.FlagSet) 
 func bindCoreOptions(opts *RawOpenStackPlatformCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.Flavor, "openstack-node-flavor", opts.Flavor, "The flavor to use for the nodepool (required)")
 	flags.StringVar(&opts.ImageName, "openstack-node-image-name", opts.ImageName, "The image name to use for the nodepool (required)")
+	flags.StringVar(&opts.AvailabityZone, "openstack-node-availability-zone", opts.AvailabityZone, "The availability zone to use for the nodepool (optional)")
 }
 
 func NewCreateCommand(coreOpts *core.CreateNodePoolOptions) *cobra.Command {
@@ -118,7 +120,8 @@ func (o *OpenStackPlatformCreateOptions) Type() hyperv1.PlatformType {
 
 func (o *OpenStackPlatformCreateOptions) NodePoolPlatform() *hyperv1.OpenStackNodePoolPlatform {
 	return &hyperv1.OpenStackNodePoolPlatform{
-		Flavor:    o.Flavor,
-		ImageName: o.ImageName,
+		Flavor:           o.Flavor,
+		ImageName:        o.ImageName,
+		AvailabilityZone: o.AvailabityZone,
 	}
 }

--- a/cmd/nodepool/openstack/create_test.go
+++ b/cmd/nodepool/openstack/create_test.go
@@ -30,6 +30,17 @@ func TestRawOpenStackPlatformCreateOptions_Validate(t *testing.T) {
 			},
 			expectedError: "image name is required",
 		},
+		{
+			name: "should pass when AZ is provided",
+			input: RawOpenStackPlatformCreateOptions{
+				OpenStackPlatformOptions: &OpenStackPlatformOptions{
+					Flavor:         "flavor",
+					ImageName:      "rhcos",
+					AvailabityZone: "az",
+				},
+			},
+			expectedError: "",
+		},
 	} {
 		var errString string
 		if _, err := test.input.Validate(); err != nil {

--- a/docs/content/how-to/openstack/create-openstack-cluster.md
+++ b/docs/content/how-to/openstack/create-openstack-cluster.md
@@ -251,13 +251,15 @@ export NODEPOOL_NAME=$CLUSTER_NAME-extra-cpu
 export WORKER_COUNT="2"
 export IMAGE_NAME="rhcos"
 export FLAVOR="m1.xlarge"
+export AZ="az1"
 
 hcp create nodepool openstack \
   --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
   --node-count $WORKER_COUNT \
   --openstack-node-image-name $IMAGE_NAME \
-  --openstack-node-flavor $FLAVOR
+  --openstack-node-flavor $FLAVOR \
+  --openstack-node-availability-zone $AZ
 ```
 
 Check the status of the NodePool by listing `nodepool` resources in the `clusters`

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -8473,6 +8473,23 @@ string
 is chosen based on the NodePool release payload image.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>availabilityZone</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>availabilityZone is the nova availability zone in which the provider will create the VM.
+If not specified, the VM will be created in the default availability zone specified in the nova configuration.
+Availability zone names must NOT contain : since it is used by admin users to specify hosts where instances
+are launched in server creation. Also, it must not contain spaces otherwise it will lead to node that belongs
+to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for further information.
+The maximum length of availability zone name is 63 as per labels limits.</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###OpenStackPlatformSpec { #hypershift.openshift.io/v1beta1.OpenStackPlatformSpec }

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -428,6 +428,13 @@ func (c *CAPI) reconcileMachineDeployment(ctx context.Context, log logr.Logger,
 		},
 	}
 
+	// The CAPI provider for OpenStack uses the FailureDomain field to set the availability zone.
+	if c.nodePool.Spec.Platform.Type == hyperv1.OpenStackPlatform && c.nodePool.Spec.Platform.OpenStack != nil {
+		if c.nodePool.Spec.Platform.OpenStack.AvailabilityZone != "" {
+			machineDeployment.Spec.Template.Spec.FailureDomain = ptr.To(c.nodePool.Spec.Platform.OpenStack.AvailabilityZone)
+		}
+	}
+
 	// After a MachineDeployment is created we propagate label/taints directly into Machines.
 	// This is to avoid a NodePool label/taints to trigger a rolling upgrade.
 	// TODO(Alberto): drop this an rely on core in-place propagation once CAPI 1.4.0 https://github.com/kubernetes-sigs/cluster-api/releases comes through the payload.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -107,6 +107,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackExternalNetworkID, "e2e.openstack-external-network-id", "", "ID of the OpenStack external network")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeFlavor, "e2e.openstack-node-flavor", "", "The flavor to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
+	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeAvailabilityZone, "e2e.openstack-node-availability-zone", "", "The availability zone to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureCredentialsFile, "e2e.azure-credentials-file", "", "Path to an Azure credentials file")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureLocation, "e2e.azure-location", "eastus", "The location to use for Azure")
 	flag.StringVar(&globalOpts.configurableClusterOptions.SSHKeyFile, "e2e.ssh-key-file", "", "Path to a ssh public key")
@@ -459,6 +460,7 @@ type configurableClusterOptions struct {
 	OpenStackExternalNetworkID    string
 	OpenStackNodeFlavor           string
 	OpenStackNodeImageName        string
+	OpenStackNodeAvailabilityZone string
 	PowerVSResourceGroup          string
 	PowerVSRegion                 string
 	PowerVSZone                   string
@@ -556,8 +558,9 @@ func (p *options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 		OpenStackExternalNetworkID: p.configurableClusterOptions.OpenStackExternalNetworkID,
 		NodePoolOpts: &openstacknodepool.RawOpenStackPlatformCreateOptions{
 			OpenStackPlatformOptions: &openstacknodepool.OpenStackPlatformOptions{
-				Flavor:    p.configurableClusterOptions.OpenStackNodeFlavor,
-				ImageName: p.configurableClusterOptions.OpenStackNodeImageName,
+				Flavor:         p.configurableClusterOptions.OpenStackNodeFlavor,
+				ImageName:      p.configurableClusterOptions.OpenStackNodeImageName,
+				AvailabityZone: p.configurableClusterOptions.OpenStackNodeAvailabilityZone,
 			},
 		},
 	}

--- a/test/e2e/nodepool_osp_az_test.go
+++ b/test/e2e/nodepool_osp_az_test.go
@@ -1,0 +1,118 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultAvailabilityZone = "nova"
+)
+
+type OpenStackAZTest struct {
+	DummyInfraSetup
+	ctx                         context.Context
+	managementClient            crclient.Client
+	hostedCluster               *hyperv1.HostedCluster
+	hostedControlPlaneNamespace string
+}
+
+func NewOpenStackAZTest(ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) *OpenStackAZTest {
+	return &OpenStackAZTest{
+		ctx:                         ctx,
+		hostedCluster:               hostedCluster,
+		managementClient:            mgmtClient,
+		hostedControlPlaneNamespace: manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name),
+	}
+}
+
+func (o OpenStackAZTest) Setup(t *testing.T) {
+	t.Log("Starting test OpenStackAZTest")
+
+	if globalOpts.Platform != hyperv1.OpenStackPlatform {
+		t.Skip("test only supported on platform OpenStack")
+	}
+}
+
+func (o OpenStackAZTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []corev1.Node) {
+	np := &hyperv1.NodePool{}
+	e2eutil.EventuallyObject(t, o.ctx, "NodePool to have availability zone configured",
+		func(ctx context.Context) (*hyperv1.NodePool, error) {
+			err := o.managementClient.Get(ctx, util.ObjectKey(&nodePool), np)
+			return np, err
+		},
+		[]e2eutil.Predicate[*hyperv1.NodePool]{
+			func(nodePool *hyperv1.NodePool) (done bool, reasons string, err error) {
+				want, got := hyperv1.OpenStackPlatform, nodePool.Spec.Platform.Type
+				return want == got, fmt.Sprintf("expected NodePool to have platform %s, got %s", want, got), nil
+			},
+			func(pool *hyperv1.NodePool) (done bool, reasons string, err error) {
+				diff := cmp.Diff(defaultAvailabilityZone, ptr.Deref(np.Spec.Platform.OpenStack, hyperv1.OpenStackNodePoolPlatform{}).AvailabilityZone)
+				return diff == "", fmt.Sprintf("incorrect availability zone: %v", diff), nil
+			},
+		},
+	)
+
+	e2eutil.EventuallyObjects(t, o.ctx, "CAPI Machines to be created with the correct availability zone",
+		func(ctx context.Context) ([]*capiv1.Machine, error) {
+			list := &capiv1.MachineList{}
+			err := o.managementClient.List(ctx, list, crclient.InNamespace(o.hostedControlPlaneNamespace), crclient.MatchingLabels{capiv1.MachineDeploymentNameLabel: nodePool.Name})
+			oms := make([]*capiv1.Machine, len(list.Items))
+			for i := range list.Items {
+				oms[i] = &list.Items[i]
+			}
+			return oms, err
+		},
+		[]e2eutil.Predicate[[]*capiv1.Machine]{
+			func(machines []*capiv1.Machine) (done bool, reasons string, err error) {
+				return len(machines) == int(*nodePool.Spec.Replicas), fmt.Sprintf("expected %d Machines, got %d", *nodePool.Spec.Replicas, len(machines)), nil
+			},
+		},
+		[]e2eutil.Predicate[*capiv1.Machine]{
+			func(machine *capiv1.Machine) (done bool, reasons string, err error) {
+				if machine.Spec.FailureDomain == nil {
+					return false, "Machine does not have a failure domain", nil
+				}
+				want, got := defaultAvailabilityZone, *machine.Spec.FailureDomain
+				return want == got, fmt.Sprintf("expected Machine to have failure domain %s, got %s", want, got), nil
+			},
+		},
+	)
+}
+
+func (o OpenStackAZTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.hostedCluster.Name + "-" + "test-osp-az",
+			Namespace: o.hostedCluster.Namespace,
+		},
+	}
+	defaultNodepool.Spec.DeepCopyInto(&nodePool.Spec)
+
+	nodePool.Spec.Replicas = &oneReplicas
+	nodePool.Spec.Platform.OpenStack.AvailabilityZone = defaultAvailabilityZone
+	return nodePool, nil
+}
+
+func (o OpenStackAZTest) SetupInfra(t *testing.T) error {
+	return nil
+}
+
+func (o OpenStackAZTest) TeardownInfra(t *testing.T) error {
+	return nil
+}

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -117,6 +117,10 @@ func TestNodePool(t *testing.T) {
 						name: "TestNodePoolPrevReleaseN2",
 						test: NewNodePoolPrevReleaseCreateTest(hostedCluster, globalOpts.n2MinorReleaseImage, clusterOpts),
 					},
+					{
+						name: "OpenStackAZTest",
+						test: NewOpenStackAZTest(ctx, mgtClient, hostedCluster),
+					},
 				}
 			},
 		},

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
@@ -12,6 +12,19 @@ type OpenStackNodePoolPlatform struct {
 	//
 	// +optional
 	ImageName string `json:"imageName,omitempty"`
+
+	// availabilityZone is the nova availability zone in which the provider will create the VM.
+	// If not specified, the VM will be created in the default availability zone specified in the nova configuration.
+	// Availability zone names must NOT contain : since it is used by admin users to specify hosts where instances
+	// are launched in server creation. Also, it must not contain spaces otherwise it will lead to node that belongs
+	// to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for further information.
+	// The maximum length of availability zone name is 63 as per labels limits.
+	//
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[^: ]*$`
+	// +kubebuilder:validation:MaxLength=63
+	// +optional
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 }
 
 // OpenStackPlatformSpec specifies configuration for clusters running on OpenStack.


### PR DESCRIPTION
**What this PR does / why we need it**:

In OpenStack NodePools, add the AZ option which will configure the Machine spec with the failure domain.
We need it because customers sometimes want to deploy their Nodepools in a given availability zone (e.g. east-1, west-1, etc). This patch enables that.