### PR TITLE
NO-JIRA: add docker script to find package versions in HO & CPO

### DIFF
--- a/contrib/snyk/READ_ME.md
+++ b/contrib/snyk/READ_ME.md
@@ -1,11 +1,17 @@
 # General
+This directory contains scripts to help with snyk duty. The scripts are written in bash.
+1. `check-for-cve-in-ho.sh` - This script returns versions of packages for the specified package in the specified HO image. Uses Podman.
+2. `check-for-cve-in-cpo.sh` - This script returns versions of packages for the specified package in the specified CPO image. Uses Podman.
+3. `check-for-cve.sh` - This script returns versions of the specified package for the latest HO image and the latest nightly CPO image for 4.14-4.18. Uses Docker.
+
+## Podman
 This script was created to quickly look for relevant CVEs in either the HO or CPO in a release image during snyk duty. To run this locally:
 
 1. Update the PULL_SECRETS_FILE env var as necessary in `check-for-cve-in-ho.sh` and `check-for-cve-in-cpo.sh`
 2. Run this commands below in your terminal passing in the search strings like `'wget,cpython,gnutls,glib'` with no spaces
    1. For the example below, I was looking for `wget or cpython or gnutls or glib` in the CPO image of a 4.16 release image
 
-## HO Example
+### HO Example
 For the example below, I was looking for `wget or cpython or gnutls or glib` in the HO image
 
 ```
@@ -20,7 +26,7 @@ glib2-2.68.4-14.el9.aarch64
 json-glib-1.6.6-1.el9.aarch64
 ```
 
-## CPO Example
+### CPO Example
 For the example below, I was looking for `wget or cpython or gnutls or glib` in the CPO image of a 4.16 release image
 
 ```
@@ -36,4 +42,47 @@ glibc-langpack-en-2.34-60.el9_2.14.aarch64
 gnutls-3.7.6-21.el9_2.3.aarch64
 wget-1.21.1-7.el9.aarch64
 ```
+
+## Docker
+
+### HO + CPO example
+To run this locally you will need to have Docker installed and running. You will also need to have the `PULL_SECRET` env var set to the contents of your pull secret file. Example of a serach for the `krb5` package is shown below:
+```
+PULL_SECRET=$PULL_SECRET /bin/bash /Users/pstefans/GitHub/openshift/hypershift/contrib/snyk/check-for-cve.sh krb5
+
+===== Searching HO Image =====
+quay.io/acm-d/rhtap-hypershift-operator:latest
+Image: quay.io/acm-d/rhtap-hypershift-operator:latest
+krb5-libs-1.21.1-1.el9.aarch64
+=============================================
+
+===== Searching CPO Image Version 4.14 =====
+Image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31ec47fa526b27e9073468c273bee662fabc11c576e2b16955f96d1ca3df22c2
+quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31ec47fa526b27e9073468c273bee662fabc11c576e2b16955f96d1ca3df22c2
+krb5-libs-1.18.2-28.el8_10.x86_64
+=============================================
+
+===== Searching CPO Image Version 4.15 =====
+Image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9be692cbde55532fe89fc4e45ade123959c2f09c12d8b6f2274e6be18e815fcd
+quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9be692cbde55532fe89fc4e45ade123959c2f09c12d8b6f2274e6be18e815fcd
+krb5-libs-1.20.1-9.el9_2.x86_64
+=============================================
+
+===== Searching CPO Image Version 4.16 =====
+Image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aaf20d8da39383e8e31677368c1d89f938c56d4f4e70cb0a51172d650604e45d
+quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aaf20d8da39383e8e31677368c1d89f938c56d4f4e70cb0a51172d650604e45d
+krb5-libs-1.20.1-9.el9_2.x86_64
+=============================================
+
+===== Searching CPO Image Version 4.17 =====
+Image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e50f438a9b6a4e6881eda977a4e4293d414b3f2abb5249837575fc30942c36fa
+quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e50f438a9b6a4e6881eda977a4e4293d414b3f2abb5249837575fc30942c36fa
+krb5-libs-1.21.1-1.el9.x86_64
+=============================================
+
+Search completed.
+```
+
+
+
 

--- a/contrib/snyk/check-for-cve.sh
+++ b/contrib/snyk/check-for-cve.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+search_image() {
+    local version=$1
+    local image_to_check
+    local hypershift_image
+
+    echo -e "\n===== Searching CPO Image Version ${version} ====="
+    image_to_check=$(curl -q "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/${version}.0-0.nightly/latest?rel=1" 2>/dev/null | jq -r .pullSpec 2>/dev/null)
+    hypershift_image=$(oc adm release info "${image_to_check}" -a "${PULL_SECRETS_FILE}" --pullspecs | grep hypershift | awk '{print $2}')
+
+    if [[ -n "${hypershift_image}" ]]; then
+        echo "Image: ${hypershift_image}"
+        docker pull "${hypershift_image}" --quiet
+        docker run -it --entrypoint=sh "${hypershift_image}" -c "${SHELL_CMD}" 2>/dev/null
+    else
+        echo "Failed to retrieve hypershift image for version ${version}"
+    fi
+    echo "============================================="
+}
+
+PULL_SECRETS_FILE=${PULL_SECRET:-$HOME/pull-secret.txt}
+
+SEARCH_TERMS=$1
+GREP_PATTERN=$(echo "${SEARCH_TERMS}" | tr ',' '|')
+SHELL_CMD="rpm -qa | grep -Ei '${GREP_PATTERN}'"
+
+if [[ -z "${SEARCH_TERMS}" ]]; then
+    echo "Error: SEARCH_TERMS is required."
+    exit 1
+fi
+
+echo -e "\n===== Searching HO Image ====="
+docker pull quay.io/acm-d/rhtap-hypershift-operator:latest --quiet
+echo "Image: quay.io/acm-d/rhtap-hypershift-operator:latest"
+docker run -it --entrypoint=sh quay.io/acm-d/rhtap-hypershift-operator:latest -c "${SHELL_CMD}" 2>/dev/null
+echo "============================================="
+
+for version in 4.14 4.15 4.16 4.17 4.18; do
+    search_image "${version}"
+done
+
+echo -e "\nSearch completed."


### PR DESCRIPTION
**What this PR does / why we need it**: script that can be used to retrieve the package versions for HO and CPO using docker without having to provide images. Uses latest nightlies for CPO and latest HO build from rhtap.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

sample output 
```
➜  hypershift git:(pstefans-add-cve-script) PULL_SECRET=$PULL_SECRET /bin/bash /Users/pstefans/GitHub/openshift/hypershift/contrib/snyk/check-for-cve.sh krb5

===== Searching HO Image =====
quay.io/acm-d/rhtap-hypershift-operator:latest
Image: quay.io/acm-d/rhtap-hypershift-operator:latest
krb5-libs-1.21.1-1.el9.aarch64
=============================================

===== Searching CPO Image Version 4.14 =====
Image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31ec47fa526b27e9073468c273bee662fabc11c576e2b16955f96d1ca3df22c2
quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31ec47fa526b27e9073468c273bee662fabc11c576e2b16955f96d1ca3df22c2
krb5-libs-1.18.2-28.el8_10.x86_64
=============================================

===== Searching CPO Image Version 4.15 =====
Image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9be692cbde55532fe89fc4e45ade123959c2f09c12d8b6f2274e6be18e815fcd
quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9be692cbde55532fe89fc4e45ade123959c2f09c12d8b6f2274e6be18e815fcd
krb5-libs-1.20.1-9.el9_2.x86_64
=============================================

===== Searching CPO Image Version 4.16 =====
Image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aaf20d8da39383e8e31677368c1d89f938c56d4f4e70cb0a51172d650604e45d
quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aaf20d8da39383e8e31677368c1d89f938c56d4f4e70cb0a51172d650604e45d
krb5-libs-1.20.1-9.el9_2.x86_64
=============================================

===== Searching CPO Image Version 4.17 =====
Image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e50f438a9b6a4e6881eda977a4e4293d414b3f2abb5249837575fc30942c36fa
quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e50f438a9b6a4e6881eda977a4e4293d414b3f2abb5249837575fc30942c36fa
krb5-libs-1.21.1-1.el9.x86_64
=============================================

Search completed.
```

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.