### PR TITLE
OCPBUGS-39525: Fix uses of MustParse* on non-constant input

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -207,7 +207,11 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 	cluster.Spec.IssuerURL = o.iamInfo.IssuerURL
 
 	if o.infra.MachineCIDR != "" {
-		cluster.Spec.Networking.MachineNetwork = []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR(o.infra.MachineCIDR)}}
+		cidr, err := ipnet.ParseCIDR(o.infra.MachineCIDR)
+		if err != nil {
+			return fmt.Errorf("parsing MachineCIDR (%s): %w", o.infra.MachineCIDR, err)
+		}
+		cluster.Spec.Networking.MachineNetwork = []hyperv1.MachineNetworkEntry{{CIDR: *cidr}}
 	}
 
 	var baseDomainPrefix *string

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -368,13 +368,21 @@ func prototypeResources(opts *CreateOptions) (*resources, error) {
 
 	var clusterNetworkEntries []hyperv1.ClusterNetworkEntry
 	for _, cidr := range opts.ClusterCIDR {
-		clusterNetworkEntries = append(clusterNetworkEntries, hyperv1.ClusterNetworkEntry{CIDR: *ipnet.MustParseCIDR(cidr)})
+		parsedCIDR, err := ipnet.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("parsing ClusterCIDR (%s): %w", cidr, err)
+		}
+		clusterNetworkEntries = append(clusterNetworkEntries, hyperv1.ClusterNetworkEntry{CIDR: *parsedCIDR})
 	}
 	prototype.Cluster.Spec.Networking.ClusterNetwork = clusterNetworkEntries
 
 	var serviceNetworkEntries []hyperv1.ServiceNetworkEntry
 	for _, cidr := range opts.ServiceCIDR {
-		serviceNetworkEntries = append(serviceNetworkEntries, hyperv1.ServiceNetworkEntry{CIDR: *ipnet.MustParseCIDR(cidr)})
+		parsedCIDR, err := ipnet.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("parsing ServiceCIDR (%s): %w", cidr, err)
+		}
+		serviceNetworkEntries = append(serviceNetworkEntries, hyperv1.ServiceNetworkEntry{CIDR: *parsedCIDR})
 	}
 	prototype.Cluster.Spec.Networking.ServiceNetwork = serviceNetworkEntries
 

--- a/cmd/nodepool/kubevirt/create.go
+++ b/cmd/nodepool/kubevirt/create.go
@@ -291,7 +291,8 @@ func (o *KubevirtPlatformCreateOptions) NodePoolPlatform() *hyperv1.KubevirtNode
 	}
 
 	if o.Memory != "" {
-		memory := apiresource.MustParse(o.Memory)
+		// TODO: add a debug trace for this error
+		memory, _ := apiresource.ParseQuantity(o.Memory)
 		platform.Compute.Memory = &memory
 	}
 	if o.Cores != 0 {

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -448,7 +448,11 @@ kubectl --kubeconfig $kc config use-context default`,
 		},
 	}
 
-	if semver.MustParse(params.ReleaseVersion).Minor == uint64(12) {
+	parsedReleaseVersion, err := semver.Parse(params.ReleaseVersion)
+	if err != nil {
+		return fmt.Errorf("parsing ReleaseVersion (%s): %w", params.ReleaseVersion, err)
+	}
+	if parsedReleaseVersion.Minor == uint64(12) {
 		dep.Spec.Template.Spec.InitContainers = append(dep.Spec.Template.Spec.InitContainers, corev1.Container{
 			Command: []string{"/bin/bash"},
 			Args: []string{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
@@ -115,7 +115,11 @@ func (r *reconciler) reconcileKubevirtPassthroughService(ctx context.Context, hc
 
 	for _, machineAddress := range machine.Status.Addresses {
 		if machineAddress.Type == capiv1.MachineInternalIP {
-			if netip.MustParseAddr(machineAddress.Address).Is4() {
+			parsedAddr, err := netip.ParseAddr(machineAddress.Address)
+			if err != nil {
+				return fmt.Errorf("parsing machine address (%s) in machine %s: %w", machineAddress.Address, machine.Name, err)
+			}
+			if parsedAddr.Is4() {
 				ipv4MachineAddresses = append(ipv4MachineAddresses, machineAddress.Address)
 			} else {
 				ipv6MachineAddresses = append(ipv6MachineAddresses, machineAddress.Address)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -2962,7 +2962,7 @@ func TestFindAdvertiseAddress(t *testing.T) {
 			avdAddress, err := findAdvertiseAddress(hc)
 			if tt.wantErr {
 				g.Expect(err).To(Not(BeNil()))
-				g.Expect(avdAddress).To(BeEmpty())
+				g.Expect(avdAddress).To(BeZero())
 			} else {
 				g.Expect(avdAddress.String()).To(Equal(tt.resultAdvAddress))
 			}

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -581,11 +581,15 @@ func reconcileVirtLauncherNetworkPolicy(policy *networkingv1.NetworkPolicy, hclu
 		} else {
 			return fmt.Errorf("could not determine if %s is an IPv4 or IPv6 address", nodeAddress)
 		}
+		parsedNodeAddress, err := netip.ParseAddr(nodeAddress)
+		if err != nil {
+			return fmt.Errorf("parsing nodeport address (%s) from service %s: %w", nodeAddress, hcService.Service, err)
+		}
 		policy.Spec.Egress = append(policy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
 			To: []networkingv1.NetworkPolicyPeer{
 				{
 					IPBlock: &networkingv1.IPBlock{
-						CIDR: netip.PrefixFrom(netip.MustParseAddr(nodeAddress), prefixLength).String(),
+						CIDR: netip.PrefixFrom(parsedNodeAddress, prefixLength).String(),
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR systematically replaces all uses of MustParse functions with non-constant input with their Parse equivalent, except in one case where the containing function does not have an error return. We add a warning comment there instead.

2 of these in particular may allow a user who is able to create a HostedCluster to cause the HostedCluster controller to panic-loop. Specifically the following 2 fields are not validated by the API server on admission, and are parsed with MustParse:

* HostedCluster.Spec.Networking.APIServer.AdvertiseAddress
* HostedCluster.Spec.Networking.ClusterNetwork.CIDR

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.