### PR TITLE
HOSTEDCP-1475: Remove hard-coded konnectivity agenty image URI

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -51,7 +51,6 @@ import (
 const (
 	defaultReleaseVersion    = "0.0.1-snapshot"
 	defaultKubernetesVersion = "0.0.1-snapshot-kubernetes"
-	konnectivityAgentImage   = "registry.ci.openshift.org/hypershift/apiserver-network-proxy:latest"
 )
 
 func NewCommand() *cobra.Command {
@@ -253,9 +252,6 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 				Delegate: &releaseinfo.CachedProvider{
 					Inner: &releaseinfo.RegistryClientProvider{},
 					Cache: map[string]*releaseinfo.ReleaseImage{},
-				},
-				ComponentImages: map[string]string{
-					"konnectivity-agent": konnectivityAgentImage,
 				},
 			},
 			RegistryOverrides: o.registryOverrides,


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the hard-coded connectivity agent image URI.

The URI points to a non-existing image and isn't used anymore. 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

Fixes [HOSTEDCP-1475](https://issues.redhat.com/browse/HOSTEDCP-1475)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.