### PR TITLE
CONSOLE-3952: Add networking-console-plugin image to CNO as an env var

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -53,6 +53,7 @@ type Images struct {
 	NetworkMetricsDaemon         string
 	NetworkCheckSource           string
 	NetworkCheckTarget           string
+	NetworkingConsolePlugin      string
 	CloudNetworkConfigController string
 	TokenMinter                  string
 	CLI                          string
@@ -94,6 +95,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 			NetworkMetricsDaemon:         userReleaseImageProvider.GetImage("network-metrics-daemon"),
 			NetworkCheckSource:           userReleaseImageProvider.GetImage("cluster-network-operator"),
 			NetworkCheckTarget:           userReleaseImageProvider.GetImage("cluster-network-operator"),
+			NetworkingConsolePlugin:      userReleaseImageProvider.GetImage("networking-console-plugin"),
 			CloudNetworkConfigController: releaseImageProvider.GetImage("cloud-network-config-controller"),
 			TokenMinter:                  releaseImageProvider.GetImage("token-minter"),
 			CLI:                          releaseImageProvider.GetImage("cli"),
@@ -515,6 +517,7 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 			{Name: "NETWORK_METRICS_DAEMON_IMAGE", Value: params.Images.NetworkMetricsDaemon},
 			{Name: "NETWORK_CHECK_SOURCE_IMAGE", Value: params.Images.NetworkCheckSource},
 			{Name: "NETWORK_CHECK_TARGET_IMAGE", Value: params.Images.NetworkCheckTarget},
+			{Name: "NETWORKING_CONSOLE_PLUGIN_IMAGE", Value: params.Images.NetworkingConsolePlugin},
 			{Name: "CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE", Value: params.Images.CloudNetworkConfigController},
 			{Name: "TOKEN_MINTER_IMAGE", Value: params.Images.TokenMinter},
 			{Name: "CLI_IMAGE", Value: params.Images.CLI},

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -79,6 +79,7 @@ spec:
         - name: NETWORK_METRICS_DAEMON_IMAGE
         - name: NETWORK_CHECK_SOURCE_IMAGE
         - name: NETWORK_CHECK_TARGET_IMAGE
+        - name: NETWORKING_CONSOLE_PLUGIN_IMAGE
         - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
         - name: TOKEN_MINTER_IMAGE
         - name: CLI_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -79,6 +79,7 @@ spec:
         - name: NETWORK_METRICS_DAEMON_IMAGE
         - name: NETWORK_CHECK_SOURCE_IMAGE
         - name: NETWORK_CHECK_TARGET_IMAGE
+        - name: NETWORKING_CONSOLE_PLUGIN_IMAGE
         - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
         - name: TOKEN_MINTER_IMAGE
         - name: CLI_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -77,6 +77,7 @@ spec:
         - name: NETWORK_METRICS_DAEMON_IMAGE
         - name: NETWORK_CHECK_SOURCE_IMAGE
         - name: NETWORK_CHECK_TARGET_IMAGE
+        - name: NETWORKING_CONSOLE_PLUGIN_IMAGE
         - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
         - name: TOKEN_MINTER_IMAGE
         - name: CLI_IMAGE


### PR DESCRIPTION
cluster-network-operator will start deploying a new console plugin for the Networking section in the OCP UI. in order to maintain compitability with hypershift guest clusters, the hosted CNO will also have to do that. for CNO to be able to access the networking console plugin image, it will need to fetch it from the OCP release payload, that is being added at https://github.com/openshift/cluster-network-operator/pull/2332.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.