### PR TITLE
OCPBUGS-37052: HTTPS proxy: do not proxy communication to cloud providers

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -209,6 +209,7 @@ func ingressOperatorKonnectivityProxyContainer(proxyImage string, proxyConfig *c
 		Command: []string{"/usr/bin/control-plane-operator", "konnectivity-https-proxy"},
 		Args: []string{
 			"run",
+			"--connect-directly-to-cloud-apis",
 		},
 		Env: []corev1.EnvVar{{
 			Name:  "KUBECONFIG",
@@ -231,6 +232,7 @@ func ingressOperatorKonnectivityProxyContainer(proxyImage string, proxyConfig *c
 		c.Args = append(c.Args, "--https-proxy", proxyConfig.HTTPSProxy)
 		c.Args = append(c.Args, "--no-proxy", noProxy)
 	}
+	proxy.SetEnvVars(&c.Env)
 	return c
 }
 

--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -54,6 +54,8 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&httpsProxyURL, "https-proxy", "", "HTTPS proxy to use on hosted cluster requests")
 	cmd.Flags().StringVar(&noProxy, "no-proxy", "", "URLs that should not use the provided http-proxy and https-proxy")
 
+	cmd.Flags().BoolVar(&opts.ConnectDirectlyToCloudAPIs, "connect-directly-to-cloud-apis", false, "If true, bypass konnectivity to connect to cloud APIs while still honoring management proxy config")
+
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		l.Info("Starting proxy", "version", version.String())
 		c, err := client.New(ctrl.GetConfigOrDie(), client.Options{})


### PR DESCRIPTION
**What this PR does / why we need it**:
The dialer that the https proxy was creating was not configured by
default to talk directly to cloud provider endpoints. This was
preventing the ingress operator from successfully tearing down hosted
clusters.

This commit configures the konnectivity-https-proxy to talk directly
to cloud api endpoints for the ingress operator and adds proxy env
variables if they exist.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-37052](https://issues.redhat.com/browse/OCPBUGS-37052)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.