### PR TITLE
OCPBUGS-38739: [Azure] Use infraID from infra-json if provided

### DIFF
--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -189,6 +189,8 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 		PrivateZoneID: o.infra.PrivateZoneID,
 	}
 
+	cluster.Spec.InfraID = o.infra.InfraID
+
 	cluster.Spec.Platform = hyperv1.PlatformSpec{
 		Type: hyperv1.AzurePlatform,
 		Azure: &hyperv1.AzurePlatformSpec{

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -39,7 +39,7 @@ spec:
         type: PersistentVolume
     managementType: Managed
   fips: false
-  infraID: bryans-cluster-f9nvz
+  infraID: fakeInfraID
   networking:
     clusterNetwork:
     - cidr: 10.132.0.0/14

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
@@ -28,7 +28,7 @@ spec:
         type: PersistentVolume
     managementType: Managed
   fips: false
-  infraID: bryans-cluster-mbm2m
+  infraID: fakeInfraID
   networking:
     clusterNetwork:
     - cidr: 10.132.0.0/14

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -39,7 +39,7 @@ spec:
         type: PersistentVolume
     managementType: Managed
   fips: false
-  infraID: example-sffhb
+  infraID: fakeInfraID
   networking:
     clusterNetwork:
     - cidr: 10.132.0.0/14

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -96,7 +96,6 @@ func NewCreateCommand() *cobra.Command {
 	_ = cmd.MarkFlagRequired("infra-id")
 	_ = cmd.MarkFlagRequired("azure-creds")
 	_ = cmd.MarkFlagRequired("name")
-	_ = cmd.MarkFlagRequired("rhcos-image")
 
 	l := log.Log
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
We should be using the infraID from the infra-json file if it is present.

Also, the --rhcos-image flag is not required, for example, when using an Azure marketplace image.





