### PR TITLE
OSASINFRA-3572: WIP: handle DNS record for Ingress for OpenStack on AWS

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
@@ -37,7 +37,7 @@ func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 	}
 	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.Ingress != nil && hcp.Spec.Configuration.Ingress.LoadBalancer.Platform.AWS != nil {
 		nlb = hcp.Spec.Configuration.Ingress.LoadBalancer.Platform.AWS.Type == configv1.NLB
-		if hcp.Spec.Platform.AWS.EndpointAccess == hyperv1.Private {
+		if hcp.Spec.Platform.AWS != nil && hcp.Spec.Platform.AWS.EndpointAccess == hyperv1.Private {
 			loadBalancerScope = v1.InternalLoadBalancer
 		}
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -56,6 +56,22 @@ func ReconcileDefaultIngressController(ingressController *operatorv1.IngressCont
 		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
 			Name: manifests.IngressDefaultIngressControllerCert().Name,
 		}
+	case hyperv1.OpenStackPlatform:
+		if useNLB {
+			ingressController.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
+				Scope: loadBalancerScope,
+				ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
+					Type: operatorv1.AWSLoadBalancerProvider,
+					AWS: &operatorv1.AWSLoadBalancerParameters{
+						Type:                          operatorv1.AWSNetworkLoadBalancer,
+						NetworkLoadBalancerParameters: &operatorv1.AWSNetworkLoadBalancerParameters{},
+					},
+				},
+			}
+		}
+		ingressController.Spec.DefaultCertificate = &corev1.LocalObjectReference{
+			Name: manifests.IngressDefaultIngressControllerCert().Name,
+		}
 	case hyperv1.IBMCloudPlatform:
 		if isIBMCloudUPI {
 			ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
@@ -44,6 +44,15 @@ func IngressDefaultIngressOctaviaService() *corev1.Service {
 	}
 }
 
+// func IngressDefaultRouterService() *corev1.Service {
+// 	return &corev1.Service{
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:      "router-default",
+// 			Namespace: "openshift-ingress",
+// 		},
+// 	}
+// }
+
 const IngressDefaultIngressPassthroughServiceName = "default-ingress-passthrough-service"
 
 func IngressDefaultIngressPassthroughService(namespace string) *corev1.Service {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -72,7 +72,6 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
-	"github.com/openshift/hypershift/support/openstackutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
@@ -946,24 +945,42 @@ func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv
 		}
 	}
 
-	if hcp.Spec.Platform.Type == hyperv1.OpenStackPlatform {
-		ingressFloatingIP := hcp.Spec.Platform.OpenStack.IngressFloatingIP
-		ingressProvider := hcp.Spec.Platform.OpenStack.IngressProvider
-		if err := openstackutil.ValidateIngressOptions(ingressProvider, ingressFloatingIP); err != nil {
-			errs = append(errs, err)
-			return errors.NewAggregate(errs)
-		}
+	// if hcp.Spec.Platform.Type == hyperv1.OpenStackPlatform {
+	// 	ingressFloatingIP := hcp.Spec.Platform.OpenStack.IngressFloatingIP
+	// 	ingressProvider := hcp.Spec.Platform.OpenStack.IngressProvider
+	// 	if err := openstackutil.ValidateIngressOptions(ingressProvider, ingressFloatingIP); err != nil {
+	// 		errs = append(errs, err)
+	// 		return errors.NewAggregate(errs)
+	// 	}
 
-		// At this point validations have passed, so we can proceed with the reconciliation
-		if ingressProvider == hyperv1.OpenStackIngressProviderOctavia {
-			ingressDefaultIngressOctaviaService := manifests.IngressDefaultIngressOctaviaService()
-			if _, err := r.CreateOrUpdate(ctx, r.client, ingressDefaultIngressOctaviaService, func() error {
-				return ingress.ReconcileDefaultIngressOctaviaService(ingressDefaultIngressOctaviaService, ingressFloatingIP)
-			}); err != nil {
-				errs = append(errs, fmt.Errorf("failed to reconcile default ingress octavia service: %w", err))
-			}
-		}
-	}
+	// 	// At this point validations have passed, so we can proceed with the reconciliation
+	// 	if ingressProvider == hyperv1.OpenStackIngressProviderOctavia {
+	// 		ingressDefaultIngressOctaviaService := manifests.IngressDefaultIngressOctaviaService()
+	// 		if _, err := r.CreateOrUpdate(ctx, r.client, ingressDefaultIngressOctaviaService, func() error {
+	// 			return ingress.ReconcileDefaultIngressOctaviaService(ingressDefaultIngressOctaviaService, ingressFloatingIP)
+	// 		}); err != nil {
+	// 			errs = append(errs, fmt.Errorf("failed to reconcile default ingress octavia service: %w", err))
+	// 		}
+	// 	} else if hcp.Annotations[hyperv1.ManagementPlatformAnnotation] == string(hyperv1.AWSPlatform) {
+	// 		// This case is mainly for CI where the management cluster runs on AWS and the hosted cluster runs on OpenStack
+	// 		var externalIP string
+	// 		ingressDefaultRouterService := manifests.IngressDefaultRouterService()
+	// 		if err := r.client.Get(ctx, client.ObjectKeyFromObject(ingressDefaultRouterService), ingressDefaultRouterService); err != nil {
+	// 			if apierrors.IsNotFound(err) {
+	// 				errs = append(errs, fmt.Errorf("router-default service not found: %w", err))
+	// 			} else {
+	// 				errs = append(errs, fmt.Errorf("failed to get router-default service: %w", err))
+	// 			}
+	// 		}
+	// 		if ingressDefaultRouterService != nil && len(ingressDefaultRouterService.Status.LoadBalancer.Ingress) > 0 {
+	// 			externalIP = ingressDefaultRouterService.Status.LoadBalancer.Ingress[0].IP
+	// 		}
+	// 		if externalIP == "" {
+	// 			errs = append(errs, fmt.Errorf("external IP not found for router-default service"))
+	// 		}
+	// 		// TODO: now if externalIP is not empty, create the DNS record on the management cluster.
+	// 	}
+	// }
 
 	// Default Ingress is passed through as a subdomain of the infra/mgmt cluster
 	// for KubeVirt when the base domain passthrough feature is in use.

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -238,7 +238,7 @@ func (h *hypershiftTest) createHostedCluster(opts *PlatformAgnosticOptions, plat
 				v.Spec.ServiceAccountSigningKey = &corev1.LocalObjectReference{
 					Name: serviceAccountSigningKeySecret.Name,
 				}
-				if platform == hyperv1.AWSPlatform {
+				if platform == hyperv1.AWSPlatform || platform == hyperv1.OpenStackPlatform {
 					if v.Spec.Configuration == nil {
 						v.Spec.Configuration = &hyperv1.ClusterConfiguration{}
 					}


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve CI workflow where we'll be able to run multiple clusters at the same time leveraging the external DNS operator for the Ingress DNS records.
