### PR TITLE
OSASINFRA-3572: e2e/openstack: handle DNS for ingress using route53

### DIFF
--- a/cmd/infra/aws/route53.go
+++ b/cmd/infra/aws/route53.go
@@ -18,7 +18,7 @@ import (
 
 func (o *CreateInfraOptions) LookupPublicZone(ctx context.Context, logger logr.Logger, client route53iface.Route53API) (string, error) {
 	name := o.BaseDomain
-	id, err := lookupZone(ctx, client, name, false)
+	id, err := LookupZone(ctx, client, name, false)
 	if err != nil {
 		logger.Error(err, "Public zone not found", "name", name)
 		return "", err
@@ -27,7 +27,7 @@ func (o *CreateInfraOptions) LookupPublicZone(ctx context.Context, logger logr.L
 	return id, nil
 }
 
-func lookupZone(ctx context.Context, client route53iface.Route53API, name string, isPrivateZone bool) (string, error) {
+func LookupZone(ctx context.Context, client route53iface.Route53API, name string, isPrivateZone bool) (string, error) {
 	var res *route53.HostedZone
 	f := func(resp *route53.ListHostedZonesOutput, lastPage bool) (shouldContinue bool) {
 		for idx, zone := range resp.HostedZones {
@@ -53,7 +53,7 @@ func lookupZone(ctx context.Context, client route53iface.Route53API, name string
 }
 
 func (o *CreateInfraOptions) CreatePrivateZone(ctx context.Context, logger logr.Logger, client route53iface.Route53API, name, vpcID string) (string, error) {
-	id, err := lookupZone(ctx, client, name, true)
+	id, err := LookupZone(ctx, client, name, true)
 	if err == nil {
 		logger.Info("Found existing private zone", "name", name, "id", id)
 		err := setSOAMinimum(ctx, client, id, name)
@@ -128,7 +128,7 @@ func (o *DestroyInfraOptions) DestroyPrivateZones(ctx context.Context, client ro
 
 func (o *DestroyInfraOptions) CleanupPublicZone(ctx context.Context, client route53iface.Route53API) error {
 	name := o.BaseDomain
-	id, err := lookupZone(ctx, client, name, false)
+	id, err := LookupZone(ctx, client, name, false)
 	if err != nil {
 		return nil
 	}

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -577,7 +577,7 @@ func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointService(ctx context.C
 	for _, recordName := range recordNames {
 		fqdn := fmt.Sprintf("%s.%s", recordName, zoneName)
 		fqdns = append(fqdns, fqdn)
-		err = createRecord(ctx, route53Client, zoneID, fqdn, *(endpointDNSEntries[0].DnsName))
+		err = CreateRecord(ctx, route53Client, zoneID, fqdn, *(endpointDNSEntries[0].DnsName), "CNAME")
 		if err != nil {
 			return err
 		}
@@ -751,7 +751,7 @@ func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointSe
 
 	for _, fqdn := range awsEndpointService.Status.DNSNames {
 		if fqdn != "" && zoneID != "" {
-			record, err := findRecord(ctx, route53Client, zoneID, fqdn)
+			record, err := FindRecord(ctx, route53Client, zoneID, fqdn, "CNAME")
 			if err != nil {
 				if awsErr, ok := err.(awserr.Error); ok {
 					if awsErr.Code() == route53.ErrCodeNoSuchHostedZone {
@@ -763,7 +763,7 @@ func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointSe
 				return false, err
 			}
 			if record != nil {
-				err = deleteRecord(ctx, route53Client, zoneID, record)
+				err = DeleteRecord(ctx, route53Client, zoneID, record)
 				if err != nil {
 					return false, err
 				}

--- a/control-plane-operator/controllers/awsprivatelink/route53.go
+++ b/control-plane-operator/controllers/awsprivatelink/route53.go
@@ -33,10 +33,10 @@ func lookupZoneID(ctx context.Context, client route53iface.Route53API, name stri
 	return cleanZoneID(*res.Id), nil
 }
 
-func createRecord(ctx context.Context, client route53iface.Route53API, zondID, name, value string) error {
+func CreateRecord(ctx context.Context, client route53iface.Route53API, zondID, name, value, recordType string) error {
 	record := &route53.ResourceRecordSet{
 		Name: aws.String(name),
-		Type: aws.String("CNAME"),
+		Type: aws.String(recordType),
 		TTL:  aws.Int64(300),
 		ResourceRecords: []*route53.ResourceRecord{
 			{
@@ -88,9 +88,8 @@ func fqdn(name string) string {
 	}
 }
 
-func findRecord(ctx context.Context, client route53iface.Route53API, id, name string) (*route53.ResourceRecordSet, error) {
+func FindRecord(ctx context.Context, client route53iface.Route53API, id, name, recordType string) (*route53.ResourceRecordSet, error) {
 	recordName := fqdn(strings.ToLower(name))
-	recordType := "CNAME"
 	input := &route53.ListResourceRecordSetsInput{
 		HostedZoneId:    aws.String(id),
 		StartRecordName: aws.String(recordName),
@@ -125,7 +124,7 @@ func findRecord(ctx context.Context, client route53iface.Route53API, id, name st
 	return record, nil
 }
 
-func deleteRecord(ctx context.Context, client route53iface.Route53API, id string, record *route53.ResourceRecordSet) error {
+func DeleteRecord(ctx context.Context, client route53iface.Route53API, id string, record *route53.ResourceRecordSet) error {
 	changeBatch := &route53.ChangeBatch{
 		Changes: []*route53.Change{
 			{

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -257,25 +257,11 @@ func (h *hypershiftTest) createHostedCluster(opts *PlatformAgnosticOptions, plat
 		}
 	}
 
-	// case platform specific options
-	var clusterName string
-	switch platform {
-	case hyperv1.OpenStackPlatform:
-		// On some platforms (OpenStack), the cluster name can be pre-set in the environment
-		// so the DNS record for Ingress can be created with the correct name prior to cluster creation.
-		clusterName = os.Getenv("CLUSTER_NAME")
-		if clusterName == "" {
-			clusterName = SimpleNameGenerator.GenerateName("example-")
-		}
-	default:
-		clusterName = SimpleNameGenerator.GenerateName("example-")
-	}
-
 	// Build the skeletal HostedCluster based on the provided platform.
 	hc := &hyperv1.HostedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace.Name,
-			Name:      clusterName,
+			Name:      SimpleNameGenerator.GenerateName("example-"),
 		},
 		Spec: hyperv1.HostedClusterSpec{
 			Platform: hyperv1.PlatformSpec{

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -392,6 +392,10 @@ func teardownHostedCluster(t *testing.T, ctx context.Context, hc *hyperv1.Hosted
 	if dumpErr != nil {
 		t.Errorf("Failed to dump cluster: %v", dumpErr)
 	}
+
+	if hc.Spec.Platform.Type == hyperv1.OpenStackPlatform && opts.AWSPlatform.Credentials.AWSCredentialsFile != "" {
+		deleteIngressRoute53Records(t, ctx, hc, opts)
+	}
 }
 
 // archive re-packs the dir into the destination

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
@@ -17,6 +18,9 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	routev1client "github.com/openshift/client-go/route/clientset/versioned"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	awsinfra "github.com/openshift/hypershift/cmd/infra/aws"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
+	awsprivatelink "github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
 	hccokasvap "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -33,6 +37,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kapierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -1378,8 +1383,109 @@ func ValidateMetrics(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluste
 	})
 }
 
+func getIngressRouterDefaultIP(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) (string, error) {
+	t.Helper()
+	guestClient := WaitForGuestClient(t, ctx, client, hostedCluster)
+
+	defaultIngressRouterService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router-default",
+			Namespace: "openshift-ingress",
+		},
+	}
+
+	if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		getErr := guestClient.Get(ctx, crclient.ObjectKeyFromObject(defaultIngressRouterService), defaultIngressRouterService)
+		if apierrors.IsNotFound(getErr) {
+			return false, nil
+		}
+		if len(defaultIngressRouterService.Status.LoadBalancer.Ingress) == 0 {
+			return false, nil
+		}
+		return getErr == nil, err
+	}); err != nil {
+		return "", fmt.Errorf("router-default service did't become available: %v", err)
+	}
+
+	routerDefaultIP := defaultIngressRouterService.Status.LoadBalancer.Ingress[0].IP
+	if routerDefaultIP == "" {
+		return "", fmt.Errorf("router-default service does not have an IP")
+	}
+
+	t.Logf("router-default service IP: %s", routerDefaultIP)
+	return routerDefaultIP, nil
+}
+
+func createIngressRoute53Record(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *PlatformAgnosticOptions) {
+	t.Helper()
+	g := NewWithT(t)
+
+	t.Logf("Creating Ingress Route53 Record for HostedCluster %s", hostedCluster.Name)
+	if clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile == "" {
+		t.Skip("AWS credentials file is not provided")
+	}
+	// This is hardcoded too in aws CreateInfraOptions
+	awsRegion := "us-east-1"
+
+	routerDefaultIP, err := getIngressRouterDefaultIP(t, ctx, client, hostedCluster)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get router-default service IP")
+
+	awsSession, err := clusterOpts.AWSPlatform.Credentials.GetSession("e2e-openstack-dns-record-on-aws", nil, awsRegion)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to create AWS session")
+
+	route53Client := route53.New(awsSession, awsutil.NewAWSRoute53Config())
+	g.Expect(route53Client).ToNot(BeNil(), "failed to create Route53 client")
+
+	clusterName := hostedCluster.Name
+	baseDomain := hostedCluster.Spec.DNS.BaseDomain
+	zoneID, err := awsinfra.LookupZone(ctx, route53Client, hostedCluster.Spec.DNS.BaseDomain, false)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to lookup Route53 hosted zone %s", baseDomain)
+
+	err = awsprivatelink.CreateRecord(ctx, route53Client, zoneID, "*.apps."+clusterName+"."+baseDomain, routerDefaultIP, "A")
+	g.Expect(err).ToNot(HaveOccurred(), "failed to create Route53 record")
+	t.Logf("Created Route53 record for HostedCluster %s: %s", hostedCluster.Name, "*.apps."+clusterName+"."+baseDomain)
+}
+
+func deleteIngressRoute53Records(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, clusterOpts *PlatformAgnosticOptions) {
+	t.Helper()
+	g := NewWithT(t)
+
+	t.Logf("Deleting Ingress Route53 Records for HostedCluster %s", hostedCluster.Name)
+	if clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile == "" {
+		t.Skip("AWS credentials file is not provided")
+	}
+	// This is hardcoded too in aws CreateInfraOptions
+	awsRegion := "us-east-1"
+
+	awsSession, err := clusterOpts.AWSPlatform.Credentials.GetSession("e2e-openstack-dns-record-on-aws", nil, awsRegion)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to create AWS session")
+
+	route53Client := route53.New(awsSession, awsutil.NewAWSRoute53Config())
+	g.Expect(route53Client).ToNot(BeNil(), "failed to create Route53 client")
+
+	clusterName := hostedCluster.Name
+	baseDomain := hostedCluster.Spec.DNS.BaseDomain
+	zoneID, err := awsinfra.LookupZone(ctx, route53Client, hostedCluster.Spec.DNS.BaseDomain, false)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to lookup Route53 hosted zone %s", baseDomain)
+
+	record, err := awsprivatelink.FindRecord(ctx, route53Client, zoneID, "*.apps."+clusterName+"."+baseDomain, "A")
+	g.Expect(err).ToNot(HaveOccurred(), "failed to find Route53 record %s", "*.apps."+clusterName+"."+baseDomain)
+
+	if len(record.ResourceRecords) == 0 {
+		t.Logf("Route53 record for HostedCluster %s not found: %s", hostedCluster.Name, "*.apps."+clusterName+"."+baseDomain)
+	} else {
+		err = awsprivatelink.DeleteRecord(ctx, route53Client, zoneID, record)
+		g.Expect(err).ToNot(HaveOccurred(), "failed to delete Route53 record %s", "*.apps."+clusterName+"."+baseDomain)
+		t.Logf("Deleted Route53 record for HostedCluster %s: %s", hostedCluster.Name, "*.apps."+clusterName+"."+baseDomain)
+	}
+}
+
 func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *PlatformAgnosticOptions) {
 	g := NewWithT(t)
+
+	if hostedCluster.Spec.Platform.Type == hyperv1.OpenStackPlatform && clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile != "" {
+		createIngressRoute53Record(t, ctx, client, hostedCluster, clusterOpts)
+	}
 
 	// Sanity check the cluster by waiting for the nodes to report ready
 	guestClient := WaitForGuestClient(t, ctx, client, hostedCluster)


### PR DESCRIPTION
This change is only for our CI.
Instead of handling the DNS prior to deploy a HostedCluster, we now leverage AWS Route53 service, using the CI credentials to create the `*.apps.<cluster-name>.<base-domain>` DNS record dynamically.
With that work, we'll be able to not only simplify our CI workflow (that used to create a FIP, update DNS, etc), but also to deploy concurrent HostedClusters.

This PR leverages as much as possible the existing functions used by AWS infra to find DNS domains or create a DNS record.