### PR TITLE
NO-JIRA: add 4.14 and 4.15 HO base images to docker cve scan scripts

### DIFF
--- a/contrib/snyk/check-for-cve.sh
+++ b/contrib/snyk/check-for-cve.sh
@@ -30,10 +30,17 @@ if [[ -z "${SEARCH_TERMS}" ]]; then
     exit 1
 fi
 
-echo -e "\n===== Searching HO Image ====="
+echo -e "\n===== Searching Latest (4.16 -> 4.18) HO Image ====="
 docker pull quay.io/acm-d/rhtap-hypershift-operator:latest --quiet
-echo "Image: quay.io/acm-d/rhtap-hypershift-operator:latest"
 docker run -it --entrypoint=sh quay.io/acm-d/rhtap-hypershift-operator:latest -c "${SHELL_CMD}" 2>/dev/null
+echo "============================================="
+echo -e "\n===== Searching 4.14 HO Image ====="
+docker pull quay.io/openshift/origin-base:4.14 --quiet
+docker run -it --entrypoint=sh quay.io/openshift/origin-base:4.14 -c "${SHELL_CMD}" 2>/dev/null
+echo "============================================="
+echo -e "\n===== Searching 4.15 HO Image ====="
+docker pull quay.io/openshift/origin-base:4.15 --quiet
+docker run -it --entrypoint=sh quay.io/openshift/origin-base:4.15 -c "${SHELL_CMD}" 2>/dev/null
 echo "============================================="
 
 for version in 4.14 4.15 4.16 4.17 4.18; do


### PR DESCRIPTION
**What this PR does / why we need it**: Adds hardcoded 4.14 and 4.14 HO base images to cve scan script

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.