### PR TITLE
OCPBUGS-38925: copy oapi ca-trust recursively when building trust anchor

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -324,7 +324,7 @@ const buildTrustAnchorScript = `
 
 set -euo pipefail
 
-cp -f /etc/pki/ca-trust/extracted/pem/* /run/ca-trust-generated/
+cp -f -r /etc/pki/ca-trust/extracted/pem/* /run/ca-trust-generated/
 
 if ! [[ -f /run/service-ca-signer/service-ca.crt ]]; then
    exit 0


### PR DESCRIPTION
**What this PR does / why we need it**: fixes conformance test failures due to [OAPI failure](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.17-periodics-e2e-aws-ovn-conformance/1827247135871995904/artifacts/e2e-aws-ovn-conformance/dump/artifacts/namespaces/clusters-86846e8bf78169421cfc/core/pods/logs/openshift-apiserver-9cd49cf48-8hrnf-oas-trust-anchor-generator-previous.log) 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-38925](https://issues.redhat.com/browse/OCPBUGS-38925)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.