### PR TITLE
OCPBUGS-38921: Set Image as mutable and trigger upgrades on Azure NodePool spec changes

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -954,7 +954,6 @@ type AzureNodePoolPlatform struct {
 	// Hosted Cluster specification respectively, HostedCluster.Spec.Platform.Azure.SubscriptionID and
 	// HostedCluster.Spec.Platform.Azure.ResourceGroupName.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Image is immutable"
 	// +kubebuilder:validation:Required
 	Image AzureVMImage `json:"image"`
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -1930,9 +1930,6 @@ spec:
                         required:
                         - azureImageType
                         type: object
-                        x-kubernetes-validations:
-                        - message: Image is immutable
-                          rule: self == oldSelf
                       machineIdentityID:
                         description: |-
                           MachineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. This

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -16,18 +16,7 @@ import (
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
-func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.NodePool, existing capiazure.AzureMachineTemplateSpec) (*capiazure.AzureMachineTemplateSpec, error) {
-	// The azure api requires passing a public key. This key is randomly generated, the private portion is thrown away and the public key
-	// gets written to the template.
-	sshKey := existing.Template.Spec.SSHPublicKey
-	if sshKey == "" {
-		var err error
-		sshKey, err = generateSSHPubkey()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate a SSH key: %w", err)
-		}
-	}
-
+func azureMachineTemplateSpec(nodePool *hyperv1.NodePool) (*capiazure.AzureMachineTemplateSpec, error) {
 	subnetName, err := azureutil.GetSubnetNameFromSubnetID(nodePool.Spec.Platform.Azure.SubnetID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine subnet name for Azure machine: %w", err)
@@ -49,7 +38,6 @@ func azureMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1
 		NetworkInterfaces: []capiazure.NetworkInterface{{
 			SubnetName: subnetName,
 		}},
-		SSHPublicKey:  sshKey,
 		FailureDomain: failureDomain(nodePool),
 	}}}
 

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -525,9 +525,12 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			cluster := &hyperv1.HostedCluster{}
 
-			azureSpec, err := azureMachineTemplateSpec(cluster, tc.nodePool, testAzureMachineTemplateSpec)
+			azureSpec, err := azureMachineTemplateSpec(tc.nodePool)
+			if azureSpec != nil && azureSpec.Template.Spec.SSHPublicKey == "" {
+				azureSpec.Template.Spec.SSHPublicKey = testAzureMachineTemplateSpec.Template.Spec.SSHPublicKey
+			}
+
 			if tc.expectedErr {
 				g.Expect(err.Error()).To(Equal(tc.expectedErrMsg))
 			} else {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -2956,14 +2956,28 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 			return nil
 		}
 	case hyperv1.AzurePlatform:
+		var err error
 		template = &capiazure.AzureMachineTemplate{}
+		machineTemplateSpec, err = azureMachineTemplateSpec(nodePool)
+		if err != nil {
+			return nil, nil, "", err
+		}
 		mutateTemplate = func(object client.Object) error {
 			o, _ := object.(*capiazure.AzureMachineTemplate)
-			spec, err := azureMachineTemplateSpec(hcluster, nodePool, o.Spec)
-			if err != nil {
-				return err
+
+			// The azure api requires passing a public key. This key is randomly generated, the private portion is thrown away and the public key
+			// gets written to the template.
+			sshKey := o.Spec.Template.Spec.SSHPublicKey
+			if sshKey == "" {
+				sshKey, err = generateSSHPubkey()
+				if err != nil {
+					return fmt.Errorf("failed to generate a SSH key: %w", err)
+				}
 			}
-			o.Spec = *spec
+
+			o.Spec = *machineTemplateSpec.(*capiazure.AzureMachineTemplateSpec)
+			o.Spec.Template.Spec.SSHPublicKey = sshKey
+
 			if o.Annotations == nil {
 				o.Annotations = make(map[string]string)
 			}
@@ -3028,7 +3042,7 @@ func machineTemplateBuilders(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.
 
 func generateMachineTemplateName(nodePool *hyperv1.NodePool, machineTemplateSpecJSON []byte) string {
 	// using HashStruct(machineTemplateSpecJSON) ensures a rolling upgrade is triggered
-	// by creating a new template with a differnt name if any field changes.
+	// by creating a new template with a different name if any field changes.
 	return getName(nodePool.GetName(), supportutil.HashSimple(machineTemplateSpecJSON),
 		validation.DNS1123SubdomainMaxLength)
 }

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -954,7 +954,6 @@ type AzureNodePoolPlatform struct {
 	// Hosted Cluster specification respectively, HostedCluster.Spec.Platform.Azure.SubscriptionID and
 	// HostedCluster.Spec.Platform.Azure.ResourceGroupName.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Image is immutable"
 	// +kubebuilder:validation:Required
 	Image AzureVMImage `json:"image"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
* lets Image be mutable in Azure NodePools. If Image is not mutable, then there is no way of upgrading the image for an Azure NodePool.
* Uses machineTemplateSpec for Azure in the NodePool controller so changes to the spec trigger NodePool upgrades.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-38921](https://issues.redhat.com/browse/OCPBUGS-38921)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.