### PR TITLE
HOSTEDCP-1883: Remove hardcoded catalog images in CPO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3906,10 +3906,16 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 				}
 			}
 
+			olmManagerImage := ""
+			exists := false
+			if olmManagerImage, exists = releaseImageProvider.ComponentImages()["operator-lifecycle-manager"]; !exists {
+				return fmt.Errorf("failed to get olm image from release image provider")
+			}
+
 			olmDeployments := olm.OLMDeployments(p, hcp.Namespace)
 			for _, dep := range olmDeployments {
 				if _, err := createOrUpdate(ctx, r, dep.Manifest, func() error {
-					return dep.Reconciler(dep.Manifest, p.OwnerRef, p.DeploymentConfig, dep.Image)
+					return dep.Reconciler(dep.Manifest, p.OwnerRef, p.DeploymentConfig, dep.Image, olmManagerImage)
 				}); err != nil {
 					return fmt.Errorf("failed to reconcile %s deployment with image %s: %w", dep.Name, dep.Image, err)
 				}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -78,23 +78,23 @@ var (
 	redHatOperatorsCatalogDeployment   = assets.MustDeployment(content.ReadFile, "assets/catalog-redhat-operators.deployment.yaml")
 )
 
-func ReconcileCertifiedOperatorsDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, imageOverride string) error {
-	return reconcileCatalogDeployment(deployment, ownerRef, dc, certifiedCatalogDeployment, imageOverride)
+func ReconcileCertifiedOperatorsDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, imageOverride, olmManagerImage string) error {
+	return reconcileCatalogDeployment(deployment, ownerRef, dc, certifiedCatalogDeployment, imageOverride, olmManagerImage)
 }
 
-func ReconcileCommunityOperatorsDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, imageOverride string) error {
-	return reconcileCatalogDeployment(deployment, ownerRef, dc, communityCatalogDeployment, imageOverride)
+func ReconcileCommunityOperatorsDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, imageOverride, olmManagerImage string) error {
+	return reconcileCatalogDeployment(deployment, ownerRef, dc, communityCatalogDeployment, imageOverride, olmManagerImage)
 }
 
-func ReconcileRedHatMarketplaceOperatorsDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, imageOverride string) error {
-	return reconcileCatalogDeployment(deployment, ownerRef, dc, redHatMarketplaceCatalogDeployment, imageOverride)
+func ReconcileRedHatMarketplaceOperatorsDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, imageOverride, olmManagerImage string) error {
+	return reconcileCatalogDeployment(deployment, ownerRef, dc, redHatMarketplaceCatalogDeployment, imageOverride, olmManagerImage)
 }
 
-func ReconcileRedHatOperatorsDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, imageOverride string) error {
-	return reconcileCatalogDeployment(deployment, ownerRef, dc, redHatOperatorsCatalogDeployment, imageOverride)
+func ReconcileRedHatOperatorsDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, imageOverride, olmManagerImage string) error {
+	return reconcileCatalogDeployment(deployment, ownerRef, dc, redHatOperatorsCatalogDeployment, imageOverride, olmManagerImage)
 }
 
-func reconcileCatalogDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, sourceDeployment *appsv1.Deployment, imageOverride string) error {
+func reconcileCatalogDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, dc config.DeploymentConfig, sourceDeployment *appsv1.Deployment, imageOverride, olmManagerImage string) error {
 	ownerRef.ApplyTo(deployment)
 	if deployment.Annotations == nil {
 		deployment.Annotations = map[string]string{}
@@ -114,6 +114,7 @@ func reconcileCatalogDeployment(deployment *appsv1.Deployment, ownerRef config.O
 	}
 	deployment.Spec = sourceDeployment.DeepCopy().Spec
 	deployment.Spec.Template.Spec.Containers[0].Image = image
+	addVolumesAndInitContainers(deployment, image, olmManagerImage)
 	dc.ApplyTo(deployment)
 	return nil
 }
@@ -273,4 +274,93 @@ func ReconcileCatalogServiceMonitor(sm *prometheusoperatorv1.ServiceMonitor, own
 	util.ApplyClusterIDLabel(&sm.Spec.Endpoints[0], clusterID)
 
 	return nil
+}
+
+func addVolumesAndInitContainers(deployment *appsv1.Deployment, image, olmManagerImage string) {
+	volumes := []corev1.Volume{
+		{
+			Name: "utilities",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: "catalog-content",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+
+	initContainers := []corev1.Container{
+		{
+			Name:            "extract-utilities",
+			Image:           olmManagerImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"cp"},
+			Args:            []string{"/bin/copy-content", "/utilities/copy-content"},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "utilities",
+					MountPath: "/utilities",
+				},
+			},
+			TerminationMessagePath:   "/dev/termination-log",
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		},
+		{
+			Name:            "extract-content",
+			Image:           image,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"/utilities/copy-content"},
+			Args: []string{
+				"--catalog.from=/configs",
+				"--catalog.to=/extracted-catalog/catalog",
+				"--cache.from=/tmp/cache",
+				"--cache.to=/extracted-catalog/cache",
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "utilities",
+					MountPath: "/utilities",
+				},
+				{
+					Name:      "catalog-content",
+					MountPath: "/extracted-catalog",
+				},
+			},
+			TerminationMessagePath:   "/dev/termination-log",
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		},
+	}
+
+	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volumes...)
+	deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, initContainers...)
+
+	olmCatalogSource := ""
+	if deployment.Spec.Template.Labels != nil {
+		olmCatalogSource = deployment.Spec.Template.Labels["olm.catalogSource"]
+	}
+
+	if deployment.Annotations == nil {
+		deployment.Annotations = map[string]string{}
+	}
+	deployment.Annotations["image.openshift.io/triggers"] = fmt.Sprintf(`[
+		{"from":{"kind":"ImageStreamTag","name":"catalogs:%s"},"fieldPath":"spec.template.spec.initContainers[?(@.name==\"extract-content\")].image"},
+		{"from":{"kind":"ImageStreamTag","name":"catalogs:%s"},"fieldPath":"spec.template.spec.containers[?(@.name==\"registry\")].image"}
+	]`, olmCatalogSource, olmCatalogSource)
+
+	// Add command, args, and volume mounts to the first container
+	if len(deployment.Spec.Template.Spec.Containers) > 0 {
+		deployment.Spec.Template.Spec.Containers[0].Command = []string{"/bin/opm"}
+		deployment.Spec.Template.Spec.Containers[0].Args = []string{
+			"serve",
+			"/extracted-catalog/catalog",
+			"--cache-dir=/extracted-catalog/cache",
+		}
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      "catalog-content",
+			MountPath: "/extracted-catalog",
+		})
+	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/deployments.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/deployments.go
@@ -9,7 +9,7 @@ import (
 type OLMDeployment struct {
 	Name       string
 	Manifest   *appsv1.Deployment
-	Reconciler func(*appsv1.Deployment, config.OwnerRef, config.DeploymentConfig, string) error
+	Reconciler func(*appsv1.Deployment, config.OwnerRef, config.DeploymentConfig, string, string) error
 	Image      string
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/olm"
+	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -16,8 +17,8 @@ type OperatorLifecycleManagerParams struct {
 	OLMCatalogPlacement     hyperv1.OLMCatalogPlacement
 }
 
-func NewOperatorLifecycleManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret) (*OperatorLifecycleManagerParams, error) {
-	catalogImages, err := olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey])
+func NewOperatorLifecycleManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret, digestLister registryclient.DigestListerFN) (*OperatorLifecycleManagerParams, error) {
+	catalogImages, err := olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], digestLister)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog images: %w", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/upsert"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -71,6 +72,7 @@ type HostedClusterConfigOperatorConfig struct {
 	OAuthPort                    int32
 	OperateOnReleaseImage        string
 	EnableCIDebugOutput          bool
+	ListDigestsFN                registryclient.DigestListerFN
 
 	kubeClient kubeclient.Interface
 }

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -467,3 +467,5 @@ func GetListDigest(ctx context.Context, imageRef string, pullSecret []byte) (dig
 	}
 	return srcDigest, nil
 }
+
+type DigestListerFN = func(ctx context.Context, image string, pullSecret []byte) (digest.Digest, error)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1131,6 +1131,10 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 			"virt-launcher":                    "kubevirt.io",
 			"azure-disk-csi-driver-controller": "app",
 			"azure-file-csi-driver-controller": "app",
+			"certified-operators-catalog":      "app",
+			"community-operators-catalog":      "app",
+			"redhat-operators-catalog":         "app",
+			"redhat-marketplace-catalog":       "app",
 		}
 
 		hcpPods := &corev1.PodList{}


### PR DESCRIPTION
**What this PR does / why we need it**: removes hardcoded catalog images in CPO which have to be updated every release, we now retrieve the openshift version from the ocp payload

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1883](https://issues.redhat.com/browse/HOSTEDCP-1883)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.