### PR TITLE
OCPBUGS-39147: regroup KAS certs into public and private certs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2187,20 +2187,20 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 		return fmt.Errorf("failed to reconcile etcd client secret: %w", err)
 	}
 
-	// Internal KAS server secret
-	kasServerInternalSecret := manifests.KASServerInternalCertSecret(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, kasServerInternalSecret, func() error {
-		return pki.ReconcileKASServerInternalCertSecret(kasServerInternalSecret, rootCASecret, p.OwnerRef, p.InternalAPIAddress, p.ServiceCIDR, p.NodeInternalAPIServerIP)
+	// KAS server secret
+	kasServerSecret := manifests.KASServerCertSecret(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, kasServerSecret, func() error {
+		return pki.ReconcileKASServerCertSecret(kasServerSecret, rootCASecret, p.OwnerRef, p.ExternalAPIAddress, p.InternalAPIAddress, p.ServiceCIDR, p.NodeInternalAPIServerIP)
 	}); err != nil {
-		return fmt.Errorf("failed to reconcile kas server internal secret: %w", err)
+		return fmt.Errorf("failed to reconcile kas server secret: %w", err)
 	}
 
-	// External KAS server secret
-	kasServerExternalSecret := manifests.KASServerExternalCertSecret(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, kasServerExternalSecret, func() error {
-		return pki.ReconcileKASServerExternalCertSecret(kasServerExternalSecret, rootCASecret, p.OwnerRef, p.ExternalAPIAddress)
+	// KAS server private secret
+	kasServerPrivateSecret := manifests.KASServerPrivateCertSecret(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, kasServerPrivateSecret, func() error {
+		return pki.ReconcileKASServerPrivateCertSecret(kasServerPrivateSecret, rootCASecret, p.OwnerRef)
 	}); err != nil {
-		return fmt.Errorf("failed to reconcile kas server external secret: %w", err)
+		return fmt.Errorf("failed to reconcile kas server private secret: %w", err)
 	}
 
 	totalKASClientCABundle := pkimanifests.TotalKASClientCABundle(hcp.Namespace)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -67,8 +67,8 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 	namedCertificates = append(namedCertificates, configv1.NamedCertificate{
 		Names: []string{},
 		CertInfo: configv1.CertInfo{
-			CertFile: cpath(kasVolumeServerExternalCert().Name, corev1.TLSCertKey),
-			KeyFile:  cpath(kasVolumeServerExternalCert().Name, corev1.TLSPrivateKeyKey),
+			CertFile: cpath(kasVolumeServerPrivateCert().Name, corev1.TLSCertKey),
+			KeyFile:  cpath(kasVolumeServerPrivateCert().Name, corev1.TLSPrivateKeyKey),
 		},
 	})
 	config := &kcpv1.KubeAPIServerConfig{
@@ -119,8 +119,8 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 			ServingInfo: configv1.HTTPServingInfo{
 				ServingInfo: configv1.ServingInfo{
 					CertInfo: configv1.CertInfo{
-						CertFile: path.Join(volumeMounts.Path(kasContainerMain().Name, kasVolumeServerInternalCert().Name), corev1.TLSCertKey),
-						KeyFile:  path.Join(volumeMounts.Path(kasContainerMain().Name, kasVolumeServerInternalCert().Name), corev1.TLSPrivateKeyKey),
+						CertFile: path.Join(volumeMounts.Path(kasContainerMain().Name, kasVolumeServerCert().Name), corev1.TLSCertKey),
+						KeyFile:  path.Join(volumeMounts.Path(kasContainerMain().Name, kasVolumeServerCert().Name), corev1.TLSPrivateKeyKey),
 					},
 					NamedCertificates: namedCertificates,
 					BindAddress:       fmt.Sprintf("0.0.0.0:%d", p.KASPodPort),
@@ -229,8 +229,8 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 	args.Set("storage-backend", "etcd3")
 	args.Set("storage-media-type", "application/vnd.kubernetes.protobuf")
 	args.Set("strict-transport-security-directives", p.APIServerSTSDirectives)
-	args.Set("tls-cert-file", cpath(kasVolumeServerInternalCert().Name, corev1.TLSCertKey))
-	args.Set("tls-private-key-file", cpath(kasVolumeServerInternalCert().Name, corev1.TLSPrivateKeyKey))
+	args.Set("tls-cert-file", cpath(kasVolumeServerCert().Name, corev1.TLSCertKey))
+	args.Set("tls-private-key-file", cpath(kasVolumeServerCert().Name, corev1.TLSPrivateKeyKey))
 	config.APIServerArguments = args
 	return config
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -51,8 +51,8 @@ var (
 			kasVolumeConfig().Name:                 "/etc/kubernetes/config",
 			kasVolumeAuditConfig().Name:            "/etc/kubernetes/audit",
 			kasVolumeKonnectivityCA().Name:         "/etc/kubernetes/certs/konnectivity-ca",
-			kasVolumeServerInternalCert().Name:     "/etc/kubernetes/certs/server-internal",
-			kasVolumeServerExternalCert().Name:     "/etc/kubernetes/certs/server-external",
+			kasVolumeServerCert().Name:             "/etc/kubernetes/certs/server",
+			kasVolumeServerPrivateCert().Name:      "/etc/kubernetes/certs/server-private",
 			kasVolumeAggregatorCert().Name:         "/etc/kubernetes/certs/aggregator",
 			common.VolumeAggregatorCA().Name:       "/etc/kubernetes/certs/aggregator-ca",
 			common.VolumeTotalClientCA().Name:      "/etc/kubernetes/certs/client-ca",
@@ -215,8 +215,8 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 				util.BuildVolume(kasVolumeAuthConfig(), buildKASVolumeAuthConfig),
 				util.BuildVolume(kasVolumeAuditConfig(), buildKASVolumeAuditConfig),
 				util.BuildVolume(kasVolumeKonnectivityCA(), buildKASVolumeKonnectivityCA),
-				util.BuildVolume(kasVolumeServerInternalCert(), buildKASVolumeServerInternalCert),
-				util.BuildVolume(kasVolumeServerExternalCert(), buildKASVolumeServerExternalCert),
+				util.BuildVolume(kasVolumeServerCert(), buildKASVolumeServerCert),
+				util.BuildVolume(kasVolumeServerPrivateCert(), buildKASVolumeServerPrivateCert),
 				util.BuildVolume(kasVolumeAggregatorCert(), buildKASVolumeAggregatorCert),
 				util.BuildVolume(common.VolumeAggregatorCA(), common.BuildVolumeAggregatorCA),
 				util.BuildVolume(kasVolumeServiceAccountKey(), buildKASVolumeServiceAccountKey),
@@ -565,30 +565,30 @@ func buildKASVolumeKonnectivityCA(v *corev1.Volume) {
 	}
 	v.ConfigMap.Name = manifests.KonnectivityCAConfigMap("").Name
 }
-func kasVolumeServerInternalCert() *corev1.Volume {
+func kasVolumeServerCert() *corev1.Volume {
 	return &corev1.Volume{
-		Name: "server-internal-crt",
+		Name: "server-crt",
 	}
 }
-func kasVolumeServerExternalCert() *corev1.Volume {
+func kasVolumeServerPrivateCert() *corev1.Volume {
 	return &corev1.Volume{
-		Name: "server-external-crt",
+		Name: "server-private-crt",
 	}
 }
-func buildKASVolumeServerInternalCert(v *corev1.Volume) {
+func buildKASVolumeServerCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
 	v.Secret.DefaultMode = pointer.Int32(0640)
-	v.Secret.SecretName = manifests.KASServerInternalCertSecret("").Name
+	v.Secret.SecretName = manifests.KASServerCertSecret("").Name
 }
 
-func buildKASVolumeServerExternalCert(v *corev1.Volume) {
+func buildKASVolumeServerPrivateCert(v *corev1.Volume) {
 	if v.Secret == nil {
 		v.Secret = &corev1.SecretVolumeSource{}
 	}
 	v.Secret.DefaultMode = pointer.Int32(0640)
-	v.Secret.SecretName = manifests.KASServerExternalCertSecret("").Name
+	v.Secret.SecretName = manifests.KASServerPrivateCertSecret("").Name
 }
 
 func kasVolumeKubeletClientCA() *corev1.Volume {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -188,12 +188,12 @@ func EtcdMetricsClientSecret(ns string) *corev1.Secret {
 	return secretFor(ns, "etcd-metrics-client-tls")
 }
 
-func KASServerInternalCertSecret(ns string) *corev1.Secret {
-	return secretFor(ns, "kas-server-internal-crt")
+func KASServerCertSecret(ns string) *corev1.Secret {
+	return secretFor(ns, "kas-server-crt")
 }
 
-func KASServerExternalCertSecret(ns string) *corev1.Secret {
-	return secretFor(ns, "kas-server-external-crt")
+func KASServerPrivateCertSecret(ns string) *corev1.Secret {
+	return secretFor(ns, "kas-server-private-crt")
 }
 
 func KASKubeletClientCertSecret(ns string) *corev1.Secret {


### PR DESCRIPTION
This mostly reverts https://github.com/openshift/hypershift/pull/4566 and regroups private mgmt cluster service network dns names for the KAS into their own cert stored in a new `kube-server-private` secret.