### PR TITLE
HOSTEDCP-1933: Expose AWS Tenancy through NodePool API

### DIFF
--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -823,6 +823,17 @@ type AWSNodePoolPlatform struct {
 	// +listMapKey=key
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
+
+	// Tenancy indicates if instance should run on shared or single-tenant hardware.
+	//
+	// Possible values:
+	// default: NodePool instances run on shared hardware.
+	// dedicated: Each NodePool instance runs on single-tenant hardware.
+	// host: NodePool instances run on user's pre-allocated dedicated hosts.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum:=default;dedicated;host
+	Tenancy string `json:"tenancy,omitempty"`
 }
 
 // AWSResourceReference is a reference to a specific AWS resource by ID or filters.

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -832,6 +832,17 @@ type AWSNodePoolPlatform struct {
 	// +kubebuilder:validation:MaxItems=25
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
+
+	// Tenancy indicates if instance should run on shared or single-tenant hardware.
+	//
+	// Possible values:
+	// default: NodePool instances run on shared hardware.
+	// dedicated: Each NodePool instance runs on single-tenant hardware.
+	// host: NodePool instances run on user's pre-allocated dedicated hosts.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum:=default;dedicated;host
+	Tenancy string `json:"tenancy,omitempty"`
 }
 
 // AWSResourceReference is a reference to a specific AWS resource by ID or filters.

--- a/client/applyconfiguration/hypershift/v1alpha1/awsnodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/awsnodepoolplatform.go
@@ -27,6 +27,7 @@ type AWSNodePoolPlatformApplyConfiguration struct {
 	SecurityGroups  []AWSResourceReferenceApplyConfiguration `json:"securityGroups,omitempty"`
 	RootVolume      *VolumeApplyConfiguration                `json:"rootVolume,omitempty"`
 	ResourceTags    []AWSResourceTagApplyConfiguration       `json:"resourceTags,omitempty"`
+	Tenancy         *string                                  `json:"tenancy,omitempty"`
 }
 
 // AWSNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AWSNodePoolPlatform type for use with
@@ -98,5 +99,13 @@ func (b *AWSNodePoolPlatformApplyConfiguration) WithResourceTags(values ...*AWSR
 		}
 		b.ResourceTags = append(b.ResourceTags, *values[i])
 	}
+	return b
+}
+
+// WithTenancy sets the Tenancy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Tenancy field is set to the value of the last call.
+func (b *AWSNodePoolPlatformApplyConfiguration) WithTenancy(value string) *AWSNodePoolPlatformApplyConfiguration {
+	b.Tenancy = &value
 	return b
 }

--- a/client/applyconfiguration/hypershift/v1beta1/awsnodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/awsnodepoolplatform.go
@@ -27,6 +27,7 @@ type AWSNodePoolPlatformApplyConfiguration struct {
 	SecurityGroups  []AWSResourceReferenceApplyConfiguration `json:"securityGroups,omitempty"`
 	RootVolume      *VolumeApplyConfiguration                `json:"rootVolume,omitempty"`
 	ResourceTags    []AWSResourceTagApplyConfiguration       `json:"resourceTags,omitempty"`
+	Tenancy         *string                                  `json:"tenancy,omitempty"`
 }
 
 // AWSNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AWSNodePoolPlatform type for use with
@@ -98,5 +99,13 @@ func (b *AWSNodePoolPlatformApplyConfiguration) WithResourceTags(values ...*AWSR
 		}
 		b.ResourceTags = append(b.ResourceTags, *values[i])
 	}
+	return b
+}
+
+// WithTenancy sets the Tenancy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Tenancy field is set to the value of the last call.
+func (b *AWSNodePoolPlatformApplyConfiguration) WithTenancy(value string) *AWSNodePoolPlatformApplyConfiguration {
+	b.Tenancy = &value
 	return b
 }

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -556,6 +556,20 @@ spec:
                             must be set, but not both
                           rule: 'has(self.id) && self.id.startsWith(''subnet-'') ?
                             !has(self.filters) : size(self.filters) > 0'
+                      tenancy:
+                        description: |-
+                          Tenancy indicates if instance should run on shared or single-tenant hardware.
+
+
+                          Possible values:
+                          default: NodePool instances run on shared hardware.
+                          dedicated: Each NodePool instance runs on single-tenant hardware.
+                          host: NodePool instances run on user's pre-allocated dedicated hosts.
+                        enum:
+                        - default
+                        - dedicated
+                        - host
+                        type: string
                     required:
                     - instanceType
                     type: object
@@ -1788,6 +1802,20 @@ spec:
                             must be set, but not both
                           rule: 'has(self.id) && self.id.startsWith(''subnet-'') ?
                             !has(self.filters) : size(self.filters) > 0'
+                      tenancy:
+                        description: |-
+                          Tenancy indicates if instance should run on shared or single-tenant hardware.
+
+
+                          Possible values:
+                          default: NodePool instances run on shared hardware.
+                          dedicated: Each NodePool instance runs on single-tenant hardware.
+                          host: NodePool instances run on user's pre-allocated dedicated hosts.
+                        enum:
+                        - default
+                        - dedicated
+                        - host
+                        type: string
                     required:
                     - instanceType
                     - subnet

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1378,6 +1378,22 @@ resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
 for the user.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>tenancy</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tenancy indicates if instance should run on shared or single-tenant hardware.</p>
+<p>Possible values:
+default: NodePool instances run on shared hardware.
+dedicated: Each NodePool instance runs on single-tenant hardware.
+host: NodePool instances run on user&rsquo;s pre-allocated dedicated hosts.</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###AWSPlatformSpec { #hypershift.openshift.io/v1beta1.AWSPlatformSpec }

--- a/hypershift-operator/controllers/nodepool/aws.go
+++ b/hypershift-operator/controllers/nodepool/aws.go
@@ -123,6 +123,7 @@ func awsMachineTemplateSpec(infraName, ami string, hostedCluster *hyperv1.Hosted
 				RootVolume:               rootVolume,
 				AdditionalTags:           tags,
 				InstanceMetadataOptions:  instanceMetadataOptions,
+				Tenancy:                  nodePool.Spec.Platform.AWS.Tenancy,
 			},
 		},
 	}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
@@ -823,6 +823,17 @@ type AWSNodePoolPlatform struct {
 	// +listMapKey=key
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
+
+	// Tenancy indicates if instance should run on shared or single-tenant hardware.
+	//
+	// Possible values:
+	// default: NodePool instances run on shared hardware.
+	// dedicated: Each NodePool instance runs on single-tenant hardware.
+	// host: NodePool instances run on user's pre-allocated dedicated hosts.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum:=default;dedicated;host
+	Tenancy string `json:"tenancy,omitempty"`
 }
 
 // AWSResourceReference is a reference to a specific AWS resource by ID or filters.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -832,6 +832,17 @@ type AWSNodePoolPlatform struct {
 	// +kubebuilder:validation:MaxItems=25
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
+
+	// Tenancy indicates if instance should run on shared or single-tenant hardware.
+	//
+	// Possible values:
+	// default: NodePool instances run on shared hardware.
+	// dedicated: Each NodePool instance runs on single-tenant hardware.
+	// host: NodePool instances run on user's pre-allocated dedicated hosts.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum:=default;dedicated;host
+	Tenancy string `json:"tenancy,omitempty"`
 }
 
 // AWSResourceReference is a reference to a specific AWS resource by ID or filters.


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows launching AWS EC2 instances into dedicated instances or dedicated hosts.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.