### PR TITLE
OCPBUGS-38794: handle version skewed NodePools that do not have rhel9 binaries

### DIFF
--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"os"
 	"os/exec"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/blang/semver"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -365,7 +366,15 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 			}
 			log.Info("copying file", "src", srcPath, "dest", destPath)
 			if err := p.ImageFileCache.extractImageFile(ctx, mcoImage, pullSecret, srcPath, file); err != nil {
-				return fmt.Errorf("failed to extract image file: %w", err)
+				if suffix == "" {
+					return fmt.Errorf("failed to extract image file: %w", err)
+				}
+				// The MCO image in the NodePool release image does not contain the suffixed binary, try to extract the unsuffixed binary
+				srcPath = filepath.Join("usr/bin/", name)
+				log.Info("suffixed binary not found, copying file", "src", srcPath, "dest", destPath)
+				if err := p.ImageFileCache.extractImageFile(ctx, mcoImage, pullSecret, filepath.Join("usr/bin/", name), file); err != nil {
+					return fmt.Errorf("failed to extract image file: %w", err)
+				}
 			}
 			if err := file.Close(); err != nil {
 				return fmt.Errorf("failed to close file: %w", err)

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -313,74 +313,13 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 	}
 
 	// Extract binaries from the MCO image into the bin directory
+	err = p.extractMCOBinaries(ctx, "/usr/lib/os-release", mcoImage, pullSecret, binDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download MCO binaries: %w", err)
+	}
+
 	err = func() error {
 		start := time.Now()
-		binaries := []string{"machine-config-operator", "machine-config-controller", "machine-config-server"}
-		suffix := ""
-
-		mcoOSReleaseBuf := &bytes.Buffer{}
-		if err := p.ImageFileCache.extractImageFile(ctx, mcoImage, pullSecret, "usr/lib/os-release", mcoOSReleaseBuf); err != nil {
-			return fmt.Errorf("failed to extract image os-release file: %w", err)
-		}
-		mcoOSRelease := mcoOSReleaseBuf.String()
-
-		// read /etc/os-release file from disk to cpoOSRelease
-		cpoOSRelease, err := os.ReadFile("/usr/lib/os-release")
-		if err != nil {
-			return fmt.Errorf("failed to read os-release file: %w", err)
-		}
-
-		// extract RHEL major version from both os-release files
-		extractMajorVersion := func(osRelease string) (string, error) {
-			for _, line := range strings.Split(osRelease, "\n") {
-				if strings.HasPrefix(line, "VERSION_ID=") {
-					return strings.Split(strings.TrimSuffix(strings.TrimPrefix(line, "VERSION_ID=\""), "\""), ".")[0], nil
-				}
-			}
-			return "", fmt.Errorf("failed to find VERSION_ID in os-release file")
-		}
-		mcoRHELMajorVersion, err := extractMajorVersion(mcoOSRelease)
-		if err != nil {
-			return fmt.Errorf("failed to extract major version from MCO os-release: %w", err)
-		}
-		cpoRHELMajorVersion, err := extractMajorVersion(string(cpoOSRelease))
-		if err != nil {
-			return fmt.Errorf("failed to extract major version from CPO os-release: %w", err)
-		}
-		log.Info("read os-release", "mcoRHELMajorVersion", mcoRHELMajorVersion, "cpoRHELMajorVersion", cpoRHELMajorVersion)
-
-		if mcoRHELMajorVersion == "8" && cpoRHELMajorVersion == "9" {
-			// NodePool MCO RHEL major version is older than the CPO, need to add suffix to the binaries
-			suffix = ".rhel9"
-		}
-
-		for _, name := range binaries {
-			srcPath := filepath.Join("usr/bin/", name+suffix)
-			destPath := filepath.Join(binDir, name)
-			file, err := os.Create(destPath)
-			if err != nil {
-				return fmt.Errorf("failed to create file: %w", err)
-			}
-			if err := file.Chmod(0777); err != nil {
-				return fmt.Errorf("failed to chmod file: %w", err)
-			}
-			log.Info("copying file", "src", srcPath, "dest", destPath)
-			if err := p.ImageFileCache.extractImageFile(ctx, mcoImage, pullSecret, srcPath, file); err != nil {
-				if suffix == "" {
-					return fmt.Errorf("failed to extract image file: %w", err)
-				}
-				// The MCO image in the NodePool release image does not contain the suffixed binary, try to extract the unsuffixed binary
-				srcPath = filepath.Join("usr/bin/", name)
-				log.Info("suffixed binary not found, copying file", "src", srcPath, "dest", destPath)
-				if err := p.ImageFileCache.extractImageFile(ctx, mcoImage, pullSecret, filepath.Join("usr/bin/", name), file); err != nil {
-					return fmt.Errorf("failed to extract image file: %w", err)
-				}
-			}
-			if err := file.Close(); err != nil {
-				return fmt.Errorf("failed to close file: %w", err)
-			}
-		}
-
 		clusterConfigImage, ok := imageProvider.ImageExist(clusterConfigComponent)
 		if !ok {
 			return fmt.Errorf("release image does not contain $%s (images: %v)", clusterConfigComponent, imageProvider.ComponentImages())
@@ -832,4 +771,76 @@ cp %[2]s/manifests/99_feature-gate.yaml %[3]s/99_feature-gate.yaml
 	}
 
 	return fmt.Sprintf(script, binary, workDir, outputDir, payloadVersion, featureGateYAML)
+}
+
+func (p *LocalIgnitionProvider) extractMCOBinaries(ctx context.Context, cpoOSReleaseFile string, mcoImage string, pullSecret []byte, binDir string) error {
+	start := time.Now()
+	binaries := []string{"machine-config-operator", "machine-config-controller", "machine-config-server"}
+	suffix := ""
+
+	mcoOSReleaseBuf := &bytes.Buffer{}
+	if err := p.ImageFileCache.extractImageFile(ctx, mcoImage, pullSecret, "usr/lib/os-release", mcoOSReleaseBuf); err != nil {
+		return fmt.Errorf("failed to extract image os-release file: %w", err)
+	}
+	mcoOSRelease := mcoOSReleaseBuf.String()
+
+	// read /etc/os-release file from disk to cpoOSRelease
+	cpoOSRelease, err := os.ReadFile(cpoOSReleaseFile)
+	if err != nil {
+		return fmt.Errorf("failed to read cpo os-release file: %w", err)
+	}
+
+	// extract RHEL major version from both os-release files
+	extractMajorVersion := func(osRelease string) (string, error) {
+		for _, line := range strings.Split(osRelease, "\n") {
+			if strings.HasPrefix(line, "VERSION_ID=") {
+				return strings.Split(strings.TrimSuffix(strings.TrimPrefix(line, "VERSION_ID=\""), "\""), ".")[0], nil
+			}
+		}
+		return "", fmt.Errorf("failed to find VERSION_ID in os-release file")
+	}
+	mcoRHELMajorVersion, err := extractMajorVersion(mcoOSRelease)
+	if err != nil {
+		return fmt.Errorf("failed to extract major version from MCO os-release: %w", err)
+	}
+	cpoRHELMajorVersion, err := extractMajorVersion(string(cpoOSRelease))
+	if err != nil {
+		return fmt.Errorf("failed to extract major version from CPO os-release: %w", err)
+	}
+	log.Info("read os-release", "mcoRHELMajorVersion", mcoRHELMajorVersion, "cpoRHELMajorVersion", cpoRHELMajorVersion)
+
+	if mcoRHELMajorVersion == "8" && cpoRHELMajorVersion == "9" {
+		// NodePool MCO RHEL major version is older than the CPO, need to add suffix to the binaries
+		suffix = ".rhel9"
+	}
+
+	for _, name := range binaries {
+		srcPath := filepath.Join("usr/bin/", name+suffix)
+		destPath := filepath.Join(binDir, name)
+		file, err := os.Create(destPath)
+		if err != nil {
+			return fmt.Errorf("failed to create file: %w", err)
+		}
+		if err := file.Chmod(0777); err != nil {
+			return fmt.Errorf("failed to chmod file: %w", err)
+		}
+		log.Info("copying file", "src", srcPath, "dest", destPath)
+		if err := p.ImageFileCache.extractImageFile(ctx, mcoImage, pullSecret, srcPath, file); err != nil {
+			if suffix == "" {
+				return fmt.Errorf("failed to extract image file: %w", err)
+			}
+			// The MCO image in the NodePool release image does not contain the suffixed binary, try to extract the unsuffixed binary
+			srcPath = filepath.Join("usr/bin/", name)
+			log.Info("suffixed binary not found, copying file", "src", srcPath, "dest", destPath)
+			if err := p.ImageFileCache.extractImageFile(ctx, mcoImage, pullSecret, filepath.Join("usr/bin/", name), file); err != nil {
+				return fmt.Errorf("failed to extract image file: %w", err)
+			}
+		}
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("failed to close file: %w", err)
+		}
+	}
+
+	log.Info("downloaded binaries", "time", time.Since(start).Round(time.Second).String())
+	return nil
 }

--- a/ignition-server/controllers/local_ignitionprovider_test.go
+++ b/ignition-server/controllers/local_ignitionprovider_test.go
@@ -1,0 +1,126 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestExtractMCOBinaries(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		mcoOSReleaseVersion   string
+		cpoOSReleaseVersion   string
+		expectedBinaryVersion string
+		cacheFunc             regClient
+	}{
+		{
+			name:                  "When both MCO and CPO are on RHEL 8, it should extract the RHEL 8 binaries with no prefix",
+			mcoOSReleaseVersion:   "8.1",
+			cpoOSReleaseVersion:   "8.2",
+			expectedBinaryVersion: "rhel8",
+		},
+		{
+			name:                  "When both MCO is in RHEL 8 and CPO on RHEL 9, it should extract the RHEL 9 binaries with the .rhel9 prefix",
+			mcoOSReleaseVersion:   "8.1",
+			cpoOSReleaseVersion:   "9.1",
+			expectedBinaryVersion: "rhel9",
+		},
+		{
+			name:                  "When MCO is in too old version and CPO on RHEL 9, and the RHEL 9 binaries do not exist it should extract the RHEL 8 binaries with no prefix",
+			mcoOSReleaseVersion:   "8.0",
+			cpoOSReleaseVersion:   "9.1",
+			expectedBinaryVersion: "rhel8",
+			cacheFunc: func(ctx context.Context, imageRef string, pullSecret []byte, file string, out io.Writer) error {
+				switch file {
+				case "usr/lib/os-release":
+					_, err := out.Write([]byte(fmt.Sprintf("VERSION_ID=\"%s\"\n", "8.0")))
+					return err
+				case "usr/bin/machine-config-operator", "usr/bin/machine-config-controller", "usr/bin/machine-config-server":
+					_, err := out.Write([]byte("rhel8"))
+					return err
+				case "usr/bin/machine-config-operator.rhel9", "usr/bin/machine-config-controller.rhel9", "usr/bin/machine-config-server.rhel9":
+					return fmt.Errorf("file not found: %s", file)
+				default:
+					return fmt.Errorf("unexpected file: %s", file)
+				}
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			tempDir, err := os.MkdirTemp("", "testExtractBinaries-*")
+			if err != nil {
+				t.Fatalf("Failed to create temporary directory: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			// Set up the necessary variables for testing.
+			ctx := context.Background()
+			mcoImage := "fake"
+			pullSecret := []byte{}
+			binDir := filepath.Join(tempDir, "bin")
+			os.Mkdir(binDir, 0755)
+
+			// Create a fake file cache that returns the expected binaries.
+			imageFileCache := &imageFileCache{
+				cacheMap: make(map[cacheKey]cacheValue),
+				cacheDir: tempDir,
+			}
+			imageFileCache.regClient = func(ctx context.Context, imageRef string, pullSecret []byte, file string, out io.Writer) error {
+				switch file {
+				case "usr/lib/os-release":
+					_, err := out.Write([]byte(fmt.Sprintf("VERSION_ID=\"%s\"\n", tc.mcoOSReleaseVersion)))
+					return err
+				case "usr/bin/machine-config-operator", "usr/bin/machine-config-controller", "usr/bin/machine-config-server":
+					_, err := out.Write([]byte("rhel8"))
+					return err
+				case "usr/bin/machine-config-operator.rhel9", "usr/bin/machine-config-controller.rhel9", "usr/bin/machine-config-server.rhel9":
+					_, err := out.Write([]byte("rhel9"))
+					return err
+				default:
+					return fmt.Errorf("unexpected file: %s", file)
+				}
+			}
+
+			// If the test case has a custom cache function, use it.
+			// This is useful to simulate the case where the ocp release for the NodePool is too old that it doesn't have the RHEL binaries.
+			if tc.cacheFunc != nil {
+				imageFileCache.regClient = tc.cacheFunc
+			}
+
+			// Create a fake cpo os-release file
+			cpoOSRelease := fmt.Sprintf("VERSION_ID=\"%s\"\n", tc.cpoOSReleaseVersion)
+			cpoOSReleaseFilePath := filepath.Join(tempDir, "usr/lib/os-release")
+			err = os.MkdirAll(filepath.Dir(cpoOSReleaseFilePath), 0755)
+			g.Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(cpoOSReleaseFilePath, []byte(cpoOSRelease), 0644)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Create a LocalIgnitionProvider instance for testing.
+			provider := &LocalIgnitionProvider{
+				ImageFileCache: imageFileCache,
+				WorkDir:        tempDir,
+			}
+
+			// Call the extractMCOBinaries.
+			err = provider.extractMCOBinaries(ctx, cpoOSReleaseFilePath, mcoImage, pullSecret, binDir)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Verify the extracted binaries match the expected version.
+			for _, name := range []string{"machine-config-operator", "machine-config-controller", "machine-config-server"} {
+				filePath := filepath.Join(binDir, name)
+				fileContent, err := os.ReadFile(filePath)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(fileContent)).To(Equal(tc.expectedBinaryVersion))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Goes before/after https://github.com/openshift/hypershift/pull/4651

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.