### PR TITLE
OCPBUGS-39396: Fix multi-arch validation by prioritizing ReleaseImage check

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -513,7 +513,7 @@ func validateMultiArch(ctx context.Context, o *RawCreateOptions, opts *core.Crea
 	}
 
 	// Check if a release stream was provided instead and its multi-arch
-	if len(opts.ReleaseStream) > 0 && strings.Contains(opts.ReleaseStream, "multi") {
+	if len(opts.ReleaseImage) == 0 && len(opts.ReleaseStream) > 0 && strings.Contains(opts.ReleaseStream, "multi") {
 		validMultiArchImage = true
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix validation for multi-arch image by checking the absence of ReleaseImage before ReleaseStream
**Which issue(s) this PR fixes**:
Fixes OCPBUGS-39396

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.