### PR TITLE
OSASINFRA-3584: openstack: remove support for floating IP

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1929,12 +1929,6 @@ type OpenStackPlatformSpec struct {
 	// +listType=set
 	// +optional
 	Tags []string `json:"tags,omitempty"`
-
-	// IngressFloatingIP is an available floating IP in your OpenStack cluster that will
-	// be associated with the OpenShift ingress port.
-	//
-	// +optional
-	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
 }
 
 // OpenStackIdentityReference is a reference to an infrastructure

--- a/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
@@ -29,7 +29,6 @@ type OpenStackPlatformSpecApplyConfiguration struct {
 	ExternalNetwork        *NetworkParamApplyConfiguration               `json:"externalNetwork,omitempty"`
 	DisableExternalNetwork *bool                                         `json:"disableExternalNetwork,omitempty"`
 	Tags                   []string                                      `json:"tags,omitempty"`
-	IngressFloatingIP      *string                                       `json:"ingressFloatingIP,omitempty"`
 }
 
 // OpenStackPlatformSpecApplyConfiguration constructs an declarative configuration of the OpenStackPlatformSpec type for use with
@@ -119,13 +118,5 @@ func (b *OpenStackPlatformSpecApplyConfiguration) WithTags(values ...string) *Op
 	for i := range values {
 		b.Tags = append(b.Tags, values[i])
 	}
-	return b
-}
-
-// WithIngressFloatingIP sets the IngressFloatingIP field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the IngressFloatingIP field is set to the value of the last call.
-func (b *OpenStackPlatformSpecApplyConfiguration) WithIngressFloatingIP(value string) *OpenStackPlatformSpecApplyConfiguration {
-	b.IngressFloatingIP = &value
 	return b
 }

--- a/cmd/cluster/openstack/create.go
+++ b/cmd/cluster/openstack/create.go
@@ -29,7 +29,6 @@ func BindOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 }
 
 func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
-	flags.StringVar(&opts.OpenStackIngressFloatingIP, "openstack-ingress-floating-ip", opts.OpenStackIngressFloatingIP, "An available floating IP in your OpenStack cluster that will be associated with the OpenShift ingress port (optional)")
 	flags.StringVar(&opts.OpenStackCredentialsFile, "openstack-credentials-file", opts.OpenStackCredentialsFile, "Path to the OpenStack credentials file (required)")
 	flags.StringVar(&opts.OpenStackCACertFile, "openstack-ca-cert-file", opts.OpenStackCACertFile, "Path to the OpenStack CA certificate file (optional)")
 	flags.StringVar(&opts.OpenStackExternalNetworkID, "openstack-external-network-id", opts.OpenStackExternalNetworkID, "ID of the OpenStack external network (optional)")
@@ -39,7 +38,6 @@ type RawCreateOptions struct {
 	OpenStackCredentialsFile   string
 	OpenStackCACertFile        string
 	OpenStackExternalNetworkID string
-	OpenStackIngressFloatingIP string
 
 	NodePoolOpts *openstacknodepool.RawOpenStackPlatformCreateOptions
 }
@@ -129,10 +127,6 @@ func (o *RawCreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster
 		cluster.Spec.Platform.OpenStack.ExternalNetwork = &hyperv1.NetworkParam{
 			ID: &o.OpenStackExternalNetworkID,
 		}
-	}
-
-	if o.OpenStackIngressFloatingIP != "" {
-		cluster.Spec.Platform.OpenStack.IngressFloatingIP = o.OpenStackIngressFloatingIP
 	}
 
 	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, false)

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedclusters.yaml
@@ -8629,11 +8629,6 @@ spec:
                         - cloudName
                         - name
                         type: object
-                      ingressFloatingIP:
-                        description: |-
-                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
-                          be associated with the OpenShift ingress port.
-                        type: string
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_hostedcontrolplanes.yaml
@@ -8593,11 +8593,6 @@ spec:
                         - cloudName
                         - name
                         type: object
-                      ingressFloatingIP:
-                        description: |-
-                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
-                          be associated with the OpenShift ingress port.
-                        type: string
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
@@ -35,15 +35,6 @@ func IngressDefaultIngressNodePortService() *corev1.Service {
 	}
 }
 
-func IngressRouterDefaultIngressService() *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "router-default",
-			Namespace: "openshift-ingress",
-		},
-	}
-}
-
 const IngressDefaultIngressPassthroughServiceName = "default-ingress-passthrough-service"
 
 func IngressDefaultIngressPassthroughService(namespace string) *corev1.Service {

--- a/docs/content/how-to/openstack/create-openstack-cluster.md
+++ b/docs/content/how-to/openstack/create-openstack-cluster.md
@@ -6,6 +6,8 @@ Install an OCP cluster running on VMs within a management OCP cluster
 
 * The HyperShift Operator with OpenStack support is currently in development and is not intended for production use.
 * OpenStack CSI (Cinder and Manila) are not functional.
+* Operators running in the workload cluster (e.g. console) won't be operational on day 1 and a manual and documented
+  action is required to make them work on day 2.
 
 ## Prerequisites
 
@@ -81,19 +83,6 @@ Here is an example of how to upload an RHCOS image to OpenStack:
 openstack image create --disk-format qcow2 --file rhcos-417.94.202407080309-0-openstack.x86_64.qcow2 rhcos
 ```
 
-## Create a floating IP for the Ingress (optional)
-
-To get Ingress functional on day 1, you need to create a floating IP that will be used by the Ingress service.
-
-```shell
-openstack floating ip create <external-network>
-```
-
-## Update the DNS record for the Ingress (optional)
-
-To get Ingress functional on day 1, you need to create a DNS record for the following wildcard domain that needs to point to the Ingress floating IP:
-`*.apps.<cluster-name>.<base-domain>`
-
 ## Create a HostedCluster
 
 Once all the [prerequisites](#prerequisites) are met, and the HyperShift
@@ -130,8 +119,6 @@ export CA_CERT_PATH="$HOME/ca.crt"
 # SSH Key for the nodepool VMs
 export SSH_KEY="$HOME/.ssh/id_rsa.pub"
 
-export INGRESS_FLOATING_IP="<ingress-floating-ip>"
-
 hcp create cluster openstack \
 --name $CLUSTER_NAME \
 --node-pool-replicas $WORKER_COUNT \
@@ -141,8 +128,7 @@ hcp create cluster openstack \
 --openstack-credentials-file $CLOUDS_YAML \
 --openstack-external-network-id $EXTERNAL_ID \
 --openstack-node-image-name $IMAGE_NAME \
---openstack-node-flavor $FLAVOR \
---openstack-ingress-floating-ip $INGRESS_FLOATING_IP
+--openstack-node-flavor $FLAVOR
 ```
 
 !!! note
@@ -158,12 +144,6 @@ hcp create cluster openstack \
     When the management cluster worker nodes are spread across different availability zones,
     the hosted control plane will be spread across different availability zones as well in `PreferredDuringSchedulingIgnoredDuringExecution` mode for
     `PodAntiAffinity`.
-
-!!! note
-    If you don't use a pre-created floating IP, you'll need to update your DNS so Ingress can work.
-    You should create a DNS A record for `*.apps.<cluster-name>.<base-domain>` that matches the external IP
-    which was assigned for the `router-default` service.
-    Once you have generated a kubeconfig, you can find that IP with `oc -n openshift-ingress get service/router-default`.
 
 After a few moments we should see our hosted control plane pods up and running:
 
@@ -222,6 +202,20 @@ oc --kubeconfig $CLUSTER_NAME-kubeconfig get clusterversion
 NAME      VERSION       AVAILABLE   PROGRESSING   SINCE   STATUS
 version   4.17.0        True        False         5m39s   Cluster version is 4.17.0
 ```
+
+## Ingress and DNS
+
+Once the workload cluster is deploying, the Ingress controller will be installed
+and a router named `router-default` will be created in the `openshift-ingress` namespace.
+
+You'll need to update your DNS with the external IP of that router so Ingress (and dependent operators like console) can work.
+You can run this command to get the external IP:
+
+```shell
+oc --kubeconfig $CLUSTER_NAME-kubeconfig -n openshift-ingress get service/router-default -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+Now you need to create a DNS A record for `*.apps.<cluster-name>.<base-domain>` that matches the returned IP address.
 
 ## Scaling an existing NodePool
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -7932,19 +7932,6 @@ to an external network is not possible or desirable, e.g. if using a provider ne
 <p>Tags to set on all resources in cluster which support tags</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>ingressFloatingIP</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>IngressFloatingIP is an available floating IP in your OpenStack cluster that will
-be associated with the OpenShift ingress port.</p>
-</td>
-</tr>
 </tbody>
 </table>
 ###PersistentVolumeAccessMode { #hypershift.openshift.io/v1beta1.PersistentVolumeAccessMode }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -106,7 +106,6 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackExternalNetworkID, "e2e.openstack-external-network-id", "", "ID of the OpenStack external network")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeFlavor, "e2e.openstack-node-flavor", "", "The flavor to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
-	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackIngressFloatingIP, "e2e.openstack-ingress-floating-ip", "", "The floating IP to use for the ingress controller (optional)")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureCredentialsFile, "e2e.azure-credentials-file", "", "Path to an Azure credentials file")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureLocation, "e2e.azure-location", "eastus", "The location to use for Azure")
 	flag.StringVar(&globalOpts.configurableClusterOptions.SSHKeyFile, "e2e.ssh-key-file", "", "Path to a ssh public key")
@@ -423,7 +422,6 @@ type configurableClusterOptions struct {
 	AzureCredentialsFile          string
 	OpenStackCredentialsFile      string
 	OpenStackCACertFile           string
-	OpenStackIngressFloatingIP    string
 	AzureLocation                 string
 	Region                        string
 	Zone                          stringSliceVar
@@ -532,7 +530,6 @@ func (p *options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 		OpenStackCredentialsFile:   p.configurableClusterOptions.OpenStackCredentialsFile,
 		OpenStackCACertFile:        p.configurableClusterOptions.OpenStackCACertFile,
 		OpenStackExternalNetworkID: p.configurableClusterOptions.OpenStackExternalNetworkID,
-		OpenStackIngressFloatingIP: p.configurableClusterOptions.OpenStackIngressFloatingIP,
 		NodePoolOpts: &openstacknodepool.RawOpenStackPlatformCreateOptions{
 			OpenStackPlatformOptions: &openstacknodepool.OpenStackPlatformOptions{
 				Flavor:    p.configurableClusterOptions.OpenStackNodeFlavor,

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1929,12 +1929,6 @@ type OpenStackPlatformSpec struct {
 	// +listType=set
 	// +optional
 	Tags []string `json:"tags,omitempty"`
-
-	// IngressFloatingIP is an available floating IP in your OpenStack cluster that will
-	// be associated with the OpenShift ingress port.
-	//
-	// +optional
-	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
 }
 
 // OpenStackIdentityReference is a reference to an infrastructure


### PR DESCRIPTION
**What this PR does / why we need it**:

This feature was added with the goal of being able to
have Ingress working on day 1 but the way it's implemented is racy
because it depends on a resource that Hypershift controller don't own,
and is owned by the Ingress controller.

Let's remove it now and re-add it later when it's safer.
