### PR TITLE
OCPBUGS-41328: Use KubeClientCABundle for HostedClusterConfigOperator cluster-signer-ca

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -456,10 +456,9 @@ func buildHCCVolumeRootCA(v *corev1.Volume) {
 }
 
 func buildHCCClusterSignerCA(v *corev1.Volume) {
-	v.Secret = &corev1.SecretVolumeSource{
-		SecretName:  manifests.CSRSignerCASecret("").Name,
-		DefaultMode: pointer.Int32(0640),
-	}
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+	v.ConfigMap.DefaultMode = pointer.Int32(0640)
+	v.ConfigMap.Name = manifests.KubeletClientCABundle("").Name
 }
 
 func IsExternalInfraKv(hcp *hyperv1.HostedControlPlane) bool {

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -140,7 +140,7 @@ func newHostedClusterConfigOperatorCommand() *cobra.Command {
 	flags.StringVar(&cpo.TargetKubeconfig, "target-kubeconfig", cpo.TargetKubeconfig, "Kubeconfig for target cluster")
 	flags.StringVar(&cpo.KubevirtInfraKubeconfig, "kubevirt-infra-kubeconfig", cpo.KubevirtInfraKubeconfig, "Kubeconfig for infra cluster (kubevirt provider)")
 	flags.StringVar(&cpo.InitialCAFile, "initial-ca-file", cpo.InitialCAFile, "Path to controller manager initial CA file")
-	flags.StringVar(&cpo.ClusterSignerCAFile, "cluster-signer-ca-file", cpo.ClusterSignerCAFile, "Path to the cluster signer CA cert")
+	flags.StringVar(&cpo.ClusterSignerCAFile, "cluster-signer-ca-file", cpo.ClusterSignerCAFile, "Path to the cluster signer CA cert bundle")
 	flags.StringSliceVar(&cpo.Controllers, "controllers", cpo.Controllers, "Controllers to run with this operator")
 	flags.StringVar(&cpo.platformType, "platform-type", "", "The platform of the cluster")
 	flags.BoolVar(&cpo.enableCIDebugOutput, "enable-ci-debug-output", false, "If extra CI debug output should be enabled")


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the certificate used by the HostedClusterConfigOperator to enable root certificate authority (root CA) rotation. 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-41328

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.