### PR TITLE
HOSTEDCP-1940: Add alert for Etcd recovery

### DIFF
--- a/api/hypershift/v1alpha1/conditions.go
+++ b/api/hypershift/v1alpha1/conditions.go
@@ -80,6 +80,10 @@ const (
 	// ReconciliationSucceeded indicates if the HostedCluster reconciliation
 	// succeeded.
 	ReconciliationSucceeded ConditionType = "ReconciliationSucceeded"
+
+	// EtcdRecoveryActive indicates that the Etcd cluster is failing and the
+	// recovery job was triggered.
+	EtcdRecoveryActive ConditionType = "EtcdRecoveryActive"
 )
 
 // Reasons.
@@ -96,6 +100,7 @@ const (
 	EtcdQuorumAvailableReason     = "QuorumAvailable"
 	EtcdWaitingForQuorumReason    = "EtcdWaitingForQuorum"
 	EtcdStatefulSetNotFoundReason = "StatefulSetNotFound"
+	EtcdRecoveryJobFailedReason   = "EtcdRecoveryJobFailed"
 
 	UnmanagedEtcdMisconfiguredReason = "UnmanagedEtcdMisconfigured"
 	UnmanagedEtcdAsExpected          = "UnmanagedEtcdAsExpected"

--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -169,6 +169,10 @@ const (
 	// A failure here often means a software bug or a non-stable cluster.
 	ReconciliationSucceeded ConditionType = "ReconciliationSucceeded"
 
+	// EtcdRecoveryActive indicates that the Etcd cluster is failing and the
+	// recovery job was triggered.
+	EtcdRecoveryActive ConditionType = "EtcdRecoveryActive"
+
 	// ClusterSizeComputed indicates that a t-shirt size was computed for this HostedCluster.
 	// The last transition time for this condition is used to manage how quickly transitions occur.
 	ClusterSizeComputed = "ClusterSizeComputed"
@@ -196,6 +200,7 @@ const (
 	EtcdQuorumAvailableReason     = "QuorumAvailable"
 	EtcdWaitingForQuorumReason    = "EtcdWaitingForQuorum"
 	EtcdStatefulSetNotFoundReason = "StatefulSetNotFound"
+	EtcdRecoveryJobFailedReason   = "EtcdRecoveryJobFailed"
 
 	UnmanagedEtcdMisconfiguredReason = "UnmanagedEtcdMisconfigured"
 	UnmanagedEtcdAsExpected          = "UnmanagedEtcdAsExpected"

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3380,6 +3380,10 @@ underlying cluster&rsquo;s ClusterVersion.</p>
 <td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.
 A failure here often means a software bug or a non-stable cluster.</p>
 </td>
+</tr><tr><td><p>&#34;EtcdRecoveryActive&#34;</p></td>
+<td><p>EtcdRecoveryActive indicates that the Etcd cluster is failing and the
+recovery job was triggered.</p>
+</td>
 </tr><tr><td><p>&#34;EtcdSnapshotRestored&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;ExternalDNSReachable&#34;</p></td>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/conditions.go
@@ -80,6 +80,10 @@ const (
 	// ReconciliationSucceeded indicates if the HostedCluster reconciliation
 	// succeeded.
 	ReconciliationSucceeded ConditionType = "ReconciliationSucceeded"
+
+	// EtcdRecoveryActive indicates that the Etcd cluster is failing and the
+	// recovery job was triggered.
+	EtcdRecoveryActive ConditionType = "EtcdRecoveryActive"
 )
 
 // Reasons.
@@ -96,6 +100,7 @@ const (
 	EtcdQuorumAvailableReason     = "QuorumAvailable"
 	EtcdWaitingForQuorumReason    = "EtcdWaitingForQuorum"
 	EtcdStatefulSetNotFoundReason = "StatefulSetNotFound"
+	EtcdRecoveryJobFailedReason   = "EtcdRecoveryJobFailed"
 
 	UnmanagedEtcdMisconfiguredReason = "UnmanagedEtcdMisconfigured"
 	UnmanagedEtcdAsExpected          = "UnmanagedEtcdAsExpected"

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -169,6 +169,10 @@ const (
 	// A failure here often means a software bug or a non-stable cluster.
 	ReconciliationSucceeded ConditionType = "ReconciliationSucceeded"
 
+	// EtcdRecoveryActive indicates that the Etcd cluster is failing and the
+	// recovery job was triggered.
+	EtcdRecoveryActive ConditionType = "EtcdRecoveryActive"
+
 	// ClusterSizeComputed indicates that a t-shirt size was computed for this HostedCluster.
 	// The last transition time for this condition is used to manage how quickly transitions occur.
 	ClusterSizeComputed = "ClusterSizeComputed"
@@ -196,6 +200,7 @@ const (
 	EtcdQuorumAvailableReason     = "QuorumAvailable"
 	EtcdWaitingForQuorumReason    = "EtcdWaitingForQuorum"
 	EtcdStatefulSetNotFoundReason = "StatefulSetNotFound"
+	EtcdRecoveryJobFailedReason   = "EtcdRecoveryJobFailed"
 
 	UnmanagedEtcdMisconfiguredReason = "UnmanagedEtcdMisconfigured"
 	UnmanagedEtcdAsExpected          = "UnmanagedEtcdAsExpected"


### PR DESCRIPTION
This PR consists of two parts.

Firstly, I've added a new condition to the HostedCluster called `EtcdRecoveryActive`, which indicates that the Etcd recovery job has been triggered due to an error in the Etcd cluster. The condition covers three scenarios:

- The job has been initiated and is in progress (Status: True / Reason: AsExpected)
- The job has completed successfully (Status: False / Reason: AsExpected)
- The job has completed but failed (Status: False / Reason: EtcdRecoveryJobFailed)

The second part of the PR introduces a new metric called `hypershift_etcd_manual_intervention_required`. This metric helps SD/SRE teams identify Etcd clusters that require manual intervention. The metric includes the following fields:

- HC Namespace
- HC Name
- HC ID
- ROSA Environment
- ROSA ID

The metric will be set to 1.0 when an Etcd cluster requires manual intervention. If manual intervention is not necessary, the metric will not be created.

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-1940](https://issues.redhat.com/browse/HOSTEDCP-1940)