### PR TITLE
OCPBUGS-39420: Let payload generation pick the release for the NodePool

### DIFF
--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -94,7 +94,7 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 
 	p := &controllers.LocalIgnitionProvider{
 		Client:              cl,
-		ReleaseProvider:     &releaseinfo.RegistryClientProvider{},
+		ReleaseProvider:     &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{},
 		CloudProvider:       "",
 		Namespace:           o.Namespace,
 		WorkDir:             o.WorkDir,

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -54,7 +54,7 @@ import (
 // measurements.
 type LocalIgnitionProvider struct {
 	Client          client.Client
-	ReleaseProvider releaseinfo.Provider
+	ReleaseProvider releaseinfo.ProviderWithOpenShiftImageRegistryOverrides
 	CloudProvider   hyperv1.PlatformType
 	Namespace       string
 
@@ -244,11 +244,14 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 	err = func() error {
 		start := time.Now()
 
-		// Replace the release image with the mirrored release image in disconnected environment cases
-		mirroredReleaseImage, ok := os.LookupEnv("MIRRORED_RELEASE_IMAGE")
-		if ok {
-			log.Info("replaced release image with mirrored release image to extract image-references", "releaseImage", releaseImage, "mirroredReleaseImage", mirroredReleaseImage)
-			releaseImage = mirroredReleaseImage
+		// Replace the release image with the mirrored release image in disconnected environment cases.
+		// ProviderWithOpenShiftImageRegistryOverrides Lookup will store the mirrored release image if it exists.
+		_, err := p.ReleaseProvider.Lookup(ctx, releaseImage, pullSecret)
+		if err != nil {
+			return fmt.Errorf("failed to look up release image metadata: %w", err)
+		}
+		if p.ReleaseProvider.GetMirroredReleaseImage() != "" {
+			releaseImage = p.ReleaseProvider.GetMirroredReleaseImage()
 		}
 
 		if err := registryclient.ExtractImageFilesToDir(ctx, releaseImage, pullSecret, "release-manifests/image-references", configDir); err != nil {

--- a/support/releaseinfo/registry_image_content_policies_test.go
+++ b/support/releaseinfo/registry_image_content_policies_test.go
@@ -1,0 +1,45 @@
+package releaseinfo
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	imagev1 "github.com/openshift/api/image/v1"
+)
+
+func TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create mock resources.
+	mirroredReleaseImage := "mirrored-release-image"
+	canonicalReleaseImage := "canonical-release-image"
+	releaseImage := &ReleaseImage{
+		ImageStream:    &imagev1.ImageStream{},
+		StreamMetadata: &CoreOSStreamMetadata{},
+	}
+
+	// Create registry providers delegating to a cached provider so we can mock the cache content for the mirroredReleaseImage.
+	delegate := &RegistryMirrorProviderDecorator{
+		Delegate: &CachedProvider{
+			Inner: &RegistryClientProvider{},
+			Cache: map[string]*ReleaseImage{
+				mirroredReleaseImage: releaseImage,
+			},
+		},
+		RegistryOverrides: map[string]string{},
+	}
+	provider := &ProviderWithOpenShiftImageRegistryOverridesDecorator{
+		Delegate: delegate,
+		OpenShiftImageRegistryOverrides: map[string][]string{
+			canonicalReleaseImage: []string{mirroredReleaseImage},
+		},
+		lock: sync.Mutex{},
+	}
+
+	// Call the Lookup method and validate GetMirroredReleaseImage.
+	_, err := provider.Lookup(context.Background(), canonicalReleaseImage, []byte("test-pull-secret"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(provider.GetMirroredReleaseImage()).To(Equal(mirroredReleaseImage))
+}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Without this the value in the env variable is always used, which comes from the HC and doesn't necessarily match the intentded nodepool version

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.