### PR TITLE
OCPBUGS-39039: Allow Encryption at Host to be Independently Toggled from DiskEncryptionSetID

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
-	golang.org/x/net v0.26.0 // indirect
-	golang.org/x/text v0.16.0 // indirect
+	golang.org/x/net v0.29.0 // indirect
+	golang.org/x/text v0.18.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -49,8 +49,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
+golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -59,8 +59,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
-golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
+golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
+golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -968,6 +968,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+	// means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+	// https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+	// for more information.
+	//
+	// +kubebuilder:default:=Enabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	EncryptionAtHost string `json:"encryptionAtHost,omitempty"`
+
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
 	// needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
 	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -996,6 +996,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+	// means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+	// https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+	// for more information.
+	//
+	// +kubebuilder:default:=Enabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	EncryptionAtHost string `json:"encryptionAtHost,omitempty"`
+
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
 	// needs to exist in the same subscription id listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.SubscriptionID.
 	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location

--- a/api/vendor/golang.org/x/net/LICENSE
+++ b/api/vendor/golang.org/x/net/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/api/vendor/golang.org/x/net/http2/transport.go
+++ b/api/vendor/golang.org/x/net/http2/transport.go
@@ -827,10 +827,6 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
 	cc.henc.SetMaxDynamicTableSizeLimit(t.maxEncoderHeaderTableSize())
 	cc.peerMaxHeaderTableSize = initialHeaderTableSize
 
-	if t.AllowHTTP {
-		cc.nextStreamID = 3
-	}
-
 	if cs, ok := c.(connectionStater); ok {
 		state := cs.ConnectionState()
 		cc.tlsState = &state

--- a/api/vendor/golang.org/x/text/LICENSE
+++ b/api/vendor/golang.org/x/text/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/api/vendor/modules.txt
+++ b/api/vendor/modules.txt
@@ -31,13 +31,13 @@ github.com/openshift/api/config/v1
 ## explicit; go 1.12
 # github.com/stretchr/testify v1.9.0
 ## explicit; go 1.17
-# golang.org/x/net v0.26.0
+# golang.org/x/net v0.29.0
 ## explicit; go 1.18
 golang.org/x/net/http/httpguts
 golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
-# golang.org/x/text v0.16.0
+# golang.org/x/text v0.18.0
 ## explicit; go 1.18
 golang.org/x/text/secure/bidirule
 golang.org/x/text/transform

--- a/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
@@ -25,6 +25,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	DiskSizeGB             *int32                          `json:"diskSizeGB,omitempty"`
 	DiskStorageAccountType *string                         `json:"diskStorageAccountType,omitempty"`
 	AvailabilityZone       *string                         `json:"availabilityZone,omitempty"`
+	EncryptionAtHost       *string                         `json:"encryptionAtHost,omitempty"`
 	DiskEncryptionSetID    *string                         `json:"diskEncryptionSetID,omitempty"`
 	EnableEphemeralOSDisk  *bool                           `json:"enableEphemeralOSDisk,omitempty"`
 	SubnetID               *string                         `json:"subnetID,omitempty"`
@@ -75,6 +76,14 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithDiskStorageAccountType(val
 // If called multiple times, the AvailabilityZone field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithAvailabilityZone(value string) *AzureNodePoolPlatformApplyConfiguration {
 	b.AvailabilityZone = &value
+	return b
+}
+
+// WithEncryptionAtHost sets the EncryptionAtHost field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EncryptionAtHost field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithEncryptionAtHost(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.EncryptionAtHost = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
@@ -25,6 +25,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	DiskSizeGB             *int32                          `json:"diskSizeGB,omitempty"`
 	DiskStorageAccountType *string                         `json:"diskStorageAccountType,omitempty"`
 	AvailabilityZone       *string                         `json:"availabilityZone,omitempty"`
+	EncryptionAtHost       *string                         `json:"encryptionAtHost,omitempty"`
 	DiskEncryptionSetID    *string                         `json:"diskEncryptionSetID,omitempty"`
 	EnableEphemeralOSDisk  *bool                           `json:"enableEphemeralOSDisk,omitempty"`
 	SubnetID               *string                         `json:"subnetID,omitempty"`
@@ -75,6 +76,14 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithDiskStorageAccountType(val
 // If called multiple times, the AvailabilityZone field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithAvailabilityZone(value string) *AzureNodePoolPlatformApplyConfiguration {
 	b.AvailabilityZone = &value
+	return b
+}
+
+// WithEncryptionAtHost sets the EncryptionAtHost field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EncryptionAtHost field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithEncryptionAtHost(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.EncryptionAtHost = &value
 	return b
 }
 

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -648,6 +648,17 @@ spec:
                         description: EnableEphemeralOSDisk is a flag when set to true,
                           will enable ephemeral OS disk.
                         type: boolean
+                      encryptionAtHost:
+                        default: Enabled
+                        description: |-
+                          encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+                          means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+                          https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+                          for more information.
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
                       image:
                         description: Image is the image to boot the VMs with
                         properties:
@@ -1896,6 +1907,17 @@ spec:
                         description: EnableEphemeralOSDisk is a flag when set to true,
                           will enable ephemeral OS disk.
                         type: boolean
+                      encryptionAtHost:
+                        default: Enabled
+                        description: |-
+                          encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+                          means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+                          https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+                          for more information.
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
                       image:
                         description: |-
                           ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -28,6 +28,7 @@ type AzurePlatformCreateOptions struct {
 	SubnetID                      string
 	ImageID                       string
 	Arch                          string
+	EncryptionAtHost              string
 }
 
 type AzureMarketPlaceImageInfo struct {
@@ -70,6 +71,7 @@ func bindCoreOptions(opts *RawAzurePlatformCreateOptions, flags *pflag.FlagSet) 
 	flags.StringVar(&opts.MarketplaceOffer, "marketplace-offer", opts.MarketplaceOffer, "The Azure Marketplace image offer.")
 	flags.StringVar(&opts.MarketplaceSKU, "marketplace-sku", opts.MarketplaceSKU, "The Azure Marketplace image SKU.")
 	flags.StringVar(&opts.MarketplaceVersion, "marketplace-version", opts.MarketplaceVersion, "The Azure Marketplace image version.")
+	flags.StringVar(&opts.EncryptionAtHost, "enable-encryption-at-host", opts.EncryptionAtHost, "Enables encryption at host on Azure VMs.")
 }
 
 func BindDeveloperOptions(opts *RawAzurePlatformCreateOptions, flags *pflag.FlagSet) {
@@ -111,6 +113,10 @@ func (o *RawAzurePlatformCreateOptions) Validate() (*ValidatedAzurePlatformCreat
 
 	if o.DiagnosticsStorageAccountType != hyperv1.AzureDiagnosticsStorageAccountTypeUserManaged && len(o.DiagnosticsStorageAccountURI) > 0 {
 		return nil, fmt.Errorf("--diagnostics-storage-account-uri is applicable only if --diagnostics-storage-account-type is set to %s", hyperv1.AzureDiagnosticsStorageAccountTypeUserManaged)
+	}
+
+	if o.EncryptionAtHost != "" && o.EncryptionAtHost != "Enabled" && o.EncryptionAtHost != "Disabled" {
+		return nil, fmt.Errorf("flag --enable-encryption-at-host has an invalid value; accepted values are 'Enabled' and 'Disabled'")
 	}
 
 	return &ValidatedAzurePlatformCreateOptions{
@@ -197,6 +203,7 @@ func (o *CompletedAzurePlatformCreateOptions) NodePoolPlatform(nodePool *hyperv1
 		DiskStorageAccountType: o.DiskStorageAccountType,
 		SubnetID:               o.SubnetID,
 		Image:                  vmImage,
+		EncryptionAtHost:       o.EncryptionAtHost,
 	}
 
 	if len(o.DiagnosticsStorageAccountType) > 0 {

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2521,6 +2521,21 @@ for clusters in a location that does not support AvailabilityZone.</p>
 </tr>
 <tr>
 <td>
+<code>encryptionAtHost</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+<a href="https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell">https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell</a>
+for more information.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>diskEncryptionSetID</code></br>
 <em>
 string

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -70,6 +70,9 @@ func azureMachineTemplateSpec(nodePool *hyperv1.NodePool) (*capiazure.AzureMachi
 		azureMachineTemplate.Template.Spec.OSDisk.ManagedDisk.DiskEncryptionSet = &capiazure.DiskEncryptionSetParameters{
 			ID: nodePool.Spec.Platform.Azure.DiskEncryptionSetID,
 		}
+	}
+
+	if nodePool.Spec.Platform.Azure.EncryptionAtHost == "Enabled" {
 		azureMachineTemplate.Template.Spec.SecurityProfile = &capiazure.SecurityProfile{
 			EncryptionAtHost: to.Ptr(true),
 		}

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -347,14 +347,9 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							},
 						},
 						SpotVMOptions: nil,
-						SecurityProfile: &capiazure.SecurityProfile{
-							EncryptionAtHost: ptr.To(true),
-							SecurityType:     "",
-							UefiSettings:     nil,
-						},
-						SubnetName:   "",
-						DNSServers:   nil,
-						VMExtensions: nil,
+						SubnetName:    "",
+						DNSServers:    nil,
+						VMExtensions:  nil,
 						NetworkInterfaces: []capiazure.NetworkInterface{
 							{
 								SubnetName:            "testSubnetName",
@@ -452,14 +447,9 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							},
 						},
 						SpotVMOptions: nil,
-						SecurityProfile: &capiazure.SecurityProfile{
-							EncryptionAtHost: ptr.To(true),
-							SecurityType:     "",
-							UefiSettings:     nil,
-						},
-						SubnetName:   "",
-						DNSServers:   nil,
-						VMExtensions: nil,
+						SubnetName:    "",
+						DNSServers:    nil,
+						VMExtensions:  nil,
 						NetworkInterfaces: []capiazure.NetworkInterface{
 							{
 								SubnetName:            "testSubnetName",

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
@@ -968,6 +968,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+	// means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+	// https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+	// for more information.
+	//
+	// +kubebuilder:default:=Enabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	EncryptionAtHost string `json:"encryptionAtHost,omitempty"`
+
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
 	// needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
 	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -996,6 +996,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+	// means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+	// https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+	// for more information.
+	//
+	// +kubebuilder:default:=Enabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	EncryptionAtHost string `json:"encryptionAtHost,omitempty"`
+
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
 	// needs to exist in the same subscription id listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.SubscriptionID.
 	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a field to the Azure NodePool API to enable EncryptionAtHost and allows EncryptionAtHost to be set in the NodePool controller independently from DiskEncryptionSetID.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-39039](https://issues.redhat.com/browse/OCPBUGS-39039)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.