### PR TITLE
ARO-10259: add install render option to write manifests to file

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -68,6 +68,7 @@ type Options struct {
 	EnableConversionWebhook                   bool
 	Template                                  bool
 	Format                                    string
+	OutputFile                                string
 	OutputTypes                               string
 	ExcludeEtcdManifests                      bool
 	PlatformMonitoring                        metrics.PlatformMonitoring


### PR DESCRIPTION
**What this PR does / why we need it**:

if `hypershift install render --output-file my-file` is given, the generated manifests will be written into that specific file instead to STDOUT

Reason: this gives an option to mitigate situations where the `install render` command logs errors to stdout and makes the consumption of the generated manifests hard, e.g. the best-effort in-cluster proxy detection for external DNS.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/ARO-10259

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.