### PR TITLE
HOSTEDCP-1569: e2e: add version gating for 4.17

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -189,6 +189,13 @@ func main(m *testing.M) int {
 		defer cleanupSharedOIDCProvider()
 	}
 
+	// set the semantic version of the latest release image for version gating tests
+	err := util.SetReleaseImageVersion(testContext, globalOpts.LatestReleaseImage, globalOpts.configurableClusterOptions.PullSecretFile)
+	if err != nil {
+		log.Error(err, "failed to set release image version")
+		return -1
+	}
+
 	// Everything's okay to run tests
 	log.Info("executing e2e tests", "options", globalOpts)
 	return m.Run()

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1218,6 +1218,7 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 	}
 	guestClient := WaitForGuestClient(t, ctx, mgmtClient, hc)
 	t.Run("EnsureValidatingAdmissionPoliciesExists", func(t *testing.T) {
+		AtLeast(t, Version418)
 		t.Log("Waiting for ValidatingAdmissionPolicies to exist")
 		var expectedVAPCount int = 3
 		g := NewWithT(t)
@@ -1261,6 +1262,7 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 		t.Logf("Successfully waited for ValidatingAdmissionPolicies to exist in %s", duration)
 	})
 	t.Run("EnsureValidatingAdmissionPoliciesCheckDeniedRequests", func(t *testing.T) {
+		AtLeast(t, Version418)
 		g := NewWithT(t)
 		t.Log("Checking Denied KAS Requests for ValidatingAdmissionPolicies")
 		apiServer := &configv1.APIServer{

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/blang/semver"
+
+	"github.com/openshift/hypershift/support/releaseinfo"
+)
+
+var (
+	// y-stream versions supported by e2e in main
+	Version418 = semver.MustParse("4.18.0")
+	Version417 = semver.MustParse("4.17.0")
+	Version416 = semver.MustParse("4.16.0")
+	Version415 = semver.MustParse("4.15.0")
+	Version414 = semver.MustParse("4.14.0")
+
+	releaseVersion semver.Version
+)
+
+func init() {
+	// Ensure that the version constants are valid semver versions
+	// This is a compile-time check to ensure that the versions are valid
+	// semver versions.
+	_ = Version418
+	_ = Version417
+	_ = Version416
+	_ = Version415
+	_ = Version414
+}
+
+func SetReleaseImageVersion(ctx context.Context, latestReleaseImage string, pullSecretFile string) error {
+	data, err := os.ReadFile(pullSecretFile)
+	if err != nil {
+		return fmt.Errorf("error reading file: %v", err)
+	}
+	releaseInfoProvider := releaseinfo.RegistryClientProvider{}
+	releaseImage, err := releaseInfoProvider.Lookup(ctx, latestReleaseImage, data)
+	if err != nil {
+		return fmt.Errorf("error looking up latest release image: %v", err)
+	}
+	releaseVersion, err = semver.Parse(releaseImage.Version())
+	if err != nil {
+		return fmt.Errorf("error parsing version: %v", err)
+	}
+	releaseVersion.Patch = 0
+	releaseVersion.Pre = nil
+	releaseVersion.Build = nil
+	return nil
+}
+
+func AtLeast(t *testing.T, version semver.Version) {
+	if releaseVersion.LT(version) {
+		t.Skipf("Only tested in %s and later", version)
+	}
+}


### PR DESCRIPTION
This PR adds a simple mechanism for gating/skipping test cases based on the version of the latest release image