### PR TITLE
OCPBUGS-38425: Update the ImageStream tag according to the OCP release

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs_test.go
@@ -1,0 +1,54 @@
+package olm
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetCatalogToImagesWithVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		releaseVersion string
+		expectedResult map[string]string
+		expectedError  bool
+	}{
+		{
+			name:           "basic case",
+			releaseVersion: "4.8.0",
+			expectedResult: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.8",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.8",
+				"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.8",
+				"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.8",
+			},
+			expectedError: false,
+		},
+		{
+			name:           "different version",
+			releaseVersion: "4.9.1",
+			expectedResult: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.9",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.9",
+				"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.9",
+				"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.9",
+			},
+			expectedError: false,
+		},
+		{
+			name:           "empty releaseVersion",
+			releaseVersion: "",
+			expectedResult: nil,
+			expectedError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result, err := GetCatalogToImagesWithVersion(tt.releaseVersion)
+			g.Expect(tt.expectedError).To(Equal(err != nil))
+			g.Expect(tt.expectedResult).To(Equal(result))
+		})
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
@@ -1,6 +1,8 @@
 package olm
 
 import (
+	"fmt"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/olm"
 )
@@ -13,14 +15,18 @@ type OperatorLifecycleManagerParams struct {
 	OLMCatalogPlacement     hyperv1.OLMCatalogPlacement
 }
 
-func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane) *OperatorLifecycleManagerParams {
+func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane) (*OperatorLifecycleManagerParams, error) {
+	catalogImages, err := olm.GetCatalogToImagesWithVersion(hcp.Status.VersionStatus.Desired.Version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get catalog images with version: %w", err)
+	}
 	params := &OperatorLifecycleManagerParams{
-		CertifiedOperatorsImage: olm.CatalogToImage["certified-operators"],
-		CommunityOperatorsImage: olm.CatalogToImage["community-operators"],
-		RedHatMarketplaceImage:  olm.CatalogToImage["redhat-marketplace"],
-		RedHatOperatorsImage:    olm.CatalogToImage["redhat-operators"],
+		CertifiedOperatorsImage: catalogImages["certified-operators"],
+		CommunityOperatorsImage: catalogImages["community-operators"],
+		RedHatMarketplaceImage:  catalogImages["redhat-marketplace"],
+		RedHatOperatorsImage:    catalogImages["redhat-operators"],
 		OLMCatalogPlacement:     hcp.Spec.OLMCatalogPlacement,
 	}
 
-	return params
+	return params, nil
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1597,7 +1597,11 @@ func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedContro
 		}
 	}
 
-	p := olm.NewOperatorLifecycleManagerParams(hcp)
+	p, err := olm.NewOperatorLifecycleManagerParams(hcp)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to create OLM params: %w", err))
+		return errs
+	}
 
 	// Check if the defaultSources are disabled
 	if err := r.client.Get(ctx, client.ObjectKeyFromObject(operatorHub), operatorHub); err != nil {


### PR DESCRIPTION
Now the OLM catalog version is purely based in the OCP Release and not hardcoded.

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-38425](https://issues.redhat.com/browse/OCPBUGS-38425)