### PR TITLE
OCPBUGS-38425: Return the right tagReference on Catalogs ImageStream

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -110,9 +110,9 @@ func reconcileCatalogDeployment(deployment *appsv1.Deployment, ownerRef config.O
 }
 
 func findTagReference(tags []imagev1.TagReference, name string) *imagev1.TagReference {
-	for _, tag := range tags {
+	for i, tag := range tags {
 		if tag.Name == name {
-			return &tag
+			return &tags[i]
 		}
 	}
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs_test.go
@@ -1,0 +1,54 @@
+package olm
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetCatalogToImageWithISImageRegistryOverrides(t *testing.T) {
+	tests := []struct {
+		name                     string
+		catalogToImage           map[string]string
+		isImageRegistryOverrides map[string][]string
+		expected                 map[string]string
+	}{
+		{
+			name: "No overrides",
+			catalogToImage: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.16",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.16",
+			},
+			isImageRegistryOverrides: map[string][]string{},
+			expected: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.16",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.16",
+			},
+		},
+		{
+			name: "Single override and different tag",
+			catalogToImage: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.17",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.17",
+			},
+			isImageRegistryOverrides: map[string][]string{
+				"registry.redhat.io": {"custom.registry.io"},
+			},
+			expected: map[string]string{
+				"certified-operators": "custom.registry.io/redhat/certified-operator-index:v4.17",
+				"community-operators": "custom.registry.io/redhat/community-operator-index:v4.17",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := getCatalogToImageWithISImageRegistryOverrides(tt.catalogToImage, tt.isImageRegistryOverrides)
+			g.Expect(result).To(Equal(tt.expected), "Expected %d entries, but got %d", len(tt.expected), len(result))
+			for key, expectedValue := range tt.expected {
+				g.Expect(expectedValue).To(Equal(result[key]), "For key %s, expected %s, but got %s", key, expectedValue, result[key])
+			}
+		})
+	}
+}


### PR DESCRIPTION
Which issue(s) this PR fixes :
Fixes #[OCPBUGS-38425](https://issues.redhat.com/browse/OCPBUGS-38425)