### PR TITLE
HOSTEDCP-1801: [CPO Refactor] Introduced an abstraction for CP Components

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -337,6 +337,13 @@ const (
 
 	// DisableIgnitionServerAnnotation controls skipping of the ignition server deployment.
 	DisableIgnitionServerAnnotation = "hypershift.openshift.io/disable-ignition-server"
+
+	// ControlPlaneOperatorV2Annotation tells the hosted cluster to set 'CPO_V2' env variable on the CPO deployment which enables
+	// the new manifest based CPO implementation.
+	ControlPlaneOperatorV2Annotation = "hypershift.openshift.io/cpo-v2"
+
+	// ControlPlaneOperatorV2EnvVar when set on the CPO deplyoment, enables the new manifest based CPO implementation.
+	ControlPlaneOperatorV2EnvVar = "CPO_V2"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/control-plane-operator/controllers/hostedcontrolplane/cco/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cco/reconcile.go
@@ -52,7 +52,7 @@ type Params struct {
 	config.OwnerRef
 }
 
-func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
+func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
 	params := Params{
 		operatorImage:           releaseImageProvider.GetImage("cloud-credential-operator"),
 		kubeRbacProxyImage:      releaseImageProvider.GetImage("kube-rbac-proxy"),

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/reconcile.go
@@ -23,7 +23,7 @@ func ReconcileCCMServiceAccount(sa *corev1.ServiceAccount, ownerRef config.Owner
 	return nil
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, deploymentConfig config.DeploymentConfig, serviceAccountName string, releaseImageProvider *imageprovider.ReleaseImageProvider) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, deploymentConfig config.DeploymentConfig, serviceAccountName string, releaseImageProvider imageprovider.ReleaseImageProvider) error {
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: ccmLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/reconcile.go
@@ -22,7 +22,7 @@ func ReconcileCCMServiceAccount(sa *corev1.ServiceAccount, ownerRef config.Owner
 	return nil
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, p *AzureParams, serviceAccountName string, releaseImageProvider *imageprovider.ReleaseImageProvider) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, p *AzureParams, serviceAccountName string, releaseImageProvider imageprovider.ReleaseImageProvider) error {
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: ccmLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/kubevirt/reconcile.go
@@ -96,7 +96,7 @@ func ReconcileCCMRoleBinding(roleBinding *rbacv1.RoleBinding, ownerRef config.Ow
 	return nil
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, serviceAccountName string, releaseImageProvider *imageprovider.ReleaseImageProvider) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, serviceAccountName string, releaseImageProvider imageprovider.ReleaseImageProvider) error {
 	clusterName, ok := hcp.Labels["cluster.x-k8s.io/cluster-name"]
 	if !ok {
 		return fmt.Errorf("\"cluster.x-k8s.io/cluster-name\" label doesn't exist in HostedControlPlane")
@@ -167,7 +167,7 @@ func podVolumeMounts(isExternalInfra bool) util.PodVolumeMounts {
 	}
 }
 
-func buildCCMContainer(clusterName string, releaseImageProvider *imageprovider.ReleaseImageProvider, isExternalInfra bool) func(c *corev1.Container) {
+func buildCCMContainer(clusterName string, releaseImageProvider imageprovider.ReleaseImageProvider, isExternalInfra bool) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = releaseImageProvider.GetImage("kubevirt-cloud-controller-manager")
 		c.ImagePullPolicy = corev1.PullIfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/reconcile.go
@@ -27,7 +27,7 @@ func ReconcileCCMServiceAccount(sa *corev1.ServiceAccount, ownerRef config.Owner
 	return nil
 }
 
-func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, p *OpenStackParams, serviceAccountName string, releaseImageProvider *imageprovider.ReleaseImageProvider, hasCACert bool) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, p *OpenStackParams, serviceAccountName string, releaseImageProvider imageprovider.ReleaseImageProvider, hasCACert bool) error {
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: ccmLabels(),

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/powervs/powervs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/powervs/powervs.go
@@ -78,7 +78,7 @@ func ReconcileCCMConfigMap(ccmConfig *corev1.ConfigMap, hcp *hyperv1.HostedContr
 	return nil
 }
 
-func ReconcileCCMDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, ccmConfig *corev1.ConfigMap, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) error {
+func ReconcileCCMDeployment(deployment *appsv1.Deployment, hcp *hyperv1.HostedControlPlane, ccmConfig *corev1.ConfigMap, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) error {
 	commandToExec := []string{
 		"/bin/ibm-cloud-controller-manager",
 		"--authentication-skip-lookup",

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -20,7 +20,7 @@ type ClusterPolicyControllerParams struct {
 	config.OwnerRef  `json:",inline"`
 }
 
-func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *ClusterPolicyControllerParams {
+func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *ClusterPolicyControllerParams {
 	params := &ClusterPolicyControllerParams{
 		Image:                   releaseImageProvider.GetImage("cluster-policy-controller"),
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -76,7 +76,7 @@ type Params struct {
 	DefaultIngressDomain    string
 }
 
-func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool, defaultIngressDomain string) Params {
+func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider imageprovider.ReleaseImageProvider, userReleaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool, defaultIngressDomain string) Params {
 	p := Params{
 		Images: Images{
 			NetworkOperator:              releaseImageProvider.GetImage("cluster-network-operator"),

--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/params.go
@@ -25,7 +25,7 @@ type HostedClusterConfigOperatorParams struct {
 	AvailabilityProberImage string
 }
 
-func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, openShiftVersion, kubernetesVersion string, setDefaultSecurityContext bool) *HostedClusterConfigOperatorParams {
+func NewHostedClusterConfigOperatorParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, openShiftVersion, kubernetesVersion string, setDefaultSecurityContext bool) *HostedClusterConfigOperatorParams {
 	params := &HostedClusterConfigOperatorParams{
 		Image:                   releaseImageProvider.GetImage("hosted-cluster-config-operator"),
 		ReleaseImage:            hcp.Spec.ReleaseImage,

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -23,7 +23,7 @@ type CVOParams struct {
 	PlatformType            hyperv1.PlatformType
 }
 
-func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext, enableCVOManagementClusterMetricsAccess bool) *CVOParams {
+func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext, enableCVOManagementClusterMetricsAccess bool) *CVOParams {
 	p := &CVOParams{
 		CLIImage:                releaseImageProvider.GetImage("cli"),
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),

--- a/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/dnsoperator/dnsoperator.go
@@ -46,7 +46,7 @@ type Params struct {
 }
 
 // NewParams creates a new Params object for a DNS operator deployment.
-func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
+func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider imageprovider.ReleaseImageProvider, userReleaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
 	p := Params{
 		Images: Images{
 			DNSOperator:   releaseImageProvider.GetImage("cluster-dns-operator"),

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -38,7 +38,7 @@ func etcdPodSelector() map[string]string {
 	return map[string]string{"app": "etcd"}
 }
 
-func NewEtcdParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider) (*EtcdParams, error) {
+func NewEtcdParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider) (*EtcdParams, error) {
 
 	ipv4, err := hyputils.IsIPv4(hcp.Spec.Networking.ClusterNetwork[0].CIDR.String())
 	if err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/imageprovider/imageprovider.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/imageprovider/imageprovider.go
@@ -2,29 +2,35 @@ package imageprovider
 
 import "github.com/openshift/hypershift/support/releaseinfo"
 
-type ReleaseImageProvider struct {
+// ReleaseImageProvider provides the functionality to retrieve OpenShift components' container image from a release image.
+type ReleaseImageProvider interface {
+	GetImage(key string) string
+	ImageExist(key string) (string, bool)
+}
+
+type SimpleReleaseImageProvider struct {
 	missingImages    []string
 	componentsImages map[string]string
 
 	*releaseinfo.ReleaseImage
 }
 
-func New(releaseImage *releaseinfo.ReleaseImage) *ReleaseImageProvider {
-	return &ReleaseImageProvider{
+func New(releaseImage *releaseinfo.ReleaseImage) *SimpleReleaseImageProvider {
+	return &SimpleReleaseImageProvider{
 		componentsImages: releaseImage.ComponentImages(),
 		missingImages:    make([]string, 0),
 		ReleaseImage:     releaseImage,
 	}
 }
 
-func NewFromImages(componentsImages map[string]string) *ReleaseImageProvider {
-	return &ReleaseImageProvider{
+func NewFromImages(componentsImages map[string]string) *SimpleReleaseImageProvider {
+	return &SimpleReleaseImageProvider{
 		componentsImages: componentsImages,
 		missingImages:    make([]string, 0),
 	}
 }
 
-func (p *ReleaseImageProvider) GetImage(key string) string {
+func (p *SimpleReleaseImageProvider) GetImage(key string) string {
 	image, exist := p.componentsImages[key]
 	if !exist || image == "" {
 		p.missingImages = append(p.missingImages, key)
@@ -33,11 +39,11 @@ func (p *ReleaseImageProvider) GetImage(key string) string {
 	return image
 }
 
-func (p *ReleaseImageProvider) GetMissingImages() []string {
+func (p *SimpleReleaseImageProvider) GetMissingImages() []string {
 	return p.missingImages
 }
 
-func (p *ReleaseImageProvider) ImageExist(key string) (string, bool) {
+func (p *SimpleReleaseImageProvider) ImageExist(key string) (string, bool) {
 	img, exist := p.componentsImages[key]
 	return img, exist
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -45,7 +45,7 @@ type Params struct {
 	NoProxy                 string
 }
 
-func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool, platform hyperv1.PlatformType) Params {
+func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider imageprovider.ReleaseImageProvider, userReleaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool, platform hyperv1.PlatformType) Params {
 	p := Params{
 		IngressOperatorImage:    releaseImageProvider.GetImage("cluster-ingress-operator"),
 		IngressCanaryImage:      userReleaseImageProvider.GetImage("cluster-ingress-operator"),

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -89,7 +89,7 @@ const (
 	defaultMaxMutatingRequestsInflight = 1000
 )
 
-func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, externalAPIAddress string, externalAPIPort int32, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {
+func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, externalAPIAddress string, externalAPIPort int32, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {
 	dns := globalconfig.DNSConfig()
 	globalconfig.ReconcileDNSConfig(dns, hcp)
 	params := &KubeAPIServerParams{

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/config.go
@@ -62,7 +62,7 @@ func generateConfig(serviceServingCA *corev1.ConfigMap) (string, error) {
 	return string(b), nil
 }
 
-func ReconcileRecyclerConfig(config *corev1.ConfigMap, ownerRef config.OwnerRef, releaseImageProvider *imageprovider.ReleaseImageProvider) error {
+func ReconcileRecyclerConfig(config *corev1.ConfigMap, ownerRef config.OwnerRef, releaseImageProvider imageprovider.ReleaseImageProvider) error {
 	var result strings.Builder
 
 	ownerRef.ApplyTo(config)

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -38,7 +38,7 @@ const (
 	DefaultPort = 10257
 )
 
-func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *KubeControllerManagerParams {
+func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *KubeControllerManagerParams {
 	params := &KubeControllerManagerParams{
 		// TODO: Come up with sane defaults for scheduling APIServer pods
 		// Expose configuration

--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -22,7 +22,7 @@ type KonnectivityParams struct {
 	AgentDeamonSetConfig   config.DeploymentConfig
 }
 
-func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, externalAddress string, externalPort int32, setDefaultSecurityContext bool) *KonnectivityParams {
+func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, externalAddress string, externalPort int32, setDefaultSecurityContext bool) *KonnectivityParams {
 	p := &KonnectivityParams{
 		KonnectivityAgentImage: releaseImageProvider.GetImage("apiserver-network-proxy"),
 		OwnerRef:               config.OwnerRefFrom(hcp),

--- a/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go
@@ -39,7 +39,7 @@ type Params struct {
 	OwnerRef                config.OwnerRef
 }
 
-func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
+func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider imageprovider.ReleaseImageProvider, userReleaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
 	p := Params{
 		Images: Images{
 			NodeTuningOperator: releaseImageProvider.GetImage(operatorName),

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -50,7 +50,7 @@ type OAuthDeploymentParams struct {
 	AccessTokenInactivityTimeout *metav1.Duration
 }
 
-func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *OpenShiftAPIServerParams {
+func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *OpenShiftAPIServerParams {
 	params := &OpenShiftAPIServerParams{
 		OpenShiftAPIServerImage: releaseImageProvider.GetImage("openshift-apiserver"),
 		OAuthAPIServerImage:     releaseImageProvider.GetImage("oauth-apiserver"),

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -84,7 +84,7 @@ type ConfigOverride struct {
 	Challenge *bool               `json:"challenge,omitempty"`
 }
 
-func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, host string, port int32, setDefaultSecurityContext bool) *OAuthServerParams {
+func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, host string, port int32, setDefaultSecurityContext bool) *OAuthServerParams {
 	p := &OAuthServerParams{
 		OwnerRef:                config.OwnerRefFrom(hcp),
 		ExternalAPIHost:         hcp.Status.ControlPlaneEndpoint.Host,

--- a/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ocm/params.go
@@ -25,7 +25,7 @@ type OpenShiftControllerManagerParams struct {
 	config.OwnerRef
 }
 
-func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *OpenShiftControllerManagerParams {
+func NewOpenShiftControllerManagerParams(hcp *hyperv1.HostedControlPlane, observedConfig *globalconfig.ObservedConfig, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *OpenShiftControllerManagerParams {
 	params := &OpenShiftControllerManagerParams{
 		OpenShiftControllerManagerImage: releaseImageProvider.GetImage("openshift-controller-manager"),
 		DockerBuilderImage:              releaseImageProvider.GetImage("docker-builder"),

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/params.go
@@ -31,7 +31,7 @@ type OperatorLifecycleManagerParams struct {
 	config.OwnerRef
 }
 
-func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, releaseVersion string, setDefaultSecurityContext bool) *OperatorLifecycleManagerParams {
+func NewOperatorLifecycleManagerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, releaseVersion string, setDefaultSecurityContext bool) *OperatorLifecycleManagerParams {
 	params := &OperatorLifecycleManagerParams{
 		CLIImage:                releaseImageProvider.GetImage("cli"),
 		OLMImage:                releaseImageProvider.GetImage("operator-lifecycle-manager"),

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -107,7 +107,7 @@ type Params struct {
 	deploymentConfig config.DeploymentConfig
 }
 
-func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
+func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider imageprovider.ReleaseImageProvider, userReleaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
 	params := Params{
 		operatorImage:    releaseImageProvider.GetImage("cluster-image-registry-operator"),
 		tokenMinterImage: releaseImageProvider.GetImage("token-minter"),

--- a/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/routecm/params.go
@@ -20,7 +20,7 @@ type OpenShiftRouteControllerManagerParams struct {
 	config.OwnerRef
 }
 
-func NewOpenShiftRouteControllerManagerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *OpenShiftRouteControllerManagerParams {
+func NewOpenShiftRouteControllerManagerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *OpenShiftRouteControllerManagerParams {
 	params := &OpenShiftRouteControllerManagerParams{
 		OpenShiftControllerManagerImage: releaseImageProvider.GetImage("route-controller-manager"),
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -26,7 +26,7 @@ type KubeSchedulerParams struct {
 	DisableProfiling        bool                    `json:"disableProfiling"`
 }
 
-func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *KubeSchedulerParams {
+func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) *KubeSchedulerParams {
 	params := &KubeSchedulerParams{
 		HyperkubeImage:          releaseImageProvider.GetImage("hyperkube"),
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/params.go
@@ -27,7 +27,7 @@ type Params struct {
 func NewParams(
 	hcp *hyperv1.HostedControlPlane,
 	version string,
-	releaseImageProvider *imageprovider.ReleaseImageProvider,
+	releaseImageProvider imageprovider.ReleaseImageProvider,
 	setDefaultSecurityContext bool) *Params {
 
 	params := Params{

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"strings"
 
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -64,17 +65,17 @@ func newEnvironmentReplacer() *environmentReplacer {
 	return &environmentReplacer{values: map[string]string{}}
 }
 
-func (er *environmentReplacer) setOperatorImageReferences(images map[string]string, userImages map[string]string) {
+func (er *environmentReplacer) setOperatorImageReferences(releaseImageProvider, userReleaseImageProvider imageprovider.ReleaseImageProvider) {
 	// `operatorImageRefs` is map from env. var name -> payload image name
 	// `images` is map from payload image name -> image URL
 	// Create map from env. var name -> image URL
 	for envVar, payloadName := range operatorImageRefs {
 		if envVar == "NODE_DRIVER_REGISTRAR_IMAGE" || envVar == "LIVENESS_PROBE_IMAGE" || strings.HasSuffix(envVar, "_DRIVER_IMAGE") {
-			if imageURL, ok := userImages[payloadName]; ok {
+			if imageURL, ok := userReleaseImageProvider.ImageExist(payloadName); ok {
 				er.values[envVar] = imageURL
 			}
 		} else {
-			if imageURL, ok := images[payloadName]; ok {
+			if imageURL, ok := releaseImageProvider.ImageExist(payloadName); ok {
 				er.values[envVar] = imageURL
 			}
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/storage/assets"
 	assets2 "github.com/openshift/hypershift/support/assets"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -21,8 +22,10 @@ func TestEnvironmentReplacer(t *testing.T) {
 		images[payloadName] = replaced
 	}
 
+	imageProviver := imageprovider.NewFromImages(images)
+
 	er := newEnvironmentReplacer()
-	er.setOperatorImageReferences(images, images)
+	er.setOperatorImageReferences(imageProviver, imageProviver)
 	version := rand.String(10)
 	er.setVersions(version)
 

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
@@ -24,13 +24,13 @@ type Params struct {
 func NewParams(
 	hcp *hyperv1.HostedControlPlane,
 	version string,
-	releaseImageProvider *imageprovider.ReleaseImageProvider,
-	userReleaseImageProvider *imageprovider.ReleaseImageProvider,
+	releaseImageProvider imageprovider.ReleaseImageProvider,
+	userReleaseImageProvider imageprovider.ReleaseImageProvider,
 	setDefaultSecurityContext bool) *Params {
 
 	ir := newEnvironmentReplacer()
 	ir.setVersions(version)
-	ir.setOperatorImageReferences(releaseImageProvider.ComponentImages(), userReleaseImageProvider.ComponentImages())
+	ir.setOperatorImageReferences(releaseImageProvider, userReleaseImageProvider)
 
 	params := Params{
 		OwnerRef:                config.OwnerRefFrom(hcp),

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents.yaml
@@ -1,0 +1,159 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cluster-autoscaler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: cluster-autoscaler
+        hypershift.openshift.io/control-plane-component: cluster-autoscaler
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        hypershift.openshift.io/need-management-kas-access: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --expander=priority,least-waste
+        - --cloud-provider=clusterapi
+        - --node-group-auto-discovery=clusterapi:namespace=$(MY_NAMESPACE)
+        - --kubeconfig=/mnt/kubeconfig/target-kubeconfig
+        - --clusterapi-cloud-config-authoritative
+        - --skip-nodes-with-local-storage=false
+        - --alsologtostderr
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-retry-period=26s
+        - --leader-elect-renew-deadline=107s
+        - --balance-similar-node-groups=true
+        - --v=4
+        - --balancing-ignore-label=hypershift.openshift.io/nodePool
+        - --balancing-ignore-label=topology.ebs.csi.aws.com/zone
+        - --balancing-ignore-label=topology.disk.csi.azure.com/zone
+        - --balancing-ignore-label=ibm-cloud.kubernetes.io/worker-id
+        - --balancing-ignore-label=vpc-block-csi-driver-labels
+        command:
+        - /usr/bin/cluster-autoscaler
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cluster-autoscaler
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health-check
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: cluster-autoscaler
+        ports:
+        - containerPort: 8085
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health-check
+            port: 8085
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 60Mi
+        volumeMounts:
+        - mountPath: /mnt/kubeconfig
+          name: kubeconfig
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: cluster-autoscaler
+      serviceAccountName: cluster-autoscaler
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          items:
+          - key: value
+            path: target-kubeconfig
+          secretName: -kubeconfig
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: openshift-route-controller-manager
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: openshift-route-controller-manager
+      hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        component.hypershift.openshift.io/config-hash: 57c9c948
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: openshift-route-controller-manager
+        hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - start
+        - --config
+        - /etc/kubernetes/config/config.yaml
+        - --kubeconfig
+        - /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --namespace=openshift-route-controller-manager
+        command:
+        - route-controller-manager
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          value: openshift-route-controller-manager
+        image: route-controller-manager
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: openshift-route-controller-manager
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/client-ca
+          name: client-ca
+        - mountPath: /etc/kubernetes/config
+          name: config
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: openshift-route-controller-manager-config
+        name: config
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: openshift-route-controller-manager-cert
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: client-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets.go
@@ -1,0 +1,70 @@
+package controlplanecomponent
+
+import (
+	"embed"
+	"io/fs"
+	"path"
+
+	hyperapi "github.com/openshift/hypershift/support/api"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//go:embed *
+var manifestsAssets embed.FS
+
+const (
+	deploymentManifest  = "deployment.yaml"
+	statefulSetManifest = "statefulset.yaml"
+)
+
+func LoadDeploymentManifest(componentName string) (*appsv1.Deployment, error) {
+	deploy := &appsv1.Deployment{}
+	_, err := LoadManifest(componentName, deploymentManifest, deploy)
+	if err != nil {
+		return nil, err
+	}
+
+	return deploy, nil
+}
+
+func LoadStatefulSetManifest(componentName string) (*appsv1.StatefulSet, error) {
+	sts := &appsv1.StatefulSet{}
+	_, err := LoadManifest(componentName, statefulSetManifest, sts)
+	if err != nil {
+		return nil, err
+	}
+
+	return sts, nil
+}
+
+// LoadManifest decodes the manifest data and load it into the provided 'into' object.
+// If 'into' is nil, it will generate and return a new object.
+func LoadManifest(componentName string, fileName string, into client.Object) (client.Object, error) {
+	filePath := path.Join(componentName, fileName)
+	bytes, err := manifestsAssets.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	obj, _, err := hyperapi.YamlSerializer.Decode(bytes, nil, into)
+	return obj.(client.Object), err
+}
+
+func ForEachManifest(componentName string, action func(manifestName string) error) error {
+	return fs.WalkDir(manifestsAssets, componentName, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		manifestName := d.Name()
+		if manifestName == deploymentManifest || manifestName == statefulSetManifest {
+			return nil
+		}
+
+		return action(manifestName)
+	})
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cluster-autoscaler
+  namespace: HCP_NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+        hypershift.openshift.io/control-plane-component: cluster-autoscaler
+        hypershift.openshift.io/need-management-kas-access: "true"
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --expander=priority,least-waste
+        - --cloud-provider=clusterapi
+        - --node-group-auto-discovery=clusterapi:namespace=$(MY_NAMESPACE)
+        - --kubeconfig=/mnt/kubeconfig/target-kubeconfig
+        - --clusterapi-cloud-config-authoritative
+        - --skip-nodes-with-local-storage=false
+        - --alsologtostderr
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-retry-period=26s
+        - --leader-elect-renew-deadline=107s
+        - --balance-similar-node-groups=true
+        - --v=4
+        - --balancing-ignore-label=hypershift.openshift.io/nodePool
+        - --balancing-ignore-label=topology.ebs.csi.aws.com/zone
+        - --balancing-ignore-label=topology.disk.csi.azure.com/zone
+        - --balancing-ignore-label=ibm-cloud.kubernetes.io/worker-id
+        - --balancing-ignore-label=vpc-block-csi-driver-labels
+        command:
+        - /usr/bin/cluster-autoscaler
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cluster-autoscaler # image name in the payload
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health-check
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: cluster-autoscaler
+        ports:
+        - containerPort: 8085
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health-check
+            port: 8085
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 60Mi
+        volumeMounts:
+        - mountPath: /mnt/kubeconfig
+          name: kubeconfig
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: cluster-autoscaler
+      serviceAccountName: cluster-autoscaler
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: e2e-clusters-9vwbx-example-wzssw
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          items:
+          - key: value
+            path: target-kubeconfig
+          secretName: example-wzssw-kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/role.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: HCP_NAMESPACE
+rules:
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/scale
+  - machines
+  - machinesets
+  - machinesets/scale
+  - machinepools
+  - machinepools/scale
+  verbs:
+  - '*'
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - capi-provider.agent-install.openshift.io
+  resources:
+  - agentmachinetemplates
+  verbs:
+  - get
+  - list

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: HCP_NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: HCP_NAMESPACE

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: HCP_NAMESPACE

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/config.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: openshiftcontrolplane.config.openshift.io/v1
+    build:
+      additionalTrustedCA: ""
+      buildDefaults: null
+      buildOverrides: null
+      imageTemplateFormat:
+        format: ""
+        latest: false
+    controllers: null
+    deployer:
+      imageTemplateFormat:
+        format: ""
+        latest: false
+    dockerPullSecret:
+      internalRegistryHostname: ""
+      registryURLs: null
+    featureGates: null
+    imageImport:
+      disableScheduledImport: false
+      maxScheduledImageImportsPerMinute: 0
+      scheduledImageImportMinimumIntervalSeconds: 0
+    ingress:
+      ingressIPNetworkCIDR: ""
+    kind: OpenShiftControllerManagerConfig
+    kubeClientConfig:
+      connectionOverrides:
+        acceptContentTypes: ""
+        burst: 0
+        contentType: ""
+        qps: 0
+      kubeConfig: ""
+    leaderElection:
+      leaseDuration: 0s
+      name: openshift-route-controllers
+      renewDeadline: 0s
+      retryPeriod: 0s
+    network:
+      clusterNetworks: null
+      networkPluginName: ""
+      serviceNetworkCIDR: ""
+      vxlanPort: 0
+    resourceQuota:
+      concurrentSyncs: 0
+      minResyncPeriod: 0s
+      syncPeriod: 0s
+    securityAllocator:
+      mcsAllocatorRange: ""
+      mcsLabelsPerProject: 0
+      uidAllocatorRange: ""
+    serviceAccount:
+      managedNames: null
+    serviceServingCert:
+      signer: null
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: /etc/kubernetes/certs/tls.crt
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      clientCA: /etc/kubernetes/client-ca/ca.crt
+      keyFile: /etc/kubernetes/certs/tls.key
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  name: openshift-route-controller-manager-config
+  namespace: HCP_NAMESPACE

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: openshift-route-controller-manager
+  namespace: HCP_NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openshift-route-controller-manager
+      hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: openshift-route-controller-manager
+        hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - start
+        - --config
+        - /etc/kubernetes/config/config.yaml
+        - --kubeconfig
+        - /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --namespace=openshift-route-controller-manager
+        command:
+        - route-controller-manager
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          value: openshift-route-controller-manager
+        image: route-controller-manager
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: openshift-route-controller-manager
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/client-ca
+          name: client-ca
+        - mountPath: /etc/kubernetes/config
+          name: config
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: openshift-route-controller-manager-config
+        name: config
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: openshift-route-controller-manager-cert
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: client-ca

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: openshift-route-controller-manager
+    hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+  name: openshift-route-controller-manager
+  namespace: HCP_NAMESPACE
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app: openshift-route-controller-manager
+    hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+  type: ClusterIP

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/servicemonitor.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: openshift-route-controller-manager
+  namespace: HCP_NAMESPACE
+spec:
+  endpoints:
+  - scheme: https
+    targetPort: https
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: openshift-controller-manager
+  namespaceSelector:
+    matchNames:
+    - HCP_NAMESPACE
+  selector:
+    matchLabels:
+      app: openshift-route-controller-manager
+      hypershift.openshift.io/control-plane-component: openshift-route-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/reconcile.go
@@ -1,0 +1,111 @@
+package autoscaler
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ComponentName = "cluster-autoscaler"
+
+	ImageStreamAutoscalerImage = "cluster-autoscaler"
+
+	kubeconfigVolumeName = "kubeconfig"
+)
+
+var _ component.ComponentOptions = &Autoscaler{}
+
+type Autoscaler struct {
+}
+
+func NewComponent() component.ControlPlaneComponent {
+	return component.NewDeploymentComponent(ComponentName, &Autoscaler{}).
+		WithAdaptFunction(AdaptDeployment).
+		WithPredicate(Predicate).
+		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		Build()
+}
+
+// IsRequestServing implements controlplanecomponent.ComponentOptions.
+func (a *Autoscaler) IsRequestServing() bool {
+	return false
+}
+
+// MultiZoneSpread implements controlplanecomponent.ComponentOptions.
+func (a *Autoscaler) MultiZoneSpread() bool {
+	return false
+}
+
+// NeedsManagementKASAccess implements controlplanecomponent.ComponentOptions.
+func (a *Autoscaler) NeedsManagementKASAccess() bool {
+	return true
+}
+
+func Predicate(cpContext component.ControlPlaneContext) (bool, error) {
+	hcp := cpContext.HCP
+
+	// Disable cluster-autoscaler component if DisableMachineManagement label is set.
+	if _, exists := hcp.Annotations[hyperv1.DisableMachineManagement]; exists {
+		return false, nil
+	}
+
+	// The deployment depends on the kubeconfig being reported.
+	if hcp.Status.KubeConfig == nil {
+		return false, nil
+	}
+	// Resolve the kubeconfig secret for CAPI which the autoscaler is deployed alongside of.
+	capiKubeConfigSecret := manifests.KASServiceCAPIKubeconfigSecret(hcp.Namespace, hcp.Spec.InfraID)
+	if err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(capiKubeConfigSecret), capiKubeConfigSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get hosted controlplane kubeconfig secret %q: %w", capiKubeConfigSecret.Name, err)
+	}
+
+	return true, nil
+}
+
+func AdaptDeployment(cpContext component.ControlPlaneContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
+	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		// TODO if the options for the cluster autoscaler continues to grow, we should take inspiration
+		// from the cluster-autoscaler-operator and create some utility functions for these assignments.
+		options := hcp.Spec.Autoscaling
+		if options.MaxNodesTotal != nil {
+			c.Args = append(c.Args, fmt.Sprintf("--max-nodes-total=%d", *options.MaxNodesTotal))
+		}
+
+		if options.MaxPodGracePeriod != nil {
+			c.Args = append(c.Args, fmt.Sprintf("--max-graceful-termination-sec=%d", *options.MaxPodGracePeriod))
+		}
+
+		if options.MaxNodeProvisionTime != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--max-node-provision-time=%s", options.MaxNodeProvisionTime))
+		}
+
+		if options.PodPriorityThreshold != nil {
+			c.Args = append(c.Args, fmt.Sprintf("--expendable-pods-priority-cutoff=%d", *options.PodPriorityThreshold))
+		}
+	})
+
+	util.UpdateVolume(kubeconfigVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+		v.Secret.SecretName = manifests.KASServiceCAPIKubeconfigSecret(hcp.Namespace, hcp.Spec.InfraID).Name
+	})
+
+	deployment.Spec.Replicas = ptr.To[int32](1)
+	if _, exists := hcp.Annotations[hyperv1.DisableClusterAutoscalerAnnotation]; exists {
+		deployment.Spec.Replicas = ptr.To[int32](0)
+	}
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/reconcile_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/reconcile_test.go
@@ -1,0 +1,262 @@
+package autoscaler
+
+import (
+	"context"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	hyperapi "github.com/openshift/hypershift/support/api"
+	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/support/upsert"
+	"github.com/openshift/hypershift/support/util"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestPredicate(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: "hcp-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			InfraID: "test-infra-id",
+		},
+	}
+
+	testCases := []struct {
+		name                 string
+		capiKubeconfigSecret client.Object
+		hcpAnnotations       map[string]string
+
+		expected bool
+	}{
+		{
+			name:                 "when CAPI kubeconfig secret exist predicate returns true",
+			capiKubeconfigSecret: manifests.KASServiceCAPIKubeconfigSecret(hcp.Namespace, hcp.Spec.InfraID),
+			expected:             true,
+		},
+		{
+			name:     "when CAPI kubeconfig secret doesn't exist, predicate return false",
+			expected: false,
+		},
+		{
+			name: "when HCP has DisableMachineManagement annotation predicate return false",
+			hcpAnnotations: map[string]string{
+				hyperv1.DisableMachineManagement: "true",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcp.Annotations = tc.hcpAnnotations
+
+			clientBuilder := fake.NewClientBuilder().WithScheme(api.Scheme)
+			if tc.capiKubeconfigSecret != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.capiKubeconfigSecret)
+				hcp.Status.KubeConfig = &hyperv1.KubeconfigSecretRef{
+					Name: tc.capiKubeconfigSecret.GetName(),
+				}
+			}
+			client := clientBuilder.Build()
+
+			cpContext := controlplanecomponent.ControlPlaneContext{
+				Context:                  context.Background(),
+				Client:                   client,
+				CreateOrUpdateProviderV2: upsert.NewV2(false),
+				HCP:                      hcp,
+			}
+
+			g := NewGomegaWithT(t)
+
+			result, err := Predicate(cpContext)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestAdaptDeployment(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: "hcp-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			InfraID: "test-infra-id",
+		},
+	}
+
+	testCases := []struct {
+		name              string
+		hcpAnnotations    map[string]string
+		AutoscalerOptions hyperv1.ClusterAutoscaling
+		ExpectedArgs      []string
+		expectedReplicas  int32
+	}{
+		{
+			name: "when HCP has DisableClusterAutoscalerAnnotation annotation replicas should be 0",
+			hcpAnnotations: map[string]string{
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
+			},
+			expectedReplicas: 0,
+		},
+		{
+			name: "when autoscaling options is set, container has optional arguments",
+			AutoscalerOptions: hyperv1.ClusterAutoscaling{
+				MaxNodesTotal:        ptr.To[int32](100),
+				MaxPodGracePeriod:    ptr.To[int32](300),
+				MaxNodeProvisionTime: "20m",
+				PodPriorityThreshold: ptr.To[int32](-5),
+			},
+			ExpectedArgs: []string{
+				"--max-nodes-total=100",
+				"--max-graceful-termination-sec=300",
+				"--max-node-provision-time=20m",
+				"--expendable-pods-priority-cutoff=-5",
+			},
+			expectedReplicas: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcp.Annotations = tc.hcpAnnotations
+			hcp.Spec.Autoscaling = tc.AutoscalerOptions
+
+			cpContext := controlplanecomponent.ControlPlaneContext{
+				HCP: hcp,
+			}
+
+			g := NewGomegaWithT(t)
+
+			deployment, err := assets.LoadDeploymentManifest(ComponentName)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			err = AdaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(deployment.Spec.Replicas).To(HaveValue(Equal(tc.expectedReplicas)))
+
+			if len(tc.ExpectedArgs) > 0 {
+				observedArgs := deployment.Spec.Template.Spec.Containers[0].Args
+				g.Expect(observedArgs).To(ContainElements(tc.ExpectedArgs))
+			}
+		})
+	}
+}
+
+func TestReconcileExisting(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: "hcp-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			InfraID: "test-infra-id",
+			Autoscaling: hyperv1.ClusterAutoscaling{
+				MaxNodesTotal:        ptr.To[int32](100),
+				MaxPodGracePeriod:    ptr.To[int32](300),
+				MaxNodeProvisionTime: "20m",
+				PodPriorityThreshold: ptr.To[int32](-5),
+			},
+		},
+	}
+
+	capiKubeconfigSecret := manifests.KASServiceCAPIKubeconfigSecret(hcp.Namespace, hcp.Spec.InfraID)
+	hcp.Status.KubeConfig = &hyperv1.KubeconfigSecretRef{
+		Name: capiKubeconfigSecret.Name,
+	}
+
+	oldDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ComponentName,
+			Namespace: hcp.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: ComponentName,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									// exisint resources requests should be preserved.
+									corev1.ResourceCPU:    resource.MustParse("777m"),
+									corev1.ResourceMemory: resource.MustParse("88Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(capiKubeconfigSecret).
+		WithObjects(oldDeployment).
+		Build()
+	cpContext := controlplanecomponent.ControlPlaneContext{
+		Context:                  context.Background(),
+		Client:                   client,
+		CreateOrUpdateProviderV2: upsert.NewV2(false),
+		ReleaseImageProvider: imageprovider.NewFromImages(map[string]string{
+			ImageStreamAutoscalerImage:       "test-image",
+			util.AvailabilityProberImageName: "availbility-prober-image",
+		}),
+		HCP: hcp,
+	}
+
+	compoent := NewComponent()
+	if err := compoent.Reconcile(cpContext); err != nil {
+		t.Fatalf("failed to reconciler autoscaler: %v", err)
+	}
+
+	var deployments appsv1.DeploymentList
+	if err := client.List(context.Background(), &deployments); err != nil {
+		t.Fatalf("failed to list deployments: %v", err)
+	}
+
+	if len(deployments.Items) == 0 {
+		t.Fatalf("expected deployment to exist")
+	}
+
+	deploymentYaml, err := util.SerializeResource(&deployments.Items[0], hyperapi.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	testutil.CompareWithFixture(t, deploymentYaml, testutil.WithSuffix("_deployment"))
+
+	// check RBAC is created
+	var roleBindings rbacv1.RoleBindingList
+	if err := client.List(context.Background(), &roleBindings); err != nil {
+		t.Fatalf("failed to list roles: %v", err)
+	}
+
+	if len(roleBindings.Items) == 0 {
+		t.Fatalf("expected role binding to exist")
+	}
+
+	roleBindingYaml, err := util.SerializeResource(&roleBindings.Items[0], hyperapi.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	testutil.CompareWithFixture(t, roleBindingYaml, testutil.WithSuffix("_rolebinding"))
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/testdata/zz_fixture_TestReconcileExisting_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/testdata/zz_fixture_TestReconcileExisting_deployment.yaml
@@ -1,0 +1,163 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cluster-autoscaler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1000"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: cluster-autoscaler
+        hypershift.openshift.io/control-plane-component: cluster-autoscaler
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        hypershift.openshift.io/need-management-kas-access: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --expander=priority,least-waste
+        - --cloud-provider=clusterapi
+        - --node-group-auto-discovery=clusterapi:namespace=$(MY_NAMESPACE)
+        - --kubeconfig=/mnt/kubeconfig/target-kubeconfig
+        - --clusterapi-cloud-config-authoritative
+        - --skip-nodes-with-local-storage=false
+        - --alsologtostderr
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-retry-period=26s
+        - --leader-elect-renew-deadline=107s
+        - --balance-similar-node-groups=true
+        - --v=4
+        - --balancing-ignore-label=hypershift.openshift.io/nodePool
+        - --balancing-ignore-label=topology.ebs.csi.aws.com/zone
+        - --balancing-ignore-label=topology.disk.csi.azure.com/zone
+        - --balancing-ignore-label=ibm-cloud.kubernetes.io/worker-id
+        - --balancing-ignore-label=vpc-block-csi-driver-labels
+        - --max-nodes-total=100
+        - --max-graceful-termination-sec=300
+        - --max-node-provision-time=20m
+        - --expendable-pods-priority-cutoff=-5
+        command:
+        - /usr/bin/cluster-autoscaler
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: test-image
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health-check
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: cluster-autoscaler
+        ports:
+        - containerPort: 8085
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health-check
+            port: 8085
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 777m
+            memory: 88Mi
+        volumeMounts:
+        - mountPath: /mnt/kubeconfig
+          name: kubeconfig
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        image: availbility-prober-image
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: cluster-autoscaler
+      serviceAccountName: cluster-autoscaler
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          items:
+          - key: value
+            path: target-kubeconfig
+          secretName: test-infra-id-kubeconfig
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/testdata/zz_fixture_TestReconcileExisting_rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/testdata/zz_fixture_TestReconcileExisting_rolebinding.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: cluster-autoscaler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config.go
@@ -1,0 +1,85 @@
+package routecm
+
+import (
+	"fmt"
+	"path"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
+
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/util"
+)
+
+const (
+	configKey = "config.yaml"
+)
+
+func adaptConfigMap(cpContext component.ControlPlaneContext, cm *corev1.ConfigMap) error {
+	hcp := cpContext.HCP
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+
+	if configStr, exists := cm.Data[configKey]; !exists || len(configStr) == 0 {
+		return fmt.Errorf("expected an existing openshift route controller manager configuration")
+	}
+
+	config := &openshiftcpv1.OpenShiftControllerManagerConfig{}
+	if err := util.DeserializeResource(cm.Data[configKey], config, api.Scheme); err != nil {
+		return fmt.Errorf("unable to decode existing openshift route controller manager configuration: %w", err)
+	}
+
+	var networkConfig *configv1.NetworkSpec
+	if hcp.Spec.Configuration != nil {
+		networkConfig = hcp.Spec.Configuration.Network
+	}
+	if err := reconcileConfig(config, minTLSVersion(hcp), cipherSuites(hcp), networkConfig); err != nil {
+		return err
+	}
+	configStr, err := util.SerializeResource(config, api.Scheme)
+	if err != nil {
+		return fmt.Errorf("failed to serialize openshift route controller manager configuration: %w", err)
+	}
+	cm.Data[configKey] = configStr
+	return nil
+}
+
+func reconcileConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, minTLSVersion string, cipherSuites []string, networkConfig *configv1.NetworkSpec) error {
+	// network config
+	if networkConfig != nil && networkConfig.ExternalIP != nil && len(networkConfig.ExternalIP.AutoAssignCIDRs) > 0 {
+		cfg.Ingress.IngressIPNetworkCIDR = networkConfig.ExternalIP.AutoAssignCIDRs[0]
+	} else {
+		cfg.Ingress.IngressIPNetworkCIDR = ""
+	}
+
+	cfg.ServingInfo.CertFile = path.Join("/etc/kubernetes/certs", corev1.TLSCertKey)
+	cfg.ServingInfo.KeyFile = path.Join("/etc/kubernetes/certs", corev1.TLSPrivateKeyKey)
+	cfg.ServingInfo.ClientCA = path.Join("/etc/kubernetes/client-ca", certs.CASignerCertMapKey)
+
+	cfg.ServingInfo.MinTLSVersion = minTLSVersion
+	cfg.ServingInfo.CipherSuites = cipherSuites
+
+	return nil
+}
+
+func minTLSVersion(hcp *hyperv1.HostedControlPlane) string {
+	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.APIServer != nil {
+		return config.MinTLSVersion(hcp.Spec.Configuration.APIServer.TLSSecurityProfile)
+	}
+	return config.MinTLSVersion(nil)
+}
+
+func cipherSuites(hcp *hyperv1.HostedControlPlane) []string {
+	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.APIServer != nil {
+		return config.CipherSuites(hcp.Spec.Configuration.APIServer.TLSSecurityProfile)
+	}
+	return config.CipherSuites(nil)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config_test.go
@@ -1,0 +1,55 @@
+package routecm
+
+import (
+	"testing"
+
+	v1 "github.com/openshift/api/config/v1"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	"github.com/openshift/hypershift/support/api"
+	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/support/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReconcileOpenShiftRouteControllerManagerConfig(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			ReleaseImage: "quay.io/ocp-dev/test-release-image:latest",
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AWSPlatform,
+			},
+			IssuerURL: "https://www.example.com",
+			Configuration: &hyperv1.ClusterConfiguration{
+				Network: &v1.NetworkSpec{
+					ExternalIP: &v1.ExternalIPConfig{
+						AutoAssignCIDRs: []string{"99.1.0.0/24"},
+					},
+				},
+			},
+		},
+	}
+
+	configMap := &corev1.ConfigMap{}
+	_, err := assets.LoadManifest(ComponentName, "config.yaml", configMap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	configMap.SetNamespace(hcp.Namespace)
+
+	if err := adaptConfigMap(controlplanecomponent.ControlPlaneContext{HCP: hcp}, configMap); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	configMapYaml, err := util.SerializeResource(configMap, api.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	testutil.CompareWithFixture(t, configMapYaml)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/reconcile.go
@@ -1,0 +1,53 @@
+package routecm
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	ComponentName = "openshift-route-controller-manager"
+
+	ConfigMapName = "openshift-route-controller-manager-config"
+)
+
+var _ component.ComponentOptions = &RouteController{}
+
+type RouteController struct {
+}
+
+func NewComponent() component.ControlPlaneComponent {
+	return component.NewDeploymentComponent(ComponentName, &RouteController{}).
+		WithManifestAdapter(
+			"config.yaml",
+			component.WithAdaptFunction(adaptConfigMap),
+		).
+		WithManifestAdapter(
+			"service.yaml",
+			component.WithPredicate(component.DisableIfAnnotationExist(hyperv1.DisableMonitoringServices)),
+		).
+		WithManifestAdapter(
+			"servicemonitor.yaml",
+			component.WithAdaptFunction(adaptServiceMonitor),
+			component.WithPredicate(component.DisableIfAnnotationExist(hyperv1.DisableMonitoringServices)),
+		).
+		WatchResource(&corev1.ConfigMap{}, ConfigMapName).
+		Build()
+}
+
+// IsRequestServing implements controlplanecomponent.ComponentOptions.
+func (r *RouteController) IsRequestServing() bool {
+	return false
+}
+
+// MultiZoneSpread implements controlplanecomponent.ComponentOptions.
+func (r *RouteController) MultiZoneSpread() bool {
+	return true
+}
+
+// NeedsManagementKASAccess implements controlplanecomponent.ComponentOptions.
+func (r *RouteController) NeedsManagementKASAccess() bool {
+	return false
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/reconcile_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/reconcile_test.go
@@ -1,0 +1,105 @@
+package routecm
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/openshift/api/config/v1"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	hyperapi "github.com/openshift/hypershift/support/api"
+	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/support/upsert"
+	"github.com/openshift/hypershift/support/util"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcile(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hcp",
+			Namespace: "hcp-namespace",
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			ClusterID: "cluster-id",
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &v1.APIServerSpec{
+					TLSSecurityProfile: &v1.TLSSecurityProfile{
+						Type: v1.TLSProfileOldType,
+					},
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(api.Scheme).Build()
+	cpContext := controlplanecomponent.ControlPlaneContext{
+		Context:                  context.Background(),
+		Client:                   client,
+		CreateOrUpdateProviderV2: upsert.NewV2(false),
+		ReleaseImageProvider: imageprovider.NewFromImages(map[string]string{
+			"route-controller-manager": "test-image",
+		}),
+		HCP: hcp,
+	}
+
+	compoent := NewComponent()
+	if err := compoent.Reconcile(cpContext); err != nil {
+		t.Fatalf("failed to reconcile routecm: %v", err)
+	}
+
+	var deployments appsv1.DeploymentList
+	if err := client.List(context.Background(), &deployments); err != nil {
+		t.Fatalf("failed to list deployments: %v", err)
+	}
+
+	if len(deployments.Items) == 0 {
+		t.Fatalf("expected deployment to exist")
+	}
+
+	deploymentYaml, err := util.SerializeResource(&deployments.Items[0], hyperapi.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	testutil.CompareWithFixture(t, deploymentYaml, testutil.WithSuffix("_deployment"))
+
+	// check configMap is created
+	var configMaps corev1.ConfigMapList
+	if err := client.List(context.Background(), &configMaps); err != nil {
+		t.Fatalf("failed to list configMaps: %v", err)
+	}
+
+	if len(configMaps.Items) == 0 {
+		t.Fatalf("expected configMap to exist")
+	}
+
+	configMapYaml, err := util.SerializeResource(&configMaps.Items[0], hyperapi.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	testutil.CompareWithFixture(t, configMapYaml, testutil.WithSuffix("_configMap"))
+
+	// check serviceMonitor is created
+	var serviceMonitors prometheusoperatorv1.ServiceMonitorList
+	if err := client.List(context.Background(), &serviceMonitors); err != nil {
+		t.Fatalf("failed to list configMaps: %v", err)
+	}
+
+	if len(serviceMonitors.Items) == 0 {
+		t.Fatalf("expected serviceMonitor to exist")
+	}
+
+	serviceMonitorYaml, err := util.SerializeResource(serviceMonitors.Items[0], hyperapi.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	testutil.CompareWithFixture(t, serviceMonitorYaml, testutil.WithSuffix("_servicemonitor"))
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/servicemonitor.go
@@ -1,0 +1,19 @@
+package routecm
+
+import (
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/util"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func adaptServiceMonitor(cpContext component.ControlPlaneContext, sm *prometheusoperatorv1.ServiceMonitor) error {
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+
+	sm.Spec.Endpoints[0].MetricRelabelConfigs = metrics.OpenShiftRouteControllerManagerRelabelConfigs(cpContext.MetricsSet)
+	util.ApplyClusterIDLabel(&sm.Spec.Endpoints[0], cpContext.HCP.Spec.ClusterID)
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/testdata/zz_fixture_TestReconcileOpenShiftRouteControllerManagerConfig.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/testdata/zz_fixture_TestReconcileOpenShiftRouteControllerManagerConfig.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: openshiftcontrolplane.config.openshift.io/v1
+    build:
+      additionalTrustedCA: ""
+      buildDefaults: null
+      buildOverrides: null
+      imageTemplateFormat:
+        format: ""
+        latest: false
+    controllers: null
+    deployer:
+      imageTemplateFormat:
+        format: ""
+        latest: false
+    dockerPullSecret:
+      internalRegistryHostname: ""
+      registryURLs: null
+    featureGates: null
+    imageImport:
+      disableScheduledImport: false
+      maxScheduledImageImportsPerMinute: 0
+      scheduledImageImportMinimumIntervalSeconds: 0
+    ingress:
+      ingressIPNetworkCIDR: 99.1.0.0/24
+    kind: OpenShiftControllerManagerConfig
+    kubeClientConfig:
+      connectionOverrides:
+        acceptContentTypes: ""
+        burst: 0
+        contentType: ""
+        qps: 0
+      kubeConfig: ""
+    leaderElection:
+      leaseDuration: 0s
+      name: openshift-route-controllers
+      renewDeadline: 0s
+      retryPeriod: 0s
+    network:
+      clusterNetworks: null
+      networkPluginName: ""
+      serviceNetworkCIDR: ""
+      vxlanPort: 0
+    resourceQuota:
+      concurrentSyncs: 0
+      minResyncPeriod: 0s
+      syncPeriod: 0s
+    securityAllocator:
+      mcsAllocatorRange: ""
+      mcsLabelsPerProject: 0
+      uidAllocatorRange: ""
+    serviceAccount:
+      managedNames: null
+    serviceServingCert:
+      signer: null
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: /etc/kubernetes/certs/tls.crt
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      clientCA: /etc/kubernetes/client-ca/ca.crt
+      keyFile: /etc/kubernetes/certs/tls.key
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS12
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: openshift-route-controller-manager-config
+  namespace: test-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/testdata/zz_fixture_TestReconcile_configMap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/testdata/zz_fixture_TestReconcile_configMap.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: openshiftcontrolplane.config.openshift.io/v1
+    build:
+      additionalTrustedCA: ""
+      buildDefaults: null
+      buildOverrides: null
+      imageTemplateFormat:
+        format: ""
+        latest: false
+    controllers: null
+    deployer:
+      imageTemplateFormat:
+        format: ""
+        latest: false
+    dockerPullSecret:
+      internalRegistryHostname: ""
+      registryURLs: null
+    featureGates: null
+    imageImport:
+      disableScheduledImport: false
+      maxScheduledImageImportsPerMinute: 0
+      scheduledImageImportMinimumIntervalSeconds: 0
+    ingress:
+      ingressIPNetworkCIDR: ""
+    kind: OpenShiftControllerManagerConfig
+    kubeClientConfig:
+      connectionOverrides:
+        acceptContentTypes: ""
+        burst: 0
+        contentType: ""
+        qps: 0
+      kubeConfig: ""
+    leaderElection:
+      leaseDuration: 0s
+      name: openshift-route-controllers
+      renewDeadline: 0s
+      retryPeriod: 0s
+    network:
+      clusterNetworks: null
+      networkPluginName: ""
+      serviceNetworkCIDR: ""
+      vxlanPort: 0
+    resourceQuota:
+      concurrentSyncs: 0
+      minResyncPeriod: 0s
+      syncPeriod: 0s
+    securityAllocator:
+      mcsAllocatorRange: ""
+      mcsLabelsPerProject: 0
+      uidAllocatorRange: ""
+    serviceAccount:
+      managedNames: null
+    serviceServingCert:
+      signer: null
+    servingInfo:
+      bindAddress: 0.0.0.0:8443
+      bindNetwork: ""
+      certFile: /etc/kubernetes/certs/tls.crt
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+      - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+      - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+      - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+      clientCA: /etc/kubernetes/client-ca/ca.crt
+      keyFile: /etc/kubernetes/certs/tls.key
+      maxRequestsInFlight: 0
+      minTLSVersion: VersionTLS10
+      requestTimeoutSeconds: 0
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: openshift-route-controller-manager-config
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/testdata/zz_fixture_TestReconcile_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/testdata/zz_fixture_TestReconcile_deployment.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: openshift-route-controller-manager
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: openshift-route-controller-manager
+      hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        component.hypershift.openshift.io/config-hash: b09dd35a
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: openshift-route-controller-manager
+        hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - start
+        - --config
+        - /etc/kubernetes/config/config.yaml
+        - --kubeconfig
+        - /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --namespace=openshift-route-controller-manager
+        command:
+        - route-controller-manager
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          value: openshift-route-controller-manager
+        image: test-image
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: openshift-route-controller-manager
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/client-ca
+          name: client-ca
+        - mountPath: /etc/kubernetes/config
+          name: config
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: openshift-route-controller-manager-config
+        name: config
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: openshift-route-controller-manager-cert
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: client-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/testdata/zz_fixture_TestReconcile_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/testdata/zz_fixture_TestReconcile_servicemonitor.yaml
@@ -1,0 +1,50 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  creationTimestamp: null
+  name: openshift-route-controller-manager
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: drop
+      regex: etcd_(debugging|disk|request|server).*
+      sourceLabels:
+      - __name__
+    - action: replace
+      replacement: cluster-id
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: cluster-id
+      targetLabel: _id
+    scheme: https
+    targetPort: https
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: openshift-controller-manager
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: openshift-route-controller-manager
+      hypershift.openshift.io/control-plane-component: openshift-route-controller-manager

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	availabilityprober "github.com/openshift/hypershift/availability-prober"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -412,6 +413,7 @@ func NewStartCommand() *cobra.Command {
 		setupLog.Info("Using metrics set", "set", metricsSet.String())
 
 		enableCVOManagementClusterMetricsAccess := (os.Getenv(config.EnableCVOManagementClusterMetricsAccessEnvVar) == "1")
+		_, isCPOV2 := os.LookupEnv(hyperv1.ControlPlaneOperatorV2EnvVar)
 
 		if err := (&hostedcontrolplane.HostedControlPlaneReconciler{
 			Client:                                  mgr.GetClient(),
@@ -424,6 +426,7 @@ func NewStartCommand() *cobra.Command {
 			MetricsSet:                              metricsSet,
 			CertRotationScale:                       certRotationScale,
 			EnableCVOManagementClusterMetricsAccess: enableCVOManagementClusterMetricsAccess,
+			IsCPOV2:                                 isCPOV2,
 		}).SetupWithManager(mgr, upsert.New(enableCIDebugOutput).CreateOrUpdate); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")
 			os.Exit(1)

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -174,7 +174,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 	}
 
 	// Look up the release image metadata
-	imageProvider, err := func() (*imageprovider.ReleaseImageProvider, error) {
+	imageProvider, err := func() (*imageprovider.SimpleReleaseImageProvider, error) {
 		img, err := p.ReleaseProvider.Lookup(ctx, releaseImage, pullSecret)
 		if err != nil {
 			return nil, fmt.Errorf("failed to look up release image metadata: %w", err)
@@ -656,7 +656,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 	return payload, nil
 }
 
-func (r *LocalIgnitionProvider) reconcileValidReleaseInfoCondition(ctx context.Context, releaseImageProvider *imageprovider.ReleaseImageProvider) error {
+func (r *LocalIgnitionProvider) reconcileValidReleaseInfoCondition(ctx context.Context, releaseImageProvider *imageprovider.SimpleReleaseImageProvider) error {
 	hcpList := &hyperv1.HostedControlPlaneList{}
 	if err := r.Client.List(ctx, hcpList, client.InNamespace(r.Namespace)); err != nil {
 		return err

--- a/support/controlplane-component/builder.go
+++ b/support/controlplane-component/builder.go
@@ -1,0 +1,83 @@
+package controlplanecomponent
+
+import (
+	"github.com/openshift/hypershift/support/util"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type controlPlaneWorkloadBuilder[T client.Object] struct {
+	workload *controlPlaneWorkload
+}
+
+func NewDeploymentComponent(name string, opts ComponentOptions) *controlPlaneWorkloadBuilder[*appsv1.Deployment] {
+	return &controlPlaneWorkloadBuilder[*appsv1.Deployment]{
+		workload: &controlPlaneWorkload{
+			name:             name,
+			workloadType:     deploymentWorkloadType,
+			ComponentOptions: opts,
+		},
+	}
+}
+
+func NewStatefulSetComponent(name string, opts ComponentOptions) *controlPlaneWorkloadBuilder[*appsv1.StatefulSet] {
+	return &controlPlaneWorkloadBuilder[*appsv1.StatefulSet]{
+		workload: &controlPlaneWorkload{
+			name:             name,
+			workloadType:     statefulSetWorkloadType,
+			ComponentOptions: opts,
+		},
+	}
+}
+
+func (b *controlPlaneWorkloadBuilder[T]) WithAdaptFunction(adapt func(cpContext ControlPlaneContext, obj T) error) *controlPlaneWorkloadBuilder[T] {
+	b.workload.adapt = func(cpContext ControlPlaneContext, obj client.Object) error {
+		return adapt(cpContext, obj.(T))
+	}
+	return b
+}
+
+func (b *controlPlaneWorkloadBuilder[T]) WithPredicate(predicate func(cpContext ControlPlaneContext) (bool, error)) *controlPlaneWorkloadBuilder[T] {
+	b.workload.predicate = predicate
+	return b
+}
+
+func (b *controlPlaneWorkloadBuilder[T]) WithManifestAdapter(manifestName string, opts ...option) *controlPlaneWorkloadBuilder[T] {
+	adapter := &genericAdapter{}
+	for _, opt := range opts {
+		opt(adapter)
+	}
+
+	if b.workload.manifestsAdapters == nil {
+		b.workload.manifestsAdapters = make(map[string]genericAdapter)
+	}
+	b.workload.manifestsAdapters[manifestName] = *adapter
+	return b
+}
+
+func (b *controlPlaneWorkloadBuilder[T]) WatchResource(resource client.Object, name string) *controlPlaneWorkloadBuilder[T] {
+	resource.SetName(name)
+	b.workload.watchedResources = append(b.workload.watchedResources, resource)
+	return b
+}
+
+func (b *controlPlaneWorkloadBuilder[T]) InjectKonnectivityContainer(opts KonnectivityContainerOptions) *controlPlaneWorkloadBuilder[T] {
+	b.workload.konnectivityContainerOpts = &opts
+	return b
+}
+
+func (b *controlPlaneWorkloadBuilder[T]) InjectAvailabilityProberContainer(opts util.AvailabilityProberOpts) *controlPlaneWorkloadBuilder[T] {
+	b.workload.availabilityProberOpts = &opts
+	return b
+}
+
+func (b *controlPlaneWorkloadBuilder[T]) Build() ControlPlaneComponent {
+	b.validate()
+	return b.workload
+}
+
+func (b *controlPlaneWorkloadBuilder[T]) validate() {
+	if b.workload.name == "" {
+		panic("name is required")
+	}
+}

--- a/support/controlplane-component/controlplane-component.go
+++ b/support/controlplane-component/controlplane-component.go
@@ -1,0 +1,341 @@
+package controlplanecomponent
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/upsert"
+	"github.com/openshift/hypershift/support/util"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type NamedComponent interface {
+	Name() string
+}
+type ControlPlaneComponent interface {
+	NamedComponent
+	Reconcile(cpContext ControlPlaneContext) error
+}
+
+type ControlPlaneContext struct {
+	context.Context
+
+	upsert.CreateOrUpdateProviderV2
+	Client                   client.Client
+	HCP                      *hyperv1.HostedControlPlane
+	ReleaseImageProvider     imageprovider.ReleaseImageProvider
+	UserReleaseImageProvider imageprovider.ReleaseImageProvider
+
+	SetDefaultSecurityContext bool
+	MetricsSet                metrics.MetricsSet
+
+	// This is needed for the generic unit test, so we can always generate a fixture for the components deployment/statefulset.
+	SkipPredicate bool
+}
+
+var _ ControlPlaneComponent = &controlPlaneWorkload{}
+
+type workloadType string
+
+const (
+	deploymentWorkloadType  workloadType = "Deployment"
+	statefulSetWorkloadType workloadType = "StatefulSet"
+)
+
+type ComponentOptions interface {
+	IsRequestServing() bool
+	MultiZoneSpread() bool
+	NeedsManagementKASAccess() bool
+}
+
+// TODO: add unit test
+type controlPlaneWorkload struct {
+	ComponentOptions
+
+	name         string
+	workloadType workloadType
+
+	adapt func(cpContext ControlPlaneContext, obj client.Object) error
+
+	// adapters for Secret, ConfigMap, Service, ServiceMonitor, etc.
+	manifestsAdapters map[string]genericAdapter
+	// predicate is called at the begining, the component is disabled if it returns false.
+	predicate func(cpContext ControlPlaneContext) (bool, error)
+	// These resources will cause the Deployment/statefulset to rollout when changed.
+	watchedResources []client.Object
+
+	// if provided, konnectivity proxy container and required volumes will be injected into the deployment/statefulset.
+	konnectivityContainerOpts *KonnectivityContainerOptions
+	// if provided, availabilityProber container and required volumes will be injected into the deployment/statefulset.
+	availabilityProberOpts *util.AvailabilityProberOpts
+}
+
+// Name implements ControlPlaneComponent.
+func (c *controlPlaneWorkload) Name() string {
+	return c.name
+}
+
+// reconcile implements ControlPlaneComponent.
+func (c *controlPlaneWorkload) Reconcile(cpContext ControlPlaneContext) error {
+	if !cpContext.SkipPredicate && c.predicate != nil {
+		shouldReconcile, err := c.predicate(cpContext)
+		if err != nil {
+			return err
+		}
+		if !shouldReconcile {
+			return nil
+		}
+	}
+
+	hcp := cpContext.HCP
+	ownerRef := config.OwnerRefFrom(hcp)
+	// reconcile resources such as ConfigMaps and Secrets first, as the deployment might depend on them.
+	if err := assets.ForEachManifest(c.name, func(manifestName string) error {
+		adapter, exist := c.manifestsAdapters[manifestName]
+		if exist {
+			return adapter.reconcile(cpContext, c.Name(), manifestName)
+		}
+
+		obj, err := assets.LoadManifest(c.name, manifestName, nil)
+		if err != nil {
+			return err
+		}
+		obj.SetNamespace(hcp.Namespace)
+		ownerRef.ApplyTo(obj)
+
+		switch typedObj := obj.(type) {
+		case *rbacv1.RoleBinding:
+			for i := range typedObj.Subjects {
+				if typedObj.Subjects[i].Kind == "ServiceAccount" {
+					typedObj.Subjects[i].Namespace = hcp.Namespace
+				}
+			}
+		}
+
+		if _, err := cpContext.CreateOrUpdateV2(cpContext, cpContext.Client, obj); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return c.reconcileWorkload(cpContext)
+}
+
+func (c *controlPlaneWorkload) reconcileWorkload(cpContext ControlPlaneContext) error {
+	var workloadObj client.Object
+	var oldWorkloadObj client.Object
+
+	switch c.workloadType {
+	case deploymentWorkloadType:
+		dep, err := assets.LoadDeploymentManifest(c.Name())
+		if err != nil {
+			return fmt.Errorf("faild loading deployment manifest: %v", err)
+		}
+		workloadObj = dep
+		oldWorkloadObj = &appsv1.Deployment{}
+	case statefulSetWorkloadType:
+		sts, err := assets.LoadStatefulSetManifest(c.Name())
+		if err != nil {
+			return fmt.Errorf("faild loading statefulset manifest: %v", err)
+		}
+		workloadObj = sts
+		oldWorkloadObj = &appsv1.StatefulSet{}
+	}
+	workloadObj.SetNamespace(cpContext.HCP.Namespace)
+
+	if err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(workloadObj), oldWorkloadObj); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get old workload object: %v", err)
+		}
+	}
+
+	ownerRef := config.OwnerRefFrom(cpContext.HCP)
+	ownerRef.ApplyTo(workloadObj)
+	if c.adapt != nil {
+		if err := c.adapt(cpContext, workloadObj); err != nil {
+			return err
+		}
+	}
+
+	switch c.workloadType {
+	case deploymentWorkloadType:
+		if err := c.applyOptionsToDeployment(cpContext, workloadObj.(*appsv1.Deployment), oldWorkloadObj.(*appsv1.Deployment)); err != nil {
+			return err
+		}
+	case statefulSetWorkloadType:
+		if err := c.applyOptionsToStatefulSet(cpContext, workloadObj.(*appsv1.StatefulSet), oldWorkloadObj.(*appsv1.StatefulSet)); err != nil {
+			return err
+		}
+	}
+
+	if _, err := cpContext.CreateOrUpdateV2(cpContext, cpContext.Client, workloadObj); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *controlPlaneWorkload) applyOptionsToDeployment(cpContext ControlPlaneContext, deployment *appsv1.Deployment, oldDeployment *appsv1.Deployment) error {
+	// preserve existing resource requirements.
+	existingResources := make(map[string]corev1.ResourceRequirements)
+	for _, container := range oldDeployment.Spec.Template.Spec.Containers {
+		existingResources[container.Name] = container.Resources
+	}
+	// preserve old label selector if it exist, this field is immutable and shouldn't be changed for the lifecycle of the component.
+	if oldDeployment.Spec.Selector != nil {
+		deployment.Spec.Selector = oldDeployment.Spec.Selector.DeepCopy()
+	}
+
+	deploymentConfig, err := c.defaultOptions(cpContext, &deployment.Spec.Template, deployment.Spec.Replicas, existingResources)
+	if err != nil {
+		return err
+	}
+	deploymentConfig.ApplyTo(deployment)
+	return nil
+}
+
+func (c *controlPlaneWorkload) applyOptionsToStatefulSet(cpContext ControlPlaneContext, statefulSet *appsv1.StatefulSet, oldStatefulSet *appsv1.StatefulSet) error {
+	// preserve existing resource requirements.
+	existingResources := make(map[string]corev1.ResourceRequirements)
+	for _, container := range oldStatefulSet.Spec.Template.Spec.Containers {
+		existingResources[container.Name] = container.Resources
+	}
+	// preserve old label selector if it exist, this field is immutable and shouldn't be changed for the lifecycle of the component.
+	if oldStatefulSet.Spec.Selector != nil {
+		statefulSet.Spec.Selector = oldStatefulSet.Spec.Selector.DeepCopy()
+	}
+
+	deploymentConfig, err := c.defaultOptions(cpContext, &statefulSet.Spec.Template, statefulSet.Spec.Replicas, existingResources)
+	if err != nil {
+		return err
+	}
+	deploymentConfig.ApplyToStatefulSet(statefulSet)
+	return nil
+}
+
+func (c *controlPlaneWorkload) defaultOptions(cpContext ControlPlaneContext, podTemplateSpec *corev1.PodTemplateSpec, desiredReplicas *int32, existingResources map[string]corev1.ResourceRequirements) (*config.DeploymentConfig, error) {
+	podTemplateSpec.Spec.AutomountServiceAccountToken = ptr.To(c.NeedsManagementKASAccess())
+
+	if err := replaceContainersImageFromPayload(cpContext.ReleaseImageProvider, podTemplateSpec.Spec.Containers); err != nil {
+		return nil, err
+	}
+	if err := replaceContainersImageFromPayload(cpContext.ReleaseImageProvider, podTemplateSpec.Spec.InitContainers); err != nil {
+		return nil, err
+	}
+
+	if err := c.applyWatchedResourcesAnnotation(cpContext, podTemplateSpec); err != nil {
+		return nil, err
+	}
+
+	if c.konnectivityContainerOpts != nil {
+		c.konnectivityContainerOpts.injectKonnectivityContainer(cpContext, &podTemplateSpec.Spec)
+	}
+
+	if c.availabilityProberOpts != nil {
+		availabilityProberImage := cpContext.ReleaseImageProvider.GetImage(util.AvailabilityProberImageName)
+		util.AvailabilityProber(
+			kas.InClusterKASReadyURL(cpContext.HCP.Spec.Platform.Type), availabilityProberImage,
+			&podTemplateSpec.Spec,
+			util.WithOptions(c.availabilityProberOpts))
+	}
+
+	deploymentConfig := &config.DeploymentConfig{
+		SetDefaultSecurityContext: cpContext.SetDefaultSecurityContext,
+		Resources:                 existingResources,
+	}
+	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
+	if cpContext.HCP.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
+		deploymentConfig.Scheduling.PriorityClass = cpContext.HCP.Annotations[hyperv1.ControlPlanePriorityClass]
+	}
+
+	if c.NeedsManagementKASAccess() {
+		deploymentConfig.AdditionalLabels = map[string]string{
+			config.NeedManagementKASAccessLabel: "true",
+		}
+	}
+
+	var replicas *int
+	if desiredReplicas != nil {
+		replicas = ptr.To(int(*desiredReplicas))
+	}
+	var multiZoneSpreadLabels map[string]string
+	if c.MultiZoneSpread() {
+		multiZoneSpreadLabels = podTemplateSpec.ObjectMeta.Labels
+	}
+	if c.IsRequestServing() {
+		deploymentConfig.SetRequestServingDefaults(cpContext.HCP, multiZoneSpreadLabels, replicas)
+	} else {
+		deploymentConfig.SetDefaults(cpContext.HCP, multiZoneSpreadLabels, replicas)
+	}
+	deploymentConfig.SetRestartAnnotation(cpContext.HCP.ObjectMeta)
+
+	return deploymentConfig, nil
+}
+
+func (c *controlPlaneWorkload) applyWatchedResourcesAnnotation(cpContext ControlPlaneContext, podTemplate *corev1.PodTemplateSpec) error {
+	if c.watchedResources == nil {
+		return nil
+	}
+
+	var hashedData []string
+	for _, resource := range c.watchedResources {
+		if err := cpContext.Client.Get(cpContext, client.ObjectKey{Namespace: cpContext.HCP.Namespace, Name: resource.GetName()}, resource); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+
+		switch obj := resource.(type) {
+		case *corev1.ConfigMap:
+			for _, value := range obj.Data {
+				hashedData = append(hashedData, util.HashSimple(value))
+			}
+		case *corev1.Secret:
+			for _, value := range obj.Data {
+				hashedData = append(hashedData, util.HashSimple(value))
+			}
+		}
+	}
+	// if not sorted, we could get a different value on each reconcilation loop and cause unneeded rollout.
+	slices.Sort(hashedData)
+
+	if podTemplate.Annotations == nil {
+		podTemplate.Annotations = map[string]string{}
+	}
+	podTemplate.Annotations["component.hypershift.openshift.io/config-hash"] = strings.Join(hashedData, "")
+	return nil
+}
+
+func replaceContainersImageFromPayload(imageProvider imageprovider.ReleaseImageProvider, containers []corev1.Container) error {
+	for i, container := range containers {
+		if container.Image == "" {
+			return fmt.Errorf("container %s has no image key specified", container.Name)
+		}
+		key := container.Image
+		if payloadImage, exist := imageProvider.ImageExist(key); exist {
+			containers[i].Image = payloadImage
+		} else {
+			return fmt.Errorf("image doesn't exist for container %s with image key %s", container.Name, key)
+		}
+	}
+
+	return nil
+}

--- a/support/controlplane-component/konnectivity-container.go
+++ b/support/controlplane-component/konnectivity-container.go
@@ -1,0 +1,200 @@
+package controlplanecomponent
+
+import (
+	"fmt"
+	"path"
+	"strconv"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/proxy"
+	"github.com/openshift/hypershift/support/util"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+type ProxyMode string
+
+const (
+	Socks5 ProxyMode = "socks5"
+	HTTPS  ProxyMode = "https"
+
+	// Dual mode will inject 2 konnectivity containers, one using HTTPS mode and the other using Socks5 mode.
+	Dual ProxyMode = "dual"
+)
+
+type KonnectivityContainerOptions struct {
+	Mode ProxyMode
+	// defaults to 'kubeconfig'
+	KubeconfingVolumeName string
+
+	// socks5 proxy mode args
+	ConnectDirectlyToCloudAPIs      bool
+	ResolveFromGuestClusterDNS      bool
+	ResolveFromManagementClusterDNS bool
+	DisableResolver                 bool
+}
+
+func (opts *KonnectivityContainerOptions) injectKonnectivityContainer(cpContext ControlPlaneContext, podSpec *corev1.PodSpec) {
+	if opts.Mode == "" {
+		// programmer error.
+		panic("Konnectivity proxy mode must be specified!")
+	}
+
+	hcp := cpContext.HCP
+	var proxyAdditionalCAs []corev1.VolumeProjection
+	if hcp.Spec.AdditionalTrustBundle != nil {
+		proxyAdditionalCAs = append(proxyAdditionalCAs, corev1.VolumeProjection{
+			ConfigMap: &corev1.ConfigMapProjection{
+				LocalObjectReference: *hcp.Spec.AdditionalTrustBundle,
+				Items:                []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "additional-ca-bundle.pem"}},
+			},
+		})
+	}
+
+	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.Proxy != nil && len(hcp.Spec.Configuration.Proxy.TrustedCA.Name) > 0 {
+		proxyAdditionalCAs = append(proxyAdditionalCAs, corev1.VolumeProjection{
+			ConfigMap: &corev1.ConfigMapProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: hcp.Spec.Configuration.Proxy.TrustedCA.Name,
+				},
+				Items: []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "proxy-trusted-ca.pem"}},
+			},
+		})
+	}
+
+	image := cpContext.ReleaseImageProvider.GetImage(util.CPOImageName)
+
+	if opts.Mode == Dual {
+		opts.Mode = HTTPS
+		podSpec.Containers = append(podSpec.Containers, opts.buildContainer(hcp, image, proxyAdditionalCAs))
+
+		opts.Mode = Socks5
+		podSpec.Containers = append(podSpec.Containers, opts.buildContainer(hcp, image, proxyAdditionalCAs))
+	} else {
+		podSpec.Containers = append(podSpec.Containers, opts.buildContainer(hcp, image, proxyAdditionalCAs))
+	}
+
+	podSpec.Volumes = append(podSpec.Volumes, opts.buildVolumes(proxyAdditionalCAs)...)
+}
+
+const certsTrustPath = "/etc/pki/tls/certs"
+
+func (opts *KonnectivityContainerOptions) buildContainer(hcp *hyperv1.HostedControlPlane, image string, proxyAdditionalCAs []corev1.VolumeProjection) corev1.Container {
+	var proxyConfig *configv1.ProxySpec
+	if hcp.Spec.Configuration != nil {
+		proxyConfig = hcp.Spec.Configuration.Proxy
+	}
+
+	command := []string{"/usr/bin/control-plane-operator"}
+	args := []string{"run"}
+	switch opts.Mode {
+	case HTTPS:
+		command = append(command, "konnectivity-https-proxy")
+		if proxyConfig != nil {
+			noProxy := proxy.DefaultNoProxy(hcp)
+			args = append(args, "--http-proxy", proxyConfig.HTTPProxy)
+			args = append(args, "--https-proxy", proxyConfig.HTTPSProxy)
+			args = append(args, "--no-proxy", noProxy)
+		}
+	case Socks5:
+		command = append(command, "konnectivity-socks5-proxy")
+		args = append(args, "--connect-directly-to-cloud-apis", strconv.FormatBool(opts.ConnectDirectlyToCloudAPIs))
+		args = append(args, "--resolve-from-guest-cluster-dns", strconv.FormatBool(opts.ResolveFromGuestClusterDNS))
+		args = append(args, "--resolve-from-management-cluster-dns", strconv.FormatBool(opts.ResolveFromManagementClusterDNS))
+		args = append(args, "--disable-resolver", strconv.FormatBool(opts.DisableResolver))
+	}
+
+	kubeconfingVolumeName := opts.KubeconfingVolumeName
+	if kubeconfingVolumeName == "" {
+		kubeconfingVolumeName = "kubeconfig"
+	}
+
+	container := corev1.Container{
+		Name:    fmt.Sprintf("konnectivity-proxy-%s", opts.Mode),
+		Image:   image,
+		Command: command,
+		Args:    args,
+
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+		},
+		Env: []corev1.EnvVar{{
+			Name:  "KUBECONFIG",
+			Value: "/etc/kubernetes/secrets/kubeconfig/kubeconfig",
+		}},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      kubeconfingVolumeName,
+				MountPath: "/etc/kubernetes/secrets/kubeconfig",
+			},
+			{
+				Name:      "konnectivity-proxy-cert",
+				MountPath: "/etc/konnectivity/proxy-client",
+			},
+			{
+				Name:      "konnectivity-proxy-ca",
+				MountPath: "/etc/konnectivity/proxy-ca",
+			},
+		},
+	}
+
+	if len(proxyAdditionalCAs) > 0 {
+		for _, additionalCA := range proxyAdditionalCAs {
+			for _, item := range additionalCA.ConfigMap.Items {
+				container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+					Name:      "proxy-additional-trust-bundle",
+					MountPath: path.Join(certsTrustPath, item.Path),
+					SubPath:   item.Path,
+				})
+			}
+		}
+	}
+
+	return container
+}
+
+func (opts *KonnectivityContainerOptions) buildVolumes(proxyAdditionalCAs []corev1.VolumeProjection) []corev1.Volume {
+	volumes := []corev1.Volume{
+		{
+			Name: "konnectivity-proxy-cert",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  manifests.KonnectivityClientSecret("").Name,
+					DefaultMode: ptr.To[int32](0640),
+				},
+			},
+		},
+		{
+			Name: "konnectivity-proxy-ca",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: manifests.KonnectivityCAConfigMap("").Name,
+					},
+				},
+			},
+		},
+	}
+
+	if len(proxyAdditionalCAs) > 0 {
+		volumes = append(volumes, corev1.Volume{
+			Name: "proxy-additional-trust-bundle",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources:     proxyAdditionalCAs,
+					DefaultMode: ptr.To[int32](420),
+				},
+			},
+		})
+	}
+
+	return volumes
+}

--- a/support/testutil/testutil.go
+++ b/support/testutil/testutil.go
@@ -70,6 +70,8 @@ type options struct {
 	Prefix    string
 	Suffix    string
 	Extension string
+
+	SubDir string
 }
 
 type option func(*options)
@@ -80,12 +82,24 @@ func WithExtension(extension string) option {
 	}
 }
 
+func WithSuffix(suffix string) option {
+	return func(opts *options) {
+		opts.Suffix = suffix
+	}
+}
+
+func WithSubDir(subDir string) option {
+	return func(opts *options) {
+		opts.SubDir = subDir
+	}
+}
+
 // golden determines the golden file to use
 func golden(t *testing.T, opts *options) (string, error) {
 	if opts.Extension == "" {
 		opts.Extension = ".yaml"
 	}
-	return filepath.Abs(filepath.Join("testdata", sanitizeFilename(opts.Prefix+t.Name()+opts.Suffix)) + opts.Extension)
+	return filepath.Abs(filepath.Join("testdata", opts.SubDir, sanitizeFilename(opts.Prefix+t.Name()+opts.Suffix)) + opts.Extension)
 }
 
 func sanitizeFilename(s string) string {

--- a/support/util/containers.go
+++ b/support/util/containers.go
@@ -22,6 +22,14 @@ func FindContainer(name string, containers []corev1.Container) *corev1.Container
 	return nil
 }
 
+func UpdateContainer(name string, containers []corev1.Container, update func(c *corev1.Container)) {
+	for i, c := range containers {
+		if c.Name == name {
+			update(&containers[i])
+		}
+	}
+}
+
 const (
 
 	// CPOImageName is the name under which components can find the CPO image in the release image..
@@ -83,3 +91,12 @@ type AvailabilityProberOpts struct {
 }
 
 type AvailabilityProberOpt func(*AvailabilityProberOpts)
+
+func WithOptions(opts *AvailabilityProberOpts) AvailabilityProberOpt {
+	return func(o *AvailabilityProberOpts) {
+		o.KubeconfigVolumeName = opts.KubeconfigVolumeName
+		o.RequiredAPIs = opts.RequiredAPIs
+		o.WaitForInfrastructureResource = opts.WaitForInfrastructureResource
+		o.WaitForLabeledPodsGone = opts.WaitForLabeledPodsGone
+	}
+}

--- a/support/util/volumes.go
+++ b/support/util/volumes.go
@@ -31,3 +31,11 @@ func DeploymentAddTrustBundleVolume(trustBundleConfigMap *corev1.LocalObjectRefe
 		},
 	})
 }
+
+func UpdateVolume(name string, volumes []corev1.Volume, update func(v *corev1.Volume)) {
+	for i, v := range volumes {
+		if v.Name == name {
+			update(&volumes[i])
+		}
+	}
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -337,6 +337,13 @@ const (
 
 	// DisableIgnitionServerAnnotation controls skipping of the ignition server deployment.
 	DisableIgnitionServerAnnotation = "hypershift.openshift.io/disable-ignition-server"
+
+	// ControlPlaneOperatorV2Annotation tells the hosted cluster to set 'CPO_V2' env variable on the CPO deployment which enables
+	// the new manifest based CPO implementation.
+	ControlPlaneOperatorV2Annotation = "hypershift.openshift.io/cpo-v2"
+
+	// ControlPlaneOperatorV2EnvVar when set on the CPO deplyoment, enables the new manifest based CPO implementation.
+	ControlPlaneOperatorV2EnvVar = "CPO_V2"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.


### PR DESCRIPTION
**What this PR does / why we need it**:

- introduces an abstraction that all control plane components should implement, allowing us to enforce opinionated defaults and settings for all components in one place
- streamline the development process by reducing the boilerplate code that needs to be copy/pasted when introducing new components.
- All Components should be defined in yaml manifests and add any dynamic reconciliation logic if necessary using the abstraction, significantly reducing LOC of components logic and hostedcontrolplane_controller.go
- This is currently hidden behind a new annotation on the HostedCluster `hypershift.openshift.io/cpo-v2` which sets the environment variable  `CPO_V2` on the CPO deployment.
- A new e2e `TestCreateClusterV2` is added to enable and test the new approach.
----

2 components refactored in this PR as an example:

- cluster-autoscaler
- openshift-router-controller-manger

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.