### PR TITLE
OCPBUGS-41824: Conditionally manage kubeconfig secrets for DNS and Ingress operators

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3655,21 +3655,23 @@ func (r *HostedControlPlaneReconciler) reconcileDNSOperator(ctx context.Context,
 func (r *HostedControlPlaneReconciler) reconcileIngressOperator(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, createOrUpdate upsert.CreateOrUpdateFN) error {
 	p := ingressoperator.NewParams(hcp, userReleaseImageProvider.Version(), releaseImageProvider, userReleaseImageProvider, r.SetDefaultSecurityContext, hcp.Spec.Platform.Type)
 
-	rootCA := manifests.RootCAConfigMap(hcp.Namespace)
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(rootCA), rootCA); err != nil {
-		return err
-	}
+	if _, exists := hcp.Annotations[hyperv1.DisablePKIReconciliationAnnotation]; !exists {
+		rootCA := manifests.RootCAConfigMap(hcp.Namespace)
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(rootCA), rootCA); err != nil {
+			return err
+		}
 
-	csrSigner := manifests.CSRSignerCASecret(hcp.Namespace)
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(csrSigner), csrSigner); err != nil {
-		return err
-	}
+		csrSigner := manifests.CSRSignerCASecret(hcp.Namespace)
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(csrSigner), csrSigner); err != nil {
+			return err
+		}
 
-	kubeconfig := manifests.IngressOperatorKubeconfig(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, kubeconfig, func() error {
-		return pki.ReconcileServiceAccountKubeconfig(kubeconfig, csrSigner, rootCA, hcp, "openshift-ingress-operator", "ingress-operator")
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile ingressoperator kubeconfig: %w", err)
+		kubeconfig := manifests.IngressOperatorKubeconfig(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, kubeconfig, func() error {
+			return pki.ReconcileServiceAccountKubeconfig(kubeconfig, csrSigner, rootCA, hcp, "openshift-ingress-operator", "ingress-operator")
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ingressoperator kubeconfig: %w", err)
+		}
 	}
 
 	deployment := manifests.IngressOperatorDeployment(hcp.Namespace)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3623,21 +3623,23 @@ func (r *HostedControlPlaneReconciler) reconcileClusterNodeTuningOperator(ctx co
 func (r *HostedControlPlaneReconciler) reconcileDNSOperator(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, createOrUpdate upsert.CreateOrUpdateFN) error {
 	p := dnsoperator.NewParams(hcp, userReleaseImageProvider.Version(), releaseImageProvider, userReleaseImageProvider, r.SetDefaultSecurityContext)
 
-	rootCA := manifests.RootCAConfigMap(hcp.Namespace)
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(rootCA), rootCA); err != nil {
-		return err
-	}
+	if _, exists := hcp.Annotations[hyperv1.DisablePKIReconciliationAnnotation]; !exists {
+		rootCA := manifests.RootCAConfigMap(hcp.Namespace)
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(rootCA), rootCA); err != nil {
+			return err
+		}
 
-	csrSigner := manifests.CSRSignerCASecret(hcp.Namespace)
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(csrSigner), csrSigner); err != nil {
-		return err
-	}
+		csrSigner := manifests.CSRSignerCASecret(hcp.Namespace)
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(csrSigner), csrSigner); err != nil {
+			return err
+		}
 
-	kubeconfig := manifests.DNSOperatorKubeconfig(hcp.Namespace)
-	if _, err := createOrUpdate(ctx, r, kubeconfig, func() error {
-		return pki.ReconcileServiceAccountKubeconfig(kubeconfig, csrSigner, rootCA, hcp, "openshift-dns-operator", "dns-operator")
-	}); err != nil {
-		return fmt.Errorf("failed to reconcile dnsoperator kubeconfig: %w", err)
+		kubeconfig := manifests.DNSOperatorKubeconfig(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, kubeconfig, func() error {
+			return pki.ReconcileServiceAccountKubeconfig(kubeconfig, csrSigner, rootCA, hcp, "openshift-dns-operator", "dns-operator")
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile dnsoperator kubeconfig: %w", err)
+		}
 	}
 
 	deployment := manifests.DNSOperatorDeployment(hcp.Namespace)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -388,7 +388,7 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 
 	log.Info("reconciling oauth client secrets")
 	if err := r.reconcileAuthOIDC(ctx, hcp); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile ingress controller: %w", err))
+		errs = append(errs, fmt.Errorf("failed to reconcile oauth client secrets: %w", err))
 	}
 
 	log.Info("reconciling kube control plane signer secret")


### PR DESCRIPTION
Hypershift should conditionally manage the kubeconfig secrets for the DNS operator and Ingress operator based off the DisablePKIReconciliationAnnotation.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-41824

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.