### PR TITLE
HOSTEDCP-1569: e2e: add version gating for 4.16

### DIFF
--- a/test/e2e/nodepool_nto_performanceprofile_test.go
+++ b/test/e2e/nodepool_nto_performanceprofile_test.go
@@ -6,8 +6,9 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/hypershift/support/util"
 	"testing"
+
+	"github.com/openshift/hypershift/support/util"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
@@ -147,6 +148,11 @@ func (mc *NTOPerformanceProfileTest) Run(t *testing.T, nodePool hyperv1.NodePool
 			},
 		},
 	)
+	// The remainder of the assertions only work in 4.17+
+	// https://github.com/openshift/hypershift/pull/4020
+	if e2eutil.IsLessThan(e2eutil.Version417) {
+		return
+	}
 	e2eutil.EventuallyObjects(t, ctx, "performance profile status ConfigMap to exist",
 		func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 			list := &corev1.ConfigMapList{}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -934,6 +934,7 @@ func EnsureSecretEncryptedUsingKMSV1(t *testing.T, ctx context.Context, hostedCl
 
 func EnsureSecretEncryptedUsingKMSV2(t *testing.T, ctx context.Context, hostedCluster *hyperv1.HostedCluster, guestClient crclient.Client) {
 	t.Run("EnsureSecretEncryptedUsingKMSV2", func(t *testing.T) {
+		AtLeast(t, Version417)
 		ensureSecretEncryptedUsingKMS(t, ctx, hostedCluster, guestClient, "k8s:enc:kms:v2")
 	})
 }

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -58,3 +58,7 @@ func AtLeast(t *testing.T, version semver.Version) {
 		t.Skipf("Only tested in %s and later", version)
 	}
 }
+
+func IsLessThan(version semver.Version) bool {
+	return releaseVersion.LT(version)
+}


### PR DESCRIPTION
Add required version gates for 4.16 to pass with e2e from `main`

Informed by the rehearsal of https://github.com/openshift/release/pull/56637

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/56637/rehearse-56637-periodic-ci-openshift-hypershift-release-4.16-periodics-e2e-aws-ovn/1834244434464608256