### PR TITLE
OCPBUGS-41689: Allow Encryption at Host to be Independently Toggled from DiskEncryptionSetID

### DIFF
--- a/api/hypershift/v1alpha1/nodepool_types.go
+++ b/api/hypershift/v1alpha1/nodepool_types.go
@@ -957,6 +957,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+	// means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+	// https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+	// for more information.
+	//
+	// +kubebuilder:default:=Enabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	EncryptionAtHost string `json:"encryptionAtHost,omitempty"`
+
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
 	// needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
 	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -985,6 +985,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+	// means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+	// https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+	// for more information.
+	//
+	// +kubebuilder:default:=Enabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	EncryptionAtHost string `json:"encryptionAtHost,omitempty"`
+
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
 	// needs to exist in the same subscription id listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.SubscriptionID.
 	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location

--- a/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1alpha1/azurenodepoolplatform.go
@@ -25,6 +25,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	DiskSizeGB             *int32                          `json:"diskSizeGB,omitempty"`
 	DiskStorageAccountType *string                         `json:"diskStorageAccountType,omitempty"`
 	AvailabilityZone       *string                         `json:"availabilityZone,omitempty"`
+	EncryptionAtHost       *string                         `json:"encryptionAtHost,omitempty"`
 	DiskEncryptionSetID    *string                         `json:"diskEncryptionSetID,omitempty"`
 	EnableEphemeralOSDisk  *bool                           `json:"enableEphemeralOSDisk,omitempty"`
 	SubnetID               *string                         `json:"subnetID,omitempty"`
@@ -75,6 +76,14 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithDiskStorageAccountType(val
 // If called multiple times, the AvailabilityZone field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithAvailabilityZone(value string) *AzureNodePoolPlatformApplyConfiguration {
 	b.AvailabilityZone = &value
+	return b
+}
+
+// WithEncryptionAtHost sets the EncryptionAtHost field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EncryptionAtHost field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithEncryptionAtHost(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.EncryptionAtHost = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
@@ -25,6 +25,7 @@ type AzureNodePoolPlatformApplyConfiguration struct {
 	DiskSizeGB             *int32                          `json:"diskSizeGB,omitempty"`
 	DiskStorageAccountType *string                         `json:"diskStorageAccountType,omitempty"`
 	AvailabilityZone       *string                         `json:"availabilityZone,omitempty"`
+	EncryptionAtHost       *string                         `json:"encryptionAtHost,omitempty"`
 	DiskEncryptionSetID    *string                         `json:"diskEncryptionSetID,omitempty"`
 	EnableEphemeralOSDisk  *bool                           `json:"enableEphemeralOSDisk,omitempty"`
 	SubnetID               *string                         `json:"subnetID,omitempty"`
@@ -75,6 +76,14 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithDiskStorageAccountType(val
 // If called multiple times, the AvailabilityZone field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithAvailabilityZone(value string) *AzureNodePoolPlatformApplyConfiguration {
 	b.AvailabilityZone = &value
+	return b
+}
+
+// WithEncryptionAtHost sets the EncryptionAtHost field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EncryptionAtHost field is set to the value of the last call.
+func (b *AzureNodePoolPlatformApplyConfiguration) WithEncryptionAtHost(value string) *AzureNodePoolPlatformApplyConfiguration {
+	b.EncryptionAtHost = &value
 	return b
 }
 

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -309,6 +309,7 @@ func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstr
 				DiskStorageAccountType: o.DiskStorageAccountType,
 				SubnetID:               o.infra.SubnetID,
 				MachineIdentityID:      o.infra.MachineIdentityID,
+				EncryptionAtHost:       o.EncryptionAtHost,
 			}
 			if len(o.DiagnosticsStorageAccountType) > 0 {
 				nodePool.Spec.Platform.Azure.Diagnostics = &hyperv1.Diagnostics{
@@ -333,6 +334,7 @@ func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstr
 		DiskStorageAccountType: o.DiskStorageAccountType,
 		SubnetID:               o.infra.SubnetID,
 		MachineIdentityID:      o.infra.MachineIdentityID,
+		EncryptionAtHost:       o.EncryptionAtHost,
 	}
 	if len(o.DiagnosticsStorageAccountType) > 0 {
 		azureNodePool.Spec.Platform.Azure.Diagnostics = &hyperv1.Diagnostics{

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_nodepools.yaml
@@ -634,6 +634,17 @@ spec:
                         description: EnableEphemeralOSDisk is a flag when set to true,
                           will enable ephemeral OS disk.
                         type: boolean
+                      encryptionAtHost:
+                        default: Enabled
+                        description: |-
+                          encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+                          means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+                          https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+                          for more information.
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
                       image:
                         description: Image is the image to boot the VMs with
                         properties:
@@ -1868,6 +1879,17 @@ spec:
                         description: EnableEphemeralOSDisk is a flag when set to true,
                           will enable ephemeral OS disk.
                         type: boolean
+                      encryptionAtHost:
+                        default: Enabled
+                        description: |-
+                          encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+                          means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+                          https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+                          for more information.
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
                       image:
                         description: |-
                           ImageID is the id of the image to boot from. If unset, the default image at the location below will be used and

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -28,6 +28,7 @@ type AzurePlatformCreateOptions struct {
 	SubnetID                      string
 	ImageID                       string
 	Arch                          string
+	EncryptionAtHost              string
 }
 
 type AzureMarketPlaceImageInfo struct {
@@ -70,6 +71,7 @@ func bindCoreOptions(opts *RawAzurePlatformCreateOptions, flags *pflag.FlagSet) 
 	flags.StringVar(&opts.MarketplaceOffer, "marketplace-offer", opts.MarketplaceOffer, "The Azure Marketplace image offer.")
 	flags.StringVar(&opts.MarketplaceSKU, "marketplace-sku", opts.MarketplaceSKU, "The Azure Marketplace image SKU.")
 	flags.StringVar(&opts.MarketplaceVersion, "marketplace-version", opts.MarketplaceVersion, "The Azure Marketplace image version.")
+	flags.StringVar(&opts.EncryptionAtHost, "enable-encryption-at-host", opts.EncryptionAtHost, "Enables encryption at host on Azure VMs.")
 }
 
 func BindDeveloperOptions(opts *RawAzurePlatformCreateOptions, flags *pflag.FlagSet) {
@@ -111,6 +113,10 @@ func (o *RawAzurePlatformCreateOptions) Validate() (*ValidatedAzurePlatformCreat
 
 	if o.DiagnosticsStorageAccountType != hyperv1.AzureDiagnosticsStorageAccountTypeUserManaged && len(o.DiagnosticsStorageAccountURI) > 0 {
 		return nil, fmt.Errorf("--diagnostics-storage-account-uri is applicable only if --diagnostics-storage-account-type is set to %s", hyperv1.AzureDiagnosticsStorageAccountTypeUserManaged)
+	}
+
+	if o.EncryptionAtHost != "" && o.EncryptionAtHost != "Enabled" && o.EncryptionAtHost != "Disabled" {
+		return nil, fmt.Errorf("flag --enable-encryption-at-host has an invalid value; accepted values are 'Enabled' and 'Disabled'")
 	}
 
 	return &ValidatedAzurePlatformCreateOptions{
@@ -197,6 +203,7 @@ func (o *CompletedAzurePlatformCreateOptions) NodePoolPlatform(nodePool *hyperv1
 		DiskStorageAccountType: o.DiskStorageAccountType,
 		SubnetID:               o.SubnetID,
 		Image:                  vmImage,
+		EncryptionAtHost:       o.EncryptionAtHost,
 	}
 
 	if len(o.DiagnosticsStorageAccountType) > 0 {

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -71,7 +71,7 @@ func bindCoreOptions(opts *RawAzurePlatformCreateOptions, flags *pflag.FlagSet) 
 	flags.StringVar(&opts.MarketplaceOffer, "marketplace-offer", opts.MarketplaceOffer, "The Azure Marketplace image offer.")
 	flags.StringVar(&opts.MarketplaceSKU, "marketplace-sku", opts.MarketplaceSKU, "The Azure Marketplace image SKU.")
 	flags.StringVar(&opts.MarketplaceVersion, "marketplace-version", opts.MarketplaceVersion, "The Azure Marketplace image version.")
-	flags.StringVar(&opts.EncryptionAtHost, "enable-encryption-at-host", opts.EncryptionAtHost, "Enables encryption at host on Azure VMs.")
+	flags.StringVar(&opts.EncryptionAtHost, "encryption-at-host", opts.EncryptionAtHost, "Enables or disables encryption at host on Azure VMs. Supported values: Enabled, Disabled.")
 }
 
 func BindDeveloperOptions(opts *RawAzurePlatformCreateOptions, flags *pflag.FlagSet) {

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2505,6 +2505,21 @@ for clusters in a location that does not support AvailabilityZone.</p>
 </tr>
 <tr>
 <td>
+<code>encryptionAtHost</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+<a href="https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell">https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell</a>
+for more information.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>diskEncryptionSetID</code></br>
 <em>
 string

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -70,6 +70,9 @@ func azureMachineTemplateSpec(nodePool *hyperv1.NodePool) (*capiazure.AzureMachi
 		azureMachineTemplate.Template.Spec.OSDisk.ManagedDisk.DiskEncryptionSet = &capiazure.DiskEncryptionSetParameters{
 			ID: nodePool.Spec.Platform.Azure.DiskEncryptionSetID,
 		}
+	}
+
+	if nodePool.Spec.Platform.Azure.EncryptionAtHost == "Enabled" {
 		azureMachineTemplate.Template.Spec.SecurityProfile = &capiazure.SecurityProfile{
 			EncryptionAtHost: to.Ptr(true),
 		}

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -347,14 +347,9 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							},
 						},
 						SpotVMOptions: nil,
-						SecurityProfile: &capiazure.SecurityProfile{
-							EncryptionAtHost: ptr.To(true),
-							SecurityType:     "",
-							UefiSettings:     nil,
-						},
-						SubnetName:   "",
-						DNSServers:   nil,
-						VMExtensions: nil,
+						SubnetName:    "",
+						DNSServers:    nil,
+						VMExtensions:  nil,
 						NetworkInterfaces: []capiazure.NetworkInterface{
 							{
 								SubnetName:            "testSubnetName",
@@ -452,14 +447,9 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							},
 						},
 						SpotVMOptions: nil,
-						SecurityProfile: &capiazure.SecurityProfile{
-							EncryptionAtHost: ptr.To(true),
-							SecurityType:     "",
-							UefiSettings:     nil,
-						},
-						SubnetName:   "",
-						DNSServers:   nil,
-						VMExtensions: nil,
+						SubnetName:    "",
+						DNSServers:    nil,
+						VMExtensions:  nil,
 						NetworkInterfaces: []capiazure.NetworkInterface{
 							{
 								SubnetName:            "testSubnetName",

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1alpha1/nodepool_types.go
@@ -957,6 +957,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+	// means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+	// https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+	// for more information.
+	//
+	// +kubebuilder:default:=Enabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	EncryptionAtHost string `json:"encryptionAtHost,omitempty"`
+
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
 	// needs to exist in the same subscription id listed in the Hosted Cluster, hcluster.Spec.Platform.Azure.SubscriptionID.
 	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -985,6 +985,16 @@ type AzureNodePoolPlatform struct {
 	// +optional
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// encryptionAtHost enables encryption at host on virtual machines. According to Microsoft documentation, this
+	// means data stored on the VM host is encrypted at rest and flows encrypted to the Storage service. See
+	// https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+	// for more information.
+	//
+	// +kubebuilder:default:=Enabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	EncryptionAtHost string `json:"encryptionAtHost,omitempty"`
+
 	// DiskEncryptionSetID is the ID of the DiskEncryptionSet resource to use to encrypt the OS disks for the VMs. This
 	// needs to exist in the same subscription id listed in the Hosted Cluster, HostedCluster.Spec.Platform.Azure.SubscriptionID.
 	// DiskEncryptionSetID should also exist in a resource group under the same subscription id and the same location


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of:
* https://github.com/openshift/hypershift/pull/4701
* https://github.com/openshift/hypershift/pull/4711

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-41689](https://issues.redhat.com/browse/OCPBUGS-41689)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.