### PR TITLE
HOSTEDCP-1965: Ignore vendor and resources.go from snyk code test

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - 'vendor/**'
+    - 'control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go'


### PR DESCRIPTION
vendor is handled by dependabot
resources.go uses MD5 that is a broken crypto but our usage is just to check if the file changed and the likelihood of collision in our managed usage does not warrant a change.