### PR TITLE
OCPBUGS-38066: [release-4.14] Use HTTP proxy for ingress controller

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -3,6 +3,7 @@ package ingressoperator
 import (
 	"fmt"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
@@ -22,11 +23,12 @@ import (
 )
 
 const (
-	operatorName                 = "ingress-operator"
-	ingressOperatorContainerName = "ingress-operator"
-	metricsHostname              = "ingress-operator"
-	socks5ProxyContainerName     = "socks-proxy"
-	ingressOperatorMetricsPort   = 60000
+	operatorName                   = "ingress-operator"
+	ingressOperatorContainerName   = "ingress-operator"
+	metricsHostname                = "ingress-operator"
+	konnectivityProxyContainerName = "konnectivity-proxy"
+	ingressOperatorMetricsPort     = 60000
+	konnectivityProxyPort          = 8090
 )
 
 type Params struct {
@@ -37,9 +39,11 @@ type Params struct {
 	ReleaseVersion          string
 	TokenMinterImage        string
 	AvailabilityProberImage string
-	Socks5ProxyImage        string
+	ProxyImage              string
 	Platform                hyperv1.PlatformType
 	DeploymentConfig        config.DeploymentConfig
+	ProxyConfig             *configv1.ProxySpec
+	NoProxy                 string
 }
 
 func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool, platform hyperv1.PlatformType) Params {
@@ -49,9 +53,13 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 		HAProxyRouterImage:      userReleaseImageProvider.GetImage("haproxy-router"),
 		ReleaseVersion:          version,
 		TokenMinterImage:        releaseImageProvider.GetImage("token-minter"),
-		Socks5ProxyImage:        releaseImageProvider.GetImage("socks5-proxy"),
+		ProxyImage:              releaseImageProvider.GetImage(util.CPOImageName),
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
 		Platform:                platform,
+	}
+	if hcp.Spec.Configuration != nil {
+		p.ProxyConfig = hcp.Spec.Configuration.Proxy
+		p.NoProxy = proxy.DefaultNoProxy(hcp)
 	}
 	p.DeploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
@@ -136,11 +144,11 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 			{Name: "KUBECONFIG", Value: "/etc/kubernetes/kubeconfig"},
 			{
 				Name:  "HTTP_PROXY",
-				Value: fmt.Sprintf("socks5://127.0.0.1:%d", kas.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("http://127.0.0.1:%d", konnectivityProxyPort),
 			},
 			{
 				Name:  "HTTPS_PROXY",
-				Value: fmt.Sprintf("socks5://127.0.0.1:%d", kas.KonnectivityServerLocalPort),
+				Value: fmt.Sprintf("http://127.0.0.1:%d", konnectivityProxyPort),
 			},
 			{
 				Name:  "NO_PROXY",
@@ -159,7 +167,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 			{Name: "ingress-operator-kubeconfig", MountPath: "/etc/kubernetes"},
 		},
 	}}
-	dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, ingressOperatorSocks5ProxyContainer(params.Socks5ProxyImage))
+	dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, ingressOperatorKonnectivityProxyContainer(params.ProxyImage, params.ProxyConfig, params.NoProxy))
 	dep.Spec.Template.Spec.Volumes = []corev1.Volume{
 		{Name: "ingress-operator-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.IngressOperatorKubeconfig("").Name, DefaultMode: utilpointer.Int32(0640)}}},
 		{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: utilpointer.Int32(0640)}}},
@@ -217,16 +225,13 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 	params.DeploymentConfig.ApplyTo(dep)
 }
 
-func ingressOperatorSocks5ProxyContainer(socks5ProxyImage string) corev1.Container {
+func ingressOperatorKonnectivityProxyContainer(proxyImage string, proxyConfig *configv1.ProxySpec, noProxy string) corev1.Container {
 	c := corev1.Container{
-		Name:    socks5ProxyContainerName,
-		Image:   socks5ProxyImage,
-		Command: []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy", "--resolve-from-guest-cluster-dns=true"},
+		Name:    konnectivityProxyContainerName,
+		Image:   proxyImage,
+		Command: []string{"/usr/bin/control-plane-operator", "konnectivity-https-proxy"},
 		Args: []string{
 			"run",
-			// Do not route cloud provider traffic through konnektivity and thus nodes to speed
-			// up cluster creation. Requires proxy env vars to be set.
-			"--connect-directly-to-cloud-apis=true",
 		},
 		Env: []corev1.EnvVar{{
 			Name:  "KUBECONFIG",
@@ -244,7 +249,11 @@ func ingressOperatorSocks5ProxyContainer(socks5ProxyImage string) corev1.Contain
 			{Name: "konnectivity-proxy-ca", MountPath: "/etc/konnectivity/proxy-ca"},
 		},
 	}
-	proxy.SetEnvVars(&c.Env)
+	if proxyConfig != nil {
+		c.Args = append(c.Args, "--http-proxy", proxyConfig.HTTPProxy)
+		c.Args = append(c.Args, "--https-proxy", proxyConfig.HTTPSProxy)
+		c.Args = append(c.Args, "--no-proxy", noProxy)
+	}
 	return c
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -232,6 +232,7 @@ func ingressOperatorKonnectivityProxyContainer(proxyImage string, proxyConfig *c
 		Command: []string{"/usr/bin/control-plane-operator", "konnectivity-https-proxy"},
 		Args: []string{
 			"run",
+			"--connect-directly-to-cloud-apis",
 		},
 		Env: []corev1.EnvVar{{
 			Name:  "KUBECONFIG",
@@ -254,6 +255,7 @@ func ingressOperatorKonnectivityProxyContainer(proxyImage string, proxyConfig *c
 		c.Args = append(c.Args, "--https-proxy", proxyConfig.HTTPSProxy)
 		c.Args = append(c.Args, "--no-proxy", noProxy)
 	}
+	proxy.SetEnvVars(&c.Env)
 	return c
 }
 

--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -54,6 +54,8 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&httpsProxyURL, "https-proxy", "", "HTTPS proxy to use on hosted cluster requests")
 	cmd.Flags().StringVar(&noProxy, "no-proxy", "", "URLs that should not use the provided http-proxy and https-proxy")
 
+	cmd.Flags().BoolVar(&opts.ConnectDirectlyToCloudAPIs, "connect-directly-to-cloud-apis", false, "If true, bypass konnectivity to connect to cloud APIs while still honoring management proxy config")
+
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		l.Info("Starting proxy", "version", version.String())
 		c, err := client.New(ctrl.GetConfigOrDie(), client.Options{})

--- a/support/konnectivityproxy/proxy_dialer.go
+++ b/support/konnectivityproxy/proxy_dialer.go
@@ -1,0 +1,87 @@
+package konnectivityproxy
+
+import (
+	"bufio"
+	"encoding/base64"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/proxy"
+)
+
+func newHTTPDialer(proxyURL *url.URL) proxy.Dialer {
+	return &httpProxyDialer{proxyURL: proxyURL, forwardDial: proxy.Direct.Dial}
+}
+
+// Everything below is a copied from https://github.com/fasthttp/websocket/blob/2f8e79d2aac1e8e5a06518870e872b15608cea90/proxy.go
+// as the golang.org/x/net/proxy package only supports socks5 proxies, but does allow registering additional protocols.
+type httpProxyDialer struct {
+	proxyURL    *url.URL
+	forwardDial func(network, addr string) (net.Conn, error)
+}
+
+func (hpd *httpProxyDialer) Dial(network string, addr string) (net.Conn, error) {
+	hostPort, _ := hostPortNoPort(hpd.proxyURL)
+	conn, err := hpd.forwardDial(network, hostPort)
+	if err != nil {
+		return nil, err
+	}
+
+	connectHeader := make(http.Header)
+	if user := hpd.proxyURL.User; user != nil {
+		proxyUser := user.Username()
+		if proxyPassword, passwordSet := user.Password(); passwordSet {
+			credential := base64.StdEncoding.EncodeToString([]byte(proxyUser + ":" + proxyPassword))
+			connectHeader.Set("Proxy-Authorization", "Basic "+credential)
+		}
+	}
+
+	connectReq := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Opaque: addr},
+		Host:   addr,
+		Header: connectHeader,
+	}
+
+	if err := connectReq.Write(conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	// Read response. It's OK to use and discard buffered reader here becaue
+	// the remote server does not speak until spoken to.
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, connectReq)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		conn.Close()
+		f := strings.SplitN(resp.Status, " ", 2)
+		return nil, errors.New(f[1])
+	}
+	return conn, nil
+}
+
+func hostPortNoPort(u *url.URL) (hostPort, hostNoPort string) {
+	hostPort = u.Host
+	hostNoPort = u.Host
+	if i := strings.LastIndex(u.Host, ":"); i > strings.LastIndex(u.Host, "]") {
+		hostNoPort = hostNoPort[:i]
+	} else {
+		switch u.Scheme {
+		case "wss":
+			hostPort += ":443"
+		case "https":
+			hostPort += ":443"
+		default:
+			hostPort += ":80"
+		}
+	}
+	return hostPort, hostNoPort
+}

--- a/support/konnectivityproxy/resolver.go
+++ b/support/konnectivityproxy/resolver.go
@@ -87,11 +87,12 @@ type proxyResolver struct {
 	dnsFallback                  *syncBool
 	guestClusterResolver         *guestClusterResolver
 	log                          logr.Logger
+	isCloudAPI                   func(string) bool
 }
 
 func (d proxyResolver) Resolve(ctx context.Context, name string) (context.Context, net.IP, error) {
 	// Preserve the host so we can recognize it
-	if isCloudAPI(name) || d.disableResolver {
+	if d.isCloudAPI(name) || d.disableResolver {
 		return d.defaultResolve(ctx, name)
 	}
 	l := d.log.WithValues("name", name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of https://github.com/openshift/hypershift/pull/4699

Ingress operator canary checks require access to the internet since they
probe the external canary routes. The socks5 proxy sidecar does not
provide external access when a user proxy is required. This commit
switches to using the konnectivity-https-proxy that does take into
account the user's proxy configuration.

The dialer that the https proxy was creating was not configured by
default to talk directly to cloud provider endpoints. This was
preventing the ingress operator from successfully tearing down hosted
clusters.

This commit configures the konnectivity-https-proxy to talk directly
to cloud api endpoints for the ingress operator and adds proxy env
variables if they exist.

Fixes dialing from ingress where we want to use the management cluster's
proxy (if configured) when connecting to cloud APIs.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.