### PR TITLE
HOSTEDCP-1569: e2e: add version gating for 4.15

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1785,6 +1785,7 @@ func EnsureNoHCPPodsLandOnDefaultNode(t *testing.T, ctx context.Context, client 
 
 func EnsureSATokenNotMountedUnlessNecessary(t *testing.T, ctx context.Context, c crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureSATokenNotMountedUnlessNecessary", func(t *testing.T) {
+		AtLeast(t, Version416)
 		g := NewWithT(t)
 
 		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)


### PR DESCRIPTION
Add gating to test cases that only run in 4.16+

Informed by rehearse on https://github.com/openshift/release/pull/56724

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/56724/rehearse-56724-periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn/1834729010085498880