### PR TITLE
OCPBUGS-32592: Add role and rolebinding for Agent's Cluster CRs

### DIFF
--- a/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -103,6 +103,32 @@ rules:
   verbs:
   - '*'
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: capi-provider-role
+  namespace: clusters
+rules:
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls
+  verbs:
+  - '*'
+- apiGroups:
+  - capi-provider.agent-install.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - '*'
+---
 apiVersion: v1
 data:
   key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Creates an additional role/rolebinding for Agent platform's resources (ClusterDeployment, AgentClusterInstall) in the Hosted Cluster namespace.

The Agent platform's resources such as ClusterDeployment and AgentClusterInstall were previously created in the Hosted Control Plane namespace. However, this caused issues when simulating the deletion portion of the backup and restore scenario since the hosted control plane namespace is removed when the hosted cluster is removed.

The [PR](https://github.com/openshift/cluster-api-provider-agent/pull/141) in the cluster-api-provider-agent side adjusts the resources to be deployed in the hosted cluster namespace, but the permissions to CRUD these resources in the hosted cluster namespace needs to be added via this change.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-32592

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.