### PR TITLE
OTA-1349: *: Propagate RetrievedUpdates from ClusterVersion up to HostedCluster

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -67,6 +67,8 @@ const (
 	ClusterVersionAvailable ConditionType = "ClusterVersionAvailable"
 	// ClusterVersionReleaseAccepted bubbles up Failing ReleaseAccepted from the CVO.
 	ClusterVersionReleaseAccepted ConditionType = "ClusterVersionReleaseAccepted"
+	// ClusterVersionRetrievedUpdates bubbles up RetrievedUpdates from the CVO.
+	ClusterVersionRetrievedUpdates ConditionType = "ClusterVersionRetrievedUpdates"
 
 	// UnmanagedEtcdAvailable indicates whether a user-managed etcd cluster is
 	// healthy.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
@@ -106,11 +106,12 @@ func (h *hcpStatusReconciler) reconcile(ctx context.Context, hcp *hyperv1.Hosted
 	}
 
 	cvoConditions := map[hyperv1.ConditionType]*configv1.ClusterOperatorStatusCondition{
-		hyperv1.ClusterVersionFailing:         findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, "Failing"),
-		hyperv1.ClusterVersionReleaseAccepted: findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, "ReleaseAccepted"),
-		hyperv1.ClusterVersionProgressing:     findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.OperatorProgressing),
-		hyperv1.ClusterVersionUpgradeable:     findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.OperatorUpgradeable),
-		hyperv1.ClusterVersionAvailable:       findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.OperatorAvailable),
+		hyperv1.ClusterVersionFailing:          findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, "Failing"),
+		hyperv1.ClusterVersionReleaseAccepted:  findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, "ReleaseAccepted"),
+		hyperv1.ClusterVersionRetrievedUpdates: findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.RetrievedUpdates),
+		hyperv1.ClusterVersionProgressing:      findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.OperatorProgressing),
+		hyperv1.ClusterVersionUpgradeable:      findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.OperatorUpgradeable),
+		hyperv1.ClusterVersionAvailable:        findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.OperatorAvailable),
 	}
 
 	for conditionType, condition := range cvoConditions {

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3382,6 +3382,9 @@ and kube resource deletion that affects cloud infra like service type load balan
 </tr><tr><td><p>&#34;ClusterVersionReleaseAccepted&#34;</p></td>
 <td><p>ClusterVersionReleaseAccepted bubbles up Failing ReleaseAccepted from the CVO.</p>
 </td>
+</tr><tr><td><p>&#34;ClusterVersionRetrievedUpdates&#34;</p></td>
+<td><p>ClusterVersionRetrievedUpdates bubbles up RetrievedUpdates from the CVO.</p>
+</td>
 </tr><tr><td><p>&#34;ClusterVersionSucceeding&#34;</p></td>
 <td><p>ClusterVersionSucceeding indicates the current status of the desired release
 version of the HostedCluster as indicated by the Failing condition in the

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -683,6 +683,12 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			}
 		}
 
+		if hcCVOCondition.Type == string(hyperv1.ClusterVersionRetrievedUpdates) && hcCVOCondition.Reason == hyperv1.StatusUnknownReason {
+			// until all HostedControlPlane controllers understand how to propagate this condition, avoid bothering folks with unknown status in HostedCluster conditions.
+			meta.RemoveStatusCondition(&hcluster.Status.Conditions, string(hyperv1.ClusterVersionRetrievedUpdates))
+			continue
+		}
+
 		meta.SetStatusCondition(&hcluster.Status.Conditions, *hcCVOCondition)
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -629,19 +629,21 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 	// Copy the CVO conditions from the HCP.
 	hcpCVOConditions := map[hyperv1.ConditionType]*metav1.Condition{
-		hyperv1.ClusterVersionSucceeding:      nil,
-		hyperv1.ClusterVersionProgressing:     nil,
-		hyperv1.ClusterVersionReleaseAccepted: nil,
-		hyperv1.ClusterVersionUpgradeable:     nil,
-		hyperv1.ClusterVersionAvailable:       nil,
+		hyperv1.ClusterVersionSucceeding:       nil,
+		hyperv1.ClusterVersionProgressing:      nil,
+		hyperv1.ClusterVersionReleaseAccepted:  nil,
+		hyperv1.ClusterVersionRetrievedUpdates: nil,
+		hyperv1.ClusterVersionUpgradeable:      nil,
+		hyperv1.ClusterVersionAvailable:        nil,
 	}
 	if hcp != nil {
 		hcpCVOConditions = map[hyperv1.ConditionType]*metav1.Condition{
-			hyperv1.ClusterVersionSucceeding:      meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionFailing)),
-			hyperv1.ClusterVersionProgressing:     meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionProgressing)),
-			hyperv1.ClusterVersionReleaseAccepted: meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionReleaseAccepted)),
-			hyperv1.ClusterVersionUpgradeable:     meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionUpgradeable)),
-			hyperv1.ClusterVersionAvailable:       meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionAvailable)),
+			hyperv1.ClusterVersionSucceeding:       meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionFailing)),
+			hyperv1.ClusterVersionProgressing:      meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionProgressing)),
+			hyperv1.ClusterVersionReleaseAccepted:  meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionReleaseAccepted)),
+			hyperv1.ClusterVersionRetrievedUpdates: meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionRetrievedUpdates)),
+			hyperv1.ClusterVersionUpgradeable:      meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionUpgradeable)),
+			hyperv1.ClusterVersionAvailable:        meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionAvailable)),
 		}
 	}
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -67,6 +67,8 @@ const (
 	ClusterVersionAvailable ConditionType = "ClusterVersionAvailable"
 	// ClusterVersionReleaseAccepted bubbles up Failing ReleaseAccepted from the CVO.
 	ClusterVersionReleaseAccepted ConditionType = "ClusterVersionReleaseAccepted"
+	// ClusterVersionRetrievedUpdates bubbles up RetrievedUpdates from the CVO.
+	ClusterVersionRetrievedUpdates ConditionType = "ClusterVersionRetrievedUpdates"
 
 	// UnmanagedEtcdAvailable indicates whether a user-managed etcd cluster is
 	// healthy.


### PR DESCRIPTION
**What this PR does / why we need it**:

The pull propagates `RetrievedUpdates` from ClusterVersion up to HostedCluster

To make it easier for folks working at the management-cluster level to notice and address issues with update-recommendation retrieval.

Especially useful since de4bcbe35e (#3576) made `updateService` a configurable knob, because:

* Users might configure a broken `updateService`, and the new condition would tell them that it wasn't working.
* Users might install a 4.15 or earlier HostedCluster, where the HostedControlPlane controller (which is extracted from the HostedCluster's release image) was too old to have de4bcbe35e, so it doesn't propagate the configured `updateService`, and the cluster-version operator ends up using the default upstream update service.  That doesn't work in disconnected/restricted-network environments where `api.openshift.com` is unreachable.  The new condition would tell them that it wasn't working, and that the CVO was using the api.openshift.com service.  They'd be left on their own to realize that the `updateService` feature required a 4.16 or later HostedCluster release image.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.