### PR TITLE
[release-4.15] OCPBUGS-42214: Make guest cluster components use the correct KAS port

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -128,7 +128,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	if util.IsPrivateHCP(hcp) {
 		p.APIServerAddress = fmt.Sprintf("api.%s.hypershift.local", hcp.Name)
-		p.APIServerPort = 443
+		p.APIServerPort = util.APIPortForLocalZone(util.IsLBKAS(hcp))
 	} else {
 		p.APIServerAddress = hcp.Status.ControlPlaneEndpoint.Host
 		p.APIServerPort = hcp.Status.ControlPlaneEndpoint.Port

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2417,6 +2417,9 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 
 	externalKubeconfigSecret := manifests.KASExternalKubeconfigSecret(hcp.Namespace, hcp.Spec.KubeConfig)
 	if _, err := createOrUpdate(ctx, r, externalKubeconfigSecret, func() error {
+		if !util.IsPublicHCP(hcp) && !util.IsRouteKAS(hcp) {
+			return kas.ReconcileExternalKubeconfigSecret(externalKubeconfigSecret, clientCertSecret, rootCA, p.OwnerRef, p.InternalURL(), p.ExternalKubeconfigKey())
+		}
 		return kas.ReconcileExternalKubeconfigSecret(externalKubeconfigSecret, clientCertSecret, rootCA, p.OwnerRef, p.ExternalURL(), p.ExternalKubeconfigKey())
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile external kubeconfig secret: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -342,7 +342,7 @@ func (p *KubeAPIServerParams) ExternalURL() string {
 
 // InternalURL is used by ReconcileBootstrapKubeconfigSecret.
 func (p *KubeAPIServerParams) InternalURL() string {
-	return fmt.Sprintf("https://%s:%d", pki.AddBracketsIfIPv6(p.InternalAddress), 443)
+	return fmt.Sprintf("https://%s:%d", pki.AddBracketsIfIPv6(p.InternalAddress), p.ExternalPort)
 }
 
 func (p *KubeAPIServerParams) ExternalKubeconfigKey() string {

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -66,7 +66,7 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 
 	if util.IsPrivateHC(hcluster) {
 		apiServerExternalAddress = fmt.Sprintf("api.%s.hypershift.local", hcluster.Name)
-		apiServerExternalPort = 443
+		apiServerExternalPort = util.APIPortForLocalZone(util.IsLBKASByHC(hcluster))
 	} else {
 		if hcluster.Status.KubeConfig == nil {
 			return "", true, nil

--- a/hypershift-operator/controllers/nodepool/haproxy_test.go
+++ b/hypershift-operator/controllers/nodepool/haproxy_test.go
@@ -138,6 +138,22 @@ kind: Config`
 			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:443"},
 		},
 		{
+			name: "private cluster uses .local address and LB kas",
+			hc: hc(func(hc *hyperv1.HostedCluster) {
+				hc.Spec.Platform.AWS.EndpointAccess = hyperv1.Private
+				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
+				hc.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+					{
+						Service: hyperv1.APIServer,
+						ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+							Type: hyperv1.LoadBalancer,
+						},
+					},
+				}
+			}),
+			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:6443"},
+		},
+		{
 			name: "public and private cluster uses .local address",
 			hc: hc(func(hc *hyperv1.HostedCluster) {
 				hc.Spec.Platform.AWS.EndpointAccess = hyperv1.PublicAndPrivate
@@ -155,6 +171,22 @@ kind: Config`
 			}),
 
 			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:443"},
+		},
+		{
+			name: "public and private cluster uses .local address and LB kas",
+			hc: hc(func(hc *hyperv1.HostedCluster) {
+				hc.Spec.Platform.AWS.EndpointAccess = hyperv1.PublicAndPrivate
+				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
+				hc.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+					{
+						Service: hyperv1.APIServer,
+						ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+							Type: hyperv1.LoadBalancer,
+						},
+					},
+				}
+			}),
+			expectedHAProxyConfigContent: []string{"api." + hc().Name + ".hypershift.local:6443"},
 		},
 		{
 			name: "public cluster uses address from kubeconfig",

--- a/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_private_cluster_uses_.local_address_and_LB_kas.yaml
+++ b/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_private_cluster_uses_.local_address_and_LB_kas.yaml
@@ -1,0 +1,29 @@
+global
+  maxconn 7000
+  log stdout local0
+  log stdout local1 notice
+
+defaults
+  mode tcp
+  timeout client 10m
+  timeout server 10m
+  timeout connect 10s
+  timeout client-fin 5s
+  timeout server-fin 5s
+  timeout queue 5s
+  retries 3
+
+frontend local_apiserver
+  bind 172.20.0.1:6443
+  log global
+  mode tcp
+  option tcplog
+  default_backend remote_apiserver
+
+backend remote_apiserver
+  mode tcp
+  log global
+  option httpchk GET /version
+  option log-health-checks
+  default-server inter 10s fall 3 rise 3
+  server controlplane api.hc.hypershift.local:6443

--- a/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_public_and_private_cluster_uses_.local_address_and_LB_kas.yaml
+++ b/hypershift-operator/controllers/nodepool/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_public_and_private_cluster_uses_.local_address_and_LB_kas.yaml
@@ -1,0 +1,29 @@
+global
+  maxconn 7000
+  log stdout local0
+  log stdout local1 notice
+
+defaults
+  mode tcp
+  timeout client 10m
+  timeout server 10m
+  timeout connect 10s
+  timeout client-fin 5s
+  timeout server-fin 5s
+  timeout queue 5s
+  retries 3
+
+frontend local_apiserver
+  bind 172.20.0.1:6443
+  log global
+  mode tcp
+  option tcplog
+  default_backend remote_apiserver
+
+backend remote_apiserver
+  mode tcp
+  log global
+  option httpchk GET /version
+  option log-health-checks
+  default-server inter 10s fall 3 rise 3
+  server controlplane api.hc.hypershift.local:6443

--- a/support/util/expose.go
+++ b/support/util/expose.go
@@ -13,6 +13,11 @@ func ServicePublishingStrategyByTypeForHCP(hcp *hyperv1.HostedControlPlane, svcT
 	return nil
 }
 
+func IsLBKAS(hcp *hyperv1.HostedControlPlane) bool {
+	apiServerService := ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.APIServer)
+	return apiServerService != nil && apiServerService.Type == hyperv1.LoadBalancer
+}
+
 func IsRouteKAS(hcp *hyperv1.HostedControlPlane) bool {
 	apiServerService := ServicePublishingStrategyByTypeForHCP(hcp, hyperv1.APIServer)
 	return apiServerService != nil && apiServerService.Type == hyperv1.Route
@@ -33,6 +38,11 @@ func ServicePublishingStrategyByTypeByHC(hc *hyperv1.HostedCluster, svcType hype
 		}
 	}
 	return nil
+}
+
+func IsLBKASByHC(hc *hyperv1.HostedCluster) bool {
+	apiServerService := ServicePublishingStrategyByTypeByHC(hc, hyperv1.APIServer)
+	return apiServerService != nil && apiServerService.Type == hyperv1.LoadBalancer
 }
 
 func UseDedicatedDNSForKASByHC(hc *hyperv1.HostedCluster) bool {

--- a/support/util/expose_test.go
+++ b/support/util/expose_test.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestIsLBKASByHC(t *testing.T) {
+	tests := []struct {
+		description string
+		hc          *hyperv1.HostedCluster
+		expected    bool
+	}{
+		{
+			description: "hc.spec.services is an empty array",
+			hc: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{},
+				},
+			},
+			expected: false,
+		},
+		{
+			description: "hc.spec.services does not contain an entry for KAS",
+			hc: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			description: "hc.spec.services contains an LB KAS entry",
+			hc: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+							},
+						},
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			description: "hc.spec.services contains a Route KAS entry",
+			hc: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+							},
+						},
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if res := IsLBKASByHC(test.hc); res != test.expected {
+				t.Errorf("IsLBKASByHC() = %v, expected %v", res, test.expected)
+			}
+		})
+	}
+}

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -78,6 +78,15 @@ func KASPodPortFromHostedCluster(hc *hyperv1.HostedCluster) int32 {
 	return 6443
 }
 
+// APIPortForLocalZone returns the port used by processes within a private hosted cluster
+// to communicate with the KAS via the api.<hc-name>.hypershift.local host.
+func APIPortForLocalZone(isLBKAS bool) int32 {
+	if isLBKAS {
+		return 6443
+	}
+	return 443
+}
+
 func AdvertiseAddress(hcp *hyperv1.HostedControlPlane) *string {
 	if hcp != nil && hcp.Spec.Networking.APIServer != nil {
 		return hcp.Spec.Networking.APIServer.AdvertiseAddress

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -171,10 +171,21 @@ func TestCreateClusterProxy(t *testing.T) {
 		Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 }
 
-// TestCreateClusterPrivate implements a smoke test that creates a private cluster.
+func TestCreateClusterPrivate(t *testing.T) {
+	testCreateClusterPrivate(t, false)
+}
+
+func TestCreateClusterPrivateWithRouteKAS(t *testing.T) {
+	testCreateClusterPrivate(t, true)
+}
+
+// testCreateClusterPrivate implements a smoke test that creates a private cluster.
 // Validations requiring guest cluster client are dropped here since the kas is not accessible when private.
 // In the future we might want to leverage https://issues.redhat.com/browse/HOSTEDCP-697 to access guest cluster.
-func TestCreateClusterPrivate(t *testing.T) {
+func testCreateClusterPrivate(t *testing.T, enableExternalDNS bool) {
+	if globalOpts.Platform != hyperv1.AWSPlatform {
+		t.Skip("test only supported on platform AWS")
+	}
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(testContext)
@@ -183,23 +194,44 @@ func TestCreateClusterPrivate(t *testing.T) {
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.AWSPlatform.EndpointAccess = string(hyperv1.Private)
+	expectGuestKubeconfHostChange := false
+	if !enableExternalDNS {
+		clusterOpts.ExternalDNSDomain = ""
+		expectGuestKubeconfHostChange = true
+	}
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		// Private -> publicAndPrivate
-		t.Run("SwitchFromPrivateToPublic", testSwitchFromPrivateToPublic(ctx, mgtClient, hostedCluster, &clusterOpts))
+		t.Run("SwitchFromPrivateToPublic", testSwitchFromPrivateToPublic(ctx, mgtClient, hostedCluster, &clusterOpts, expectGuestKubeconfHostChange))
 		// publicAndPrivate -> Private
 		t.Run("SwitchFromPublicToPrivate", testSwitchFromPublicToPrivate(ctx, mgtClient, hostedCluster, &clusterOpts))
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 }
 
-func testSwitchFromPrivateToPublic(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *core.CreateOptions) func(t *testing.T) {
+func testSwitchFromPrivateToPublic(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *core.CreateOptions, expectGuestKubeconfHostChange bool) func(t *testing.T) {
 	return func(t *testing.T) {
 		g := NewWithT(t)
 
-		err := e2eutil.UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
+		var (
+			host string
+			err  error
+		)
+		if expectGuestKubeconfHostChange {
+			// Get guest kubeconfig host before switching endpoint access
+			host, err = e2eutil.GetGuestKubeconfigHost(t, ctx, client, hostedCluster)
+			g.Expect(err).ToNot(HaveOccurred(), "failed to get guest kubeconfig host")
+			t.Logf("Found guest kubeconfig host before switching endpoint access: %s", host)
+		}
+
+		// Switch to PublicAndPrivate endpoint access
+		err = e2eutil.UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.Platform.AWS.EndpointAccess = hyperv1.PublicAndPrivate
 		})
 		g.Expect(err).ToNot(HaveOccurred(), "failed to update hostedcluster EndpointAccess")
+
+		if expectGuestKubeconfHostChange {
+			e2eutil.WaitForGuestKubeconfigHostUpdate(t, ctx, client, hostedCluster, host)
+		}
 
 		e2eutil.ValidatePublicCluster(t, ctx, client, hostedCluster, clusterOpts)
 	}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -170,6 +170,48 @@ func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Clien
 	return guestClient
 }
 
+func GetGuestKubeconfigHost(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) (string, error) {
+	guestKubeConfigSecretData, err := WaitForGuestKubeConfig(t, ctx, client, hostedCluster)
+	if err != nil {
+		return "", fmt.Errorf("couldn't get guest kubeconfig: %v", err)
+	}
+
+	guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
+	if err != nil {
+		return "", fmt.Errorf("couldn't load guest kubeconfig: %v", err)
+	}
+
+	host := guestConfig.Host
+	if len(host) == 0 {
+		return "", fmt.Errorf("guest kubeconfig host is empty")
+	}
+	return host, nil
+}
+
+func WaitForGuestKubeconfigHostUpdate(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, oldHost string) {
+	g := NewWithT(t)
+	waitTimeout := 30 * time.Minute
+	pollingInterval := 15 * time.Second
+
+	t.Logf("Waiting for guest kubeconfig host update")
+	var newHost string
+	var getHostError error
+	err := wait.PollUntilContextTimeout(ctx, pollingInterval, waitTimeout, true, func(ctx context.Context) (done bool, err error) {
+		newHost, getHostError = GetGuestKubeconfigHost(t, ctx, client, hostedCluster)
+		if getHostError != nil {
+			t.Logf("failed to get guest kubeconfig host: %v", getHostError)
+			return false, nil
+		}
+		if newHost == oldHost {
+			t.Logf("guest kubeconfig host is not yet updated, keep polling")
+			return false, nil
+		}
+		return true, nil
+	})
+	g.Expect(err).NotTo(HaveOccurred(), "failed to wait for guest kubeconfig host update")
+	t.Logf("Guest kubeconfig host switched from %s to %s", oldHost, newHost)
+}
+
 func WaitForNReadyNodes(t *testing.T, ctx context.Context, client crclient.Client, n int32, platform hyperv1.PlatformType) []corev1.Node {
 	g := NewWithT(t)
 	start := time.Now()
@@ -1250,7 +1292,7 @@ func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 	WaitForNodePoolDesiredNodes(t, ctx, client, hostedCluster)
 
 	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
-	// rollout will not complete if there are no wroker nodes.
+	// rollout will not complete if there are no worker nodes.
 	if numNodes > 0 {
 		// Wait for the rollout to be complete
 		t.Logf("Waiting for cluster rollout. Image: %s", clusterOpts.ReleaseImage)
@@ -1262,8 +1304,6 @@ func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 
 	serviceStrategy := util.ServicePublishingStrategyByTypeByHC(hostedCluster, hyperv1.APIServer)
 	g.Expect(serviceStrategy).ToNot(BeNil())
-	// Private clusters should always use Route
-	g.Expect(serviceStrategy.Type).To(Equal(hyperv1.Route))
 	if serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
 		g.Expect(hostedCluster.Status.ControlPlaneEndpoint.Host).To(Equal(serviceStrategy.Route.Hostname))
 	} else {


### PR DESCRIPTION
Manual backport of https://github.com/openshift/hypershift/pull/4275 due to conflict in e2e