### PR TITLE
[release-4.16] NO-JIRA: Security fixes for openshift-ci-security job

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - 'vendor/**'
+    - 'control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go'

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -246,6 +247,14 @@ func run(ctx context.Context, opts Options) error {
 			return
 		}
 
+		var jsonPayload map[string]interface{}
+		if err := json.Unmarshal(value.Payload, &jsonPayload); err != nil {
+			log.Printf("Invalid JSON payload")
+			http.Error(w, "Invalid payload", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		w.Write(value.Payload)
 

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -247,10 +246,9 @@ func run(ctx context.Context, opts Options) error {
 			return
 		}
 
-		var jsonPayload map[string]interface{}
-		if err := json.Unmarshal(value.Payload, &jsonPayload); err != nil {
-			log.Printf("Invalid JSON payload")
-			http.Error(w, "Invalid payload", http.StatusInternalServerError)
+		if err := util.SanitizeIgnitionPayload(value.Payload); err != nil {
+			log.Printf("Invalid ignition payload: %s", err)
+			http.Error(w, "Invalid ignition payload", http.StatusInternalServerError)
 			return
 		}
 

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -20,6 +20,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/util"
 
+	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -469,4 +470,16 @@ func getHostedClusterScopeAnnotation(obj client.Object, r client.Reader) string 
 		return hcluster.GetAnnotations()[HostedClustersScopeAnnotation]
 	}
 	return ""
+}
+
+// SanitizeIgnitionPayload make sure the IgnitionPayload is valid
+// and does not contain inconsistencies.
+func SanitizeIgnitionPayload(payload []byte) error {
+	var jsonPayload ignitionapi.Config
+
+	if err := json.Unmarshal(payload, &jsonPayload); err != nil {
+		return fmt.Errorf("error unmarshalling Ignition payload: %v", err)
+	}
+
+	return nil
 }

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -438,3 +438,50 @@ func TestDoesMgmtClusterAndNodePoolCPUArchMatch(t *testing.T) {
 		})
 	}
 }
+func TestSanitizeIgnitionPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		wantErr bool
+	}{
+		{
+			name:    "Simple valid Ignition payload",
+			payload: []byte(`{"ignition": {"version": "3.0.0"}}`),
+			wantErr: false,
+		},
+		{
+			name:    "More complex valid Ignition payload",
+			payload: []byte(`{"ignition":{"version":"3.0.0"},"storage":{"files":[{"path":"/etc/someconfig","mode":420,"contents":{"source":"data:,example%20file%0A"}}]}}`),
+			wantErr: false,
+		},
+		{
+			name:    "Simple invalid Ignition payload (missing closing brace)",
+			payload: []byte(`{"ignition": {"version": "3.0.0"`),
+			wantErr: true,
+		},
+		{
+			name:    "Empty payload",
+			payload: []byte(``),
+			wantErr: true,
+		},
+		{
+			name:    "Nil payload",
+			payload: nil,
+			wantErr: true,
+		},
+	}
+
+	t.Parallel()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := SanitizeIgnitionPayload(tt.payload)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
These PR is a manual backport of :

- https://github.com/openshift/hypershift/pull/4748

This one prepares the release branch to execute (without High security issues) the Openshift CI Security job which under the hood uses the `snyk code test` command and the job fails if SNYK find any high security issue.

After this PR we will need to add a new one to add the CI Job to the release repo as we did with 4.17, 4.18, 4.19 and Main branches in these PRs:

- https://github.com/openshift/release/pull/56687 (4.18, 4.19, Main)
- https://github.com/openshift/release/pull/56912 (4.17)