### PR TITLE
[release-4.14] NO-JIRA: Security fixes for openshift-ci-security job

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - 'vendor/**'
+    - 'control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go'

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -239,10 +238,9 @@ func run(ctx context.Context, opts Options) error {
 			return
 		}
 
-		var jsonPayload map[string]interface{}
-		if err := json.Unmarshal(value.Payload, &jsonPayload); err != nil {
-			log.Printf("Invalid JSON payload")
-			http.Error(w, "Invalid payload", http.StatusInternalServerError)
+		if err := util.SanitizeIgnitionPayload(value.Payload); err != nil {
+			log.Printf("Invalid ignition payload: %s", err)
+			http.Error(w, "Invalid ignition payload", http.StatusInternalServerError)
 			return
 		}
 

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -238,6 +239,14 @@ func run(ctx context.Context, opts Options) error {
 			return
 		}
 
+		var jsonPayload map[string]interface{}
+		if err := json.Unmarshal(value.Payload, &jsonPayload); err != nil {
+			log.Printf("Invalid JSON payload")
+			http.Error(w, "Invalid payload", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		w.Write(value.Payload)
 

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -320,4 +321,16 @@ func ParseNodeSelector(str string) map[string]string {
 		result[kv[0]] = kv[1]
 	}
 	return result
+}
+
+// SanitizeIgnitionPayload make sure the IgnitionPayload is valid
+// and does not contain inconsistencies.
+func SanitizeIgnitionPayload(payload []byte) error {
+	var jsonPayload ignitionapi.Config
+
+	if err := json.Unmarshal(payload, &jsonPayload); err != nil {
+		return fmt.Errorf("error unmarshalling Ignition payload: %v", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
These PR is a manual backport of :

- https://github.com/openshift/hypershift/pull/4751

This one prepares the release branch to execute (without High security issues) the Openshift CI Security job which under the hood uses the `snyk code test` command and the job fails if SNYK find any high security issue.

After this PR we will need to add a new one to add the CI Job to the release repo as we did with 4.17, 4.18, 4.19 and Main branches in these PRs:

- https://github.com/openshift/release/pull/56687 (4.18, 4.19, Main)
- https://github.com/openshift/release/pull/56912 (4.17)
- https://github.com/openshift/release/pull/56938 (4.16)
- https://github.com/openshift/release/pull/56941 (4.15)