### PR TITLE
OCPBUGS-39369: Add TokenMinter container and RBAC for the CNO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -1,10 +1,12 @@
 package cno
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"strconv"
+	"text/template"
 
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
@@ -27,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -34,6 +37,42 @@ const (
 	konnectivityProxyName = "konnectivity-proxy"
 	caConfigMap           = "root-ca"
 	caConfigMapKey        = "ca.crt"
+
+	hostedNamespace          = "openshift-network-operator"
+	hostedServiceAccount     = "cluster-network-operator"
+	tokenFile                = "token"
+	tokenMinterContainerName = "client-token-minter"
+
+	mgmtTokenDir   = "/var/run/secrets/kubernetes.io/serviceaccount"
+	hostedTokenDir = "/var/run/secrets/kubernetes.io/hosted"
+	hostedCABundle = "/etc/certificate/ca/ca.crt"
+
+	startScriptTemplateStr = `#!/bin/bash
+set -xeuo pipefail
+
+kc=/configs/management
+kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+kubectl --kubeconfig $kc config set clusters.default.certificate-authority {{ .MgmtTokenDir }}/ca.crt
+kubectl --kubeconfig $kc config set users.admin.tokenFile {{ .MgmtTokenDir }}/token
+kubectl --kubeconfig $kc config set contexts.default.cluster default
+kubectl --kubeconfig $kc config set contexts.default.user admin
+kubectl --kubeconfig $kc config set contexts.default.namespace $(cat {{ .MgmtTokenDir }}/namespace)
+kubectl --kubeconfig $kc config use-context default
+
+
+kc=/configs/hosted
+kubectl --kubeconfig $kc config set clusters.default.server "https://kube-apiserver:${KUBE_APISERVER_SERVICE_PORT}"
+kubectl --kubeconfig $kc config set clusters.default.certificate-authority {{ .CABundle }}
+kubectl --kubeconfig $kc config set users.admin.tokenFile {{ .HostedTokenDir }}/token
+kubectl --kubeconfig $kc config set contexts.default.cluster default
+kubectl --kubeconfig $kc config set contexts.default.user admin
+kubectl --kubeconfig $kc config set contexts.default.namespace {{ .HostedNamespace }}
+kubectl --kubeconfig $kc config use-context default
+`
+)
+
+var (
+	startScript string
 )
 
 type Images struct {
@@ -74,6 +113,15 @@ type Params struct {
 	DeploymentConfig        config.DeploymentConfig
 	IsPrivate               bool
 	DefaultIngressDomain    string
+}
+
+func init() {
+	var err error
+	startScriptTemplate := template.Must(template.New("script").Parse(startScriptTemplateStr))
+	startScript, err = sideContainerStartScript(startScriptTemplate)
+	if err != nil {
+		panic(err.Error())
+	}
 }
 
 func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider imageprovider.ReleaseImageProvider, userReleaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool, defaultIngressDomain string) Params {
@@ -298,6 +346,13 @@ func ReconcileServiceAccount(sa *corev1.ServiceAccount, ownerRef config.OwnerRef
 func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyperv1.PlatformType) error {
 	params.OwnerRef.ApplyTo(dep)
 
+	cnoArgs := []string{"start",
+		"--listen=0.0.0.0:9104",
+		"--kubeconfig=/configs/hosted",
+		"--namespace=openshift-network-operator",
+		"--extra-clusters=management=/configs/management",
+	}
+
 	cnoResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -342,12 +397,6 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 		hyperv1.ControlPlaneComponent: operatorName,
 	}
 
-	cnoArgs := []string{"start",
-		"--listen=0.0.0.0:9104",
-		"--kubeconfig=/etc/hosted-kubernetes/kubeconfig",
-		"--namespace=openshift-network-operator",
-		"--extra-clusters=management=/configs/management",
-	}
 	var cnoEnv []corev1.EnvVar
 
 	if !params.IsPrivate {
@@ -403,26 +452,44 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 				{Name: "hosted-etc-kube", MountPath: "/etc/hosted-kubernetes"},
 			},
 		},
-
+		{
+			// Token minter InitContainer
+			// This will create the initial token for the CNO to use
+			// then the sidecar will refresh it
+			Command: []string{
+				"/usr/bin/control-plane-operator",
+				"token-minter",
+			},
+			Args: []string{
+				"--service-account-namespace",
+				hostedNamespace,
+				"--service-account-name",
+				hostedServiceAccount,
+				"--token-file",
+				fmt.Sprintf("/var/client-token/%s", tokenFile),
+				"--token-audience",
+				params.TokenAudience,
+				"--kubeconfig",
+				fmt.Sprintf("/etc/kubernetes/%s", kas.KubeconfigKey),
+				"--oneshot",
+			},
+			Name:                     fmt.Sprintf("init-%s", tokenMinterContainerName),
+			Image:                    params.Images.TokenMinter,
+			ImagePullPolicy:          corev1.PullIfNotPresent,
+			Resources:                util.DefaultTokenMinterResources(),
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "client-token", MountPath: "/var/client-token"},
+				{Name: "hosted-etc-kube", MountPath: "/etc/kubernetes"},
+			},
+		},
 		// Add an InitContainer that transmutes the in-cluster config to a Kubeconfig
-		// So CNO thinks the "default" config is the hosted cluster
+		// So CNO thinks the "default" config is the hosted cluster.
 		{
 			Command: []string{"/bin/bash"},
-			Args: []string{
-				"-c",
-				`
-set -xeuo pipefail
-kc=/configs/management
-kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
-kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/serviceaccount/token
-kubectl --kubeconfig $kc config set contexts.default.cluster default
-kubectl --kubeconfig $kc config set contexts.default.user admin
-kubectl --kubeconfig $kc config set contexts.default.namespace $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-kubectl --kubeconfig $kc config use-context default`,
-			},
-			Name:  "rewrite-config",
-			Image: params.Images.CLI,
+			Args:    []string{"-c", startScript},
+			Name:    "rewrite-config",
+			Image:   params.Images.CLI,
 			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
@@ -431,6 +498,8 @@ kubectl --kubeconfig $kc config use-context default`,
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: "hosted-etc-kube", MountPath: "/etc/hosted-kubernetes"},
 				{Name: "configs", MountPath: "/configs"},
+				{Name: "client-token", MountPath: hostedTokenDir},
+				{Name: "ca-bundle", MountPath: "/etc/certificate/ca"},
 			},
 		},
 	}
@@ -464,68 +533,26 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 	}
 
 	dep.Spec.Template.Spec.ServiceAccountName = manifests.ClusterNetworkOperatorServiceAccount("").Name
-	dep.Spec.Template.Spec.Containers = []corev1.Container{{
-		Command: []string{"/usr/bin/cluster-network-operator"},
-		Args:    cnoArgs,
-		Env: append(cnoEnv, []corev1.EnvVar{
-			{Name: "HYPERSHIFT", Value: "true"},
-			{Name: "HOSTED_CLUSTER_NAME", Value: params.HostedClusterName},
-			{Name: "CA_CONFIG_MAP", Value: params.CAConfigMap},
-			{Name: "CA_CONFIG_MAP_KEY", Value: params.CAConfigMapKey},
-			{Name: "TOKEN_AUDIENCE", Value: params.TokenAudience},
-
-			{Name: "RELEASE_VERSION", Value: params.ReleaseVersion},
-			{Name: "APISERVER_OVERRIDE_HOST", Value: params.APIServerAddress}, // We need to pass this down to networking components on the nodes
-			{Name: "APISERVER_OVERRIDE_PORT", Value: fmt.Sprint(params.APIServerPort)},
-			{Name: "OVN_NB_RAFT_ELECTION_TIMER", Value: "10"},
-			{Name: "OVN_SB_RAFT_ELECTION_TIMER", Value: "16"},
-			{Name: "OVN_NORTHD_PROBE_INTERVAL", Value: "5000"},
-			{Name: "OVN_CONTROLLER_INACTIVITY_PROBE", Value: "180000"},
-			{Name: "OVN_NB_INACTIVITY_PROBE", Value: "60000"},
-			{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.name",
-				},
-			}},
-			{Name: "HOSTED_CLUSTER_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.namespace",
-				},
-			}},
-
-			{Name: "KUBE_PROXY_IMAGE", Value: params.Images.KubeProxy},
-			{Name: "KUBE_RBAC_PROXY_IMAGE", Value: params.Images.KubeRBACProxy},
-			{Name: "MULTUS_IMAGE", Value: params.Images.Multus},
-			{Name: "MULTUS_ADMISSION_CONTROLLER_IMAGE", Value: params.Images.MultusAdmissionController},
-			{Name: "CNI_PLUGINS_IMAGE", Value: params.Images.CNIPlugins},
-			{Name: "BOND_CNI_PLUGIN_IMAGE", Value: params.Images.BondCNIPlugin},
-			{Name: "WHEREABOUTS_CNI_IMAGE", Value: params.Images.WhereaboutsCNI},
-			{Name: "ROUTE_OVERRRIDE_CNI_IMAGE", Value: params.Images.RouteOverrideCNI},
-			{Name: "MULTUS_NETWORKPOLICY_IMAGE", Value: params.Images.MultusNetworkPolicy},
-			{Name: "OVN_IMAGE", Value: params.Images.OVN},
-			{Name: "OVN_CONTROL_PLANE_IMAGE", Value: params.Images.OVNControlPlane},
-			{Name: "EGRESS_ROUTER_CNI_IMAGE", Value: params.Images.EgressRouterCNI},
-			{Name: "NETWORK_METRICS_DAEMON_IMAGE", Value: params.Images.NetworkMetricsDaemon},
-			{Name: "NETWORK_CHECK_SOURCE_IMAGE", Value: params.Images.NetworkCheckSource},
-			{Name: "NETWORK_CHECK_TARGET_IMAGE", Value: params.Images.NetworkCheckTarget},
-			{Name: "NETWORKING_CONSOLE_PLUGIN_IMAGE", Value: params.Images.NetworkingConsolePlugin},
-			{Name: "CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE", Value: params.Images.CloudNetworkConfigController},
-			{Name: "TOKEN_MINTER_IMAGE", Value: params.Images.TokenMinter},
-			{Name: "CLI_IMAGE", Value: params.Images.CLI},
-			{Name: "SOCKS5_PROXY_IMAGE", Value: params.Images.Socks5Proxy},
-			{Name: "OPENSHIFT_RELEASE_IMAGE", Value: params.DeploymentConfig.AdditionalAnnotations[hyperv1.ReleaseImageAnnotation]},
-		}...),
-		Name:                     operatorName,
-		Image:                    params.Images.NetworkOperator,
-		ImagePullPolicy:          corev1.PullIfNotPresent,
-		Resources:                cnoResources,
-		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-		VolumeMounts: []corev1.VolumeMount{
-			{Name: "hosted-etc-kube", MountPath: "/etc/hosted-kubernetes"},
-			{Name: "configs", MountPath: "/configs"},
-		},
-	},
+	dep.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(true)
+	dep.Spec.Template.Spec.Containers = []corev1.Container{
 		{
+			// CNO Main container
+			Command:                  []string{"/usr/bin/cluster-network-operator"},
+			Args:                     cnoArgs,
+			Env:                      buildCNOEnvVars(cnoEnv, params),
+			Name:                     operatorName,
+			Image:                    params.Images.NetworkOperator,
+			ImagePullPolicy:          corev1.PullIfNotPresent,
+			Resources:                cnoResources,
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "configs", MountPath: "/configs"},
+				{Name: "client-token", MountPath: hostedTokenDir},
+				{Name: "ca-bundle", MountPath: "/etc/certificate/ca"},
+			},
+		},
+		{
+			// Konnectivity proxy container
 			// CNO uses konnectivity-proxy to perform proxy readiness checks through the hosted cluster's network
 			Name:    konnectivityProxyName,
 			Image:   params.Images.Socks5Proxy,
@@ -542,12 +569,42 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 				{Name: "konnectivity-proxy-ca", MountPath: "/etc/konnectivity/proxy-ca"},
 			},
 		},
+		{
+			// Token minter container
+			Command: []string{
+				"/usr/bin/control-plane-operator",
+				"token-minter",
+			},
+			Args: []string{
+				"--service-account-namespace",
+				hostedNamespace,
+				"--service-account-name",
+				hostedServiceAccount,
+				"--token-file",
+				fmt.Sprintf("/var/client-token/%s", tokenFile),
+				"--token-audience",
+				params.TokenAudience,
+				"--kubeconfig",
+				fmt.Sprintf("/etc/kubernetes/%s", kas.KubeconfigKey),
+			},
+			Name:                     tokenMinterContainerName,
+			Image:                    params.Images.TokenMinter,
+			ImagePullPolicy:          corev1.PullIfNotPresent,
+			Resources:                util.DefaultTokenMinterResources(),
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "client-token", MountPath: "/var/client-token"},
+				{Name: "hosted-etc-kube", MountPath: "/etc/kubernetes"},
+			},
+		},
 	}
 	dep.Spec.Template.Spec.Volumes = []corev1.Volume{
 		{Name: "hosted-etc-kube", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KASServiceKubeconfigSecret("").Name}}},
 		{Name: "configs", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: utilpointer.Int32(0640)}}},
 		{Name: "konnectivity-proxy-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: manifests.KonnectivityCAConfigMap("").Name}, DefaultMode: utilpointer.Int32(0640)}}},
+		{Name: "client-token", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "ca-bundle", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.RootCASecret("").Name, DefaultMode: ptr.To(int32(0640))}}},
 	}
 
 	params.DeploymentConfig.ApplyTo(dep)
@@ -558,6 +615,7 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 			{Group: "network.operator.openshift.io", Version: "v1", Kind: "EgressRouter"},
 			{Group: "network.operator.openshift.io", Version: "v1", Kind: "OperatorPKI"},
 		}
+		o.WaitForClusterRolebinding = operatorName
 		o.WaitForInfrastructureResource = true
 	})
 	return nil
@@ -587,4 +645,74 @@ func SetRestartAnnotationAndPatch(ctx context.Context, crclient client.Client, d
 	}
 
 	return nil
+}
+
+func sideContainerStartScript(startScriptTemplate *template.Template) (string, error) {
+	out := &bytes.Buffer{}
+	params := struct {
+		HostedNamespace string
+		MgmtTokenDir    string
+		HostedTokenDir  string
+		CABundle        string
+	}{
+		HostedNamespace: hostedNamespace,
+		MgmtTokenDir:    mgmtTokenDir,
+		HostedTokenDir:  hostedTokenDir,
+		CABundle:        hostedCABundle,
+	}
+	if err := startScriptTemplate.Execute(out, params); err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+func buildCNOEnvVars(envVars []corev1.EnvVar, params Params) []corev1.EnvVar {
+	return append(envVars, []corev1.EnvVar{
+		{Name: "HYPERSHIFT", Value: "true"},
+		{Name: "HOSTED_CLUSTER_NAME", Value: params.HostedClusterName},
+		{Name: "CA_CONFIG_MAP", Value: params.CAConfigMap},
+		{Name: "CA_CONFIG_MAP_KEY", Value: params.CAConfigMapKey},
+		{Name: "TOKEN_AUDIENCE", Value: params.TokenAudience},
+
+		{Name: "RELEASE_VERSION", Value: params.ReleaseVersion},
+		{Name: "APISERVER_OVERRIDE_HOST", Value: params.APIServerAddress}, // We need to pass this down to networking components on the nodes
+		{Name: "APISERVER_OVERRIDE_PORT", Value: fmt.Sprint(params.APIServerPort)},
+		{Name: "OVN_NB_RAFT_ELECTION_TIMER", Value: "10"},
+		{Name: "OVN_SB_RAFT_ELECTION_TIMER", Value: "16"},
+		{Name: "OVN_NORTHD_PROBE_INTERVAL", Value: "5000"},
+		{Name: "OVN_CONTROLLER_INACTIVITY_PROBE", Value: "180000"},
+		{Name: "OVN_NB_INACTIVITY_PROBE", Value: "60000"},
+		{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.name",
+			},
+		}},
+		{Name: "HOSTED_CLUSTER_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.namespace",
+			},
+		}},
+
+		{Name: "KUBE_PROXY_IMAGE", Value: params.Images.KubeProxy},
+		{Name: "KUBE_RBAC_PROXY_IMAGE", Value: params.Images.KubeRBACProxy},
+		{Name: "MULTUS_IMAGE", Value: params.Images.Multus},
+		{Name: "MULTUS_ADMISSION_CONTROLLER_IMAGE", Value: params.Images.MultusAdmissionController},
+		{Name: "CNI_PLUGINS_IMAGE", Value: params.Images.CNIPlugins},
+		{Name: "BOND_CNI_PLUGIN_IMAGE", Value: params.Images.BondCNIPlugin},
+		{Name: "WHEREABOUTS_CNI_IMAGE", Value: params.Images.WhereaboutsCNI},
+		{Name: "ROUTE_OVERRRIDE_CNI_IMAGE", Value: params.Images.RouteOverrideCNI},
+		{Name: "MULTUS_NETWORKPOLICY_IMAGE", Value: params.Images.MultusNetworkPolicy},
+		{Name: "OVN_IMAGE", Value: params.Images.OVN},
+		{Name: "OVN_CONTROL_PLANE_IMAGE", Value: params.Images.OVNControlPlane},
+		{Name: "EGRESS_ROUTER_CNI_IMAGE", Value: params.Images.EgressRouterCNI},
+		{Name: "NETWORK_METRICS_DAEMON_IMAGE", Value: params.Images.NetworkMetricsDaemon},
+		{Name: "NETWORK_CHECK_SOURCE_IMAGE", Value: params.Images.NetworkCheckSource},
+		{Name: "NETWORK_CHECK_TARGET_IMAGE", Value: params.Images.NetworkCheckTarget},
+		{Name: "NETWORKING_CONSOLE_PLUGIN_IMAGE", Value: params.Images.NetworkingConsolePlugin},
+		{Name: "CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE", Value: params.Images.CloudNetworkConfigController},
+		{Name: "TOKEN_MINTER_IMAGE", Value: params.Images.TokenMinter},
+		{Name: "CLI_IMAGE", Value: params.Images.CLI},
+		{Name: "SOCKS5_PROXY_IMAGE", Value: params.Images.Socks5Proxy},
+		{Name: "OPENSHIFT_RELEASE_IMAGE", Value: params.DeploymentConfig.AdditionalAnnotations[hyperv1.ReleaseImageAnnotation]},
+	}...)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs,client-token
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null
       labels:
@@ -23,11 +23,12 @@ spec:
         hypershift.openshift.io/control-plane-component: cluster-network-operator
         name: cluster-network-operator
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - start
         - --listen=0.0.0.0:9104
-        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        - --kubeconfig=/configs/hosted
         - --namespace=openshift-network-operator
         - --extra-clusters=management=/configs/management
         command:
@@ -93,10 +94,12 @@ spec:
             memory: 100Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /etc/hosted-kubernetes
-          name: hosted-etc-kube
         - mountPath: /configs
           name: configs
+        - mountPath: /var/run/secrets/kubernetes.io/hosted
+          name: client-token
+        - mountPath: /etc/certificate/ca
+          name: ca-bundle
       - args:
         - run
         command:
@@ -118,6 +121,32 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+      - args:
+        - --service-account-namespace
+        - openshift-network-operator
+        - --service-account-name
+        - cluster-network-operator
+        - --token-file
+        - /var/client-token/token
+        - --token-audience
+        - ""
+        - --kubeconfig
+        - /etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        imagePullPolicy: IfNotPresent
+        name: client-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/client-token
+          name: client-token
+        - mountPath: /etc/kubernetes
+          name: hosted-etc-kube
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -129,6 +158,7 @@ spec:
         - --required-api=network.operator.openshift.io,v1,EgressRouter
         - --required-api=network.operator.openshift.io,v1,OperatorPKI
         - --wait-for-infrastructure-resource
+        - --wait-for-cluster-rolebinding=cluster-network-operator
         imagePullPolicy: IfNotPresent
         name: availability-prober
         resources: {}
@@ -154,10 +184,38 @@ spec:
         - mountPath: /etc/hosted-kubernetes
           name: hosted-etc-kube
       - args:
+        - --service-account-namespace
+        - openshift-network-operator
+        - --service-account-name
+        - cluster-network-operator
+        - --token-file
+        - /var/client-token/token
+        - --token-audience
+        - ""
+        - --kubeconfig
+        - /etc/kubernetes/kubeconfig
+        - --oneshot
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        imagePullPolicy: IfNotPresent
+        name: init-client-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/client-token
+          name: client-token
+        - mountPath: /etc/kubernetes
+          name: hosted-etc-kube
+      - args:
         - -c
-        - |2-
-
+        - |
+          #!/bin/bash
           set -xeuo pipefail
+
           kc=/configs/management
           kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
           kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -165,6 +223,16 @@ spec:
           kubectl --kubeconfig $kc config set contexts.default.cluster default
           kubectl --kubeconfig $kc config set contexts.default.user admin
           kubectl --kubeconfig $kc config set contexts.default.namespace $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          kubectl --kubeconfig $kc config use-context default
+
+
+          kc=/configs/hosted
+          kubectl --kubeconfig $kc config set clusters.default.server "https://kube-apiserver:${KUBE_APISERVER_SERVICE_PORT}"
+          kubectl --kubeconfig $kc config set clusters.default.certificate-authority /etc/certificate/ca/ca.crt
+          kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/hosted/token
+          kubectl --kubeconfig $kc config set contexts.default.cluster default
+          kubectl --kubeconfig $kc config set contexts.default.user admin
+          kubectl --kubeconfig $kc config set contexts.default.namespace openshift-network-operator
           kubectl --kubeconfig $kc config use-context default
         command:
         - /bin/bash
@@ -179,6 +247,10 @@ spec:
           name: hosted-etc-kube
         - mountPath: /configs
           name: configs
+        - mountPath: /var/run/secrets/kubernetes.io/hosted
+          name: client-token
+        - mountPath: /etc/certificate/ca
+          name: ca-bundle
       serviceAccountName: cluster-network-operator
       volumes:
       - name: hosted-etc-kube
@@ -194,4 +266,10 @@ spec:
           defaultMode: 416
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: client-token
+      - name: ca-bundle
+        secret:
+          defaultMode: 416
+          secretName: root-ca
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs,client-token
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null
       labels:
@@ -23,11 +23,12 @@ spec:
         hypershift.openshift.io/control-plane-component: cluster-network-operator
         name: cluster-network-operator
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - start
         - --listen=0.0.0.0:9104
-        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        - --kubeconfig=/configs/hosted
         - --namespace=openshift-network-operator
         - --extra-clusters=management=/configs/management
         command:
@@ -96,10 +97,12 @@ spec:
             memory: 500Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /etc/hosted-kubernetes
-          name: hosted-etc-kube
         - mountPath: /configs
           name: configs
+        - mountPath: /var/run/secrets/kubernetes.io/hosted
+          name: client-token
+        - mountPath: /etc/certificate/ca
+          name: ca-bundle
       - args:
         - run
         command:
@@ -121,6 +124,32 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+      - args:
+        - --service-account-namespace
+        - openshift-network-operator
+        - --service-account-name
+        - cluster-network-operator
+        - --token-file
+        - /var/client-token/token
+        - --token-audience
+        - ""
+        - --kubeconfig
+        - /etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        imagePullPolicy: IfNotPresent
+        name: client-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/client-token
+          name: client-token
+        - mountPath: /etc/kubernetes
+          name: hosted-etc-kube
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -132,6 +161,7 @@ spec:
         - --required-api=network.operator.openshift.io,v1,EgressRouter
         - --required-api=network.operator.openshift.io,v1,OperatorPKI
         - --wait-for-infrastructure-resource
+        - --wait-for-cluster-rolebinding=cluster-network-operator
         imagePullPolicy: IfNotPresent
         name: availability-prober
         resources: {}
@@ -157,10 +187,38 @@ spec:
         - mountPath: /etc/hosted-kubernetes
           name: hosted-etc-kube
       - args:
+        - --service-account-namespace
+        - openshift-network-operator
+        - --service-account-name
+        - cluster-network-operator
+        - --token-file
+        - /var/client-token/token
+        - --token-audience
+        - ""
+        - --kubeconfig
+        - /etc/kubernetes/kubeconfig
+        - --oneshot
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        imagePullPolicy: IfNotPresent
+        name: init-client-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/client-token
+          name: client-token
+        - mountPath: /etc/kubernetes
+          name: hosted-etc-kube
+      - args:
         - -c
-        - |2-
-
+        - |
+          #!/bin/bash
           set -xeuo pipefail
+
           kc=/configs/management
           kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
           kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -168,6 +226,16 @@ spec:
           kubectl --kubeconfig $kc config set contexts.default.cluster default
           kubectl --kubeconfig $kc config set contexts.default.user admin
           kubectl --kubeconfig $kc config set contexts.default.namespace $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          kubectl --kubeconfig $kc config use-context default
+
+
+          kc=/configs/hosted
+          kubectl --kubeconfig $kc config set clusters.default.server "https://kube-apiserver:${KUBE_APISERVER_SERVICE_PORT}"
+          kubectl --kubeconfig $kc config set clusters.default.certificate-authority /etc/certificate/ca/ca.crt
+          kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/hosted/token
+          kubectl --kubeconfig $kc config set contexts.default.cluster default
+          kubectl --kubeconfig $kc config set contexts.default.user admin
+          kubectl --kubeconfig $kc config set contexts.default.namespace openshift-network-operator
           kubectl --kubeconfig $kc config use-context default
         command:
         - /bin/bash
@@ -182,6 +250,10 @@ spec:
           name: hosted-etc-kube
         - mountPath: /configs
           name: configs
+        - mountPath: /var/run/secrets/kubernetes.io/hosted
+          name: client-token
+        - mountPath: /etc/certificate/ca
+          name: ca-bundle
       serviceAccountName: cluster-network-operator
       volumes:
       - name: hosted-etc-kube
@@ -197,4 +269,10 @@ spec:
           defaultMode: 416
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: client-token
+      - name: ca-bundle
+        secret:
+          defaultMode: 416
+          secretName: root-ca
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs,client-token
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null
       labels:
@@ -23,11 +23,12 @@ spec:
         hypershift.openshift.io/control-plane-component: cluster-network-operator
         name: cluster-network-operator
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - start
         - --listen=0.0.0.0:9104
-        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        - --kubeconfig=/configs/hosted
         - --namespace=openshift-network-operator
         - --extra-clusters=management=/configs/management
         command:
@@ -91,10 +92,12 @@ spec:
             memory: 100Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /etc/hosted-kubernetes
-          name: hosted-etc-kube
         - mountPath: /configs
           name: configs
+        - mountPath: /var/run/secrets/kubernetes.io/hosted
+          name: client-token
+        - mountPath: /etc/certificate/ca
+          name: ca-bundle
       - args:
         - run
         command:
@@ -116,6 +119,32 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+      - args:
+        - --service-account-namespace
+        - openshift-network-operator
+        - --service-account-name
+        - cluster-network-operator
+        - --token-file
+        - /var/client-token/token
+        - --token-audience
+        - ""
+        - --kubeconfig
+        - /etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        imagePullPolicy: IfNotPresent
+        name: client-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/client-token
+          name: client-token
+        - mountPath: /etc/kubernetes
+          name: hosted-etc-kube
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -127,6 +156,7 @@ spec:
         - --required-api=network.operator.openshift.io,v1,EgressRouter
         - --required-api=network.operator.openshift.io,v1,OperatorPKI
         - --wait-for-infrastructure-resource
+        - --wait-for-cluster-rolebinding=cluster-network-operator
         imagePullPolicy: IfNotPresent
         name: availability-prober
         resources: {}
@@ -152,10 +182,38 @@ spec:
         - mountPath: /etc/hosted-kubernetes
           name: hosted-etc-kube
       - args:
+        - --service-account-namespace
+        - openshift-network-operator
+        - --service-account-name
+        - cluster-network-operator
+        - --token-file
+        - /var/client-token/token
+        - --token-audience
+        - ""
+        - --kubeconfig
+        - /etc/kubernetes/kubeconfig
+        - --oneshot
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        imagePullPolicy: IfNotPresent
+        name: init-client-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/client-token
+          name: client-token
+        - mountPath: /etc/kubernetes
+          name: hosted-etc-kube
+      - args:
         - -c
-        - |2-
-
+        - |
+          #!/bin/bash
           set -xeuo pipefail
+
           kc=/configs/management
           kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
           kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -163,6 +221,16 @@ spec:
           kubectl --kubeconfig $kc config set contexts.default.cluster default
           kubectl --kubeconfig $kc config set contexts.default.user admin
           kubectl --kubeconfig $kc config set contexts.default.namespace $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          kubectl --kubeconfig $kc config use-context default
+
+
+          kc=/configs/hosted
+          kubectl --kubeconfig $kc config set clusters.default.server "https://kube-apiserver:${KUBE_APISERVER_SERVICE_PORT}"
+          kubectl --kubeconfig $kc config set clusters.default.certificate-authority /etc/certificate/ca/ca.crt
+          kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/hosted/token
+          kubectl --kubeconfig $kc config set contexts.default.cluster default
+          kubectl --kubeconfig $kc config set contexts.default.user admin
+          kubectl --kubeconfig $kc config set contexts.default.namespace openshift-network-operator
           kubectl --kubeconfig $kc config use-context default
         command:
         - /bin/bash
@@ -177,6 +245,10 @@ spec:
           name: hosted-etc-kube
         - mountPath: /configs
           name: configs
+        - mountPath: /var/run/secrets/kubernetes.io/hosted
+          name: client-token
+        - mountPath: /etc/certificate/ca
+          name: ca-bundle
       serviceAccountName: cluster-network-operator
       volumes:
       - name: hosted-etc-kube
@@ -192,4 +264,10 @@ spec:
           defaultMode: 416
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: client-token
+      - name: ca-bundle
+        secret:
+          defaultMode: 416
+          secretName: root-ca
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -77,7 +77,6 @@ var (
 		"0000_50_operator-marketplace_11_service_monitor.yaml",
 		"0000_70_dns-operator_02-deployment-ibm-cloud-managed.yaml",
 		"0000_50_cluster-ingress-operator_02-deployment-ibm-cloud-managed.yaml",
-		"0000_70_cluster-network-operator_02_rbac.yaml",
 		"0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml",
 		"0000_80_machine-config_01_containerruntimeconfigs.crd.yaml",
 		"0000_80_machine-config_01_kubeletconfigs.crd.yaml",

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies_test.go
@@ -1,0 +1,131 @@
+package kas
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker/decls"
+	. "github.com/onsi/gomega"
+)
+
+func TestGenerateCelExpression(t *testing.T) {
+	tests := []struct {
+		name                 string
+		usernames            []string
+		expectedExpression   string
+		shouldPassValidation bool
+		inputObjects         map[string]interface{}
+	}{
+		{
+			name:                 "single username, should pass validation, should pass",
+			usernames:            []string{"user1"},
+			expectedExpression:   "request.userInfo.username in ['user1'] || (has(object.spec) && has(oldObject.spec) && object.spec == oldObject.spec)",
+			shouldPassValidation: true,
+			inputObjects: map[string]interface{}{
+				"request.userInfo.username": "user1",
+				"object": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"field": "value",
+					},
+				},
+				"oldObject": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"field": "value",
+					},
+				},
+			},
+		},
+		{
+			name:                 "multiple usernames, same spec, invalid user, should pass",
+			usernames:            []string{"user2", "user3"},
+			expectedExpression:   "request.userInfo.username in ['user2', 'user3'] || (has(object.spec) && has(oldObject.spec) && object.spec == oldObject.spec)",
+			shouldPassValidation: true,
+			inputObjects: map[string]interface{}{
+				"request.userInfo.username": "user1",
+				"object": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"field": "value",
+					},
+				},
+				"oldObject": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"field": "value",
+					},
+				},
+			},
+		},
+		{
+			name:                 "multiple usernames, different spec, valid username, should pass",
+			usernames:            []string{"user2", "user3"},
+			expectedExpression:   "request.userInfo.username in ['user2', 'user3'] || (has(object.spec) && has(oldObject.spec) && object.spec == oldObject.spec)",
+			shouldPassValidation: true,
+			inputObjects: map[string]interface{}{
+				"request.userInfo.username": "user3",
+				"object": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"field": "value",
+					},
+				},
+				"oldObject": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"field": "wrongValue",
+					},
+				},
+			},
+		},
+		{
+			name:                 "multiple usernames, different spec, invalid username, should not pass",
+			usernames:            []string{"user2", "user3"},
+			expectedExpression:   "request.userInfo.username in ['user2', 'user3'] || (has(object.spec) && has(oldObject.spec) && object.spec == oldObject.spec)",
+			shouldPassValidation: false,
+			inputObjects: map[string]interface{}{
+				"request.userInfo.username": "user1",
+				"object": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"field": "value",
+					},
+				},
+				"oldObject": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"field": "wrongValue",
+					},
+				},
+			},
+		},
+		{
+			name:               "no usernames, should pass",
+			usernames:          []string{},
+			expectedExpression: "has(object.spec) && has(oldObject.spec) && object.spec == oldObject.spec",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := generateCelExpression(tt.usernames)
+			g.Expect(result).To(Equal(tt.expectedExpression))
+
+			if len(tt.usernames) != 0 {
+				env, err := cel.NewEnv(
+					cel.Declarations(
+						decls.NewVar("object", decls.NewMapType(decls.String, decls.Dyn)),
+						decls.NewVar("oldObject", decls.NewMapType(decls.String, decls.Dyn)),
+						decls.NewVar("request.userInfo.username", decls.String),
+					),
+				)
+
+				g.Expect(err).To(BeNil())
+
+				ast, issues := env.Compile(result)
+				g.Expect(issues).To(BeNil(), "Compile errors: %v", issues)
+
+				prog, err := env.Program(ast)
+				g.Expect(err).To(BeNil(), "Program errors: %v", err)
+
+				out, _, err := prog.Eval(tt.inputObjects)
+				g.Expect(err).To(BeNil())
+				g.Expect(tt.shouldPassValidation).To(BeEquivalentTo(out.Value().(bool)))
+			}
+		})
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -65,9 +65,11 @@ var initialObjects = []client.Object{
 	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameConfig),
 	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameMirror),
 	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameICSP),
+	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameInfra),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameConfig)),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameMirror)),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameICSP)),
+	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameInfra)),
 
 	fakeOperatorHub(),
 }

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+	github.com/google/cel-go v0.20.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.6.0
@@ -157,7 +158,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
-	github.com/google/cel-go v0.20.1 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/support/util/containers.go
+++ b/support/util/containers.go
@@ -75,6 +75,9 @@ func AvailabilityProber(target string, image string, spec *corev1.PodSpec, o ...
 	if opts.WaitForLabeledPodsGone != "" {
 		availabilityProberContainer.Command = append(availabilityProberContainer.Command, fmt.Sprintf("--wait-for-labeled-pods-gone=%s", opts.WaitForLabeledPodsGone))
 	}
+	if opts.WaitForClusterRolebinding != "" {
+		availabilityProberContainer.Command = append(availabilityProberContainer.Command, fmt.Sprintf("--wait-for-cluster-rolebinding=%s", opts.WaitForClusterRolebinding))
+	}
 	if len(spec.InitContainers) == 0 || spec.InitContainers[0].Name != "availability-prober" {
 		spec.InitContainers = append([]corev1.Container{{}}, spec.InitContainers...)
 	}
@@ -88,6 +91,7 @@ type AvailabilityProberOpts struct {
 	RequiredAPIs                  []schema.GroupVersionKind
 	WaitForInfrastructureResource bool
 	WaitForLabeledPodsGone        string
+	WaitForClusterRolebinding     string
 }
 
 type AvailabilityProberOpt func(*AvailabilityProberOpts)
@@ -98,5 +102,6 @@ func WithOptions(opts *AvailabilityProberOpts) AvailabilityProberOpt {
 		o.RequiredAPIs = opts.RequiredAPIs
 		o.WaitForInfrastructureResource = opts.WaitForInfrastructureResource
 		o.WaitForLabeledPodsGone = opts.WaitForLabeledPodsGone
+		o.WaitForClusterRolebinding = opts.WaitForClusterRolebinding
 	}
 }

--- a/support/util/manifests.go
+++ b/support/util/manifests.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func DefaultTokenMinterResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{Requests: corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("10m"),
+		corev1.ResourceMemory: resource.MustParse("10Mi"),
+	}}
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1236,7 +1236,7 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 	t.Run("EnsureValidatingAdmissionPoliciesExists", func(t *testing.T) {
 		AtLeast(t, Version418)
 		t.Log("Waiting for ValidatingAdmissionPolicies to exist")
-		var expectedVAPCount int = 3
+		var expectedVAPCount int = 4
 		g := NewWithT(t)
 		start := time.Now()
 		var validatingAdmissionPolicies k8sadmissionv1beta1.ValidatingAdmissionPolicyList
@@ -1270,6 +1270,8 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 				g.Expect(vap.Name).To(Equal(hccokasvap.AdmissionPolicyNameMirror), fmt.Sprintf("ValidatingAdmissionPolicy %s not found in the list", hccokasvap.AdmissionPolicyNameMirror))
 			case hccokasvap.AdmissionPolicyNameICSP:
 				g.Expect(vap.Name).To(Equal(hccokasvap.AdmissionPolicyNameICSP), fmt.Sprintf("ValidatingAdmissionPolicy %s not found in the list", hccokasvap.AdmissionPolicyNameICSP))
+			case hccokasvap.AdmissionPolicyNameInfra:
+				g.Expect(vap.Name).To(Equal(hccokasvap.AdmissionPolicyNameInfra), fmt.Sprintf("ValidatingAdmissionPolicy %s not found in the list", hccokasvap.AdmissionPolicyNameICSP))
 			default:
 				t.Errorf("Unexpected ValidatingAdmissionPolicy %s found in the list", vap.Name)
 			}


### PR DESCRIPTION
This PR adds:

- [x] RBAC for CNO in the data plane side
- [x] Added availability probe for CNO ClusterRoleBinding
- [x] token-minter container to the CNO pod
- [x] New ValidatingAdmissionPolicy for the Infrastructure resource in the data plane
- [x] Adapted E2E VAPs tests 

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-39369](https://issues.redhat.com/browse/OCPBUGS-39369)