### PR TITLE
NO-JIRA: Fix docker check 'AS' as uppercase in container and docker files

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
 
 WORKDIR /hypershift
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 AS builder
 
 WORKDIR /hypershift
 

--- a/support/releaseinfo/registryclient/test/Dockerfile.testdriver
+++ b/support/releaseinfo/registryclient/test/Dockerfile.testdriver
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 
 WORKDIR /hypershift
 
 COPY . .
 
-RUN go build -o registryclient-test ./releaseinfo/registryclient/test/main.go 
+RUN go build -o registryclient-test ./releaseinfo/registryclient/test/main.go
 
 FROM quay.io/openshift/origin-base:4.7
 COPY --from=builder /hypershift/registryclient-test /usr/bin/registryclient-test


### PR DESCRIPTION
Getting this error in local:

![CleanShot 2024-09-23 at 12 23 43](https://github.com/user-attachments/assets/30b7a292-3a84-4a37-b6f6-bec014a7b1fe)

I've check that we have some `Dockerfiles` and `Containerfiles` entries with the `AS` "command" in lowercase. 