### PR TITLE
NO-JIRA: Add Dockerfile.dev to build all-in-one container image for development purposes

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,38 @@
+# Disclaimer: The purpose of this Dockerfile is to simplify development tasks by building a container image with all-in-one binaries.
+# The control-plane-operator should not be included in the Hypershift operator image because it is already part of the OpenShift payload.
+
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 AS builder
+WORKDIR /hypershift
+
+COPY . .
+
+RUN make build
+
+FROM registry.access.redhat.com/ubi9:latest
+COPY --from=builder /hypershift/bin/hypershift \
+                    /hypershift/bin/hcp \
+                    /hypershift/bin/hypershift-operator \
+                    /hypershift/bin/control-plane-operator \
+                    /hypershift/bin/control-plane-pki-operator \
+     /usr/bin/
+
+RUN cd /usr/bin && \
+    ln -s control-plane-operator ignition-server && \
+    ln -s control-plane-operator konnectivity-socks5-proxy && \
+    ln -s control-plane-operator availability-prober && \
+    ln -s control-plane-operator token-minter
+
+ENTRYPOINT ["/usr/bin/hypershift"]
+
+LABEL io.openshift.hypershift.control-plane-operator-subcommands=true
+LABEL io.openshift.hypershift.control-plane-operator-skips-haproxy=true
+LABEL io.openshift.hypershift.ignition-server-healthz-handler=true
+LABEL io.openshift.hypershift.control-plane-operator-manages-ignition-server=true
+LABEL io.openshift.hypershift.control-plane-operator-manages.cluster-machine-approver=true
+LABEL io.openshift.hypershift.control-plane-operator-manages.cluster-autoscaler=true
+LABEL io.openshift.hypershift.control-plane-operator-manages.decompress-decode-config=true
+LABEL io.openshift.hypershift.control-plane-operator-creates-aws-sg=true
+LABEL io.openshift.hypershift.control-plane-operator-applies-management-kas-network-policy-label=true
+LABEL io.openshift.hypershift.restricted-psa=true
+LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
+LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true


### PR DESCRIPTION
This allows us to continue building all-in-one container images in local with the benefits of https://github.com/openshift/hypershift/pull/4754 PR