### PR TITLE
NO-JIRA: e2e: add service and cluster CIDRs as flags to the e2e framework

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -132,6 +132,8 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.ManagementClusterName, "e2e.management-cluster-name", "", "Name of the management cluster's HostedCluster (required to test request serving isolation)")
 	flag.BoolVar(&globalOpts.DisablePKIReconciliation, "e2e.disable-pki-reconciliation", false, "If set, TestUpgradeControlPlane will upgrade the control plane without reconciling the pki components")
 	flag.Var(&globalOpts.configurableClusterOptions.Annotations, "e2e.annotations", "Annotations to apply to the HostedCluster (key=value). Can be specified multiple times")
+	flag.Var(&globalOpts.configurableClusterOptions.ServiceCIDR, "e2e.service-cidr", "The CIDR of the service network. Can be specified multiple times.")
+	flag.Var(&globalOpts.configurableClusterOptions.ClusterCIDR, "e2e.cluster-cidr", "The CIDR of the cluster network. Can be specified multiple times.")
 
 	flag.Parse()
 
@@ -468,6 +470,8 @@ type configurableClusterOptions struct {
 	PowerVSTransitGateway         string
 	EtcdStorageClass              string
 	Annotations                   stringMapVar
+	ServiceCIDR                   stringSliceVar
+	ClusterCIDR                   stringSliceVar
 }
 
 var nextAWSZoneIndex = 0
@@ -520,6 +524,14 @@ func (o *options) DefaultClusterOptions(t *testing.T) e2eutil.PlatformAgnosticOp
 		for k, v := range o.configurableClusterOptions.Annotations {
 			createOption.Annotations = append(createOption.Annotations, fmt.Sprintf("%s=%s", k, v))
 		}
+	}
+
+	if len(o.configurableClusterOptions.ServiceCIDR) != 0 {
+		createOption.ServiceCIDR = o.configurableClusterOptions.ServiceCIDR
+	}
+
+	if len(o.configurableClusterOptions.ClusterCIDR) != 0 {
+		createOption.ClusterCIDR = o.configurableClusterOptions.ClusterCIDR
 	}
 
 	return createOption


### PR DESCRIPTION
In some complex test scenarios, we would like to allow specifying custom IP ranges for the service and the cluster CIDR, to avoid overlapping addresses that use the defaults.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.