### PR TITLE
WIP: STOR-1140: Generate kubeconfigs for AWS-EBS CSI operator and controller

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/storage.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/storage.go
@@ -4,6 +4,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ClusterStorageOperatorDeployment(ns string) *appsv1.Deployment {
@@ -32,4 +33,22 @@ func ClusterStorageOperatorServiceAccount(ns string) *corev1.ServiceAccount {
 	sa.Name = "cluster-storage-operator"
 	sa.Namespace = ns
 	return sa
+}
+
+func AWSEBSCSIDriverOperatorKubeconfig(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-ebs-csi-driver-operator-kubeconfig",
+			Namespace: ns,
+		},
+	}
+}
+
+func AWSEBSCSIDriverControllerKubeconfig(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-ebs-csi-driver-controller-kubeconfig",
+			Namespace: ns,
+		},
+	}
 }


### PR DESCRIPTION
This PR will let AWS-EBS CSI operator and controller use fine-grained kubeconfigs (rather than omnipotent `service-network-admin-kubeconfig`)