### PR TITLE
HOSTEDCP-1569: add dockerfile for e2e

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,7 @@
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 AS builder
+
+WORKDIR /hypershift
+
+COPY . .
+
+RUN make e2e


### PR DESCRIPTION
This PR is in service to consolidating the `hypershift-aws-e2e-nested` and `hypershift-aws-e2e-external` workflows in the o/r step-registry.

The only real difference between the two is the former uses `test-bin` as the image and the latter uses `hypershift-tests`.

https://github.com/openshift/release/blob/master/ci-operator/step-registry/hypershift/aws/run-e2e/hypershift-aws-run-e2e-ref.yaml#L35

https://github.com/openshift/release/blob/master/ci-operator/step-registry/hypershift/aws/run-e2e/external/hypershift-aws-run-e2e-external-ref.yaml#L24

The two flows are being synced in https://github.com/openshift/release/pull/57123/commits/b650be1daa2c418766f709fa59d7f65f5647ed28

If we have our own Dockerfile for the e2e, instead of using `test_binary_build_commands`, we can specify the name to be `hypershift-tests` on the `main` presubmits (rather than `test-bin`).  Then we can get rid of the `hypershift-aws-e2e-nested` workflow and just use `hypershift-aws-e2e-external`.

https://github.com/openshift/release/blob/master/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml#L88