### PR TITLE
OCPBUGS-42433: Retry reconciliation with invalid configuration

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1136,8 +1136,8 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	{
 		validConfig := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.ValidHostedClusterConfiguration))
 		if validConfig != nil && validConfig.Status == metav1.ConditionFalse {
-			log.Error(fmt.Errorf("configuration is invalid"), "reconciliation is blocked", "message", validConfig.Message)
-			return ctrl.Result{}, nil
+			// an error should be returned here because the ValidHostedClusterConfiguration status may be transient
+			return ctrl.Result{}, fmt.Errorf("configuration is invalid: %s", validConfig.Message)
 		}
 		supportedHostedCluster := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.SupportedHostedCluster))
 		if supportedHostedCluster != nil && supportedHostedCluster.Status == metav1.ConditionFalse {


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this commit, if configuration was determined to be invalid, we simply returned a nil from the reconciliation loop and waited for something to change in the HostedCluster. This fails to account for when the reason for the invalid configuration is transient, such as a missing ConfigMap. When the ConfigMap is finally made available, the HostedCluster does not resume reconciliation.

Now an error is thrown when configuration is not valid, resulting in a requeue of the HostedCluster, until the invalid configuration is resolved.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-42433](https://issues.redhat.com/browse/OCPBUGS-42433)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.