### PR TITLE
NO-JIRA: e2e: openstack: fix nil deref in route53 teardown

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1489,7 +1489,7 @@ func deleteIngressRoute53Records(t *testing.T, ctx context.Context, hostedCluste
 	record, err := awsprivatelink.FindRecord(ctx, route53Client, zoneID, "*.apps."+clusterName+"."+baseDomain, "A")
 	g.Expect(err).ToNot(HaveOccurred(), "failed to find Route53 record %s", "*.apps."+clusterName+"."+baseDomain)
 
-	if len(record.ResourceRecords) == 0 {
+	if record == nil || len(record.ResourceRecords) == 0 {
 		t.Logf("Route53 record for HostedCluster %s not found: %s", hostedCluster.Name, "*.apps."+clusterName+"."+baseDomain)
 	} else {
 		err = awsprivatelink.DeleteRecord(ctx, route53Client, zoneID, record)


### PR DESCRIPTION
observed in MCO rehearsal

```
--- FAIL: TestCreateCluster (2136.19s)
    --- FAIL: TestCreateCluster/ValidateHostedCluster (1908.04s)
    --- FAIL: TestCreateCluster/Teardown (225.96s)
        --- PASS: TestCreateCluster/Teardown/ValidateMetricsAreExposed (0.07s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x712fa07]

goroutine 1383 [running]:
testing.tRunner.func1.2({0x799cd20, 0xb3ccb30})
	/usr/lib/golang/src/testing/testing.go:1631 +0x49e
testing.tRunner.func1()
	/usr/lib/golang/src/testing/testing.go:1634 +0x669
panic({0x799cd20?, 0xb3ccb30?})
	/usr/lib/golang/src/runtime/panic.go:770 +0x136
github.com/openshift/hypershift/test/e2e/util.deleteIngressRoute53Records(0xc000bbab60, {0x8d44be8, 0xc000a9d130}, 0xc00137f008, 0xc001002a08)
	/go/src/github.com/openshift/hypershift/test/e2e/util/util.go:1492 +0xb87
github.com/openshift/hypershift/test/e2e/util.teardownHostedCluster(0xc000bbab60, {0x8d44be8, 0xc000a9d130}, 0xc00137f008, {0x8d574e0, 0xc000eccbd0}, 0xc001002a08, {0xc0014fe810, 0x21}, 0x0)
	/go/src/github.com/openshift/hypershift/test/e2e/util/hypershift_framework.go:402 +0x119d
```

https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_release/57194/rehearse-57194-pull-ci-openshift-machine-config-operator-master-e2e-openstack-hypershift/1839081537698533376/build-log.txt

Seems to be triggered by earlier failure in `ValidateHostedCluster`

```
=== RUN   TestCreateCluster/ValidateHostedCluster
    util.go:1505: Creating Ingress Route53 Record for HostedCluster example-zc75b
    util.go:146: Waiting for kubeconfig to be published for HostedCluster e2e-clusters-jl5nh/example-zc75b
    eventually.go:220: observed *v1beta1.HostedCluster e2e-clusters-jl5nh/example-zc75b invalid at RV 11891 after 0s: expected a kubeconfig reference in status
    util.go:146: Successfully waited for kubeconfig to be published for HostedCluster e2e-clusters-jl5nh/example-zc75b in 51s
    util.go:163: Waiting for kubeconfig secret to have data
    eventually.go:220: observed *v1.Secret e2e-clusters-jl5nh/example-zc75b-admin-kubeconfig valid at RV 12689 after 0s: expected secret to contain kubeconfig in data
    util.go:163: Successfully waited for kubeconfig secret to have data in 0s
    util.go:206: Waiting for a successful connection to the guest API server
    eventually.go:100: Failed to get *v1.SelfSubjectReview: Post "https://ac04d3ce43ec7444db9aa372573ea145-23216860.us-east-1.elb.amazonaws.com:6443/apis/authentication.k8s.io/v1/selfsubjectreviews": dial tcp: lookup ac04d3ce43ec7444db9aa372573ea145-23216860.us-east-1.elb.amazonaws.com on 172.30.0.10:53: no such host
    util.go:206: Successfully waited for a successful connection to the guest API server in 57.025s
    util.go:1505: 
        failed to get router-default service IP
        Unexpected error:
            <*errors.errorString | 0xc000f8a210>: 
            router-default service did't become available: context deadline exceeded
            {
                s: "router-default service did't become available: context deadline exceeded",
            }
        occurred
```