### PR TITLE
HOSTEDCP-1788: use getResourceGroupName for infra deletion in azure so destroy infra can be ran without --resource-group-name

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -165,7 +165,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		if err != nil {
 			return nil, fmt.Errorf("failed to create resource group for network security group: %w", err)
 		}
-		l.Info(msg, "name", nsgResourceGroupName)
+		l.Info(msg, "name", nsgRG)
 
 		// Create a network security group
 		nsgID, err := createSecurityGroup(ctx, subscriptionID, nsgRG, o.Name, o.InfraID, o.Location, azureCreds)

--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -78,7 +78,7 @@ func (o *DestroyInfraOptions) Run(ctx context.Context, logger logr.Logger) error
 	}
 
 	var resourceGroups []string
-	resourceGroups = append(resourceGroups, o.ResourceGroupName)
+	resourceGroups = append(resourceGroups, o.GetResourceGroupName())
 
 	for _, rg := range additionalResourceGroups {
 		exists, err := resourceGroupClient.CheckExistence(ctx, rg, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

use getResourceGroupName for infra deletion in azure so destroy infra can be ran without --resource-group-name

Follow up PR for comments on https://github.com/openshift/hypershift/pull/4282

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-1788](https://issues.redhat.com/browse/HOSTEDCP-1788)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.