### PR TITLE
NO-JIRA: Fix recover-etcd cmd marking a missing flag required

### DIFF
--- a/etcd-recovery/etcdrecovery.go
+++ b/etcd-recovery/etcdrecovery.go
@@ -66,8 +66,12 @@ func NewRecoveryCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.etcdClientKeyFile, "etcd-client-key", opts.etcdClientKeyFile, "etcd client cert key file.")
 	cmd.PersistentFlags().StringVar(&opts.etcdCAFile, "etcd-ca-cert", opts.etcdCAFile, "etcd trusted CA cert file.")
 	cmd.PersistentFlags().StringVar(&opts.namespace, "namespace", "", "namespace of etcd cluster")
-	_ = cmd.MarkFlagRequired("etcd-endpoints")
-	_ = cmd.MarkFlagRequired("namespace")
+
+	err := cmd.MarkPersistentFlagRequired("namespace")
+	if err != nil {
+		cmd.PrintErrf("error setting up namespace flag as required: %v\n", err)
+		os.Exit(1)
+	}
 
 	cmd.AddCommand(NewStatusCommand(&opts))
 	cmd.AddCommand(NewRunCommand(&opts))


### PR DESCRIPTION
**What this PR does / why we need it**:

The `recover-etcd` command was setting up a flag that doesn't exist as required. This PR cleans up that and fixes the require flags handling logic.

There were two main problems that were hidden by the swallowed errors:
1. The `etcd-endpoints` flag didn't exist
Here's a test when I changed the code to not swallow the error 

```shell
./bin/hypershift-operator recover-etcd --help
error occurred no such flag -etcd-endpoints
```
2. The `namespace` flag was set using the wrong method. It is a `PersistedFlag` so must be set using `MarkPersistentFlagRequired`  instead of `MarkFlagRequired`. 


```shell
./bin/hypershift-operator recover-etcd --help
error setting up namespace flag as required: no such flag -namespace
```

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.