### PR TITLE
OCPBUGS-49611: Konnectivity: add agent readiness

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/konnectivity/params.go
@@ -49,11 +49,42 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider
 					Path:   "healthz",
 				},
 			},
-			InitialDelaySeconds: 120,
-			TimeoutSeconds:      30,
-			PeriodSeconds:       60,
-			FailureThreshold:    3,
-			SuccessThreshold:    1,
+			TimeoutSeconds:   5,
+			PeriodSeconds:    30,
+			FailureThreshold: 6,
+			SuccessThreshold: 1,
+		},
+	}
+
+	p.AgentDeploymentConfig.ReadinessProbes = config.ReadinessProbes{
+		konnectivityAgentContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "readyz",
+				},
+			},
+			TimeoutSeconds:   5,
+			PeriodSeconds:    30,
+			FailureThreshold: 1,
+			SuccessThreshold: 1,
+		},
+	}
+
+	p.AgentDeploymentConfig.StartupProbes = config.StartupProbes{
+		konnectivityAgentContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			TimeoutSeconds:   5,
+			PeriodSeconds:    5,
+			FailureThreshold: 60,
+			SuccessThreshold: 1,
 		},
 	}
 
@@ -79,11 +110,42 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider
 					Path:   "healthz",
 				},
 			},
-			InitialDelaySeconds: 120,
-			TimeoutSeconds:      30,
-			PeriodSeconds:       60,
-			FailureThreshold:    3,
-			SuccessThreshold:    1,
+			TimeoutSeconds:   5,
+			PeriodSeconds:    30,
+			FailureThreshold: 6,
+			SuccessThreshold: 1,
+		},
+	}
+
+	p.AgentDeamonSetConfig.ReadinessProbes = config.ReadinessProbes{
+		konnectivityAgentContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "readyz",
+				},
+			},
+			TimeoutSeconds:   5,
+			PeriodSeconds:    30,
+			FailureThreshold: 1,
+			SuccessThreshold: 1,
+		},
+	}
+
+	p.AgentDeamonSetConfig.StartupProbes = config.StartupProbes{
+		konnectivityAgentContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			TimeoutSeconds:   5,
+			PeriodSeconds:    5,
+			FailureThreshold: 60,
+			SuccessThreshold: 1,
 		},
 	}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/params.go
@@ -49,13 +49,45 @@ func NewKonnectivityParams(hcp *hyperv1.HostedControlPlane, images map[string]st
 					Path:   "healthz",
 				},
 			},
-			InitialDelaySeconds: 120,
-			TimeoutSeconds:      30,
-			PeriodSeconds:       60,
-			FailureThreshold:    3,
-			SuccessThreshold:    1,
+			TimeoutSeconds:   5,
+			PeriodSeconds:    30,
+			FailureThreshold: 6,
+			SuccessThreshold: 1,
 		},
 	}
+
+	p.DeploymentConfig.ReadinessProbes = config.ReadinessProbes{
+		konnectivityAgentContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "readyz",
+				},
+			},
+			TimeoutSeconds:   5,
+			PeriodSeconds:    30,
+			FailureThreshold: 1,
+			SuccessThreshold: 1,
+		},
+	}
+
+	p.DeploymentConfig.StartupProbes = config.StartupProbes{
+		konnectivityAgentContainer().Name: {
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Port:   intstr.FromInt(int(healthPort)),
+					Path:   "healthz",
+				},
+			},
+			TimeoutSeconds:   5,
+			PeriodSeconds:    5,
+			FailureThreshold: 60,
+			SuccessThreshold: 1,
+		},
+	}
+
 	// check apiserver-network-proxy image in ocp payload and use it
 	if _, ok := images["apiserver-network-proxy"]; ok {
 		p.Image = images["apiserver-network-proxy"]

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -41,6 +41,7 @@ type DeploymentConfig struct {
 	SetDefaultSecurityContext bool
 	LivenessProbes            LivenessProbes
 	ReadinessProbes           ReadinessProbes
+	StartupProbes             StartupProbes
 	Resources                 ResourcesSpec
 	DebugDeployments          sets.String
 	ResourceRequestOverrides  ResourceOverrides
@@ -142,6 +143,7 @@ func (c *DeploymentConfig) ApplyTo(deployment *appsv1.Deployment) {
 	c.SecurityContexts.ApplyTo(&deployment.Spec.Template.Spec)
 	c.LivenessProbes.ApplyTo(&deployment.Spec.Template.Spec)
 	c.ReadinessProbes.ApplyTo(&deployment.Spec.Template.Spec)
+	c.StartupProbes.ApplyTo(&deployment.Spec.Template.Spec)
 	c.Resources.ApplyTo(&deployment.Spec.Template.Spec)
 	c.ResourceRequestOverrides.ApplyRequestsTo(deployment.Name, &deployment.Spec.Template.Spec)
 	c.AdditionalAnnotations.ApplyTo(&deployment.Spec.Template.ObjectMeta)
@@ -154,6 +156,7 @@ func (c *DeploymentConfig) ApplyToDaemonSet(daemonset *appsv1.DaemonSet) {
 	c.SecurityContexts.ApplyTo(&daemonset.Spec.Template.Spec)
 	c.LivenessProbes.ApplyTo(&daemonset.Spec.Template.Spec)
 	c.ReadinessProbes.ApplyTo(&daemonset.Spec.Template.Spec)
+	c.StartupProbes.ApplyTo(&daemonset.Spec.Template.Spec)
 	c.Resources.ApplyTo(&daemonset.Spec.Template.Spec)
 	c.ResourceRequestOverrides.ApplyRequestsTo(daemonset.Name, &daemonset.Spec.Template.Spec)
 	c.AdditionalAnnotations.ApplyTo(&daemonset.Spec.Template.ObjectMeta)
@@ -166,6 +169,7 @@ func (c *DeploymentConfig) ApplyToStatefulSet(sts *appsv1.StatefulSet) {
 	c.SecurityContexts.ApplyTo(&sts.Spec.Template.Spec)
 	c.LivenessProbes.ApplyTo(&sts.Spec.Template.Spec)
 	c.ReadinessProbes.ApplyTo(&sts.Spec.Template.Spec)
+	c.StartupProbes.ApplyTo(&sts.Spec.Template.Spec)
 	c.Resources.ApplyTo(&sts.Spec.Template.Spec)
 	c.ResourceRequestOverrides.ApplyRequestsTo(sts.Name, &sts.Spec.Template.Spec)
 	c.AdditionalAnnotations.ApplyTo(&sts.Spec.Template.ObjectMeta)

--- a/support/config/probes.go
+++ b/support/config/probes.go
@@ -37,3 +37,20 @@ func (p ReadinessProbes) ApplyToContainer(container string, c *corev1.Container)
 		c.ReadinessProbe = &probe
 	}
 }
+
+type StartupProbes map[string]corev1.Probe
+
+func (p StartupProbes) ApplyTo(podSpec *corev1.PodSpec) {
+	for i, c := range podSpec.InitContainers {
+		p.ApplyToContainer(c.Name, &podSpec.InitContainers[i])
+	}
+	for i, c := range podSpec.Containers {
+		p.ApplyToContainer(c.Name, &podSpec.Containers[i])
+	}
+}
+
+func (p StartupProbes) ApplyToContainer(container string, c *corev1.Container) {
+	if probe, ok := p[c.Name]; ok {
+		c.StartupProbe = &probe
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds readiness probe to Konnectivity agent on hosted user plane.
It is helpful to indicate pod readiness when the connection to Konnectivity server drops. In this case pod goes to "0/1 Running" status.

implementation: https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/485

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.