### PR TITLE
Enforce privileged PSA by default

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/config.go
@@ -67,5 +67,24 @@ func reconcileConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, minTLS
 			CipherSuites:  cipherSuites,
 		},
 	}
+
+	// disables automatically setting the `pod-security.kubernetes.io/enforce` label on namespaces by the pod-security-admission-label-synchronization-controller
+	// see https://github.com/openshift/cluster-policy-controller/blob/50c2a8337f08856bbae4cd419bb8ffcbdf92567c/pkg/cmd/controller/psalabelsyncer.go#L19
+	index := -1
+	for i := range cfg.FeatureGates {
+		fg := cfg.FeatureGates[i]
+		if strings.HasPrefix(fg, "OpenShiftPodSecurityAdmission") {
+			index = i
+			break
+		}
+	}
+
+	if index != -1 {
+		// overwrite
+		cfg.FeatureGates[index] = "OpenShiftPodSecurityAdmission=false"
+	} else {
+		cfg.FeatureGates = append(cfg.FeatureGates, "OpenShiftPodSecurityAdmission=false")
+	}
+
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -99,7 +99,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 									Kind:       "PodSecurityConfiguration",
 								},
 								Defaults: podsecurityadmissionv1beta1.PodSecurityDefaults{
-									Enforce:        "restricted",
+									Enforce:        "privileged",
 									EnforceVersion: "latest",
 									Audit:          "restricted",
 									AuditVersion:   "latest",


### PR DESCRIPTION
**What this PR does / why we need it**:
OpenShiftPodSecurityAdmission feature gate is not enabled by default in 4.17 any longer: https://github.com/openshift/api/blob/release-4.17/features/features.go, https://github.com/openshift/api/pull/2018. Therefore, to ensure namespace security is not enforcing restricted by default any longer, this PR is required to properly enforce privileged PSA by default.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.