### PR TITLE
CNF-14742: HCCO: copy KubeletConfigs to hosted-cluster

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -2140,6 +2140,7 @@ func mutateKubeletConfig(controlPlaneConfigMap, hostedClusterConfigMap *corev1.C
 	hostedClusterConfigMap.Labels = labels.Merge(hostedClusterConfigMap.Labels, map[string]string{
 		nodepool.KubeletConfigConfigMapLabel: "true",
 		hyperv1.NodePoolLabel:                controlPlaneConfigMap.Labels[hyperv1.NodePoolLabel],
+		nodepool.NTOMirroredConfigLabel:      "true",
 	})
 	hostedClusterConfigMap.Data = controlPlaneConfigMap.Data
 	return nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -2127,7 +2127,7 @@ func (r *reconciler) reconcileKubeletConfig(ctx context.Context) error {
 		if want.Has(cm.Name) {
 			continue
 		}
-		log.Info("delete mirror config", "config", client.ObjectKeyFromObject(cm).String())
+		log.Info("delete mirror config ConfigMap", "config", client.ObjectKeyFromObject(cm).String())
 		if _, err := util.DeleteIfNeeded(ctx, r.client, cm); err != nil {
 			return fmt.Errorf("failed to delete ConfigMap %s: %w", client.ObjectKeyFromObject(cm).String(), err)
 		}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -70,6 +70,7 @@ var initialObjects = []client.Object{
 	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameMirror),
 	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameICSP),
 	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameInfra),
+	manifests.ValidatingAdmissionPolicy(kas.AdmissionPolicyNameNTOMirroredConfigs),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameConfig)),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameMirror)),
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameICSP)),

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -66,13 +66,13 @@ const (
 	nodePoolAnnotationTaints                  = "hypershift.openshift.io/nodePoolTaints"
 	nodePoolCoreIgnitionConfigLabel           = "hypershift.openshift.io/core-ignition-config"
 
-	tuningConfigKey                                  = "tuning"
-	tunedConfigMapLabel                              = "hypershift.openshift.io/tuned-config"
-	nodeTuningGeneratedConfigLabel                   = "hypershift.openshift.io/nto-generated-machine-config"
-	PerformanceProfileConfigMapLabel                 = "hypershift.openshift.io/performanceprofile-config"
-	NodeTuningGeneratedPerformanceProfileStatusLabel = "hypershift.openshift.io/nto-generated-performance-profile-status"
-	ContainerRuntimeConfigConfigMapLabel             = "hypershift.openshift.io/containerruntimeconfig-config"
-
+	tuningConfigKey                                      = "tuning"
+	tunedConfigMapLabel                                  = "hypershift.openshift.io/tuned-config"
+	nodeTuningGeneratedConfigLabel                       = "hypershift.openshift.io/nto-generated-machine-config"
+	PerformanceProfileConfigMapLabel                     = "hypershift.openshift.io/performanceprofile-config"
+	NodeTuningGeneratedPerformanceProfileStatusLabel     = "hypershift.openshift.io/nto-generated-performance-profile-status"
+	ContainerRuntimeConfigConfigMapLabel                 = "hypershift.openshift.io/containerruntimeconfig-config"
+	KubeletConfigConfigMapLabel                          = "hypershift.openshift.io/kubeletconfig-config"
 	controlPlaneOperatorManagesDecompressAndDecodeConfig = "io.openshift.hypershift.control-plane-operator-manages.decompress-decode-config"
 
 	controlPlaneOperatorCreatesDefaultAWSSecurityGroup = "io.openshift.hypershift.control-plane-operator-creates-aws-sg"

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -78,8 +78,8 @@ const (
 	controlPlaneOperatorCreatesDefaultAWSSecurityGroup = "io.openshift.hypershift.control-plane-operator-creates-aws-sg"
 
 	labelManagedPrefix = "managed.hypershift.openshift.io"
-	// mirroredConfigLabel added to objects that were mirrored from the node pool namespace into the HCP namespace
-	mirroredConfigLabel = "hypershift.openshift.io/mirrored-config"
+	// NTOMirroredConfigLabel added to objects that were mirrored from the node pool namespace into the HCP namespace
+	NTOMirroredConfigLabel = "hypershift.openshift.io/mirrored-config"
 )
 
 type NodePoolReconciler struct {

--- a/hypershift-operator/controllers/nodepool/nto.go
+++ b/hypershift-operator/controllers/nodepool/nto.go
@@ -45,7 +45,7 @@ func (r *NodePoolReconciler) reconcileMirroredConfigs(ctx context.Context, logr 
 	if err := r.List(ctx, existingConfigsList, &client.ListOptions{
 		Namespace: controlPlaneNamespace,
 		LabelSelector: labels.SelectorFromValidatedSet(labels.Set{
-			NTOMirroredConfigLabel:   "true",
+			NTOMirroredConfigLabel: "true",
 			hyperv1.NodePoolLabel:  nodePool.Name}),
 	}); err != nil && !apierrors.IsNotFound(err) {
 		return err

--- a/hypershift-operator/controllers/nodepool/nto.go
+++ b/hypershift-operator/controllers/nodepool/nto.go
@@ -45,8 +45,8 @@ func (r *NodePoolReconciler) reconcileMirroredConfigs(ctx context.Context, logr 
 	if err := r.List(ctx, existingConfigsList, &client.ListOptions{
 		Namespace: controlPlaneNamespace,
 		LabelSelector: labels.SelectorFromValidatedSet(labels.Set{
-			mirroredConfigLabel:   "",
-			hyperv1.NodePoolLabel: nodePool.Name}),
+			NTOMirroredConfigLabel: "true",
+			hyperv1.NodePoolLabel:  nodePool.Name}),
 	}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -183,7 +183,7 @@ func mutateMirroredConfig(cm *corev1.ConfigMap, mirroredConfig *MirrorConfig, no
 		cm.Labels = make(map[string]string)
 	}
 	cm.Labels[hyperv1.NodePoolLabel] = nodePool.GetName()
-	cm.Labels[mirroredConfigLabel] = ""
+	cm.Labels[NTOMirroredConfigLabel] = "true"
 	cm.Labels = labels.Merge(cm.Labels, mirroredConfig.Labels)
 	cm.Data = mirroredConfig.Data
 	return nil
@@ -422,12 +422,12 @@ func getMirrorConfigForManifest(manifest []byte) (*MirrorConfig, error) {
 	case *mcfgv1.ContainerRuntimeConfig:
 		mirrorConfig = &MirrorConfig{Labels: map[string]string{
 			ContainerRuntimeConfigConfigMapLabel: "true",
-			mirroredConfigLabel:                  "true",
+			NTOMirroredConfigLabel:               "true",
 		}}
 	case *mcfgv1.KubeletConfig:
 		mirrorConfig = &MirrorConfig{Labels: map[string]string{
 			KubeletConfigConfigMapLabel: "true",
-			mirroredConfigLabel:         "true",
+			NTOMirroredConfigLabel:      "true",
 		}}
 	}
 	return mirrorConfig, err

--- a/hypershift-operator/controllers/nodepool/nto.go
+++ b/hypershift-operator/controllers/nodepool/nto.go
@@ -43,8 +43,10 @@ func (r *NodePoolReconciler) reconcileMirroredConfigs(ctx context.Context, logr 
 	// get configs which already mirrored to the HCP namespace
 	existingConfigsList := &corev1.ConfigMapList{}
 	if err := r.List(ctx, existingConfigsList, &client.ListOptions{
-		Namespace:     controlPlaneNamespace,
-		LabelSelector: labels.SelectorFromValidatedSet(labels.Set{mirroredConfigLabel: ""}),
+		Namespace: controlPlaneNamespace,
+		LabelSelector: labels.SelectorFromValidatedSet(labels.Set{
+			mirroredConfigLabel:   "",
+			hyperv1.NodePoolLabel: nodePool.Name}),
 	}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -70,13 +72,33 @@ func (r *NodePoolReconciler) reconcileMirroredConfigs(ctx context.Context, logr 
 	// delete the redundant configs that are no longer part of the nodepool spec
 	for i := 0; i < len(existingConfigsList.Items); i++ {
 		existingConfig := &existingConfigsList.Items[i]
-		if toDelete.Has(existingConfig.Name) {
-			_, err := supportutil.DeleteIfNeeded(ctx, r.Client, existingConfig)
-			if err != nil {
-				return fmt.Errorf("failed to delete ConfigMap %s/%s: %w", existingConfig.Namespace, existingConfig.Name, err)
-			}
+		if !toDelete.Has(existingConfig.Name) {
+			continue
+		}
+		_, err := supportutil.DeleteIfNeeded(ctx, r.Client, existingConfig)
+		if err != nil {
+			return fmt.Errorf("failed to delete ConfigMap %s: %w", client.ObjectKeyFromObject(existingConfig).String(), err)
 		}
 	}
+	// NTO also generates config in the HCP namespace.
+	ntoGeneratedKubeletConfigs := &corev1.ConfigMapList{}
+	if err := r.List(ctx, ntoGeneratedKubeletConfigs, &client.ListOptions{
+		Namespace: controlPlaneNamespace,
+		LabelSelector: labels.SelectorFromValidatedSet(labels.Set{
+			nodeTuningGeneratedConfigLabel: "true",
+			KubeletConfigConfigMapLabel:    "true",
+			hyperv1.NodePoolLabel:          nodePool.Name,
+		}),
+	}); err != nil {
+		return err
+	}
+	// we need to validate that generated configs and user-provided configs
+	// are not conflicting with each other, before we create the new ones
+	err := validateMirroredConfigs(ntoGeneratedKubeletConfigs.Items, mirroredConfigs, nodePool.Name)
+	if err != nil {
+		return fmt.Errorf("failed to validate mirrored configs: %w", err)
+	}
+
 	// update or create the configs that need to be mirrored into the HCP NS
 	for _, mirroredConfig := range mirroredConfigs {
 		cm := &corev1.ConfigMap{
@@ -91,6 +113,21 @@ func (r *NodePoolReconciler) reconcileMirroredConfigs(ctx context.Context, logr 
 		} else {
 			logr.Info("Reconciled ConfigMap", "result", result)
 		}
+	}
+	return nil
+}
+
+func validateMirroredConfigs(generatedKubeletConfigs []corev1.ConfigMap, mirroredConfigs []*MirrorConfig, nodePoolName string) error {
+	KubeletConfigConfigMapCount := len(generatedKubeletConfigs)
+
+	for _, mirroredConfig := range mirroredConfigs {
+		if _, ok := mirroredConfig.Labels[KubeletConfigConfigMapLabel]; ok {
+			KubeletConfigConfigMapCount++
+		}
+	}
+	if KubeletConfigConfigMapCount > 1 {
+		// whether the config provided by the user or by NTO, only a single KubeletConfig ConfigMap allow per NodePool
+		return fmt.Errorf("More than a single KubeletConfig ConfigMap is referred under NodePool %s.\nPlease delete the redundant configs", nodePoolName)
 	}
 	return nil
 }
@@ -145,7 +182,6 @@ func mutateMirroredConfig(cm *corev1.ConfigMap, mirroredConfig *MirrorConfig, no
 	if cm.Labels == nil {
 		cm.Labels = make(map[string]string)
 	}
-	cm.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
 	cm.Labels[hyperv1.NodePoolLabel] = nodePool.GetName()
 	cm.Labels[mirroredConfigLabel] = ""
 	cm.Labels = labels.Merge(cm.Labels, mirroredConfig.Labels)
@@ -326,25 +362,17 @@ func getNTOGeneratedConfig(ctx context.Context, cg *ConfigGenerator) ([]corev1.C
 	return nodeTuningGeneratedConfigs.Items, nil
 }
 
-// BuildMirrorConfigs returns a slice of MirrorConfigs for all the NTO generated config.
+// BuildMirrorConfigs returns a slice of MirrorConfigs for user configs that are supposed
+// to be mirrored to the HCP namespace.
 func BuildMirrorConfigs(ctx context.Context, cg *ConfigGenerator) ([]*MirrorConfig, error) {
-	var configs []corev1.ConfigMap
-	// Look for NTO generated MachineConfigs from the hosted control plane namespace
-	nodeTuningGeneratedConfigs, err := getNTOGeneratedConfig(ctx, cg)
-	if err != nil {
-		return nil, err
-	}
-	configs = append(configs, nodeTuningGeneratedConfigs...)
-
 	userConfig, err := cg.getUserConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}
-	configs = append(configs, userConfig...)
 
 	var errors []error
 	var mirrorConfigs []*MirrorConfig
-	for i, config := range configs {
+	for i, config := range userConfig {
 		cmPayload := config.Data[TokenSecretConfigKey]
 		// ignition config-map payload may contain multiple manifests
 		yamlReader := yaml.NewYAMLReader(bufio.NewReader(strings.NewReader(cmPayload)))
@@ -361,7 +389,7 @@ func BuildMirrorConfigs(ctx context.Context, cg *ConfigGenerator) ([]*MirrorConf
 					continue
 				}
 				if mirrorConfig != nil {
-					mirrorConfig.ConfigMap = &configs[i]
+					mirrorConfig.ConfigMap = &userConfig[i]
 					mirrorConfigs = append(mirrorConfigs, mirrorConfig)
 				}
 			}
@@ -392,7 +420,15 @@ func getMirrorConfigForManifest(manifest []byte) (*MirrorConfig, error) {
 
 	switch cr.(type) {
 	case *mcfgv1.ContainerRuntimeConfig:
-		mirrorConfig = &MirrorConfig{Labels: map[string]string{ContainerRuntimeConfigConfigMapLabel: ""}}
+		mirrorConfig = &MirrorConfig{Labels: map[string]string{
+			ContainerRuntimeConfigConfigMapLabel: "true",
+			mirroredConfigLabel:                  "true",
+		}}
+	case *mcfgv1.KubeletConfig:
+		mirrorConfig = &MirrorConfig{Labels: map[string]string{
+			KubeletConfigConfigMapLabel: "true",
+			mirroredConfigLabel:         "true",
+		}}
 	}
 	return mirrorConfig, err
 }
@@ -402,9 +438,23 @@ func (r *NodePoolReconciler) ntoReconcile(ctx context.Context, nodePool *hyperv1
 
 	mirroredConfigs, err := BuildMirrorConfigs(ctx, configGenerator)
 	if err != nil {
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolValidMachineConfigConditionType,
+			Status:             corev1.ConditionFalse,
+			Reason:             hyperv1.NodePoolValidationFailedReason,
+			Message:            err.Error(),
+			ObservedGeneration: nodePool.Generation,
+		})
 		return fmt.Errorf("failed to build mirror configs: %w", err)
 	}
 	if err := r.reconcileMirroredConfigs(ctx, log, mirroredConfigs, controlPlaneNamespace, nodePool); err != nil {
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolValidMachineConfigConditionType,
+			Status:             corev1.ConditionFalse,
+			Reason:             hyperv1.NodePoolValidationFailedReason,
+			Message:            err.Error(),
+			ObservedGeneration: nodePool.Generation,
+		})
 		return fmt.Errorf("failed to mirror configs: %w", err)
 	}
 

--- a/hypershift-operator/controllers/nodepool/nto_test.go
+++ b/hypershift-operator/controllers/nodepool/nto_test.go
@@ -496,6 +496,17 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 	 containerRuntimeConfig:
 	   defaultRuntime: crun
 	`
+
+	kubeletConfig1 := `
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: KubeletConfig
+    metadata:
+      name: set-max-pods
+    spec:
+      kubeletConfig:
+        maxPods: 100
+`
+
 	hcpNamespace := "hostedcontrolplane-namespace"
 	npNamespace := "nodepool-namespace"
 	npName := "nodepool-test"
@@ -513,6 +524,7 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 		existingConfigsInHcpNs  []client.Object
 		expectedMirroredConfigs []corev1.ConfigMap
 		configsForDeletion      []corev1.ConfigMap
+		expectedError           bool
 	}{
 		{
 			name:                  "with containerruntime",
@@ -546,7 +558,6 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 							nodePoolAnnotation:                   npName,
 							ContainerRuntimeConfigConfigMapLabel: "",
 						},
-						Annotations: map[string]string{nodePoolAnnotation: npNamespace + "/" + npName},
 					},
 					Data: map[string]string{
 						TokenSecretConfigKey: containerRuntimeConfig1,
@@ -596,7 +607,6 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 							nodePoolAnnotation:                   npName,
 							ContainerRuntimeConfigConfigMapLabel: "",
 						},
-						Annotations: map[string]string{nodePoolAnnotation: npNamespace + "/" + npName},
 					},
 					Data: map[string]string{
 						TokenSecretConfigKey: containerRuntimeConfig2,
@@ -615,6 +625,84 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                  "with kubeletconfig objects",
+			nodePool:              np,
+			controlPlaneNamespace: hcpNamespace,
+			configsToBeMirrored: []*MirrorConfig{
+				{
+					ConfigMap: &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: npNamespace,
+						},
+						Data: map[string]string{
+							TokenSecretConfigKey: kubeletConfig1,
+						},
+					},
+					Labels: map[string]string{
+						KubeletConfigConfigMapLabel: "true",
+					},
+				},
+			},
+			existingConfigsInHcpNs: nil,
+			expectedMirroredConfigs: []corev1.ConfigMap{
+				{
+					Immutable: ptr.To(true),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      supportutil.ShortenName("bar", npName, validation.LabelValueMaxLength),
+						Namespace: hcpNamespace,
+						Labels: map[string]string{
+							mirroredConfigLabel:         "",
+							nodePoolAnnotation:          npName,
+							KubeletConfigConfigMapLabel: "true",
+						},
+					},
+					Data: map[string]string{
+						TokenSecretConfigKey: kubeletConfig1,
+					},
+				},
+			},
+		},
+		{
+			name:                  "negative: with multiple kubeletconfig objects expect validation error",
+			nodePool:              np,
+			controlPlaneNamespace: hcpNamespace,
+			configsToBeMirrored: []*MirrorConfig{
+				{
+					ConfigMap: &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: npNamespace,
+						},
+						Data: map[string]string{
+							TokenSecretConfigKey: kubeletConfig1,
+						},
+					},
+					Labels: map[string]string{
+						KubeletConfigConfigMapLabel: "true",
+					},
+				},
+			},
+			existingConfigsInHcpNs: []client.Object{
+				&corev1.ConfigMap{
+					Immutable: ptr.To(true),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      supportutil.ShortenName("bar-2", npName, validation.LabelValueMaxLength),
+						Namespace: hcpNamespace,
+						Labels: map[string]string{
+							nodeTuningGeneratedConfigLabel: "true",
+							nodePoolAnnotation:             npName,
+							KubeletConfigConfigMapLabel:    "true",
+						},
+					},
+					Data: map[string]string{
+						TokenSecretConfigKey: kubeletConfig1,
+					},
+				},
+			},
+			expectedError: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -624,6 +712,10 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 				CreateOrUpdateProvider: upsert.New(true),
 			}
 			err := r.reconcileMirroredConfigs(context.Background(), logr.Discard(), tc.configsToBeMirrored, tc.controlPlaneNamespace, tc.nodePool)
+			if tc.expectedError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
 			g.Expect(err).ToNot(HaveOccurred())
 			for _, config := range tc.expectedMirroredConfigs {
 				cm := &corev1.ConfigMap{}

--- a/hypershift-operator/controllers/nodepool/nto_test.go
+++ b/hypershift-operator/controllers/nodepool/nto_test.go
@@ -554,7 +554,7 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 						Name:      supportutil.ShortenName("foo", npName, validation.LabelValueMaxLength),
 						Namespace: hcpNamespace,
 						Labels: map[string]string{
-							mirroredConfigLabel:                  "",
+							NTOMirroredConfigLabel:               "true",
 							nodePoolAnnotation:                   npName,
 							ContainerRuntimeConfigConfigMapLabel: "",
 						},
@@ -603,7 +603,7 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 						Name:      supportutil.ShortenName("foo", npName, validation.LabelValueMaxLength),
 						Namespace: hcpNamespace,
 						Labels: map[string]string{
-							mirroredConfigLabel:                  "",
+							NTOMirroredConfigLabel:               "true",
 							nodePoolAnnotation:                   npName,
 							ContainerRuntimeConfigConfigMapLabel: "",
 						},
@@ -653,7 +653,7 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 						Name:      supportutil.ShortenName("bar", npName, validation.LabelValueMaxLength),
 						Namespace: hcpNamespace,
 						Labels: map[string]string{
-							mirroredConfigLabel:         "",
+							NTOMirroredConfigLabel:      "true",
 							nodePoolAnnotation:          npName,
 							KubeletConfigConfigMapLabel: "true",
 						},

--- a/test/e2e/nodepool_mirrorconfigs_test.go
+++ b/test/e2e/nodepool_mirrorconfigs_test.go
@@ -63,6 +63,9 @@ func (mc *MirrorConfigsTest) Setup(t *testing.T) {
 	if globalOpts.Platform == hyperv1.OpenStackPlatform {
 		t.Skip("test is being skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
 	}
+	if e2eutil.IsLessThan(e2eutil.Version418) {
+		t.Skip("test only applicable for 4.18+")
+	}
 }
 
 func (mc *MirrorConfigsTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {

--- a/test/e2e/nodepool_mirrorconfigs_test.go
+++ b/test/e2e/nodepool_mirrorconfigs_test.go
@@ -1,0 +1,184 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/google/go-cmp/cmp"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
+	"github.com/openshift/hypershift/support/util"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+)
+
+const (
+	kubeletConfig1 = `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: set-max-pods
+spec:
+  kubeletConfig:
+    maxPods: 100
+`
+)
+
+const (
+	configKey              = "config"
+	configManagedNamespace = "openshift-config-managed"
+)
+
+type MirrorConfigsTest struct {
+	DummyInfraSetup
+	ctx                 context.Context
+	managementClient    crclient.Client
+	hostedClusterClient crclient.Client
+	hostedCluster       *hyperv1.HostedCluster
+}
+
+func NewMirrorConfigsTest(ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hcClient crclient.Client) *MirrorConfigsTest {
+	return &MirrorConfigsTest{
+		ctx:                 ctx,
+		hostedCluster:       hostedCluster,
+		hostedClusterClient: hcClient,
+		managementClient:    mgmtClient,
+	}
+}
+
+func (mc *MirrorConfigsTest) Setup(t *testing.T) {
+	t.Log("Starting test MirrorConfigsTest")
+
+	if globalOpts.Platform == hyperv1.OpenStackPlatform {
+		t.Skip("test is being skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
+	}
+}
+
+func (mc *MirrorConfigsTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mc.hostedCluster.Name + "-" + "test-mirrorconfigs",
+			Namespace: mc.hostedCluster.Namespace,
+		},
+	}
+	defaultNodepool.Spec.DeepCopyInto(&nodePool.Spec)
+	nodePool.Spec.Replicas = &oneReplicas
+
+	return nodePool, nil
+}
+
+func (mc *MirrorConfigsTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
+	t.Log("Entering MirrorConfigs test")
+	ctx := mc.ctx
+
+	KubeletConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kc-test",
+			Namespace: nodePool.Namespace,
+		},
+		Data: map[string]string{configKey: kubeletConfig1},
+	}
+	if err := mc.managementClient.Create(ctx, KubeletConfigMap); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("failed to create configmap for KubeletConfig object: %v", err)
+		}
+	}
+
+	defer func() {
+		if err := mc.managementClient.Delete(ctx, KubeletConfigMap); err != nil {
+			t.Logf("failed to delete configmap for KubeletConfigMap object: %v", err)
+		}
+		t.Log("Exiting MirrorConfigs test: OK")
+	}()
+
+	np := nodePool.DeepCopy()
+	nodePool.Spec.Config = append(nodePool.Spec.Config, corev1.LocalObjectReference{Name: KubeletConfigMap.Name})
+	if err := mc.managementClient.Patch(ctx, &nodePool, crclient.MergeFrom(np)); err != nil {
+		t.Fatalf("failed to update nodepool %s after adding KubeletConfig config: %v", nodePool.Name, err)
+	}
+
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(mc.hostedCluster.Namespace, mc.hostedCluster.Name)
+	t.Logf("Hosted control plane namespace is %s", controlPlaneNamespace)
+
+	e2eutil.EventuallyObjects(t, ctx, "kubeletConfig should be mirrored and present in the hosted cluster",
+		func(ctx context.Context) ([]*corev1.ConfigMap, error) {
+			list := &corev1.ConfigMapList{}
+			err := mc.hostedClusterClient.List(ctx, list, crclient.InNamespace(configManagedNamespace),
+				crclient.MatchingLabels(map[string]string{
+					nodepool.KubeletConfigConfigMapLabel: "true",
+					hyperv1.NodePoolLabel:                nodePool.Name,
+				}))
+			configMaps := make([]*corev1.ConfigMap, len(list.Items))
+			for i := range list.Items {
+				configMaps[i] = &list.Items[i]
+			}
+			return configMaps, err
+		},
+		[]e2eutil.Predicate[[]*corev1.ConfigMap]{
+			func(configMaps []*corev1.ConfigMap) (done bool, reasons string, err error) {
+				want, got := 1, len(configMaps)
+				return want == got, fmt.Sprintf("expected %d kubelet config ConfigMaps, got %d", want, got), nil
+			},
+		},
+		[]e2eutil.Predicate[*corev1.ConfigMap]{
+			func(configMap *corev1.ConfigMap) (done bool, reasons string, err error) {
+				if want, got := util.ShortenName(KubeletConfigMap.Name, nodePool.Name, nodepool.QualifiedNameMaxLength), configMap.Name; want != got {
+					return false, fmt.Sprintf("expected kubelet config ConfigMap name to be '%s', got '%s'", want, got), nil
+				}
+				return true, fmt.Sprintf("kubelet config ConfigMap name is as expected"), nil
+			},
+			func(configMap *corev1.ConfigMap) (done bool, reasons string, err error) {
+				if diff := cmp.Diff(map[string]string{
+					nodepool.KubeletConfigConfigMapLabel: configMap.Labels[nodepool.KubeletConfigConfigMapLabel],
+					hyperv1.NodePoolLabel:                configMap.Labels[hyperv1.NodePoolLabel],
+					nodepool.NTOMirroredConfigLabel:      configMap.Labels[nodepool.NTOMirroredConfigLabel],
+				}, map[string]string{
+					nodepool.KubeletConfigConfigMapLabel: "true",
+					hyperv1.NodePoolLabel:                nodePool.Name,
+					nodepool.NTOMirroredConfigLabel:      "true",
+				}); diff != "" {
+					return false, fmt.Sprintf("incorrect labels: %v", diff), nil
+				}
+				return true, "labels are correct", nil
+			},
+		},
+	)
+
+	t.Log("Deleting KubeletConfig configmap reference from nodepool ...")
+	baseNP := nodePool.DeepCopy()
+	nodePool.Spec = np.Spec
+	if err := mc.managementClient.Patch(ctx, &nodePool, crclient.MergeFrom(baseNP)); err != nil {
+		t.Fatalf("failed to update nodepool %s after removing KubeletConfig configmap: %v", nodePool.Name, err)
+	}
+	e2eutil.EventuallyObjects(t, ctx, "KubeletConfig configmap to be deleted",
+		func(ctx context.Context) ([]*corev1.ConfigMap, error) {
+			list := &corev1.ConfigMapList{}
+			err := mc.hostedClusterClient.List(ctx, list, crclient.InNamespace(configManagedNamespace), crclient.MatchingLabels(map[string]string{
+				nodepool.KubeletConfigConfigMapLabel: "true",
+				hyperv1.NodePoolLabel:                nodePool.Name,
+			}))
+			configMaps := make([]*corev1.ConfigMap, len(list.Items))
+			for i := range list.Items {
+				configMaps[i] = &list.Items[i]
+			}
+			return configMaps, err
+		},
+		[]e2eutil.Predicate[[]*corev1.ConfigMap]{
+			func(configMaps []*corev1.ConfigMap) (done bool, reasons string, err error) {
+				want, got := 0, len(configMaps)
+				return want == got, fmt.Sprintf("expected %d KubeletConfig configmap, got %d", want, got), nil
+			},
+		}, nil,
+	)
+}

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -121,6 +121,10 @@ func TestNodePool(t *testing.T) {
 						name: "OpenStackAZTest",
 						test: NewOpenStackAZTest(ctx, mgtClient, hostedCluster),
 					},
+					{
+						name: "TestMirrorConfigs",
+						test: NewMirrorConfigsTest(ctx, mgtClient, hostedCluster, hostedClusterClient),
+					},
 				}
 			},
 		},

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1296,7 +1296,7 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 	t.Run("EnsureValidatingAdmissionPoliciesExists", func(t *testing.T) {
 		AtLeast(t, Version418)
 		t.Log("Waiting for ValidatingAdmissionPolicies to exist")
-		var expectedVAPCount int = 4
+		var expectedVAPCount = 5
 		g := NewWithT(t)
 		start := time.Now()
 		var validatingAdmissionPolicies k8sadmissionv1beta1.ValidatingAdmissionPolicyList
@@ -1331,7 +1331,9 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 			case hccokasvap.AdmissionPolicyNameICSP:
 				g.Expect(vap.Name).To(Equal(hccokasvap.AdmissionPolicyNameICSP), fmt.Sprintf("ValidatingAdmissionPolicy %s not found in the list", hccokasvap.AdmissionPolicyNameICSP))
 			case hccokasvap.AdmissionPolicyNameInfra:
-				g.Expect(vap.Name).To(Equal(hccokasvap.AdmissionPolicyNameInfra), fmt.Sprintf("ValidatingAdmissionPolicy %s not found in the list", hccokasvap.AdmissionPolicyNameICSP))
+				g.Expect(vap.Name).To(Equal(hccokasvap.AdmissionPolicyNameInfra), fmt.Sprintf("ValidatingAdmissionPolicy %s not found in the list", hccokasvap.AdmissionPolicyNameInfra))
+			case hccokasvap.AdmissionPolicyNameNTOMirroredConfigs:
+				g.Expect(vap.Name).To(Equal(hccokasvap.AdmissionPolicyNameNTOMirroredConfigs), fmt.Sprintf("ValidatingAdmissionPolicy %s not found in the list", hccokasvap.AdmissionPolicyNameNTOMirroredConfigs))
 			default:
 				t.Errorf("Unexpected ValidatingAdmissionPolicy %s found in the list", vap.Name)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding capability for HCCO to copy KubeletConfig objects to the Hosted-Cluster in a ConfigMap.
This is needed for a day-2 operators like NUMA-Resources-Operator to function properly.

Implementation of enhancement: https://github.com/openshift/enhancements/blob/master/enhancements/hypershift/topology-aware-scheduling/topology-aware-scheduling.md 


- [x]  Implemetation
- [x] Unit-tests
- [x] E2e-tests

**Which issue(s) this PR fixes** 
Fixes: [CNF-14742](https://issues.redhat.com/browse/CNF-14742)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.