### PR TITLE
OSASINFRA-3644: openstack: allow to pre-define a floating IP for Ingress router-default

### DIFF
--- a/api/hypershift/v1beta1/openstack.go
+++ b/api/hypershift/v1beta1/openstack.go
@@ -123,6 +123,19 @@ type OpenStackPlatformSpec struct {
 	// +listType=set
 	// +optional
 	Tags []string `json:"tags,omitempty"`
+
+	// IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+	// be associated with the OpenShift ingress port.
+	// When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+	// When specified, the floating IP has to be pre-created.  If the
+	// specified value is not a floating IP or is already claimed, the
+	// OpenStack cloud provider won't be able to provision the load
+	// balancer.
+	// This value must be a valid IPv4 or IPv6 address.
+	//
+	// +kubebuilder:validation:XValidation:rule="isIP(self)",message="floatingIP must be a valid IPv4 or IPv6 address"
+	// +optional
+	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
 }
 
 // OpenStackIdentityReference is a reference to an infrastructure

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -3423,6 +3423,20 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      ingressFloatingIP:
+                        description: |-
+                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                          be associated with the OpenShift ingress port.
+                          When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                          When specified, the floating IP has to be pre-created.  If the
+                          specified value is not a floating IP or is already claimed, the
+                          OpenStack cloud provider won't be able to provision the load
+                          balancer.
+                          This value must be a valid IPv4 or IPv6 address.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: floatingIP must be a valid IPv4 or IPv6 address
+                          rule: isIP(self)
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -3312,6 +3312,20 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      ingressFloatingIP:
+                        description: |-
+                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                          be associated with the OpenShift ingress port.
+                          When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                          When specified, the floating IP has to be pre-created.  If the
+                          specified value is not a floating IP or is already claimed, the
+                          OpenStack cloud provider won't be able to provision the load
+                          balancer.
+                          This value must be a valid IPv4 or IPv6 address.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: floatingIP must be a valid IPv4 or IPv6 address
+                          rule: isIP(self)
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
@@ -29,6 +29,7 @@ type OpenStackPlatformSpecApplyConfiguration struct {
 	ExternalNetwork        *NetworkParamApplyConfiguration               `json:"externalNetwork,omitempty"`
 	DisableExternalNetwork *bool                                         `json:"disableExternalNetwork,omitempty"`
 	Tags                   []string                                      `json:"tags,omitempty"`
+	IngressFloatingIP      *string                                       `json:"ingressFloatingIP,omitempty"`
 }
 
 // OpenStackPlatformSpecApplyConfiguration constructs an declarative configuration of the OpenStackPlatformSpec type for use with
@@ -118,5 +119,13 @@ func (b *OpenStackPlatformSpecApplyConfiguration) WithTags(values ...string) *Op
 	for i := range values {
 		b.Tags = append(b.Tags, values[i])
 	}
+	return b
+}
+
+// WithIngressFloatingIP sets the IngressFloatingIP field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the IngressFloatingIP field is set to the value of the last call.
+func (b *OpenStackPlatformSpecApplyConfiguration) WithIngressFloatingIP(value string) *OpenStackPlatformSpecApplyConfiguration {
+	b.IngressFloatingIP = &value
 	return b
 }

--- a/cmd/cluster/openstack/create.go
+++ b/cmd/cluster/openstack/create.go
@@ -42,6 +42,7 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.OpenStackCloud, "openstack-cloud", opts.OpenStackCloud, "Name of the cloud in clouds.yaml (optional) (default: 'openstack')")
 	flags.StringVar(&opts.OpenStackCACertFile, "openstack-ca-cert-file", opts.OpenStackCACertFile, "Path to the OpenStack CA certificate file (optional)")
 	flags.StringVar(&opts.OpenStackExternalNetworkID, "openstack-external-network-id", opts.OpenStackExternalNetworkID, "ID of the OpenStack external network (optional)")
+	flags.StringVar(&opts.OpenStackIngressFloatingIP, "openstack-ingress-floating-ip", opts.OpenStackIngressFloatingIP, "An available floating IP in your OpenStack cluster that will be associated with the OpenShift ingress port (optional)")
 }
 
 type RawCreateOptions struct {
@@ -49,6 +50,7 @@ type RawCreateOptions struct {
 	OpenStackCloud             string
 	OpenStackCACertFile        string
 	OpenStackExternalNetworkID string
+	OpenStackIngressFloatingIP string
 
 	NodePoolOpts *openstacknodepool.RawOpenStackPlatformCreateOptions
 }
@@ -161,6 +163,10 @@ func (o *RawCreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster
 		cluster.Spec.Platform.OpenStack.ExternalNetwork = &hyperv1.NetworkParam{
 			ID: &o.OpenStackExternalNetworkID,
 		}
+	}
+
+	if o.OpenStackIngressFloatingIP != "" {
+		cluster.Spec.Platform.OpenStack.IngressFloatingIP = o.OpenStackIngressFloatingIP
 	}
 
 	cluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(cluster.Spec.Networking.NetworkType, false)

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -4074,6 +4074,20 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      ingressFloatingIP:
+                        description: |-
+                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                          be associated with the OpenShift ingress port.
+                          When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                          When specified, the floating IP has to be pre-created.  If the
+                          specified value is not a floating IP or is already claimed, the
+                          OpenStack cloud provider won't be able to provision the load
+                          balancer.
+                          This value must be a valid IPv4 or IPv6 address.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: floatingIP must be a valid IPv4 or IPv6 address
+                          rule: isIP(self)
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -4074,6 +4074,20 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      ingressFloatingIP:
+                        description: |-
+                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                          be associated with the OpenShift ingress port.
+                          When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                          When specified, the floating IP has to be pre-created.  If the
+                          specified value is not a floating IP or is already claimed, the
+                          OpenStack cloud provider won't be able to provision the load
+                          balancer.
+                          This value must be a valid IPv4 or IPv6 address.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: floatingIP must be a valid IPv4 or IPv6 address
+                          rule: isIP(self)
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3963,6 +3963,20 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      ingressFloatingIP:
+                        description: |-
+                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                          be associated with the OpenShift ingress port.
+                          When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                          When specified, the floating IP has to be pre-created.  If the
+                          specified value is not a floating IP or is already claimed, the
+                          OpenStack cloud provider won't be able to provision the load
+                          balancer.
+                          This value must be a valid IPv4 or IPv6 address.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: floatingIP must be a valid IPv4 or IPv6 address
+                          rule: isIP(self)
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -3963,6 +3963,20 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      ingressFloatingIP:
+                        description: |-
+                          IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+                          be associated with the OpenShift ingress port.
+                          When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                          When specified, the floating IP has to be pre-created.  If the
+                          specified value is not a floating IP or is already claimed, the
+                          OpenStack cloud provider won't be able to provision the load
+                          balancer.
+                          This value must be a valid IPv4 or IPv6 address.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: floatingIP must be a valid IPv4 or IPv6 address
+                          rule: isIP(self)
                       managedSubnets:
                         description: |-
                           ManagedSubnets describe the OpenStack Subnet to be created. Cluster actuator will create a network,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/params.go
@@ -15,6 +15,7 @@ type IngressParams struct {
 	IBMCloudUPI       bool
 	AWSNLB            bool
 	LoadBalancerScope v1.LoadBalancerScope
+	LoadBalancerIP    string
 }
 
 func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
@@ -22,6 +23,7 @@ func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 	isPrivate := false
 	ibmCloudUPI := false
 	nlb := false
+	var loadBalancerIP string
 	loadBalancerScope := v1.ExternalLoadBalancer
 	if hcp.Spec.Platform.IBMCloud != nil && hcp.Spec.Platform.IBMCloud.ProviderType == configv1.IBMCloudProviderTypeUPI {
 		ibmCloudUPI = true
@@ -41,6 +43,9 @@ func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 			loadBalancerScope = v1.InternalLoadBalancer
 		}
 	}
+	if hcp.Spec.Platform.OpenStack != nil && hcp.Spec.Platform.OpenStack.IngressFloatingIP != "" {
+		loadBalancerIP = hcp.Spec.Platform.OpenStack.IngressFloatingIP
+	}
 
 	return &IngressParams{
 		IngressSubdomain:  globalconfig.IngressDomain(hcp),
@@ -50,5 +55,6 @@ func NewIngressParams(hcp *hyperv1.HostedControlPlane) *IngressParams {
 		IBMCloudUPI:       ibmCloudUPI,
 		AWSNLB:            nlb,
 		LoadBalancerScope: loadBalancerScope,
+		LoadBalancerIP:    loadBalancerIP,
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
@@ -24,6 +24,7 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 		inputIsPrivate            bool
 		inputIsNLB                bool
 		inputLoadBalancerScope    operatorv1.LoadBalancerScope
+		inputLoadBalancerIP       string
 		expectedIngressController *operatorv1.IngressController
 	}{
 		{
@@ -284,11 +285,42 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                   "OpenStack uses Loadbalancer publishing strategy with a floating IP",
+			inputIngressController: manifests.IngressDefaultIngressController(),
+			inputIngressDomain:     fakeIngressDomain,
+			inputPlatformType:      hyperv1.OpenStackPlatform,
+			inputReplicas:          fakeInputReplicas,
+			inputIsIBMCloudUPI:     false,
+			inputIsPrivate:         false,
+			inputLoadBalancerIP:    "1.2.3.4",
+			expectedIngressController: &operatorv1.IngressController{
+				ObjectMeta: manifests.IngressDefaultIngressController().ObjectMeta,
+				Spec: operatorv1.IngressControllerSpec{
+					Domain:   fakeIngressDomain,
+					Replicas: &fakeInputReplicas,
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
+								Type: operatorv1.OpenStackLoadBalancerProvider,
+								OpenStack: &operatorv1.OpenStackLoadBalancerParameters{
+									FloatingIP: "1.2.3.4",
+								},
+							},
+						},
+					},
+					DefaultCertificate: &corev1.LocalObjectReference{
+						Name: manifests.IngressDefaultIngressControllerCert().Name,
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			err := ReconcileDefaultIngressController(tc.inputIngressController, tc.inputIngressDomain, tc.inputPlatformType, tc.inputReplicas, tc.inputIsIBMCloudUPI, tc.inputIsPrivate, tc.inputIsNLB, tc.inputLoadBalancerScope)
+			err := ReconcileDefaultIngressController(tc.inputIngressController, tc.inputIngressDomain, tc.inputPlatformType, tc.inputReplicas, tc.inputIsIBMCloudUPI, tc.inputIsPrivate, tc.inputIsNLB, tc.inputLoadBalancerScope, tc.inputLoadBalancerIP)
 			g.Expect(err).To(BeNil())
 			g.Expect(tc.inputIngressController).To(BeEquivalentTo(tc.expectedIngressController))
 		})

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
@@ -3,12 +3,16 @@ package ingress
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 )
 
 func TestReconcileDefaultIngressController(t *testing.T) {
@@ -285,37 +289,6 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:                   "OpenStack uses Loadbalancer publishing strategy with a floating IP",
-			inputIngressController: manifests.IngressDefaultIngressController(),
-			inputIngressDomain:     fakeIngressDomain,
-			inputPlatformType:      hyperv1.OpenStackPlatform,
-			inputReplicas:          fakeInputReplicas,
-			inputIsIBMCloudUPI:     false,
-			inputIsPrivate:         false,
-			inputLoadBalancerIP:    "1.2.3.4",
-			expectedIngressController: &operatorv1.IngressController{
-				ObjectMeta: manifests.IngressDefaultIngressController().ObjectMeta,
-				Spec: operatorv1.IngressControllerSpec{
-					Domain:   fakeIngressDomain,
-					Replicas: &fakeInputReplicas,
-					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
-						Type: operatorv1.LoadBalancerServiceStrategyType,
-						LoadBalancer: &operatorv1.LoadBalancerStrategy{
-							ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
-								Type: operatorv1.OpenStackLoadBalancerProvider,
-								OpenStack: &operatorv1.OpenStackLoadBalancerParameters{
-									FloatingIP: "1.2.3.4",
-								},
-							},
-						},
-					},
-					DefaultCertificate: &corev1.LocalObjectReference{
-						Name: manifests.IngressDefaultIngressControllerCert().Name,
-					},
-				},
-			},
-		},
 	}
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -324,5 +297,46 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 			g.Expect(err).To(BeNil())
 			g.Expect(tc.inputIngressController).To(BeEquivalentTo(tc.expectedIngressController))
 		})
+	}
+}
+
+func TestReconcileOpenStackDefaultIngressController(t *testing.T) {
+	ingressController := manifests.IngressDefaultIngressControllerAsUnstructured()
+	if err := ReconcileOpenStackDefaultIngressController(ingressController, "example.com", 1, false, operatorv1.ExternalLoadBalancer, "1.2.3.4"); err != nil {
+		t.Errorf("unexpected: %v", err)
+	}
+	typedIngressController := &operatorv1.IngressController{}
+	expected := &operatorv1.IngressController{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "IngressController",
+			APIVersion: operatorv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      manifests.IngressDefaultIngressController().Name,
+			Namespace: manifests.IngressDefaultIngressController().Namespace,
+		},
+		Spec: operatorv1.IngressControllerSpec{
+			Domain:   "example.com",
+			Replicas: ptr.To[int32](1),
+			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+				Type: operatorv1.LoadBalancerServiceStrategyType,
+				LoadBalancer: &operatorv1.LoadBalancerStrategy{
+					Scope: operatorv1.ExternalLoadBalancer,
+				},
+			},
+			DefaultCertificate: &corev1.LocalObjectReference{
+				Name: "default-ingress-cert",
+			},
+		},
+	}
+
+	// Before converting, remove extra field from provider parameters, since it does not exist in type yet
+	unstructured.RemoveNestedField(ingressController.Object, "spec", "endpointPublishingStrategy", "loadBalancer", "providerParameters")
+
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(ingressController.Object, typedIngressController); err != nil {
+		t.Errorf("unexpected: %v", err)
+	}
+	if diff := cmp.Diff(typedIngressController, expected); diff != "" {
+		t.Errorf("IngressController does not match expected:\n%s", diff)
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -15,6 +16,16 @@ func IngressDefaultIngressController() *operatorv1.IngressController {
 			Namespace: "openshift-ingress-operator",
 		},
 	}
+}
+
+func IngressDefaultIngressControllerAsUnstructured() *unstructured.Unstructured {
+	src := IngressDefaultIngressController()
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(operatorv1.GroupVersion.String())
+	obj.SetKind("IngressController")
+	obj.SetName(src.Name)
+	obj.SetNamespace(src.Namespace)
+	return obj
 }
 
 func IngressDefaultIngressControllerCert() *corev1.Secret {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -978,7 +978,7 @@ func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv
 	p := ingress.NewIngressParams(hcp)
 	ingressController := manifests.IngressDefaultIngressController()
 	if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
-		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, p.IBMCloudUPI, p.IsPrivate, p.AWSNLB, p.LoadBalancerScope)
+		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, p.IBMCloudUPI, p.IsPrivate, p.AWSNLB, p.LoadBalancerScope, p.LoadBalancerIP)
 	}); err != nil {
 		errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -976,11 +976,23 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	var errs []error
 	p := ingress.NewIngressParams(hcp)
-	ingressController := manifests.IngressDefaultIngressController()
-	if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
-		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, p.IBMCloudUPI, p.IsPrivate, p.AWSNLB, p.LoadBalancerScope, p.LoadBalancerIP)
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
+
+	// This is a workaround until we bump openshift/api which has the floatingIP field in the IngessControllerSpec
+	// TODO (cewong): Remove this when updated openshift/api is vendored
+	if hcp.Spec.Platform.Type == hyperv1.OpenStackPlatform {
+		ingressController := manifests.IngressDefaultIngressControllerAsUnstructured()
+		if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
+			return ingress.ReconcileOpenStackDefaultIngressController(ingressController, p.IngressSubdomain, p.Replicas, p.IsPrivate, p.LoadBalancerScope, p.LoadBalancerIP)
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile openstack default ingress controller: %w", err))
+		}
+	} else {
+		ingressController := manifests.IngressDefaultIngressController()
+		if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
+			return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, p.IBMCloudUPI, p.IsPrivate, p.AWSNLB, p.LoadBalancerScope, p.LoadBalancerIP)
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
+		}
 	}
 
 	sourceCert := cpomanifests.IngressCert(hcp.Namespace)

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -8966,6 +8966,25 @@ to an external network is not possible or desirable, e.g. if using a provider ne
 <p>Tags to set on all resources in cluster which support tags</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>ingressFloatingIP</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+be associated with the OpenShift ingress port.
+When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+When specified, the floating IP has to be pre-created.  If the
+specified value is not a floating IP or is already claimed, the
+OpenStack cloud provider won&rsquo;t be able to provision the load
+balancer.
+This value must be a valid IPv4 or IPv6 address.</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###PayloadArchType { #hypershift.openshift.io/v1beta1.PayloadArchType }

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
@@ -123,6 +123,19 @@ type OpenStackPlatformSpec struct {
 	// +listType=set
 	// +optional
 	Tags []string `json:"tags,omitempty"`
+
+	// IngressFloatingIP is an available floating IP in your OpenStack cluster that will
+	// be associated with the OpenShift ingress port.
+	// When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+	// When specified, the floating IP has to be pre-created.  If the
+	// specified value is not a floating IP or is already claimed, the
+	// OpenStack cloud provider won't be able to provision the load
+	// balancer.
+	// This value must be a valid IPv4 or IPv6 address.
+	//
+	// +kubebuilder:validation:XValidation:rule="isIP(self)",message="floatingIP must be a valid IPv4 or IPv6 address"
+	// +optional
+	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
 }
 
 // OpenStackIdentityReference is a reference to an infrastructure


### PR DESCRIPTION
**What this PR does / why we need it**:

Leverage a new feature in the Cluster Ingress Operator where we can now pre-define a floating IP for the Default Ingress Controller.
This will allow customers to pre-create a floating IP, update their DNS and then deploy a HostedCluster. This floating IP will be the load balancer IP for the `router-default` Service created by the Ingress controller.

Feature: [OSASINFRA-3644](https://issues.redhat.com//browse/OSASINFRA-3644)

Note: this contains a workaround commit that will be reverted as soon as we bump openshift/api here.