### PR TITLE
NO-JIRA: e2e: skip ValidKubeVirtInfraNetworkMTU condition check on 4.14 and ea…

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1592,6 +1592,10 @@ func validateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
 		delete(expectedConditions, hyperv1.KubeVirtNodesLiveMigratable)
 	}
+	if IsLessThan(Version415) {
+		// ValidKubeVirtInfraNetworkMTU condition is not present in versions < 4.15
+		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
+	}
 
 	var predicates []Predicate[*hyperv1.HostedCluster]
 	for conditionType, conditionStatus := range expectedConditions {


### PR DESCRIPTION
4.14 kubevirt presubs are failing with
```
eventually.go:220: observed *v1beta1.HostedCluster e2e-clusters-qlpcv/example-5sdbz invalid at RV 90020 after 10m0s: missing condition: wanted ValidKubeVirtInfraNetworkMTU=True, did not find condition of this type
```
This condition was added in 4.15 and shouldn't be checked on earlier releases.