### PR TITLE
OCPBUGS-42579: Add network policies for konnectivity server and ignition server proxy

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -151,6 +151,13 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 				}); err != nil {
 					return fmt.Errorf("failed to reconcile ignition nodeport network policy: %w", err)
 				}
+				// Reconcile nodeport-ignition-proxy Network Policy
+				policy = networkpolicy.NodePortIgnitionProxyNetworkPolicy(controlPlaneNamespaceName)
+				if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
+					return reconcileNodePortIgnitionProxyNetworkPolicy(policy, hcluster)
+				}); err != nil {
+					return fmt.Errorf("failed to reconcile ignition proxy nodeport network policy: %w", err)
+				}
 			}
 		case hyperv1.Konnectivity:
 			if svc.ServicePublishingStrategy.Type == hyperv1.NodePort {
@@ -161,6 +168,15 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 				}); err != nil {
 					return fmt.Errorf("failed to reconcile konnectivity nodeport network policy: %w", err)
 				}
+
+				// Reconcile nodeport-konnectivity Network Policy when konnectivity is hosted in the kas pod
+				policy = networkpolicy.NodePortKonnectivityKASNetworkPolicy(controlPlaneNamespaceName)
+				if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
+					return reconcileNodePortKonnectivityKASNetworkPolicy(policy, hcluster)
+				}); err != nil {
+					return fmt.Errorf("failed to reconcile konnectivity nodeport network policy: %w", err)
+				}
+
 			}
 		}
 	}
@@ -357,6 +373,29 @@ func reconcileNodePortOauthNetworkPolicy(policy *networkingv1.NetworkPolicy, hcl
 	return nil
 }
 
+func reconcileNodePortIgnitionProxyNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster) error {
+	port := intstr.FromInt(8443)
+	protocol := corev1.ProtocolTCP
+	policy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+		{
+			From: []networkingv1.NetworkPolicyPeer{},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Port:     &port,
+					Protocol: &protocol,
+				},
+			},
+		},
+	}
+	policy.Spec.PodSelector = metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": "ignition-server-proxy",
+		},
+	}
+	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
+	return nil
+}
+
 func reconcileNodePortIgnitionNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster) error {
 	port := intstr.FromInt(9090)
 	protocol := corev1.ProtocolTCP
@@ -374,6 +413,29 @@ func reconcileNodePortIgnitionNetworkPolicy(policy *networkingv1.NetworkPolicy, 
 	policy.Spec.PodSelector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"app": "ignition-server",
+		},
+	}
+	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
+	return nil
+}
+
+func reconcileNodePortKonnectivityKASNetworkPolicy(policy *networkingv1.NetworkPolicy, hcluster *hyperv1.HostedCluster) error {
+	port := intstr.FromInt(8091)
+	protocol := corev1.ProtocolTCP
+	policy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+		{
+			From: []networkingv1.NetworkPolicyPeer{},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Port:     &port,
+					Protocol: &protocol,
+				},
+			},
+		},
+	}
+	policy.Spec.PodSelector = metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": "kube-apiserver",
 		},
 	}
 	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}

--- a/hypershift-operator/controllers/manifests/networkpolicy/manifests.go
+++ b/hypershift-operator/controllers/manifests/networkpolicy/manifests.go
@@ -95,11 +95,29 @@ func NodePortIgnitionNetworkPolicy(namespace string) *networkingv1.NetworkPolicy
 	}
 }
 
+func NodePortIgnitionProxyNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "nodeport-ignition-proxy",
+		},
+	}
+}
+
 func NodePortKonnectivityNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      "nodeport-konnectivity",
+		},
+	}
+}
+
+func NodePortKonnectivityKASNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "nodeport-konnectivity-kas",
 		},
 	}
 }


### PR DESCRIPTION
This fixes two issues that impact HCP with the NodePort publishing strategy.

1. The konnectivity server component has moved in and out of the kas pod throughout several releases. The result is, some releases have network policies that allow connections to the konnectivity server, and others do not. To account for this, the hypershift operator needs to support both when the konnectivity server is in the kas pod and when it is outside of the pod.

This is resolved by adding a new network policy that allows access to the konnectivity server when it is hosted within the kas pod (which is how this is currently deployed in 4.17)

2. Nodes currently can't access the ignition proxy to retrieve their configs. This is resolved by adding a network policy for the ignition proxy.

