### PR TITLE
NO-JIRA: disable ensurePSANotPrivileged test on <4.17

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -638,6 +638,7 @@ func EnsureMachineDeploymentGeneration(t *testing.T, ctx context.Context, hostCl
 
 func EnsurePSANotPrivileged(t *testing.T, ctx context.Context, guestClient crclient.Client) {
 	t.Run("EnsurePSANotPrivileged", func(t *testing.T) {
+		AtLeast(t, Version417)
 		testNamespaceName := "e2e-psa-check"
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**: disables the ensurePSANotPrivileged test on 4.16 as we use privileged instead of restricted ref https://github.com/openshift/hypershift/pull/4193

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.