### PR TITLE
OCPBUGS-42737: add nil check to etcdRecoveryActiveCondition when coll…

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -473,7 +473,7 @@ func (c *hostedClustersMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 				if metricLabels["cluster_type"] == "rosa" {
 					etcdRecoveryActiveCondition := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.EtcdRecoveryActive))
-					if etcdRecoveryActiveCondition.Status == metav1.ConditionFalse && etcdRecoveryActiveCondition.Reason == hyperv1.EtcdRecoveryJobFailedReason {
+					if etcdRecoveryActiveCondition != nil && etcdRecoveryActiveCondition.Status == metav1.ConditionFalse && etcdRecoveryActiveCondition.Reason == hyperv1.EtcdRecoveryJobFailedReason {
 						etcdManualInterventionRequiredValue := 1.0
 						ch <- prometheus.MustNewConstMetric(
 							etcdManualInterventionRequiredMetricDesc,
@@ -481,7 +481,6 @@ func (c *hostedClustersMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 							etcdManualInterventionRequiredValue,
 							append(hclusterLabelValues, metricLabels["rosa_environment"], metricLabels["rosa_id"])...,
 						)
-
 					}
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**: currently HO crashes due to nil pointer  on upgrades because we try to retrieve a status condition when its not available.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-42737](https://issues.redhat.com/browse/OCPBUGS-42737)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.