### PR TITLE
NO-JIRA: Fixes kubevirt image cacher

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt.go
@@ -10,6 +10,22 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func (r *NodePoolReconciler) addKubeVirtCacheNameToStatus(kubevirtBootImage kubevirt.BootImage, nodePool *hyperv1.NodePool) {
+	if namer, ok := kubevirtBootImage.(kubevirt.BootImageNamer); ok {
+		if cacheName := namer.GetCacheName(); len(cacheName) > 0 {
+			if nodePool.Status.Platform == nil {
+				nodePool.Status.Platform = &hyperv1.NodePoolPlatformStatus{}
+			}
+
+			if nodePool.Status.Platform.KubeVirt == nil {
+				nodePool.Status.Platform.KubeVirt = &hyperv1.KubeVirtNodePoolStatus{}
+			}
+
+			nodePool.Status.Platform.KubeVirt.CacheName = cacheName
+		}
+	}
+}
+
 func (r *NodePoolReconciler) setKubevirtConditions(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, releaseImage *releaseinfo.ReleaseImage) error {
 	// moved KubeVirt specific handling up here, so the caching of the boot image will start as early as possible
 	// in order to actually save time. Caching form the original location will take more time, because the VMs can't

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -899,22 +899,6 @@ func (r *NodePoolReconciler) setCIDRConflictCondition(nodePool *hyperv1.NodePool
 	return nil
 }
 
-func (r *NodePoolReconciler) addKubeVirtCacheNameToStatus(kubevirtBootImage kubevirt.BootImage, nodePool *hyperv1.NodePool) {
-	if namer, ok := kubevirtBootImage.(kubevirt.BootImageNamer); ok {
-		if cacheName := namer.GetCacheName(); len(cacheName) > 0 {
-			if nodePool.Status.Platform == nil {
-				nodePool.Status.Platform = &hyperv1.NodePoolPlatformStatus{}
-			}
-
-			if nodePool.Status.Platform.KubeVirt == nil {
-				nodePool.Status.Platform.KubeVirt = &hyperv1.KubeVirtNodePoolStatus{}
-			}
-
-			nodePool.Status.Platform.KubeVirt.CacheName = cacheName
-		}
-	}
-}
-
 // createReachedIgnitionEndpointCondition creates a condition for the NodePool based on the tokenSecret data.
 func (r NodePoolReconciler) createReachedIgnitionEndpointCondition(ctx context.Context, tokenSecret *corev1.Secret, generation int64) (*hyperv1.NodePoolCondition, error) {
 	var condition *hyperv1.NodePoolCondition


### PR DESCRIPTION
This fixes a regression to the kubevirt provider that was introduced sept 26th by some nodepool refactoring PRs, https://github.com/openshift/hypershift/pull/4795 and https://github.com/openshift/hypershift/pull/4823 