### PR TITLE
OSASINFRA-3623: openstack: Only upload required cloud credentials

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
@@ -54,6 +54,8 @@ func getCloudConfig(externalNetworkID *string, cloudName string, credentialsSecr
 	config += "use-clouds = true\n"
 	config += "clouds-file=" + CloudCredentialsDir + "/" + CloudsSecretKey + "\n"
 	config += "cloud=" + cloudName + "\n"
+	// This takes priority over the 'cacert' value in 'clouds.yaml' and we therefore
+	// unset then when creating the initial secret.
 	if caCertData != nil {
 		config += "ca-file=" + CaDir + "/" + CABundleKey + "\n"
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

A `clouds.yaml` can contain multiple "clouds" or sets of credentials. If you provide a `clouds.yaml` with more than one entry, we should only use the relevant entry in our cloud credentials secret. Start doing this by building our own `clouds.yaml` with only a single entry. This also allows us to start doing other smart (TM) things, like using the `cacert` value in a cloud rather than insisting users provide this manually.
