### PR TITLE
NO-JIRA: Remove EnsurePSANotPrivileged check

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -129,7 +129,6 @@ func TestCreateClusterRequestServingIsolation(t *testing.T) {
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		guestClient := e2eutil.WaitForGuestClient(t, testContext, mgtClient, hostedCluster)
-		e2eutil.EnsurePSANotPrivileged(t, ctx, guestClient)
 		e2eutil.EnsureAllReqServingPodsLandOnReqServingNodes(t, ctx, guestClient)
 		e2eutil.EnsureOnlyRequestServingPodsOnRequestServingNodes(t, ctx, guestClient)
 		e2eutil.EnsureNoHCPPodsLandOnDefaultNode(t, ctx, guestClient, hostedCluster)


### PR DESCRIPTION
**What this PR does / why we need it**:
OpenShiftPodSecurityAdmission feature gate is not enabled by default in 4.17 any longer. We need to stop enforcing that PSA is privileged

https://github.com/openshift/api/blob/release-4.17/features/features.go
https://github.com/openshift/api/pull/2018

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.