### PR TITLE
OCPBUGS-42783: Use guest DNS resolution in Konnectivity HTTPS proxy by default

### DIFF
--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -40,7 +40,8 @@ func NewStartCommand() *cobra.Command {
 	}
 
 	opts := konnectivityproxy.Options{
-		ResolveBeforeDial: true,
+		ResolveBeforeDial:          true,
+		ResolveFromGuestClusterDNS: true,
 	}
 
 	var servingPort uint32


### PR DESCRIPTION
**What this PR does / why we need it**:
When sending traffic through konnectivity (whether proxied or not) we need dns names to be resolved by the data plane. This change ensures we do that (not only for internal service names).

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-42783](https://issues.redhat.com/browse/OCPBUGS-42783)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.