### PR TITLE
HOSTEDCP-1994: Create separate secrets for Azure disk and file

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
@@ -25,3 +25,21 @@ func AzureProviderConfigWithCredentials(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func AzureDiskConfigWithCredentials(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-disk-csi-config",
+			Namespace: ns,
+		},
+	}
+}
+
+func AzureFileConfigWithCredentials(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-file-csi-config",
+			Namespace: ns,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Azure disk and file csi controllers currently reuse the cloud provider secret to set up their authentication with Azure cloud API. These components should each use their own secrets; this will be required on ARO HCP deployments.

A follow on PR will be created providing different credentials for azure disk and file to use respectively.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.