### PR TITLE
HOSTEDCP-2009: change from NumberOfProbes to ProbeThreshold

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -759,7 +759,7 @@ func createLoadBalancer(ctx context.Context, subscriptionID string, resourceGrou
 							Protocol:          ptr.To(armnetwork.ProbeProtocolHTTP),
 							Port:              ptr.To[int32](30595),
 							IntervalInSeconds: ptr.To[int32](5),
-							NumberOfProbes:    ptr.To[int32](2),
+							ProbeThreshold:    ptr.To[int32](2),
 							RequestPath:       ptr.To("/healthz"),
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**: Changing from NumberOfProbes to ProbeThreshold when creating LoadBalancer for Azure infra as NumberOfProbes will become deprecated in 2027


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-2009](https://issues.redhat.com/browse/HOSTEDCP-2009)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.