### PR TITLE
OCPBUGS-42873: Do not send traffic to local audit-webhook through konnectivity

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -372,6 +372,11 @@ func buildOASKonnectivityProxyContainer(konnectivityHTTPSProxyImage string, prox
 
 func buildOASContainerMain(image string, etcdHostname string, port int32, internalOAuthDisable bool) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
+		noProxy := []string{
+			manifests.KubeAPIServerService("").Name,
+			etcdHostname,
+			config.AuditWebhookService,
+		}
 		cpath := func(volume, file string) string {
 			return path.Join(volumeMounts.Path(c.Name, volume), file)
 		}
@@ -402,7 +407,7 @@ func buildOASContainerMain(image string, etcdHostname string, port int32, intern
 			},
 			{
 				Name:  "NO_PROXY",
-				Value: fmt.Sprintf("%s,%s", manifests.KubeAPIServerService("").Name, etcdHostname),
+				Value: strings.Join(noProxy, ","),
 			},
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -95,7 +95,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider 
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
 		Availability:            hcp.Spec.ControllerAvailabilityPolicy,
 		ProxyImage:              releaseImageProvider.GetImage("socks5-proxy"),
-		OAuthNoProxy:            []string{manifests.KubeAPIServerService("").Name},
+		OAuthNoProxy:            []string{manifests.KubeAPIServerService("").Name, config.AuditWebhookService},
 	}
 	if hcp.Spec.Configuration != nil {
 		p.APIServer = hcp.Spec.Configuration.APIServer

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -45,4 +45,6 @@ const (
 	EnableCVOManagementClusterMetricsAccessEnvVar = "ENABLE_CVO_MANAGEMENT_CLUSTER_METRICS_ACCESS"
 
 	EnableEtcdRecoveryEnvVar = "ENABLE_ETCD_RECOVERY"
+
+	AuditWebhookService = "audit-webhook"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
In managed services, a local audit-webhook service is used to forward audit logs externally. This traffic should not be routed through konnectivity since it goes to a local service in the control plane.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-42873](https://issues.redhat.com/browse/OCPBUGS-42873)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.