### PR TITLE
HOSTEDCP-2025: Allow setting the VPC CIDR when creating AWS infrastructure

### DIFF
--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -62,7 +62,7 @@ func (o *CreateInfraOptions) createVPC(l logr.Logger, client ec2iface.EC2API) (s
 	}
 	if len(vpcID) == 0 {
 		createResult, err := client.CreateVpc(&ec2.CreateVpcInput{
-			CidrBlock:         aws.String(DefaultCIDRBlock),
+			CidrBlock:         aws.String(o.VPCCIDR),
 			TagSpecifications: o.ec2TagSpecifications("vpc", vpcName),
 		})
 		if err != nil {

--- a/cmd/infra/aws/util/util.go
+++ b/cmd/infra/aws/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"k8s.io/utils/ptr"
@@ -123,4 +124,18 @@ func NewConfig() *aws.Config {
 		MinThrottleDelay: 5 * time.Second,
 	}
 	return awsConfig
+}
+
+func ValidateVPCCIDR(in string) error {
+	if in == "" {
+		return nil
+	}
+	_, network, err := net.ParseCIDR(in)
+	if err != nil {
+		return fmt.Errorf("invalid CIDR (%s): %w", in, err)
+	}
+	if ones, _ := network.Mask.Size(); ones != 16 {
+		return fmt.Errorf("only /16 size VPC CIDR supported (%s)", in)
+	}
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes it possible to create VPC peering connections between different cluster infrastructures. It is a prerequisite for more extensive proxy testing.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-2025](https://issues.redhat.com/browse/HOSTEDCP-2025)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.