### PR TITLE
OCPBUGS-43087: openstack/e2e: re-work nodepool tests

### DIFF
--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -1281,6 +1281,11 @@ func (c *CAPI) listMachineTemplates() ([]client.Object, error) {
 		if err != nil {
 			return nil, err
 		}
+	case hyperv1.OpenStackPlatform:
+		gvk, err = apiutil.GVKForObject(&capiopenstack.OpenStackMachineTemplate{}, api.Scheme)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		// need a default path that returns a value that does not cause the hypershift operator to crash
 		// if no explicit machineTemplate is defined safe to assume none exist

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -37,6 +37,7 @@ import (
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	capiopenstack "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -121,6 +122,7 @@ func (r *NodePoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&capiaws.AWSMachineTemplate{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		Watches(&agentv1.AgentMachineTemplate{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		Watches(&capiazure.AzureMachineTemplate{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
+		Watches(&capiopenstack.OpenStackMachineTemplate{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		// We want to reconcile when the user data Secret or the token Secret is unexpectedly changed out of band.
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		// We want to reconcile when the ConfigMaps referenced by the spec.config and also the core ones change.
@@ -636,6 +638,10 @@ func isArchAndPlatformSupported(nodePool *hyperv1.NodePool) bool {
 			supported = true
 		}
 	case hyperv1.KubevirtPlatform:
+		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 {
+			supported = true
+		}
+	case hyperv1.OpenStackPlatform:
 		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 {
 			supported = true
 		}

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/gomega"
-
 	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -79,8 +77,6 @@ func (mc *NodePoolMachineconfigRolloutTest) BuildNodePoolManifest(defaultNodepoo
 }
 
 func (mc *NodePoolMachineconfigRolloutTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
-	g := NewWithT(t)
-
 	// MachineConfig Actions
 	ignitionConfig := ignitionapi.Config{
 		Ignition: ignitionapi.Ignition{
@@ -142,8 +138,8 @@ func (mc *NodePoolMachineconfigRolloutTest) Run(t *testing.T, nodePool hyperv1.N
 	}
 
 	eventuallyDaemonSetRollsOut(t, ctx, mc.hostedClusterClient, len(nodes), np, ds)
-	g.Expect(nodePool.Status.Replicas).To(BeEquivalentTo(len(nodes)))
-
+	e2eutil.WaitForReadyNodesByNodePool(t, ctx, mc.hostedClusterClient, &nodePool, mc.hostedCluster.Spec.Platform.Type)
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mc.mgmtClient, mc.hostedClusterClient, mc.hostedCluster.Spec.Platform.Type, mc.hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, mc.mgmtClient, mc.hostedCluster)
 	e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, ctx, mc.mgmtClient, mc.hostedCluster)
 	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, mc.mgmtClient, mc.hostedCluster)

--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -8,8 +8,6 @@ import (
 	_ "embed"
 	"testing"
 
-	. "github.com/onsi/gomega"
-
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -72,6 +70,10 @@ func (mc *NTOMachineConfigRolloutTest) Setup(t *testing.T) {
 	if globalOpts.Platform == hyperv1.KubevirtPlatform {
 		t.Skip("test is being skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
 	}
+
+	if globalOpts.Platform == hyperv1.OpenStackPlatform {
+		t.Skip("test is being skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
+	}
 }
 
 func (mc *NTOMachineConfigRolloutTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
@@ -96,8 +98,6 @@ func (mc *NTOMachineConfigRolloutTest) BuildNodePoolManifest(defaultNodepool hyp
 }
 
 func (mc *NTOMachineConfigRolloutTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
-	g := NewWithT(t)
-
 	ctx := mc.ctx
 
 	tuningConfigConfigMap := &corev1.ConfigMap{
@@ -132,7 +132,7 @@ func (mc *NTOMachineConfigRolloutTest) Run(t *testing.T, nodePool hyperv1.NodePo
 
 	eventuallyDaemonSetRollsOut(t, ctx, mc.hostedClusterClient, len(nodes), np, ds)
 	e2eutil.WaitForReadyNodesByNodePool(t, ctx, mc.hostedClusterClient, &nodePool, mc.hostedCluster.Spec.Platform.Type)
-	g.Expect(nodePool.Status.Replicas).To(BeEquivalentTo(len(nodes)))
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mc.mgmtClient, mc.hostedClusterClient, mc.hostedCluster.Spec.Platform.Type, mc.hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, mc.mgmtClient, mc.hostedCluster)
 	e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, ctx, mc.mgmtClient, mc.hostedCluster)
 	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, mc.mgmtClient, mc.hostedCluster)

--- a/test/e2e/nodepool_nto_performanceprofile_test.go
+++ b/test/e2e/nodepool_nto_performanceprofile_test.go
@@ -58,6 +58,10 @@ func NewNTOPerformanceProfileTest(ctx context.Context, mgmtClient crclient.Clien
 
 func (mc *NTOPerformanceProfileTest) Setup(t *testing.T) {
 	t.Log("Starting test NTOPerformanceProfileTest")
+
+	if globalOpts.Platform == hyperv1.OpenStackPlatform {
+		t.Skip("test is being skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
+	}
 }
 
 func (mc *NTOPerformanceProfileTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -178,6 +178,14 @@ func executeNodePoolTests(t *testing.T, nodePoolTestCasesPerHostedCluster []Host
 			// create their own NodePools with the proper replicas
 			clusterOpts.NodePoolReplicas = 0
 
+			// On OpenStack, we need to create at least one replica of the default nodepool
+			// so we can create the Route53 record for the ingress router. If we don't do that,
+			// the HostedCluster conditions won't be met and the test will fail as some operators
+			// will be marked as degraded.
+			if globalOpts.Platform == hyperv1.OpenStackPlatform {
+				clusterOpts.NodePoolReplicas = 1
+			}
+
 			ctx, cancel := context.WithCancel(testContext)
 			defer cancel()
 			e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {


### PR DESCRIPTION
* When running the nodepool tests, the HostedCluster is created with a
  initial Nodepool and a replica == 0. That involves that the
  router-default won't exist and therefore we can't expect the Ingress to
  work. So let's skip the DNS record creation when there is no nodepool
  but show a warning because we can't expect the cluster to be healthy.

* Remove double get guestClient when creating Route54 records.

* nodepool: force replica to 1 for the default since we need one
  nodepool for Ingress to be working.

* Use an existing function to test the Nodepool replicas and the nodes
  numbers.

* skip NTO tests which can't work on the OpenStack platform at this
  time.

* nodepool/openstack: support AMD64 arch.

* nodepool/openstack: add missing watch in the reconciler.