### PR TITLE
NO-JIRA: Enforce EnsurePSANotPrivileged for 4.18 and later

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -638,7 +638,7 @@ func EnsureMachineDeploymentGeneration(t *testing.T, ctx context.Context, hostCl
 
 func EnsurePSANotPrivileged(t *testing.T, ctx context.Context, guestClient crclient.Client) {
 	t.Run("EnsurePSANotPrivileged", func(t *testing.T) {
-		AtLeast(t, Version417)
+		AtLeast(t, Version418)
 		testNamespaceName := "e2e-psa-check"
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
OpenShiftPodSecurityAdmission feature gate is not enabled by default in 4.17 any longer. We need to stop enforcing that PSA is privileged

https://github.com/openshift/api/blob/release-4.17/features/features.go
https://github.com/openshift/api/pull/2018

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.