### PR TITLE
HOSTEDCP-2023: [release-4.17] Split worker and vpc endpoint security groups

### DIFF
--- a/api/hypershift/v1beta1/endpointservice_types.go
+++ b/api/hypershift/v1beta1/endpointservice_types.go
@@ -62,6 +62,9 @@ type AWSEndpointServiceStatus struct {
 	// +optional
 	DNSZoneID string `json:"dnsZoneID,omitempty"`
 
+	// SecurityGroupID is the ID for the VPC endpoint SecurityGroup
+	SecurityGroupID string `json:"securityGroupID,omitempty"`
+
 	// Conditions contains details for the current state of the Endpoint Service
 	// request If there is an error processing the request e.g. the NLB doesn't
 	// exist, then the Available condition will be false, reason AWSErrorReason,

--- a/cmd/install/assets/hypershift-operator/hypershift.openshift.io_awsendpointservices.yaml
+++ b/cmd/install/assets/hypershift-operator/hypershift.openshift.io_awsendpointservices.yaml
@@ -361,6 +361,9 @@ spec:
                   EndpointServiceName is the name of the Endpoint Service created in the
                   management VPC
                 type: string
+              securityGroupID:
+                description: SecurityGroupID is the ID for the VPC endpoint SecurityGroup
+                type: string
             type: object
         type: object
     served: true

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
@@ -1,10 +1,14 @@
 package awsprivatelink
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -121,6 +125,80 @@ func TestRecordForService(t *testing.T) {
 			if diff := cmp.Diff(actual, tc.expected); diff != "" {
 				t.Errorf("actual differs from expected: %s", diff)
 			}
+		})
+	}
+}
+
+func TestDiffPermissions(t *testing.T) {
+	r := func(desc, cidr string) *ec2.IpRange {
+		return &ec2.IpRange{
+			Description: aws.String(desc),
+			CidrIp:      aws.String(cidr),
+		}
+	}
+
+	p := func(from, to int64, protocol string, ranges ...*ec2.IpRange) *ec2.IpPermission {
+		return &ec2.IpPermission{
+			FromPort:   aws.Int64(from),
+			ToPort:     aws.Int64(to),
+			IpProtocol: aws.String(protocol),
+			IpRanges:   ranges,
+		}
+	}
+
+	pp := func(perms ...*ec2.IpPermission) []*ec2.IpPermission {
+		return perms
+	}
+
+	tests := []struct {
+		actual   []*ec2.IpPermission
+		required []*ec2.IpPermission
+		expected []*ec2.IpPermission
+	}{
+		{
+			actual: pp(),
+			required: pp(
+				p(100, 200, "tcp", r("test1", "1.1.1.1/32")),
+				p(300, 400, "udp", r("test2", "2.2.2.2/16"), r("test3", "3.3.3.3/24")),
+			),
+			expected: pp(
+				p(100, 200, "tcp", r("test1", "1.1.1.1/32")),
+				p(300, 400, "udp", r("test2", "2.2.2.2/16"), r("test3", "3.3.3.3/24")),
+			),
+		},
+		{
+			actual: pp(
+				p(50000, 60000, "tcp", r("", "10.0.0.0/16")),
+				p(60000, 70000, "udp", r("test", "0.0.0.0/0")),
+			),
+			required: pp(
+				p(50000, 60000, "tcp", r("", "10.0.0.0/16")),
+			),
+			expected: pp(),
+		},
+		{
+			actual: pp(
+				p(100, 200, "tcp", r("one", "10.0.0.0/16"), r("two", "127.0.0.1/32")),
+				p(100, 200, "udp", r("one", "10.0.0.0/16"), r("two", "127.0.0.1/32")),
+				p(300, 400, "tcp", r("one", "10.0.0.0/16")),
+			),
+			required: pp(
+				p(100, 200, "tcp", r("one", "10.0.0.0/16"), r("two", "127.0.0.1/32")),
+				p(100, 200, "udp", r("one", "10.0.0.0/16"), r("two", "127.0.0.1/32")),
+				p(300, 400, "tcp", r("one", "10.0.0.0/16")),
+				p(300, 400, "udp", r("one", "10.0.0.0/16")),
+			),
+			expected: pp(
+				p(300, 400, "udp", r("one", "10.0.0.0/16")),
+			),
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := diffPermissions(test.actual, test.required)
+			g.Expect(result).To(Equal(test.expected))
 		})
 	}
 }

--- a/hypershift-operator/conversion/conversion_test.go
+++ b/hypershift-operator/conversion/conversion_test.go
@@ -407,6 +407,14 @@ func fixNodePoolAfterFuzz(in runtime.Object) {
 	}
 }
 
+func fixAWSEndpointServiceAfterFuzz(in runtime.Object) {
+	epsvc, ok := in.(*hyperv1beta1.AWSEndpointService)
+	if !ok {
+		panic(fmt.Sprintf("unexpected convertible type: %T", in))
+	}
+	epsvc.Status.SecurityGroupID = ""
+}
+
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for HostedCluster", FuzzTestFunc(FuzzTestFuncInput{
 		Hub:                &hyperv1beta1.HostedCluster{},
@@ -439,6 +447,7 @@ func TestFuzzyConversion(t *testing.T) {
 		Spoke:              &hyperv1alpha1.AWSEndpointService{},
 		SpokeAfterMutation: removeTypeMeta,
 		FuzzerFuncs:        []fuzzer.FuzzerFuncs{awsEndpointServiceFuzzerFuncs},
+		HubAfterFuzz:       fixAWSEndpointServiceAfterFuzz,
 	}))
 }
 

--- a/support/awsutil/errorcode.go
+++ b/support/awsutil/errorcode.go
@@ -1,0 +1,15 @@
+package awsutil
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+func AWSErrorCode(err error) string {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code()
+	}
+	return "Unknown"
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/endpointservice_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/endpointservice_types.go
@@ -62,6 +62,9 @@ type AWSEndpointServiceStatus struct {
 	// +optional
 	DNSZoneID string `json:"dnsZoneID,omitempty"`
 
+	// SecurityGroupID is the ID for the VPC endpoint SecurityGroup
+	SecurityGroupID string `json:"securityGroupID,omitempty"`
+
 	// Conditions contains details for the current state of the Endpoint Service
 	// request If there is an error processing the request e.g. the NLB doesn't
 	// exist, then the Available condition will be false, reason AWSErrorReason,


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds code to the AWS privatelink controller to create a security group
  per AWSEndpointResource.
- No longer actively removes additional security groups from vpc
  endpoints, allowing customers to add their own security groups if
  desired.
- Tidies the security group rules for workers, adding descriptions and
  missing rules required for IPSEC.
- Fixes deletion bug that caused the default security group to remain in
  some instances because the CPO did not make sure that it had actually
  been removed.

Backport of https://github.com/openshift/hypershift/pull/4742

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-2023](https://issues.redhat.com/browse/HOSTEDCP-2023)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.