### PR TITLE
OCPBUGS-44964: Reconcile SecretProviderClass for Ingress on ARO HCP

### DIFF
--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -33,6 +33,7 @@ func DefaultOptions(client crclient.Client, log logr.Logger) (*RawCreateOptions,
 		Location:           "eastus",
 		TechPreviewEnabled: false,
 		NodePoolOpts:       azurenodepool.DefaultOptions(),
+		DNSZoneRGName:      "os4-common",
 	}
 
 	if client == nil {
@@ -73,6 +74,7 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 		flags.StringVar(&opts.KeyVaultInfo.KeyVaultName, "management-key-vault-name", opts.KeyVaultInfo.KeyVaultName, "The name of the management Azure Key Vault where the managed identity certificates are stored.")
 		flags.StringVar(&opts.KeyVaultInfo.KeyVaultTenantID, "management-key-vault-tenant-id", opts.KeyVaultInfo.KeyVaultTenantID, "The tenant ID of the management Azure Key Vault where the managed identity certificates are stored.")
 		flags.StringVar(&opts.MangedIdentitiesFile, "managed-identities-file", opts.MangedIdentitiesFile, "Path to a file containing the managed identities configuration in json format.")
+		flags.StringVar(&opts.DNSZoneRGName, "dns-zone-rg-name", opts.DNSZoneRGName, "The name of the resource group where the DNS Zone resides. This is needed for the ingress controller. This is just the name and not the full ID of the resource group.")
 	}
 }
 
@@ -98,6 +100,7 @@ type RawCreateOptions struct {
 	TechPreviewEnabled     bool
 	KeyVaultInfo           ManagementKeyVaultInfo
 	MangedIdentitiesFile   string
+	DNSZoneRGName          string
 
 	NodePoolOpts *azurenodepool.RawAzurePlatformCreateOptions
 }
@@ -539,6 +542,7 @@ func CreateInfraOptions(ctx context.Context, azureOpts *ValidatedCreateOptions, 
 		ManagedIdentityKeyVaultTenantID: azureOpts.KeyVaultInfo.KeyVaultTenantID,
 		TechPreviewEnabled:              azureOpts.TechPreviewEnabled,
 		ManagedIdentitiesFile:           azureOpts.MangedIdentitiesFile,
+		DNSZoneRG:                       azureOpts.DNSZoneRGName,
 	}, nil
 }
 

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -68,6 +68,7 @@ type CreateInfraOptions struct {
 	ManagedIdentityKeyVaultTenantID string
 	TechPreviewEnabled              bool
 	ManagedIdentitiesFile           string
+	DNSZoneRG                       string
 }
 
 type CreateInfraOutput struct {
@@ -229,7 +230,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		}
 
 		// Create ServicePrincipals with backing certificates
-		cmdStr := buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, ingress, o.InfraID, o.ManagedIdentityKeyVaultName)
+		cmdStr := buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, ingress, o.InfraID, o.ManagedIdentityKeyVaultName, o.DNSZoneRG)
 		clientID, err := createServicePrincipalWithCertificate(cmdStr)
 		if err != nil {
 			return nil, err
@@ -238,7 +239,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		result.ControlPlaneMIs.ControlPlane.Ingress.CertificateName = fmt.Sprintf("%s-%s", ingress, o.InfraID)
 		l.Info("Successfully created ingress service principal", "ID", clientID)
 
-		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, cncc, o.InfraID, o.ManagedIdentityKeyVaultName)
+		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, cncc, o.InfraID, o.ManagedIdentityKeyVaultName, o.DNSZoneRG)
 		clientID, err = createServicePrincipalWithCertificate(cmdStr)
 		if err != nil {
 			return nil, err
@@ -247,7 +248,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		result.ControlPlaneMIs.ControlPlane.Network.CertificateName = fmt.Sprintf("%s-%s", cncc, o.InfraID)
 		l.Info("Successfully created cncc service principal", "ID", clientID)
 
-		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, azureDisk, o.InfraID, o.ManagedIdentityKeyVaultName)
+		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, azureDisk, o.InfraID, o.ManagedIdentityKeyVaultName, o.DNSZoneRG)
 		clientID, err = createServicePrincipalWithCertificate(cmdStr)
 		if err != nil {
 			return nil, err
@@ -256,7 +257,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		result.ControlPlaneMIs.ControlPlane.Disk.CertificateName = fmt.Sprintf("%s-%s", azureDisk, o.InfraID)
 		l.Info("Successfully created azure-disk service principal", "ID", clientID)
 
-		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, azureFile, o.InfraID, o.ManagedIdentityKeyVaultName)
+		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, azureFile, o.InfraID, o.ManagedIdentityKeyVaultName, o.DNSZoneRG)
 		clientID, err = createServicePrincipalWithCertificate(cmdStr)
 		if err != nil {
 			return nil, err
@@ -265,7 +266,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		result.ControlPlaneMIs.ControlPlane.File.CertificateName = fmt.Sprintf("%s-%s", azureFile, o.InfraID)
 		l.Info("Successfully created azure-file service principal", "ID", clientID)
 
-		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, cloudProvider, o.InfraID, o.ManagedIdentityKeyVaultName)
+		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, cloudProvider, o.InfraID, o.ManagedIdentityKeyVaultName, o.DNSZoneRG)
 		clientID, err = createServicePrincipalWithCertificate(cmdStr)
 		if err != nil {
 			return nil, err
@@ -274,7 +275,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		result.ControlPlaneMIs.ControlPlane.CloudProvider.CertificateName = fmt.Sprintf("%s-%s", cloudProvider, o.InfraID)
 		l.Info("Successfully created cloud provider service principal", "ID", clientID)
 
-		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, nodePoolMgmt, o.InfraID, o.ManagedIdentityKeyVaultName)
+		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, nodePoolMgmt, o.InfraID, o.ManagedIdentityKeyVaultName, o.DNSZoneRG)
 		clientID, err = createServicePrincipalWithCertificate(cmdStr)
 		if err != nil {
 			return nil, err
@@ -283,7 +284,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		result.ControlPlaneMIs.ControlPlane.NodePoolManagement.CertificateName = fmt.Sprintf("%s-%s", nodePoolMgmt, o.InfraID)
 		l.Info("Successfully created nodepool management service principal", "ID", clientID)
 
-		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, cpo, o.InfraID, o.ManagedIdentityKeyVaultName)
+		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, cpo, o.InfraID, o.ManagedIdentityKeyVaultName, o.DNSZoneRG)
 		clientID, err = createServicePrincipalWithCertificate(cmdStr)
 		if err != nil {
 			return nil, err
@@ -292,7 +293,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		result.ControlPlaneMIs.ControlPlane.ControlPlaneOperator.CertificateName = fmt.Sprintf("%s-%s", cpo, o.InfraID)
 		l.Info("Successfully created cpo service principal", "ID", clientID)
 
-		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, ciro, o.InfraID, o.ManagedIdentityKeyVaultName)
+		cmdStr = buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, ciro, o.InfraID, o.ManagedIdentityKeyVaultName, o.DNSZoneRG)
 		clientID, err = createServicePrincipalWithCertificate(cmdStr)
 		if err != nil {
 			return nil, err
@@ -378,7 +379,7 @@ func createServicePrincipalWithCertificate(cmdStr string) (string, error) {
 }
 
 // buildCreateServicePrincipalCommand builds the command string to create a service principal, output the results in a JSON format to get the client ID, and strips off the quotes.
-func buildCreateServicePrincipalCommand(subscriptionID, managedResourceGroupName, nsgResourceGroupName, vnetResourceGroupName, component, infraID, managedIdentityKeyVaultName string) string {
+func buildCreateServicePrincipalCommand(subscriptionID, managedResourceGroupName, nsgResourceGroupName, vnetResourceGroupName, component, infraID, managedIdentityKeyVaultName, dnsZoneRGName string) string {
 	// Create a name with the component and infraID; this is used for both the service principal name and its certificate name.
 	name := fmt.Sprintf("%s-%s", component, infraID)
 
@@ -387,12 +388,13 @@ func buildCreateServicePrincipalCommand(subscriptionID, managedResourceGroupName
 	managedRG := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, managedResourceGroupName)
 	nsgRG := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, nsgResourceGroupName)
 	vnetRG := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, vnetResourceGroupName)
+	dnsZoneRG := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, dnsZoneRGName)
 	scopes := managedRG
 	switch component {
 	case cloudProvider:
 		scopes = fmt.Sprintf("%s %s", scopes, nsgRG)
 	case ingress:
-		scopes = fmt.Sprintf("%s %s", scopes, vnetRG)
+		scopes = fmt.Sprintf("%s %s %s", scopes, vnetRG, dnsZoneRG)
 	}
 
 	// The command creates a Service Principal with a role(s) over resource group(s), create a new certificate for it, and store it in an existing keyvault

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -5,7 +5,6 @@ import (
 	crand "crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass"
 	"math/big"
 	"net/http"
 	"os"
@@ -3765,7 +3764,7 @@ func (r *HostedControlPlaneReconciler) reconcileIngressOperator(ctx context.Cont
 			return fmt.Errorf("failed to reconcile ingress operator secret provider class: %w", err)
 		}
 
-		credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.Azure.Credentials.Name}}
+		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
 		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
 			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
@@ -3,8 +3,8 @@ package azure
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 
@@ -52,7 +52,7 @@ func azureConfig(cpContext component.ControlPlaneContext, withCredentials bool) 
 	hcp := cpContext.HCP
 	azureplatform := hcp.Spec.Platform.Azure
 
-	credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
+	credentialsSecret := manifests.AzureCredentialInformation(cpContext.HCP.Namespace)
 	if err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
 		return AzureConfig{}, fmt.Errorf("failed to get Azure credentials secret: %w", err)
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -152,7 +152,11 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 		return fmt.Errorf("failed to get secret %s: %w", name, err)
 	}
 
-	// Reconcile the user cloud-credentials secret contents into the control plane version of the same secret, azure-credential-information
+	// Reconcile the user cloud-credentials secret contents into the control plane version of the same secret,
+	// azure-credential-information. This secret is primarily used in retrieving the tenant ID, which is needed anytime
+	// an HCP component needs to authenticate with Azure Cloud. The operators needing this information are ingress
+	// cluster network config controller, azure disk/file CSI drivers, CAPZ, cloud provider, control plane operator, and
+	// KMS.
 	azureCredsInfo := manifests.AzureCredentialInformation(controlPlaneNamespace)
 	if _, err := createOrUpdate(ctx, c, azureCredsInfo, func() error {
 		if azureCredsInfo.Data == nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -623,6 +623,7 @@ func (o *options) DefaultAzureOptions() azure.RawCreateOptions {
 	opts := azure.RawCreateOptions{
 		CredentialsFile: o.configurableClusterOptions.AzureCredentialsFile,
 		Location:        o.configurableClusterOptions.AzureLocation,
+		DNSZoneRGName:   "os4-common",
 
 		NodePoolOpts: azurenodepool.DefaultOptions(),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Reconcile the SecretProviderClass for the ingress operator for ARO HCP deployments. The SecretProviderClass is used by the Secrets Store CSI driver to mount a certificate to a volume in the ingress pod deployment.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-44964](https://issues.redhat.com/browse/OCPBUGS-44964)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.