### PR TITLE
OCPBUGS-43064: move resource.k8s.io to v1alpha3 for kube 1.31

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -215,7 +215,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 			runtimeConfig = append(runtimeConfig, "admissionregistration.k8s.io/v1beta1=true")
 		}
 		if gate == "DynamicResourceAllocation=true" {
-			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1alpha2=true")
+			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1alpha3=true")
 		}
 	}
 	args.Set("runtime-config", runtimeConfig...)


### PR DESCRIPTION
KASO did this here
https://github.com/openshift/cluster-kube-apiserver-operator/pull/1731/files#diff-1460721532208bb105e22ac02386e5e51a23c597dac5ab57ba59592a0e0eef1bR22-R25