### PR TITLE
HOSTEDCP-2022: Reconcile SecretProviderClass for Image Registry on ARO HCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -5,6 +5,7 @@ import (
 	crand "crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass"
 	"math/big"
 	"net/http"
 	"os"
@@ -85,6 +86,7 @@ import (
 	pkimanifests "github.com/openshift/hypershift/control-plane-pki-operator/manifests"
 	sharedingress "github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	supportawsutil "github.com/openshift/hypershift/support/awsutil"
+	hyperazureutil "github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/conditions"
@@ -4112,6 +4114,24 @@ func checkCatalogImageOverides(images ...string) (bool, error) {
 
 func (r *HostedControlPlaneReconciler) reconcileImageRegistryOperator(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider, userReleaseImageProvider *imageprovider.SimpleReleaseImageProvider, createOrUpdate upsert.CreateOrUpdateFN) error {
 	params := registryoperator.NewParams(hcp, userReleaseImageProvider.Version(), releaseImageProvider, userReleaseImageProvider, r.SetDefaultSecurityContext)
+
+	// Create SecretProviderClass when deploying on managed Azure
+	if hyperazureutil.IsAroHCP() {
+		imageRegistrySecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureImageRegistrySecretStoreProviderClassName, hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, imageRegistrySecretProviderClass, func() error {
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(imageRegistrySecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.CertificateName)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile image registry operator secret provider class: %w", err)
+		}
+
+		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
+			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
+		}
+
+		params.AzureTenantID = string(credentialsSecret.Data["AZURE_TENANT_ID"])
+	}
 
 	deployment := manifests.ImageRegistryOperatorDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2691,7 +2691,7 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 			return fmt.Errorf("failed to reconcile aws provider config: %w", err)
 		}
 	case hyperv1.AzurePlatform:
-		credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.Azure.Credentials.Name}}
+		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
 		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
 			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
 		}
@@ -4936,7 +4936,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 	params := storage.NewParams(hcp, userReleaseImageProvider.Version(), releaseImageProvider, userReleaseImageProvider, r.SetDefaultSecurityContext)
 
 	if hcp.Spec.Platform.Type == hyperv1.AzurePlatform {
-		credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.Azure.Credentials.Name}}
+		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
 		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
 			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
 		}
@@ -5410,7 +5410,7 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 	}
 	azureKmsSpec := hcp.Spec.SecretEncryption.KMS.Azure
 
-	credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.Azure.Credentials.Name}}
+	credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
 		condition := metav1.Condition{
 			Type:               string(hyperv1.ValidAzureKMSConfig),

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1630,6 +1630,13 @@ func TestControlPlaneComponents(t *testing.T) {
 		},
 	}
 
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-credential-information",
+			Namespace: "hcp-namespace",
+		},
+	}
+
 	cpContext := controlplanecomponent.ControlPlaneContext{
 		Context:                  context.Background(),
 		CreateOrUpdateProviderV2: upsert.NewV2(false),
@@ -1642,6 +1649,7 @@ func TestControlPlaneComponents(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(api.Scheme).
 			WithObjects(componentsFakeObjects(hcp.Namespace)...).
 			WithObjects(componentsFakeDependencies(component.Name(), hcp.Namespace)...).
+			WithObjects(secret).
 			Build()
 		cpContext.Client = fakeClient
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
@@ -43,3 +43,12 @@ func AzureFileConfigWithCredentials(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func AzureCredentialInformation(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-credential-information",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/secretproviderclass.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/secretproviderclass.go
@@ -1,50 +1,15 @@
 package manifests
 
 import (
-	"fmt"
-	"github.com/openshift/hypershift/support/azureutil"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 )
 
-const (
-	objectFormat = `
-array:
-  - |
-    objectName: %s
-    objectType: secret
-`
-)
-
-// ManagedAzureKeyVaultSecretProviderClass returns an instance of a SecretProviderClass completed with its name, Azure Key Vault set
-// up, and the certificate name it needs to pull from the Key Vault.
-//
-// https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity
-func ManagedAzureKeyVaultSecretProviderClass(secretProviderClassName, namespace, keyVaultName, KeyVaultTenantID, certificateName string) *secretsstorev1.SecretProviderClass {
+func ManagedAzureSecretProviderClass(name, namespace string) *secretsstorev1.SecretProviderClass {
 	return &secretsstorev1.SecretProviderClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretProviderClassName,
+			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: secretsstorev1.SecretProviderClassSpec{
-			Provider: "azure",
-			Parameters: map[string]string{
-				"usePodIdentity":         "false",
-				"useVMManagedIdentity":   "true",
-				"userAssignedIdentityID": azureutil.GetKeyVaultAuthorizedUser(),
-				"keyvaultName":           keyVaultName,
-				"tenantId":               KeyVaultTenantID,
-				"objects":                formatSecretProviderClassObject(certificateName),
-			},
-		},
 	}
-}
-
-// formatSecretProviderClassObject places the certificate name in the appropriate string structure the
-// SecretProviderClass expects for an object. More details here:
-// - https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity#configure-managed-identity
-// - https://secrets-store-csi-driver.sigs.k8s.io/concepts.html?highlight=object#custom-resource-definitions-crds
-func formatSecretProviderClassObject(certName string) string {
-	return fmt.Sprintf(objectFormat, certName)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass/secretproviderclass.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass/secretproviderclass.go
@@ -1,0 +1,44 @@
+package secretproviderclass
+
+import (
+	"fmt"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azureutil"
+
+	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
+)
+
+const (
+	objectFormat = `
+array:
+  - |
+    objectName: %s
+    objectType: secret
+`
+)
+
+// ReconcileManagedAzureSecretProviderClass reconciles the Spec of a SecretProviderClass completed with its name, Azure
+// Key Vault setup, and the certificate name it needs to pull from the Key Vault.
+//
+// https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity
+func ReconcileManagedAzureSecretProviderClass(secretProviderClass *secretsstorev1.SecretProviderClass, hcp *hyperv1.HostedControlPlane, certName string) {
+	secretProviderClass.Spec = secretsstorev1.SecretProviderClassSpec{
+		Provider: "azure",
+		Parameters: map[string]string{
+			"usePodIdentity":         "false",
+			"useVMManagedIdentity":   "true",
+			"userAssignedIdentityID": azureutil.GetKeyVaultAuthorizedUser(),
+			"keyvaultName":           hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.Name,
+			"tenantId":               hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.TenantID,
+			"objects":                formatSecretProviderClassObject(certName),
+		},
+	}
+}
+
+// formatSecretProviderClassObject places the certificate name in the appropriate string structure the
+// SecretProviderClass expects for an object. More details here:
+// - https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity#configure-managed-identity
+// - https://secrets-store-csi-driver.sigs.k8s.io/concepts.html?highlight=object#custom-resource-definitions-crds
+func formatSecretProviderClassObject(certName string) string {
+	return fmt.Sprintf(objectFormat, certName)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
@@ -3,13 +3,12 @@ package azure
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 
 	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -53,10 +52,7 @@ func azureConfig(cpContext component.ControlPlaneContext, withCredentials bool) 
 	hcp := cpContext.HCP
 	azureplatform := hcp.Spec.Platform.Azure
 
-	credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-		Namespace: cpContext.HCP.Namespace,
-		Name:      azureplatform.Credentials.Name,
-	}}
+	credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
 	if err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
 		return AzureConfig{}, fmt.Errorf("failed to get Azure credentials secret: %w", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1426,7 +1426,7 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 			}
 		}
 	case hyperv1.AzurePlatform:
-		referenceCredentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.Azure.Credentials.Name}}
+		referenceCredentialsSecret := cpomanifests.AzureCredentialInformation(hcp.Namespace)
 		if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(referenceCredentialsSecret), referenceCredentialsSecret); err != nil {
 			return []error{fmt.Errorf("failed to get cloud credentials secret in hcp namespace: %w", err)}
 		}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/upsert"
@@ -151,13 +152,14 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 		return fmt.Errorf("failed to get secret %s: %w", name, err)
 	}
 
-	userCloudCreds := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: controlPlaneNamespace, Name: name.Name}}
-	if _, err := createOrUpdate(ctx, c, userCloudCreds, func() error {
-		if userCloudCreds.Data == nil {
-			userCloudCreds.Data = map[string][]byte{}
+	// Reconcile the user cloud-credentials secret contents into the control plane version of the same secret, azure-credential-information
+	azureCredsInfo := manifests.AzureCredentialInformation(controlPlaneNamespace)
+	if _, err := createOrUpdate(ctx, c, azureCredsInfo, func() error {
+		if azureCredsInfo.Data == nil {
+			azureCredsInfo.Data = map[string][]byte{}
 		}
 		for k, v := range source.Data {
-			userCloudCreds.Data[k] = v
+			azureCredsInfo.Data[k] = v
 		}
 		return nil
 	}); err != nil {
@@ -184,13 +186,13 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 	// Sync CNCC secret
 	cloudNetworkConfigCreds := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: controlPlaneNamespace, Name: "cloud-network-config-controller-creds"}}
 	secretData := map[string][]byte{
-		"azure_client_id":       userCloudCreds.Data["AZURE_CLIENT_ID"],
-		"azure_client_secret":   userCloudCreds.Data["AZURE_CLIENT_SECRET"],
+		"azure_client_id":       azureCredsInfo.Data["AZURE_CLIENT_ID"],
+		"azure_client_secret":   azureCredsInfo.Data["AZURE_CLIENT_SECRET"],
 		"azure_region":          []byte(hcluster.Spec.Platform.Azure.Location),
 		"azure_resource_prefix": []byte(hcluster.Name + "-" + hcluster.Spec.InfraID),
 		"azure_resourcegroup":   []byte(hcluster.Spec.Platform.Azure.ResourceGroupName),
-		"azure_subscription_id": userCloudCreds.Data["AZURE_SUBSCRIPTION_ID"],
-		"azure_tenant_id":       userCloudCreds.Data["AZURE_TENANT_ID"],
+		"azure_subscription_id": azureCredsInfo.Data["AZURE_SUBSCRIPTION_ID"],
+		"azure_tenant_id":       azureCredsInfo.Data["AZURE_TENANT_ID"],
 	}
 	if _, err := createOrUpdate(ctx, c, cloudNetworkConfigCreds, func() error {
 		cloudNetworkConfigCreds.Data = secretData
@@ -248,9 +250,9 @@ func reconcileAzureCluster(azureCluster *capiazure.AzureCluster, hcluster *hyper
 }
 
 func reconcileAzureClusterIdentity(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, azureClusterIdentity *capiazure.AzureClusterIdentity, controlPlaneNamespace string) error {
-	credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: hcluster.Spec.Platform.Azure.Credentials.Name, Namespace: controlPlaneNamespace}}
+	credentialsSecret := manifests.AzureCredentialInformation(controlPlaneNamespace)
 	if err := c.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-		return fmt.Errorf("failed to get secret %s: %w", credentialsSecret, err)
+		return fmt.Errorf("failed to get Azure credentials secret: %w", err)
 	}
 
 	azureClusterIdentity.Spec = capiazure.AzureClusterIdentitySpec{

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -228,3 +228,43 @@ func IsAroHCP() bool {
 func GetKeyVaultAuthorizedUser() string {
 	return os.Getenv(config.AROHCPKeyVaultManagedIdentityClientID)
 }
+
+func CreateEnvVarsForAzureManagedIdentity(azureClientID, azureTenantID, azureCertificateName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  config.ManagedAzureClientIdEnvVarKey,
+			Value: azureClientID,
+		},
+		{
+			Name:  config.ManagedAzureTenantIdEnvVarKey,
+			Value: azureTenantID,
+		},
+		{
+			Name:  config.ManagedAzureCertificatePathEnvVarKey,
+			Value: config.ManagedAzureCertificatePath + azureCertificateName,
+		},
+	}
+}
+
+func CreateVolumeMountForAzureSecretStoreProviderClass(secretStoreVolumeName string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      secretStoreVolumeName,
+		MountPath: config.ManagedAzureCertificateMountPath,
+		ReadOnly:  true,
+	}
+}
+
+func CreateVolumeForAzureSecretStoreProviderClass(secretStoreVolumeName, secretProviderClassName string) corev1.Volume {
+	return corev1.Volume{
+		Name: secretStoreVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver:   config.ManagedAzureSecretsStoreCSIDriver,
+				ReadOnly: ptr.To(true),
+				VolumeAttributes: map[string]string{
+					config.ManagedAzureSecretProviderClass: secretProviderClassName,
+				},
+			},
+		},
+	}
+}

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -50,11 +50,38 @@ const (
 
 	AuditWebhookService = "audit-webhook"
 
+	// DefaultMachineNetwork is the default network CIDR for the machine network.
+	DefaultMachineNetwork = "10.0.0.0/16"
+)
+
+// Managed Azure Related Constants
+const (
 	// AROHCPKeyVaultManagedIdentityClientID captures the client ID of the managed identity created on an ARO HCP
 	// management cluster. This managed identity is used to pull secrets and certificates out of Azure Key Vaults in the
 	// management cluster's resource group in Azure.
 	AROHCPKeyVaultManagedIdentityClientID = "ARO_HCP_KEY_VAULT_USER_CLIENT_ID"
 
-	// DefaultMachineNetwork is the default network CIDR for the machine network.
-	DefaultMachineNetwork = "10.0.0.0/16"
+	ManagedAzureClientIdEnvVarKey        = "ARO_HCP_MI_CLIENT_ID"
+	ManagedAzureTenantIdEnvVarKey        = "ARO_HCP_TENANT_ID"
+	ManagedAzureCertificatePathEnvVarKey = "ARO_HCP_CLIENT_CERTIFICATE_PATH"
+	ManagedAzureCertificateMountPath     = "/mnt/certs"
+	ManagedAzureCertificatePath          = "/mnt/certs/"
+	ManagedAzureSecretsStoreCSIDriver    = "secrets-store.csi.k8s.io"
+	ManagedAzureSecretProviderClass      = "secretProviderClass"
+
+	ManagedAzureCPOSecretProviderClassName                = "managed-azure-cpo"
+	ManagedAzureCPOSecretStoreVolumeName                  = "cpo-cert"
+	ManagedAzureCloudProviderSecretProviderClassName      = "managed-azure-cloud-provider"
+	ManagedAzureCloudProviderSecretStoreVolumeName        = "cloud-provider-cert"
+	ManagedAzureDiskCSISecretStoreProviderClassName       = "managed-azure-disk-csi"
+	ManagedAzureFileCSISecretStoreProviderClassName       = "managed-azure-file-csi"
+	ManagedAzureImageRegistrySecretStoreProviderClassName = "managed-azure-image-registry"
+	ManagedAzureImageRegistrySecretStoreVolumeName        = "image-registry-cert"
+	ManagedAzureIngressSecretStoreProviderClassName       = "managed-azure-ingress"
+	ManagedAzureIngressSecretStoreVolumeName              = "ingress-cert"
+	ManagedAzureKMSSecretProviderClassName                = "managed-azure-kms"
+	ManagedAzureKMSSecretStoreVolumeName                  = "kms-cert"
+	ManagedAzureNetworkSecretStoreProviderClassName       = "managed-azure-network"
+	ManagedAzureNodePoolMgmtSecretProviderClassName       = "managed-azure-nodepool-management"
+	ManagedAzureNodePoolMgmtSecretStoreVolumeName         = "nodepool-management-cert"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Reconcile the SecretProviderClass for the image registry operator for ARO HCP deployments. The SecretProviderClass is used by the Secrets Store CSI driver to mount a certificate to a volume in the image registry pod deployment.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.