### PR TITLE
HOSTEDCP-2026: Add support for static control plane operator overrides

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -377,6 +377,7 @@ type HyperShiftOperatorDeployment struct {
 	ManagedService                          string
 	EnableSizeTagging                       bool
 	EnableEtcdRecovery                      bool
+	EnableCPOOverrides                      bool
 }
 
 func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
@@ -489,6 +490,13 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 	if o.EnableEtcdRecovery {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  config.EnableEtcdRecoveryEnvVar,
+			Value: "1",
+		})
+	}
+
+	if o.EnableCPOOverrides {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  config.CPOOverridesEnvVar,
 			Value: "1",
 		})
 	}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -104,6 +104,7 @@ type Options struct {
 	ManagedService                            string
 	EnableSizeTagging                         bool
 	EnableEtcdRecovery                        bool
+	EnableCPOOverrides                        bool
 }
 
 func (o *Options) Validate() error {
@@ -235,6 +236,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ManagedService, "managed-service", opts.ManagedService, "The type of managed service the HyperShift Operator is installed on; this is used to configure different HostedCluster options depending on the managed service. Examples: ARO-HCP, ROSA-HCP")
 	cmd.PersistentFlags().BoolVar(&opts.EnableSizeTagging, "enable-size-tagging", opts.EnableSizeTagging, "If true, HyperShift will tag the HostedCluster with a size label corresponding to the number of worker nodes")
 	cmd.PersistentFlags().BoolVar(&opts.EnableEtcdRecovery, "enable-etcd-recovery", opts.EnableEtcdRecovery, "If true, the HyperShift operator checks for failed etcd pods and attempts a recovery if possible")
+	cmd.PersistentFlags().BoolVar(&opts.EnableCPOOverrides, "enable-cpo-overrides", opts.EnableCPOOverrides, "If true, the HyperShift operator uses a set of static overrides for the CPO image given specific release versions")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		opts.ApplyDefaults()
@@ -681,6 +683,7 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		ManagedService:                          opts.ManagedService,
 		EnableSizeTagging:                       opts.EnableSizeTagging,
 		EnableEtcdRecovery:                      opts.EnableEtcdRecovery,
+		EnableCPOOverrides:                      opts.EnableCPOOverrides,
 	}.Build()
 	operatorService := assets.HyperShiftOperatorService{
 		Namespace: operatorNamespace,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -91,6 +91,7 @@ import (
 	controlplanepkioperatormanifests "github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplanepkioperator"
 	etcdrecoverymanifests "github.com/openshift/hypershift/hypershift-operator/controllers/manifests/etcdrecovery"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
+	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
 	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/azureutil"
@@ -2411,6 +2412,12 @@ func GetControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 	version, err := semver.Parse(releaseInfo.Version())
 	if err != nil {
 		return "", err
+	}
+	if controlplaneoperatoroverrides.IsOverridesEnabled() {
+		overrideImage := controlplaneoperatoroverrides.CPOImage(version.String())
+		if overrideImage != "" {
+			return overrideImage, nil
+		}
 	}
 
 	if hypershiftImage, exists := releaseInfo.ComponentImages()["hypershift"]; exists {

--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -1,0 +1,1 @@
+overrides: []

--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides_sample.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides_sample.yaml
@@ -1,0 +1,8 @@
+overrides:
+- version: 4.16.17
+  cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1a50894aafa6b750bf890ef147a20699ff5b807e586d15506426a8a615580797
+- version: 4.16.18
+  cpoImage: quay.io/hypershift/hypershift-cpo:patch
+testing:
+  latest: quay.io/openshift-release-dev/ocp-release:4.16.17-x86_64
+  previous: quay.io/openshift-release-dev/ocp-release:4.16.16-x86_64

--- a/hypershift-operator/controlplaneoperator-overrides/overrides.go
+++ b/hypershift-operator/controlplaneoperator-overrides/overrides.go
@@ -1,0 +1,75 @@
+package controlplaneoperatoroverrides
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+
+	"github.com/openshift/hypershift/support/config"
+	"gopkg.in/yaml.v2"
+)
+
+type CPOOverrides struct {
+	Overrides []CPOOverride           `yaml:"overrides,omitempty"`
+	Testing   CPOOverrideTestReleases `yaml:"testing"`
+}
+
+type CPOOverride struct {
+	Version  string `yaml:"version"`
+	CPOImage string `yaml:"cpoImage"`
+}
+
+type CPOOverrideTestReleases struct {
+	Latest   string `yaml:"latest"`
+	Previous string `yaml:"previous"`
+}
+
+//go:embed assets/overrides.yaml
+var overridesYAML []byte
+
+var (
+	overrides          = mustLoadOverrides()
+	overridesByVersion map[string]*CPOOverride
+)
+
+func init() {
+	initOverridesByVersion()
+}
+
+func IsOverridesEnabled() bool {
+	return os.Getenv(config.CPOOverridesEnvVar) == "1"
+}
+
+func CPOImage(version string) string {
+	if override, exists := overridesByVersion[version]; exists {
+		return override.CPOImage
+	}
+	return ""
+}
+
+func LatestOverrideTestReleases() (string, string) {
+	return overrides.Testing.Latest, overrides.Testing.Previous
+}
+
+func mustLoadOverrides() *CPOOverrides {
+	overrides, err := loadOverrides(overridesYAML)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to load cpo overrides: %v", err))
+	}
+	return overrides
+}
+
+func loadOverrides(yamlContent []byte) (*CPOOverrides, error) {
+	result := &CPOOverrides{}
+	if err := yaml.Unmarshal(yamlContent, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func initOverridesByVersion() {
+	overridesByVersion = map[string]*CPOOverride{}
+	for i, override := range overrides.Overrides {
+		overridesByVersion[override.Version] = &overrides.Overrides[i]
+	}
+}

--- a/hypershift-operator/controlplaneoperator-overrides/overrides_test.go
+++ b/hypershift-operator/controlplaneoperator-overrides/overrides_test.go
@@ -1,0 +1,83 @@
+package controlplaneoperatoroverrides
+
+import (
+	_ "embed"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCPOImage(t *testing.T) {
+	overrides = fakeOverrides()
+	initOverridesByVersion()
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{
+			version:  "4.17.8",
+			expected: "quay.io/hypershift/control-plane-operator:4.17.8",
+		},
+		{
+			version:  "4.15.9",
+			expected: "quay.io/hypershift/control-plane-operator:4.15.9",
+		},
+		{
+			version:  "4.13.9",
+			expected: "",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("test-%d", i+1), func(t *testing.T) {
+			g := NewWithT(t)
+			actual := CPOImage(test.version)
+			g.Expect(actual).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestLatestOverrideTestReleases(t *testing.T) {
+	overrides = fakeOverrides()
+	initOverridesByVersion()
+	g := NewWithT(t)
+	resultLatest, resultPrevious := LatestOverrideTestReleases()
+	g.Expect(resultLatest).To(Equal("quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64"))
+	g.Expect(resultPrevious).To(Equal("quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64"))
+}
+
+func TestLoadOverrides(t *testing.T) {
+	g := NewWithT(t)
+	o, err := loadOverrides(overridesSampleYAML)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(o).ToNot(BeNil())
+	g.Expect(o.Overrides).To(HaveLen(2))
+	g.Expect(o.Testing.Previous).To(Equal("quay.io/openshift-release-dev/ocp-release:4.16.16-x86_64"))
+	g.Expect(o.Testing.Latest).To(Equal("quay.io/openshift-release-dev/ocp-release:4.16.17-x86_64"))
+	g.Expect(o.Overrides[1].Version).To(Equal("4.16.18"))
+	g.Expect(o.Overrides[1].CPOImage).To(Equal("quay.io/hypershift/hypershift-cpo:patch"))
+	g.Expect(o.Overrides[0].Version).To(Equal("4.16.17"))
+	g.Expect(o.Overrides[0].CPOImage).To(Equal("quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1a50894aafa6b750bf890ef147a20699ff5b807e586d15506426a8a615580797"))
+}
+
+func fakeOverrides() *CPOOverrides {
+	result := &CPOOverrides{
+		Testing: CPOOverrideTestReleases{
+			Latest:   fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64"),
+			Previous: fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64"),
+		},
+	}
+	for _, minor := range []int{15, 16, 17} {
+		for patch := range 10 {
+			result.Overrides = append(result.Overrides, CPOOverride{
+				Version:  fmt.Sprintf("4.%d.%d", minor, patch),
+				CPOImage: fmt.Sprintf("quay.io/hypershift/control-plane-operator:4.%d.%d", minor, patch),
+			})
+		}
+	}
+	return result
+}
+
+//go:embed assets/overrides_sample.yaml
+var overridesSampleYAML []byte

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -46,5 +46,7 @@ const (
 
 	EnableEtcdRecoveryEnvVar = "ENABLE_ETCD_RECOVERY"
 
+	CPOOverridesEnvVar = "ENABLE_CPO_OVERRIDES"
+
 	AuditWebhookService = "audit-webhook"
 )

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -38,6 +38,7 @@ import (
 	kubevirtnodepool "github.com/openshift/hypershift/cmd/nodepool/kubevirt"
 	openstacknodepool "github.com/openshift/hypershift/cmd/nodepool/openstack"
 	"github.com/openshift/hypershift/cmd/version"
+	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
 	"github.com/openshift/hypershift/test/e2e/podtimingcontroller"
 	"github.com/openshift/hypershift/test/e2e/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
@@ -645,6 +646,11 @@ func (o *options) DefaultPowerVSOptions() powervs.RawCreateOptions {
 // Complete is intended to be called after flags have been bound and sets
 // up additional contextual defaulting.
 func (o *options) Complete() error {
+
+	if shouldTestCPOOverride() {
+		o.LatestReleaseImage, o.PreviousReleaseImage = controlplaneoperatoroverrides.LatestOverrideTestReleases()
+	}
+
 	if len(o.LatestReleaseImage) == 0 {
 		defaultVersion, err := version.LookupDefaultOCPVersion("")
 		if err != nil {
@@ -744,4 +750,8 @@ func (s *stringMapVar) Set(value string) error {
 	}
 	map[string]string(*s)[split[0]] = split[1]
 	return nil
+}
+
+func shouldTestCPOOverride() bool {
+	return os.Getenv("TEST_CPO_OVERRIDE") == "1"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a file where we can statically specify replacement CPO images for specific OCP releases. Enables e2e testing of this combination by setting previous and latest release images in e2e based on the presence of an environment variable.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-2026](https://issues.redhat.com/browse/HOSTEDCP-2026)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.