### PR TITLE
OCPBUGS-43104: label routes only when HCP router used

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1082,6 +1082,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 		config.OwnerRefFrom(hostedControlPlane),
 		openShiftTrustedCABundleConfigMapForCPOExists,
 		r.ReleaseProvider.GetMirroredReleaseImage(),
+		useHCPRouter(hostedControlPlane),
 	); err != nil {
 		return fmt.Errorf("failed to reconcile ignition server: %w", err)
 	}
@@ -1625,7 +1626,7 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivityServerService(ctx co
 			if serviceStrategy.Route != nil {
 				hostname = serviceStrategy.Route.Hostname
 			}
-			return kas.ReconcileKonnectivityExternalRoute(konnectivityRoute, p.OwnerRef, hostname, r.DefaultIngressDomain)
+			return kas.ReconcileKonnectivityExternalRoute(konnectivityRoute, p.OwnerRef, hostname, r.DefaultIngressDomain, useHCPRouter(hcp))
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Konnectivity server external route: %w", err)
 		}
@@ -1652,47 +1653,41 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServerService(ctx context.C
 	oauthExternalPrivateRoute := manifests.OauthServerExternalPrivateRoute(hcp.Namespace)
 	if util.IsPublicHCP(hcp) {
 		// Remove the external private route if it exists
-		err := r.Get(ctx, client.ObjectKeyFromObject(oauthExternalPrivateRoute), oauthExternalPrivateRoute)
+		_, err := util.DeleteIfNeeded(ctx, r.Client, oauthExternalPrivateRoute)
 		if err != nil {
-			if !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to check whether OAuth external private route exists: %w", err)
-			}
-		} else {
-			if err := r.Delete(ctx, oauthExternalPrivateRoute); err != nil {
-				return fmt.Errorf("failed to delete OAuth external private route: %w", err)
-			}
+			return fmt.Errorf("failed to delete OAuth external private route: %w", err)
 		}
+
 		// Reconcile the external public route
 		if _, err := createOrUpdate(ctx, r.Client, oauthExternalPublicRoute, func() error {
 			hostname := ""
 			if serviceStrategy.Route != nil {
 				hostname = serviceStrategy.Route.Hostname
 			}
-			return oauth.ReconcileExternalPublicRoute(oauthExternalPublicRoute, p.OwnerRef, hostname, r.DefaultIngressDomain)
+			return oauth.ReconcileExternalPublicRoute(oauthExternalPublicRoute, p.OwnerRef, hostname, r.DefaultIngressDomain, useHCPRouter(hcp))
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile OAuth external public route: %w", err)
 		}
 	} else {
-		// Remove the external route if it exists
-		err := r.Get(ctx, client.ObjectKeyFromObject(oauthExternalPublicRoute), oauthExternalPublicRoute)
+		// Remove the external public route if it exists
+		_, err := util.DeleteIfNeeded(ctx, r.Client, oauthExternalPublicRoute)
 		if err != nil {
-			if !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to check whether OAuth external public route exists: %w", err)
+			return fmt.Errorf("failed to delete OAuth external public route: %w", err)
+		}
+
+		// Reconcile the external private route if a hostname is specified
+		if serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
+			if _, err := createOrUpdate(ctx, r.Client, oauthExternalPrivateRoute, func() error {
+				return oauth.ReconcileExternalPrivateRoute(oauthExternalPrivateRoute, p.OwnerRef, serviceStrategy.Route.Hostname, r.DefaultIngressDomain, useHCPRouter(hcp))
+			}); err != nil {
+				return fmt.Errorf("failed to reconcile OAuth external private route: %w", err)
 			}
 		} else {
-			if err := r.Delete(ctx, oauthExternalPublicRoute); err != nil {
-				return fmt.Errorf("failed to delete OAuth external public route: %w", err)
+			// Remove the external private route if it exists when hostname is not specified
+			_, err := util.DeleteIfNeeded(ctx, r.Client, oauthExternalPrivateRoute)
+			if err != nil {
+				return fmt.Errorf("failed to delete OAuth external private route: %w", err)
 			}
-		}
-		// Reconcile the external private route
-		if _, err := createOrUpdate(ctx, r.Client, oauthExternalPrivateRoute, func() error {
-			hostname := ""
-			if serviceStrategy.Route != nil {
-				hostname = serviceStrategy.Route.Hostname
-			}
-			return oauth.ReconcileExternalPrivateRoute(oauthExternalPrivateRoute, p.OwnerRef, hostname, r.DefaultIngressDomain)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile OAuth external private route: %w", err)
 		}
 	}
 	if util.IsPrivateHCP(hcp) {
@@ -2008,8 +2003,18 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServiceStatus(ctx context.C
 				err = fmt.Errorf("failed to get oauth external route: %w", err)
 				return
 			}
-		} else {
+		} else if serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
 			route = manifests.OauthServerExternalPrivateRoute(hcp.Namespace)
+			if err = r.Get(ctx, client.ObjectKeyFromObject(route), route); err != nil {
+				if apierrors.IsNotFound(err) {
+					err = nil
+					return
+				}
+				err = fmt.Errorf("failed to get oauth internal route: %w", err)
+				return
+			}
+		} else {
+			route = manifests.OauthServerInternalRoute(hcp.Namespace)
 			if err = r.Get(ctx, client.ObjectKeyFromObject(route), route); err != nil {
 				if apierrors.IsNotFound(err) {
 					err = nil

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -46,6 +46,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 	ownerRef config.OwnerRef,
 	openShiftTrustedCABundleConfigMapExists bool,
 	mirroredReleaseImage string,
+	labelHCPRoutes bool,
 ) error {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -101,7 +102,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 				if serviceStrategy.Route != nil {
 					hostname = serviceStrategy.Route.Hostname
 				}
-				err := reconcileExternalRoute(ignitionServerRoute, ownerRef, routeServiceName, hostname, defaultIngressDomain)
+				err := reconcileExternalRoute(ignitionServerRoute, ownerRef, routeServiceName, hostname, defaultIngressDomain, labelHCPRoutes)
 				if err != nil {
 					return fmt.Errorf("failed to reconcile external route in ignition server: %w", err)
 				}
@@ -350,9 +351,9 @@ func reconcileIgnitionServerServiceWithProxy(svc *corev1.Service, strategy *hype
 	return nil
 }
 
-func reconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, svcName string, hostname string, defaultIngressDomain string) error {
+func reconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, svcName string, hostname string, defaultIngressDomain string, labelHCPRoutes bool) error {
 	ownerRef.ApplyTo(route)
-	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, svcName)
+	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, svcName, labelHCPRoutes)
 }
 
 func reconcileInternalRoute(route *routev1.Route, ownerRef config.OwnerRef, svcName string) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -287,9 +287,9 @@ func ReconcileKonnectivityServerService(svc *corev1.Service, ownerRef config.Own
 	return nil
 }
 
-func ReconcileKonnectivityExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
+func ReconcileKonnectivityExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string, labelHCPRoutes bool) error {
 	ownerRef.ApplyTo(route)
-	if err := util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.KonnectivityServerService(route.Namespace).Name); err != nil {
+	if err := util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.KonnectivityServerService(route.Namespace).Name, labelHCPRoutes); err != nil {
 		return err
 	}
 	if route.Annotations == nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/route.go
@@ -10,14 +10,14 @@ import (
 	"github.com/openshift/hypershift/support/util"
 )
 
-func ReconcileExternalPublicRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
+func ReconcileExternalPublicRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string, labelHCPRoutes bool) error {
 	ownerRef.ApplyTo(route)
-	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.OauthServerService(route.Namespace).Name)
+	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.OauthServerService(route.Namespace).Name, labelHCPRoutes)
 }
 
-func ReconcileExternalPrivateRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string) error {
+func ReconcileExternalPrivateRoute(route *routev1.Route, ownerRef config.OwnerRef, hostname string, defaultIngressDomain string, labelHCPRoutes bool) error {
 	ownerRef.ApplyTo(route)
-	if err := util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.OauthServerService(route.Namespace).Name); err != nil {
+	if err := util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, manifests.OauthServerService(route.Namespace).Name, labelHCPRoutes); err != nil {
 		return err
 	}
 	if route.Labels == nil {

--- a/hypershift-operator/controllers/hostedcluster/ignitionserver/ignitionserver.go
+++ b/hypershift-operator/controllers/hostedcluster/ignitionserver/ignitionserver.go
@@ -97,7 +97,7 @@ func ReconcileIgnitionServer(ctx context.Context,
 				if serviceStrategy.Route != nil {
 					hostname = serviceStrategy.Route.Hostname
 				}
-				err := reconcileExternalRoute(ignitionServerRoute, ownerRef, routeServiceName, hostname, defaultIngressDomain)
+				err := reconcileExternalRoute(ignitionServerRoute, ownerRef, routeServiceName, hostname, defaultIngressDomain, hostname != "")
 				if err != nil {
 					return fmt.Errorf("failed to reconcile external route in ignition server: %w", err)
 				}
@@ -325,9 +325,9 @@ func reconcileIgnitionServerServiceWithProxy(svc *corev1.Service, strategy *hype
 	return nil
 }
 
-func reconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, svcName string, hostname string, defaultIngressDomain string) error {
+func reconcileExternalRoute(route *routev1.Route, ownerRef config.OwnerRef, svcName string, hostname string, defaultIngressDomain string, labelHCPRoutes bool) error {
 	ownerRef.ApplyTo(route)
-	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, svcName)
+	return util.ReconcileExternalRoute(route, hostname, defaultIngressDomain, svcName, labelHCPRoutes)
 }
 
 func reconcileInternalRoute(route *routev1.Route, ownerRef config.OwnerRef, svcName string) error {

--- a/support/util/route.go
+++ b/support/util/route.go
@@ -86,9 +86,11 @@ func hash(s string) string {
 	return result
 }
 
-func ReconcileExternalRoute(route *routev1.Route, hostname string, defaultIngressDomain string, serviceName string) error {
-	if hostname != "" {
+func ReconcileExternalRoute(route *routev1.Route, hostname string, defaultIngressDomain string, serviceName string, labelHCPRoutes bool) error {
+	if labelHCPRoutes {
 		AddHCPRouteLabel(route)
+	}
+	if hostname != "" {
 		route.Spec.Host = hostname
 	} else {
 		if route.Spec.Host == "" {


### PR DESCRIPTION
manual backport of https://github.com/openshift/hypershift/pull/4845 without the shared ingress fix since 4.16 never supported that