### PR TITLE
HOSTEDCP-2028: e2e: use TechPreviewNoUpgrade feature set in TestCreateCluster

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/assets"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
@@ -67,6 +68,9 @@ func TestCreateCluster(t *testing.T) {
 		clusterOpts.AWSPlatform.Zones = zones
 		clusterOpts.InfrastructureAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 		clusterOpts.NodePoolReplicas = 1
+	}
+	if !e2eutil.IsLessThan(e2eutil.Version418) {
+		clusterOpts.FeatureSet = string(configv1.TechPreviewNoUpgrade)
 	}
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1723,6 +1723,11 @@ func EnsureHCPPodsAffinitiesAndTolerations(t *testing.T, ctx context.Context, cl
 				continue
 			}
 
+			// SRO is being removed in 4.18, not worth correcting the tolerations on back releases
+			if pod.Labels["name"] == "shared-resource-csi-driver-operator" {
+				continue
+			}
+
 			// aws-ebs-csi-driver-operator tolerations are set through CSO and are different from the ones in the DC
 			if strings.Contains(pod.Name, awsEbsCsiDriverOperatorPodSubstring) {
 				g.Expect(pod.Spec.Tolerations).To(ContainElements(awsEbsCsiDriverOperatorTolerations))
@@ -1821,6 +1826,7 @@ func EnsureSATokenNotMountedUnlessNecessary(t *testing.T, ctx context.Context, c
 			"packageserver",
 			"csi-snapshot-webhook",
 			"csi-snapshot-controller",
+			"shared-resource-csi-driver-operator",
 		)
 
 		if hostedCluster.Spec.Platform.Type == hyperv1.AzurePlatform {


### PR DESCRIPTION
We currently have no test coverage for `TechPreviewNoUpgrade` feature set in hypershift.  We uncovered https://github.com/openshift/cluster-storage-operator/pull/519 and https://github.com/openshift/hypershift/pull/4887 recently.

As of `4.18.0-0.ci-2024-10-11-065556`, this was working again.

This makes `TestCreateCluster` deploy a `TechPreviewNoUpgrade` cluster so we can ensure it stays working.

