### PR TITLE
OCPBUGS-44967: Reconcile SecretProvider for CNCC on ARO HCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3621,6 +3621,24 @@ func (r *HostedControlPlaneReconciler) reconcileClusterVersionOperator(ctx conte
 func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider, userReleaseImageProvider *imageprovider.SimpleReleaseImageProvider, hasRouteCap bool, createOrUpdate upsert.CreateOrUpdateFN) error {
 	p := cno.NewParams(hcp, userReleaseImageProvider.Version(), releaseImageProvider, userReleaseImageProvider, r.SetDefaultSecurityContext, r.DefaultIngressDomain)
 
+	// Create SecretProviderClass when deploying on ARO HCP
+	if hyperazureutil.IsAroHCP() {
+		cnccSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureNetworkSecretStoreProviderClassName, hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, cnccSecretProviderClass, func() error {
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cnccSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CertificateName)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile ingressoperator secret provider class: %w", err)
+		}
+
+		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
+			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
+		}
+
+		p.AzureTenantID = string(credentialsSecret.Data["AZURE_TENANT_ID"])
+	}
+
 	sa := manifests.ClusterNetworkOperatorServiceAccount(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, sa, func() error {
 		return cno.ReconcileServiceAccount(sa, p.OwnerRef)


### PR DESCRIPTION
**What this PR does / why we need it**:
Reconcile the SecretProviderClass for the cluster network operator for ARO HCP deployments. The SecretProviderClass is used by the Secrets Store CSI driver to mount a certificate to a volume in the ingress pod deployment.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-44967](https://issues.redhat.com/browse/OCPBUGS-44967)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.