### PR TITLE
OCPBUGS-44968: Reconcile SecretProvider for CSO on ARO HCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -123,4 +123,5 @@ type AzureConfig struct {
 	LoadBalancerSku              string `json:"loadBalancerSku"`
 	DisableOutboundSNAT          bool   `json:"disableOutboundSNAT"`
 	LoadBalancerName             string `json:"loadBalancerName"`
+	AADClientCertPath            string `json:"aadClientCertPath"`
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -4986,6 +4986,31 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure File Secret Provider Class: %w", err)
 		}
+
+		// Get the credentials secret so we can retrieve the tenant ID for the configuration
+		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
+			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
+		}
+		tenantID := string(credentialsSecret.Data["AZURE_TENANT_ID"])
+
+		// Reconcile the secret needed for azure-disk-csi-controller
+		// This is related to https://github.com/openshift/csi-operator/pull/290.
+		azureDiskCSISecret := manifests.AzureDiskConfigWithCredentials(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, azureDiskCSISecret, func() error {
+			return storage.ReconcileAzureDiskCSISecret(azureDiskCSISecret, hcp, tenantID)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile Azure Disk CSI config: %w", err)
+		}
+
+		// Reconcile the secret needed for azure-disk-csi-controller
+		// This is related to https://github.com/openshift/csi-operator/pull/290.
+		azureFileCSISecret := manifests.AzureFileConfigWithCredentials(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, azureDiskCSISecret, func() error {
+			return storage.ReconcileAzureFileCSISecret(azureFileCSISecret, hcp, tenantID)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile Azure File CSI config: %w", err)
+		}
 	}
 
 	if hcp.Spec.Platform.Type == hyperv1.AzurePlatform {

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// initializeAzureCSIControllerConfig initializes an AzureConfig object which will be used to populate the secrets
+// needed by azure-disk-csi-controller and azure-file-csi-controller.
+func initializeAzureCSIControllerConfig(hcp *hyperv1.HostedControlPlane, tenantID string) azure.AzureConfig {
+	azureConfig := azure.AzureConfig{
+		Cloud:          hcp.Spec.Platform.Azure.Cloud,
+		TenantID:       tenantID,
+		SubscriptionID: hcp.Spec.Platform.Azure.SubscriptionID,
+		ResourceGroup:  hcp.Spec.Platform.Azure.ResourceGroupName,
+		Location:       hcp.Spec.Platform.Azure.Location,
+	}
+
+	return azureConfig
+}
+
+// ReconcileAzureDiskCSISecret reconciles the configuration for the secret as expected by azure-disk-csi-controller
+func ReconcileAzureDiskCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane, tenantID string) error {
+	config := initializeAzureCSIControllerConfig(hcp, tenantID)
+	config.AADClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.ClientID
+	config.AADClientCertPath = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.CertificateName
+
+	serializedConfig, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize cloudconfig: %w", err)
+	}
+
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+	secret.Data[azure.CloudConfigKey] = serializedConfig
+	return nil
+}
+
+// ReconcileAzureFileCSISecret reconciles the configuration for the secret as expected by azure-file-csi-controller
+func ReconcileAzureFileCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane, tenantID string) error {
+	config := initializeAzureCSIControllerConfig(hcp, tenantID)
+	config.AADClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.ClientID
+	config.AADClientCertPath = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.CertificateName
+
+	serializedConfig, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize cloudconfig: %w", err)
+	}
+
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+	secret.Data[azure.CloudConfigKey] = serializedConfig
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/operator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/storage/assets"
 	assets2 "github.com/openshift/hypershift/support/assets"
 	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,11 +44,11 @@ func ReconcileOperatorDeployment(
 				deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env,
 					corev1.EnvVar{
 						Name:  "ARO_HCP_SECRET_PROVIDER_CLASS_FOR_DISK",
-						Value: params.AzureDiskSecretProviderClassName,
+						Value: config.ManagedAzureDiskCSISecretStoreProviderClassName,
 					},
 					corev1.EnvVar{
 						Name:  "ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE",
-						Value: params.AzureFileSecretProviderClassName,
+						Value: config.ManagedAzureFileCSISecretStoreProviderClassName,
 					})
 			}
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
@@ -33,10 +33,10 @@ func NewParams(
 	ir.setOperatorImageReferences(releaseImageProvider, userReleaseImageProvider)
 
 	params := Params{
-		OwnerRef:                         config.OwnerRefFrom(hcp),
-		StorageOperatorImage:             releaseImageProvider.GetImage(storageOperatorImageName),
-		AvailabilityProberImage:          releaseImageProvider.GetImage(util.AvailabilityProberImageName),
-		ImageReplacer:                    ir,
+		OwnerRef:                config.OwnerRefFrom(hcp),
+		StorageOperatorImage:    releaseImageProvider.GetImage(storageOperatorImageName),
+		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
+		ImageReplacer:           ir,
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
 		AdditionalLabels: map[string]string{

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/params.go
@@ -33,10 +33,10 @@ func NewParams(
 	ir.setOperatorImageReferences(releaseImageProvider, userReleaseImageProvider)
 
 	params := Params{
-		OwnerRef:                config.OwnerRefFrom(hcp),
-		StorageOperatorImage:    releaseImageProvider.GetImage(storageOperatorImageName),
-		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
-		ImageReplacer:           ir,
+		OwnerRef:                         config.OwnerRefFrom(hcp),
+		StorageOperatorImage:             releaseImageProvider.GetImage(storageOperatorImageName),
+		AvailabilityProberImage:          releaseImageProvider.GetImage(util.AvailabilityProberImageName),
+		ImageReplacer:                    ir,
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
 		AdditionalLabels: map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:
Reconcile the SecretProviderClass for the cluster storage operator (CSO) for ARO HCP deployments. The SecretProviderClass is used by the Secrets Store CSI driver to mount a certificate to a volume in the azure-disk-csi-controller and azure-file-csi-controller pod deployments.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [OCPBUGS-44968](https://issues.redhat.com/browse/OCPBUGS-44968)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.