### PR TITLE
OCPBUGS-43313: Delete CAPI Cluster CR on HC deletion early

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3903,6 +3903,12 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		return false, err
 	}
 
+	// Signal CAPI Cluster resource for deletion early so child objects make decisions based on this. E.g. exlude drain and wait for volumes.
+	_, err = hyperutil.DeleteIfNeeded(ctx, r.Client, controlplaneoperator.CAPICluster(controlPlaneNamespace, hc.Spec.InfraID))
+	if err != nil {
+		return false, err
+	}
+
 	// There are scenarios where CAPI might not be operational e.g None Platform.
 	// We want to ensure the HCP resource is deleted before deleting the Namespace.
 	// Otherwise the CPO will be deleted leaving the HCP in a perpetual terminating state preventing further progress.


### PR DESCRIPTION
Currently the CAPI Cluster is deleted by deleting the namespace and we block HC deletion on the HCP resource. We should signal CAPI Cluster resource for deletion early so child objects make decisions based on this. E.g. exlude drain and wait for volumes. This would also prevent edge chicken-egg scenarios

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.