### PR TITLE
OCPBUGS-43374 (manual backport) openstack/e2e: re-work nodepool tests

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -166,6 +166,7 @@ func (r *NodePoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&capiaws.AWSMachineTemplate{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		Watches(&agentv1.AgentMachineTemplate{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		Watches(&capiazure.AzureMachineTemplate{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
+		Watches(&capiopenstack.OpenStackMachineTemplate{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		// We want to reconcile when the user data Secret or the token Secret is unexpectedly changed out of band.
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		// We want to reconcile when the ConfigMaps referenced by the spec.config and also the core ones change.
@@ -1033,6 +1034,10 @@ func isArchAndPlatformSupported(nodePool *hyperv1.NodePool) bool {
 			supported = true
 		}
 	case hyperv1.KubevirtPlatform:
+		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 {
+			supported = true
+		}
+	case hyperv1.OpenStackPlatform:
 		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 {
 			supported = true
 		}
@@ -2804,6 +2809,11 @@ func (r *NodePoolReconciler) listMachineTemplates(nodePool *hyperv1.NodePool) ([
 		}
 	case hyperv1.AzurePlatform:
 		gvk, err = apiutil.GVKForObject(&capiazure.AzureMachineTemplate{}, api.Scheme)
+		if err != nil {
+			return nil, err
+		}
+	case hyperv1.OpenStackPlatform:
+		gvk, err = apiutil.GVKForObject(&capiopenstack.OpenStackMachineTemplate{}, api.Scheme)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/gomega"
-
 	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -79,8 +77,6 @@ func (mc *NodePoolMachineconfigRolloutTest) BuildNodePoolManifest(defaultNodepoo
 }
 
 func (mc *NodePoolMachineconfigRolloutTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
-	g := NewWithT(t)
-
 	// MachineConfig Actions
 	ignitionConfig := ignitionapi.Config{
 		Ignition: ignitionapi.Ignition{
@@ -142,8 +138,8 @@ func (mc *NodePoolMachineconfigRolloutTest) Run(t *testing.T, nodePool hyperv1.N
 	}
 
 	eventuallyDaemonSetRollsOut(t, ctx, mc.hostedClusterClient, len(nodes), np, ds)
-	g.Expect(nodePool.Status.Replicas).To(BeEquivalentTo(len(nodes)))
-
+	e2eutil.WaitForReadyNodesByNodePool(t, ctx, mc.hostedClusterClient, &nodePool, mc.hostedCluster.Spec.Platform.Type)
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mc.mgmtClient, mc.hostedClusterClient, mc.hostedCluster.Spec.Platform.Type, mc.hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, mc.mgmtClient, mc.hostedCluster)
 	e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, ctx, mc.mgmtClient, mc.hostedCluster)
 	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, mc.mgmtClient, mc.hostedCluster)

--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -8,8 +8,6 @@ import (
 	_ "embed"
 	"testing"
 
-	. "github.com/onsi/gomega"
-
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -72,6 +70,10 @@ func (mc *NTOMachineConfigRolloutTest) Setup(t *testing.T) {
 	if globalOpts.Platform == hyperv1.KubevirtPlatform {
 		t.Skip("test is being skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
 	}
+
+	if globalOpts.Platform == hyperv1.OpenStackPlatform {
+		t.Skip("test is being skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
+	}
 }
 
 func (mc *NTOMachineConfigRolloutTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
@@ -96,8 +98,6 @@ func (mc *NTOMachineConfigRolloutTest) BuildNodePoolManifest(defaultNodepool hyp
 }
 
 func (mc *NTOMachineConfigRolloutTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
-	g := NewWithT(t)
-
 	ctx := mc.ctx
 
 	tuningConfigConfigMap := &corev1.ConfigMap{
@@ -132,7 +132,7 @@ func (mc *NTOMachineConfigRolloutTest) Run(t *testing.T, nodePool hyperv1.NodePo
 
 	eventuallyDaemonSetRollsOut(t, ctx, mc.hostedClusterClient, len(nodes), np, ds)
 	e2eutil.WaitForReadyNodesByNodePool(t, ctx, mc.hostedClusterClient, &nodePool, mc.hostedCluster.Spec.Platform.Type)
-	g.Expect(nodePool.Status.Replicas).To(BeEquivalentTo(len(nodes)))
+	e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mc.mgmtClient, mc.hostedClusterClient, mc.hostedCluster.Spec.Platform.Type, mc.hostedCluster.Namespace)
 	e2eutil.EnsureNoCrashingPods(t, ctx, mc.mgmtClient, mc.hostedCluster)
 	e2eutil.EnsureAllContainersHavePullPolicyIfNotPresent(t, ctx, mc.mgmtClient, mc.hostedCluster)
 	e2eutil.EnsureHCPContainersHaveResourceRequests(t, ctx, mc.mgmtClient, mc.hostedCluster)

--- a/test/e2e/nodepool_nto_performanceprofile_test.go
+++ b/test/e2e/nodepool_nto_performanceprofile_test.go
@@ -57,6 +57,10 @@ func NewNTOPerformanceProfileTest(ctx context.Context, mgmtClient crclient.Clien
 
 func (mc *NTOPerformanceProfileTest) Setup(t *testing.T) {
 	t.Log("Starting test NTOPerformanceProfileTest")
+
+	if globalOpts.Platform == hyperv1.OpenStackPlatform {
+		t.Skip("test is being skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
+	}
 }
 
 func (mc *NTOPerformanceProfileTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -170,6 +170,14 @@ func executeNodePoolTests(t *testing.T, nodePoolTestCasesPerHostedCluster []Host
 			// create their own NodePools with the proper replicas
 			clusterOpts.NodePoolReplicas = 0
 
+			// On OpenStack, we need to create at least one replica of the default nodepool
+			// so we can create the Route53 record for the ingress router. If we don't do that,
+			// the HostedCluster conditions won't be met and the test will fail as some operators
+			// will be marked as degraded.
+			if globalOpts.Platform == hyperv1.OpenStackPlatform {
+				clusterOpts.NodePoolReplicas = 1
+			}
+
 			ctx, cancel := context.WithCancel(testContext)
 			defer cancel()
 			e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1282,7 +1282,6 @@ func ValidateMetrics(t *testing.T, ctx context.Context, hc *hyperv1.HostedCluste
 
 func getIngressRouterDefaultIP(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) (string, error) {
 	t.Helper()
-	guestClient := WaitForGuestClient(t, ctx, client, hostedCluster)
 
 	defaultIngressRouterService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1292,7 +1291,7 @@ func getIngressRouterDefaultIP(t *testing.T, ctx context.Context, client crclien
 	}
 
 	if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
-		getErr := guestClient.Get(ctx, crclient.ObjectKeyFromObject(defaultIngressRouterService), defaultIngressRouterService)
+		getErr := client.Get(ctx, crclient.ObjectKeyFromObject(defaultIngressRouterService), defaultIngressRouterService)
 		if apierrors.IsNotFound(getErr) {
 			return false, nil
 		}
@@ -1380,12 +1379,17 @@ func deleteIngressRoute53Records(t *testing.T, ctx context.Context, hostedCluste
 func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *PlatformAgnosticOptions) {
 	g := NewWithT(t)
 
-	if hostedCluster.Spec.Platform.Type == hyperv1.OpenStackPlatform && clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile != "" {
-		createIngressRoute53Record(t, ctx, client, hostedCluster, clusterOpts)
-	}
-
 	// Sanity check the cluster by waiting for the nodes to report ready
 	guestClient := WaitForGuestClient(t, ctx, client, hostedCluster)
+
+	// Create Ingress Route53 Record for OpenStack clusters when AWS credentials are provided
+	if hostedCluster.Spec.Platform.Type == hyperv1.OpenStackPlatform && clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile != "" {
+		if clusterOpts.NodePoolReplicas > 0 {
+			createIngressRoute53Record(t, ctx, guestClient, hostedCluster, clusterOpts)
+		} else {
+			t.Logf("Skipping creating Ingress Route53 Record for HostedCluster %s as there are no worker nodes", hostedCluster.Name)
+		}
+	}
 
 	// Wait for Nodes to be Ready
 	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual backport (almost clean) which will help to get our 4.17 CI able to test NodePools.

* When running the nodepool tests, the HostedCluster is created with a
  initial Nodepool and a replica == 0. That involves that the
  router-default won't exist and therefore we can't expect the Ingress to
  work. So let's skip the DNS record creation when there is no nodepool
  but show a warning because we can't expect the cluster to be healthy.

* Remove double get guestClient when creating Route54 records.

* nodepool: force replica to 1 for the default since we need one
  nodepool for Ingress to be working.

* Use an existing function to test the Nodepool replicas and the nodes
  numbers.

* skip NTO tests which can't work on the OpenStack platform at this
  time.

* nodepool/openstack: support AMD64 arch.

* nodepool/openstack: add missing watch in the reconciler
