### PR TITLE
OCPBUGS-43448: Pass feature flags to clusterpolicy controller

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/config.go
@@ -22,7 +22,7 @@ const (
 	bindPort  = 10357
 )
 
-func ReconcileClusterPolicyControllerConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef, minTLSVersion string, cipherSuites []string) error {
+func ReconcileClusterPolicyControllerConfig(cm *corev1.ConfigMap, ownerRef config.OwnerRef, minTLSVersion string, cipherSuites []string, featureGates []string) error {
 	if cm.Data == nil {
 		cm.Data = map[string]string{}
 	}
@@ -33,7 +33,7 @@ func ReconcileClusterPolicyControllerConfig(cm *corev1.ConfigMap, ownerRef confi
 			return fmt.Errorf("unable to decode existing cluster policy controller configuration: %w", err)
 		}
 	}
-	if err := reconcileConfig(config, minTLSVersion, cipherSuites); err != nil {
+	if err := reconcileConfig(config, minTLSVersion, cipherSuites, featureGates); err != nil {
 		return err
 	}
 	buf := &bytes.Buffer{}
@@ -44,7 +44,7 @@ func ReconcileClusterPolicyControllerConfig(cm *corev1.ConfigMap, ownerRef confi
 	return nil
 }
 
-func reconcileConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, minTLSVersion string, cipherSuites []string) error {
+func reconcileConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, minTLSVersion string, cipherSuites []string, featureGates []string) error {
 	cpath := func(volume, file string) string {
 		dir := volumeMounts.Path(cpcContainerMain().Name, volume)
 		return path.Join(dir, file)
@@ -67,5 +67,8 @@ func reconcileConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, minTLS
 			CipherSuites:  cipherSuites,
 		},
 	}
+
+	cfg.FeatureGates = featureGates
+
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/clusterpolicy/params.go
@@ -13,9 +13,10 @@ import (
 )
 
 type ClusterPolicyControllerParams struct {
-	Image                   string                  `json:"image"`
-	APIServer               *configv1.APIServerSpec `json:"apiServer"`
-	AvailabilityProberImage string                  `json:"availabilityProberImage"`
+	FeatureGate             *configv1.FeatureGateSpec `json:"featureGate"`
+	Image                   string                    `json:"image"`
+	APIServer               *configv1.APIServerSpec   `json:"apiServer"`
+	AvailabilityProberImage string                    `json:"availabilityProberImage"`
 
 	DeploymentConfig config.DeploymentConfig `json:"deploymentConfig"`
 	config.OwnerRef  `json:",inline"`
@@ -28,6 +29,7 @@ func NewClusterPolicyControllerParams(hcp *hyperv1.HostedControlPlane, releaseIm
 	}
 	if hcp.Spec.Configuration != nil {
 		params.APIServer = hcp.Spec.Configuration.APIServer
+		params.FeatureGate = hcp.Spec.Configuration.FeatureGate
 	}
 	params.DeploymentConfig = config.DeploymentConfig{
 		Scheduling: config.Scheduling{
@@ -63,6 +65,16 @@ func (p *ClusterPolicyControllerParams) MinTLSVersion() string {
 		return config.MinTLSVersion(p.APIServer.TLSSecurityProfile)
 	} else {
 		return config.MinTLSVersion(nil)
+	}
+}
+
+func (p *ClusterPolicyControllerParams) FeatureGates() []string {
+	if p.FeatureGate != nil {
+		return config.FeatureGates(&p.FeatureGate.FeatureGateSelection)
+	} else {
+		return config.FeatureGates(&configv1.FeatureGateSelection{
+			FeatureSet: configv1.Default,
+		})
 	}
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3540,7 +3540,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterPolicyController(ctx cont
 
 	config := manifests.ClusterPolicyControllerConfig(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, config, func() error {
-		return clusterpolicy.ReconcileClusterPolicyControllerConfig(config, p.OwnerRef, p.MinTLSVersion(), p.CipherSuites())
+		return clusterpolicy.ReconcileClusterPolicyControllerConfig(config, p.OwnerRef, p.MinTLSVersion(), p.CipherSuites(), p.FeatureGates())
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile cluster policy controller config: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a general bug fix. The cluster policy controller was previously not using the proper feature flags, this data needs to be passed to it.

https://ibm-argonauts.slack.com/archives/C015MKYUVSR/p1729088012086239?thread_ts=1729086853.463239&cid=C015MKYUVSR

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.