### PR TITLE
HOSTEDCP-1994: Pass Azure Key Vault's Managed Identity's Client ID to HO and CPO Deployments

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -379,6 +379,7 @@ type HyperShiftOperatorDeployment struct {
 	EnableSizeTagging                       bool
 	EnableEtcdRecovery                      bool
 	EnableCPOOverrides                      bool
+	AROHCPKeyVaultUsersClientID             string
 	TechPreviewNoUpgrade                    bool
 }
 
@@ -493,6 +494,13 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "MANAGED_SERVICE",
 			Value: o.ManagedService,
+		})
+	}
+
+	if len(o.AROHCPKeyVaultUsersClientID) > 0 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  config.AROHCPKeyVaultManagedIdentityClientID,
+			Value: o.AROHCPKeyVaultUsersClientID,
 		})
 	}
 

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -105,6 +105,7 @@ type Options struct {
 	EnableSizeTagging                         bool
 	EnableEtcdRecovery                        bool
 	EnableCPOOverrides                        bool
+	AroHCPKeyVaultUsersClientID               string
 	TechPreviewNoUpgrade                      bool
 }
 
@@ -238,6 +239,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.EnableSizeTagging, "enable-size-tagging", opts.EnableSizeTagging, "If true, HyperShift will tag the HostedCluster with a size label corresponding to the number of worker nodes")
 	cmd.PersistentFlags().BoolVar(&opts.EnableEtcdRecovery, "enable-etcd-recovery", opts.EnableEtcdRecovery, "If true, the HyperShift operator checks for failed etcd pods and attempts a recovery if possible")
 	cmd.PersistentFlags().BoolVar(&opts.EnableCPOOverrides, "enable-cpo-overrides", opts.EnableCPOOverrides, "If true, the HyperShift operator uses a set of static overrides for the CPO image given specific release versions")
+	cmd.PersistentFlags().StringVar(&opts.AroHCPKeyVaultUsersClientID, "aro-hcp-key-vault-users-client-id", opts.AroHCPKeyVaultUsersClientID, "The client ID of the managed identity which can access the Azure Key Vaults, in an AKS management cluster, to retrieve secrets and certificates.")
 	cmd.PersistentFlags().BoolVar(&opts.TechPreviewNoUpgrade, "tech-preview-no-upgrade", opts.TechPreviewNoUpgrade, "If true, the HyperShift operator runs with TechPreviewNoUpgrade features enabled")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -706,6 +708,7 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		EnableSizeTagging:                       opts.EnableSizeTagging,
 		EnableEtcdRecovery:                      opts.EnableEtcdRecovery,
 		EnableCPOOverrides:                      opts.EnableCPOOverrides,
+		AROHCPKeyVaultUsersClientID:             opts.AroHCPKeyVaultUsersClientID,
 		TechPreviewNoUpgrade:                    opts.TechPreviewNoUpgrade,
 	}.Build()
 	operatorService := assets.HyperShiftOperatorService{

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2721,6 +2721,15 @@ func reconcileControlPlaneOperatorDeployment(
 		)
 	}
 
+	aroHCPKVMIClientID, ok := os.LookupEnv(config.AROHCPKeyVaultManagedIdentityClientID)
+	if ok {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  config.AROHCPKeyVaultManagedIdentityClientID,
+				Value: aroHCPKVMIClientID,
+			})
+	}
+
 	mainContainer = hyperutil.FindContainer("control-plane-operator", deployment.Spec.Template.Spec.Containers)
 	proxy.SetEnvVars(&mainContainer.Env)
 

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -49,4 +49,9 @@ const (
 	CPOOverridesEnvVar = "ENABLE_CPO_OVERRIDES"
 
 	AuditWebhookService = "audit-webhook"
+
+	// AROHCPKeyVaultManagedIdentityClientID captures the client ID of the managed identity created on an ARO HCP
+	// management cluster. This managed identity is used to pull secrets and certificates out of Azure Key Vaults in the
+	// management cluster's resource group in Azure.
+	AROHCPKeyVaultManagedIdentityClientID = "ARO_HCP_KEY_VAULT_USER_CLIENT_ID"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
In ARO HCP deployments, a managed identity will be assigned to each AKS management cluster. This managed identity will be responsible for pulling out the secrets from any Azure Key Vault on the management cluster, such as the HCP component's managed identity's backing certificate.

Since there is a single managed identity doing this for all HostedClusters on a management cluster, it makes sense for this value to be passed to the HyperShift Operator (HO) installed on the management cluster. However, the control plane operator (CPO) also needs this value when it creates the SecretProviderClass for the Secrets Store CSI driver. 

This PR:
- adds a flag to the HO installation to pass the client ID of the previously mentioned managed identity
- passes the client ID to the CPO deployment

**Which issue(s) this PR fixes**:
This PR is a part of [HOSTEDCP-1994](https://issues.redhat.com/browse/HOSTEDCP-1994)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.