### PR TITLE
OCPBUGS-43444: Allow kubevirt-csi storageclass default to be changed by user

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -351,9 +351,16 @@ func reconcileCustomTenantStorageClass(sc *storagev1.StorageClass, infraSCName s
 }
 
 func reconcileDefaultTenantStorageClass(sc *storagev1.StorageClass) error {
-	sc.Annotations = map[string]string{
-		"storageclass.kubernetes.io/is-default-class": "true",
+	if sc.Annotations == nil {
+		sc.Annotations = map[string]string{}
 	}
+
+	// Only set the default storage class when the annotation doesn't exist.
+	// Otherwise, we should allow people to set is-default-class=false if they wish to
+	if _, exists := sc.Annotations["storageclass.kubernetes.io/is-default-class"]; !exists {
+		sc.Annotations["storageclass.kubernetes.io/is-default-class"] = "true"
+	}
+
 	sc.Provisioner = "csi.kubevirt.io"
 	sc.Parameters = map[string]string{
 		"bus": "scsi",


### PR DESCRIPTION
People should be able to change the kubevirt-csi default storageClass's `storageclass.kubernetes.io/is-default-class` to false and not have our operator squash that change. 

This allows for the owner of the HCP cluster to install their own csi drivers and accurately choose what default they want. 