### PR TITLE
OSASINFRA-3636: Enable cluster-storage-operator for OpenStack Cinder

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,6 +1,19 @@
 # Hacking
 
-## Development How-to Guides
+## Overview
+
+What do I need to do to test...
+
+* ...changes to `hypershift-operator`
+
+  * [Install the HyperShift in development mode and run the operator locally](#how-to-run-the-hypershift-operator-in-a-local-process); or
+  * [Install HyperShift using a custom image](#how-to-install-hypershift-with-a-custom-image)
+
+* ...changes to `control-plane-operator` or any control plane operator
+
+  * [Create a cluster using a custom image](#how-to-create-a-hypershift-guest-cluster-with-a-custom-image)
+
+## Development How-To Guides
 
 ### How to run the HyperShift Operator in a local process
 
@@ -36,14 +49,22 @@
 
         oc create secret generic hypershift-operator-pull-secret  -n hypershift --from-file=.dockerconfig=/my/pull-secret --type=kubernetes.io/dockerconfig
 
-Then update the operator ServiceAccount in the hypershift namespace:
+   Then update the operator ServiceAccount in the hypershift namespace:
 
        oc patch serviceaccount operator -n hypershift -p '{"imagePullSecrets": [{"name": "hypershift-operator-pull-secret"}]}'
+
+### How to create a HyperShift Guest Cluster with a custom image
+
+1. Build and push a custom release image to your own repository.
+
+2. Create a guest cluster using the custom image:
+
+        $ bin/hypershift create cluster openstack --release-image quay.io ...
 
 ### How to run the e2e tests
 
 1. Complete [Prerequisites](https://hypershift-docs.netlify.app/getting-started/#prerequisites) with a public Route53
-Hosted Zone, for example with the following environment variables:
+   Hosted Zone, for example with the following environment variables:
 
    ```shell
    BASE_DOMAIN="my.hypershift.dev"
@@ -55,27 +76,27 @@ Hosted Zone, for example with the following environment variables:
    ```
 
 2. Install the HyperShift Operator on a cluster, filling in variables such as the S3 bucket name and region based on
-what was done in the prerequisites phase and potentially supplying a custom image.
+   what was done in the prerequisites phase and potentially supplying a custom image.
 
    ```shell
-   bin/hypershift install \
-   --oidc-storage-provider-s3-bucket-name "${BUCKET_NAME}" \
-   --oidc-storage-provider-s3-credentials "${AWS_CREDS}" \
-   --oidc-storage-provider-s3-region "${AWS_REGION}" \
-   --hypershift-image "${HYPERSHIFT_IMAGE}"
+   $ bin/hypershift install \
+       --oidc-storage-provider-s3-bucket-name "${BUCKET_NAME}" \
+       --oidc-storage-provider-s3-credentials "${AWS_CREDS}" \
+       --oidc-storage-provider-s3-region "${AWS_REGION}" \
+       --hypershift-image "${HYPERSHIFT_IMAGE}"
    ```
 
 2. Run the tests.
 
    ```shell
-        $ make e2e
-        $ bin/test-e2e -test.v -test.timeout 0 \
-          --e2e.aws-credentials-file "${AWS_CREDS}" \
-          --e2e.pull-secret-file "${PULL_SECRET}" \
-          --e2e.aws-region "${AWS_REGION}" \
-          --e2e.availability-zones "${AWS_REGION}a,${AWS_REGION}b,${AWS_REGION}c" \
-          --e2e.aws-oidc-s3-bucket-name "${BUCKET_NAME}" \
-          --e2e.base-domain "${BASE_DOMAIN}"
+   $ make e2e
+   $ bin/test-e2e -test.v -test.timeout 0 \
+       --e2e.aws-credentials-file "${AWS_CREDS}" \
+       --e2e.pull-secret-file "${PULL_SECRET}" \
+       --e2e.aws-region "${AWS_REGION}" \
+       --e2e.availability-zones "${AWS_REGION}a,${AWS_REGION}b,${AWS_REGION}c" \
+       --e2e.aws-oidc-s3-bucket-name "${BUCKET_NAME}" \
+       --e2e.base-domain "${BASE_DOMAIN}"
    ```
 
 ### How to visualize the Go dependency graph
@@ -129,13 +150,13 @@ $ git clone git@github.com:openshift/hypershift
 ```
 
 Initialize the go workspace
+
 ```shell
-go work init
-go work use ./hypershift
-go work use ./hypershift/api
-go work sync
-go work vendor
+$ go work init
+$ go work use ./hypershift
+$ go work use ./hypershift/api
+$ go work sync
+$ go work vendor
 ```
 
-Now when running vscode, open the workspace directory to work
-with hypershift code.
+Now when running vscode, open the workspace directory to work with hypershift code.

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/config.go
@@ -13,7 +13,7 @@ func ProviderConfigKey(provider string) string {
 	case azure.Provider:
 		return azure.CloudConfigKey
 	case openstack.Provider:
-		return openstack.CredentialsFile
+		return openstack.CloudConfigKey
 	default:
 		return ""
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
@@ -10,7 +10,7 @@ import (
 const (
 	CloudConfigDir      = "/etc/openstack/config"
 	CloudCredentialsDir = "/etc/openstack/secret"
-	CredentialsFile     = "cloud.conf"
+	CloudConfigKey      = "cloud.conf"
 	CADir               = "/etc/pki/ca-trust/extracted/pem"
 	CABundleKey         = "ca-bundle.pem"
 	Provider            = "openstack"
@@ -29,7 +29,7 @@ func ReconcileCloudConfigSecret(platformSpec *hyperv1.OpenStackPlatformSpec, sec
 	if caCertData != nil {
 		secret.Data[CABundleKey] = caCertData
 	}
-	secret.Data[CredentialsFile] = []byte(config)
+	secret.Data[CloudConfigKey] = []byte(config)
 
 	return nil
 }
@@ -44,14 +44,14 @@ func ReconcileCloudConfigConfigMap(platformSpec *hyperv1.OpenStackPlatformSpec, 
 	if caCertData != nil {
 		cm.Data[CABundleKey] = string(caCertData)
 	}
-	cm.Data[CredentialsFile] = config
+	cm.Data[CloudConfigKey] = config
 
 	return nil
 }
 
 // getCloudConfig returns the cloud config.
 func getCloudConfig(platformSpec *hyperv1.OpenStackPlatformSpec, credentialsSecret *corev1.Secret, caCertData []byte, machineNetwork []hyperv1.MachineNetworkEntry) string {
-	config := string(credentialsSecret.Data[CredentialsFile])
+	config := string(credentialsSecret.Data[CloudConfigKey])
 	config += "[Global]\n"
 	config += "use-clouds = true\n"
 	config += "clouds-file = " + CloudCredentialsDir + "/" + CloudsSecretKey + "\n"

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
@@ -11,7 +11,7 @@ const (
 	CloudConfigDir      = "/etc/openstack/config"
 	CloudCredentialsDir = "/etc/openstack/secret"
 	CredentialsFile     = "cloud.conf"
-	CaDir               = "/etc/pki/ca-trust/extracted/pem"
+	CADir               = "/etc/pki/ca-trust/extracted/pem"
 	CABundleKey         = "ca-bundle.pem"
 	Provider            = "openstack"
 	CloudsSecretKey     = "clouds.yaml"
@@ -54,14 +54,17 @@ func getCloudConfig(platformSpec *hyperv1.OpenStackPlatformSpec, credentialsSecr
 	config := string(credentialsSecret.Data[CredentialsFile])
 	config += "[Global]\n"
 	config += "use-clouds = true\n"
-	config += "clouds-file=" + CloudCredentialsDir + "/" + CloudsSecretKey + "\n"
-	config += "cloud=" + platformSpec.IdentityRef.CloudName + "\n"
+	config += "clouds-file = " + CloudCredentialsDir + "/" + CloudsSecretKey + "\n"
+	config += "cloud = " + platformSpec.IdentityRef.CloudName + "\n"
 	// This takes priority over the 'cacert' value in 'clouds.yaml' and we therefore
-	// unset then when creating the initial secret.
+	// unset that when creating the initial secret.
 	if caCertData != nil {
-		config += "ca-file=" + CaDir + "/" + CABundleKey + "\n"
+		config += "ca-file = " + CADir + "/" + CABundleKey + "\n"
 	}
-	config += "\n[LoadBalancer]\nmax-shared-lb = 1\nmanage-security-groups = true\n"
+	config += "\n"
+	config += "[LoadBalancer]\n"
+	config += "max-shared-lb = 1\n"
+	config += "manage-security-groups = true\n"
 	if platformSpec.ExternalNetwork != nil {
 		externalNetworkID := ptr.Deref(platformSpec.ExternalNetwork.ID, "")
 		if externalNetworkID != "" {

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig_test.go
@@ -26,7 +26,7 @@ func TestGetCloudConfig(t *testing.T) {
 			},
 			credentialsSecret: &corev1.Secret{
 				Data: map[string][]byte{
-					CredentialsFile: []byte(""),
+					CloudConfigKey: []byte(""),
 				},
 			},
 			machineNetwork: []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.0.0/24")}},
@@ -55,7 +55,7 @@ address-sort-order = 192.168.0.0/24
 			},
 			credentialsSecret: &corev1.Secret{
 				Data: map[string][]byte{
-					CredentialsFile: []byte(""),
+					CloudConfigKey: []byte(""),
 				},
 			},
 			machineNetwork: []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.0.0/24")}},

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig_test.go
@@ -32,8 +32,8 @@ func TestGetCloudConfig(t *testing.T) {
 			machineNetwork: []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.0.0/24")}},
 			expectedConfig: `[Global]
 use-clouds = true
-clouds-file=/etc/openstack/secret/clouds.yaml
-cloud=test-cloud
+clouds-file = /etc/openstack/secret/clouds.yaml
+cloud = test-cloud
 
 [LoadBalancer]
 max-shared-lb = 1
@@ -61,8 +61,8 @@ address-sort-order = 192.168.0.0/24
 			machineNetwork: []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.0.0/24")}},
 			expectedConfig: `[Global]
 use-clouds = true
-clouds-file=/etc/openstack/secret/clouds.yaml
-cloud=test-cloud
+clouds-file = /etc/openstack/secret/clouds.yaml
+cloud = test-cloud
 
 [LoadBalancer]
 max-shared-lb = 1

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/reconcile.go
@@ -90,7 +90,7 @@ func addCACert(deployment *appsv1.Deployment) {
 	ccmContainer := &deployment.Spec.Template.Spec.Containers[0]
 	ccmContainer.VolumeMounts = append(ccmContainer.VolumeMounts, corev1.VolumeMount{
 		Name:      ccmCloudCA().Name,
-		MountPath: CaDir,
+		MountPath: CADir,
 		ReadOnly:  true,
 	})
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/reconcile.go
@@ -117,7 +117,7 @@ func buildCCMContainer(controllerManagerImage, infraID string) func(c *corev1.Co
 		c.Env = []corev1.EnvVar{
 			{
 				Name:  "CLOUD_CONFIG",
-				Value: CloudConfigDir + "/" + CredentialsFile,
+				Value: CloudConfigDir + "/" + CloudConfigKey,
 			},
 			{
 				Name:  "OCP_INFRASTRUCTURE_NAME",
@@ -155,8 +155,8 @@ func buildCCMCloudConfig(v *corev1.Volume) {
 		LocalObjectReference: corev1.LocalObjectReference{Name: manifests.OpenStackProviderConfig("").Name},
 		Items: []corev1.KeyToPath{
 			{
-				Key:  CredentialsFile,
-				Path: CredentialsFile,
+				Key:  CloudConfigKey,
+				Path: CloudConfigKey,
 			},
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2716,18 +2716,12 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 		}
 		caCertData := openstack.GetCACertFromCredentialsSecret(credentialsSecret)
 
+		// Reconcile the Cloud Provider configuration config map
 		cfg := manifests.OpenStackProviderConfig(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, cfg, func() error {
 			return openstack.ReconcileCloudConfigConfigMap(hcp.Spec.Platform.OpenStack, cfg, credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile OpenStack cloud config: %w", err)
-		}
-
-		withSecrets := manifests.OpenStackProviderConfigWithCredentials(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, withSecrets, func() error {
-			return openstack.ReconcileCloudConfigSecret(hcp.Spec.Platform.OpenStack, withSecrets, credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile OpenStack cloud config with credentials: %w", err)
 		}
 
 		// This is for CCM to use the CA cert for OpenStack.

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/openstack.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/openstack.go
@@ -14,15 +14,6 @@ func OpenStackProviderConfig(ns string) *corev1.ConfigMap {
 	}
 }
 
-func OpenStackProviderConfigWithCredentials(ns string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "openstack-cloud-config",
-			Namespace: ns,
-		},
-	}
-}
-
 func OpenStackTrustedCA(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
@@ -105,6 +105,8 @@ spec:
           value: quay.io/openshift/origin-aws-ebs-csi-driver:latest
         - name: AZURE_DISK_DRIVER_CONTROL_PLANE_IMAGE
           value: quay.io/openshift/origin-azure-disk-csi-driver-operator:latest
+        - name: OPENSTACK_CINDER_DRIVER_CONTROL_PLANE_IMAGE
+          value: quay.io/openshift/origin-openstack-cinder-csi-driver-operator:latest
         - name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
           value: quay.io/openshift/origin-csi-livenessprobe:latest
         - name: AZURE_FILE_DRIVER_CONTROL_PLANE_IMAGE

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
@@ -52,6 +52,7 @@ var (
 		"AWS_EBS_DRIVER_CONTROL_PLANE_IMAGE":              "aws-ebs-csi-driver",
 		"AZURE_DISK_DRIVER_CONTROL_PLANE_IMAGE":           "azure-disk-csi-driver",
 		"AZURE_FILE_DRIVER_CONTROL_PLANE_IMAGE":           "azure-file-csi-driver",
+		"OPENSTACK_CINDER_DRIVER_CONTROL_PLANE_IMAGE":     "openstack-cinder-csi-driver",
 		"LIVENESS_PROBE_CONTROL_PLANE_IMAGE":              "csi-livenessprobe",
 		"KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE":             "kube-rbac-proxy",
 		"TOOLS_IMAGE":                                     "tools",

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_component.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_component.yaml
@@ -22,9 +22,6 @@ status:
     type: Progressing
   resources:
   - group: ""
-    kind: Secret
-    name: openstack-cloud-config
-  - group: ""
     kind: ConfigMap
     name: openstack-cloud-config
   - group: ""

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-openstack/config-secret.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-openstack/config-secret.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-data:
-  cloud.conf: ""
-kind: Secret
-metadata:
-  name: openstack-cloud-config

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-openstack/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-openstack/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           value: /etc/openstack/config/cloud.conf
         image: openstack-cloud-controller-manager
         name: cloud-controller-manager
-        resources: 
+        resources:
           requests:
               cpu: 200m
               memory: 50Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/component.go
@@ -38,10 +38,6 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithAdaptFunction(adaptConfig),
 		).
 		WithManifestAdapter(
-			"config-secret.yaml",
-			component.WithAdaptFunction(adaptConfigSecret),
-		).
-		WithManifestAdapter(
 			"openstack-trusted-ca.yaml",
 			component.WithAdaptFunction(adaptTrustedCA),
 		).

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config.go
@@ -59,12 +59,17 @@ func getCloudConfig(hcpSpec hyperv1.HostedControlPlaneSpec, credentialsSecret *c
 	config := string(credentialsSecret.Data[CredentialsFile])
 	config += "[Global]\n"
 	config += "use-clouds = true\n"
-	config += "clouds-file=" + CloudCredentialsDir + "/" + CloudsSecretKey + "\n"
-	config += "cloud=" + hcpSpec.Platform.OpenStack.IdentityRef.CloudName + "\n"
+	config += "clouds-file = " + CloudCredentialsDir + "/" + CloudsSecretKey + "\n"
+	config += "cloud = " + hcpSpec.Platform.OpenStack.IdentityRef.CloudName + "\n"
+	// This takes priority over the 'cacert' value in 'clouds.yaml' and we therefore
+	// unset that when creating the initial secret.
 	if caCertData != nil {
-		config += "ca-file=" + CaDir + "/" + CABundleKey + "\n"
+		config += "ca-file = " + CADir + "/" + CABundleKey + "\n"
 	}
-	config += "\n[LoadBalancer]\nmax-shared-lb = 1\nmanage-security-groups = true\n"
+	config += "\n"
+	config += "[LoadBalancer]\n"
+	config += "max-shared-lb = 1\n"
+	config += "manage-security-groups = true\n"
 	if hcpSpec.Platform.OpenStack.ExternalNetwork != nil {
 		externalNetworkID := ptr.Deref(hcpSpec.Platform.OpenStack.ExternalNetwork.ID, "")
 		if externalNetworkID != "" {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config.go
@@ -52,24 +52,6 @@ func adaptConfig(cpContext component.ControlPlaneContext, cm *corev1.ConfigMap) 
 	return nil
 }
 
-// For some controllers (e.g. Manila CSI, CNCC, etc), the cloud config needs to be stored in a secret.
-// In the hosted cluster config operator, we create the secrets needed by these controllers.
-func adaptConfigSecret(cpContext component.ControlPlaneContext, secret *corev1.Secret) error {
-	credentialsSecret, err := getCredentialsSecret(cpContext)
-	if err != nil {
-		return err
-	}
-
-	caCertData := GetCACertFromCredentialsSecret(credentialsSecret)
-	if caCertData != nil {
-		secret.Data[CABundleKey] = caCertData
-	}
-
-	config := getCloudConfig(cpContext.HCP.Spec, credentialsSecret)
-	secret.Data[CredentialsFile] = []byte(config)
-	return nil
-}
-
 // getCloudConfig returns the cloud config.
 func getCloudConfig(hcpSpec hyperv1.HostedControlPlaneSpec, credentialsSecret *corev1.Secret) string {
 	caCertData := GetCACertFromCredentialsSecret(credentialsSecret)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	CloudCredentialsDir = "/etc/openstack/secret"
-	CredentialsFile     = "cloud.conf"
+	CloudConfigKey      = "cloud.conf"
 	CloudsSecretKey     = "clouds.yaml"
 	CABundleKey         = "ca-bundle.pem"
 )
@@ -48,7 +48,7 @@ func adaptConfig(cpContext component.ControlPlaneContext, cm *corev1.ConfigMap) 
 		cm.Data[CABundleKey] = string(caCertData)
 	}
 
-	cm.Data[CredentialsFile] = getCloudConfig(cpContext.HCP.Spec, credentialsSecret)
+	cm.Data[CloudConfigKey] = getCloudConfig(cpContext.HCP.Spec, credentialsSecret)
 	return nil
 }
 
@@ -56,7 +56,7 @@ func adaptConfig(cpContext component.ControlPlaneContext, cm *corev1.ConfigMap) 
 func getCloudConfig(hcpSpec hyperv1.HostedControlPlaneSpec, credentialsSecret *corev1.Secret) string {
 	caCertData := GetCACertFromCredentialsSecret(credentialsSecret)
 
-	config := string(credentialsSecret.Data[CredentialsFile])
+	config := string(credentialsSecret.Data[CloudConfigKey])
 	config += "[Global]\n"
 	config += "use-clouds = true\n"
 	config += "clouds-file = " + CloudCredentialsDir + "/" + CloudsSecretKey + "\n"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config_test.go
@@ -38,8 +38,8 @@ func TestGetCloudConfig(t *testing.T) {
 			},
 			expectedConfig: `[Global]
 use-clouds = true
-clouds-file=/etc/openstack/secret/clouds.yaml
-cloud=test-cloud
+clouds-file = /etc/openstack/secret/clouds.yaml
+cloud = test-cloud
 
 [LoadBalancer]
 max-shared-lb = 1
@@ -74,8 +74,8 @@ address-sort-order = 192.168.0.0/24
 			},
 			expectedConfig: `[Global]
 use-clouds = true
-clouds-file=/etc/openstack/secret/clouds.yaml
-cloud=test-cloud
+clouds-file = /etc/openstack/secret/clouds.yaml
+cloud = test-cloud
 
 [LoadBalancer]
 max-shared-lb = 1

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config_test.go
@@ -33,7 +33,7 @@ func TestGetCloudConfig(t *testing.T) {
 			},
 			credentialsSecret: &corev1.Secret{
 				Data: map[string][]byte{
-					CredentialsFile: []byte(""),
+					CloudConfigKey: []byte(""),
 				},
 			},
 			expectedConfig: `[Global]
@@ -69,7 +69,7 @@ address-sort-order = 192.168.0.0/24
 			},
 			credentialsSecret: &corev1.Secret{
 				Data: map[string][]byte{
-					CredentialsFile: []byte(""),
+					CloudConfigKey: []byte(""),
 				},
 			},
 			expectedConfig: `[Global]

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
@@ -15,7 +15,7 @@ const (
 	secretOCCMVolumeName = "secret-occm"
 	trustedCAVolumeName  = "trusted-ca"
 
-	CaDir       = "/etc/pki/ca-trust/extracted/pem"
+	CADir       = "/etc/pki/ca-trust/extracted/pem"
 	CASecretKey = "cacert"
 )
 
@@ -39,7 +39,7 @@ func adaptDeployment(cpContext component.ControlPlaneContext, deployment *appsv1
 		if hasCACert {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
 				Name:      trustedCAVolumeName,
-				MountPath: CaDir,
+				MountPath: CADir,
 				ReadOnly:  true,
 			})
 		}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1798,7 +1798,7 @@ func (r *reconciler) reconcileCloudConfig(ctx context.Context, hcp *hyperv1.Host
 			if cmCPC.Data == nil {
 				cmCPC.Data = map[string]string{}
 			}
-			cmCPC.Data[openstack.CredentialsFile] = reference.Data[openstack.CredentialsFile]
+			cmCPC.Data[openstack.CloudConfigKey] = reference.Data[openstack.CloudConfigKey]
 			if reference.Data[openstack.CABundleKey] != "" {
 				cmCPC.Data[openstack.CABundleKey] = reference.Data[openstack.CABundleKey]
 			}
@@ -1818,7 +1818,7 @@ func (r *reconciler) reconcileCloudConfig(ctx context.Context, hcp *hyperv1.Host
 			if cmKCC.Data == nil {
 				cmKCC.Data = map[string]string{}
 			}
-			cmKCC.Data[openstack.CredentialsFile] = reference.Data[openstack.CredentialsFile]
+			cmKCC.Data[openstack.CloudConfigKey] = reference.Data[openstack.CloudConfigKey]
 			if reference.Data[openstack.CABundleKey] != "" {
 				cmKCC.Data[openstack.CABundleKey] = reference.Data[openstack.CABundleKey]
 			}

--- a/docs/content/contribute/develop_in_cluster.md
+++ b/docs/content/contribute/develop_in_cluster.md
@@ -13,7 +13,7 @@ very tedious and slow, the HyperShift project includes a few tools and technique
 to help make the feedback loop as fast as possible.
 
 This guide makes use of the [ko](https://github.com/google/ko) tool to rapidly
-build lightweight images which are then published directly into an OCP cluster's 
+build lightweight images which are then published directly into an OCP cluster's
 internal registry. This approach has the following properties which can speed up
 development:
 
@@ -22,7 +22,7 @@ development:
 - Resulting images are almost as small as the Go binary being published.
 - Images are published directly into OCP's internal image registry, so images
   are immediately available on or near the machines that will be pulling them.
-  
+
 ## Prerequisites
 
 - An OCP 4.9+ cluster
@@ -93,7 +93,7 @@ make it easy to incorporate the script into pipelines.
     Pods in the cluster cannot pull the image using the public repo name because the
     host's certificate is likely self-signed, which would require additional
     configuration in the cluster to enable pods to pull it.
-    
+
     Pods must reference the _internal repo pullspec_ as printed to stdout on line
     10: `image-registry.openshift-image-registry.svc:5000/hypershift/hypershift-operator-cd22...`.
 
@@ -158,9 +158,18 @@ scaled to 0, enabling developers to replace the components with their own proces
 (inside or outside the cluster) while preserving the `Deployment` resources to
 use as templates for the replacement process environments.
 
-For example, the following `HostedCluster` resource will result in a control
-plane with the `control-plane-operator` and `ignition-server` deployments
-scaled to 0:
+For example, to scale the `control-plane-operator` and `ignition-server` deployments
+to 0:
+
+```shell
+oc annotate -n clusters HostedCluster test-cluster hypershift.openshift.io/debug-deployments=control-plane-operator,ignition-server
+```
+
+!!! note
+
+    Update the name of the HostedCluster to match your cluster.
+
+This will result in a `HostedCluster` like so:
 
 ```yaml linenums="1" hl_lines="5"
 apiVersion: hypershift.openshift.io/v1alpha1
@@ -179,10 +188,17 @@ spec:
 To scale back up a given component's original deployment simply remove the component's
 deployment name from the list.
 
+The `hypershift.openshift.io/pod-security-admission-label-override` annotation
+may also need to be set in order to run debug pods locally.
+
+```shell
+oc annotate -n clusters HostedCluster test-cluster hypershift.openshift.io/pod-security-admission-label-override=baseline
+```
+
 ## Launch a custom `control-plane-operator` image interactively
 
 To iterate on the `control-plane-operator` binary in-cluster interactively, first
-[configure the HostedCluster](#configure-a-hostedcluster-for-iterative-control-plane-development) 
+[configure the HostedCluster](#configure-a-hostedcluster-for-iterative-control-plane-development)
 to scale down the `control-plane-operator` deployment.
 
 Now, you can build and publish the `control-plane-operator` image and run it interactively
@@ -202,7 +218,7 @@ press `ctrl-c` to terminate and delete the pod.
     The default arguments to `control-plane-operator run` should be sufficient to
     get started.
 
-## Launch a custom ignition server interactively
+## Launch a custom `ignition-server` interactively
 
 To iterate on the ignition server in-cluster interactively, first
 [configure the HostedCluster](#configure-a-hostedcluster-for-iterative-control-plane-development)

--- a/support/globalconfig/infrastructure.go
+++ b/support/globalconfig/infrastructure.go
@@ -87,7 +87,7 @@ func ReconcileInfrastructure(infra *configv1.Infrastructure, hcp *hyperv1.Hosted
 		infra.Spec.PlatformSpec.OpenStack = &configv1.OpenStackPlatformSpec{}
 		// This ConfigMap is populated by the local ignition provider and given to MCO
 		infra.Spec.CloudConfig.Name = "cloud-provider-config"
-		infra.Spec.CloudConfig.Key = openstack.CredentialsFile
+		infra.Spec.CloudConfig.Key = openstack.CloudConfigKey
 		infra.Status.PlatformStatus.OpenStack = &configv1.OpenStackPlatformStatus{
 			CloudName:            "openstack",
 			LoadBalancer:         &configv1.OpenStackPlatformLoadBalancer{Type: configv1.LoadBalancerTypeUserManaged},

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1163,34 +1163,35 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 		g := NewWithT(t)
 
 		auditedAppList := map[string]string{
-			"cloud-controller-manager":         "app",
-			"cloud-credential-operator":        "app",
-			"aws-ebs-csi-driver-controller":    "app",
-			"capi-provider-controller-manager": "app",
-			"cloud-network-config-controller":  "app",
-			"cluster-network-operator":         "app",
-			"cluster-version-operator":         "app",
-			"control-plane-operator":           "app",
-			"ignition-server":                  "app",
-			"ingress-operator":                 "app",
-			"kube-apiserver":                   "app",
-			"kube-controller-manager":          "app",
-			"kube-scheduler":                   "app",
-			"multus-admission-controller":      "app",
-			"oauth-openshift":                  "app",
-			"openshift-apiserver":              "app",
-			"openshift-oauth-apiserver":        "app",
-			"packageserver":                    "app",
-			"ovnkube-master":                   "app",
-			"kubevirt-csi-driver":              "app",
-			"cluster-image-registry-operator":  "name",
-			"virt-launcher":                    "kubevirt.io",
-			"azure-disk-csi-driver-controller": "app",
-			"azure-file-csi-driver-controller": "app",
-			"certified-operators-catalog":      "app",
-			"community-operators-catalog":      "app",
-			"redhat-operators-catalog":         "app",
-			"redhat-marketplace-catalog":       "app",
+			"cloud-controller-manager":               "app",
+			"cloud-credential-operator":              "app",
+			"aws-ebs-csi-driver-controller":          "app",
+			"capi-provider-controller-manager":       "app",
+			"cloud-network-config-controller":        "app",
+			"cluster-network-operator":               "app",
+			"cluster-version-operator":               "app",
+			"control-plane-operator":                 "app",
+			"ignition-server":                        "app",
+			"ingress-operator":                       "app",
+			"kube-apiserver":                         "app",
+			"kube-controller-manager":                "app",
+			"kube-scheduler":                         "app",
+			"multus-admission-controller":            "app",
+			"oauth-openshift":                        "app",
+			"openshift-apiserver":                    "app",
+			"openshift-oauth-apiserver":              "app",
+			"packageserver":                          "app",
+			"ovnkube-master":                         "app",
+			"kubevirt-csi-driver":                    "app",
+			"cluster-image-registry-operator":        "name",
+			"virt-launcher":                          "kubevirt.io",
+			"azure-disk-csi-driver-controller":       "app",
+			"azure-file-csi-driver-controller":       "app",
+			"certified-operators-catalog":            "app",
+			"community-operators-catalog":            "app",
+			"redhat-operators-catalog":               "app",
+			"redhat-marketplace-catalog":             "app",
+			"openstack-cinder-csi-driver-controller": "app",
 		}
 
 		hcpPods := &corev1.PodList{}
@@ -1902,6 +1903,13 @@ func EnsureSATokenNotMountedUnlessNecessary(t *testing.T, ctx context.Context, c
 				"azure-disk-csi-driver-operator",
 				"azure-file-csi-driver-controller",
 				"azure-file-csi-driver-operator",
+			)
+		}
+
+		if hostedCluster.Spec.Platform.Type == hyperv1.OpenStackPlatform {
+			expectedComponentsWithTokenMount = append(expectedComponentsWithTokenMount,
+				"openstack-cinder-csi-driver-controller",
+				"openstack-cinder-csi-driver-operator",
 			)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable the Cluster Storage Operator for the OpenStack platform, enabling storage.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

Fixes [OSASINFRA-3636](https://issues.redhat.com//browse/OSASINFRA-3636)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.

**Testing notes**

This has been manually tested using a release image built (by cluster-bot) with this PR and the other two below (URL exported as `RELEASE_IMAGE`) along with a custom `hypershift-operator` image. Initial deployment on a 4.17.2 management cluster was done like so:

```bash
❯ cd hypershift

# build and publish custom hypershift-operator image

❯ HYPERSHIFT_IMAGE="ghcr.io/stephenfin/hypershift-operator:latest"
❯ podman build -t "${HYPERSHIFT_IMAGE}" -f Dockerfile
❯ podman push "${HYPERSHIFT_IMAGE}"

# install hypershift-operator in management cluster

❯ ./bin/hypershift install --wait-until-available --tech-preview-no-upgrade --hypershift-image "${HYPERSHIFT_IMAGE}"

# create guest cluster

❯ EXTERNAL_NET_ID=$(openstack network show -f value -c id provider_net_shared
❯ FLAVOR="ci.m1.large"
❯ RHCOS_IMAGE="rhcos-4.17"
❯ ./bin/hypershift create cluster openstack \
    --base-domain shiftstack-dev.devcluster.openshift.com \
    --machine-cidr "192.168.25.0/24" \
    --name stephenfin-hcp \
    --node-pool-replicas 1 \
    --openstack-cloud "${OS_CLOUD}" \
    --openstack-external-network-id "${EXTERNAL_NET_ID}" \
    --openstack-node-flavor "${FLAVOR}" \
    --openstack-node-image-name "${RHCOS_IMAGE}" \
    --pull-secret ~/.config/openshift/pull-secret.json \
    --release-image "${RELEASE_IMAGE}" \
    --ssh-key ~/.ssh/id_ed25519.pub
```

Once the guest cluster was up and running, I created a pod with a PVC attached.

```bash
❯ ./bin/hypershift create kubeconfig --name stephenfin-hcp > stephenfin-hcp-kubeconfig
❯ export KUBECONFIG=$PWD/stephenfin-hcp-kubeconfig

❯ oc get sc
NAME                     PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
standard-csi (default)   cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   17h
❯ oc get csinodes.storage.k8s.io 
NAME                         DRIVERS   AGE
stephenfin-hcp-dl2kp-kscvx   1         17h
❯ oc get csidrivers.storage.k8s.io 
NAME                       ATTACHREQUIRED   PODINFOONMOUNT   STORAGECAPACITY   TOKENREQUESTS   REQUIRESREPUBLISH   MODES        AGE
cinder.csi.openstack.org   true             true             false             <unset>         false               Persistent   17h

❯ cat cinder-persistent-volume.yaml 
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: demo-pvc
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: standard-csi
---
apiVersion: v1
kind: Pod
metadata:
  name: my-csi-app
spec:
  containers:
    - name: my-frontend
      image: quay.io/quay/busybox:latest
      volumeMounts:
      - mountPath: "/data"
        name: my-csi-vol
      command: [ "sleep", "1000000" ]
  volumes:
    - name: my-csi-vol
      persistentVolumeClaim:
        claimName: demo-pvc
❯ oc apply -f cinder-persistent-volume.yaml

# wait ~ 30 seconds for the pod to be created

❯ oc get pvc
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
demo-pvc   Bound    pvc-cd9bb8b3-d597-45e0-b02b-9291ed65254e   1Gi        RWO            standard-csi   <unset>                 5s

❯ oc get pod
NAME         READY   STATUS    RESTARTS   AGE
my-csi-app   1/1     Running   0          33s
```


**Related changes**

- https://github.com/openshift/csi-operator/pull/302
- https://github.com/openshift/cluster-storage-operator/pull/525