### PR TITLE
HOSTEDCP-2000: Add E2E test validating the node runtime

### DIFF
--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -215,5 +215,6 @@ func (ru *NodePoolUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, node
 		},
 		e2eutil.WithTimeout(20*time.Minute),
 	)
-	e2eutil.WaitForReadyNodesByNodePool(t, ctx, ru.hostedClusterClient, &nodePool, ru.hostedCluster.Spec.Platform.Type)
+	newNodes := e2eutil.WaitForReadyNodesByNodePool(t, ctx, ru.hostedClusterClient, &nodePool, ru.hostedCluster.Spec.Platform.Type)
+	e2eutil.EnsureNodesRuntime(t, newNodes)
 }


### PR DESCRIPTION
Starting from OpenShift 4.18, the container runtime on worker nodes has been changed to crun. This new test validates that all those worker nodes in this release version contain the correct runtime handlers.

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-2000](https://issues.redhat.com/browse/HOSTEDCP-2000)