### PR TITLE
OCPBUGS-38132: cpo: produce valid oauth config even if idp config is invalid

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/config.go
@@ -51,13 +51,9 @@ func ReconcileOAuthServerConfig(ctx context.Context, cm *corev1.ConfigMap, owner
 }
 
 func generateOAuthConfig(ctx context.Context, client crclient.Client, namespace string, params *OAuthConfigParams) (*osinv1.OsinServerConfig, error) {
-	var identityProviders []osinv1.IdentityProvider
-	identityProviders, _, err := ConvertIdentityProviders(ctx, params.IdentityProviders, params.OauthConfigOverrides, client, namespace)
-	if err != nil {
-		// Eat the error here, since we don't want to fail the deployment if the identity providers are invalid
-		// A condition will be set on the HC to indicate the error
-		return nil, nil
-	}
+	// Ignore the error here since we don't want to fail the deployment if the identity providers are invalid
+	// A condition will be set on the HC to indicate the error
+	identityProviders, _, _ := ConvertIdentityProviders(ctx, params.IdentityProviders, params.OauthConfigOverrides, client, namespace)
 
 	cpath := func(volume, file string) string {
 		dir := volumeMounts.Path(oauthContainerMain().Name, volume)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -164,10 +164,10 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 
 	deploymentConfig.ApplyTo(deployment)
 	if len(identityProviders) > 0 {
-		_, volumeMountInfo, err := ConvertIdentityProviders(ctx, identityProviders, providerOverrides, client, deployment.Namespace)
-		// Eat the error here, since we don't want to fail the deployment if the identity providers are invalid
+		_, volumeMountInfo, _ := ConvertIdentityProviders(ctx, identityProviders, providerOverrides, client, deployment.Namespace)
+		// Ignore the error here, since we don't want to fail the deployment if the identity providers are invalid
 		// A condition will be set on the HC to indicate the error
-		if err == nil {
+		if len(volumeMountInfo.Volumes) > 0 {
 			deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volumeMountInfo.Volumes...)
 			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMountInfo.VolumeMounts.ContainerMounts(oauthContainerMain().Name)...)
 		}


### PR DESCRIPTION
follow up fix to https://github.com/openshift/hypershift/pull/4852

After https://github.com/openshift/hypershift/pull/4852, we returned `nil` instead of the valid oauth config (without the invalid IDPs).  We want is a valid oauth config with the invalid IDPs removed.