### PR TITLE
OCPBUGS-42434: Reconcile SecretProviderClass for Cloud Provider on ARO HCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/params.go
@@ -11,13 +11,15 @@ import (
 )
 
 type AzureParams struct {
-	ClusterID        string                  `json:"clusterID"`
-	ClusterNetwork   string                  `json:"clusterNetwork"`
-	OwnerRef         *metav1.OwnerReference  `json:"ownerRef"`
-	DeploymentConfig config.DeploymentConfig `json:"deploymentConfig"`
+	ClusterID               string                  `json:"clusterID"`
+	ClusterNetwork          string                  `json:"clusterNetwork"`
+	OwnerRef                *metav1.OwnerReference  `json:"ownerRef"`
+	DeploymentConfig        config.DeploymentConfig `json:"deploymentConfig"`
+	TenantID                string                  `json:"tenantID"`
+	SecretProviderClassName string                  `json:"secretProviderClassName"`
 }
 
-func NewAzureParams(hcp *hyperv1.HostedControlPlane) *AzureParams {
+func NewAzureParams(hcp *hyperv1.HostedControlPlane, tenantID, secretProviderClassName string) *AzureParams {
 	if hcp.Spec.Platform.Azure == nil {
 		return nil
 	}
@@ -26,6 +28,8 @@ func NewAzureParams(hcp *hyperv1.HostedControlPlane) *AzureParams {
 		ClusterNetwork: hcp.Spec.Networking.ClusterNetwork[0].CIDR.String(),
 	}
 	p.OwnerRef = config.ControllerOwnerRef(hcp)
+	p.TenantID = tenantID
+	p.SecretProviderClassName = secretProviderClassName
 
 	p.DeploymentConfig.SetDefaults(hcp, ccmLabels(), ptr.To(1))
 	p.DeploymentConfig.Resources = config.ResourcesSpec{

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -42,10 +42,11 @@ func ReconcileCloudConfigWithCredentials(secret *corev1.Secret, hcp *hyperv1.Hos
 		return err
 	}
 
-	cfg.AADClientID = string(credentialsSecret.Data["AZURE_CLIENT_ID"])
-	cfg.AADClientSecret = string(credentialsSecret.Data["AZURE_CLIENT_SECRET"])
+	cfg.AADClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider.ClientID
+	cfg.AADClientCertPath = "/mnt/certs/" + hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider.CertificateName
 	cfg.UseManagedIdentityExtension = false
 	cfg.UseInstanceMetadata = false
+
 	serializedConfig, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to serialize cloudconfig: %w", err)
@@ -103,12 +104,14 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 // Now the source is https://github.com/kubernetes-sigs/cloud-provider-azure/blob/e5d670328a51e31787fc949ddf41a3efcd90d651/examples/out-of-tree/cloud-controller-manager.yaml#L232
 // https://github.com/kubernetes-sigs/cloud-provider-azure/tree/e5d670328a51e31787fc949ddf41a3efcd90d651/pkg/provider/config
 type AzureConfig struct {
-	Cloud                        string `json:"cloud"`
-	TenantID                     string `json:"tenantId"`
-	UseManagedIdentityExtension  bool   `json:"useManagedIdentityExtension"`
-	SubscriptionID               string `json:"subscriptionId"`
-	AADClientID                  string `json:"aadClientId"`
+	Cloud                       string `json:"cloud"`
+	TenantID                    string `json:"tenantId"`
+	UseManagedIdentityExtension bool   `json:"useManagedIdentityExtension"`
+	SubscriptionID              string `json:"subscriptionId"`
+	AADClientID                 string `json:"aadClientId"`
+	// TODO HOSTEDCP-1542 - Bryan - drop client secret once we have WorkloadIdentity working
 	AADClientSecret              string `json:"aadClientSecret"`
+	AADClientCertPath            string `json:"aadClientCertPath"`
 	ResourceGroup                string `json:"resourceGroup"`
 	Location                     string `json:"location"`
 	VnetName                     string `json:"vnetName"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Reconcile the SecretProviderClass for the cloud provider for ARO HCP deployments. The SecretProviderClass is used by the Secrets Store CSI driver to mount a certificate to a volume in the cloud provider pod deployment.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.