### PR TITLE
HOSTEDCP-1994: Add generic create function for SecretProvider

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/secretproviderclass.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/secretproviderclass.go
@@ -1,0 +1,50 @@
+package manifests
+
+import (
+	"fmt"
+	"github.com/openshift/hypershift/support/azureutil"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
+)
+
+const (
+	objectFormat = `
+array:
+  - |
+    objectName: %s
+    objectType: secret
+`
+)
+
+// ManagedAzureKeyVaultSecretProviderClass returns an instance of a SecretProviderClass completed with its name, Azure Key Vault set
+// up, and the certificate name it needs to pull from the Key Vault.
+//
+// https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity
+func ManagedAzureKeyVaultSecretProviderClass(secretProviderClassName, namespace, keyVaultName, KeyVaultTenantID, certificateName string) *secretsstorev1.SecretProviderClass {
+	return &secretsstorev1.SecretProviderClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretProviderClassName,
+			Namespace: namespace,
+		},
+		Spec: secretsstorev1.SecretProviderClassSpec{
+			Provider: "azure",
+			Parameters: map[string]string{
+				"usePodIdentity":         "false",
+				"useVMManagedIdentity":   "true",
+				"userAssignedIdentityID": azureutil.GetKeyVaultAuthorizedUser(),
+				"keyvaultName":           keyVaultName,
+				"tenantId":               KeyVaultTenantID,
+				"objects":                formatSecretProviderClassObject(certificateName),
+			},
+		},
+	}
+}
+
+// formatSecretProviderClassObject places the certificate name in the appropriate string structure the
+// SecretProviderClass expects for an object. More details here:
+// - https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity#configure-managed-identity
+// - https://secrets-store-csi-driver.sigs.k8s.io/concepts.html?highlight=object#custom-resource-definitions-crds
+func formatSecretProviderClassObject(certName string) string {
+	return fmt.Sprintf(objectFormat, certName)
+}

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -222,4 +223,8 @@ func VerifyResourceGroupLocationsMatch(ctx context.Context, hc *hyperv1.HostedCl
 // IsAroHCP returns true if the managed service environment variable is set to ARO-HCP
 func IsAroHCP() bool {
 	return os.Getenv("MANAGED_SERVICE") == hyperv1.AroHCP
+}
+
+func GetKeyVaultAuthorizedUser() string {
+	return os.Getenv(config.AROHCPKeyVaultManagedIdentityClientID)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add generic create function for SecretProviderClass for ARO HCP. 

Example usage - https://github.com/openshift/hypershift/pull/4884.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.