### PR TITLE
OSASINFRA-3639: Enable cluster-storage-operator for OpenStack Manila

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
@@ -115,6 +115,8 @@ spec:
           value: quay.io/openshift/origin-kube-rbac-proxy:latest
         - name: TOOLS_IMAGE
           value: quay.io/openshift/origin-tools:latest
+        - name: MANILA_DRIVER_CONTROL_PLANE_IMAGE
+          value: quay.io/openshift/origin-csi-driver-manila-operator:latest
         image: quay.io/openshift/origin-cluster-storage-operator:latest
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
@@ -53,6 +53,7 @@ var (
 		"AZURE_DISK_DRIVER_CONTROL_PLANE_IMAGE":           "azure-disk-csi-driver",
 		"AZURE_FILE_DRIVER_CONTROL_PLANE_IMAGE":           "azure-file-csi-driver",
 		"OPENSTACK_CINDER_DRIVER_CONTROL_PLANE_IMAGE":     "openstack-cinder-csi-driver",
+		"MANILA_DRIVER_CONTROL_PLANE_IMAGE":               "csi-driver-manila",
 		"LIVENESS_PROBE_CONTROL_PLANE_IMAGE":              "csi-livenessprobe",
 		"KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE":             "kube-rbac-proxy",
 		"TOOLS_IMAGE":                                     "tools",

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -2524,8 +2524,10 @@ func (r *reconciler) reconcileStorage(ctx context.Context, hcp *hyperv1.HostedCo
 	case hyperv1.AWSPlatform:
 		driverNames = []operatorv1.CSIDriverName{operatorv1.AWSEBSCSIDriver}
 	case hyperv1.OpenStackPlatform:
-		// TODO(stephenfin): Add Manila here once it supports Hypershift
-		driverNames = []operatorv1.CSIDriverName{operatorv1.CinderCSIDriver}
+		driverNames = []operatorv1.CSIDriverName{
+			operatorv1.CinderCSIDriver,
+			operatorv1.ManilaCSIDriver,
+		}
 	}
 	for _, driverName := range driverNames {
 		driver := manifests.ClusterCSIDriver(driverName)

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -259,6 +259,11 @@ func (a OpenStack) ReconcileCredentials(ctx context.Context, c client.Client, cr
 		return err
 	}
 
+	// Sync Manila CSI driver secret
+	if err := a.reconcileOpenStackCredentialsSecret(ctx, c, createOrUpdate, hcluster, controlPlaneNamespace, "manila-cloud-credentials"); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1192,6 +1192,7 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 			"redhat-operators-catalog":               "app",
 			"redhat-marketplace-catalog":             "app",
 			"openstack-cinder-csi-driver-controller": "app",
+			"manila-csi-driver-controller":           "app",
 		}
 
 		hcpPods := &corev1.PodList{}
@@ -1910,6 +1911,8 @@ func EnsureSATokenNotMountedUnlessNecessary(t *testing.T, ctx context.Context, c
 			expectedComponentsWithTokenMount = append(expectedComponentsWithTokenMount,
 				"openstack-cinder-csi-driver-controller",
 				"openstack-cinder-csi-driver-operator",
+				"manila-csi-driver-controller",
+				"openstack-manila-csi-driver-operator",
 			)
 		}
 


### PR DESCRIPTION
This PR enables the Manila CSI integration to Hypershift. It reconciles the OpenStack credentials needed by Manila and defines the `MANILA_DRIVER_CONTROL_PLANE_IMAGE`.

Related Changes:

-  https://github.com/openshift/csi-operator/pull/312
-  https://github.com/openshift/cluster-storage-operator/pull/527