### PR TITLE
HOSTEDCP-1989: Prevent kubevirt from removing valid machine config condition

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt.go
@@ -41,7 +41,6 @@ func (r *NodePoolReconciler) setKubevirtConditions(ctx context.Context, nodePool
 		})
 		return fmt.Errorf("validation of NodePool KubeVirt platform failed: %w", err)
 	}
-	removeStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolValidMachineConfigConditionType)
 
 	infraNS := controlPlaneNamespace
 	if hcluster.Spec.Platform.Kubevirt != nil &&


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.