### PR TITLE
OCPBUGS-44001: handle errors returned by createServicePrincipalWithCe…

### DIFF
--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -2,8 +2,10 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/log"
@@ -164,9 +166,14 @@ func destroyServicePrincipals(o *DestroyInfraOptions) error {
 func destroyServicePrincipal(clientID string) error {
 	cmdStr := `az ad app delete --id ` + clientID
 	cmd := exec.Command("sh", "-c", cmdStr)
-	_, err := cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
+
 	if err != nil {
 		return fmt.Errorf("failed to delete service principal, %s: %w", clientID, err)
+	}
+
+	if strings.Contains(string(output), "ERROR") {
+		return errors.New(string(output))
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

- handle errors returned by createServicePrincipalWithCertificate command
- use generated vnet and nsg resource group names

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-44001](https://issues.redhat.com/browse/OCPBUGS-44001)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.