### PR TITLE
HOSTEDCP-2046: Parametrize Control Plane Dockerfile

### DIFF
--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -1,4 +1,7 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+ARG EL9_BUILD_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17
+ARG BASE_IMAGE=registry.ci.openshift.org/ocp/4.18:base-rhel9
+
+FROM ${EL9_BUILD_IMAGE} AS builder
 
 WORKDIR /hypershift
 
@@ -6,7 +9,7 @@ COPY . .
 
 RUN make control-plane-operator control-plane-pki-operator
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM ${BASE_IMAGE}
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to get the Konflux CPO Application to be able to use the same containerfile as we use for ART, we need to parametrize the image references, keeping the current values as defaults. Then, the konflux tekton configuration can override.

**Which issue(s) this PR fixes**
Fixes #[HOSTEDCP-2046](https://issues.redhat.com//browse/HOSTEDCP-2046)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.