### PR TITLE
OCPBUGS-44037: change Azure infra destroy CLI to use prefixes and inf…

### DIFF
--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -40,7 +40,6 @@ type DestroyOptions struct {
 	DestroyCloudResources bool
 	Log                   logr.Logger
 	CredentialSecretName  string
-	TechPreviewEnabled    bool
 }
 
 type AWSPlatformDestroyOptions struct {
@@ -58,7 +57,6 @@ type AzurePlatformDestroyOptions struct {
 	CredentialsFile              string
 	Location                     string
 	ResourceGroupName            string
-	ControlPlaneMIs              hyperv1.AzureResourceManagedIdentities
 	SkipServicePrincipalDeletion bool
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- fixes OCPBUGS-44037 by changing Azure infra destroy CLI to use prefixes and infra-id for SP deletion.
- 
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-44037](https://issues.redhat.com/browse/OCPBUGS-44037)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.