### PR TITLE
OCPBUGS-43985: failure to retrieve techPreview CM in azure cli should…

### DIFF
--- a/cmd/cluster/azure/create_test.go
+++ b/cmd/cluster/azure/create_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	azureinfra "github.com/openshift/hypershift/cmd/infra/azure"
 	azurenodepool "github.com/openshift/hypershift/cmd/nodepool/azure"
@@ -125,10 +126,11 @@ func TestCreateCluster(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(api.Scheme).Build()
+			log := logr.Logger{}
 			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
 			coreOpts := core.DefaultOptions()
 			core.BindDeveloperOptions(coreOpts, flags)
-			azureOpts, err := DefaultOptions(fakeClient)
+			azureOpts, err := DefaultOptions(fakeClient, log)
 			if err != nil {
 				t.Fatal("failed to create azure options: ", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

- failure to retrieve techPreview CM in azure cli should be a warning

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-43985](https://issues.redhat.com/browse/OCPBUGS-43985)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.