### PR TITLE
OCPBUGS-36387: resource group not found should not prevent azure infr…

### DIFF
--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/log"
@@ -97,6 +98,10 @@ func (o *DestroyInfraOptions) Run(ctx context.Context, logger logr.Logger) error
 		logger.Info("Deleting resource group", "resource-group", rg)
 		destroyFuture, err = resourceGroupClient.BeginDelete(ctx, rg, nil)
 		if err != nil {
+			if strings.Contains(err.Error(), "ResourceGroupNotFound") {
+				logger.Info("Resource group not found, continuing with infra deletion", "resource-group", rg)
+				continue
+			}
 			return fmt.Errorf("failed to start deletion for resource group %s: %w", rg, err)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- OCPBUGS-36387: resource group not found should not prevent azure infra deletion from proceeding


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-36387](https://issues.redhat.com/browse/OCPBUGS-36387)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.