### PR TITLE
[release-4.17] OSASINFRA-3623: openstack: Only upload required cloud credentials

### DIFF
--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
@@ -23,17 +23,19 @@ func TestCreateOptions_Validate(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name:          "missing OpenStack credentials file",
-			input:         RawCreateOptions{},
-			expectedError: "OpenStack credentials file is required",
+			name: "missing OpenStack credentials file",
+			input: RawCreateOptions{
+				OpenStackCredentialsFile: "thisisajunkfilename.yaml",
+			},
+			expectedError: "OpenStack credentials file does not exist",
 		},
 	} {
 		var errString string
 		if _, err := test.input.Validate(context.Background(), nil); err != nil {
 			errString = err.Error()
 		}
-		if diff := cmp.Diff(test.expectedError, errString); diff != "" {
-			t.Errorf("got incorrect error: %v", diff)
+		if !strings.Contains(errString, test.expectedError) {
+			t.Errorf("got incorrect error: expected: %v actual: %v", test.expectedError, errString)
 		}
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
@@ -54,6 +54,8 @@ func getCloudConfig(externalNetworkID *string, cloudName string, credentialsSecr
 	config += "use-clouds = true\n"
 	config += "clouds-file=" + CloudCredentialsDir + "/" + CloudsSecretKey + "\n"
 	config += "cloud=" + cloudName + "\n"
+	// This takes priority over the 'cacert' value in 'clouds.yaml' and we therefore
+	// unset then when creating the initial secret.
 	if caCertData != nil {
 		config += "ca-file=" + CaDir + "/" + CABundleKey + "\n"
 	}

--- a/docs/content/how-to/openstack/create-openstack-cluster.md
+++ b/docs/content/how-to/openstack/create-openstack-cluster.md
@@ -101,8 +101,7 @@ export CLUSTER_NAME=example
 export PULL_SECRET="$HOME/pull-secret"
 export WORKER_COUNT="2"
 
-# clouds.yaml should be in the format of the OpenStack clouds.yaml file and the cloud name has to be 'openstack' for now.
-export CLOUDS_YAML="$HOME/clouds.yaml"
+export OS_CLOUD="openstack"
 
 # Image name is the name of the image in OpenStack that was pushed in the previous step.
 export IMAGE_NAME="rhcos"
@@ -126,7 +125,6 @@ hcp create cluster openstack \
 --pull-secret $PULL_SECRET \
 --ssh-key $SSH_KEY \
 --openstack-ca-cert-file $CA_CERT_PATH \
---openstack-credentials-file $CLOUDS_YAML \
 --openstack-external-network-id $EXTERNAL_ID \
 --openstack-node-image-name $IMAGE_NAME \
 --openstack-node-flavor $FLAVOR


### PR DESCRIPTION
**What this PR does / why we need it**:

This backport will ease the user experience for our cloud credentials.
They are well tested by our CI and we also performed manual testing.
- **trivial: Inline clouds.yaml validation**
- **openstack: Support clouds.yaml discovery, different cloud names**
- **openstack: Only upload the cloud we want**
- **openstack: Support reading cacert from clouds.yaml**
