### PR TITLE
WIP - cmd/openstack: remove cred file & cacert options

### DIFF
--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -78,7 +78,6 @@ func TestCreateCluster(t *testing.T) {
 		{
 			name: "minimal flags necessary to render",
 			args: []string{
-				"--openstack-credentials-file=" + credentialsFile,
 				"--openstack-node-flavor=m1.xlarge",
 				"--openstack-node-image-name=rhcos",
 				"--pull-secret=" + pullSecretFile,
@@ -88,7 +87,6 @@ func TestCreateCluster(t *testing.T) {
 		{
 			name: "default creation flags",
 			args: []string{
-				"--openstack-credentials-file=" + credentialsFile,
 				"--openstack-external-network-id=5387f86a-a10e-47fe-91c6-41ac131f9f30",
 				"--openstack-node-image-name=rhcos",
 				"--openstack-node-flavor=fakeFlavor",
@@ -148,7 +146,7 @@ func TestExtractCloud(t *testing.T) {
 		// we know a new temporary directory will be empty so this file will never exist
 		cloudsYAMLPath := filepath.Join(tempDir, "clouds.yaml")
 
-		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "", "openstack")
+		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "openstack")
 
 		assert.Nil(t, cloudsYAML)
 		assert.Nil(t, caCert)
@@ -163,7 +161,7 @@ func TestExtractCloud(t *testing.T) {
 			t.Fatalf("failed to write clouds.yaml: %v", err)
 		}
 
-		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "", "openstack")
+		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "openstack")
 
 		assert.Nil(t, cloudsYAML)
 		assert.Nil(t, caCert)
@@ -178,7 +176,7 @@ func TestExtractCloud(t *testing.T) {
 			t.Fatalf("failed to write clouds.yaml: %v", err)
 		}
 
-		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "", "openstack")
+		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "openstack")
 
 		assert.Nil(t, cloudsYAML)
 		assert.Nil(t, caCert)
@@ -193,7 +191,7 @@ func TestExtractCloud(t *testing.T) {
 		}
 		dumpYAML(t, cloudsYAMLPath, clouds)
 
-		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "", "openstack")
+		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "openstack")
 
 		assert.Nil(t, cloudsYAML)
 		assert.Nil(t, caCert)
@@ -217,7 +215,7 @@ func TestExtractCloud(t *testing.T) {
 		}
 		dumpYAML(t, cloudsYAMLPath, clouds)
 
-		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "", "openstack")
+		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "openstack")
 
 		assert.Nil(t, cloudsYAML)
 		assert.Nil(t, caCert)
@@ -259,47 +257,8 @@ func TestExtractCloud(t *testing.T) {
 		})
 		assert.Nil(t, err)
 
-		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "", "openstack")
+		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, "openstack")
 
-		assert.Equal(t, cloudsYAML, expectedCloudsYAML)
-		assert.Equal(t, caCert, caCertData)
-		assert.Nil(t, err)
-	})
-
-	t.Run("explicit cacert preferred to clouds.yaml", func(t *testing.T) {
-		tempDir := t.TempDir()
-		cloudsYAMLPath := filepath.Join(tempDir, "clouds.yaml")
-		// we know a new temporary directory will be empty so this file will not exist
-		invalidCACertPath := filepath.Join(tempDir, "invalid-ca.crt")
-		validCACertPath := filepath.Join(tempDir, "valid-ca.crt")
-		caCertData := []byte("this is not real CA cert data but that's okay")
-		if err := os.WriteFile(validCACertPath, caCertData, 0600); err != nil {
-			t.Fatalf("failed to write %s: %v", validCACertPath, err)
-		}
-		clouds := map[string]any{
-			"clouds": map[string]any{
-				"openstack": map[string]any{
-					"auth": map[string]any{
-						"auth_url": "fakeAuthURL",
-					},
-					// this should be ignored/not checked
-					"cacert": invalidCACertPath,
-				},
-			},
-		}
-		dumpYAML(t, cloudsYAMLPath, clouds)
-		expectedCloudsYAML, err := yaml.Marshal(map[string]any{
-			"clouds": map[string]any{
-				"openstack": map[string]any{
-					"auth": map[string]any{
-						"auth_url": "fakeAuthURL",
-					},
-				},
-			},
-		})
-		assert.Nil(t, err)
-
-		cloudsYAML, caCert, err := extractCloud(cloudsYAMLPath, validCACertPath, "openstack")
 		assert.Equal(t, cloudsYAML, expectedCloudsYAML)
 		assert.Equal(t, caCert, caCertData)
 		assert.Nil(t, err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -102,8 +102,6 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.BaseDomain, "e2e.base-domain", "", "The ingress base domain for the cluster")
 	flag.StringVar(&globalOpts.configurableClusterOptions.ControlPlaneOperatorImage, "e2e.control-plane-operator-image", "", "The image to use for the control plane operator. If none specified, the default is used.")
 	flag.Var(&globalOpts.additionalTags, "e2e.additional-tags", "Additional tags to set on AWS resources")
-	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackCredentialsFile, "e2e.openstack-credentials-file", "", "Path to the OpenStack credentials file")
-	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackCACertFile, "e2e.openstack-ca-cert-file", "", "Path to the OpenStack CA certificate file")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackExternalNetworkID, "e2e.openstack-external-network-id", "", "ID of the OpenStack external network")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeFlavor, "e2e.openstack-node-flavor", "", "The flavor to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
@@ -553,8 +551,6 @@ func (o *options) DefaultNoneOptions() none.RawCreateOptions {
 
 func (p *options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions {
 	opts := hypershiftopenstack.RawCreateOptions{
-		OpenStackCredentialsFile:   p.configurableClusterOptions.OpenStackCredentialsFile,
-		OpenStackCACertFile:        p.configurableClusterOptions.OpenStackCACertFile,
 		OpenStackExternalNetworkID: p.configurableClusterOptions.OpenStackExternalNetworkID,
 		NodePoolOpts: &openstacknodepool.RawOpenStackPlatformCreateOptions{
 			OpenStackPlatformOptions: &openstacknodepool.OpenStackPlatformOptions{


### PR DESCRIPTION
**What this PR does / why we need it**:

These options shouldn't be necessary with the recent changes in the CLI.
The user experience is being simplified here to avoid potential misuse
of clouds.yaml.

