### PR TITLE
HOSTEDCP-2070: add e2e flags for controlling AKS keyvault name and te…

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -109,6 +109,8 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeAvailabilityZone, "e2e.openstack-node-availability-zone", "", "The availability zone to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureCredentialsFile, "e2e.azure-credentials-file", "", "Path to an Azure credentials file")
+	flag.StringVar(&globalOpts.configurableClusterOptions.ManagementKeyVaultName, "e2e.management-key-vault-name", "", "Name of the Azure Key Vault to use for Certificates")
+	flag.StringVar(&globalOpts.configurableClusterOptions.ManagementKeyVaultTenantId, "e2e.management-key-vault-tenant-id", "", "Tenant ID of the Azure Key Vault to use for Certificates")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureLocation, "e2e.azure-location", "eastus", "The location to use for Azure")
 	flag.StringVar(&globalOpts.configurableClusterOptions.SSHKeyFile, "e2e.ssh-key-file", "", "Path to a ssh public key")
 	flag.StringVar(&globalOpts.platformRaw, "e2e.platform", string(hyperv1.AWSPlatform), "The platform to use for the tests")
@@ -435,6 +437,8 @@ type configurableClusterOptions struct {
 	AWSCredentialsFile            string
 	AWSMultiArch                  bool
 	AzureCredentialsFile          string
+	ManagementKeyVaultName        string
+	ManagementKeyVaultTenantId    string
 	OpenStackCredentialsFile      string
 	OpenStackCACertFile           string
 	AzureLocation                 string
@@ -626,6 +630,18 @@ func (o *options) DefaultAzureOptions() azure.RawCreateOptions {
 		zones := strings.Split(o.configurableClusterOptions.Zone.String(), ",")
 		// Assign all Azure zones to guest cluster
 		opts.AvailabilityZones = zones
+	}
+
+	if o.configurableClusterOptions.ManagementKeyVaultName != "" {
+		opts.KeyVaultInfo.KeyVaultName = o.configurableClusterOptions.ManagementKeyVaultName
+	}
+
+	if o.configurableClusterOptions.ManagementKeyVaultTenantId != "" {
+		opts.KeyVaultInfo.KeyVaultTenantID = o.configurableClusterOptions.ManagementKeyVaultTenantId
+	}
+
+	if opts.KeyVaultInfo.KeyVaultName != "" && opts.KeyVaultInfo.KeyVaultTenantID != "" {
+		opts.TechPreviewEnabled = true
 	}
 
 	return opts


### PR DESCRIPTION
**What this PR does / why we need it**: 
- adds e2e flags to control the keyvault settings for AKS e2e

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-2070](https://issues.redhat.com/browse/HOSTEDCP-2070)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.