### PR TITLE
[4.17] OCPBUGS-44184: dont use registryOverrides on kube rbac proxy image be…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -57,6 +57,7 @@ type Images struct {
 	CloudNetworkConfigController string
 	TokenMinter                  string
 	CLI                          string
+	CLIControlPlane              string
 	Socks5Proxy                  string
 }
 
@@ -98,7 +99,8 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 			NetworkingConsolePlugin:      userReleaseImageProvider.GetImage("networking-console-plugin"),
 			CloudNetworkConfigController: releaseImageProvider.GetImage("cloud-network-config-controller"),
 			TokenMinter:                  releaseImageProvider.GetImage("token-minter"),
-			CLI:                          releaseImageProvider.GetImage("cli"),
+			CLI:                          userReleaseImageProvider.GetImage("cli"),
+			CLIControlPlane:              releaseImageProvider.GetImage("cli"),
 			Socks5Proxy:                  releaseImageProvider.GetImage("socks5-proxy"),
 		},
 		ReleaseVersion:          version,
@@ -406,7 +408,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 				"network-operator",
 			},
 			Name:  "remove-old-cno",
-			Image: params.Images.CLI,
+			Image: params.Images.CLIControlPlane,
 			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
@@ -435,7 +437,7 @@ kubectl --kubeconfig $kc config set contexts.default.namespace $(cat /var/run/se
 kubectl --kubeconfig $kc config use-context default`,
 			},
 			Name:  "rewrite-config",
-			Image: params.Images.CLI,
+			Image: params.Images.CLIControlPlane,
 			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
@@ -460,7 +462,7 @@ sc=$(kubectl --kubeconfig $kc get --ignore-not-found validatingwebhookconfigurat
 if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validatingwebhookconfiguration multus.openshift.io; fi`,
 			},
 			Name:  "remove-old-multus-validating-webhook-configuration",
-			Image: params.Images.CLI,
+			Image: params.Images.CLIControlPlane,
 			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
@@ -521,6 +523,7 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 			{Name: "CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE", Value: params.Images.CloudNetworkConfigController},
 			{Name: "TOKEN_MINTER_IMAGE", Value: params.Images.TokenMinter},
 			{Name: "CLI_IMAGE", Value: params.Images.CLI},
+			{Name: "CLI_CONTROL_PLANE_IMAGE", Value: params.Images.CLIControlPlane},
 			{Name: "SOCKS5_PROXY_IMAGE", Value: params.Images.Socks5Proxy},
 			{Name: "OPENSHIFT_RELEASE_IMAGE", Value: params.DeploymentConfig.AdditionalAnnotations[hyperv1.ReleaseImageAnnotation]},
 		}...),

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -83,6 +83,7 @@ spec:
         - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
         - name: TOKEN_MINTER_IMAGE
         - name: CLI_IMAGE
+        - name: CLI_CONTROL_PLANE_IMAGE
         - name: SOCKS5_PROXY_IMAGE
         - name: OPENSHIFT_RELEASE_IMAGE
         imagePullPolicy: IfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -83,6 +83,7 @@ spec:
         - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
         - name: TOKEN_MINTER_IMAGE
         - name: CLI_IMAGE
+        - name: CLI_CONTROL_PLANE_IMAGE
         - name: SOCKS5_PROXY_IMAGE
         - name: OPENSHIFT_RELEASE_IMAGE
         imagePullPolicy: IfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -81,6 +81,7 @@ spec:
         - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
         - name: TOKEN_MINTER_IMAGE
         - name: CLI_IMAGE
+        - name: CLI_CONTROL_PLANE_IMAGE
         - name: SOCKS5_PROXY_IMAGE
         - name: OPENSHIFT_RELEASE_IMAGE
         imagePullPolicy: IfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
@@ -109,6 +109,8 @@ spec:
           value: quay.io/openshift/origin-csi-livenessprobe:latest
         - name: AZURE_FILE_DRIVER_CONTROL_PLANE_IMAGE
           value: quay.io/openshift/origin-azure-file-csi-driver-operator:latest
+        - name: KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE
+          value: quay.io/openshift/origin-kube-rbac-proxy:latest
         - name: TOOLS_IMAGE
           value: quay.io/openshift/origin-tools:latest
         image: quay.io/openshift/origin-cluster-storage-operator:latest

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/envreplace.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"k8s.io/utils/strings/slices"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -51,6 +52,7 @@ var (
 		"AZURE_DISK_DRIVER_CONTROL_PLANE_IMAGE":           "azure-disk-csi-driver",
 		"AZURE_FILE_DRIVER_CONTROL_PLANE_IMAGE":           "azure-file-csi-driver",
 		"LIVENESS_PROBE_CONTROL_PLANE_IMAGE":              "csi-livenessprobe",
+		"KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE":             "kube-rbac-proxy",
 		"TOOLS_IMAGE":                                     "tools",
 	}
 )
@@ -68,8 +70,16 @@ func (er *environmentReplacer) setOperatorImageReferences(images map[string]stri
 	// `operatorImageRefs` is map from env. var name -> payload image name
 	// `images` is map from payload image name -> image URL
 	// Create map from env. var name -> image URL
+
+	dataPlaneImageRefs := []string{
+		"NODE_DRIVER_REGISTRAR_IMAGE",
+		"LIVENESS_PROBE_IMAGE",
+		"CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE",
+		"KUBE_RBAC_PROXY_IMAGE",
+	}
+
 	for envVar, payloadName := range operatorImageRefs {
-		if envVar == "NODE_DRIVER_REGISTRAR_IMAGE" || envVar == "LIVENESS_PROBE_IMAGE" || strings.HasSuffix(envVar, "_DRIVER_IMAGE") {
+		if slices.Contains(dataPlaneImageRefs, envVar) || strings.HasSuffix(envVar, "_DRIVER_IMAGE") {
 			if imageURL, ok := userImages[payloadName]; ok {
 				er.values[envVar] = imageURL
 			}

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -258,7 +258,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 					"konnectivity-agent": konnectivityAgentImage,
 				},
 			},
-			RegistryOverrides: o.registryOverrides,
+			RegistryOverrides: nil,
 		},
 		OpenShiftImageRegistryOverrides: imageRegistryOverrides,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: 
- Manual cherry pick of [openshift/hypershift/pull/4791](https://github.com/openshift/hypershift/pull/4791)

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-44184](https://issues.redhat.com/browse/OCPBUGS-44184)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.