### PR TITLE
HOSTEDCP-1924: Set the InfrastructureAvailabilityPolicy to HighlyAvailable by default

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -421,7 +421,7 @@ type HostedClusterSpec struct {
 	// SingleReplica.
 	//
 	// +optional
-	// +kubebuilder:default:="SingleReplica"
+	// +kubebuilder:default:="HighlyAvailable"
 	// +immutable
 	InfrastructureAvailabilityPolicy AvailabilityPolicy `json:"infrastructureAvailabilityPolicy,omitempty"`
 

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -2229,7 +2229,7 @@ spec:
                   and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   InfrastructureAvailabilityPolicy specifies the availability policy applied
                   to infrastructure services which run on cluster nodes. The default value is

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -2225,7 +2225,7 @@ spec:
                   and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   InfrastructureAvailabilityPolicy specifies the availability policy applied
                   to infrastructure services which run on cluster nodes. The default value is

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2246,7 +2246,7 @@ spec:
                   and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   InfrastructureAvailabilityPolicy specifies the availability policy applied
                   to infrastructure services which run on cluster nodes. The default value is

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2467,7 +2467,7 @@ spec:
                   and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   InfrastructureAvailabilityPolicy specifies the availability policy applied
                   to infrastructure services which run on cluster nodes. The default value is

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2377,7 +2377,7 @@ spec:
                   and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   InfrastructureAvailabilityPolicy specifies the availability policy applied
                   to infrastructure services which run on cluster nodes. The default value is

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -2225,7 +2225,7 @@ spec:
                   and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   InfrastructureAvailabilityPolicy specifies the availability policy applied
                   to infrastructure services which run on cluster nodes. The default value is

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -2643,7 +2643,7 @@ spec:
                   and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   InfrastructureAvailabilityPolicy specifies the availability policy applied
                   to infrastructure services which run on cluster nodes. The default value is

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -2643,7 +2643,7 @@ spec:
                   and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   InfrastructureAvailabilityPolicy specifies the availability policy applied
                   to infrastructure services which run on cluster nodes. The default value is

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -2643,7 +2643,7 @@ spec:
                   and its associated NodePools.
                 type: string
               infrastructureAvailabilityPolicy:
-                default: SingleReplica
+                default: HighlyAvailable
                 description: |-
                   InfrastructureAvailabilityPolicy specifies the availability policy applied
                   to infrastructure services which run on cluster nodes. The default value is

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -421,7 +421,7 @@ type HostedClusterSpec struct {
 	// SingleReplica.
 	//
 	// +optional
-	// +kubebuilder:default:="SingleReplica"
+	// +kubebuilder:default:="HighlyAvailable"
 	// +immutable
 	InfrastructureAvailabilityPolicy AvailabilityPolicy `json:"infrastructureAvailabilityPolicy,omitempty"`
 


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This is important in cases such as compact HCP. When the InfrastructureAvailablityPolicy is set to Single, it causes issues such as:
+ VMs not properly live migrating on node drains/upgrades
  + Per VM PDBs are never created
  + VMs are forcefully restarted on cluster upgrade
+ Virt component replicas are not scaled to total node count – this can lead to Virt control plane delays under load


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.