### PR TITLE
OCPBUGS-42422: Fix order rendering HCP objects

### DIFF
--- a/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -17,6 +17,31 @@ metadata:
   name: example-pull-secret
   namespace: clusters
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: capi-provider-role
+rules:
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  verbs:
+  - '*'
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -89,31 +114,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  name: capi-provider-role
-rules:
-- apiGroups:
-  - agent-install.openshift.io
-  resources:
-  - agents
-  verbs:
-  - '*'
----
-apiVersion: v1
-data:
-  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: example-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -17,6 +17,30 @@ metadata:
   name: bryans-cluster-pull-secret
   namespace: clusters
 ---
+apiVersion: v1
+data:
+  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
+  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
+  AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
+  AZURE_TENANT_ID: ZmFrZVRlbmFudElE
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: bryans-cluster-cloud-credentials
+  namespace: clusters
+---
+apiVersion: v1
+data:
+  key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: bryans-cluster-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -114,30 +138,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-apiVersion: v1
-data:
-  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
-  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
-  AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
-  AZURE_TENANT_ID: ZmFrZVRlbmFudElE
-kind: Secret
-metadata:
-  creationTimestamp: null
-  name: bryans-cluster-cloud-credentials
-  namespace: clusters
----
-apiVersion: v1
-data:
-  key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: bryans-cluster-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -17,6 +17,30 @@ metadata:
   name: example-pull-secret
   namespace: clusters
 ---
+apiVersion: v1
+data:
+  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
+  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
+  AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
+  AZURE_TENANT_ID: ZmFrZVRlbmFudElE
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: example-cloud-credentials
+  namespace: clusters
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -114,30 +138,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-apiVersion: v1
-data:
-  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
-  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
-  AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
-  AZURE_TENANT_ID: ZmFrZVRlbmFudElE
-kind: Secret
-metadata:
-  creationTimestamp: null
-  name: example-cloud-credentials
-  namespace: clusters
----
-apiVersion: v1
-data:
-  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: example-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -17,6 +17,30 @@ metadata:
   name: example-pull-secret
   namespace: clusters
 ---
+apiVersion: v1
+data:
+  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
+  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
+  AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
+  AZURE_TENANT_ID: ZmFrZVRlbmFudElE
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: example-cloud-credentials
+  namespace: clusters
+---
+apiVersion: v1
+data:
+  key: RtBxtzupSh9bkzEqKY5VZOOLLDVYsAKqPIYkEMK7R1A=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -114,30 +138,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-apiVersion: v1
-data:
-  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
-  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
-  AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
-  AZURE_TENANT_ID: ZmFrZVRlbmFudElE
-kind: Secret
-metadata:
-  creationTimestamp: null
-  name: example-cloud-credentials
-  namespace: clusters
----
-apiVersion: v1
-data:
-  key: RtBxtzupSh9bkzEqKY5VZOOLLDVYsAKqPIYkEMK7R1A=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: example-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -188,10 +188,10 @@ type resources struct {
 func (r *resources) asObjects() []crclient.Object {
 	var objects []crclient.Object
 
-	if object := r.AdditionalTrustBundle; object != nil {
+	if object := r.Namespace; object != nil {
 		objects = append(objects, object)
 	}
-	if object := r.Namespace; object != nil {
+	if object := r.AdditionalTrustBundle; object != nil {
 		objects = append(objects, object)
 	}
 	if object := r.PullSecret; object != nil {
@@ -200,14 +200,14 @@ func (r *resources) asObjects() []crclient.Object {
 	if object := r.SSHKey; object != nil {
 		objects = append(objects, object)
 	}
-	if object := r.Cluster; object != nil {
-		objects = append(objects, object)
-	}
 
 	// there's no way to check that the objects in `r.Resources` are not nil, as we can have
 	// a non-nil controllerruntime.Object interface vtable but a nil object that it points to
 	objects = append(objects, r.Resources...)
 
+	if object := r.Cluster; object != nil {
+		objects = append(objects, object)
+	}
 	for _, object := range r.NodePools {
 		if object != nil {
 			objects = append(objects, object)

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	corev1 "k8s.io/api/core/v1"
 	apiversion "k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakekubeclient "k8s.io/client-go/kubernetes/fake"
@@ -83,6 +86,64 @@ func TestValidateMgmtClusterAndNodePoolCPUArchitectures(t *testing.T) {
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 			}
+		})
+	}
+}
+
+// This test will make sure the order of the objects is correct
+// being the HC and NP the last ones and the firts one the namespace.
+func TestAsObjects(t *testing.T) {
+	tests := []struct {
+		name         string
+		resources    *resources
+		expectedFail bool
+	}{
+		{
+			name: "All resources are present",
+			resources: &resources{
+				Namespace:             &corev1.Namespace{},
+				AdditionalTrustBundle: &corev1.ConfigMap{},
+				PullSecret:            &corev1.Secret{},
+				SSHKey:                &corev1.Secret{},
+				Cluster:               &hyperv1.HostedCluster{},
+				Resources: []crclient.Object{
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
+				},
+				NodePools: []*hyperv1.NodePool{{}, {}},
+			},
+			expectedFail: false,
+		},
+		{
+			name: "Namespace resource is nil",
+			resources: &resources{
+				Namespace:             nil,
+				AdditionalTrustBundle: &corev1.ConfigMap{},
+				PullSecret:            &corev1.Secret{},
+				SSHKey:                &corev1.Secret{},
+				Cluster:               &hyperv1.HostedCluster{},
+				Resources: []crclient.Object{
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
+				},
+				NodePools: []*hyperv1.NodePool{{}, {}},
+			},
+			expectedFail: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			objects := tc.resources.asObjects()
+			if tc.expectedFail {
+				g.Expect(objects[0]).To(Not(Equal(tc.resources.Namespace)))
+				return
+			}
+			g.Expect(objects[0]).To(Equal(tc.resources.Namespace), "Namespace should be the first object in the slice")
+			hcPosition := len(objects) - len(tc.resources.NodePools) - 1
+			g.Expect(objects[hcPosition]).To(Equal(tc.resources.Cluster), "HostedCluster should be the secodn-to-last object in the slice")
+			g.Expect(objects[len(objects)-1]).To(Equal(tc.resources.NodePools[len(tc.resources.NodePools)-1]), "NodePools should be the last object in the slice")
 		})
 	}
 }

--- a/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -17,6 +17,18 @@ metadata:
   name: example-pull-secret
   namespace: clusters
 ---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -76,18 +88,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-apiVersion: v1
-data:
-  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: example-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool

--- a/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_test_from_dvossel.yaml
+++ b/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_test_from_dvossel.yaml
@@ -17,6 +17,18 @@ metadata:
   name: test1-pull-secret
   namespace: clusters
 ---
+apiVersion: v1
+data:
+  key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: test1-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -96,18 +108,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-apiVersion: v1
-data:
-  key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: test1-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool

--- a/cmd/cluster/none/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/none/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -17,6 +17,18 @@ metadata:
   name: example-pull-secret
   namespace: clusters
 ---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -87,18 +99,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-apiVersion: v1
-data:
-  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: example-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
@@ -17,6 +17,30 @@ metadata:
   name: test-pull-secret
   namespace: clusters
 ---
+apiVersion: v1
+data:
+  clouds.yaml: Y2xvdWRzOgogICAgb3BlbnN0YWNrOgogICAgICAgIGF1dGg6CiAgICAgICAgICAgIGF1dGhfdXJsOiBmYWtlQXV0aFVSTAo=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: test-cloud-credentials
+  namespace: clusters
+type: Opaque
+---
+apiVersion: v1
+data:
+  key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: test-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -85,30 +109,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-apiVersion: v1
-data:
-  clouds.yaml: Y2xvdWRzOgogICAgb3BlbnN0YWNrOgogICAgICAgIGF1dGg6CiAgICAgICAgICAgIGF1dGhfdXJsOiBmYWtlQXV0aFVSTAo=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: test-cloud-credentials
-  namespace: clusters
-type: Opaque
----
-apiVersion: v1
-data:
-  key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: test-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -17,6 +17,30 @@ metadata:
   name: example-pull-secret
   namespace: clusters
 ---
+apiVersion: v1
+data:
+  clouds.yaml: Y2xvdWRzOgogICAgb3BlbnN0YWNrOgogICAgICAgIGF1dGg6CiAgICAgICAgICAgIGF1dGhfdXJsOiBmYWtlQXV0aFVSTAo=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-cloud-credentials
+  namespace: clusters
+type: Opaque
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -78,30 +102,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-apiVersion: v1
-data:
-  clouds.yaml: Y2xvdWRzOgogICAgb3BlbnN0YWNrOgogICAgICAgIGF1dGg6CiAgICAgICAgICAgIGF1dGhfdXJsOiBmYWtlQXV0aFVSTAo=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: example-cloud-credentials
-  namespace: clusters
-type: Opaque
----
-apiVersion: v1
-data:
-  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: example-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool

--- a/cmd/cluster/powervs/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/powervs/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -17,6 +17,43 @@ metadata:
   name: example-pull-secret
   namespace: clusters
 ---
+metadata:
+  creationTimestamp: null
+  name: KubeCloudControllerManager
+  namespace: ns
+---
+metadata:
+  creationTimestamp: null
+  name: NodePoolManagement
+  namespace: ns
+---
+metadata:
+  creationTimestamp: null
+  name: IngressOperator
+  namespace: ns
+---
+metadata:
+  creationTimestamp: null
+  name: StorageOperator
+  namespace: ns
+---
+metadata:
+  creationTimestamp: null
+  name: ImageRegistryOperator
+  namespace: ns
+---
+apiVersion: v1
+data:
+  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
@@ -102,43 +139,6 @@ status:
   controlPlaneEndpoint:
     host: ""
     port: 0
----
-metadata:
-  creationTimestamp: null
-  name: KubeCloudControllerManager
-  namespace: ns
----
-metadata:
-  creationTimestamp: null
-  name: NodePoolManagement
-  namespace: ns
----
-metadata:
-  creationTimestamp: null
-  name: IngressOperator
-  namespace: ns
----
-metadata:
-  creationTimestamp: null
-  name: StorageOperator
-  namespace: ns
----
-metadata:
-  creationTimestamp: null
-  name: ImageRegistryOperator
-  namespace: ns
----
-apiVersion: v1
-data:
-  key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
-  name: example-etcd-encryption-key
-  namespace: clusters
-type: Opaque
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool


### PR DESCRIPTION
Fix order rendering HCP objects, modified to be always first the Namespace, and the last ones the HC and NP. Covered with unit tests.

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-42422](https://issues.redhat.com/browse/OCPBUGS-42422)