### PR TITLE
OCM-12313: expose NodeStartupTimeout in MHC as annotation in HC/NP

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -300,6 +300,11 @@ const (
 	// one on the NodePool takes precedence. The value is a go duration string with a number and a unit (ie. 8m, 1h, etc)
 	MachineHealthCheckTimeoutAnnotation = "hypershift.openshift.io/machine-health-check-timeout"
 
+	// MachineHealthCheckNodeStartupTimeoutAnnotation allows overriding the default machine health check timeout for
+	// node startup on nodepools. The annotation can be set in either the HostedCluster or the NodePool. If set on both, the
+	// one on the NodePool takes precedence. The value is a go duration string with a number and a unit (ie. 8m, 1h, etc)
+	MachineHealthCheckNodeStartupTimeoutAnnotation = "hypershift.openshift.io/machine-health-check-node-startup-timeout"
+
 	// MachineHealthCheckMaxUnhealthyAnnotation allows overriding the max unhealthy value of the machine
 	// health check created for a NodePool. The annotation can be set in either the HostedCluster or the NodePool.
 	// If set on both, the one on the NodePool takes precedence. The value can be a number or a percentage value.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -300,6 +300,11 @@ const (
 	// one on the NodePool takes precedence. The value is a go duration string with a number and a unit (ie. 8m, 1h, etc)
 	MachineHealthCheckTimeoutAnnotation = "hypershift.openshift.io/machine-health-check-timeout"
 
+	// MachineHealthCheckNodeStartupTimeoutAnnotation allows overriding the default machine health check timeout for
+	// node startup on nodepools. The annotation can be set in either the HostedCluster or the NodePool. If set on both, the
+	// one on the NodePool takes precedence. The value is a go duration string with a number and a unit (ie. 8m, 1h, etc)
+	MachineHealthCheckNodeStartupTimeoutAnnotation = "hypershift.openshift.io/machine-health-check-node-startup-timeout"
+
 	// MachineHealthCheckMaxUnhealthyAnnotation allows overriding the max unhealthy value of the machine
 	// health check created for a NodePool. The annotation can be set in either the HostedCluster or the NodePool.
 	// If set on both, the one on the NodePool takes precedence. The value can be a number or a percentage value.


### PR DESCRIPTION
The MachineHealthCheck that is generated for node pools when autorepair is enable has NodeStartupTimeout currently hardcoded to 20 minutes. For bare metal instances, this may need to be set to a bigger value, as the instance is slower to join the cluster.

This commit exposes this parameter as annotation on the HostedCluster and/or NodePool, with NodePool level annotation which will take precedence. This is aligned with the annotation already exposed for the readiness timeout.

Change covered by unit testing.

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [X] This change includes unit tests.