### PR TITLE
OCPBUGS-44163: Configure OAuth https proxy to dial cloud endpoints directly

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -241,7 +241,7 @@ func buildOAuthContainerHTTPProxy(image string, proxyConfig *configv1.ProxySpec,
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.Command = []string{"/usr/bin/control-plane-operator", "konnectivity-https-proxy"}
-		c.Args = []string{"run", fmt.Sprintf("--serving-port=%d", httpKonnectivityProxyPort)}
+		c.Args = []string{"run", fmt.Sprintf("--serving-port=%d", httpKonnectivityProxyPort), "--connect-directly-to-cloud-apis"}
 		if proxyConfig != nil {
 			c.Args = append(c.Args, "--http-proxy", proxyConfig.HTTPProxy)
 			c.Args = append(c.Args, "--https-proxy", proxyConfig.HTTPSProxy)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
@@ -106,6 +106,7 @@ spec:
       - args:
         - run
         - --serving-port=8092
+        - --connect-directly-to-cloud-apis
         command:
         - /usr/bin/control-plane-operator
         - konnectivity-https-proxy


### PR DESCRIPTION
**What this PR does / why we need it**:
In the case of IBM Cloud, the identity provider is a cloud provider endpoint that should be reached directly from the management cluster and not through the data plane. This commit adds the --connect-directly-to-cloud-apis flag to the https proxy container of the oauth server pod to accomplish this.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-44163](https://issues.redhat.com/browse/OCPBUGS-44163)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.