### PR TITLE
OCPBUGS-42434: Authenticate Azure KMS with cert authentication

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
@@ -118,6 +118,7 @@ func (p *azureKMSProvider) ApplyKMSConfig(podSpec *corev1.PodSpec) error {
 	podSpec.Volumes = append(podSpec.Volumes,
 		util.BuildVolume(kasVolumeAzureKMSCredentials(), buildVolumeAzureKMSCredentials),
 		util.BuildVolume(kasVolumeKMSSocket(), buildVolumeKMSSocket),
+		util.BuildVolume(kasVolumeKMSSecretStore(), buildVolumeKMSSecretStore),
 	)
 
 	podSpec.Containers = append(podSpec.Containers,
@@ -145,6 +146,12 @@ func (p *azureKMSProvider) ApplyKMSConfig(podSpec *corev1.PodSpec) error {
 	}
 	container.VolumeMounts = append(container.VolumeMounts,
 		azureKMSVolumeMounts.ContainerMounts(KasMainContainerName)...)
+
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      config.ManagedAzureKMSSecretStoreVolumeName,
+		MountPath: config.ManagedAzureCertificateMountPath,
+		ReadOnly:  true,
+	})
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/kms.go
@@ -1,8 +1,11 @@
 package kms
 
 import (
+	"github.com/openshift/hypershift/support/config"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+	"k8s.io/utils/ptr"
 )
 
 type IKMSProvider interface {
@@ -26,4 +29,22 @@ func kasVolumeKMSSocket() *corev1.Volume {
 
 func buildVolumeKMSSocket(v *corev1.Volume) {
 	v.EmptyDir = &corev1.EmptyDirVolumeSource{}
+}
+
+func kasVolumeKMSSecretStore() *corev1.Volume {
+	return &corev1.Volume{
+		Name: config.ManagedAzureKMSSecretStoreVolumeName,
+	}
+}
+
+func buildVolumeKMSSecretStore(v *corev1.Volume) {
+	v.VolumeSource = corev1.VolumeSource{
+		CSI: &corev1.CSIVolumeSource{
+			Driver:   config.ManagedAzureSecretsStoreCSIDriver,
+			ReadOnly: ptr.To(true),
+			VolumeAttributes: map[string]string{
+				config.ManagedAzureSecretProviderClass: config.ManagedAzureKMSSecretStoreVolumeName,
+			},
+		},
+	}
 }

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -49,9 +49,22 @@ const (
 	CPOOverridesEnvVar = "ENABLE_CPO_OVERRIDES"
 
 	AuditWebhookService = "audit-webhook"
+)
 
+// Azure related constants
+const (
 	// AROHCPKeyVaultManagedIdentityClientID captures the client ID of the managed identity created on an ARO HCP
 	// management cluster. This managed identity is used to pull secrets and certificates out of Azure Key Vaults in the
 	// management cluster's resource group in Azure.
 	AROHCPKeyVaultManagedIdentityClientID = "ARO_HCP_KEY_VAULT_USER_CLIENT_ID"
+
+	ManagedAzureClientIdEnvVarKey        = "ARO_HCP_MI_CLIENT_ID"
+	ManagedAzureTenantIdEnvVarKey        = "ARO_HCP_TENANT_ID"
+	ManagedAzureCertificatePathEnvVarKey = "ARO_HCP_CLIENT_CERTIFICATE_PATH"
+	ManagedAzureCertificateMountPath     = "/mnt/certs"
+	ManagedAzureSecretsStoreCSIDriver    = "secrets-store.csi.k8s.io"
+	ManagedAzureSecretProviderClass      = "secretProviderClass"
+
+	ManagedAzureKMSSecretStoreVolumeName   = "azure-kms-cert"
+	ManagedAzureKMSSecretProviderClassName = "managed-azure-kms"
 )

--- a/support/filewatcher/filewatcher.go
+++ b/support/filewatcher/filewatcher.go
@@ -1,0 +1,69 @@
+package filewatcher
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	watchCertificateFileOnce sync.Once
+	log                      = ctrl.Log.WithName("file-change-watcher")
+)
+
+// WatchFileForChanges watches the file, fileToWatch. If the file contents have changed, the pod this function is
+// running on will be restarted.
+func WatchFileForChanges(fileToWatch string) error {
+	var err error
+
+	// This starts only one occurrence of the file watcher, which watches the file, fileToWatch, for changes every interval.
+	// In addition, it also captures an initial hash of the file contents to use to monitor the file for changes.
+	watchCertificateFileOnce.Do(func() {
+		log.Info("Starting the file change watcher...")
+
+		// Update the file path to watch in case this is a symlink
+		fileToWatch, err = filepath.EvalSymlinks(fileToWatch)
+		if err != nil {
+			return
+		}
+		log.Info("Watching file...", "file", fileToWatch)
+
+		// Start the file watcher to monitor file changes
+		go checkForFileChanges(fileToWatch)
+	})
+	return err
+}
+
+// checkForFileChanges starts a new file watcher. If the file is changed, the pod running this function will exit.
+func checkForFileChanges(path string) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if ok && (event.Has(fsnotify.Write) || event.Has(fsnotify.Chmod) || event.Has(fsnotify.Remove)) {
+					log.Info("file was modified, exiting", "event name", event.Name, "event operation", event.Op)
+					os.Exit(0)
+				}
+			case err, ok := <-watcher.Errors:
+				if ok {
+					log.Error(err, "file watcher error")
+				}
+			}
+		}
+	}()
+
+	err = watcher.Add(path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit authenticates Azure KMS with certificate authentication in order to communicate with Azure Cloud API. The certificate is stored in an Azure key vault and mounted into the KAS pod through a Secrets Store CSI driver SecretProviderClass.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-42434:](https://github.com/openshift/hypershift/pull/4997/files#top)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.