### PR TITLE
HOSTEDCP-2003: Add sharedVPC support on product-cli

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -362,6 +362,7 @@ func DefaultOptions() *RawCreateOptions {
 func BindOptions(opts *RawCreateOptions, flags *flag.FlagSet) {
 	bindCoreOptions(opts, flags)
 	opts.Credentials.BindProductFlags(flags)
+	opts.VPCOwnerCredentials.BindVPCOwnerFlags(flags)
 }
 
 func bindCoreOptions(opts *RawCreateOptions, flags *flag.FlagSet) {

--- a/product-cli/cmd/cluster/aws/destroy.go
+++ b/product-cli/cmd/cluster/aws/destroy.go
@@ -28,6 +28,7 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd.Flags().DurationVar(&opts.AWSPlatform.AwsInfraGracePeriod, "aws-infra-grace-period", opts.AWSPlatform.AwsInfraGracePeriod, "Timeout for destroying infrastructure in minutes")
 
 	opts.AWSPlatform.Credentials.BindProductFlags(cmd.Flags())
+	opts.AWSPlatform.Credentials.BindVPCOwnerFlags(cmd.Flags())
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		err := hypershiftaws.ValidateCredentialInfo(opts.AWSPlatform.Credentials, opts.CredentialSecretName, opts.Namespace)


### PR DESCRIPTION
Add `--vpc-owner-aws-creds` flag in `hcp` product CLI to support sharedVPC cluster creation

**Which issue(s) this PR fixes**:
Fixes #[HOSTEDCP-2003](https://issues.redhat.com/browse/HOSTEDCP-2003)