### PR TITLE
HOSTEDCP-2070: add az cli to e2e dockerfile

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -4,4 +4,7 @@ WORKDIR /hypershift
 
 COPY . .
 
+RUN yum -y install azure-cli && \
+    yum clean all
+
 RUN make e2e

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -514,19 +514,20 @@ func CreateInfraOptions(ctx context.Context, azureOpts *ValidatedCreateOptions, 
 	}
 
 	return azureinfra.CreateInfraOptions{
-		Name:                        opts.Name,
-		Location:                    azureOpts.Location,
-		InfraID:                     opts.InfraID,
-		CredentialsFile:             azureOpts.CredentialsFile,
-		BaseDomain:                  opts.BaseDomain,
-		RHCOSImage:                  rhcosImage,
-		VnetID:                      azureOpts.VnetID,
-		ResourceGroupName:           azureOpts.ResourceGroupName,
-		NetworkSecurityGroupID:      azureOpts.NetworkSecurityGroupID,
-		ResourceGroupTags:           azureOpts.ResourceGroupTags,
-		SubnetID:                    azureOpts.SubnetID,
-		ManagedIdentityKeyVaultName: azureOpts.KeyVaultInfo.KeyVaultName,
-		TechPreviewEnabled:          azureOpts.TechPreviewEnabled,
+		Name:                            opts.Name,
+		Location:                        azureOpts.Location,
+		InfraID:                         opts.InfraID,
+		CredentialsFile:                 azureOpts.CredentialsFile,
+		BaseDomain:                      opts.BaseDomain,
+		RHCOSImage:                      rhcosImage,
+		VnetID:                          azureOpts.VnetID,
+		ResourceGroupName:               azureOpts.ResourceGroupName,
+		NetworkSecurityGroupID:          azureOpts.NetworkSecurityGroupID,
+		ResourceGroupTags:               azureOpts.ResourceGroupTags,
+		SubnetID:                        azureOpts.SubnetID,
+		ManagedIdentityKeyVaultName:     azureOpts.KeyVaultInfo.KeyVaultName,
+		ManagedIdentityKeyVaultTenantID: azureOpts.KeyVaultInfo.KeyVaultTenantID,
+		TechPreviewEnabled:              azureOpts.TechPreviewEnabled,
 	}, nil
 }
 

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -51,21 +51,22 @@ const (
 )
 
 type CreateInfraOptions struct {
-	Name                        string
-	BaseDomain                  string
-	Location                    string
-	InfraID                     string
-	CredentialsFile             string
-	Credentials                 *util.AzureCreds
-	OutputFile                  string
-	RHCOSImage                  string
-	ResourceGroupName           string
-	VnetID                      string
-	NetworkSecurityGroupID      string
-	ResourceGroupTags           map[string]string
-	SubnetID                    string
-	ManagedIdentityKeyVaultName string
-	TechPreviewEnabled          bool
+	Name                            string
+	BaseDomain                      string
+	Location                        string
+	InfraID                         string
+	CredentialsFile                 string
+	Credentials                     *util.AzureCreds
+	OutputFile                      string
+	RHCOSImage                      string
+	ResourceGroupName               string
+	VnetID                          string
+	NetworkSecurityGroupID          string
+	ResourceGroupTags               map[string]string
+	SubnetID                        string
+	ManagedIdentityKeyVaultName     string
+	ManagedIdentityKeyVaultTenantID string
+	TechPreviewEnabled              bool
 }
 
 type CreateInfraOutput struct {
@@ -218,6 +219,9 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 	}
 
 	if o.TechPreviewEnabled {
+		result.ControlPlaneMIs.ControlPlane.ManagedIdentitiesKeyVault.Name = o.ManagedIdentityKeyVaultName
+		result.ControlPlaneMIs.ControlPlane.ManagedIdentitiesKeyVault.TenantID = o.ManagedIdentityKeyVaultTenantID
+
 		// Create ServicePrincipals with backing certificates
 		cmdStr := buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, ingress, o.InfraID, o.ManagedIdentityKeyVaultName)
 		clientID, err := createServicePrincipalWithCertificate(cmdStr)


### PR DESCRIPTION
**What this PR does / why we need it**: 

- add az cli to e2e dockerfile
- We need to add the az cli to the e2e dockerfile so that we can execute the az cli commands for creating SPs during the e2e

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [HOSTEDCP-2070](https://issues.redhat.com/browse/HOSTEDCP-2070)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.