### PR TITLE
OCPBUGS-41365: use controlplaneCLI image in CNO init containers

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -443,7 +443,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 				"network-operator",
 			},
 			Name:  "remove-old-cno",
-			Image: params.Images.CLI,
+			Image: params.Images.CLIControlPlane,
 			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
@@ -490,7 +490,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 			Command: []string{"/bin/bash"},
 			Args:    []string{"-c", startScript},
 			Name:    "rewrite-config",
-			Image:   params.Images.CLI,
+			Image:   params.Images.CLIControlPlane,
 			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
@@ -521,7 +521,7 @@ sc=$(kubectl --kubeconfig $kc get --ignore-not-found validatingwebhookconfigurat
 if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validatingwebhookconfiguration multus.openshift.io; fi`,
 			},
 			Name:  "remove-old-multus-validating-webhook-configuration",
-			Image: params.Images.CLI,
+			Image: params.Images.CLIControlPlane,
 			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),


### PR DESCRIPTION
**What this PR does / why we need it**: to fix registry overrides in the dataplane a new controlPlaneCli image was added to distinguish between the two, I forgot to update the init container to use the new controlplane image so registryOverrides wouldn't have been working on the init containers because of this.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-41365](https://issues.redhat.com/browse/OCPBUGS-41365)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.