### PR TITLE
OCPBUGS-44375: openstack: make external network ID really optional

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2708,14 +2708,14 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 
 		cfg := manifests.OpenStackProviderConfig(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, cfg, func() error {
-			return openstack.ReconcileCloudConfigConfigMap(hcp.Spec.Platform.OpenStack.ExternalNetwork.ID, cfg, hcp.Spec.Platform.OpenStack.IdentityRef.CloudName, credentialsSecret, caCertData)
+			return openstack.ReconcileCloudConfigConfigMap(hcp.Spec.Platform.OpenStack, cfg, credentialsSecret, caCertData)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile OpenStack cloud config: %w", err)
 		}
 
 		withSecrets := manifests.OpenStackProviderConfigWithCredentials(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, withSecrets, func() error {
-			return openstack.ReconcileCloudConfigSecret(hcp.Spec.Platform.OpenStack.ExternalNetwork.ID, withSecrets, hcp.Spec.Platform.OpenStack.IdentityRef.CloudName, credentialsSecret, caCertData)
+			return openstack.ReconcileCloudConfigSecret(hcp.Spec.Platform.OpenStack, withSecrets, credentialsSecret, caCertData)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile OpenStack cloud config with credentials: %w", err)
 		}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1458,14 +1458,11 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 			return []error{fmt.Errorf("failed to get cloud credentials secret in hcp namespace: %w", err)}
 		}
 		caCertData := openstack.GetCACertFromCredentialsSecret(credentialsSecret)
-		cloudName := hcp.Spec.Platform.OpenStack.IdentityRef.CloudName
-		externalNetworkID := hcp.Spec.Platform.OpenStack.ExternalNetwork.ID
-
 		errs = append(errs,
-			r.reconcileOpenStackCredentialsSecret(ctx, externalNetworkID, "openshift-cluster-csi-drivers", "openstack-cloud-credentials", credentialsSecret, cloudName, caCertData),
-			r.reconcileOpenStackCredentialsSecret(ctx, externalNetworkID, "openshift-image-registry", "installer-cloud-credentials", credentialsSecret, cloudName, caCertData),
-			r.reconcileOpenStackCredentialsSecret(ctx, externalNetworkID, "openshift-cloud-network-config-controller", "cloud-credentials", credentialsSecret, cloudName, caCertData),
-			r.reconcileOpenStackCredentialsSecret(ctx, externalNetworkID, "openshift-cluster-csi-drivers", "manila-cloud-credentials", credentialsSecret, cloudName, caCertData),
+			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cluster-csi-drivers", "openstack-cloud-credentials", credentialsSecret, caCertData),
+			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-image-registry", "installer-cloud-credentials", credentialsSecret, caCertData),
+			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cloud-network-config-controller", "cloud-credentials", credentialsSecret, caCertData),
+			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cluster-csi-drivers", "manila-cloud-credentials", credentialsSecret, caCertData),
 		)
 	case hyperv1.PowerVSPlatform:
 		createPowerVSSecret := func(srcSecret, destSecret *corev1.Secret) error {
@@ -1542,7 +1539,7 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 }
 
 // reconcileOpenStackCredentialsSecret is a wrapper used to reconcile the OpenStack cloud config secrets.
-func (r *reconciler) reconcileOpenStackCredentialsSecret(ctx context.Context, externalNetworkID *string, namespace, name string, credentialsSecret *corev1.Secret, cloudName string, caCertData []byte) error {
+func (r *reconciler) reconcileOpenStackCredentialsSecret(ctx context.Context, platformSpec *hyperv1.OpenStackPlatformSpec, namespace, name string, credentialsSecret *corev1.Secret, caCertData []byte) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -1551,7 +1548,7 @@ func (r *reconciler) reconcileOpenStackCredentialsSecret(ctx context.Context, ex
 		Data: credentialsSecret.Data,
 	}
 	if _, err := r.CreateOrUpdate(ctx, r.client, secret, func() error {
-		return openstack.ReconcileCloudConfigSecret(externalNetworkID, secret, cloudName, credentialsSecret, caCertData)
+		return openstack.ReconcileCloudConfigSecret(platformSpec, secret, credentialsSecret, caCertData)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile secret %s/%s: %w", secret.Namespace, secret.Name, err)
 	}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -293,7 +293,7 @@ func (a OpenStack) ReconcileCredentials(ctx context.Context, c client.Client, cr
 	}
 
 	if _, err := createOrUpdate(ctx, c, cloudNetworkConfigCreds, func() error {
-		return openstack.ReconcileCloudConfigSecret(hcluster.Spec.Platform.OpenStack.ExternalNetwork.ID, cloudNetworkConfigCreds, hcluster.Spec.Platform.OpenStack.IdentityRef.CloudName, credentialsSecret, caCertData)
+		return openstack.ReconcileCloudConfigSecret(hcluster.Spec.Platform.OpenStack, cloudNetworkConfigCreds, credentialsSecret, caCertData)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile OpenStack cloud config: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When we introduced the support for providing the external network ID, we
used pointers and this is causing pointer nil issues when the user
doesn't provide the external network ID (which is a valid use case).

For that, I refactored a few function's signatures (and I did it in the
same way as it was done for the v2 controllers to ease readability).
