### PR TITLE
OCPBUGS-44041: add flags for passing in ManageIdentities on Azure HC …

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -67,6 +67,7 @@ type CreateInfraOptions struct {
 	ManagedIdentityKeyVaultName     string
 	ManagedIdentityKeyVaultTenantID string
 	TechPreviewEnabled              bool
+	ManagedIdentitiesFile           string
 }
 
 type CreateInfraOutput struct {
@@ -218,9 +219,14 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		l.Info("Successfully created vnet", "ID", result.VNetID)
 	}
 
-	if o.TechPreviewEnabled {
-		result.ControlPlaneMIs.ControlPlane.ManagedIdentitiesKeyVault.Name = o.ManagedIdentityKeyVaultName
-		result.ControlPlaneMIs.ControlPlane.ManagedIdentitiesKeyVault.TenantID = o.ManagedIdentityKeyVaultTenantID
+	if o.TechPreviewEnabled && o.ManagedIdentitiesFile == "" {
+		if o.ManagedIdentityKeyVaultName != "" {
+			result.ControlPlaneMIs.ControlPlane.ManagedIdentitiesKeyVault.Name = o.ManagedIdentityKeyVaultName
+
+		}
+		if o.ManagedIdentityKeyVaultTenantID != "" {
+			result.ControlPlaneMIs.ControlPlane.ManagedIdentitiesKeyVault.TenantID = o.ManagedIdentityKeyVaultTenantID
+		}
 
 		// Create ServicePrincipals with backing certificates
 		cmdStr := buildCreateServicePrincipalCommand(subscriptionID, resourceGroupName, nsgResourceGroupName, vnetResourceGroupName, ingress, o.InfraID, o.ManagedIdentityKeyVaultName)


### PR DESCRIPTION
**What this PR does / why we need it**: Adds a managedIdentitiesFile flag to azure create cluster so that we can pass in pre created certnames and client ids when creating hostedclusters. This allows for avoiding the az and jq dependency.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-44041](https://issues.redhat.com/browse/OCPBUGS-44041)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.