### PR TITLE
OCPBUGS-44438: Remove non-matching feature-gated CVO manifests from payload 

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/params.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 
@@ -21,6 +22,7 @@ type CVOParams struct {
 	OwnerRef                config.OwnerRef
 	DeploymentConfig        config.DeploymentConfig
 	PlatformType            hyperv1.PlatformType
+	FeatureSet              configv1.FeatureSet
 }
 
 func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext, enableCVOManagementClusterMetricsAccess bool) *CVOParams {
@@ -37,6 +39,9 @@ func NewCVOParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imagepro
 	// This could happen for example in local dev enviroments if the "OPERATE_ON_RELEASE_IMAGE" env variable is not set.
 	if p.ReleaseImage == "" {
 		p.ReleaseImage = hcp.Spec.ReleaseImage
+	}
+	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.FeatureGate != nil {
+		p.FeatureSet = hcp.Spec.Configuration.FeatureGate.FeatureSet
 	}
 
 	if enableCVOManagementClusterMetricsAccess {

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -115,7 +115,7 @@ func cvoLabels() map[string]string {
 
 var port int32 = 8443
 
-func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, controlPlaneImage, releaseImage, cliImage, availabilityProberImage, clusterID string, updateService configv1.URL, platformType hyperv1.PlatformType, oauthEnabled, enableCVOManagementClusterMetricsAccess bool) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, controlPlaneImage, releaseImage, cliImage, availabilityProberImage, clusterID string, updateService configv1.URL, platformType hyperv1.PlatformType, oauthEnabled, enableCVOManagementClusterMetricsAccess bool, featureSet configv1.FeatureSet) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main CVO container
@@ -138,7 +138,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: ptr.To(false),
 				InitContainers: []corev1.Container{
-					util.BuildContainer(cvoContainerPrepPayload(), buildCVOContainerPrepPayload(releaseImage, platformType, oauthEnabled)),
+					util.BuildContainer(cvoContainerPrepPayload(), buildCVOContainerPrepPayload(releaseImage, platformType, oauthEnabled, featureSet)),
 					util.BuildContainer(cvoContainerBootstrap(), buildCVOContainerBootstrap(cliImage, clusterID)),
 				},
 				Containers: []corev1.Container{
@@ -188,13 +188,13 @@ func cvoContainerMain() *corev1.Container {
 	}
 }
 
-func buildCVOContainerPrepPayload(image string, platformType hyperv1.PlatformType, oauthEnabled bool) func(c *corev1.Container) {
+func buildCVOContainerPrepPayload(image string, platformType hyperv1.PlatformType, oauthEnabled bool, featureSet configv1.FeatureSet) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = image
 		c.Command = []string{"/bin/bash"}
 		c.Args = []string{
 			"-c",
-			preparePayloadScript(platformType, oauthEnabled),
+			preparePayloadScript(platformType, oauthEnabled, featureSet),
 		}
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}
@@ -249,7 +249,7 @@ func ResourcesToRemove(platformType hyperv1.PlatformType) []client.Object {
 	}
 }
 
-func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool) string {
+func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool, featureSet configv1.FeatureSet) string {
 	payloadDir := volumeMounts.Path(cvoContainerPrepPayload().Name, cvoVolumePayload().Name)
 	var stmts []string
 
@@ -259,6 +259,37 @@ func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool) 
 		fmt.Sprintf("rm %s/manifests/*_servicemonitor.yaml", payloadDir),
 		fmt.Sprintf("cp -R /release-manifests %s/", payloadDir),
 	)
+
+	// NOTE: We would need part of the manifest.Include logic (https://github.com/openshift/library-go/blob/0064ad7bd060b9fd52f7840972c1d3e72186d0f0/pkg/manifest/manifest.go#L190-L196)
+	// to properly evaluate which CVO manifests to select based on featureset. In the absence of that logic, use simple filename filtering, which is not ideal
+	// but better than nothing.  Ideally, we filter based on the feature-set annotation in the manifests.
+	switch featureSet {
+	case configv1.Default, "":
+		stmts = append(stmts,
+			fmt.Sprintf("rm -f %s/manifests/*-CustomNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-DevPreviewNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-TechPreviewNoUpgrade*.yaml", payloadDir),
+		)
+	case configv1.CustomNoUpgrade:
+		stmts = append(stmts,
+			fmt.Sprintf("rm -f %s/manifests/*-Default*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-DevPreviewNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-TechPreviewNoUpgrade*.yaml", payloadDir),
+		)
+	case configv1.DevPreviewNoUpgrade:
+		stmts = append(stmts,
+			fmt.Sprintf("rm -f %s/manifests/*-Default*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-CustomNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-TechPreviewNoUpgrade*.yaml", payloadDir),
+		)
+	case configv1.TechPreviewNoUpgrade:
+		stmts = append(stmts,
+			fmt.Sprintf("rm -f %s/manifests/*-Default*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-CustomNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-DevPreviewNoUpgrade*.yaml", payloadDir),
+		)
+	}
+
 	for _, manifest := range manifestsToOmit {
 		if platformType == hyperv1.IBMCloudPlatform || platformType == hyperv1.PowerVSPlatform {
 			if manifest == "0000_50_cluster-storage-operator_10_deployment-ibm-cloud-managed.yaml" || manifest == "0000_50_cluster-csi-snapshot-controller-operator_07_deployment-ibm-cloud-managed.yaml" {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3641,7 +3641,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterVersionOperator(ctx conte
 
 	deployment := manifests.ClusterVersionOperatorDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return cvo.ReconcileDeployment(deployment, p.OwnerRef, p.DeploymentConfig, p.ControlPlaneImage, p.ReleaseImage, p.CLIImage, p.AvailabilityProberImage, p.ClusterID, hcp.Spec.UpdateService, p.PlatformType, util.HCPOAuthEnabled(hcp), r.EnableCVOManagementClusterMetricsAccess)
+		return cvo.ReconcileDeployment(deployment, p.OwnerRef, p.DeploymentConfig, p.ControlPlaneImage, p.ReleaseImage, p.CLIImage, p.AvailabilityProberImage, p.ClusterID, hcp.Spec.UpdateService, p.PlatformType, util.HCPOAuthEnabled(hcp), r.EnableCVOManagementClusterMetricsAccess, p.FeatureSet)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile cluster version operator deployment: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cloud-controller-manager-aws
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: cloud-controller-manager
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: cloud-controller-manager
+        hypershift.openshift.io/control-plane-component: cloud-controller-manager-aws
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --cloud-provider=aws
+        - --use-service-account-credentials=false
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --cloud-config=/etc/cloud/aws.conf
+        - --configure-cloud-routes=false
+        - --leader-elect=true
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-renew-deadline=107s
+        - --leader-elect-retry-period=26s
+        - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        command:
+        - /bin/aws-cloud-controller-manager
+        env:
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /etc/kubernetes/secrets/cloud-provider/credentials
+        - name: AWS_SDK_LOAD_CONFIG
+          value: "true"
+        - name: AWS_EC2_METADATA_DISABLED
+          value: "true"
+        image: aws-cloud-controller-manager
+        imagePullPolicy: IfNotPresent
+        name: cloud-controller-manager
+        resources:
+          requests:
+            cpu: 75m
+            memory: 60Mi
+        volumeMounts:
+        - mountPath: /etc/cloud
+          name: cloud-config
+        - mountPath: /etc/aws
+          name: cloud-controller-creds
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/secrets/cloud-provider
+          name: cloud-creds
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
+      - args:
+        - --service-account-namespace=kube-system
+        - --service-account-name=kube-controller-manager
+        - --token-audience=openshift
+        - --token-file=/var/run/secrets/openshift/serviceaccount/token
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        image: token-minter
+        imagePullPolicy: IfNotPresent
+        name: token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
+        - mountPath: /etc/kubernetes
+          name: kubeconfig
+      priorityClassName: hypershift-control-plane
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: aws-cloud-config
+        name: cloud-config
+      - name: cloud-controller-creds
+        secret:
+          defaultMode: 416
+          secretName: cloud-controller-creds
+      - name: cloud-creds
+        secret:
+          defaultMode: 416
+          secretName: cloud-controller-creds
+      - emptyDir:
+          medium: Memory
+        name: cloud-token
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,25 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: cloud-controller-manager-aws
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: cloud-controller-manager-aws Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: cloud-controller-manager-aws Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: aws-cloud-config
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cloud-controller-manager-azure
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: cloud-controller-manager
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: cloud-controller-manager
+        hypershift.openshift.io/control-plane-component: cloud-controller-manager-azure
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --cloud-config=/etc/cloud/cloud.conf
+        - --cloud-provider=azure
+        - --controllers=*,-cloud-node
+        - --configure-cloud-routes=false
+        - --bind-address=127.0.0.1
+        - --leader-elect=true
+        - --route-reconciliation-period=10s
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-renew-deadline=107s
+        - --leader-elect-retry-period=26s
+        - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        - --v=4
+        - --cluster-name=
+        command:
+        - /bin/azure-cloud-controller-manager
+        image: azure-cloud-controller-manager
+        imagePullPolicy: IfNotPresent
+        name: cloud-controller-manager
+        resources:
+          requests:
+            cpu: 75m
+            memory: 60Mi
+        volumeMounts:
+        - mountPath: /etc/cloud
+          name: cloud-config
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeconfig
+        - mountPath: /mnt/certs
+          name: cloud-provider-cert
+          readOnly: true
+      priorityClassName: hypershift-control-plane
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - name: cloud-config
+        secret:
+          defaultMode: 416
+          secretName: azure-cloud-config
+      - csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: managed-azure-cloud-provider
+        name: cloud-provider-cert
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,31 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: cloud-controller-manager-azure
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: cloud-controller-manager-azure Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: cloud-controller-manager-azure Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: Secret
+    name: azure-cloud-config
+  - group: secrets-store.csi.x-k8s.io
+    kind: SecretProviderClass
+    name: managed-azure-cloud-provider
+  - group: ""
+    kind: ConfigMap
+    name: azure-cloud-config
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cloud-controller-manager-kubevirt
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: cloud-controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: cloud-controller-manager
+        hypershift.openshift.io/control-plane-component: cloud-controller-manager-kubevirt
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        hypershift.openshift.io/need-management-kas-access: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: cloud-controller-manager
+                hypershift.openshift.io/control-plane-component: cloud-controller-manager-kubevirt
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+                hypershift.openshift.io/need-management-kas-access: "true"
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: cloud-controller-manager
+                hypershift.openshift.io/control-plane-component: cloud-controller-manager-kubevirt
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+                hypershift.openshift.io/need-management-kas-access: "true"
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --cloud-provider=kubevirt
+        - --cloud-config=/etc/cloud/cloud-config
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --authentication-skip-lookup
+        - --cluster-name=cluster_name
+        command:
+        - /bin/kubevirt-cloud-controller-manager
+        image: kubevirt-cloud-controller-manager
+        imagePullPolicy: IfNotPresent
+        name: cloud-controller-manager
+        resources:
+          requests:
+            cpu: 75m
+            memory: 60Mi
+        volumeMounts:
+        - mountPath: /etc/cloud
+          name: cloud-config
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeconfig
+      priorityClassName: hypershift-control-plane
+      serviceAccountName: kubevirt-cloud-controller-manager
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: kubevirt-cloud-config
+        name: cloud-config
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,36 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: cloud-controller-manager-kubevirt
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: cloud-controller-manager-kubevirt Deployment Available condition not
+      found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: cloud-controller-manager-kubevirt Deployment Progressing condition not
+      found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: kubevirt-cloud-config
+  - group: rbac.authorization.k8s.io
+    kind: Role
+    name: kubevirt-cloud-controller-manager
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: kubevirt-cloud-controller-manager
+  - group: ""
+    kind: ServiceAccount
+    name: kubevirt-cloud-controller-manager
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,129 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cloud-controller-manager-openstack
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      infrastructure.openshift.io/cloud-controller-manager: OpenStack
+      k8s-app: openstack-cloud-controller-manager
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        hypershift.openshift.io/control-plane-component: cloud-controller-manager-openstack
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        infrastructure.openshift.io/cloud-controller-manager: OpenStack
+        k8s-app: openstack-cloud-controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --v=1
+        - --cloud-config=$(CLOUD_CONFIG)
+        - --cluster-name=$(OCP_INFRASTRUCTURE_NAME)
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --cloud-provider=openstack
+        - --use-service-account-credentials=false
+        - --configure-cloud-routes=false
+        - --bind-address=127.0.0.1
+        - --leader-elect=true
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-renew-deadline=107s
+        - --leader-elect-retry-period=26s
+        - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+        command:
+        - /usr/bin/openstack-cloud-controller-manager
+        env:
+        - name: CLOUD_CONFIG
+          value: /etc/openstack/config/cloud.conf
+        - name: OCP_INFRASTRUCTURE_NAME
+        image: openstack-cloud-controller-manager
+        name: cloud-controller-manager
+        resources:
+          requests:
+            cpu: 200m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeconfig
+          readOnly: true
+        - mountPath: /etc/openstack/config
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/openstack/secret
+          name: secret-occm
+          readOnly: true
+      priorityClassName: hypershift-control-plane
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: cloud.conf
+            path: cloud.conf
+          name: openstack-cloud-config
+        name: cloud-config
+      - name: secret-occm
+        secret:
+          defaultMode: 416
+          items:
+          - key: clouds.yaml
+            path: clouds.yaml
+          secretName: fake-cloud-credentials-secret
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,30 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: cloud-controller-manager-openstack
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: cloud-controller-manager-openstack Deployment Available condition not
+      found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: cloud-controller-manager-openstack Deployment Progressing condition not
+      found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: openstack-cloud-config
+  - group: ""
+    kind: ConfigMap
+    name: openstack-trusted-ca
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,134 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cloud-controller-manager-powervs
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: cloud-controller-manager
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        hypershift.openshift.io/control-plane-component: cloud-controller-manager-powervs
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        k8s-app: cloud-controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - /bin/ibm-cloud-controller-manager
+        - --authentication-skip-lookup
+        - --bind-address=$(POD_IP_ADDRESS)
+        - --use-service-account-credentials=true
+        - --configure-cloud-routes=false
+        - --cloud-provider=ibm
+        - --cloud-config=/etc/ibm/ccm-config
+        - --profiling=false
+        - --leader-elect=true
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-renew-deadline=107s
+        - --leader-elect-retry-period=26s
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --use-service-account-credentials=false
+        env:
+        - name: POD_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: VPCCTL_CLOUD_CONFIG
+          value: /etc/ibm/ccm-config
+        - name: ENABLE_VPC_PUBLIC_ENDPOINT
+          value: "true"
+        image: powervs-cloud-controller-manager
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10258
+            scheme: HTTPS
+          initialDelaySeconds: 300
+          timeoutSeconds: 5
+        name: cloud-controller-manager
+        ports:
+        - containerPort: 10258
+          name: https
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 75m
+            memory: 60Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: service-network-admin-kubeconfig
+        - mountPath: /etc/ibm
+          name: ccm-config
+        - mountPath: /etc/vpc
+          name: cloud-creds
+      priorityClassName: hypershift-control-plane
+      terminationGracePeriodSeconds: 90
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: service-network-admin-kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: ccm-config
+        name: ccm-config
+      - name: cloud-creds
+        secret:
+          defaultMode: 416
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,26 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: cloud-controller-manager-powervs
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: cloud-controller-manager-powervs Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: cloud-controller-manager-powervs Deployment Progressing condition not
+      found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: ccm-config
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,159 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cluster-autoscaler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: cluster-autoscaler
+        hypershift.openshift.io/control-plane-component: cluster-autoscaler
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        hypershift.openshift.io/need-management-kas-access: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --expander=priority,least-waste
+        - --cloud-provider=clusterapi
+        - --node-group-auto-discovery=clusterapi:namespace=$(MY_NAMESPACE)
+        - --kubeconfig=/mnt/kubeconfig/target-kubeconfig
+        - --clusterapi-cloud-config-authoritative
+        - --skip-nodes-with-local-storage=false
+        - --alsologtostderr
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-retry-period=26s
+        - --leader-elect-renew-deadline=107s
+        - --balance-similar-node-groups=true
+        - --v=4
+        - --balancing-ignore-label=hypershift.openshift.io/nodePool
+        - --balancing-ignore-label=topology.ebs.csi.aws.com/zone
+        - --balancing-ignore-label=topology.disk.csi.azure.com/zone
+        - --balancing-ignore-label=ibm-cloud.kubernetes.io/worker-id
+        - --balancing-ignore-label=vpc-block-csi-driver-labels
+        command:
+        - /usr/bin/cluster-autoscaler
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cluster-autoscaler
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health-check
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: cluster-autoscaler
+        ports:
+        - containerPort: 8085
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health-check
+            port: 8085
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 60Mi
+        volumeMounts:
+        - mountPath: /mnt/kubeconfig
+          name: kubeconfig
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: cluster-autoscaler
+      serviceAccountName: cluster-autoscaler
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          items:
+          - key: value
+            path: target-kubeconfig
+          secretName: -kubeconfig
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,31 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: cluster-autoscaler
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: cluster-autoscaler Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: cluster-autoscaler Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: rbac.authorization.k8s.io
+    kind: Role
+    name: cluster-autoscaler
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: cluster-autoscaler
+  - group: ""
+    kind: ServiceAccount
+    name: cluster-autoscaler
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cluster-policy-controller
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: cluster-policy-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: cluster-policy-controller
+        hypershift.openshift.io/control-plane-component: cluster-policy-controller
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: cluster-policy-controller
+                hypershift.openshift.io/control-plane-component: cluster-policy-controller
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: cluster-policy-controller
+                hypershift.openshift.io/control-plane-component: cluster-policy-controller
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - start
+        - --config
+        - /etc/kubernetes/config/config.yaml
+        - --kubeconfig
+        - /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --namespace=openshift-kube-controller-manager
+        command:
+        - cluster-policy-controller
+        env:
+        - name: POD_NAMESPACE
+          value: openshift-kube-controller-manager
+        image: cluster-policy-controller
+        imagePullPolicy: IfNotPresent
+        name: cluster-policy-controller
+        resources:
+          requests:
+            cpu: 10m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/client-ca
+          name: client-ca
+        - mountPath: /etc/kubernetes/config
+          name: config
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      priorityClassName: hypershift-control-plane
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: cluster-policy-controller-config
+        name: config
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: cluster-policy-controller-cert
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: client-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,25 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: cluster-policy-controller
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: cluster-policy-controller Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: cluster-policy-controller Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: cluster-policy-controller-config
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -131,6 +131,9 @@ spec:
           rm /var/payload/manifests/*_deployment.yaml
           rm /var/payload/manifests/*_servicemonitor.yaml
           cp -R /release-manifests /var/payload/
+          rm -f /var/payload/manifests/*-CustomNoUpgrade*.yaml
+          rm -f /var/payload/manifests/*-DevPreviewNoUpgrade*.yaml
+          rm -f /var/payload/manifests/*-TechPreviewNoUpgrade*.yaml
           rm /var/payload/release-manifests/0000_50_olm_00-pprof-config.yaml
           rm /var/payload/release-manifests/0000_50_olm_00-pprof-rbac.yaml
           rm /var/payload/release-manifests/0000_50_olm_00-pprof-secret.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,364 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: cluster-version-operator
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: cluster-version-operator
+      k8s-app: cluster-version-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payload,update-payloads
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: cluster-version-operator
+        hypershift.openshift.io/control-plane-component: cluster-version-operator
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        k8s-app: cluster-version-operator
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - start
+        - --release-image
+        - $(RELEASE_IMAGE)
+        - --enable-auto-update=false
+        - --kubeconfig
+        - /etc/openshift/kubeconfig/kubeconfig
+        - --listen=0.0.0.0:8443
+        - --serving-cert-file=/etc/kubernetes/certs/server/tls.crt
+        - --serving-key-file=/etc/kubernetes/certs/server/tls.key
+        - --hypershift=true
+        - --v=4
+        command:
+        - cluster-version-operator
+        env:
+        - name: PAYLOAD_OVERRIDE
+          value: /var/payload
+        - name: CLUSTER_PROFILE
+          value: ibm-cloud-managed
+        - name: RELEASE_IMAGE
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: cluster-version-operator
+        imagePullPolicy: IfNotPresent
+        name: cluster-version-operator
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 20m
+            memory: 70Mi
+        volumeMounts:
+        - mountPath: /etc/openshift/kubeconfig
+          name: kubeconfig
+        - mountPath: /var/payload
+          name: payload
+        - mountPath: /etc/kubernetes/certs/server
+          name: server-crt
+        - mountPath: /etc/cvo/updatepayloads
+          name: update-payloads
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        - --kubeconfig=/var/kubeconfig/kubeconfig
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/kubeconfig
+          name: kubeconfig
+      - args:
+        - -c
+        - |-
+          cp -R /manifests /var/payload/
+          rm /var/payload/manifests/*_deployment.yaml
+          rm /var/payload/manifests/*_servicemonitor.yaml
+          cp -R /release-manifests /var/payload/
+          rm -f /var/payload/manifests/*-CustomNoUpgrade*.yaml
+          rm -f /var/payload/manifests/*-DevPreviewNoUpgrade*.yaml
+          rm -f /var/payload/manifests/*-TechPreviewNoUpgrade*.yaml
+          rm /var/payload/release-manifests/0000_50_olm_00-pprof-config.yaml
+          rm /var/payload/release-manifests/0000_50_olm_00-pprof-rbac.yaml
+          rm /var/payload/release-manifests/0000_50_olm_00-pprof-secret.yaml
+          rm /var/payload/release-manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+          rm /var/payload/release-manifests/0000_50_olm_02-services.yaml
+          rm /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.yaml
+          rm /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
+          rm /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
+          rm /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+          rm /var/payload/release-manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+          rm /var/payload/release-manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+          rm /var/payload/release-manifests/0000_50_olm_99-operatorstatus.yaml
+          rm /var/payload/release-manifests/0000_90_olm_00-service-monitor.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_04_service_account.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_05_role.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_06_role_binding.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_07_configmap.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_08_service.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_09_operator-ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_09_operator.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_10_clusteroperator.yaml
+          rm /var/payload/release-manifests/0000_50_operator-marketplace_11_service_monitor.yaml
+          rm /var/payload/release-manifests/0000_70_dns-operator_02-deployment-ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_cluster-ingress-operator_02-deployment-ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_80_machine-config_01_containerruntimeconfigs.crd.yaml
+          rm /var/payload/release-manifests/0000_80_machine-config_01_kubeletconfigs.crd.yaml
+          rm /var/payload/release-manifests/0000_80_machine-config_01_machineconfigs.crd.yaml
+          rm /var/payload/release-manifests/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml
+          rm /var/payload/release-manifests/0000_50_cluster-node-tuning-operator_20-performance-profile.crd.yaml
+          rm /var/payload/release-manifests/0000_50_cluster-node-tuning-operator_50-operator-ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_cluster-image-registry-operator_07-operator-ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_cluster-image-registry-operator_07-operator-service.yaml
+          rm /var/payload/release-manifests/0000_90_cluster-image-registry-operator_02_operator-servicemonitor.yaml
+          rm /var/payload/release-manifests/0000_50_cluster-storage-operator_10_deployment-ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_50_cloud-credential-operator_01-operator-config.yaml
+          rm /var/payload/release-manifests/0000_50_cluster-authentication-operator_02_config.cr.yaml
+          rm /var/payload/release-manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+          rm /var/payload/release-manifests/0000_50_cluster-csi-snapshot-controller-operator_07_deployment-ibm-cloud-managed.yaml
+          rm /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
+          cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
+          ---
+          apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            name: machineconfigs.machineconfiguration.openshift.io
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            name: machineconfigpools.machineconfiguration.openshift.io
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: network-operator
+            namespace: openshift-network-operator
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: default-account-cluster-network-operator
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: cluster-node-tuning-operator
+            namespace: openshift-cluster-node-tuning-operator
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: cluster-image-registry-operator
+            namespace: openshift-image-registry
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: cluster-storage-operator
+            namespace: openshift-cluster-storage-operator
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: csi-snapshot-controller-operator
+            namespace: openshift-cluster-storage-operator
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: aws-ebs-csi-driver-operator
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: aws-ebs-csi-driver-controller
+            namespace: openshift-cluster-csi-drivers
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: csi-snapshot-webhook
+            namespace: openshift-cluster-storage-operator
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: csi-snapshot-controller
+            namespace: openshift-cluster-storage-operator
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+        command:
+        - /bin/bash
+        image: cluster-version-operator
+        imagePullPolicy: IfNotPresent
+        name: prepare-payload
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /var/payload
+          name: payload
+      - args:
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+          cat > /tmp/clusterversion.yaml <<EOF
+          apiVersion: config.openshift.io/v1
+          kind: ClusterVersion
+          metadata:
+            name: version
+          spec:
+            clusterID: ${CLUSTER_ID}
+          EOF
+          oc get ns openshift-config &> /dev/null || oc create ns openshift-config
+          oc get ns openshift-config-managed &> /dev/null || oc create ns openshift-config-managed
+          while true; do
+            echo "Applying CVO bootstrap manifests"
+            if oc apply -f /var/payload/manifests; then
+              echo "Bootstrap manifests applied successfully."
+              break
+            fi
+            sleep 1
+          done
+          oc get clusterversion/version &> /dev/null || oc create -f /tmp/clusterversion.yaml
+        command:
+        - /bin/bash
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig
+        - name: CLUSTER_ID
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: bootstrap
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: kubeconfig
+        - mountPath: /var/payload
+          name: payload
+      priorityClassName: hypershift-control-plane
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - emptyDir: {}
+        name: payload
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: update-payloads
+      - name: server-crt
+        secret:
+          defaultMode: 416
+          secretName: cvo-server
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -131,9 +131,9 @@ spec:
           rm /var/payload/manifests/*_deployment.yaml
           rm /var/payload/manifests/*_servicemonitor.yaml
           cp -R /release-manifests /var/payload/
+          rm -f /var/payload/manifests/*-Default*.yaml
           rm -f /var/payload/manifests/*-CustomNoUpgrade*.yaml
           rm -f /var/payload/manifests/*-DevPreviewNoUpgrade*.yaml
-          rm -f /var/payload/manifests/*-TechPreviewNoUpgrade*.yaml
           rm /var/payload/release-manifests/0000_50_olm_00-pprof-config.yaml
           rm /var/payload/release-manifests/0000_50_olm_00-pprof-rbac.yaml
           rm /var/payload/release-manifests/0000_50_olm_00-pprof-secret.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,28 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: cluster-version-operator
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: cluster-version-operator Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: cluster-version-operator Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: Service
+    name: cluster-version-operator
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: cluster-version-operator
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,385 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  name: etcd
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+  podManagementPolicy: Parallel
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: etcd
+  serviceName: etcd-discovery
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: etcd
+        hypershift.openshift.io/control-plane-component: etcd
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        hypershift.openshift.io/need-management-kas-access: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: etcd
+                hypershift.openshift.io/control-plane-component: etcd
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+                hypershift.openshift.io/need-management-kas-access: "true"
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: etcd
+                hypershift.openshift.io/control-plane-component: etcd
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+                hypershift.openshift.io/need-management-kas-access: "true"
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: true
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - ETCD_INITIAL_CLUSTER_STATE=$(cat /etc/etcd/clusterstate/state) /usr/bin/etcd
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ETCD_NAME
+          value: $(HOSTNAME)
+        - name: ETCD_QUOTA_BACKEND_BYTES
+          value: "8589934592"
+        - name: ETCD_DATA_DIR
+          value: /var/lib/data
+        - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
+          value: https://$(HOSTNAME).etcd-discovery.$(NAMESPACE).svc:2380
+        - name: ETCD_LISTEN_PEER_URLS
+          value: https://$(POD_IP):2380
+        - name: ETCD_LISTEN_CLIENT_URLS
+          value: https://$(POD_IP):2379,https://localhost:2379
+        - name: ETCD_ADVERTISE_CLIENT_URLS
+          value: https://$(HOSTNAME).etcd-discovery.$(NAMESPACE).svc:2379
+        - name: ETCD_LISTEN_METRICS_URLS
+          value: https://0.0.0.0:2382
+        - name: ETCD_SNAPSHOT_COUNT
+          value: "10000"
+        - name: ETCD_PEER_CLIENT_CERT_AUTH
+          value: "true"
+        - name: ETCD_PEER_CERT_FILE
+          value: /etc/etcd/tls/peer/peer.crt
+        - name: ETCD_PEER_KEY_FILE
+          value: /etc/etcd/tls/peer/peer.key
+        - name: ETCD_PEER_TRUSTED_CA_FILE
+          value: /etc/etcd/tls/etcd-ca/ca.crt
+        - name: ETCD_CLIENT_CERT_AUTH
+          value: "true"
+        - name: ETCD_CERT_FILE
+          value: /etc/etcd/tls/server/server.crt
+        - name: ETCD_KEY_FILE
+          value: /etc/etcd/tls/server/server.key
+        - name: ETCD_TRUSTED_CA_FILE
+          value: /etc/etcd/tls/etcd-ca/ca.crt
+        - name: ETCD_INITIAL_CLUSTER
+          value: etcd-0=https://etcd-0.etcd-discovery.hcp-namespace.svc:2380
+        image: etcd
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: healthz
+            port: 9980
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 30
+        name: etcd
+        ports:
+        - containerPort: 2379
+          name: client
+          protocol: TCP
+        - containerPort: 2380
+          name: peer
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 15
+          httpGet:
+            path: readyz
+            port: 9980
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          requests:
+            cpu: 300m
+            memory: 600Mi
+        startupProbe:
+          failureThreshold: 18
+          httpGet:
+            path: readyz
+            port: 9980
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        volumeMounts:
+        - mountPath: /var/lib
+          name: data
+        - mountPath: /etc/etcd/tls/peer
+          name: peer-tls
+        - mountPath: /etc/etcd/tls/server
+          name: server-tls
+        - mountPath: /etc/etcd/tls/client
+          name: client-tls
+        - mountPath: /etc/etcd/tls/etcd-ca
+          name: etcd-ca
+        - mountPath: /etc/etcd/clusterstate
+          name: cluster-state
+      - args:
+        - grpc-proxy
+        - start
+        - --endpoints=https://localhost:2382
+        - --advertise-client-url=""
+        - --key=/etc/etcd/tls/peer/peer.key
+        - --key-file=/etc/etcd/tls/server/server.key
+        - --cert=/etc/etcd/tls/peer/peer.crt
+        - --cert-file=/etc/etcd/tls/server/server.crt
+        - --cacert=/etc/etcd/tls/etcd-ca/ca.crt
+        - --trusted-ca-file=/etc/etcd/tls/etcd-metrics-ca/ca.crt
+        - --listen-addr=127.0.0.1:2383
+        - --metrics-addr=https://0.0.0.0:2381
+        command:
+        - etcd
+        image: etcd
+        imagePullPolicy: IfNotPresent
+        name: etcd-metrics
+        ports:
+        - containerPort: 2381
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 40m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /etc/etcd/tls/peer
+          name: peer-tls
+        - mountPath: /etc/etcd/tls/server
+          name: server-tls
+        - mountPath: /etc/etcd/tls/etcd-ca
+          name: etcd-ca
+        - mountPath: /etc/etcd/tls/etcd-metrics-ca
+          name: etcd-metrics-ca
+      - args:
+        - readyz
+        - --target=https://localhost:2379
+        - --listen-port=9980
+        - --serving-cert-file=/etc/etcd/tls/server/server.crt
+        - --serving-key-file=/etc/etcd/tls/server/server.key
+        - --client-cert-file=/etc/etcd/tls/client/etcd-client.crt
+        - --client-key-file=/etc/etcd/tls/client/etcd-client.key
+        - --client-cacert-file=/etc/etcd/tls/etcd-ca/ca.crt
+        command:
+        - cluster-etcd-operator
+        image: cluster-etcd-operator
+        imagePullPolicy: IfNotPresent
+        name: healthz
+        ports:
+        - containerPort: 9980
+          name: healthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /etc/etcd/tls/server
+          name: server-tls
+        - mountPath: /etc/etcd/tls/client
+          name: client-tls
+        - mountPath: /etc/etcd/tls/etcd-ca
+          name: etcd-ca
+      initContainers:
+      - args:
+        - -c
+        - exec control-plane-operator resolve-dns ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
+        command:
+        - /bin/bash
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: controlplane-operator
+        imagePullPolicy: IfNotPresent
+        name: ensure-dns
+        resources: {}
+      - args:
+        - -c
+        - |
+          #!/bin/bash
+
+          set -eu
+
+          # This script checks whether the data directory of this etcd member is empty.
+          # If it is, and there is a functional etcd cluster, then it ensures that a member
+          # corresponding to this pod does not exist in the cluster so it can be added
+          # as a new member.
+
+          # Setup the etcdctl environment
+          export ETCDCTL_API=3
+          export ETCDCTL_CACERT=/etc/etcd/tls/etcd-ca/ca.crt
+          export ETCDCTL_CERT=/etc/etcd/tls/server/server.crt
+          export ETCDCTL_KEY=/etc/etcd/tls/server/server.key
+          export ETCDCTL_ENDPOINTS=https://etcd-client:2379
+
+          echo "new" > /etc/etcd/clusterstate/state
+
+          if [[ ! -f /var/lib/data/member/snap/db ]]; then
+            echo "No existing etcd data found"
+            echo "Checking if cluster is functional"
+            if etcdctl member list; then
+              echo "Cluster is functional"
+              MEMBER_ID=$(etcdctl member list -w simple | grep "${HOSTNAME}" | awk -F, '{ print $1 }')
+              if [[ -n "${MEMBER_ID}" ]]; then
+                echo "A member with this name (${HOSTNAME}) already exists, removing"
+                etcdctl member remove "${MEMBER_ID}"
+                echo "Adding new member"
+                etcdctl member add ${HOSTNAME} --peer-urls https://${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc:2380
+                echo "existing" > /etc/etcd/clusterstate/state
+              else
+                echo "A member does not exist with name (${HOSTNAME}), nothing to do"
+              fi
+            else
+              echo "Cannot list members in cluster, so likely not up yet"
+            fi
+          else
+            echo "Snapshot db exists, member has data"
+          fi
+        command:
+        - /bin/bash
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: etcd
+        imagePullPolicy: IfNotPresent
+        name: reset-member
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib
+          name: data
+        - mountPath: /etc/etcd/tls/server
+          name: server-tls
+        - mountPath: /etc/etcd/tls/etcd-ca
+          name: etcd-ca
+        - mountPath: /etc/etcd/clusterstate
+          name: cluster-state
+      priorityClassName: hypershift-etcd
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: peer-tls
+        secret:
+          defaultMode: 416
+          secretName: etcd-peer-tls
+      - name: server-tls
+        secret:
+          defaultMode: 416
+          secretName: etcd-server-tls
+      - name: client-tls
+        secret:
+          defaultMode: 416
+          secretName: etcd-client-tls
+      - configMap:
+          defaultMode: 420
+          name: etcd-ca
+        name: etcd-ca
+      - configMap:
+          defaultMode: 420
+          name: etcd-metrics-ca
+        name: etcd-metrics-ca
+      - emptyDir: {}
+        name: cluster-state
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      creationTimestamp: null
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi
+      volumeMode: Filesystem
+    status: {}
+status:
+  availableReplicas: 0
+  replicas: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,34 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: etcd
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: 'etcd StatefulSet is not available: 0/3 replicas ready'
+    reason: WaitingForAvailable
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: 'etcd StatefulSet progressing: 0/3 replicas ready'
+    reason: WaitingForAvailable
+    status: "True"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: Service
+    name: etcd-discovery
+  - group: policy
+    kind: PodDisruptionBudget
+    name: etcd
+  - group: ""
+    kind: Service
+    name: etcd-client
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: etcd
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,187 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: hosted-cluster-config-operator
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: hosted-cluster-config-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: hosted-cluster-config-operator
+        hypershift.openshift.io/control-plane-component: hosted-cluster-config-operator
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        hypershift.openshift.io/need-management-kas-access: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: true
+      containers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - hosted-cluster-config-operator
+        - --initial-ca-file=/etc/kubernetes/root-ca/ca.crt
+        - --cluster-signer-ca-file=/etc/kubernetes/cluster-signer-ca/ca.crt
+        - --target-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --namespace
+        - $(POD_NAMESPACE)
+        - --platform-type
+        - ""
+        - --enable-ci-debug-output=false
+        - --hosted-control-plane=hcp
+        - --konnectivity-address=
+        - --konnectivity-port=0
+        - --oauth-address=
+        - --oauth-port=0
+        - --registry-overrides
+        - =
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: OPENSHIFT_RELEASE_VERSION
+          value: "4.18"
+        - name: KUBERNETES_VERSION
+          value: "1.30"
+        - name: OPERATE_ON_RELEASE_IMAGE
+        - name: OPENSHIFT_IMG_OVERRIDES
+          value: =
+        image: hosted-cluster-config-operator
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 6060
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: hosted-cluster-config-operator
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 6060
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 60m
+            memory: 80Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/cluster-signer-ca
+          name: cluster-signer-ca
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/root-ca
+          name: root-ca
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        - --kubeconfig=/var/kubeconfig/kubeconfig
+        - --required-api=imageregistry.operator.openshift.io,v1,Config
+        - --required-api=config.openshift.io,v1,Infrastructure
+        - --required-api=config.openshift.io,v1,DNS
+        - --required-api=config.openshift.io,v1,Ingress
+        - --required-api=config.openshift.io,v1,Network
+        - --required-api=config.openshift.io,v1,Proxy
+        - --required-api=config.openshift.io,v1,Build
+        - --required-api=config.openshift.io,v1,Image
+        - --required-api=config.openshift.io,v1,Project
+        - --required-api=config.openshift.io,v1,ClusterVersion
+        - --required-api=config.openshift.io,v1,FeatureGate
+        - --required-api=config.openshift.io,v1,ClusterOperator
+        - --required-api=config.openshift.io,v1,OperatorHub
+        - --required-api=operator.openshift.io,v1,Network
+        - --required-api=operator.openshift.io,v1,CloudCredential
+        - --required-api=operator.openshift.io,v1,IngressController
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/kubeconfig
+          name: kubeconfig
+      priorityClassName: hypershift-control-plane
+      schedulerName: default-scheduler
+      serviceAccount: hosted-cluster-config-operator
+      serviceAccountName: hosted-cluster-config-operator
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: hcco-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: root-ca
+        name: root-ca
+      - configMap:
+          defaultMode: 420
+          name: kubelet-client-ca
+        name: cluster-signer-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,34 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: hosted-cluster-config-operator
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: hosted-cluster-config-operator Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: hosted-cluster-config-operator Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: monitoring.coreos.com
+    kind: PodMonitor
+    name: hosted-cluster-config-operator
+  - group: rbac.authorization.k8s.io
+    kind: Role
+    name: hosted-cluster-config-operator
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: hosted-cluster-config-operator
+  - group: ""
+    kind: ServiceAccount
+    name: hosted-cluster-config-operator
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
-        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e23415eb6680075ec3
+        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e23415eb667d1e0a2d
         hypershift.openshift.io/release-image: ""
       creationTimestamp: null
       labels:
@@ -347,7 +347,8 @@ spec:
             metadata:
               creationTimestamp: null
               name: cluster
-            spec: {}
+            spec:
+              featureSet: TechPreviewNoUpgrade
             status:
               featureGates: null
         image: cluster-config-api

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,485 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: kube-apiserver
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 3
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: kube-apiserver
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
+        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e23415eb6680075ec3
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: kube-apiserver
+        hypershift.openshift.io/control-plane-component: kube-apiserver
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        hypershift.openshift.io/request-serving-component: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: kube-apiserver
+                hypershift.openshift.io/control-plane-component: kube-apiserver
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+                hypershift.openshift.io/request-serving-component: "true"
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: kube-apiserver
+                hypershift.openshift.io/control-plane-component: kube-apiserver
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+                hypershift.openshift.io/request-serving-component: "true"
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          while true; do
+            if oc apply -f /work; then
+              echo "Bootstrap manifests applied successfully."
+              break
+            fi
+            sleep 1
+          done
+          while true; do
+            if oc replace --subresource=status -f /work/99_feature-gate.yaml; then
+              echo "FeatureGate status applied successfully."
+              break
+            fi
+            sleep 1
+          done
+          while true; do
+            sleep 1000
+          done
+        command:
+        - /bin/bash
+        env:
+        - name: KUBECONFIG
+          value: /var/secrets/localhost-kubeconfig/kubeconfig
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: apply-bootstrap
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /work
+          name: bootstrap-manifests
+        - mountPath: /var/secrets/localhost-kubeconfig
+          name: localhost-kubeconfig
+      - args:
+        - kube-apiserver
+        - --openshift-config=/etc/kubernetes/config/config.json
+        - --v=2
+        command:
+        - hyperkube
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        image: hyperkube
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: livez?exclude=etcd
+            port: client
+            scheme: HTTPS
+          initialDelaySeconds: 300
+          periodSeconds: 180
+          successThreshold: 1
+          timeoutSeconds: 160
+        name: kube-apiserver
+        ports:
+        - containerPort: 6443
+          name: client
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 18
+          httpGet:
+            path: readyz
+            port: client
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          requests:
+            cpu: 350m
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/certs/aggregator-ca
+          name: aggregator-ca
+        - mountPath: /etc/kubernetes/certs/aggregator
+          name: aggregator-crt
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+        - mountPath: /etc/kubernetes/auth
+          name: auth-config
+        - mountPath: /etc/kubernetes/auth-token-webhook
+          name: auth-token-webhook-config
+        - mountPath: /etc/kubernetes/certs/client-ca
+          name: client-ca
+        - mountPath: /etc/kubernetes/egress-selector
+          name: egress-selector-config
+        - mountPath: /etc/kubernetes/certs/etcd-ca
+          name: etcd-ca
+        - mountPath: /etc/kubernetes/certs/etcd
+          name: etcd-client-crt
+        - mountPath: /etc/kubernetes/config
+          name: kas-config
+        - mountPath: /etc/kubernetes/certs/konnectivity-ca
+          name: konnectivity-ca
+        - mountPath: /etc/kubernetes/certs/konnectivity-client
+          name: konnectivity-client
+        - mountPath: /etc/kubernetes/certs/kubelet-ca
+          name: kubelet-client-ca
+        - mountPath: /etc/kubernetes/certs/kubelet
+          name: kubelet-client-crt
+        - mountPath: /var/log/kube-apiserver
+          name: logs
+        - mountPath: /etc/kubernetes/oauth
+          name: oauth-metadata
+        - mountPath: /etc/kubernetes/certs/server
+          name: server-crt
+        - mountPath: /etc/kubernetes/certs/server-private
+          name: server-private-crt
+        - mountPath: /etc/kubernetes/secrets/svcacct-key
+          name: svcacct-key
+        workingDir: /var/log/kube-apiserver
+      - args:
+        - --logtostderr=true
+        - --log-file-max-size=0
+        - --cluster-cert
+        - /etc/konnectivity/cluster/tls.crt
+        - --cluster-key
+        - /etc/konnectivity/cluster/tls.key
+        - --server-cert
+        - /etc/konnectivity/server/tls.crt
+        - --server-key
+        - /etc/konnectivity/server/tls.key
+        - --server-ca-cert
+        - /etc/konnectivity/ca/ca.crt
+        - --server-port
+        - "8090"
+        - --agent-port
+        - "8091"
+        - --health-port
+        - "2041"
+        - --admin-port=8093
+        - --mode=http-connect
+        - --proxy-strategies=destHost,defaultRoute
+        - --keepalive-time
+        - 30s
+        - --frontend-keepalive-time
+        - 30s
+        - --server-count
+        - "1"
+        - --cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        command:
+        - /usr/bin/proxy-server
+        image: apiserver-network-proxy
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - sleep 70
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 2041
+            scheme: HTTP
+          initialDelaySeconds: 120
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 30
+        name: konnectivity-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 2041
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /etc/konnectivity/cluster
+          name: cluster-certs
+        - mountPath: /etc/konnectivity/ca
+          name: konnectivity-ca
+        - mountPath: /etc/konnectivity/server
+          name: server-certs
+      - args:
+        - -c
+        - |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
+          function cleanup() {
+            kill -- -$$
+            wait
+          }
+          trap cleanup SIGTERM
+
+          /usr/bin/tail -c+1 -F /var/log/kube-apiserver/audit.log &
+          wait $!
+        command:
+        - /bin/bash
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: audit-logs
+        resources:
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kube-apiserver
+          name: logs
+      initContainers:
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          cd /tmp
+          mkdir input output manifests
+
+          touch /tmp/manifests/99_feature-gate.yaml
+          cat <<EOF >/tmp/manifests/99_feature-gate.yaml
+          $(FEATURE_GATE_YAML)
+          EOF
+
+          touch /tmp/manifests/hcco-rolebinding.yaml
+          cat <<EOF >/tmp/manifests/hcco-rolebinding.yaml
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: hcco-cluster-admin
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: cluster-admin
+          subjects:
+          - apiGroup: rbac.authorization.k8s.io
+            kind: User
+            name: system:hosted-cluster-config
+          EOF
+
+          /usr/bin/render \
+             --asset-output-dir /tmp/output \
+             --rendered-manifest-dir=/tmp/manifests \
+             --cluster-profile=ibm-cloud-managed \
+             --payload-version=$(PAYLOAD_VERSION)
+          cp /tmp/output/manifests/* /work
+          cp /tmp/manifests/* /work
+        command:
+        - /bin/bash
+        env:
+        - name: PAYLOAD_VERSION
+          value: "4.18"
+        - name: FEATURE_GATE_YAML
+          value: |
+            apiVersion: config.openshift.io/v1
+            kind: FeatureGate
+            metadata:
+              creationTimestamp: null
+              name: cluster
+            spec: {}
+            status:
+              featureGates: null
+        image: cluster-config-api
+        imagePullPolicy: IfNotPresent
+        name: init-bootstrap
+        resources:
+          requests:
+            cpu: 30m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /work
+          name: bootstrap-manifests
+      - args:
+        - -c
+        - |
+          #!/bin/sh
+          while ! nslookup etcd-client.$(POD_NAMESPACE).svc; do sleep 1; done
+        command:
+        - /bin/bash
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: wait-for-etcd
+        resources: {}
+      priorityClassName: hypershift-api-critical
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 95
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - emptyDir: {}
+        name: bootstrap-manifests
+      - name: localhost-kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: localhost-kubeconfig
+      - emptyDir: {}
+        name: logs
+      - configMap:
+          defaultMode: 420
+          name: kas-config
+        name: kas-config
+      - configMap:
+          defaultMode: 420
+          name: auth-config
+        name: auth-config
+      - configMap:
+          defaultMode: 420
+          name: kas-audit-config
+        name: audit-config
+      - configMap:
+          defaultMode: 420
+          name: konnectivity-ca-bundle
+        name: konnectivity-ca
+      - name: server-crt
+        secret:
+          defaultMode: 416
+          secretName: kas-server-crt
+      - name: server-private-crt
+        secret:
+          defaultMode: 416
+          secretName: kas-server-private-crt
+      - name: aggregator-crt
+        secret:
+          defaultMode: 416
+          secretName: kas-aggregator-crt
+      - configMap:
+          defaultMode: 420
+          name: aggregator-client-ca
+        name: aggregator-ca
+      - name: svcacct-key
+        secret:
+          defaultMode: 416
+          secretName: sa-signing-key
+      - configMap:
+          defaultMode: 420
+          name: etcd-ca
+        name: etcd-ca
+      - name: etcd-client-crt
+        secret:
+          defaultMode: 416
+          secretName: etcd-client-tls
+      - configMap:
+          defaultMode: 420
+          name: oauth-metadata
+        name: oauth-metadata
+      - name: auth-token-webhook-config
+        secret:
+          defaultMode: 416
+          secretName: kas-authentication-token-webhook-config
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: client-ca
+      - name: kubelet-client-crt
+        secret:
+          defaultMode: 416
+          secretName: kas-kubelet-client-crt
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: kubelet-client-ca
+      - name: konnectivity-client
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          defaultMode: 420
+          name: kas-egress-selector-config
+        name: egress-selector-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: localhost-kubeconfig
+      - name: server-certs
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-server
+      - name: cluster-certs
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-cluster
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,67 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: kube-apiserver
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: kube-apiserver Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: kube-apiserver Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: kas-audit-config
+  - group: ""
+    kind: ConfigMap
+    name: auth-config
+  - group: ""
+    kind: Secret
+    name: kas-authentication-token-webhook-config
+  - group: ""
+    kind: Secret
+    name: bootstrap-kubeconfig
+  - group: ""
+    kind: Secret
+    name: <cluster-name>-kubeconfig
+  - group: ""
+    kind: ConfigMap
+    name: kas-egress-selector-config
+  - group: ""
+    kind: Secret
+    name: admin-kubeconfig
+  - group: ""
+    kind: Secret
+    name: hcco-kubeconfig
+  - group: ""
+    kind: ConfigMap
+    name: kas-config
+  - group: ""
+    kind: Secret
+    name: localhost-kubeconfig
+  - group: ""
+    kind: ConfigMap
+    name: oauth-metadata
+  - group: policy
+    kind: PodDisruptionBudget
+    name: kube-apiserver
+  - group: monitoring.coreos.com
+    kind: PrometheusRule
+    name: recording-rules
+  - group: ""
+    kind: Secret
+    name: service-network-admin-kubeconfig
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-apiserver
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -118,74 +118,74 @@ spec:
         - --feature-gates=ExternalCloudProviderAzure=true
         - --feature-gates=ExternalCloudProviderGCP=true
         - --feature-gates=ExternalCloudProviderExternal=true
+        - --feature-gates=CSIDriverSharedResource=true
         - --feature-gates=BuildCSIVolumes=true
+        - --feature-gates=MachineAPIProviderOpenStack=true
+        - --feature-gates=InsightsConfigAPI=true
         - --feature-gates=AzureWorkloadIdentity=true
         - --feature-gates=PrivateHostedZoneAWS=true
+        - --feature-gates=SigstoreImageVerification=true
+        - --feature-gates=GCPLabelsTags=true
         - --feature-gates=AlibabaPlatform=true
+        - --feature-gates=VSphereMultiVCenters=true
         - --feature-gates=VSphereStaticIPs=true
+        - --feature-gates=RouteExternalCertificate=true
         - --feature-gates=AdminNetworkPolicy=true
         - --feature-gates=NetworkLiveMigration=true
         - --feature-gates=NetworkDiagnosticsConfig=true
         - --feature-gates=HardwareSpeed=true
+        - --feature-gates=EtcdBackendQuota=true
+        - --feature-gates=AutomatedEtcdBackup=true
+        - --feature-gates=DNSNameResolver=true
         - --feature-gates=VSphereControlPlaneMachineSet=true
+        - --feature-gates=MachineConfigNodes=true
         - --feature-gates=MetricsServer=true
+        - --feature-gates=InstallAlternateInfrastructureAWS=true
+        - --feature-gates=GCPClusterHostedDNS=true
+        - --feature-gates=MixedCPUsAllocation=true
+        - --feature-gates=ManagedBootImages=true
+        - --feature-gates=OnClusterBuild=true
+        - --feature-gates=SignatureStores=true
+        - --feature-gates=PinnedImages=true
+        - --feature-gates=UpgradeStatus=true
         - --feature-gates=ExternalOIDC=true
+        - --feature-gates=Example=true
+        - --feature-gates=PlatformOperators=true
+        - --feature-gates=NewOLM=true
+        - --feature-gates=ExternalRouteCertificate=true
+        - --feature-gates=InsightsOnDemandDataGather=true
         - --feature-gates=BareMetalLoadBalancer=true
+        - --feature-gates=InsightsConfig=true
+        - --feature-gates=ImagePolicy=true
+        - --feature-gates=NodeDisruptionPolicy=true
+        - --feature-gates=MetricsCollectionProfiles=true
         - --feature-gates=VSphereDriverConfiguration=true
         - --feature-gates=ClusterAPIInstallAWS=true
+        - --feature-gates=ClusterAPIInstallGCP=true
         - --feature-gates=ClusterAPIInstallNutanix=true
         - --feature-gates=ClusterAPIInstallOpenStack=true
+        - --feature-gates=ClusterAPIInstallPowerVS=true
         - --feature-gates=ClusterAPIInstallVSphere=true
+        - --feature-gates=ChunkSizeMiB=true
+        - --feature-gates=ServiceAccountTokenNodeBindingValidation=true
+        - --feature-gates=ServiceAccountTokenNodeBinding=true
+        - --feature-gates=ServiceAccountTokenPodNodeInfo=true
         - --feature-gates=ValidatingAdmissionPolicy=true
+        - --feature-gates=NodeSwap=true
+        - --feature-gates=DynamicResourceAllocation=true
+        - --feature-gates=MaxUnavailableStatefulSet=true
         - --feature-gates=CloudDualStackNodeIPs=true
         - --feature-gates=DisableKubeletCloudCredentialProviders=true
         - --feature-gates=KMSv1=true
+        - --feature-gates=TranslateStreamCloseWebsocketRequests=true
+        - --feature-gates=VolumeGroupSnapshot=true
         - --feature-gates=GatewayAPI=false
-        - --feature-gates=CSIDriverSharedResource=false
-        - --feature-gates=MachineAPIProviderOpenStack=false
-        - --feature-gates=InsightsConfigAPI=false
-        - --feature-gates=SigstoreImageVerification=false
-        - --feature-gates=GCPLabelsTags=false
-        - --feature-gates=VSphereMultiVCenters=false
-        - --feature-gates=RouteExternalCertificate=false
-        - --feature-gates=EtcdBackendQuota=false
-        - --feature-gates=AutomatedEtcdBackup=false
         - --feature-gates=MachineAPIOperatorDisableMachineHealthCheckController=false
-        - --feature-gates=DNSNameResolver=false
-        - --feature-gates=MachineConfigNodes=false
         - --feature-gates=ClusterAPIInstall=false
-        - --feature-gates=InstallAlternateInfrastructureAWS=false
-        - --feature-gates=GCPClusterHostedDNS=false
-        - --feature-gates=MixedCPUsAllocation=false
-        - --feature-gates=ManagedBootImages=false
-        - --feature-gates=OnClusterBuild=false
-        - --feature-gates=SignatureStores=false
-        - --feature-gates=PinnedImages=false
-        - --feature-gates=UpgradeStatus=false
-        - --feature-gates=Example=false
-        - --feature-gates=PlatformOperators=false
-        - --feature-gates=NewOLM=false
-        - --feature-gates=ExternalRouteCertificate=false
-        - --feature-gates=InsightsOnDemandDataGather=false
-        - --feature-gates=InsightsConfig=false
-        - --feature-gates=ImagePolicy=false
-        - --feature-gates=NodeDisruptionPolicy=false
-        - --feature-gates=MetricsCollectionProfiles=false
         - --feature-gates=ClusterAPIInstallAzure=false
-        - --feature-gates=ClusterAPIInstallGCP=false
         - --feature-gates=ClusterAPIInstallIBMCloud=false
-        - --feature-gates=ClusterAPIInstallPowerVS=false
-        - --feature-gates=ChunkSizeMiB=false
         - --feature-gates=MachineAPIMigration=false
-        - --feature-gates=ServiceAccountTokenNodeBindingValidation=false
-        - --feature-gates=ServiceAccountTokenNodeBinding=false
-        - --feature-gates=ServiceAccountTokenPodNodeInfo=false
-        - --feature-gates=NodeSwap=false
-        - --feature-gates=DynamicResourceAllocation=false
-        - --feature-gates=MaxUnavailableStatefulSet=false
         - --feature-gates=EventedPLEG=false
-        - --feature-gates=TranslateStreamCloseWebsocketRequests=false
-        - --feature-gates=VolumeGroupSnapshot=false
         command:
         - hyperkube
         - kube-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,296 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: kube-controller-manager
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: kube-controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,certs
+        component.hypershift.openshift.io/config-hash: "1252551421580954"
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: kube-controller-manager
+        hypershift.openshift.io/control-plane-component: kube-controller-manager
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: kube-controller-manager
+                hypershift.openshift.io/control-plane-component: kube-controller-manager
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: kube-controller-manager
+                hypershift.openshift.io/control-plane-component: kube-controller-manager
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --openshift-config=/etc/kubernetes/config/config.json
+        - --kubeconfig=/etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --authentication-kubeconfig=/etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --authorization-kubeconfig=/etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --allocate-node-cidrs=false
+        - --cert-dir=/var/run/kubernetes
+        - --cluster-signing-cert-file=/etc/kubernetes/certs/cluster-signer/ca.crt
+        - --cluster-signing-key-file=/etc/kubernetes/certs/cluster-signer/ca.key
+        - --configure-cloud-routes=false
+        - --controllers=*
+        - --controllers=-ttl
+        - --controllers=-bootstrapsigner
+        - --controllers=-tokencleaner
+        - --enable-dynamic-provisioning=true
+        - --flex-volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec
+        - --pv-recycler-pod-template-filepath-nfs=/etc/kubernetes/recycler-config/recycler-pod.yaml
+        - --kube-api-burst=300
+        - --kube-api-qps=150
+        - --leader-elect-resource-lock=leases
+        - --leader-elect=true
+        - --leader-elect-renew-deadline=12s
+        - --leader-elect-retry-period=3s
+        - --root-ca-file=/etc/kubernetes/certs/root-ca/ca.crt
+        - --secure-port=10257
+        - --service-account-private-key-file=/etc/kubernetes/certs/service-signer/service-account.key
+        - --use-service-account-credentials=true
+        - --cluster-signing-duration=17520h
+        - --tls-cert-file=/etc/kubernetes/certs/server/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/server/tls.key
+        - --node-monitor-grace-period=50s
+        - --cluster-cidr=10.132.0.0/14
+        - --service-cluster-ip-range=
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - --feature-gates=OpenShiftPodSecurityAdmission=true
+        - --feature-gates=ExternalCloudProvider=true
+        - --feature-gates=ExternalCloudProviderAzure=true
+        - --feature-gates=ExternalCloudProviderGCP=true
+        - --feature-gates=ExternalCloudProviderExternal=true
+        - --feature-gates=BuildCSIVolumes=true
+        - --feature-gates=AzureWorkloadIdentity=true
+        - --feature-gates=PrivateHostedZoneAWS=true
+        - --feature-gates=AlibabaPlatform=true
+        - --feature-gates=VSphereStaticIPs=true
+        - --feature-gates=AdminNetworkPolicy=true
+        - --feature-gates=NetworkLiveMigration=true
+        - --feature-gates=NetworkDiagnosticsConfig=true
+        - --feature-gates=HardwareSpeed=true
+        - --feature-gates=VSphereControlPlaneMachineSet=true
+        - --feature-gates=MetricsServer=true
+        - --feature-gates=ExternalOIDC=true
+        - --feature-gates=BareMetalLoadBalancer=true
+        - --feature-gates=VSphereDriverConfiguration=true
+        - --feature-gates=ClusterAPIInstallAWS=true
+        - --feature-gates=ClusterAPIInstallNutanix=true
+        - --feature-gates=ClusterAPIInstallOpenStack=true
+        - --feature-gates=ClusterAPIInstallVSphere=true
+        - --feature-gates=ValidatingAdmissionPolicy=true
+        - --feature-gates=CloudDualStackNodeIPs=true
+        - --feature-gates=DisableKubeletCloudCredentialProviders=true
+        - --feature-gates=KMSv1=true
+        - --feature-gates=GatewayAPI=false
+        - --feature-gates=CSIDriverSharedResource=false
+        - --feature-gates=MachineAPIProviderOpenStack=false
+        - --feature-gates=InsightsConfigAPI=false
+        - --feature-gates=SigstoreImageVerification=false
+        - --feature-gates=GCPLabelsTags=false
+        - --feature-gates=VSphereMultiVCenters=false
+        - --feature-gates=RouteExternalCertificate=false
+        - --feature-gates=EtcdBackendQuota=false
+        - --feature-gates=AutomatedEtcdBackup=false
+        - --feature-gates=MachineAPIOperatorDisableMachineHealthCheckController=false
+        - --feature-gates=DNSNameResolver=false
+        - --feature-gates=MachineConfigNodes=false
+        - --feature-gates=ClusterAPIInstall=false
+        - --feature-gates=InstallAlternateInfrastructureAWS=false
+        - --feature-gates=GCPClusterHostedDNS=false
+        - --feature-gates=MixedCPUsAllocation=false
+        - --feature-gates=ManagedBootImages=false
+        - --feature-gates=OnClusterBuild=false
+        - --feature-gates=SignatureStores=false
+        - --feature-gates=PinnedImages=false
+        - --feature-gates=UpgradeStatus=false
+        - --feature-gates=Example=false
+        - --feature-gates=PlatformOperators=false
+        - --feature-gates=NewOLM=false
+        - --feature-gates=ExternalRouteCertificate=false
+        - --feature-gates=InsightsOnDemandDataGather=false
+        - --feature-gates=InsightsConfig=false
+        - --feature-gates=ImagePolicy=false
+        - --feature-gates=NodeDisruptionPolicy=false
+        - --feature-gates=MetricsCollectionProfiles=false
+        - --feature-gates=ClusterAPIInstallAzure=false
+        - --feature-gates=ClusterAPIInstallGCP=false
+        - --feature-gates=ClusterAPIInstallIBMCloud=false
+        - --feature-gates=ClusterAPIInstallPowerVS=false
+        - --feature-gates=ChunkSizeMiB=false
+        - --feature-gates=MachineAPIMigration=false
+        - --feature-gates=ServiceAccountTokenNodeBindingValidation=false
+        - --feature-gates=ServiceAccountTokenNodeBinding=false
+        - --feature-gates=ServiceAccountTokenPodNodeInfo=false
+        - --feature-gates=NodeSwap=false
+        - --feature-gates=DynamicResourceAllocation=false
+        - --feature-gates=MaxUnavailableStatefulSet=false
+        - --feature-gates=EventedPLEG=false
+        - --feature-gates=TranslateStreamCloseWebsocketRequests=false
+        - --feature-gates=VolumeGroupSnapshot=false
+        command:
+        - hyperkube
+        - kube-controller-manager
+        image: hyperkube
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 10257
+            scheme: HTTPS
+          initialDelaySeconds: 45
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: kube-controller-manager
+        ports:
+        - containerPort: 10257
+          name: client
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 10257
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          requests:
+            cpu: 60m
+            memory: 400Mi
+        volumeMounts:
+        - mountPath: /var/run/kubernetes
+          name: certs
+        - mountPath: /etc/kubernetes/certs/cluster-signer
+          name: cluster-signer
+        - mountPath: /etc/kubernetes/config
+          name: kcm-config
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /var/log/kube-controller-manager
+          name: logs
+        - mountPath: /etc/kubernetes/recycler-config
+          name: recycler-config
+        - mountPath: /etc/kubernetes/certs/root-ca
+          name: root-ca
+        - mountPath: /etc/kubernetes/certs/server
+          name: server-crt
+        - mountPath: /etc/kubernetes/certs/service-signer
+          name: service-signer
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: kcm-config
+        name: kcm-config
+      - configMap:
+          defaultMode: 420
+          name: root-ca
+        name: root-ca
+      - emptyDir: {}
+        name: logs
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: kube-controller-manager-kubeconfig
+      - name: cluster-signer
+        secret:
+          defaultMode: 416
+          secretName: cluster-signer-ca
+      - emptyDir: {}
+        name: certs
+      - name: service-signer
+        secret:
+          defaultMode: 416
+          secretName: sa-signing-key
+      - name: server-crt
+        secret:
+          defaultMode: 416
+          secretName: kcm-server
+      - configMap:
+          defaultMode: 420
+          name: recycler-config
+        name: recycler-config
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,37 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: kube-controller-manager
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: kube-controller-manager Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: kube-controller-manager Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: kcm-config
+  - group: ""
+    kind: Secret
+    name: kube-controller-manager-kubeconfig
+  - group: ""
+    kind: ConfigMap
+    name: recycler-config
+  - group: ""
+    kind: Service
+    name: kube-controller-manager
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-controller-manager
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -92,74 +92,74 @@ spec:
         - --feature-gates=ExternalCloudProviderAzure=true
         - --feature-gates=ExternalCloudProviderGCP=true
         - --feature-gates=ExternalCloudProviderExternal=true
+        - --feature-gates=CSIDriverSharedResource=true
         - --feature-gates=BuildCSIVolumes=true
+        - --feature-gates=MachineAPIProviderOpenStack=true
+        - --feature-gates=InsightsConfigAPI=true
         - --feature-gates=AzureWorkloadIdentity=true
         - --feature-gates=PrivateHostedZoneAWS=true
+        - --feature-gates=SigstoreImageVerification=true
+        - --feature-gates=GCPLabelsTags=true
         - --feature-gates=AlibabaPlatform=true
+        - --feature-gates=VSphereMultiVCenters=true
         - --feature-gates=VSphereStaticIPs=true
+        - --feature-gates=RouteExternalCertificate=true
         - --feature-gates=AdminNetworkPolicy=true
         - --feature-gates=NetworkLiveMigration=true
         - --feature-gates=NetworkDiagnosticsConfig=true
         - --feature-gates=HardwareSpeed=true
+        - --feature-gates=EtcdBackendQuota=true
+        - --feature-gates=AutomatedEtcdBackup=true
+        - --feature-gates=DNSNameResolver=true
         - --feature-gates=VSphereControlPlaneMachineSet=true
+        - --feature-gates=MachineConfigNodes=true
         - --feature-gates=MetricsServer=true
+        - --feature-gates=InstallAlternateInfrastructureAWS=true
+        - --feature-gates=GCPClusterHostedDNS=true
+        - --feature-gates=MixedCPUsAllocation=true
+        - --feature-gates=ManagedBootImages=true
+        - --feature-gates=OnClusterBuild=true
+        - --feature-gates=SignatureStores=true
+        - --feature-gates=PinnedImages=true
+        - --feature-gates=UpgradeStatus=true
         - --feature-gates=ExternalOIDC=true
+        - --feature-gates=Example=true
+        - --feature-gates=PlatformOperators=true
+        - --feature-gates=NewOLM=true
+        - --feature-gates=ExternalRouteCertificate=true
+        - --feature-gates=InsightsOnDemandDataGather=true
         - --feature-gates=BareMetalLoadBalancer=true
+        - --feature-gates=InsightsConfig=true
+        - --feature-gates=ImagePolicy=true
+        - --feature-gates=NodeDisruptionPolicy=true
+        - --feature-gates=MetricsCollectionProfiles=true
         - --feature-gates=VSphereDriverConfiguration=true
         - --feature-gates=ClusterAPIInstallAWS=true
+        - --feature-gates=ClusterAPIInstallGCP=true
         - --feature-gates=ClusterAPIInstallNutanix=true
         - --feature-gates=ClusterAPIInstallOpenStack=true
+        - --feature-gates=ClusterAPIInstallPowerVS=true
         - --feature-gates=ClusterAPIInstallVSphere=true
+        - --feature-gates=ChunkSizeMiB=true
+        - --feature-gates=ServiceAccountTokenNodeBindingValidation=true
+        - --feature-gates=ServiceAccountTokenNodeBinding=true
+        - --feature-gates=ServiceAccountTokenPodNodeInfo=true
         - --feature-gates=ValidatingAdmissionPolicy=true
+        - --feature-gates=NodeSwap=true
+        - --feature-gates=DynamicResourceAllocation=true
+        - --feature-gates=MaxUnavailableStatefulSet=true
         - --feature-gates=CloudDualStackNodeIPs=true
         - --feature-gates=DisableKubeletCloudCredentialProviders=true
         - --feature-gates=KMSv1=true
+        - --feature-gates=TranslateStreamCloseWebsocketRequests=true
+        - --feature-gates=VolumeGroupSnapshot=true
         - --feature-gates=GatewayAPI=false
-        - --feature-gates=CSIDriverSharedResource=false
-        - --feature-gates=MachineAPIProviderOpenStack=false
-        - --feature-gates=InsightsConfigAPI=false
-        - --feature-gates=SigstoreImageVerification=false
-        - --feature-gates=GCPLabelsTags=false
-        - --feature-gates=VSphereMultiVCenters=false
-        - --feature-gates=RouteExternalCertificate=false
-        - --feature-gates=EtcdBackendQuota=false
-        - --feature-gates=AutomatedEtcdBackup=false
         - --feature-gates=MachineAPIOperatorDisableMachineHealthCheckController=false
-        - --feature-gates=DNSNameResolver=false
-        - --feature-gates=MachineConfigNodes=false
         - --feature-gates=ClusterAPIInstall=false
-        - --feature-gates=InstallAlternateInfrastructureAWS=false
-        - --feature-gates=GCPClusterHostedDNS=false
-        - --feature-gates=MixedCPUsAllocation=false
-        - --feature-gates=ManagedBootImages=false
-        - --feature-gates=OnClusterBuild=false
-        - --feature-gates=SignatureStores=false
-        - --feature-gates=PinnedImages=false
-        - --feature-gates=UpgradeStatus=false
-        - --feature-gates=Example=false
-        - --feature-gates=PlatformOperators=false
-        - --feature-gates=NewOLM=false
-        - --feature-gates=ExternalRouteCertificate=false
-        - --feature-gates=InsightsOnDemandDataGather=false
-        - --feature-gates=InsightsConfig=false
-        - --feature-gates=ImagePolicy=false
-        - --feature-gates=NodeDisruptionPolicy=false
-        - --feature-gates=MetricsCollectionProfiles=false
         - --feature-gates=ClusterAPIInstallAzure=false
-        - --feature-gates=ClusterAPIInstallGCP=false
         - --feature-gates=ClusterAPIInstallIBMCloud=false
-        - --feature-gates=ClusterAPIInstallPowerVS=false
-        - --feature-gates=ChunkSizeMiB=false
         - --feature-gates=MachineAPIMigration=false
-        - --feature-gates=ServiceAccountTokenNodeBindingValidation=false
-        - --feature-gates=ServiceAccountTokenNodeBinding=false
-        - --feature-gates=ServiceAccountTokenPodNodeInfo=false
-        - --feature-gates=NodeSwap=false
-        - --feature-gates=DynamicResourceAllocation=false
-        - --feature-gates=MaxUnavailableStatefulSet=false
         - --feature-gates=EventedPLEG=false
-        - --feature-gates=TranslateStreamCloseWebsocketRequests=false
-        - --feature-gates=VolumeGroupSnapshot=false
         command:
         - hyperkube
         - kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,221 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: kube-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work
+        component.hypershift.openshift.io/config-hash: 022a8a3a
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: kube-scheduler
+        hypershift.openshift.io/control-plane-component: kube-scheduler
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: kube-scheduler
+                hypershift.openshift.io/control-plane-component: kube-scheduler
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: kube-scheduler
+                hypershift.openshift.io/control-plane-component: kube-scheduler
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --config=/etc/kubernetes/config/config.json
+        - --cert-dir=/var/run/kubernetes
+        - --secure-port=10259
+        - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - -v=2
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - --feature-gates=OpenShiftPodSecurityAdmission=true
+        - --feature-gates=ExternalCloudProvider=true
+        - --feature-gates=ExternalCloudProviderAzure=true
+        - --feature-gates=ExternalCloudProviderGCP=true
+        - --feature-gates=ExternalCloudProviderExternal=true
+        - --feature-gates=BuildCSIVolumes=true
+        - --feature-gates=AzureWorkloadIdentity=true
+        - --feature-gates=PrivateHostedZoneAWS=true
+        - --feature-gates=AlibabaPlatform=true
+        - --feature-gates=VSphereStaticIPs=true
+        - --feature-gates=AdminNetworkPolicy=true
+        - --feature-gates=NetworkLiveMigration=true
+        - --feature-gates=NetworkDiagnosticsConfig=true
+        - --feature-gates=HardwareSpeed=true
+        - --feature-gates=VSphereControlPlaneMachineSet=true
+        - --feature-gates=MetricsServer=true
+        - --feature-gates=ExternalOIDC=true
+        - --feature-gates=BareMetalLoadBalancer=true
+        - --feature-gates=VSphereDriverConfiguration=true
+        - --feature-gates=ClusterAPIInstallAWS=true
+        - --feature-gates=ClusterAPIInstallNutanix=true
+        - --feature-gates=ClusterAPIInstallOpenStack=true
+        - --feature-gates=ClusterAPIInstallVSphere=true
+        - --feature-gates=ValidatingAdmissionPolicy=true
+        - --feature-gates=CloudDualStackNodeIPs=true
+        - --feature-gates=DisableKubeletCloudCredentialProviders=true
+        - --feature-gates=KMSv1=true
+        - --feature-gates=GatewayAPI=false
+        - --feature-gates=CSIDriverSharedResource=false
+        - --feature-gates=MachineAPIProviderOpenStack=false
+        - --feature-gates=InsightsConfigAPI=false
+        - --feature-gates=SigstoreImageVerification=false
+        - --feature-gates=GCPLabelsTags=false
+        - --feature-gates=VSphereMultiVCenters=false
+        - --feature-gates=RouteExternalCertificate=false
+        - --feature-gates=EtcdBackendQuota=false
+        - --feature-gates=AutomatedEtcdBackup=false
+        - --feature-gates=MachineAPIOperatorDisableMachineHealthCheckController=false
+        - --feature-gates=DNSNameResolver=false
+        - --feature-gates=MachineConfigNodes=false
+        - --feature-gates=ClusterAPIInstall=false
+        - --feature-gates=InstallAlternateInfrastructureAWS=false
+        - --feature-gates=GCPClusterHostedDNS=false
+        - --feature-gates=MixedCPUsAllocation=false
+        - --feature-gates=ManagedBootImages=false
+        - --feature-gates=OnClusterBuild=false
+        - --feature-gates=SignatureStores=false
+        - --feature-gates=PinnedImages=false
+        - --feature-gates=UpgradeStatus=false
+        - --feature-gates=Example=false
+        - --feature-gates=PlatformOperators=false
+        - --feature-gates=NewOLM=false
+        - --feature-gates=ExternalRouteCertificate=false
+        - --feature-gates=InsightsOnDemandDataGather=false
+        - --feature-gates=InsightsConfig=false
+        - --feature-gates=ImagePolicy=false
+        - --feature-gates=NodeDisruptionPolicy=false
+        - --feature-gates=MetricsCollectionProfiles=false
+        - --feature-gates=ClusterAPIInstallAzure=false
+        - --feature-gates=ClusterAPIInstallGCP=false
+        - --feature-gates=ClusterAPIInstallIBMCloud=false
+        - --feature-gates=ClusterAPIInstallPowerVS=false
+        - --feature-gates=ChunkSizeMiB=false
+        - --feature-gates=MachineAPIMigration=false
+        - --feature-gates=ServiceAccountTokenNodeBindingValidation=false
+        - --feature-gates=ServiceAccountTokenNodeBinding=false
+        - --feature-gates=ServiceAccountTokenPodNodeInfo=false
+        - --feature-gates=NodeSwap=false
+        - --feature-gates=DynamicResourceAllocation=false
+        - --feature-gates=MaxUnavailableStatefulSet=false
+        - --feature-gates=EventedPLEG=false
+        - --feature-gates=TranslateStreamCloseWebsocketRequests=false
+        - --feature-gates=VolumeGroupSnapshot=false
+        command:
+        - hyperkube
+        - kube-scheduler
+        image: hyperkube
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: kube-scheduler
+        resources:
+          requests:
+            cpu: 25m
+            memory: 150Mi
+        volumeMounts:
+        - mountPath: /var/run/kubernetes
+          name: cert-work
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/config
+          name: scheduler-config
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      priorityClassName: hypershift-control-plane
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: kube-scheduler
+        name: scheduler-config
+      - emptyDir: {}
+        name: cert-work
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: kube-scheduler-kubeconfig
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,28 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: kube-scheduler
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: kube-scheduler Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: kube-scheduler Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: kube-scheduler
+  - group: ""
+    kind: Secret
+    name: kube-scheduler-kubeconfig
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,272 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: oauth-openshift
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: oauth-openshift
+  strategy:
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs
+        component.hypershift.openshift.io/config-hash: 4ebc1fdd
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: oauth-openshift
+        hypershift.openshift.io/control-plane-component: oauth-openshift
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        hypershift.openshift.io/request-serving-component: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - osinserver
+        - --config=/etc/kubernetes/config/config.yaml
+        - --audit-log-format=json
+        - --audit-log-maxbackup=1
+        - --audit-log-maxsize=10
+        - --audit-log-path=/var/run/kubernetes/audit.log
+        - --audit-policy-file=/etc/kubernetes/audit-config/policy.yaml
+        env:
+        - name: HTTP_PROXY
+          value: http://127.0.0.1:8092
+        - name: HTTPS_PROXY
+          value: http://127.0.0.1:8092
+        - name: ALL_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: NO_PROXY
+          value: kube-apiserver,audit-webhook
+        image: oauth-server
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 120
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: oauth-openshift
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 25m
+            memory: 40Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/audit-config
+          name: audit-config
+        - mountPath: /etc/kubernetes/secrets/templates/error
+          name: error-template
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/secrets/templates/login
+          name: login-template
+        - mountPath: /var/run/kubernetes
+          name: logs
+        - mountPath: /etc/kubernetes/certs/master-ca
+          name: master-ca-bundle
+        - mountPath: /etc/kubernetes/config
+          name: oauth-config
+        - mountPath: /etc/kubernetes/secrets/templates/providers
+          name: providers-template
+        - mountPath: /etc/kubernetes/certs/serving-cert
+          name: serving-cert
+        - mountPath: /etc/kubernetes/secrets/session
+          name: session-secret
+        workingDir: /var/run/kubernetes
+      - args:
+        - -c
+        - |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
+          function cleanup() {
+            kill -- -$$
+            wait
+          }
+          trap cleanup SIGTERM
+
+          /usr/bin/tail -c+1 -F /var/run/kubernetes/audit.log &
+          wait $!
+        command:
+        - /bin/bash
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: audit-logs
+        resources:
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/run/kubernetes
+          name: logs
+      - args:
+        - run
+        - --serving-port=8092
+        - --connect-directly-to-cloud-apis=true
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-https-proxy
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/secrets/kubeconfig/kubeconfig
+        image: controlplane-operator
+        name: konnectivity-proxy-https
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/secrets/kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/konnectivity/proxy-client
+          name: konnectivity-proxy-cert
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
+      - args:
+        - run
+        - --resolve-from-guest-cluster-dns=true
+        - --resolve-from-management-cluster-dns=true
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-socks5-proxy
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/secrets/kubeconfig/kubeconfig
+        image: controlplane-operator
+        name: konnectivity-proxy-socks5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/secrets/kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/konnectivity/proxy-client
+          name: konnectivity-proxy-cert
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      priorityClassName: hypershift-api-critical
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: oauth-openshift
+        name: oauth-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: oauth-server-crt
+      - name: session-secret
+        secret:
+          defaultMode: 416
+          secretName: oauth-openshift-session
+      - name: error-template
+        secret:
+          defaultMode: 416
+          secretName: oauth-openshift-default-error-template
+      - name: login-template
+        secret:
+          defaultMode: 416
+          secretName: oauth-openshift-default-login-template
+      - name: providers-template
+        secret:
+          defaultMode: 416
+          secretName: oauth-openshift-default-provider-selection-template
+      - emptyDir: {}
+        name: logs
+      - configMap:
+          defaultMode: 420
+          name: oauth-master-ca-bundle
+        name: master-ca-bundle
+      - configMap:
+          defaultMode: 420
+          name: oauth-openshift-audit
+        name: audit-config
+      - name: konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          name: konnectivity-ca-bundle
+        name: konnectivity-proxy-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,43 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: oauth-openshift
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: oauth-openshift Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: oauth-openshift Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: oauth-openshift-audit
+  - group: ""
+    kind: ConfigMap
+    name: oauth-openshift
+  - group: ""
+    kind: Secret
+    name: oauth-openshift-default-error-template
+  - group: ""
+    kind: Secret
+    name: oauth-openshift-default-login-template
+  - group: ""
+    kind: Secret
+    name: oauth-openshift-default-provider-selection-template
+  - group: policy
+    kind: PodDisruptionBudget
+    name: oauth-openshift
+  - group: ""
+    kind: Secret
+    name: oauth-openshift-session
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,299 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: openshift-apiserver
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 3
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: openshift-apiserver
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,oas-trust-anchor
+        component.hypershift.openshift.io/config-hash: 19dc307e3415eb666d06370b
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: openshift-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-apiserver
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: openshift-apiserver
+                hypershift.openshift.io/control-plane-component: openshift-apiserver
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: openshift-apiserver
+                hypershift.openshift.io/control-plane-component: openshift-apiserver
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - start
+        - --config=/etc/kubernetes/config/config.yaml
+        - --authorization-kubeconfig=/etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --authentication-kubeconfig=/etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --requestheader-client-ca-file=/etc/kubernetes/certs/aggregator-client-ca/ca.crt
+        - --requestheader-allowed-names=kube-apiserver-proxy,system:kube-apiserver-proxy,system:openshift-aggregator
+        - --requestheader-username-headers=X-Remote-User
+        - --requestheader-group-headers=X-Remote-Group
+        - --requestheader-extra-headers-prefix=X-Remote-Extra-
+        - --client-ca-file=/etc/kubernetes/certs/client-ca/ca.crt
+        env:
+        - name: HTTP_PROXY
+          value: http://127.0.0.1:8090
+        - name: HTTPS_PROXY
+          value: http://127.0.0.1:8090
+        - name: NO_PROXY
+          value: kube-apiserver,etcd-client,audit-webhook
+        image: openshift-apiserver
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: openshift-apiserver
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: healthz
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/certs/aggregator-client-ca
+          name: aggregator-ca
+        - mountPath: /etc/kubernetes/audit-config
+          name: audit-config
+        - mountPath: /etc/kubernetes/certs/client-ca
+          name: client-ca
+        - mountPath: /etc/kubernetes/config
+          name: config
+        - mountPath: /etc/kubernetes/certs/etcd-client-ca
+          name: etcd-client-ca
+        - mountPath: /etc/kubernetes/certs/etcd-client
+          name: etcd-client-cert
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: oas-trust-anchor
+        - mountPath: /var/lib/kubelet
+          name: pull-secret
+        - mountPath: /etc/kubernetes/certs/serving
+          name: serving-cert
+        - mountPath: /var/log/openshift-apiserver
+          name: work-logs
+        workingDir: /var/log/openshift-apiserver
+      - args:
+        - -c
+        - |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
+          function cleanup() {
+            kill -- -$$
+            wait
+          }
+          trap cleanup SIGTERM
+
+          /usr/bin/tail -c+1 -F /var/log/openshift-apiserver/audit.log &
+          wait $!
+        command:
+        - /bin/bash
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: audit-logs
+        resources:
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/openshift-apiserver
+          name: work-logs
+      - args:
+        - run
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-https-proxy
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/secrets/kubeconfig/kubeconfig
+        image: controlplane-operator
+        name: konnectivity-proxy-https
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/secrets/kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/konnectivity/proxy-client
+          name: konnectivity-proxy-cert
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      - command:
+        - /bin/bash
+        - -c
+        - |2
+
+          #!/bin/bash
+
+          set -euo pipefail
+
+          cp -f -r /etc/pki/ca-trust/extracted/pem/* /run/ca-trust-generated/
+
+          if ! [[ -f /run/service-ca-signer/service-ca.crt ]]; then
+             exit 0
+          fi
+
+          chmod 0666 /run/ca-trust-generated/tls-ca-bundle.pem
+          echo '#service signer ca' >> /run/ca-trust-generated/tls-ca-bundle.pem
+          cat /run/service-ca-signer/service-ca.crt >>/run/ca-trust-generated/tls-ca-bundle.pem
+          chmod 0444 /run/ca-trust-generated/tls-ca-bundle.pem
+        image: openshift-apiserver
+        imagePullPolicy: IfNotPresent
+        name: oas-trust-anchor-generator
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/ca-trust-generated
+          name: oas-trust-anchor
+      priorityClassName: hypershift-api-critical
+      terminationGracePeriodSeconds: 120
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - emptyDir: {}
+        name: work-logs
+      - configMap:
+          defaultMode: 420
+          name: openshift-apiserver
+        name: config
+      - configMap:
+          defaultMode: 420
+          name: openshift-apiserver-audit
+        name: audit-config
+      - configMap:
+          defaultMode: 420
+          name: aggregator-client-ca
+        name: aggregator-ca
+      - configMap:
+          defaultMode: 420
+          name: etcd-ca
+        name: etcd-client-ca
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: client-ca
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: openshift-apiserver-cert
+      - name: etcd-client-cert
+        secret:
+          defaultMode: 416
+          secretName: etcd-client-tls
+      - emptyDir: {}
+        name: oas-trust-anchor
+      - name: pull-secret
+        secret:
+          defaultMode: 416
+          items:
+          - key: .dockerconfigjson
+            path: config.json
+          secretName: pull-secret
+      - name: konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          name: konnectivity-ca-bundle
+        name: konnectivity-proxy-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,34 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: openshift-apiserver
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: openshift-apiserver Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: openshift-apiserver Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: openshift-apiserver-audit
+  - group: ""
+    kind: ConfigMap
+    name: openshift-apiserver
+  - group: policy
+    kind: PodDisruptionBudget
+    name: openshift-apiserver
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: openshift-apiserver
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: openshift-controller-manager
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: openshift-controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        component.hypershift.openshift.io/config-hash: 8bcb4d22
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: openshift-controller-manager
+        hypershift.openshift.io/control-plane-component: openshift-controller-manager
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: openshift-controller-manager
+                hypershift.openshift.io/control-plane-component: openshift-controller-manager
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: openshift-controller-manager
+                hypershift.openshift.io/control-plane-component: openshift-controller-manager
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - start
+        - --config
+        - /etc/kubernetes/config/config.yaml
+        command:
+        - openshift-controller-manager
+        image: openshift-controller-manager
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: openshift-controller-manager
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/kubernetes/client-ca
+          name: client-ca
+        - mountPath: /etc/kubernetes/config
+          name: config
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
+      priorityClassName: hypershift-control-plane
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: openshift-controller-manager-config
+        name: config
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: openshift-controller-manager-cert
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: client-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,31 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: openshift-controller-manager
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: openshift-controller-manager Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: openshift-controller-manager Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: openshift-controller-manager-config
+  - group: ""
+    kind: Service
+    name: openshift-controller-manager
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: openshift-controller-manager
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,235 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: openshift-oauth-apiserver
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 3
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: openshift-oauth-apiserver
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs
+        component.hypershift.openshift.io/config-hash: 19dc307e3415eb66
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: openshift-oauth-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-oauth-apiserver
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: openshift-oauth-apiserver
+                hypershift.openshift.io/control-plane-component: openshift-oauth-apiserver
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: openshift-oauth-apiserver
+                hypershift.openshift.io/control-plane-component: openshift-oauth-apiserver
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - start
+        - --authorization-kubeconfig=/etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --authentication-kubeconfig=/etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --kubeconfig=/etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --secure-port=8443
+        - --audit-log-path=/var/log/openshift-oauth-apiserver/audit.log
+        - --audit-log-format=json
+        - --audit-log-maxsize=10
+        - --audit-log-maxbackup=1
+        - --etcd-cafile=/etc/kubernetes/certs/etcd-client-ca/ca.crt
+        - --etcd-keyfile=/etc/kubernetes/certs/etcd-client/etcd-client.key
+        - --etcd-certfile=/etc/kubernetes/certs/etcd-client/etcd-client.crt
+        - --shutdown-delay-duration=15s
+        - --tls-private-key-file=/etc/kubernetes/certs/serving/tls.key
+        - --tls-cert-file=/etc/kubernetes/certs/serving/tls.crt
+        - --audit-policy-file=/etc/kubernetes/audit-config/policy.yaml
+        - --cors-allowed-origins='//127\.0\.0\.1(:|$)'
+        - --cors-allowed-origins='//localhost(:|$)'
+        - --v=2
+        - --requestheader-client-ca-file=/etc/kubernetes/certs/aggregator-client-ca/ca.crt
+        - --requestheader-allowed-names=kube-apiserver-proxy,system:kube-apiserver-proxy,system:openshift-aggregator
+        - --requestheader-username-headers=X-Remote-User
+        - --requestheader-group-headers=X-Remote-Group
+        - --requestheader-extra-headers-prefix=X-Remote-Extra-
+        - --client-ca-file=/etc/kubernetes/certs/client-ca/ca.crt
+        - --api-audiences=
+        - --etcd-servers=https://etcd-client:2379
+        - --tls-min-version=VersionTLS12
+        command:
+        - /usr/bin/oauth-apiserver
+        image: oauth-apiserver
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: openshift-oauth-apiserver
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: readyz
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 150m
+            memory: 80Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/certs/aggregator-client-ca
+          name: aggregator-ca
+        - mountPath: /etc/kubernetes/audit-config
+          name: audit-config
+        - mountPath: /etc/kubernetes/certs/client-ca
+          name: client-ca
+        - mountPath: /etc/kubernetes/certs/etcd-client-ca
+          name: etcd-client-ca
+        - mountPath: /etc/kubernetes/certs/etcd-client
+          name: etcd-client-cert
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/certs/serving
+          name: serving-cert
+        - mountPath: /var/log/openshift-oauth-apiserver
+          name: work-logs
+        workingDir: /var/log/openshift-oauth-apiserver
+      - args:
+        - -c
+        - |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
+          function cleanup() {
+            kill -- -$$
+            wait
+          }
+          trap cleanup SIGTERM
+
+          /usr/bin/tail -c+1 -F /var/log/openshift-oauth-apiserver/audit.log &
+          wait $!
+        command:
+        - /bin/bash
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: audit-logs
+        resources:
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/openshift-oauth-apiserver
+          name: work-logs
+      initContainers:
+      - command:
+        - /usr/bin/control-plane-operator
+        - availability-prober
+        - --target
+        - https://kube-apiserver:6443/readyz
+        image: availability-prober
+        imagePullPolicy: IfNotPresent
+        name: availability-prober
+        resources: {}
+      priorityClassName: hypershift-api-critical
+      terminationGracePeriodSeconds: 120
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - emptyDir: {}
+        name: work-logs
+      - configMap:
+          defaultMode: 420
+          name: openshift-oauth-apiserver-audit
+        name: audit-config
+      - configMap:
+          defaultMode: 420
+          name: aggregator-client-ca
+        name: aggregator-ca
+      - configMap:
+          defaultMode: 420
+          name: etcd-ca
+        name: etcd-client-ca
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: openshift-oauth-apiserver-cert
+      - name: etcd-client-cert
+        secret:
+          defaultMode: 416
+          secretName: etcd-client-tls
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: client-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,28 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: openshift-oauth-apiserver
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: openshift-oauth-apiserver Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: openshift-oauth-apiserver Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: openshift-oauth-apiserver-audit
+  - group: policy
+    kind: PodDisruptionBudget
+    name: openshift-oauth-apiserver
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,167 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: openshift-route-controller-manager
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: openshift-route-controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        component.hypershift.openshift.io/config-hash: 57c9c948
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: openshift-route-controller-manager
+        hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: openshift-route-controller-manager
+                hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: openshift-route-controller-manager
+                hypershift.openshift.io/control-plane-component: openshift-route-controller-manager
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - start
+        - --config
+        - /etc/kubernetes/config/config.yaml
+        - --kubeconfig
+        - /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --namespace=openshift-route-controller-manager
+        command:
+        - route-controller-manager
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          value: openshift-route-controller-manager
+        image: route-controller-manager
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: openshift-route-controller-manager
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/client-ca
+          name: client-ca
+        - mountPath: /etc/kubernetes/config
+          name: config
+        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: openshift-route-controller-manager-config
+        name: config
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: openshift-route-controller-manager-cert
+      - name: kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: client-ca
+        name: client-ca
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,33 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: openshift-route-controller-manager
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: openshift-route-controller-manager Deployment Available condition not
+      found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: openshift-route-controller-manager Deployment Progressing condition not
+      found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: openshift-route-controller-manager-config
+  - group: ""
+    kind: Service
+    name: openshift-route-controller-manager
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: openshift-route-controller-manager
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,132 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
+  name: router
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  replicas: 3
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: private-router
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        component.hypershift.openshift.io/config-hash: 417672c4
+        hypershift.openshift.io/release-image: ""
+      creationTimestamp: null
+      labels:
+        app: private-router
+        hypershift.openshift.io/control-plane-component: router
+        hypershift.openshift.io/hosted-control-plane: hcp-namespace
+        hypershift.openshift.io/request-serving-component: "true"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - hcp-namespace
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: hcp-namespace
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: private-router
+                hypershift.openshift.io/control-plane-component: router
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+                hypershift.openshift.io/request-serving-component: "true"
+            topologyKey: topology.kubernetes.io/zone
+          - labelSelector:
+              matchLabels:
+                app: private-router
+                hypershift.openshift.io/control-plane-component: router
+                hypershift.openshift.io/hosted-control-plane: hcp-namespace
+                hypershift.openshift.io/request-serving-component: "true"
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - -f
+        - /usr/local/etc/haproxy
+        command:
+        - haproxy
+        image: haproxy-router
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /haproxy_ready
+            port: 9444
+            scheme: HTTP
+          initialDelaySeconds: 50
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: router
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 40Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+        volumeMounts:
+        - mountPath: /usr/local/etc/haproxy/haproxy.cfg
+          name: config
+          subPath: haproxy.cfg
+      priorityClassName: hypershift-api-critical
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: hcp-namespace
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: router
+        name: config
+status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -1,0 +1,28 @@
+apiVersion: hypershift.openshift.io/v1beta1
+kind: ControlPlaneComponent
+metadata:
+  creationTimestamp: null
+  name: router
+  namespace: hcp-namespace
+  resourceVersion: "1"
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: router Deployment Available condition not found
+    reason: NotFound
+    status: "False"
+    type: Available
+  - lastTransitionTime: null
+    message: router Deployment Progressing condition not found
+    reason: NotFound
+    status: "False"
+    type: Progressing
+  resources:
+  - group: ""
+    kind: ConfigMap
+    name: router
+  - group: policy
+    kind: PodDisruptionBudget
+    name: router
+  version: "4.18"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
@@ -30,10 +32,15 @@ func (cvo *clusterVersionOperator) adaptDeployment(cpContext component.WorkloadC
 		deployment.Spec.Template.Spec.ServiceAccountName = ComponentName
 	}
 
+	featureSet := configv1.Default
+	if cpContext.HCP.Spec.Configuration != nil && cpContext.HCP.Spec.Configuration.FeatureGate != nil {
+		featureSet = cpContext.HCP.Spec.Configuration.FeatureGate.FeatureSet
+	}
+
 	util.UpdateContainer("prepare-payload", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 		c.Args = []string{
 			"-c",
-			preparePayloadScript(cpContext.HCP.Spec.Platform.Type, util.HCPOAuthEnabled(cpContext.HCP)),
+			preparePayloadScript(cpContext.HCP.Spec.Platform.Type, util.HCPOAuthEnabled(cpContext.HCP), featureSet),
 		}
 	})
 	util.UpdateContainer("bootstrap", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
@@ -121,7 +128,7 @@ var (
 	}
 )
 
-func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool) string {
+func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool, featureSet configv1.FeatureSet) string {
 	payloadDir := "/var/payload"
 	var stmts []string
 
@@ -131,6 +138,37 @@ func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool) 
 		fmt.Sprintf("rm %s/manifests/*_servicemonitor.yaml", payloadDir),
 		fmt.Sprintf("cp -R /release-manifests %s/", payloadDir),
 	)
+
+	// NOTE: We would need part of the manifest.Include logic (https://github.com/openshift/library-go/blob/0064ad7bd060b9fd52f7840972c1d3e72186d0f0/pkg/manifest/manifest.go#L190-L196)
+	// to properly evaluate which CVO manifests to select based on featureset. In the absence of that logic, use simple filename filtering, which is not ideal
+	// but better than nothing.  Ideally, we filter based on the feature-set annotation in the manifests.
+	switch featureSet {
+	case configv1.Default, "":
+		stmts = append(stmts,
+			fmt.Sprintf("rm -f %s/manifests/*-CustomNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-DevPreviewNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-TechPreviewNoUpgrade*.yaml", payloadDir),
+		)
+	case configv1.CustomNoUpgrade:
+		stmts = append(stmts,
+			fmt.Sprintf("rm -f %s/manifests/*-Default*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-DevPreviewNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-TechPreviewNoUpgrade*.yaml", payloadDir),
+		)
+	case configv1.DevPreviewNoUpgrade:
+		stmts = append(stmts,
+			fmt.Sprintf("rm -f %s/manifests/*-Default*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-CustomNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-TechPreviewNoUpgrade*.yaml", payloadDir),
+		)
+	case configv1.TechPreviewNoUpgrade:
+		stmts = append(stmts,
+			fmt.Sprintf("rm -f %s/manifests/*-Default*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-CustomNoUpgrade*.yaml", payloadDir),
+			fmt.Sprintf("rm -f %s/manifests/*-DevPreviewNoUpgrade*.yaml", payloadDir),
+		)
+	}
+
 	for _, manifest := range manifestsToOmit {
 		if platformType == hyperv1.IBMCloudPlatform || platformType == hyperv1.PowerVSPlatform {
 			if manifest == "0000_50_cluster-storage-operator_10_deployment-ibm-cloud-managed.yaml" || manifest == "0000_50_cluster-csi-snapshot-controller-operator_07_deployment-ibm-cloud-managed.yaml" {


### PR DESCRIPTION
**What this PR does / why we need it**:

CVO manifests contain some feature-gated ones:

- since at least 4.16, there are feature-gated `ClusterVersion` CRDs
- `UpdateStatus` feature is delivered through DevPreview (now) and TechPreview (later) feature set

We observed HyperShift CI jobs to fail when adding DevPreview-gated deployment manifests, which was unexpected. Investigating further, we discovered that HyperShift applies these manifests:

[cluster-version-operator-665c5789d5-8sr59-bootstrap.log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-version-operator/1091/pull-ci-openshift-cluster-version-operator-master-e2e-hypershift-conformance/1853764751801192448/artifacts/e2e-hypershift-conformance/dump/artifacts/namespaces/clusters-c01d0e18fc19f1e0757b/core/pods/logs/cluster-version-operator-665c5789d5-8sr59-bootstrap.log):

```
error: error parsing /var/payload/manifests/0000_00_update-status-controller_03_deployment-DevPreviewNoUpgrade.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{".ReleaseImage":interface {}(nil)}
```

But even without these added manifests, this happens for existing `ClusterVersion` CRD manifests present in the payload:

```console
$ ls -1 manifests/*clusterversions*crd.yaml
manifests/0000_00_cluster-version-operator_01_clusterversions-CustomNoUpgrade.crd.yaml
manifests/0000_00_cluster-version-operator_01_clusterversions-Default.crd.yaml
manifests/0000_00_cluster-version-operator_01_clusterversions-DevPreviewNoUpgrade.crd.yaml
manifests/0000_00_cluster-version-operator_01_clusterversions-TechPreviewNoUpgrade.crd.yaml
```

In a passing HyperShift CI job, the [same log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-version-operator/1105/pull-ci-openshift-cluster-version-operator-master-e2e-hypershift-conformance/1854708481941049344/artifacts/e2e-hypershift-conformance/dump/artifacts/namespaces/clusters-a5d1b5c3fcb2445935f2/core/pods/logs/cluster-version-operator-96cdfbf7c-cxt9r-bootstrap.log) shows that all four manifests are applied instead of just one:

```
customresourcedefinition.apiextensions.k8s.io/clusterversions.config.openshift.io created
customresourcedefinition.apiextensions.k8s.io/clusterversions.config.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterversions.config.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterversions.config.openshift.io configured
```

This likely means that HyperShift hosted clusters end up using TechPreviewNoUpgrade `ClusterVersion` CRD?

The proper fix is probably to wire through the `FeatureGate` with desired featureset through `CVOParams` but we would need a bit of selection logic so for now we can just remove entropy by deleting all feature-gated manifests instead of stumbling at them.

**Which issue(s) this PR fixes**:

OCPBUGS-44438

**Checklist**

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.
