### PR TITLE
OCPNODE-2552: Add ImagePolicy to the list of valid config manifests

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -138,6 +138,7 @@ type NodePoolSpec struct {
 	// * ContainerRuntimeConfig
 	// * MachineConfig
 	// * ClusterImagePolicy
+	// * ImagePolicy
 	// * ImageContentSourcePolicy
 	// * ImageDigestMirrorSet
 	//

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -146,6 +146,7 @@ spec:
                   * ContainerRuntimeConfig
                   * MachineConfig
                   * ClusterImagePolicy
+                  * ImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
 

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -146,6 +146,7 @@ spec:
                   * ContainerRuntimeConfig
                   * MachineConfig
                   * ClusterImagePolicy
+                  * ImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
 

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -149,6 +149,7 @@ spec:
                   * ContainerRuntimeConfig
                   * MachineConfig
                   * ClusterImagePolicy
+                  * ImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
 

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -149,6 +149,7 @@ spec:
                   * ContainerRuntimeConfig
                   * MachineConfig
                   * ClusterImagePolicy
+                  * ImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
 

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -149,6 +149,7 @@ spec:
                   * ContainerRuntimeConfig
                   * MachineConfig
                   * ClusterImagePolicy
+                  * ImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -803,6 +803,7 @@ with one or more serialized machineconfiguration.openshift.io resources:</p>
 <li>ContainerRuntimeConfig</li>
 <li>MachineConfig</li>
 <li>ClusterImagePolicy</li>
+<li>ImagePolicy</li>
 <li>ImageContentSourcePolicy</li>
 <li>ImageDigestMirrorSet</li>
 </ul>
@@ -8417,6 +8418,7 @@ with one or more serialized machineconfiguration.openshift.io resources:</p>
 <li>ContainerRuntimeConfig</li>
 <li>MachineConfig</li>
 <li>ClusterImagePolicy</li>
+<li>ImagePolicy</li>
 <li>ImageContentSourcePolicy</li>
 <li>ImageDigestMirrorSet</li>
 </ul>

--- a/hypershift-operator/controllers/nodepool/config.go
+++ b/hypershift-operator/controllers/nodepool/config.go
@@ -288,6 +288,7 @@ func (cg *ConfigGenerator) defaultAndValidateConfigManifest(manifest []byte) ([]
 	case *v1alpha1.ImageContentSourcePolicy:
 	case *configv1.ImageDigestMirrorSet:
 	case *configv1alpha1.ClusterImagePolicy:
+	case *configv1alpha1.ImagePolicy:
 	case *mcfgv1.KubeletConfig:
 		obj.Spec.MachineConfigPoolSelector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -138,6 +138,7 @@ type NodePoolSpec struct {
 	// * ContainerRuntimeConfig
 	// * MachineConfig
 	// * ClusterImagePolicy
+	// * ImagePolicy
 	// * ImageContentSourcePolicy
 	// * ImageDigestMirrorSet
 	//


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Add [ImagePolicy](https://github.com/openshift/machine-config-operator/pull/4587)  CRD to valid manifests as MCO bootstraps it. This is a namespaced CRD for image sigstore signature verification.  Previously, we introduced the ClusterImagePolicy in [PR #3894](https://github.com/openshift/release/pull/3894) to support IBM ROKS deployments.
This change aligns with our ongoing effort to ensure Hypershift remains consistent with OpenShift's functionality.
we also allow hypershift users to configure imagepolicy for their namespaces, make sure hypershift provides the same set of features as OpenShift.
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com//browse/OCPNODE-2552

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.