### PR TITLE
OCPBUGS-44041: add --skip-service-principal-deletion flag

### DIFF
--- a/cmd/cluster/azure/destroy.go
+++ b/cmd/cluster/azure/destroy.go
@@ -32,6 +32,7 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AzurePlatform.CredentialsFile, "azure-creds", opts.AzurePlatform.CredentialsFile, "Path to an Azure credentials file (required)")
 	cmd.Flags().StringVar(&opts.AzurePlatform.Location, "location", opts.AzurePlatform.Location, "Location for the cluster")
 	cmd.Flags().StringVar(&opts.AzurePlatform.ResourceGroupName, "resource-group-name", opts.AzurePlatform.ResourceGroupName, "The name of the resource group containing the HostedCluster infrastructure resources that need to be destroyed.")
+	cmd.Flags().BoolVar(&opts.AzurePlatform.SkipServicePrincipalDeletion, "skip-service-principal-deletion", opts.AzurePlatform.SkipServicePrincipalDeletion, "Skip deletion of service principals")
 
 	_ = cmd.MarkFlagRequired("azure-creds")
 
@@ -131,6 +132,7 @@ func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error
 	if o.TechPreviewEnabled {
 		destroyInfraOptions.TechPreviewEnabled = o.TechPreviewEnabled
 		destroyInfraOptions.ControlPlaneMIs = o.AzurePlatform.ControlPlaneMIs
+		destroyInfraOptions.SkipServicePrincipalDeletion = o.AzurePlatform.SkipServicePrincipalDeletion
 	}
 	return destroyInfraOptions.Run(ctx, o.Log)
 }

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -55,10 +55,11 @@ type AWSPlatformDestroyOptions struct {
 }
 
 type AzurePlatformDestroyOptions struct {
-	CredentialsFile   string
-	Location          string
-	ResourceGroupName string
-	ControlPlaneMIs   hyperv1.AzureResourceManagedIdentities
+	CredentialsFile              string
+	Location                     string
+	ResourceGroupName            string
+	ControlPlaneMIs              hyperv1.AzureResourceManagedIdentities
+	SkipServicePrincipalDeletion bool
 }
 
 type PowerVSPlatformDestroyOptions struct {

--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -18,14 +18,15 @@ import (
 )
 
 type DestroyInfraOptions struct {
-	Name               string
-	Location           string
-	InfraID            string
-	CredentialsFile    string
-	Credentials        *util.AzureCreds
-	ResourceGroupName  string
-	TechPreviewEnabled bool
-	ControlPlaneMIs    hyperv1.AzureResourceManagedIdentities
+	Name                         string
+	Location                     string
+	InfraID                      string
+	CredentialsFile              string
+	Credentials                  *util.AzureCreds
+	ResourceGroupName            string
+	TechPreviewEnabled           bool
+	ControlPlaneMIs              hyperv1.AzureResourceManagedIdentities
+	SkipServicePrincipalDeletion bool
 }
 
 func NewDestroyCommand() *cobra.Command {
@@ -111,7 +112,7 @@ func (o *DestroyInfraOptions) Run(ctx context.Context, logger logr.Logger) error
 		}
 	}
 
-	if o.TechPreviewEnabled {
+	if o.TechPreviewEnabled && !o.SkipServicePrincipalDeletion {
 		// Destroy created service principals
 		logger.Info("Destroying service principals")
 		err = destroyServicePrincipals(o)


### PR DESCRIPTION
**What this PR does / why we need it**:

-  adds --skip-service-principal-deletion flag to remove az cli dependency when deleting clusters

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.