### PR TITLE
OCPBUGS-44473: Add openshift to the groups of system:hosted-cluster-config

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -102,7 +102,7 @@ func ReconcileSystemAdminClientCertSecret(secret, ca *corev1.Secret, ownerRef co
 }
 
 func ReconcileHCCOClientCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
-	return reconcileSignedCert(secret, ca, ownerRef, fmt.Sprintf("system:%s", config.HCCOUser), []string{"kubernetes"}, X509UsageClientAuth)
+	return reconcileSignedCert(secret, ca, ownerRef, fmt.Sprintf("system:%s", config.HCCOUser), []string{"kubernetes", "system:serviceaccounts:openshift"}, X509UsageClientAuth)
 }
 
 func ReconcileServiceAccountKubeconfig(secret, csrSigner *corev1.Secret, ca *corev1.ConfigMap, hcp *hyperv1.HostedControlPlane, serviceAccountNamespace, serviceAccountName string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
The managed-cluster-validating-webhooks that are deployed to rosa clusters are preventing the HCCO from updating certain resources including ingress.config.openshift.io. This is because they have a list of privileged users and groups that are allowed. We recently changed the user for the HCCO to system:hosted-cluster-config which is not considered a privileged user.

This commit adds "system:serviceaccounts:openshift" as an organization to the certificate of the system:hosted-cluster-config user. Kubernetes considers any organizations specified in the certificate subject as the groups to which the subject belongs, effectively making
system:hosted-cluster-config a member of the system:serviceaccounts:openshift group, which is one of the accepted privileged groups in the webhook.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-44473](https://issues.redhat.com/browse/OCPBUGS-44473)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.