### PR TITLE
NO-JIRA: e2e: skip OSP multinet before 4.18

### DIFF
--- a/test/e2e/nodepool_osp_multinet_test.go
+++ b/test/e2e/nodepool_osp_multinet_test.go
@@ -51,6 +51,11 @@ func (o OpenStackMultinetTest) Setup(t *testing.T) {
 	if globalOpts.Platform != hyperv1.OpenStackPlatform {
 		t.Skip("test only supported on platform OpenStack")
 	}
+
+	// The feature that is being tested here is only available in 4.18+
+	if e2eutil.IsLessThan(e2eutil.Version418) {
+		t.Skip("test only applicable for 4.18+")
+	}
 }
 
 func (o OpenStackMultinetTest) Run(t *testing.T, nodePool hyperv1.NodePool, _ []corev1.Node) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This feature was only added in 4.18 so let's skip the test otherwise.
