### PR TITLE
OCPBUGS-44568: update diskStorageAccountType consts

### DIFF
--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -749,18 +749,19 @@ spec:
                         properties:
                           diskStorageAccountType:
                             description: |-
-                              storageAccountType is the disk storage account type to use.
-                              Valid values are Standard, StandardSSD, PremiumSSD and UltraSSD and omitted.
+                              diskStorageAccountType is the disk storage account type to use.
+                              Valid values are Premium_LRS, PremiumV2_LRS, Standard_LRS, StandardSSD_LRS, UltraSSD_LRS.
                               Note that Standard means a HDD.
                               The disk performance is tied to the disk type, please refer to the Azure documentation for further details
                               https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison.
                               When omitted this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
-                              The current default is PremiumSSD.
+                              The current default is Premium SSD LRS.
                             enum:
-                            - Standard
-                            - StandardSSD
-                            - PremiumSSD
-                            - UltraSSD
+                            - Premium_LRS
+                            - PremiumV2_LRS
+                            - Standard_LRS
+                            - StandardSSD_LRS
+                            - UltraSSD_LRS
                             type: string
                           encryptionSetID:
                             description: |-
@@ -805,7 +806,7 @@ spec:
                           sizeGiB:
                             description: |-
                               SizeGiB is the size in GiB (1024^3 bytes) to assign to the OS disk.
-                              This should be between 16 and 65,536 when using the UltraSSD storage account type and between 16 and 32,767 when using any other storage account type.
+                              This should be between 16 and 65,536 when using the UltraSSD_LRS storage account type and between 16 and 32,767 when using any other storage account type.
                               When not set, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
                               The current default is 30.
                             format: int32
@@ -814,10 +815,10 @@ spec:
                             type: integer
                         type: object
                         x-kubernetes-validations:
-                        - message: When not using storageAccountType UltraSSD, the
-                            SizeGB value must be less than or equal to 32,767
+                        - message: When not using diskStorageAccountType UltraSSD_LRS,
+                            the SizeGB value must be less than or equal to 32,767
                           rule: '!has(self.diskStorageAccountType) || self.diskStorageAccountType
-                            != ''UltraSSD'' || self.sizeGiB <= 32767'
+                            != ''UltraSSD_LRS'' || self.sizeGiB <= 32767'
                       subnetID:
                         description: |-
                           subnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -749,18 +749,19 @@ spec:
                         properties:
                           diskStorageAccountType:
                             description: |-
-                              storageAccountType is the disk storage account type to use.
-                              Valid values are Standard, StandardSSD, PremiumSSD and UltraSSD and omitted.
+                              diskStorageAccountType is the disk storage account type to use.
+                              Valid values are Premium_LRS, PremiumV2_LRS, Standard_LRS, StandardSSD_LRS, UltraSSD_LRS.
                               Note that Standard means a HDD.
                               The disk performance is tied to the disk type, please refer to the Azure documentation for further details
                               https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison.
                               When omitted this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
-                              The current default is PremiumSSD.
+                              The current default is Premium SSD LRS.
                             enum:
-                            - Standard
-                            - StandardSSD
-                            - PremiumSSD
-                            - UltraSSD
+                            - Premium_LRS
+                            - PremiumV2_LRS
+                            - Standard_LRS
+                            - StandardSSD_LRS
+                            - UltraSSD_LRS
                             type: string
                           encryptionSetID:
                             description: |-
@@ -805,7 +806,7 @@ spec:
                           sizeGiB:
                             description: |-
                               SizeGiB is the size in GiB (1024^3 bytes) to assign to the OS disk.
-                              This should be between 16 and 65,536 when using the UltraSSD storage account type and between 16 and 32,767 when using any other storage account type.
+                              This should be between 16 and 65,536 when using the UltraSSD_LRS storage account type and between 16 and 32,767 when using any other storage account type.
                               When not set, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
                               The current default is 30.
                             format: int32
@@ -814,10 +815,10 @@ spec:
                             type: integer
                         type: object
                         x-kubernetes-validations:
-                        - message: When not using storageAccountType UltraSSD, the
-                            SizeGB value must be less than or equal to 32,767
+                        - message: When not using diskStorageAccountType UltraSSD_LRS,
+                            the SizeGB value must be less than or equal to 32,767
                           rule: '!has(self.diskStorageAccountType) || self.diskStorageAccountType
-                            != ''UltraSSD'' || self.sizeGiB <= 32767'
+                            != ''UltraSSD_LRS'' || self.sizeGiB <= 32767'
                       subnetID:
                         description: |-
                           subnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -752,18 +752,19 @@ spec:
                         properties:
                           diskStorageAccountType:
                             description: |-
-                              storageAccountType is the disk storage account type to use.
-                              Valid values are Standard, StandardSSD, PremiumSSD and UltraSSD and omitted.
+                              diskStorageAccountType is the disk storage account type to use.
+                              Valid values are Premium_LRS, PremiumV2_LRS, Standard_LRS, StandardSSD_LRS, UltraSSD_LRS.
                               Note that Standard means a HDD.
                               The disk performance is tied to the disk type, please refer to the Azure documentation for further details
                               https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison.
                               When omitted this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
-                              The current default is PremiumSSD.
+                              The current default is Premium SSD LRS.
                             enum:
-                            - Standard
-                            - StandardSSD
-                            - PremiumSSD
-                            - UltraSSD
+                            - Premium_LRS
+                            - PremiumV2_LRS
+                            - Standard_LRS
+                            - StandardSSD_LRS
+                            - UltraSSD_LRS
                             type: string
                           encryptionSetID:
                             description: |-
@@ -808,7 +809,7 @@ spec:
                           sizeGiB:
                             description: |-
                               SizeGiB is the size in GiB (1024^3 bytes) to assign to the OS disk.
-                              This should be between 16 and 65,536 when using the UltraSSD storage account type and between 16 and 32,767 when using any other storage account type.
+                              This should be between 16 and 65,536 when using the UltraSSD_LRS storage account type and between 16 and 32,767 when using any other storage account type.
                               When not set, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
                               The current default is 30.
                             format: int32
@@ -817,10 +818,10 @@ spec:
                             type: integer
                         type: object
                         x-kubernetes-validations:
-                        - message: When not using storageAccountType UltraSSD, the
-                            SizeGB value must be less than or equal to 32,767
+                        - message: When not using diskStorageAccountType UltraSSD_LRS,
+                            the SizeGB value must be less than or equal to 32,767
                           rule: '!has(self.diskStorageAccountType) || self.diskStorageAccountType
-                            != ''UltraSSD'' || self.sizeGiB <= 32767'
+                            != ''UltraSSD_LRS'' || self.sizeGiB <= 32767'
                       subnetID:
                         description: |-
                           subnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -752,18 +752,19 @@ spec:
                         properties:
                           diskStorageAccountType:
                             description: |-
-                              storageAccountType is the disk storage account type to use.
-                              Valid values are Standard, StandardSSD, PremiumSSD and UltraSSD and omitted.
+                              diskStorageAccountType is the disk storage account type to use.
+                              Valid values are Premium_LRS, PremiumV2_LRS, Standard_LRS, StandardSSD_LRS, UltraSSD_LRS.
                               Note that Standard means a HDD.
                               The disk performance is tied to the disk type, please refer to the Azure documentation for further details
                               https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison.
                               When omitted this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
-                              The current default is PremiumSSD.
+                              The current default is Premium SSD LRS.
                             enum:
-                            - Standard
-                            - StandardSSD
-                            - PremiumSSD
-                            - UltraSSD
+                            - Premium_LRS
+                            - PremiumV2_LRS
+                            - Standard_LRS
+                            - StandardSSD_LRS
+                            - UltraSSD_LRS
                             type: string
                           encryptionSetID:
                             description: |-
@@ -808,7 +809,7 @@ spec:
                           sizeGiB:
                             description: |-
                               SizeGiB is the size in GiB (1024^3 bytes) to assign to the OS disk.
-                              This should be between 16 and 65,536 when using the UltraSSD storage account type and between 16 and 32,767 when using any other storage account type.
+                              This should be between 16 and 65,536 when using the UltraSSD_LRS storage account type and between 16 and 32,767 when using any other storage account type.
                               When not set, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
                               The current default is 30.
                             format: int32
@@ -817,10 +818,10 @@ spec:
                             type: integer
                         type: object
                         x-kubernetes-validations:
-                        - message: When not using storageAccountType UltraSSD, the
-                            SizeGB value must be less than or equal to 32,767
+                        - message: When not using diskStorageAccountType UltraSSD_LRS,
+                            the SizeGB value must be less than or equal to 32,767
                           rule: '!has(self.diskStorageAccountType) || self.diskStorageAccountType
-                            != ''UltraSSD'' || self.sizeGiB <= 32767'
+                            != ''UltraSSD_LRS'' || self.sizeGiB <= 32767'
                       subnetID:
                         description: |-
                           subnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -752,18 +752,19 @@ spec:
                         properties:
                           diskStorageAccountType:
                             description: |-
-                              storageAccountType is the disk storage account type to use.
-                              Valid values are Standard, StandardSSD, PremiumSSD and UltraSSD and omitted.
+                              diskStorageAccountType is the disk storage account type to use.
+                              Valid values are Premium_LRS, PremiumV2_LRS, Standard_LRS, StandardSSD_LRS, UltraSSD_LRS.
                               Note that Standard means a HDD.
                               The disk performance is tied to the disk type, please refer to the Azure documentation for further details
                               https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison.
                               When omitted this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
-                              The current default is PremiumSSD.
+                              The current default is Premium SSD LRS.
                             enum:
-                            - Standard
-                            - StandardSSD
-                            - PremiumSSD
-                            - UltraSSD
+                            - Premium_LRS
+                            - PremiumV2_LRS
+                            - Standard_LRS
+                            - StandardSSD_LRS
+                            - UltraSSD_LRS
                             type: string
                           encryptionSetID:
                             description: |-
@@ -808,7 +809,7 @@ spec:
                           sizeGiB:
                             description: |-
                               SizeGiB is the size in GiB (1024^3 bytes) to assign to the OS disk.
-                              This should be between 16 and 65,536 when using the UltraSSD storage account type and between 16 and 32,767 when using any other storage account type.
+                              This should be between 16 and 65,536 when using the UltraSSD_LRS storage account type and between 16 and 32,767 when using any other storage account type.
                               When not set, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
                               The current default is 30.
                             format: int32
@@ -817,10 +818,10 @@ spec:
                             type: integer
                         type: object
                         x-kubernetes-validations:
-                        - message: When not using storageAccountType UltraSSD, the
-                            SizeGB value must be less than or equal to 32,767
+                        - message: When not using diskStorageAccountType UltraSSD_LRS,
+                            the SizeGB value must be less than or equal to 32,767
                           rule: '!has(self.diskStorageAccountType) || self.diskStorageAccountType
-                            != ''UltraSSD'' || self.sizeGiB <= 32767'
+                            != ''UltraSSD_LRS'' || self.sizeGiB <= 32767'
                       subnetID:
                         description: |-
                           subnetID is the subnet ID of an existing subnet where the nodes in the nodepool will be created. This can be a

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2594,17 +2594,25 @@ toleration of full disruption of the component.</p>
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;PremiumSSD&#34;</p></td>
-<td><p>PremiumSSDStorageAccountType is the premium SSD storage account type.</p>
+<tbody><tr><td><p>&#34;Premium_LRS&#34;</p></td>
+<td><p>DiskStorageAccountTypesPremiumLRS - Premium SSD locally redundant storage. Best for production and performance sensitive
+workloads.</p>
 </td>
-</tr><tr><td><p>&#34;StandardSSD&#34;</p></td>
-<td><p>StandardSSDStorageAccountType is the standard SSD storage account type.</p>
+</tr><tr><td><p>&#34;PremiumV2_LRS&#34;</p></td>
+<td><p>DiskStorageAccountTypesPremiumV2LRS - Premium SSD v2 locally redundant storage. Best for production and performance-sensitive
+workloads that consistently require low latency and high IOPS and throughput.</p>
 </td>
-</tr><tr><td><p>&#34;Standard&#34;</p></td>
-<td><p>StandardStorageAccountType is the standard HDD storage account type.</p>
+</tr><tr><td><p>&#34;Standard_LRS&#34;</p></td>
+<td><p>DiskStorageAccountTypesStandardLRS - Standard HDD locally redundant storage. Best for backup, non-critical, and infrequent
+access.</p>
 </td>
-</tr><tr><td><p>&#34;UltraSSD&#34;</p></td>
-<td><p>UltraSSDStorageAccountType is the ultra SSD storage account type.</p>
+</tr><tr><td><p>&#34;StandardSSD_LRS&#34;</p></td>
+<td><p>DiskStorageAccountTypesStandardSSDLRS - Standard SSD locally redundant storage. Best for web servers, lightly used enterprise
+applications and dev/test.</p>
+</td>
+</tr><tr><td><p>&#34;UltraSSD_LRS&#34;</p></td>
+<td><p>DiskStorageAccountTypesUltraSSDLRS - Ultra SSD locally redundant storage. Best for IO-intensive workloads such as SAP HANA,
+top tier databases (for example, SQL, Oracle), and other transaction-heavy workloads.</p>
 </td>
 </tr></tbody>
 </table>
@@ -2816,7 +2824,7 @@ int32
 <td>
 <em>(Optional)</em>
 <p>SizeGiB is the size in GiB (1024^3 bytes) to assign to the OS disk.
-This should be between 16 and 65,536 when using the UltraSSD storage account type and between 16 and 32,767 when using any other storage account type.
+This should be between 16 and 65,536 when using the UltraSSD_LRS storage account type and between 16 and 32,767 when using any other storage account type.
 When not set, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
 The current default is 30.</p>
 </td>
@@ -2832,13 +2840,13 @@ AzureDiskStorageAccountType
 </td>
 <td>
 <em>(Optional)</em>
-<p>storageAccountType is the disk storage account type to use.
-Valid values are Standard, StandardSSD, PremiumSSD and UltraSSD and omitted.
+<p>diskStorageAccountType is the disk storage account type to use.
+Valid values are Premium_LRS, PremiumV2_LRS, Standard_LRS, StandardSSD_LRS, UltraSSD_LRS.
 Note that Standard means a HDD.
 The disk performance is tied to the disk type, please refer to the Azure documentation for further details
 <a href="https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison">https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison</a>.
 When omitted this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
-The current default is PremiumSSD.</p>
+The current default is Premium SSD LRS.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
**What this PR does / why we need it**: this is causing issues as capz expects these values https://github.com/openshift/cluster-api-provider-azure/blob/711d907f6902cdca76f675f5a5f19bb96423c24e/vendor/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5/constants.go\#L616"


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-44568](https://issues.redhat.com/browse/OCPBUGS-44568)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.