### PR TITLE
OCPBUGS-44476: Use ingress role in private link controller for DNS operations

### DIFF
--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -474,16 +474,18 @@ func NewStartCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			var assumeRole *string
+			var assumeEndpointRole, assumeRoute53Role *string
 			var localZoneID *string
 
 			if hcp.Spec.Platform.AWS != nil && hcp.Spec.Platform.AWS.SharedVPC != nil {
-				assumeRole = &hcp.Spec.Platform.AWS.SharedVPC.RolesRef.ControlPlaneARN
+				assumeEndpointRole = &hcp.Spec.Platform.AWS.SharedVPC.RolesRef.ControlPlaneARN
+				assumeRoute53Role = &hcp.Spec.Platform.AWS.SharedVPC.RolesRef.IngressARN
 				localZoneID = &hcp.Spec.Platform.AWS.SharedVPC.LocalZoneID
 			}
 
 			if err := (&awsprivatelink.AWSEndpointServiceReconciler{
-				AssumeRoleARN:          assumeRole,
+				AssumeEndpointRoleARN:  assumeEndpointRole,
+				AssumeRoute53RoleARN:   assumeRoute53Role,
 				CreateOrUpdateProvider: upsert.New(enableCIDebugOutput),
 				LocalZoneID:            localZoneID,
 			}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Before this commit, the private link controller was assuming the same role for all cloud operations in a shared VPC infrastructure. In order to support the topology in which private hosted zones are created in the cluster account and not in the VPC owner account, the private link controller will now use the ingress role for route53 operations and only use the shared control plane operator role for vpc endpoint operations. This allows customers to create the ingress role in the account where the private hosted zones live, and the ingress role can be used to manage dns records by both the ingress operator and the private link controller.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-44476](https://issues.redhat.com/browse/OCPBUGS-44476)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.