### PR TITLE
HOSTEDCP-2178: Add CLI flag to support shared vpc private zones in cluster account

### DIFF
--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -44,14 +44,15 @@ type DestroyOptions struct {
 }
 
 type AWSPlatformDestroyOptions struct {
-	Credentials         awsutil.AWSCredentialsOptions
-	BaseDomain          string
-	BaseDomainPrefix    string
-	PreserveIAM         bool
-	Region              string
-	PostDeleteAction    func()
-	AwsInfraGracePeriod time.Duration
-	VPCOwnerCredentials awsutil.AWSCredentialsOptions
+	Credentials                  awsutil.AWSCredentialsOptions
+	BaseDomain                   string
+	BaseDomainPrefix             string
+	PreserveIAM                  bool
+	Region                       string
+	PostDeleteAction             func()
+	AwsInfraGracePeriod          time.Duration
+	VPCOwnerCredentials          awsutil.AWSCredentialsOptions
+	PrivateZonesInClusterAccount bool
 }
 
 type AzurePlatformDestroyOptions struct {

--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -92,6 +92,16 @@ func (o *CreateInfraOptions) createVPC(l logr.Logger, client ec2iface.EC2API) (s
 	return vpcID, nil
 }
 
+func (o *CreateInfraOptions) deleteVPC(l logr.Logger, client ec2iface.EC2API, vpcID string) error {
+	if _, err := client.DeleteVpc(&ec2.DeleteVpcInput{
+		VpcId: aws.String(vpcID),
+	}); err != nil {
+		return fmt.Errorf("failed to delete VPC %s: %w", vpcID, err)
+	}
+	l.Info("deleted VPC", "id", vpcID)
+	return nil
+}
+
 func (o *CreateInfraOptions) existingVPC(client ec2iface.EC2API, vpcName string) (string, error) {
 	var vpcID string
 	result, err := client.DescribeVpcs(&ec2.DescribeVpcsInput{Filters: o.ec2Filters(vpcName)})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a flag `--private-zones-in-cluster-account` to the following commands: hypershift create infra aws
hypershift create iam aws
hypershift create cluster aws
hypershift destroy infra aws
hypershift destroy iam aws
hypershift destroy cluster aws

The flag enables private hosted zones to be created in the cluster creator account in a shared vpc infrastructure.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-2178](https://issues.redhat.com/browse/HOSTEDCP-2178)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.