### PR TITLE
NO-JIRA: openstack/e2e: allow to change AZ name

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -564,9 +564,8 @@ func (p *options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 		OpenStackExternalNetworkID: p.configurableClusterOptions.OpenStackExternalNetworkID,
 		NodePoolOpts: &openstacknodepool.RawOpenStackPlatformCreateOptions{
 			OpenStackPlatformOptions: &openstacknodepool.OpenStackPlatformOptions{
-				Flavor:         p.configurableClusterOptions.OpenStackNodeFlavor,
-				ImageName:      p.configurableClusterOptions.OpenStackNodeImageName,
-				AvailabityZone: p.configurableClusterOptions.OpenStackNodeAvailabilityZone,
+				Flavor:    p.configurableClusterOptions.OpenStackNodeFlavor,
+				ImageName: p.configurableClusterOptions.OpenStackNodeImageName,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

In some environments, we'll want to change the name of the availability
zone where the nodepool AZ will be tested on.
Let's allow that with this change.
