### PR TITLE
OSASINFRA-3492: feat(openstack): leverage ORC to manage the release image

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -356,6 +356,21 @@ const (
 	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"
 )
 
+// RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.
+//
+// +kubebuilder:validation:Enum:=Orphan;Prune
+type RetentionPolicy string
+
+const (
+	// OrphanRetentionPolicy will keep the resources associated with the cluster
+	// when the cluster is deleted.
+	OrphanRetentionPolicy RetentionPolicy = "Orphan"
+
+	// PruneRetentionPolicy will delete the resources associated with the cluster
+	// when the cluster is deleted.
+	PruneRetentionPolicy RetentionPolicy = "Prune"
+)
+
 // +kubebuilder:validation:Enum=ImageRegistry
 type OptionalCapability string
 

--- a/api/hypershift/v1beta1/openstack.go
+++ b/api/hypershift/v1beta1/openstack.go
@@ -1,5 +1,7 @@
 package v1beta1
 
+import "fmt"
+
 // PortSecurityPolicy defines whether or not to enable port security on a port.
 type PortSecurityPolicy string
 
@@ -12,7 +14,31 @@ const (
 
 	// PortSecurityDefault uses the default port security policy.
 	PortSecurityDefault PortSecurityPolicy = ""
+
+	// PruneRetentionPolicy is the default policy for handling OpenStack Glance Images
+	// when the HostedCluster is deleted.
+	DefaultImageRetentionPolicy RetentionPolicy = PruneRetentionPolicy
 )
+
+func (p *RetentionPolicy) String() string {
+	return string(*p)
+}
+
+func (p *RetentionPolicy) Set(s string) error {
+	switch s {
+	case string(OrphanRetentionPolicy):
+		*p = OrphanRetentionPolicy
+	case string(PruneRetentionPolicy):
+		*p = PruneRetentionPolicy
+	default:
+		return fmt.Errorf("invalid RetentionPolicy: %s", s)
+	}
+	return nil
+}
+
+func (p *RetentionPolicy) Type() string {
+	return "RetentionPolicy"
+}
 
 type OpenStackNodePoolPlatform struct {
 	// Flavor is the OpenStack flavor to use for the node instances.
@@ -136,6 +162,20 @@ type OpenStackPlatformSpec struct {
 	// +kubebuilder:validation:XValidation:rule="isIP(self)",message="floatingIP must be a valid IPv4 or IPv6 address"
 	// +optional
 	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
+
+	// imageRetentionPolicy defines the policy for handling resources associated with the image
+	// when the cluster is deleted.
+	// The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
+	// behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
+	// HostedCluster deletion.
+	// It is defined at the HostedCluster level and will be used for all nodepools images
+	// so there is no conflict between different ORC objects.
+	// On day 2 operations, if this field is changed, the corresponding ORC object will be updated
+	// to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
+	// (either 'delete' or 'detach' in ORC terminology).
+	//
+	// +optional
+	ImageRetentionPolicy RetentionPolicy `json:"imageRetentionPolicy,omitempty"`
 }
 
 // OpenStackIdentityReference is a reference to an infrastructure

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -4001,6 +4001,22 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      imageRetentionPolicy:
+                        description: |-
+                          imageRetentionPolicy defines the policy for handling resources associated with the image
+                          when the cluster is deleted.
+                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
+                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
+                          HostedCluster deletion.
+                          It is defined at the HostedCluster level and will be used for all nodepools images
+                          so there is no conflict between different ORC objects.
+                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
+                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
+                          (either 'delete' or 'detach' in ORC terminology).
+                        enum:
+                        - Orphan
+                        - Prune
+                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -3886,6 +3886,22 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      imageRetentionPolicy:
+                        description: |-
+                          imageRetentionPolicy defines the policy for handling resources associated with the image
+                          when the cluster is deleted.
+                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
+                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
+                          HostedCluster deletion.
+                          It is defined at the HostedCluster level and will be used for all nodepools images
+                          so there is no conflict between different ORC objects.
+                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
+                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
+                          (either 'delete' or 'detach' in ORC terminology).
+                        enum:
+                        - Orphan
+                        - Prune
+                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
@@ -17,6 +17,10 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
 // OpenStackPlatformSpecApplyConfiguration represents an declarative configuration of the OpenStackPlatformSpec type for use
 // with apply.
 type OpenStackPlatformSpecApplyConfiguration struct {
@@ -30,6 +34,7 @@ type OpenStackPlatformSpecApplyConfiguration struct {
 	DisableExternalNetwork *bool                                         `json:"disableExternalNetwork,omitempty"`
 	Tags                   []string                                      `json:"tags,omitempty"`
 	IngressFloatingIP      *string                                       `json:"ingressFloatingIP,omitempty"`
+	ImageRetentionPolicy   *hypershiftv1beta1.RetentionPolicy            `json:"imageRetentionPolicy,omitempty"`
 }
 
 // OpenStackPlatformSpecApplyConfiguration constructs an declarative configuration of the OpenStackPlatformSpec type for use with
@@ -127,5 +132,13 @@ func (b *OpenStackPlatformSpecApplyConfiguration) WithTags(values ...string) *Op
 // If called multiple times, the IngressFloatingIP field is set to the value of the last call.
 func (b *OpenStackPlatformSpecApplyConfiguration) WithIngressFloatingIP(value string) *OpenStackPlatformSpecApplyConfiguration {
 	b.IngressFloatingIP = &value
+	return b
+}
+
+// WithImageRetentionPolicy sets the ImageRetentionPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ImageRetentionPolicy field is set to the value of the last call.
+func (b *OpenStackPlatformSpecApplyConfiguration) WithImageRetentionPolicy(value hypershiftv1beta1.RetentionPolicy) *OpenStackPlatformSpecApplyConfiguration {
+	b.ImageRetentionPolicy = &value
 	return b
 }

--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
@@ -308,4 +309,40 @@ func TestExtractCloud(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
+}
+func TestValidateRetentionPolicy(t *testing.T) {
+	testCases := []struct {
+		name          string
+		policy        hyperv1.RetentionPolicy
+		expectedError string
+	}{
+		{
+			name: "empty policy",
+		},
+		{
+			name:          "invalid policy",
+			policy:        "invalid",
+			expectedError: "invalid retention policy: invalid",
+		},
+		{
+			name:   "orphan policy",
+			policy: "Orphan",
+		},
+		{
+			name:   "prune policy",
+			policy: "Prune",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRetentionPolicy(tc.policy)
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			}
+		})
+	}
 }

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
@@ -29,21 +29,6 @@ metadata:
   namespace: clusters
 type: Opaque
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  name: capi-provider-role
-  namespace: clusters
-rules:
-- apiGroups:
-  - openstack.k-orc.cloud
-  resources:
-  - images
-  verbs:
-  - list
-  - watch
----
 apiVersion: v1
 data:
   key: FYHY8RFxHaJUPFFWuo2z9iWCO01hcj3fqHMMWMeEHHw=
@@ -96,6 +81,7 @@ spec:
       identityRef:
         cloudName: openstack
         name: test-cloud-credentials
+      imageRetentionPolicy: Prune
     type: OpenStack
   pullSecret:
     name: test-pull-secret

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -29,21 +29,6 @@ metadata:
   namespace: clusters
 type: Opaque
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  name: capi-provider-role
-  namespace: clusters
-rules:
-- apiGroups:
-  - openstack.k-orc.cloud
-  resources:
-  - images
-  verbs:
-  - list
-  - watch
----
 apiVersion: v1
 data:
   key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=
@@ -91,6 +76,7 @@ spec:
       identityRef:
         cloudName: openstack
         name: example-cloud-credentials
+      imageRetentionPolicy: Prune
     type: OpenStack
   pullSecret:
     name: example-pull-secret

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -4533,6 +4533,22 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      imageRetentionPolicy:
+                        description: |-
+                          imageRetentionPolicy defines the policy for handling resources associated with the image
+                          when the cluster is deleted.
+                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
+                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
+                          HostedCluster deletion.
+                          It is defined at the HostedCluster level and will be used for all nodepools images
+                          so there is no conflict between different ORC objects.
+                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
+                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
+                          (either 'delete' or 'detach' in ORC terminology).
+                        enum:
+                        - Orphan
+                        - Prune
+                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -4515,6 +4515,22 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      imageRetentionPolicy:
+                        description: |-
+                          imageRetentionPolicy defines the policy for handling resources associated with the image
+                          when the cluster is deleted.
+                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
+                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
+                          HostedCluster deletion.
+                          It is defined at the HostedCluster level and will be used for all nodepools images
+                          so there is no conflict between different ORC objects.
+                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
+                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
+                          (either 'delete' or 'detach' in ORC terminology).
+                        enum:
+                        - Orphan
+                        - Prune
+                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -4418,6 +4418,22 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      imageRetentionPolicy:
+                        description: |-
+                          imageRetentionPolicy defines the policy for handling resources associated with the image
+                          when the cluster is deleted.
+                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
+                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
+                          HostedCluster deletion.
+                          It is defined at the HostedCluster level and will be used for all nodepools images
+                          so there is no conflict between different ORC objects.
+                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
+                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
+                          (either 'delete' or 'detach' in ORC terminology).
+                        enum:
+                        - Orphan
+                        - Prune
+                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -4400,6 +4400,22 @@ spec:
                         - cloudName
                         - name
                         type: object
+                      imageRetentionPolicy:
+                        description: |-
+                          imageRetentionPolicy defines the policy for handling resources associated with the image
+                          when the cluster is deleted.
+                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
+                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
+                          HostedCluster deletion.
+                          It is defined at the HostedCluster level and will be used for all nodepools images
+                          so there is no conflict between different ORC objects.
+                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
+                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
+                          (either 'delete' or 'detach' in ORC terminology).
+                        enum:
+                        - Orphan
+                        - Prune
+                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1172,14 +1172,11 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Resources: []string{"ipaddresses", "ipaddresses/status"},
 				Verbs:     []string{"create", "delete", "get", "list", "update", "watch"},
 			},
-			// The following rule is required for CAPO to watch for the Images resources created by ORC,
-			// which is a dependency since CAPO v0.11.0.
-			// This rule is also defined in the Hypershift HostedCluster controller and the Hypershift CLI when creating
-			// the cluster.
+			// This allows hypershift operator to grant RBAC permissions for ORC to the capi-provider.
 			{
 				APIGroups: []string{"openstack.k-orc.cloud"},
-				Resources: []string{"images"},
-				Verbs:     []string{"list", "watch"},
+				Resources: []string{"images", "images/status"},
+				Verbs:     []string{rbacv1.VerbAll},
 			},
 			{ // This allows the kubevirt csi driver to hotplug volumes to KubeVirt VMs.
 				APIGroups: []string{"subresources.kubevirt.io"},

--- a/cmd/nodepool/openstack/create.go
+++ b/cmd/nodepool/openstack/create.go
@@ -70,15 +70,6 @@ func (o *RawOpenStackPlatformCreateOptions) Validate() (*ValidatedOpenStackPlatf
 		return nil, fmt.Errorf("flavor is required")
 	}
 
-	// TODO(emilien): Remove that validation once we support using the image from the release payload.
-	// This will be possible when CAPO supports managing images in the OpenStack cluster:
-	// https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2130
-	// For 4.17 we might leave this as is and let the user provide the image name as
-	// we plan to deliver the OpenStack provider as a dev preview.
-	if o.ImageName == "" {
-		return nil, fmt.Errorf("image name is required")
-	}
-
 	additionalports, err := convertAdditionalPorts(o.AdditionalPorts)
 	if err != nil {
 		return nil, err
@@ -100,7 +91,7 @@ func BindOptions(opts *RawOpenStackPlatformCreateOptions, flags *pflag.FlagSet) 
 
 func bindCoreOptions(opts *RawOpenStackPlatformCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.Flavor, "openstack-node-flavor", opts.Flavor, "The flavor to use for the nodepool (required)")
-	flags.StringVar(&opts.ImageName, "openstack-node-image-name", opts.ImageName, "The image name to use for the nodepool (required)")
+	flags.StringVar(&opts.ImageName, "openstack-node-image-name", opts.ImageName, "The image name to use for the nodepool (optional)")
 	flags.StringVar(&opts.AvailabityZone, "openstack-node-availability-zone", opts.AvailabityZone, "The availability zone to use for the nodepool (optional)")
 	flags.StringArrayVar(&opts.AdditionalPorts, "openstack-node-additional-port", opts.AdditionalPorts, fmt.Sprintf(`Specify additional port that should be attached to the nodes, the "network-id" field should point to an existing neutron network ID and the "vnic-type" is the type of the port to create, it can be specified multiple times to attach to multiple ports. Supported parameters: %s, example: "network-id:40a355cb-596d-495c-8766-419d98cadd57,vnic-type:direct"`, cmdutil.Supported(PortSpec{})))
 }

--- a/cmd/nodepool/openstack/create_test.go
+++ b/cmd/nodepool/openstack/create_test.go
@@ -15,20 +15,9 @@ func TestRawOpenStackPlatformCreateOptions_Validate(t *testing.T) {
 		{
 			name: "should fail if flavor is missing",
 			input: RawOpenStackPlatformCreateOptions{
-				OpenStackPlatformOptions: &OpenStackPlatformOptions{
-					ImageName: "rhcos",
-				},
+				OpenStackPlatformOptions: &OpenStackPlatformOptions{},
 			},
 			expectedError: "flavor is required",
-		},
-		{
-			name: "should fail if image name is missing",
-			input: RawOpenStackPlatformCreateOptions{
-				OpenStackPlatformOptions: &OpenStackPlatformOptions{
-					Flavor: "flavor",
-				},
-			},
-			expectedError: "image name is required",
 		},
 		{
 			name: "should pass when AZ is provided",

--- a/docs/content/how-to/openstack/additional-ports.md
+++ b/docs/content/how-to/openstack/additional-ports.md
@@ -33,14 +33,12 @@ The following example demonstrates how to create a HostedCluster with additional
 ```shell
 export NODEPOOL_NAME=$CLUSTER_NAME-ports
 export WORKER_COUNT="2"
-export IMAGE_NAME="rhcos"
 export FLAVOR="m1.xlarge"
 
 hcp create nodepool openstack \
   --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
   --node-count $WORKER_COUNT \
-  --openstack-node-image-name $IMAGE_NAME \
   --openstack-node-flavor $FLAVOR \
   --openstack-node-additional-port "network-id=<SRIOV_NET_ID>,vnic-type=direct,disable-port-security=true" \
   --openstack-node-additional-port "network-id=<LB_NET_ID>,address-pairs:192.168.0.1-192.168.0.2"

--- a/docs/content/how-to/openstack/az.md
+++ b/docs/content/how-to/openstack/az.md
@@ -6,7 +6,6 @@ Availability Zones do not necessarily correspond to fault domains and do not inh
 ```shell
 export NODEPOOL_NAME=$CLUSTER_NAME-az1
 export WORKER_COUNT="2"
-export IMAGE_NAME="rhcos"
 export FLAVOR="m1.xlarge"
 export AZ="az1"
 
@@ -14,7 +13,6 @@ hcp create nodepool openstack \
   --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
   --node-count $WORKER_COUNT \
-  --openstack-node-image-name $IMAGE_NAME \
   --openstack-node-flavor $FLAVOR \
   --openstack-node-availability-zone $AZ \
 ```

--- a/docs/content/how-to/openstack/destroy.md
+++ b/docs/content/how-to/openstack/destroy.md
@@ -6,4 +6,4 @@ To delete a HostedCluster on OpenStack:
 hcp destroy cluster openstack --name $CLUSTER_NAME
 ```
 
-The process will take a few minutes to complete and will destroy all resources associated with the HostedCluster including OpenStack resources such as servers, networks, etc.
+The process will take a few minutes to complete and will destroy all resources associated with the HostedCluster including OpenStack resources such as servers, the RHCOS image, networks, etc.

--- a/docs/content/how-to/openstack/hostedcluster.md
+++ b/docs/content/how-to/openstack/hostedcluster.md
@@ -4,18 +4,19 @@ Once all the [prerequisites](prerequisites.md) are met, it is now possible to cr
 
 Here are the available options specific to the OpenStack platform:
 
-| Option                           | Description                                                                                  | Required | Default       |
-|----------------------------------|----------------------------------------------------------------------------------------------|----------|---------------|
-| `--openstack-ca-cert-file`       | Path to the OpenStack CA certificate file                                                    | No       |               |
-| `--openstack-cloud`              | Name of the cloud in `clouds.yaml`                                                           | No       | `'openstack'` |
-| `--openstack-credentials-file`   | Path to the OpenStack credentials file                                                       | No       |               |
-| `--openstack-external-network-id`| ID of the OpenStack external network                                                         | No       |               |
-| `--openstack-ingress-floating-ip`| A floating IP for OpenShift ingress                                                          | No       |               |
-| `--openstack-node-additional-port`| Attach additional ports to nodes. Params: `network-id`, `vnic-type`, `disable-port-security`, `address-pairs`. | No       |               |
-| `--openstack-node-availability-zone`| Availability zone for the nodepool                                                        | No       |               |
-| `--openstack-node-flavor`        | Flavor for the nodepool                                                                      | Yes      |               |
-| `--openstack-node-image-name`    | Image name for the nodepool                                                                  | Yes      |               |
-| `--openstack-dns-nameservers`    | List of DNS server addresses that will be provided when creating the subnet                  | No       |               |
+| Option                                  | Description                                                                                  | Required | Default       |
+|-----------------------------------------|----------------------------------------------------------------------------------------------|----------|---------------|
+| `--openstack-ca-cert-file`              | Path to the OpenStack CA certificate file                                                    | No       |               |
+| `--openstack-cloud`                     | Name of the cloud in `clouds.yaml`                                                           | No       | `'openstack'` |
+| `--openstack-credentials-file`          | Path to the OpenStack credentials file                                                       | No       |               |
+| `--openstack-external-network-id`       | ID of the OpenStack external network                                                         | No       |               |
+| `--openstack-ingress-floating-ip`       | A floating IP for OpenShift ingress                                                          | No       |               |
+| `--openstack-node-additional-port`      | Attach additional ports to nodes. Params: `network-id`, `vnic-type`, `disable-port-security`, `address-pairs`. | No       |               |
+| `--openstack-node-availability-zone`    | Availability zone for the nodepool                                                           | No       |               |
+| `--openstack-node-flavor`               | Flavor for the nodepool                                                                      | Yes      |               |
+| `--openstack-image-retention-policy`    | OpenStack Glance Image retention policy. Valid values are 'Orphan' and 'Prune'.              | No       | `Prune`       |
+| `--openstack-node-image-name`           | Image name for the nodepool                                                                  | No       |               |
+| `--openstack-dns-nameservers`           | List of DNS server addresses that will be provided when creating the subnet                  | No       |               |
 
 Below is an example of how to create a cluster using environment variables and the `hcp` cli tool.
 
@@ -32,9 +33,6 @@ export WORKER_COUNT="2"
 # OpenStack resources for the HostedCluster will be created
 # in that project.
 export OS_CLOUD="openstack"
-
-# Image name is the name of the image in OpenStack that was pushed in the previous step.
-export IMAGE_NAME="rhcos"
 
 # Flavor for the nodepool
 export FLAVOR="m1.large"
@@ -68,7 +66,6 @@ hcp create cluster openstack \
 --openstack-credentials-file $CLOUDS_YAML \
 --openstack-ca-cert-file $CA_CERT_PATH \
 --openstack-external-network-id $EXTERNAL_NETWORK_ID \
---openstack-node-image-name $IMAGE_NAME \
 --openstack-node-flavor $FLAVOR \
 --openstack-ingress-floating-ip $INGRESS_FLOATING_IP \
 --openstack-dns-nameservers $DNS_NAMESERVERS
@@ -88,6 +85,13 @@ hcp create cluster openstack \
     `PreferredDuringSchedulingIgnoredDuringExecution` mode for `PodAntiAffinity`.
     If your management cluster doesn't have enough workers (less than 3), which is not recommended nor supported,
     you'll need to specify the `--control-plane-availability-policy` flag to `SingleReplica`.
+
+!!! note
+
+    When not providing the `--openstack-node-image-name` flag, the latest RHCOS image will be used.
+    ORC will handle the RHCOS image lifecycle by downloading the image from the OpenShift mirror and deleting it when it's no longer needed.
+    If you want ORC to not delete the image, you can create the HostedCluster with the following option: `--openstack-image-retention-policy=Orphan`.
+    This will prevent ORC from deleting the image resource.
 
 After a few moments we should see our hosted control plane pods up and running:
 

--- a/docs/content/how-to/openstack/index.md
+++ b/docs/content/how-to/openstack/index.md
@@ -14,6 +14,7 @@ and Nodepools can be deployed on the [OpenStack](https://www.openstack.org) plat
 !!! note
     When you create a HostedCluster with the OpenStack platform, HyperShift will install the [CAPI Provider for OpenStack (CAPO)](https://github.com/kubernetes-sigs/cluster-api-provider-openstack).
     in the Hosted Control Plane (HCP) namespace.
+    It will also install [OpenStack Resource Controller (ORC)](https://github.com/k-orc/openstack-resource-controller) in the HCP namespace to manage the OpenStack resources such as the Image.
     Upon scaling up a NodePool, a Machine will be created, and the CAPI provider will create the necessary resources in OpenStack.
     CAPO created OpenStack resources by leveraging [Gophercloud](https://github.com/gophercloud/gophercloud), the OpenStack SDK for Go.
 

--- a/docs/content/how-to/openstack/performance-tuning.md
+++ b/docs/content/how-to/openstack/performance-tuning.md
@@ -81,14 +81,12 @@ After creating the PerformanceProfile, we can create a Nodepool that will use th
 
 ```shell
 export NODEPOOL_NAME=$CLUSTER_NAME-cnf
-export IMAGE_NAME="rhcos"
 export FLAVOR="m1.xlarge.nfv"
 
 hcp create nodepool openstack \
   --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
   --node-count 0 \
-  --openstack-node-image-name $IMAGE_NAME \
   --openstack-node-flavor $FLAVOR
 ```
 

--- a/docs/content/how-to/openstack/prerequisites.md
+++ b/docs/content/how-to/openstack/prerequisites.md
@@ -15,7 +15,6 @@
 * OpenStack Octavia service must be running in the cloud hosting the guest cluster when ingress is configured with an Octavia load balancer.
   In the future, we'll explore other Ingress options like MetalLB.
 * The default external network (on which the kube-apiserver LoadBalancer type service is created) of the Management OCP cluster must be reachable from the guest cluster.
-* The RHCOS image must be uploaded to OpenStack (explained later).
 
 ## Install the HyperShift and HCP CLI
 
@@ -71,11 +70,19 @@ operator-755d587f44-lrtrq   1/1     Running   0          114s
 operator-755d587f44-qj6pz   1/1     Running   0          114s
 ```
 
-## Upload RHCOS image in OpenStack
+## Prepare the management cluster to store etcd locally
 
-For now, we need to manually push an RHCOS image that will be used when deploying the node pools
-on OpenStack. In the [future](https://issues.redhat.com/browse/OSASINFRA-3492), the CAPI provider (CAPO) will handle the RHCOS image
-lifecycle by using the image available in the chosen release payload.
+HostedClusters will have pod(s) for etcd and its performance is essential for the cluster health.
+In production environments, it's required to put etcd data on fast storage and in the case of OpenStack it'll be local storage.
+Follow this [procedure](etcd-local-storage.md) to leverage a well-known and tested solution.
+
+## Upload RHCOS image in OpenStack (optional)
+
+The user can specify which RHCOS image to use when deploying the node pools
+on OpenStack by uploading the image to the OpenStack cloud. If the image is not
+uploaded to OpenStack, [OpenStack Resource Controller (ORC)](https://github.com/k-orc/openstack-resource-controller) will
+manage the RHCOS image lifecycle by downloading the image from the OpenShift mirror and deleting it when it's no longer needed
+or left as an orphan image that can be re-used by other clusters and deleted when it's no longer needed.
 
 Here is an example of how to upload an RHCOS image to OpenStack:
 
@@ -87,12 +94,6 @@ openstack image create --disk-format qcow2 --file rhcos-openstack.x86_64.qcow2 r
 
     The `rhcos-openstack.x86_64.qcow2` file is the RHCOS image that was downloaded from the OpenShift mirror.
     You can download the latest RHCOS image from the [Red Hat OpenShift Container Platform mirror](https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/).
-
-## Prepare the management cluster to store etcd locally
-
-HostedClusters will have pod(s) for etcd and its performance is essential for the cluster health.
-In production environments, it's required to put etcd data on fast storage and in the case of OpenStack it'll be local storage.
-Follow this [procedure](etcd-local-storage.md) to leverage a well-known and tested solution.
 
 ## Create a floating IP for the Ingress (optional)
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -9448,6 +9448,29 @@ balancer.
 This value must be a valid IPv4 or IPv6 address.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>imageRetentionPolicy</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.RetentionPolicy">
+RetentionPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>imageRetentionPolicy defines the policy for handling resources associated with the image
+when the cluster is deleted.
+The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
+behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
+HostedCluster deletion.
+It is defined at the HostedCluster level and will be used for all nodepools images
+so there is no conflict between different ORC objects.
+On day 2 operations, if this field is changed, the corresponding ORC object will be updated
+to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
+(either &lsquo;delete&rsquo; or &lsquo;detach&rsquo; in ORC terminology).</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###OperatorConfiguration { #hypershift.openshift.io/v1beta1.OperatorConfiguration }
@@ -10627,6 +10650,35 @@ creating new nodes and deleting the old ones.</p>
 </td>
 </tr>
 </tbody>
+</table>
+###RetentionPolicy { #hypershift.openshift.io/v1beta1.RetentionPolicy }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.OpenStackPlatformSpec">OpenStackPlatformSpec</a>)
+</p>
+<p>
+<p>RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Prune&#34;</p></td>
+<td><p>PruneRetentionPolicy is the default policy for handling OpenStack Glance Images
+when the HostedCluster is deleted.</p>
+</td>
+</tr><tr><td><p>&#34;Orphan&#34;</p></td>
+<td><p>OrphanRetentionPolicy will keep the resources associated with the cluster
+when the cluster is deleted.</p>
+</td>
+</tr><tr><td><p>&#34;Prune&#34;</p></td>
+<td><p>PruneRetentionPolicy will delete the resources associated with the cluster
+when the cluster is deleted.</p>
+</td>
+</tr></tbody>
 </table>
 ###RollingUpdate { #hypershift.openshift.io/v1beta1.RollingUpdate }
 <p>

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack_test.go
@@ -444,6 +444,7 @@ func TestCAPIProviderDeploymentSpec(t *testing.T) {
 									"--namespace=$(MY_NAMESPACE)",
 									"--leader-elect",
 									"--health-probe-bind-address=:8081",
+									"--zap-log-level=4",
 								},
 								SecurityContext: &corev1.SecurityContext{
 									AllowPrivilegeEscalation: ptr.To(false),

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -846,7 +846,7 @@ func (c *CAPI) machineTemplateBuilders() (client.Object, func(object client.Obje
 	case hyperv1.OpenStackPlatform:
 		template = &capiopenstackv1beta1.OpenStackMachineTemplate{}
 		var err error
-		machineTemplateSpec, err = openstack.MachineTemplateSpec(hcluster, nodePool)
+		machineTemplateSpec, err = openstack.MachineTemplateSpec(hcluster, nodePool, c.releaseImage)
 		if err != nil {
 			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 				Type:               hyperv1.NodePoolValidMachineTemplateConditionType,

--- a/hypershift-operator/controllers/nodepool/conditions.go
+++ b/hypershift-operator/controllers/nodepool/conditions.go
@@ -148,6 +148,8 @@ func (r *NodePoolReconciler) setPlatformConditions(ctx context.Context, hcluster
 		return r.setAWSConditions(ctx, nodePool, hcluster, controlPlaneNamespace, releaseImage)
 	case hyperv1.PowerVSPlatform:
 		return r.setPowerVSconditions(ctx, nodePool, hcluster, controlPlaneNamespace, releaseImage)
+	case hyperv1.OpenStackPlatform:
+		return r.setOpenStackConditions(ctx, nodePool, hcluster, controlPlaneNamespace, releaseImage)
 	default:
 		return nil
 	}

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -9,6 +9,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	openstack "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/openstack"
 	suppconfig "github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/releaseinfo"
 
@@ -56,27 +57,6 @@ func defaultImage(releaseImage *releaseinfo.ReleaseImage) (string, string, error
 	return containerImage, split[1], nil
 }
 
-func unsupportedOpenstackDefaultImage(releaseImage *releaseinfo.ReleaseImage) (string, string, error) {
-	arch, foundArch := releaseImage.StreamMetadata.Architectures["x86_64"]
-	if !foundArch {
-		return "", "", fmt.Errorf("couldn't find OS metadata for architecture %q", "x64_64")
-	}
-	openStack, exists := arch.Artifacts["openstack"]
-	if !exists {
-		return "", "", fmt.Errorf("couldn't find OS metadata for openstack")
-	}
-	artifact, exists := openStack.Formats["qcow2.gz"]
-	if !exists {
-		return "", "", fmt.Errorf("couldn't find OS metadata for openstack qcow2.gz")
-	}
-	disk, exists := artifact["disk"]
-	if !exists {
-		return "", "", fmt.Errorf("couldn't find OS metadata for the openstack qcow2.gz disk")
-	}
-
-	return disk.Location, disk.SHA256, nil
-}
-
 func allowUnsupportedRHCOSVariants(nodePool *hyperv1.NodePool) bool {
 	val, exists := nodePool.Annotations[hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation]
 	if exists && strings.ToLower(val) == "true" {
@@ -103,7 +83,7 @@ func GetImage(nodePool *hyperv1.NodePool, releaseImage *releaseinfo.ReleaseImage
 
 	imageName, imageHash, err := defaultImage(releaseImage)
 	if err != nil && allowUnsupportedRHCOSVariants(nodePool) {
-		imageName, imageHash, err = unsupportedOpenstackDefaultImage(releaseImage)
+		imageName, imageHash, err = openstack.OpenstackDefaultImage(releaseImage)
 		if err != nil {
 			return nil, err
 		}

--- a/hypershift-operator/controllers/nodepool/openstack.go
+++ b/hypershift-operator/controllers/nodepool/openstack.go
@@ -1,0 +1,99 @@
+package nodepool
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/openstack"
+	"github.com/openshift/hypershift/support/releaseinfo"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	orc "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
+)
+
+func (r *NodePoolReconciler) setOpenStackConditions(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, releaseImage *releaseinfo.ReleaseImage) error {
+	if nodePool.Spec.Platform.OpenStack.ImageName == "" {
+		_, err := openstack.OpenStackReleaseImage(releaseImage)
+		if err != nil {
+			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+				Type:               hyperv1.NodePoolValidPlatformImageType,
+				Status:             corev1.ConditionFalse,
+				Reason:             hyperv1.NodePoolValidationFailedReason,
+				Message:            fmt.Sprintf("Couldn't discover an OpenStack Image for release image %q: %s", nodePool.Spec.Release.Image, err.Error()),
+				ObservedGeneration: nodePool.Generation,
+			})
+			return fmt.Errorf("couldn't discover an OpenStack Image for release image: %w", err)
+		}
+		imageName, err := r.reconcileOpenStackImageCR(ctx, r.Client, hcluster, releaseImage, nodePool)
+		if err != nil {
+			return err
+		}
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolValidPlatformImageType,
+			Status:             corev1.ConditionTrue,
+			Reason:             hyperv1.AsExpectedReason,
+			Message:            fmt.Sprintf("Bootstrap OpenStack Image is %q", imageName),
+			ObservedGeneration: nodePool.Generation,
+		})
+	} else {
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolValidPlatformImageType,
+			Status:             corev1.ConditionTrue,
+			Reason:             hyperv1.AsExpectedReason,
+			Message:            fmt.Sprintf("Bootstrap OpenStack Image is %q", nodePool.Spec.Platform.OpenStack.ImageName),
+			ObservedGeneration: nodePool.Generation,
+		})
+	}
+	return nil
+}
+
+// reconcileOpenStackImageCR reconciles the OpenStack Image CR for the given NodePool.
+// An ORC object will be created or updated with the image spec.
+// The image name will be returned.
+func (r *NodePoolReconciler) reconcileOpenStackImageCR(ctx context.Context, client client.Client, hcluster *hyperv1.HostedCluster, release *releaseinfo.ReleaseImage, nodePool *hyperv1.NodePool) (string, error) {
+	releaseVersion, err := openstack.OpenStackReleaseImage(release)
+	if err != nil {
+		return "", err
+	}
+	controlPlaneNamespace := fmt.Sprintf("%s-%s", nodePool.Namespace, strings.ReplaceAll(nodePool.Spec.ClusterName, ".", "-"))
+	openstackCluster, err := openstack.GetOpenStackClusterForHostedCluster(ctx, client, hcluster, controlPlaneNamespace)
+	if err != nil {
+		return "", err
+	}
+	imageName := "rhcos-" + releaseVersion
+	openStackImage := orc.Image{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      imageName,
+			Namespace: controlPlaneNamespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					// Since there is no code that deletes the ORC image object, the only way the OpenStack Glance image
+					// can be deleted is when the OpenStackCluster CR is deleted and that the imageRetentionPolicy is set to "Prune".
+					// That means Nodepools can share the same image and changing the image of a Nodepool will not affect the other Nodepools.
+					APIVersion: openstackCluster.APIVersion,
+					Kind:       openstackCluster.Kind,
+					Name:       openstackCluster.Name,
+					UID:        openstackCluster.UID,
+				},
+			},
+		},
+		Spec: orc.ImageSpec{},
+	}
+
+	if _, err := r.CreateOrUpdate(ctx, client, &openStackImage, func() error {
+		err := openstack.ReconcileOpenStackImageSpec(hcluster, &openStackImage.Spec, release)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	return imageName, nil
+}

--- a/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
+++ b/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
@@ -1,9 +1,11 @@
 package openstack
 
 import (
+	"strings"
 	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/releaseinfo"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +14,7 @@ import (
 	capiopenstackv1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 
 	"github.com/google/go-cmp/cmp"
+	orc "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 )
 
 const flavor = "m1.xlarge"
@@ -109,29 +112,6 @@ func TestOpenStackMachineTemplate(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "missing image name",
-			nodePool: hyperv1.NodePoolSpec{
-				ClusterName: "",
-				Replicas:    nil,
-				Config:      nil,
-				Management:  hyperv1.NodePoolManagement{},
-				AutoScaling: nil,
-				Platform: hyperv1.NodePoolPlatform{
-					Type: hyperv1.OpenStackPlatform,
-					OpenStack: &hyperv1.OpenStackNodePoolPlatform{
-						Flavor: flavor,
-					},
-				},
-				Release: hyperv1.Release{},
-			},
-
-			checkError: func(t *testing.T, err error) {
-				if err == nil {
-					t.Errorf("image name is required")
-				}
-			},
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -157,7 +137,7 @@ func TestOpenStackMachineTemplate(t *testing.T) {
 						Name: "tests",
 					},
 					Spec: tc.nodePool,
-				})
+				}, &releaseinfo.ReleaseImage{})
 			if tc.checkError != nil {
 				tc.checkError(t, err)
 			} else {
@@ -170,6 +150,453 @@ func TestOpenStackMachineTemplate(t *testing.T) {
 			}
 			if !equality.Semantic.DeepEqual(tc.expected, result) {
 				t.Error(cmp.Diff(tc.expected, result))
+			}
+		})
+	}
+}
+func TestOpenstackDefaultImage(t *testing.T) {
+	testCases := []struct {
+		name          string
+		releaseImage  *releaseinfo.ReleaseImage
+		expectedURL   string
+		expectedHash  string
+		expectedError bool
+	}{
+		{
+			name: "valid metadata",
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {
+							Artifacts: map[string]releaseinfo.CoreOSArtifact{
+								"openstack": {
+									Formats: map[string]map[string]releaseinfo.CoreOSFormat{
+										"qcow2.gz": {
+											"disk": {
+												Location: "https://example.com/image.qcow2.gz",
+												SHA256:   "abcdef1234567890",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedURL:   "https://example.com/image.qcow2.gz",
+			expectedHash:  "abcdef1234567890",
+			expectedError: false,
+		},
+		{
+			name:          "missing architecture",
+			releaseImage:  &releaseinfo.ReleaseImage{StreamMetadata: &releaseinfo.CoreOSStreamMetadata{Architectures: map[string]releaseinfo.CoreOSArchitecture{}}},
+			expectedError: true,
+		},
+		{
+			name: "missing openstack artifact",
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {Artifacts: map[string]releaseinfo.CoreOSArtifact{}},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing qcow2.gz format",
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {
+							Artifacts: map[string]releaseinfo.CoreOSArtifact{
+								"openstack": {Formats: map[string]map[string]releaseinfo.CoreOSFormat{}},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing disk artifact",
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {
+							Artifacts: map[string]releaseinfo.CoreOSArtifact{
+								"openstack": {
+									Formats: map[string]map[string]releaseinfo.CoreOSFormat{
+										"qcow2.gz": {},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			url, hash, err := OpenstackDefaultImage(tc.releaseImage)
+			if tc.expectedError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if url != tc.expectedURL {
+					t.Errorf("expected URL %q but got %q", tc.expectedURL, url)
+				}
+				if hash != tc.expectedHash {
+					t.Errorf("expected hash %q but got %q", tc.expectedHash, hash)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenStackReleaseImage(t *testing.T) {
+	testCases := []struct {
+		name           string
+		releaseImage   *releaseinfo.ReleaseImage
+		expectedResult string
+		expectedError  bool
+	}{
+		{
+			name: "valid metadata",
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {
+							Artifacts: map[string]releaseinfo.CoreOSArtifact{
+								"openstack": {
+									Release: "4.9.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: "4.9.0",
+			expectedError:  false,
+		},
+		{
+			name:          "missing architecture",
+			releaseImage:  &releaseinfo.ReleaseImage{StreamMetadata: &releaseinfo.CoreOSStreamMetadata{Architectures: map[string]releaseinfo.CoreOSArchitecture{}}},
+			expectedError: true,
+		},
+		{
+			name: "missing openstack artifact",
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {Artifacts: map[string]releaseinfo.CoreOSArtifact{}},
+					},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := OpenStackReleaseImage(tc.releaseImage)
+			if tc.expectedError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if result != tc.expectedResult {
+					t.Errorf("expected result %q but got %q", tc.expectedResult, result)
+				}
+			}
+		})
+	}
+}
+func TestReconcileOpenStackImageSpec(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		hostedCluster          *hyperv1.HostedCluster
+		releaseImage           *releaseinfo.ReleaseImage
+		expectedImageSpec      *orc.ImageSpec
+		expectedError          bool
+		expectedErrorSubstring string
+	}{
+		{
+			name: "valid configuration with no retention policy",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						OpenStack: &hyperv1.OpenStackPlatformSpec{
+							IdentityRef: hyperv1.OpenStackIdentityReference{
+								Name:      "test-secret",
+								CloudName: "test-cloud",
+							},
+						},
+					},
+				},
+			},
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {
+							Artifacts: map[string]releaseinfo.CoreOSArtifact{
+								"openstack": {
+									Release: "4.9.0",
+									Formats: map[string]map[string]releaseinfo.CoreOSFormat{
+										"qcow2.gz": {
+											"disk": {
+												Location: "https://example.com/image.qcow2.gz",
+												SHA256:   "abcdef1234567890",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedImageSpec: &orc.ImageSpec{
+				CloudCredentialsRef: orc.CloudCredentialsReference{
+					SecretName: "test-secret",
+					CloudName:  "test-cloud",
+				},
+				Resource: &orc.ImageResourceSpec{
+					Name: "rhcos-4.9.0",
+					Content: &orc.ImageContent{
+						ContainerFormat: "bare",
+						DiskFormat:      "qcow2",
+						Download: &orc.ImageContentSourceDownload{
+							URL:        "https://example.com/image.qcow2.gz",
+							Decompress: ptr.To(orc.ImageCompressionGZ),
+							Hash: &orc.ImageHash{
+								Algorithm: "sha256",
+								Value:     "abcdef1234567890",
+							},
+						},
+					},
+				},
+				ManagedOptions: &orc.ManagedOptions{OnDelete: orc.OnDeleteDelete},
+			},
+		},
+		{
+			name: "valid configuration with orphan retention policy",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						OpenStack: &hyperv1.OpenStackPlatformSpec{
+							IdentityRef: hyperv1.OpenStackIdentityReference{
+								Name:      "test-secret",
+								CloudName: "test-cloud",
+							},
+							ImageRetentionPolicy: hyperv1.OrphanRetentionPolicy,
+						},
+					},
+				},
+			},
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {
+							Artifacts: map[string]releaseinfo.CoreOSArtifact{
+								"openstack": {
+									Release: "4.9.0",
+									Formats: map[string]map[string]releaseinfo.CoreOSFormat{
+										"qcow2.gz": {
+											"disk": {
+												Location: "https://example.com/image.qcow2.gz",
+												SHA256:   "abcdef1234567890",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedImageSpec: &orc.ImageSpec{
+				CloudCredentialsRef: orc.CloudCredentialsReference{
+					SecretName: "test-secret",
+					CloudName:  "test-cloud",
+				},
+				Resource: &orc.ImageResourceSpec{
+					Name: "rhcos-4.9.0",
+					Content: &orc.ImageContent{
+						ContainerFormat: "bare",
+						DiskFormat:      "qcow2",
+						Download: &orc.ImageContentSourceDownload{
+							URL:        "https://example.com/image.qcow2.gz",
+							Decompress: ptr.To(orc.ImageCompressionGZ),
+							Hash: &orc.ImageHash{
+								Algorithm: "sha256",
+								Value:     "abcdef1234567890",
+							},
+						},
+					},
+				},
+				ManagedOptions: &orc.ManagedOptions{OnDelete: orc.OnDeleteDetach},
+			},
+		},
+		{
+			name: "valid configuration with prune retention policy",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						OpenStack: &hyperv1.OpenStackPlatformSpec{
+							IdentityRef: hyperv1.OpenStackIdentityReference{
+								Name:      "test-secret",
+								CloudName: "test-cloud",
+							},
+							ImageRetentionPolicy: hyperv1.PruneRetentionPolicy,
+						},
+					},
+				},
+			},
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {
+							Artifacts: map[string]releaseinfo.CoreOSArtifact{
+								"openstack": {
+									Release: "4.9.0",
+									Formats: map[string]map[string]releaseinfo.CoreOSFormat{
+										"qcow2.gz": {
+											"disk": {
+												Location: "https://example.com/image.qcow2.gz",
+												SHA256:   "abcdef1234567890",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedImageSpec: &orc.ImageSpec{
+				CloudCredentialsRef: orc.CloudCredentialsReference{
+					SecretName: "test-secret",
+					CloudName:  "test-cloud",
+				},
+				Resource: &orc.ImageResourceSpec{
+					Name: "rhcos-4.9.0",
+					Content: &orc.ImageContent{
+						ContainerFormat: "bare",
+						DiskFormat:      "qcow2",
+						Download: &orc.ImageContentSourceDownload{
+							URL:        "https://example.com/image.qcow2.gz",
+							Decompress: ptr.To(orc.ImageCompressionGZ),
+							Hash: &orc.ImageHash{
+								Algorithm: "sha256",
+								Value:     "abcdef1234567890",
+							},
+						},
+					},
+				},
+				ManagedOptions: &orc.ManagedOptions{OnDelete: orc.OnDeleteDelete},
+			},
+		},
+		{
+			name: "invalid retention policy",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						OpenStack: &hyperv1.OpenStackPlatformSpec{
+							IdentityRef: hyperv1.OpenStackIdentityReference{
+								Name:      "test-secret",
+								CloudName: "test-cloud",
+							},
+							ImageRetentionPolicy: "invalid",
+						},
+					},
+				},
+			},
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						"x86_64": {
+							Artifacts: map[string]releaseinfo.CoreOSArtifact{
+								"openstack": {
+									Release: "4.9.0",
+									Formats: map[string]map[string]releaseinfo.CoreOSFormat{
+										"qcow2.gz": {
+											"disk": {
+												Location: "https://example.com/image.qcow2.gz",
+												SHA256:   "abcdef1234567890",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:          true,
+			expectedErrorSubstring: "unsupported image retention policy",
+		},
+		{
+			name: "release image error",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						OpenStack: &hyperv1.OpenStackPlatformSpec{
+							IdentityRef: hyperv1.OpenStackIdentityReference{
+								Name:      "test-secret",
+								CloudName: "test-cloud",
+							},
+							ImageRetentionPolicy: hyperv1.PruneRetentionPolicy,
+						},
+					},
+				},
+			},
+			releaseImage: &releaseinfo.ReleaseImage{
+				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
+					Architectures: map[string]releaseinfo.CoreOSArchitecture{
+						// Missing x86_64 architecture data will cause the OpenstackDefaultImage to fail
+					},
+				},
+			},
+			expectedError:          true,
+			expectedErrorSubstring: "couldn't find OS metadata for architecture",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			imageSpec := &orc.ImageSpec{}
+			err := ReconcileOpenStackImageSpec(tc.hostedCluster, imageSpec, tc.releaseImage)
+
+			if tc.expectedError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if tc.expectedErrorSubstring != "" && !strings.Contains(err.Error(), tc.expectedErrorSubstring) {
+					t.Errorf("expected error containing %q but got %q", tc.expectedErrorSubstring, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tc.expectedImageSpec != nil {
+				if !equality.Semantic.DeepEqual(tc.expectedImageSpec, imageSpec) {
+					t.Error(cmp.Diff(tc.expectedImageSpec, imageSpec))
+				}
 			}
 		})
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -138,6 +138,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.OpenStackNodeFlavor, "e2e.openstack-node-flavor", "", "The flavor to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
 	flag.Var(&globalOpts.ConfigurableClusterOptions.OpenStackDNSNameservers, "e2e.openstack-dns-nameservers", "List of DNS nameservers to use for the cluster")
+	flag.Var(&globalOpts.ConfigurableClusterOptions.OpenStackImageRetentionPolicy, "e2e.openstack-image-retention-policy", "The image retention policy to use for OpenStack nodes. Valid values are 'Orphan' and 'Prune'. When not set, images will be retained indefinitely so that they can be reused by other tests")
 
 	// PowerVS specific flags
 	flag.BoolVar(&globalOpts.ConfigurableClusterOptions.PowerVSPER, "e2e-powervs-power-edge-router", false, "Enabling this flag will utilize Power Edge Router solution via transit gateway instead of cloud connection to create a connection between PowerVS and VPC")

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -129,6 +129,7 @@ type ConfigurableClusterOptions struct {
 	OpenStackNodeFlavor                   string
 	OpenStackNodeImageName                string
 	OpenStackDNSNameservers               stringSliceVar
+	OpenStackImageRetentionPolicy         hyperv1.RetentionPolicy
 	PowerVSCloudConnection                string
 	PowerVSCloudInstanceID                string
 	PowerVSMemory                         int
@@ -219,6 +220,14 @@ func (o *Options) DefaultNoneOptions() none.RawCreateOptions {
 }
 
 func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions {
+	var e2eOpenStackImageRetentionPolicy hyperv1.RetentionPolicy
+	if p.ConfigurableClusterOptions.OpenStackImageRetentionPolicy == "" {
+		// Default to orphaning images for e2e tests so they can be reused
+		// across multiple tests.
+		e2eOpenStackImageRetentionPolicy = hyperv1.OrphanRetentionPolicy
+	} else {
+		e2eOpenStackImageRetentionPolicy = p.ConfigurableClusterOptions.OpenStackImageRetentionPolicy
+	}
 	opts := hypershiftopenstack.RawCreateOptions{
 		OpenStackCredentialsFile:   p.ConfigurableClusterOptions.OpenStackCredentialsFile,
 		OpenStackCACertFile:        p.ConfigurableClusterOptions.OpenStackCACertFile,
@@ -226,11 +235,11 @@ func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 		NodePoolOpts: &openstacknodepool.RawOpenStackPlatformCreateOptions{
 			OpenStackPlatformOptions: &openstacknodepool.OpenStackPlatformOptions{
 				Flavor:         p.ConfigurableClusterOptions.OpenStackNodeFlavor,
-				ImageName:      p.ConfigurableClusterOptions.OpenStackNodeImageName,
 				AvailabityZone: p.ConfigurableClusterOptions.OpenStackNodeAvailabilityZone,
 			},
 		},
-		OpenStackDNSNameservers: p.ConfigurableClusterOptions.OpenStackDNSNameservers,
+		OpenStackDNSNameservers:       p.ConfigurableClusterOptions.OpenStackDNSNameservers,
+		OpenStackImageRetentionPolicy: e2eOpenStackImageRetentionPolicy,
 	}
 
 	return opts

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -356,6 +356,21 @@ const (
 	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"
 )
 
+// RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.
+//
+// +kubebuilder:validation:Enum:=Orphan;Prune
+type RetentionPolicy string
+
+const (
+	// OrphanRetentionPolicy will keep the resources associated with the cluster
+	// when the cluster is deleted.
+	OrphanRetentionPolicy RetentionPolicy = "Orphan"
+
+	// PruneRetentionPolicy will delete the resources associated with the cluster
+	// when the cluster is deleted.
+	PruneRetentionPolicy RetentionPolicy = "Prune"
+)
+
 // +kubebuilder:validation:Enum=ImageRegistry
 type OptionalCapability string
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
@@ -1,5 +1,7 @@
 package v1beta1
 
+import "fmt"
+
 // PortSecurityPolicy defines whether or not to enable port security on a port.
 type PortSecurityPolicy string
 
@@ -12,7 +14,31 @@ const (
 
 	// PortSecurityDefault uses the default port security policy.
 	PortSecurityDefault PortSecurityPolicy = ""
+
+	// PruneRetentionPolicy is the default policy for handling OpenStack Glance Images
+	// when the HostedCluster is deleted.
+	DefaultImageRetentionPolicy RetentionPolicy = PruneRetentionPolicy
 )
+
+func (p *RetentionPolicy) String() string {
+	return string(*p)
+}
+
+func (p *RetentionPolicy) Set(s string) error {
+	switch s {
+	case string(OrphanRetentionPolicy):
+		*p = OrphanRetentionPolicy
+	case string(PruneRetentionPolicy):
+		*p = PruneRetentionPolicy
+	default:
+		return fmt.Errorf("invalid RetentionPolicy: %s", s)
+	}
+	return nil
+}
+
+func (p *RetentionPolicy) Type() string {
+	return "RetentionPolicy"
+}
 
 type OpenStackNodePoolPlatform struct {
 	// Flavor is the OpenStack flavor to use for the node instances.
@@ -136,6 +162,20 @@ type OpenStackPlatformSpec struct {
 	// +kubebuilder:validation:XValidation:rule="isIP(self)",message="floatingIP must be a valid IPv4 or IPv6 address"
 	// +optional
 	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
+
+	// imageRetentionPolicy defines the policy for handling resources associated with the image
+	// when the cluster is deleted.
+	// The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
+	// behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
+	// HostedCluster deletion.
+	// It is defined at the HostedCluster level and will be used for all nodepools images
+	// so there is no conflict between different ORC objects.
+	// On day 2 operations, if this field is changed, the corresponding ORC object will be updated
+	// to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
+	// (either 'delete' or 'detach' in ORC terminology).
+	//
+	// +optional
+	ImageRetentionPolicy RetentionPolicy `json:"imageRetentionPolicy,omitempty"`
 }
 
 // OpenStackIdentityReference is a reference to an infrastructure


### PR DESCRIPTION
This PR enhances OpenStack support in HyperShift by improving image management
and ORC (OpenStack Resource Controller) integration.

- Added a new `RetentionPolicy` type with `Orphan` and `Prune` options.
- Implemented `ImageRetentionPolicy` for OpenStack platform in `OpenStackPlatformSpec`.
- Updated CRDs to include `imageRetentionPolicy` with a default value of `Prune`.
- Enhanced the OpenStack CLI options to support `--openstack-image-retention-policy`.
- Updated OpenStack resource management to ensure proper handling of Glance images via ORC.
- Removed the mandatory requirement for `--openstack-node-image-name`, allowing ORC to manage RHCOS images dynamically.
- Modified RBAC policies for ORC to ensure proper permissions on `images` resources.
- Refactored related test cases and documentation to align with the new behavior.

This change improves flexibility in managing OpenStack resources, enabling users to retain or prune images based on policy.